### PR TITLE
Make it possible to run just one integration testcase in a module (in…

### DIFF
--- a/tests/integrationTests/lib.py
+++ b/tests/integrationTests/lib.py
@@ -485,5 +485,5 @@ def testcase(func):
     global to_run
     to_run[modname].wrapper = tw
     to_run[modname].testcases.append(wrapper)
-    to_run[modname].testcases_names.append(func.__name)
+    to_run[modname].testcases_names.append(func.__name__)
     return wrapper

--- a/tests/integrationTests/tests/__init__.py
+++ b/tests/integrationTests/tests/__init__.py
@@ -1,7 +1,7 @@
 import pkgutil
 
 __all__ = []
-for loader, module_name, is_pkg in  pkgutil.iter_modules(__path__):
+for loader, module_name, is_pkg in pkgutil.iter_modules(__path__):
     __all__.append(module_name)
     module = loader.find_module(module_name).load_module(module_name)
     exec("%s = module" % module_name)


### PR DESCRIPTION
…stead of all test cases in a specified module)

Usage example is "cpp_cats.allcorrect" (capitalization doesn't matter)