### PR TITLE
Fix issue of some assigned rotating sections being empty

### DIFF
--- a/TAGradingServer/account/submit/admin-rotating-sections.php
+++ b/TAGradingServer/account/submit/admin-rotating-sections.php
@@ -2,6 +2,8 @@
 
 require_once "../../toolbox/functions.php";
 
+use lib\Database;
+
 check_administrator();
 
 if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
@@ -15,35 +17,43 @@ $grading_sections = intval($_POST['sections']);
 if ($grading_sections > 0) {
     $complete_update = 1;
     
-    \lib\Database::query("SELECT user_id FROM users WHERE (user_group=? AND registration_section IS NOT NULL) OR (manual_registration) ORDER BY user_lastname ASC;", array(4));
+    Database::query("SELECT user_id FROM users WHERE (user_group=? AND registration_section IS NOT NULL) OR (manual_registration) ORDER BY user_id ASC;", array(4));
     
     $good_users = array();
     foreach (\lib\Database::rows() as $user) {
-        array_push($good_users, $user['user_id']);
+        $good_users[] = $user['user_id'];
     }
 
     if ($_POST['arrange_type'] == 'random') {
         shuffle($good_users);
     }
-    
-    \lib\Database::query("UPDATE users SET rotating_section=NULL");
-    \lib\Database::query("SELECT MAX(sections_rotating_id) as max FROM sections_rotating", array());
-    $highest_section = \lib\Database::row()['max'];
-    
-    $per_section = ceil(count($good_users) / $grading_sections);
-    for ($i = 1; $i <= $grading_sections; $i++) {
-        $update = array_slice($good_users, ($i-1) * $per_section, $per_section * $i);
-        // this should only happen if we try to split n users into n+1 grading sections
-        if (count($update) == 0) {
-            continue;
+
+    Database::query("UPDATE users SET rotating_section=NULL");
+    Database::query("SELECT MAX(sections_rotating_id) as max FROM sections_rotating", array());
+    $highest_section = Database::row()['max'];
+
+    // We have to determine the number of students to put into each section. We cannot simply
+    // divide number of students by number of grading sections as that might give a non-round
+    // number as there's no way to easily resolve that. We can however, go through the number
+    // of students saying that all sections get 1 student, all sections get 2 students, etc.
+    // until we run out of students to give to sections. This should mean that at worst, some
+    // sections will have one less student than others.
+
+    $section_counts = array_fill(0, $grading_sections, 0);
+    for ($i = 0; $i < count($good_users); $i++) {
+        $section = $i % $grading_sections;
+        $section_counts[$section]++;
+        if ($section > $highest_section) {
+            Database::query("INSERT INTO sections_rotating (sections_rotating_id) VALUES (?)", array($section));
         }
-        $update_string = array_pad(array(), count($update), "?");
-        if ($i > $highest_section){
-            \lib\Database::query("INSERT INTO sections_rotating (sections_rotating_id) VALUES(?)", array($i));
-        }
-        \lib\Database::query("UPDATE users SET rotating_section=? WHERE user_id IN (".implode(",", $update_string).")", array_merge(array($i), $update));
+    }
+    var_dump($section_counts);
+    for ($i = 0; $i < $grading_sections; $i++) {
+        $users = array_splice($good_users, 0, $section_counts[$i]);
+        $update_array = array_merge(array($i+1), $users);
+        $update_string = implode(",", array_pad(array(), count($users), "?"));
+        Database::query("UPDATE users SET rotating_section=? WHERE user_id IN ({$update_string})", $update_array);
     }
 }
-
 
 header('Location: '.__BASE_URL__.'/account/admin-rotating-sections.php?course='.$_GET['course'].'&semester='.$_GET['semester']."&update={$complete_update}");


### PR DESCRIPTION
Right now, we can the `ceil(number_of_students / number_of_sections)` which can lead to the problem that all students are assigned to number of sections less than what was assigned (ex case: 4 students, 3 sections).