### PR TITLE
Update submitty license terms as well as provide list of third party licenses

### DIFF
--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -1,0 +1,36 @@
+Third Party Licenses
+====================
+
+While Submitty is made available under the [BSD "3-Clause" License](https://github.com/Submitty/Submitty/blob/master/LICENSE.md) 
+we utilize several third-party libraries to help power various components. We provide a list of these components and
+their relevant licenses.
+
+#### jQuery
+&nbsp;&nbsp;&nbsp;&nbsp;Copyright jQuery Foundation and other contributors  
+&nbsp;&nbsp;&nbsp;&nbsp;https://jquery.com  
+&nbsp;&nbsp;&nbsp;&nbsp;[MIT License](https://github.com/jquery/jquery/blob/master/LICENSE.txt)  
+
+#### jQuery-UI
+&nbsp;&nbsp;&nbsp;&nbsp;Copyright jQuery Foundation and other contributors  
+&nbsp;&nbsp;&nbsp;&nbsp;https://jquery.com  
+&nbsp;&nbsp;&nbsp;&nbsp;[MIT License](https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt)
+
+#### jQuery-Color
+&nbsp;&nbsp;&nbsp;&nbsp;Copyright jQuery Foundation and other contributors  
+&nbsp;&nbsp;&nbsp;&nbsp;https://jquery.com  
+&nbsp;&nbsp;&nbsp;&nbsp;[MIT License](https://github.com/jquery/jquery-color/blob/master/LICENSE.txt)
+
+#### jQuery-UI-Timepicker-Addon
+&nbsp;&nbsp;&nbsp;&nbsp;Copyright (c) 2013 Trent Richardson  
+&nbsp;&nbsp;&nbsp;&nbsp;http://trentrichardson.com/examples/timepicker/  
+&nbsp;&nbsp;&nbsp;&nbsp;[MIT License](https://github.com/trentrichardson/jQuery-Timepicker-Addon/blob/master/LICENSE-MIT)
+
+#### CodeMirror
+&nbsp;&nbsp;&nbsp;&nbsp;Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others  
+&nbsp;&nbsp;&nbsp;&nbsp;https://codemirror.net/  
+&nbsp;&nbsp;&nbsp;&nbsp;[MIT License](https://github.com/codemirror/CodeMirror/blob/master/LICENSE)
+
+#### Bootstrap
+&nbsp;&nbsp;&nbsp;&nbsp;Copyright (c) 2011-2016 Twitter, Inc.  
+&nbsp;&nbsp;&nbsp;&nbsp;https://getbootstrap.com/  
+&nbsp;&nbsp;&nbsp;&nbsp;[MIT License](https://github.com/twbs/bootstrap/blob/master/LICENSE)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,29 @@
-##BSD License
+BSD 3-Clause License
 
-Copyright (c) 2014, Chris Berger, Jesse Freitas, Severin Ibarluzea, Kiana McNellis, Kienan Knight-Boehm, Samuel Seng
-
+Copyright (c) 2016, [Submitty team](https://github.com/Submitty/Submitty/blob/master/AUTHORS.md)  
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Provides a centralized list of licenses for third-parties based on discussion from #772. It seems like some of our libraries (CodeMirror) does not provide any sort of license terms in the header of their JS files so we'd have to make reference to it in this fashion if we wanted to use https://cdnjs.com