### PR TITLE
Allow group writing of files into directories in shared vagrant folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.cpus = 2
   end
-  
-  config.vm.synced_folder ".", "/usr/local/submitty/GIT_CHECKOUT_Submitty", owner: "vagrant", group: "vagrant"
+
+  config.vm.synced_folder ".", "/usr/local/submitty/GIT_CHECKOUT_Submitty", owner: "vagrant", group: "vagrant", mount_options: ["dmode=775", "fmode=775"]
 
   config.vm.provision "shell" do |s|
     s.path = ".setup/vagrant.sh"


### PR DESCRIPTION
This then allows the hwphp user (who is part of the vagrant group) to write to the files in /usr/local/submitty/GIT_REPO_submitty/.vagrant/*_logs folders which are created as symlinks within the installation script for vagrant.