### PR TITLE
Rotating Sections Exception

### DIFF
--- a/TAGradingServer/account/index.php
+++ b/TAGradingServer/account/index.php
@@ -40,7 +40,7 @@ if(isset($_GET["g_id"]) && isset($rubric["g_id"])) {
     $g_title = $rubric['g_title'];
     $rubric_late_days = $rubric['eg_late_days'];
     $grade_by_reg_section = $rubric['g_grade_by_registration'];
-    $section_param = ($grade_by_reg_section ? 'sections_registration_id': 'sections_rotating_id');
+    $section_param = ($grade_by_reg_section ? 'sections_registration_id': 'sections_rotating');
     $user_section_param = ($grade_by_reg_section ? 'registration_section': 'rotating_section');
     $grading_section_param = ($grade_by_reg_section ? 'sections_registration_id': 'sections_rotating');
     $section_title = ($grade_by_reg_section ? 'Registration': 'Rotating');


### PR DESCRIPTION
Was looking for the incorrect column from grading_rotating table. Pointed it to the correct column. I think this will clear up the issue where TA were incorrectly told that they were finished grading when they weren't.