### PR TITLE
Badge Fixes

### DIFF
--- a/site/app/models/GradeableTestcase.php
+++ b/site/app/models/GradeableTestcase.php
@@ -148,4 +148,8 @@ class GradeableTestcase {
     public function getAutochecks() {
         return $this->autochecks;
     }
+    
+    public function hasDetails() {
+        return count($this->autochecks) > 0 || $this->hasCompilationOutput() || $this->hasExecuteLog();
+    }
 }

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -50,7 +50,7 @@ HTML;
 <html>
 <head>
     <title>{$this->core->getFullCourseName()}</title>
-    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css" />
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/server.css" />
     <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/diff-viewer.css" />
     {$override_css}

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -377,14 +377,17 @@ HTML;
 HTML;
                             }
                             else {
+                                $background = "";
                                 if ($testcase->getPointsAwarded() >= $testcase->getPoints()) {
                                     $background = "green-background";
                                 }
-                                else if ($testcase->getPointsAwarded() > 0) {
-                                    $background = "yellow-background";
-                                }
-                                else {
-                                    $background = "red-background";
+                                else if (!$testcase->isExtraCredit()) {
+                                    if ($testcase->getPointsAwarded() > 0) {
+                                        $background = "yellow-background";
+                                    }
+                                    else {
+                                        $background = "red-background";
+                                    }
                                 }
                                 $return .= <<<HTML
                             <span class="badge {$background}">{$testcase->getPointsAwarded()} / {$testcase->getPoints()}</span>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -358,8 +358,10 @@ HTML;
                         }
                         $return .= <<<HTML
         <div class="box">
-            <span class="badge {$background}">{$results['points']} / {$gradeable->getNormalPoints()}</span>
-            <h4>Total</h4>
+            <div class="box-title">
+                <span class="badge {$background}">{$results['points']} / {$gradeable->getNormalPoints()}</span>
+                <h4>Total</h4>
+            </div>
         </div>
 HTML;
                     }
@@ -367,13 +369,23 @@ HTML;
                     $count = 0;
                     $display_box = (count($gradeable->getTestcases()) == 1) ? "block" : "none";
                     foreach ($gradeable->getTestcases() as $testcase) {
+                        $div_click = "";
+                        if ($testcase->hasDetails()) {
+                            $div_click = "onclick=\"return toggleDiv('testcase_{$count}');\" style=\"cursor: pointer;\"";
+                        }
                         $return .= <<<HTML
         <div class="box">
+            <div class="box-title" {$div_click}>
 HTML;
+                        if ($testcase->hasDetails()) {
+                            $return .= <<<HTML
+                <span style="float:right; color: #0000EE; text-decoration: underline">Details</span>
+HTML;
+                        }
                         if ($testcase->hasPoints()) {
                             if ($testcase->isHidden()) {
                                 $return .= <<<HTML
-            <span class="badge">Hidden</span>
+                <span class="badge">Hidden</span>
 HTML;
                             }
                             else {
@@ -390,7 +402,7 @@ HTML;
                                     }
                                 }
                                 $return .= <<<HTML
-                            <span class="badge {$background}">{$testcase->getPointsAwarded()} / {$testcase->getPoints()}</span>
+                <span class="badge {$background}">{$testcase->getPointsAwarded()} / {$testcase->getPoints()}</span>
 HTML;
                             }
                         }
@@ -401,7 +413,8 @@ HTML;
                         }
                         $command = htmlentities($testcase->getDetails());
                         $return .= <<<HTML
-            <h4 onclick="return toggleDiv('testcase_{$count}');" style="cursor: pointer;">{$name} <code>{$command}</code></h4>
+                <h4>{$name}&nbsp;&nbsp;&nbsp;<code>{$command}</code></h4>
+            </div>
             <div id="testcase_{$count}" style="display: {$display_box};">
 HTML;
                         if(!$testcase->isHidden()) {
@@ -425,30 +438,52 @@ HTML;
 HTML;
                             }
                     
+                            $autocheck_cnt = 0;
+                            $autocheck_len = count($testcase->getAutochecks());
                             foreach ($testcase->getAutochecks() as $autocheck) {
+                                $description = $autocheck->getDescription();
+                                $diff_viewer = $autocheck->getDiffViewer();
+                                
                                 $return .= <<<HTML
                 <div class="box-block">
 HTML;
+                                
+                                $title = "";
+                                $return .= <<<HTML
+                            <div class='diff-element'>
+HTML;
+                                if ($diff_viewer->hasDisplayExpected()) {
+                                    $title = "Student ";
+                                }
+                                $title .= $description;
+                                $return .= <<<HTML
+                                <h4>{$title}</h4>
+HTML;
                                 foreach ($autocheck->getMessages() as $message) {
                                     $return .= <<<HTML
-                    <div class="red-message">{$message}</div>
+                                <span class="red-message">{$message}</span><br />
 HTML;
                                 }
-                                $diff_viewer = $autocheck->getDiffViewer();
-                                $description = $autocheck->getDescription();
-                                if($diff_viewer->hasDisplayActual()) {
+                                if ($diff_viewer->hasDisplayActual()) {
                                     $return .= <<<HTML
-                            <div class='diff-element'>
-                                <h4>Student {$description}</h4>
                                 {$diff_viewer->getDisplayActual()}
+HTML;
+                                }
+                                $return .= <<<HTML
                             </div>
 HTML;
-                                }
                     
-                                if($diff_viewer->hasDisplayExpected()) {
+                                if ($diff_viewer->hasDisplayExpected()) {
                                     $return .= <<<HTML
                             <div class='diff-element'>
-                                <h4>Instructor {$description}</h4>
+                                <h4>Expected {$description}</h4>
+HTML;
+                                    for ($i = 0; $i < count($autocheck->getMessages()); $i++) {
+                                        $return .= <<<HTML
+                                <br />
+HTML;
+                                    }
+                                    $return .= <<<HTML
                                 {$diff_viewer->getDisplayExpected()}
                             </div>
 HTML;
@@ -456,8 +491,12 @@ HTML;
                     
                                 $return .= <<<HTML
                 </div>
+HTML;
+                                if (++$autocheck_cnt < $autocheck_len) {
+                                    $return .= <<<HTML
                 <div class="clear"></div>
 HTML;
+                                }
                             }
                         }
                         $return .= <<<HTML

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -252,7 +252,8 @@ textarea {
 
 .clear {
     clear: both;
-    margin-bottom: 20px;
+    border-bottom: 1px solid lightgrey;
+    padding-top: 20px;
 }
 
 #page-info {
@@ -387,6 +388,10 @@ select {
     padding: 5px 5px 10px;
 }
 
+.box-title {
+    margin-top: 10px;
+}
+
 .box > h4 {
     margin-bottom: 10px;
     margin-left: 10px;
@@ -421,7 +426,7 @@ select {
 }
 
 .badge {
-    float: right;
+    float: left;
     display: inline-block;
     min-width: 10px;
     padding: 3px 7px;
@@ -433,8 +438,8 @@ select {
     vertical-align: baseline;
     background-color: #999;
     border-radius: 10px;
-    margin-top: 10px;
     margin-right: 20px;
+    margin-left: 10px;
 }
 
 .green-background {


### PR DESCRIPTION
Solves:
- [x] Move badges to left of title line
- [x] Clicking on the points badge should expand bar
- [x] Put a "Details" text on testcases that have something to show and while things with nothing don't show anything (ex: successful compliation test)
- [x] Maximize test results only if one test, otherwise minimize all test results boxes
- [x] badges for tests that are extra credit should be green if they are full credit, or gray otherwise.  (never red)  For example, submit "julian_full_credit.cpp" to cpp_simple_lab
- [x] If there are one or more "message"s for an autocheck, list them in red below the autocheck title and above the file contents box. (In the 101 version I think the message was above the title. In the 104 version, it's currently to the right of the file contents box.)

from #462