### PR TITLE
create method for reprovisioning vagrant box without doing up/destroy

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -70,7 +70,6 @@ echo "\n" | add-apt-repository ppa:webupd8team/java
 apt-get -qq update
 
 
-
 ############################
 # NTP: Network Time Protocol
 # You want to be sure the clock stays in sync, especially if you have
@@ -86,8 +85,6 @@ apt-get -qq update
 
 apt-get install -qqy ntp
 service ntp restart
-
-
 
 # path for untrusted user creation script will be different if not using Vagrant
 ${SUBMITTY_REPOSITORY}/.setup/create.untrusted.users.pl
@@ -125,6 +122,9 @@ apache2-suexec-custom libapache2-mod-authnz-external libapache2-mod-authz-unixgr
 libgnupg-interface-perl php5-pgsql php5-mcrypt libbsd-resource-perl libarchive-zip-perl gcc g++ g++-multilib jq libseccomp-dev \
 libseccomp2 seccomp junit cmake xlsx2csv libpcre3 libpcre3-dev flex bison
 
+apt-get install -qqy subversion subversion-tools
+apt-get install -qqy libapache2-svn
+
 # Enable PHP5-mcrypt
 php5enmod mcrypt
 
@@ -141,7 +141,10 @@ apt-get install -qqy racket > /dev/null 2>&1
 apt-get install -qqy swi-prolog > /dev/null 2>&1
 
 # Install Image Magick for image comparison, etc.
-apt-get install imagemagick
+apt-get install -qqy imagemagick
+
+apt-get -qqy autoremove
+
 
 #################################################################
 # NETWORK CONFIGURATION
@@ -184,10 +187,11 @@ echo "Binding static IPs to \"Host-Only\" virtual network interface."
 # eth1 is statically bound to 192.168.56.101, 102, and 103.
 printf "auto eth1\niface eth1 inet static\naddress 192.168.56.101\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
 printf "auto eth1:1\niface eth1:1 inet static\naddress 192.168.56.102\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
-printf "auto eth1:2\niface eth1:2 inet static\naddress 192.168.56.103\nnetmask 255.255.255.0\n" >> /etc/network/interfaces.d/eth1.cfg
+printf "auto eth1:2\niface eth1:2 inet static\naddress 192.168.56.103\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
+printf "auto eth1:3\niface eth1:3 inet static\naddress 192.168.56.104\nnetmask 255.255.255.0\n" >> /etc/network/interfaces.d/eth1.cfg
 
 # Turn them on.
-ifup eth1 eth1:1 eth1:2
+ifup eth1 eth1:1 eth1:2 eth1:3
 
 #################################################################
 # JAR SETUP
@@ -393,16 +397,16 @@ fi
 adduser hwphp hwcronphp
 adduser hwcron hwcronphp
 
-for COURSE in csci1100 csci1200 csci2600
+for COURSE in csci1000 csci1100 csci1200 csci2600
 do
 
-        # for each course, create a group to contain the current
-        # instructor along the lines of:
+    # for each course, create a group to contain the current
+    # instructor along the lines of:
 
 	addgroup $COURSE
 
-        # and another group to contain the current instructor, TAs,
-        # hwcron, and hwphp along the lines of
+    # and another group to contain the current instructor, TAs,
+    # hwcron, and hwphp along the lines of
 
 	addgroup $COURSE\_tas_www
 	adduser hwphp $COURSE\_tas_www
@@ -436,8 +440,6 @@ ls /home | sort > ${SUBMITTY_DATA_DIR}/instructors/valid
 #################################################################
 # SVN SETUP
 #################
-apt-get install -qqy subversion subversion-tools
-apt-get install -qqy libapache2-svn
 a2enmod dav
 a2enmod dav_fs
 a2enmod authz_svn
@@ -474,15 +476,13 @@ if [ ${VAGRANT} == 1 ]; then
 	echo "postgres:postgres" | chpasswd postgres
 	adduser postgres shadow
 	service postgresql restart
-	sed -i -e "s/# ----------------------------------/# ----------------------------------\nhostssl    all    all    192.168.56.0\/24    pam\nhost    all    all    192.168.56.0\/24    pam/" /etc/postgresql/9.3/main/pg_hba.conf
+	PG_VERSION="$(psql -V | egrep -o '[0-9]{1,}\.[0-9]{1,}')"
+	sed -i -e "s/# ----------------------------------/# ----------------------------------\nhostssl    all    all    192.168.56.0\/24    pam\nhost       all    all    192.168.56.0\/24    pam\nhost       all    all    all                md5/" /etc/postgresql/${PG_VERSION}/main/pg_hba.conf
 	echo "Creating PostgreSQL users"
 	su postgres -c "source ${SUBMITTY_REPOSITORY}/.setup/vagrant/db_users.sh";
 	echo "Finished creating PostgreSQL users"
 
-    echo "Setting up Postgres to connect to via host"
-    PG_VERSION="$(psql -V | egrep -o '[0-9]{1,}\.[0-9]{1,}')"
 	sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" "/etc/postgresql/${PG_VERSION}/main/postgresql.conf"
-	echo "host    all             all             all                     md5" >> "/etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
 	service postgresql restart
 fi
 

--- a/.setup/vagrant/reset_system.py
+++ b/.setup/vagrant/reset_system.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+"""
+Script to reset the vagrant box and the configurations that install_system does
+to set up the submitty system with regards to apache, postgresql, etc. This then
+allows for install_system.sh to run cleanly and not end up with duplicate lines
+in configuration files or pre-existing databses.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+
+def remove_lines(filename, lines):
+    """
+    Given a file, go through and remove a line if it's contained in the lines
+    list
+
+    :param filename: file to remove lines from
+    :type filename: str
+    :param lines: list of strings to remove from the filename
+    :type lines: list
+    """
+    if not os.path.isfile(filename):
+        return
+    if not isinstance(lines, list) or len(lines) == 0:
+        return
+    stat = os.stat(filename)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+        with open(filename, "r") as read_file:
+            for line in read_file:
+                if line.strip() in lines:
+                    continue
+                tmp_file.write(line)
+        shutil.copystat(filename, tmp_file.name)
+        shutil.move(tmp_file.name, filename)
+    os.chown(filename, stat.st_uid, stat.st_gid)
+
+
+def cmd_exists(cmd):
+    """
+    Given a command name, checks to see if it exists on the system, return True or False
+    """
+    return os.system("type " + str(cmd)) == 0
+
+
+def remove_file(filename):
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+
+if __name__ == '__main__':
+    # Remove the MOT.D
+    remove_file("/etc/motd");
+
+    # Scrub the hosts file
+    hosts = ["192.168.56.101    test-submit test-submit.cs.rpi.edu", "192.168.56.102    test-svn test-svn.cs.rpi.edu",
+             "192.168.56.103    test-hwgrading test-hwgrading.cs.rpi.edu hwgrading"]
+    remove_lines("/etc/hosts", hosts)
+
+    # Scrub out the network interfaces that were created for Vagrant
+    subprocess.call(["ifdown", "eth1", "eth1:1", "eth1:2", "eth1:3"])
+    remove_file("/etc/network/interfaces.d/eth1.cfg")
+
+    # Remove the data directories for submitty
+    shutil.rmtree('/usr/local/submitty/.setup', True)
+    shutil.rmtree('/var/local/submitty', True)
+    shutil.rmtree('/var/lib/svn', True)
+
+    # If we have psql cmd available, then PostgreSQL is installed so we should scrub out any submitty DBs
+    if (cmd_exists('psql')):
+        os.environ['PGPASSWORD'] = 'hsdbu'
+        os.system("psql -h localhost -U hsdbu --list | grep submitty_* | awk '{print $1}' | xargs -I \"@@\" dropdb -h localhost -U hsdbu \"@@\"")
+        del os.environ['PGPASSWORD']
+
+        psql_version = subprocess.check_output("psql -V | egrep -o '[0-9]{1,}\.[0-9]{1,}'", shell=True).strip()
+        lines = ["hostssl    all    all    192.168.56.0/24    pam", "host       all    all    192.168.56.0/24    pam",
+                 "host       all    all    all                md5"]
+        remove_lines('/etc/postgresql/' + psql_version + '/main/pg_hba.conf', lines)
+
+    for i in range(0, 60):
+        j = str(i).zfill(2)
+        os.system("userdel untrusted" + j)
+
+    lines = ["#%PAM-1.0", "auth required pam_unix.so", "account required pam_unix.so"]
+    remove_lines('/etc/pam.d/httpd', lines)
+
+    # Scrub some stuff from apache
+    shutil.rmtree('/etc/apache2/ssl', True)
+    remove_file('/etc/apache2/suexec/www-data')
+
+    os.system("a2dissite submit")
+    os.system("a2dissite hwgrading")
+    for folder in ["/etc/apache2/sites-available", "/etc/apache2/sites-enabled"]:
+        if os.path.isdir(folder):
+            for the_file in os.listdir(folder):
+                file_path = os.path.join(folder, the_file)
+                remove_file(file_path)
+
+    remove_lines('/etc/apache2/apache2.conf', ["ServerName 10.0.2.15"])
+
+    shutil.rmtree('/root/bin', True)
+
+    users = ["instructor", "ta", "developer", "student", "hwphp", "hwcron", "hsdbu"]
+    for user in users:
+        os.system("userdel " + user)
+
+    groups = ["hwcronphp", "course_builders"]
+    courses = ["csci1000", "csci1100", "csci1200", "csci2600"]
+    for course in courses:
+        groups.append(course)
+        groups.append(course + "_tas_www")
+
+    for group in groups:
+        os.system('groupdel ' + group)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,11 @@ Vagrant.configure(2) do |config|
     v.cpus = 2
   end
 
-  config.vm.synced_folder ".", "/usr/local/submitty/GIT_CHECKOUT_Submitty", owner: "vagrant", group: "vagrant", mount_options: ["dmode=775", "fmode=775"]
+  config.vm.synced_folder ".", "/usr/local/submitty/GIT_CHECKOUT_Submitty", create: true, owner: "vagrant", group: "vagrant", mount_options: ["dmode=775", "fmode=775"]
+
+  config.vm.provision "shell" do |s|
+    s.path = ".setup/vagrant/reset_system.py"
+  end
 
   config.vm.provision "shell" do |s|
     s.path = ".setup/vagrant.sh"


### PR DESCRIPTION
This allows for if you want to test something in the install_setup.sh script, you don't need to do a full ```vagrant up``` and ```vagrant destroy``` sequence as we don't need to reinstall all packages and such through this.

Running it would be:
1. If vagrant box is halted: ```vagrant up --provision```
2. If vagrant box is running: ```vagrant reload --provision```