### PR TITLE
Spring Prep work

### DIFF
--- a/TAGradingServer/account/admin-gradeable.php
+++ b/TAGradingServer/account/admin-gradeable.php
@@ -640,8 +640,14 @@ HTML;
 
     $db->query("SELECT COUNT(*) AS cnt FROM sections_rotating", array());
     $num_rotating_sections = $db->row()['cnt'];
-    $all_sections = str_replace(array('[', ']'), '',
-                    htmlspecialchars(json_encode(range(1,$num_rotating_sections)), ENT_NOQUOTES));
+    if ($num_rotating_sections > 0) {
+        $all_sections = str_replace(array('[', ']'), '',
+            htmlspecialchars(json_encode(range(1,$num_rotating_sections)), ENT_NOQUOTES));
+    }
+    else {
+        $all_sections = "";
+    }
+
 
     $db->query("
     SELECT 
@@ -759,7 +765,7 @@ HTML;
           <td style="padding: 8px; border: 3px solid black; text-align: center;">{$sections}</td>      
 HTML;
     $last = $row['user_id'];
-  }  
+  }
   
   print <<<HTML
             </table>

--- a/TAGradingServer/account/submit/admin-gradeable.php
+++ b/TAGradingServer/account/submit/admin-gradeable.php
@@ -57,14 +57,49 @@ if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) 
       * @param \lib\Database $db
       */
     function createGradeable($db){
-        $params = array($this->g_id,$this->g_title, $this->g_overall_ta_instr, $this->g_use_teams,
-                        $this->g_gradeable_type, $this->g_grade_by_registration, $this->g_grade_start_date,
-                        $this->g_grade_released_date, $this->g_syllabus_bucket, $this->g_min_grading_group,
-                        $this->g_instructions_url, $this->g_ta_view_start_date);
-        $db->query("INSERT INTO gradeable(g_id,g_title, g_overall_ta_instructions, g_team_assignment, 
-                    g_gradeable_type, g_grade_by_registration, g_grade_start_date, g_grade_released_date,
-                    g_syllabus_bucket,g_min_grading_group, g_instructions_url, g_ta_view_start_date) 
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?, ?)", $params);
+        $params = array(
+            $this->g_id,
+            $this->g_title,
+            $this->g_instructions_url,
+            $this->g_overall_ta_instr,
+            $this->g_use_teams,
+            $this->g_gradeable_type,
+            $this->g_grade_by_registration,
+            $this->g_ta_view_start_date,
+            $this->g_grade_start_date,
+            $this->g_grade_released_date,
+            $this->g_min_grading_group,
+            $this->g_syllabus_bucket);
+
+        $db->query("
+INSERT INTO gradeable(
+  g_id, 
+  g_title, 
+  g_instructions_url,
+  g_overall_ta_instructions, 
+  g_team_assignment, 
+  g_gradeable_type, 
+  g_grade_by_registration,
+  g_ta_view_start_date,
+  g_grade_start_date, 
+  g_grade_released_date, 
+  g_min_grading_group,
+  g_syllabus_bucket
+  ) 
+  VALUES (
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    ?, 
+    ?
+  )", $params);
     }
     
      /**
@@ -287,61 +322,71 @@ abstract class GradeableType{
     const numeric = 2;
 }
  
- function constructGradeable ($db, $request_args){
-     $g_id = $request_args['gradeable_id'];
-     if ($g_id === null or $g_id === "") {
-         throw new Exception("Gradeable id cannot be blank or null");
-     }
-     
-     if ($_GET['action'] != 'edit'){
-         $db->query("SELECT COUNT(*) AS cnt FROM gradeable WHERE g_id=?", array($g_id));
-         if ($db->row()['cnt'] > 0){
-            throw new Exception('Gradeable already exists');
-         }
-     }
+function constructGradeable ($db, $request_args){
+    $g_id = $request_args['gradeable_id'];
+    if ($g_id === null or $g_id === "") {
+     throw new Exception("Gradeable id cannot be blank or null");
+    }
 
-     $g_title = $request_args['gradeable_title'];
-     $g_instructions_url = $request_args['instructions_url'];
-     $g_overall_ta_instr = $request_args['ta_instructions'];
-     $g_use_teams = (isset($request_args['team_assignment']) && $request_args['team_assignment'] === 'yes') ? "true" : "false";
-     $g_min_grading_group=(isset($request_args['minimum_grading_group'])) ? intval($request_args['minimum_grading_group']) : 1;
-     $g_grade_by_registration = (isset($request_args['section_type']) && $request_args['section_type'] === 'reg_section') ? "true" : "false";
-     $g_ta_view_start_date = $request_args['date_ta_view'];
-     $g_grade_start_date = $request_args['date_grade'];
-     $g_grade_released_date = $request_args['date_released'];
-     $g_syllabus_bucket = $request_args['gradeable_buckets'];
-     
-     $g_constructor_params = array('gradeable_id' => $g_id, 'gradeable_title' => $g_title,
-                                   'instructions_url' => $g_instructions_url,'ta_instructions' => $g_overall_ta_instr,
-                                   'team_assignment' => $g_use_teams, 'min_grading_group' => $g_min_grading_group,
-                                   'section_type' => $g_grade_by_registration, 'date_grade' => $g_grade_start_date,
-                                   'date_released' =>$g_grade_released_date, 'bucket' => $g_syllabus_bucket,
-                                   'date_ta_view' => $g_ta_view_start_date);
+    if ($_GET['action'] != 'edit'){
+     $db->query("SELECT COUNT(*) AS cnt FROM gradeable WHERE g_id=?", array($g_id));
+     if ($db->row()['cnt'] > 0){
+        throw new Exception('Gradeable already exists');
+     }
+    }
 
-     if ($request_args['gradeable_type'] === "Electronic File"){
+    $g_title = $request_args['gradeable_title'];
+    $g_instructions_url = $request_args['instructions_url'];
+    $g_overall_ta_instr = $request_args['ta_instructions'];
+    $g_use_teams = (isset($request_args['team_assignment']) && $request_args['team_assignment'] === 'yes') ? "true" : "false";
+    $g_min_grading_group=(isset($request_args['minimum_grading_group'])) ? intval($request_args['minimum_grading_group']) : 1;
+    $g_grade_by_registration = (isset($request_args['section_type']) && $request_args['section_type'] === 'reg_section') ? "true" : "false";
+    $g_ta_view_start_date = $request_args['date_ta_view'];
+    $g_grade_start_date = $request_args['date_grade'];
+    $g_grade_released_date = $request_args['date_released'];
+    $g_syllabus_bucket = $request_args['gradeable_buckets'];
+
+    $g_constructor_params = array(
+        'gradeable_id' => $g_id,
+        'gradeable_title' => $g_title,
+        'instructions_url' => $g_instructions_url,
+        'ta_instructions' => $g_overall_ta_instr,
+        'team_assignment' => $g_use_teams,
+        'min_grading_group' => $g_min_grading_group,
+        'section_type' => $g_grade_by_registration,
+        'date_grade' => $g_grade_start_date,
+        'date_released' => $g_grade_released_date,
+        'bucket' => $g_syllabus_bucket,
+        'date_ta_view' => $g_ta_view_start_date
+    );
+
+    if ($request_args['gradeable_type'] === "Electronic File") {
         $g_constructor_params['gradeable_type'] = GradeableType::electronic_file;
 
         $ta_grading = ($request_args['ta_grading'] == "true") ? "true" : "false";
         $date_submit = $request_args['date_submit'];
         $date_due = $request_args['date_due'];
         if (strtotime($date_submit) < strtotime($g_ta_view_start_date)) {
-          throw new Exception('DATE CONSISTENCY:  Submission Open Date must be >= TA Beta Testing Date');
+            throw new Exception('DATE CONSISTENCY:  Submission Open Date must be >= TA Beta Testing Date');
         }
         if (strtotime($date_due) < strtotime($date_submit)) {
-          throw new Exception('DATE CONSISTENCY:  Due Date must be >= Submission Open Date');
+            throw new Exception('DATE CONSISTENCY:  Due Date must be >= Submission Open Date');
         }
         if ($ta_grading === "true") {
-          if (strtotime($g_grade_start_date) < strtotime($date_due)) {
-            throw new Exception('DATE CONSISTENCY:  TA Grading Open Date must be >= Due Date');
-          }
-          if(strtotime($g_grade_released_date) < strtotime($g_grade_start_date)) {
-            throw new Exception('DATE CONSISTENCY:  Grades Released Date must be >= TA Grading Open Date');
-          }
-        } else {
-          if(strtotime($g_grade_released_date) < strtotime($date_due)) {
-            throw new Exception('DATE CONSISTENCY:  Grades Released Date must be >= Due Date');
-          }
+            if (strtotime($g_grade_start_date) < strtotime($date_due)) {
+                throw new Exception('DATE CONSISTENCY:  TA Grading Open Date must be >= Due Date');
+            }
+            if(strtotime($g_grade_released_date) < strtotime($g_grade_start_date)) {
+                throw new Exception('DATE CONSISTENCY:  Grades Released Date must be >= TA Grading Open Date');
+            }
         }
+        else {
+            if(strtotime($g_grade_released_date) < strtotime($date_due)) {
+                throw new Exception('DATE CONSISTENCY:  Grades Released Date must be >= Due Date');
+            }
+            $g_constructor_params['date_grade'] = $g_grade_released_date;
+        }
+
         $is_repo = ($request_args['upload_type'] == 'Repository')? "true" : "false";
         $subdirectory = (isset($request_args['subdirectory']) && $is_repo == "true")? $request_args['subdirectory'] : '';
 
@@ -359,8 +404,8 @@ abstract class GradeableType{
         $g_constructor_params['point_precision'] = $eg_pt_precision;
         
         $gradeable = new ElectronicGradeable($g_constructor_params);
-     }
-     else if ($request_args['gradeable_type'] === "Checkpoints"){
+    }
+    else if ($request_args['gradeable_type'] === "Checkpoints"){
         $g_constructor_params['gradeable_type'] = GradeableType::checkpoints;
         $gradeable = new CheckpointGradeable($g_constructor_params);
         if (strtotime($g_grade_start_date) < strtotime($g_ta_view_start_date)) {
@@ -369,8 +414,8 @@ abstract class GradeableType{
         if(strtotime($g_grade_released_date) < strtotime($g_grade_start_date)){
           throw new Exception('DATE CONSISTENCY:  Grade Released Date must be >= TA Grading Open Date');
         }
-     }
-     else if ($request_args['gradeable_type'] === "Numeric"){
+    }
+    else if ($request_args['gradeable_type'] === "Numeric"){
         $g_constructor_params['gradeable_type'] = GradeableType::numeric;
         $gradeable = new NumericGradeable($g_constructor_params);
         if (strtotime($g_grade_start_date) < strtotime($g_ta_view_start_date)) {
@@ -379,8 +424,8 @@ abstract class GradeableType{
         if(strtotime($g_grade_released_date) < strtotime($g_grade_start_date)){
           throw new Exception('DATE CONSISTENCY:  Grade Released Date must be >= TA Grading Open Date');
         }
-     }
-     return $gradeable;
+    }
+    return $gradeable;
  }
   
 function getGraders($var){

--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -31,12 +31,14 @@ class NavigationController extends AbstractController {
   		$this->core->getOutput()->addCSS("https://fonts.googleapis.com/css?family=Inconsolata");
         
         $future_gradeables_list = $this->gradeables_list->getFutureGradeables();
+        $beta_gradeables_list = $this->gradeables_list->getBetaGradeables();
         $open_gradeables_list = $this->gradeables_list->getOpenElectronicGradeables();
         $closed_gradeables_list = $this->gradeables_list->getClosedElectronicGradeables();
         $grading_gradeables_list = $this->gradeables_list->getGradingGradeables();
         $graded_gradeables_list = $this->gradeables_list->getGradedGradeables();
         
         $sections_to_lists = array("FUTURE" => $future_gradeables_list,
+                                   "BETA" => $beta_gradeables_list,
                                    "OPEN" => $open_gradeables_list,
                                    "CLOSED" => $closed_gradeables_list,
                                    "ITEMS BEING GRADED" => $grading_gradeables_list,

--- a/site/app/models/GradeableList.php
+++ b/site/app/models/GradeableList.php
@@ -17,7 +17,7 @@ class GradeableList {
     private $gradeables = array();
 
     /*
-     * All elements of $this->>gradeables should fall into one of the following six lists. There should
+     * All elements of $this->gradeables should fall into one of the following six lists. There should
      * be no overlap between them.
      */
     /** @var Gradeable[] */

--- a/site/app/models/GradeableList.php
+++ b/site/app/models/GradeableList.php
@@ -15,9 +15,27 @@ class GradeableList {
      * @var Gradeable[]
      */
     private $gradeables = array();
+
+    /*
+     * All elements of $this->>gradeables should fall into one of the following six lists. There should
+     * be no overlap between them.
+     */
+    /** @var Gradeable[] */
+    private $future_gradeables = array();
+    /** @var Gradeable[] */
+    private $beta_gradeables = array();
+    /** @var Gradeable[] */
+    private $open_gradeables = array();
+    /** @var Gradeable[] */
+    private $closed_gradeables = array();
+    /** @var Gradeable[] */
+    private $grading_gradeables = array();
+    /** @var Gradeable[] */
+    private $graded_gradeables = array();
+
     
     /**
-     * @var DateTime
+     * @var \DateTime
      *
     */
     private $now;
@@ -48,7 +66,50 @@ class GradeableList {
         else {
             $this->gradeables = $this->core->getQueries()->getAllGradeables($this->core->getUser()->getId());
         }
-        $this->now = new \DateTime("now", new \DateTimeZone($this->core->getConfig()->getTimezone()));
+        $now = new \DateTime("now", new \DateTimeZone($this->core->getConfig()->getTimezone()));
+
+        foreach ($this->gradeables as $gradeable) {
+            if ($gradeable->getGradeReleasedDate() <= $now) {
+                $this->graded_gradeables[$gradeable->getId()] = $gradeable;
+            }
+            else if ((($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->useTAGrading()) ||
+                    $gradeable->getType() !== GradeableType::ELECTRONIC_FILE) &&
+                    $gradeable->getGradeStartDate() <= $now) {
+                $this->grading_gradeables[$gradeable->getId()] = $gradeable;
+            }
+            else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
+                $gradeable->getOpenDate() <= $now && $gradeable->getDueDate() <= $now) {
+                $this->closed_gradeables[$gradeable->getId()] = $gradeable;
+            }
+            else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
+                $gradeable->getOpenDate() <= $now && $gradeable->getTAViewDate() <= $now) {
+                $this->open_gradeables[$gradeable->getId()] = $gradeable;
+            }
+            else if ($this->core->getUser()->accessGrading() && $gradeable->getTAViewDate() <= $now) {
+                $this->beta_gradeables[$gradeable->getId()] = $gradeable;
+            }
+            else if ($this->core->getUser()->accessAdmin()) {
+                $this->future_gradeables[$gradeable->getId()] = $gradeable;
+            }
+        }
+        $sort_array = array(
+            'future_gradeables' => 'getGradeStartDate',
+            'beta_gradeables' => 'getGradeStartDate',
+            'open_gradeables' => 'getDueDate',
+            'closed_gradeables' => 'getDueDate',
+            'grading_gradeables' => 'getGradeStartDate',
+            'graded_gradeables' => 'getGradeReleasedDate'
+        );
+        foreach ($sort_array as $list => $function) {
+            uasort($this->$list, function(Gradeable $a, Gradeable $b) use ($function) {
+                if ($a->$function() === $b->$function()) {
+                    return $a->getId() < $b->getId();
+                }
+                else {
+                    return $a->$function() < $b->$function();
+                }
+            });
+        }
     }
     
     /**
@@ -121,107 +182,32 @@ class GradeableList {
             return $list;
         }
     }
+
+    public function getFutureGradeables() {
+        return $this->future_gradeables;
+    }
+
+    public function getBetaGradeables() {
+        return $this->beta_gradeables;
+    }
     
     public function getSubmittableElectronicGradeables() {
-        /** @var Gradeable[] $list */
-        $list = array();
-    
-        foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getType() == GradeableType::ELECTRONIC_FILE &&
-
-	        // ORIGINAL
-                //($gradeable->getOpenDate() < $this->now || $this->core->getUser()->accessAdmin())) {
-		
-		// TEMPORARY - ALLOW LIMITED & FULL ACCESS GRADERS TO PRACTICE ALL FUTURE HOMEWORKS
-                ($gradeable->getOpenDate() < $this->now || $this->core->getUser()->accessGrading())) {
-
-                $list[$gradeable->getId()] = $gradeable;
-            }
-        }
-        uasort($list, function(Gradeable $a, Gradeable $b) {
-            return $a->getDueDate() < $b->getDueDate();
-        });
-        return $list;
+        return array_merge($this->future_gradeables, $this->beta_gradeables, $this->open_gradeables);
     }
     
     public function getOpenElectronicGradeables() {
-        /** @var Gradeable[] $list */
-        $list = array();
-        
-        foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getType() == GradeableType::ELECTRONIC_FILE) {
-                if ($gradeable->getOpenDate() < $this->now && $gradeable->getDueDate() > $this->now) {
-                    $list[$gradeable->getId()] = $gradeable;
-                }
-            }
-        }
-        uasort($list, function(Gradeable $a, Gradeable $b) {
-            return $a->getDueDate() < $b->getDueDate();
-        });
-        return $list;
+        return $this->open_gradeables;
     }
     
     public function getClosedElectronicGradeables() {
-        $list = array();
-        foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getType() == GradeableType::ELECTRONIC_FILE) {
-                if ($gradeable->getDueDate() < $this->now && $gradeable->getGradeStartDate() > $this->now) {
-                    $list[$gradeable->getId()] = $gradeable;
-                }
-            }
-        }
-        uasort($list, function(Gradeable $a, Gradeable $b) {
-            return $a->getDueDate() < $b->getDueDate();
-        });
-        return $list;
+        return $this->closed_gradeables;
     }
     
     public function getGradingGradeables() {
-        $list = array();
-        foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->useTAGrading()) {
-                continue;
-            }
-            if ($gradeable->getGradeStartDate() < $this->now && $gradeable->getGradeReleasedDate() > $this->now) {
-                $list[$gradeable->getId()] = $gradeable;
-            }
-        }
-        uasort($list, function(Gradeable $a, Gradeable $b) {
-            return $a->getGradeStartDate() < $b->getGradeStartDate();
-        });
-        return $list;
+        return $this->grading_gradeables;
     }
     
     public function getGradedGradeables() {
-        $list = array();
-        foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getGradeReleasedDate() < $this->now) {
-                $list[$gradeable->getId()] = $gradeable;
-            }
-        }
-        uasort($list, function(Gradeable $a, Gradeable $b) {
-            return $a->getGradeStartDate() < $b->getGradeStartDate();
-        });
-        return $list;
+        return $this->graded_gradeables;
     }
-    
-    public function getFutureGradeables() {
-        $list = array();
-        foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getType()==GradeableType::ELECTRONIC_FILE) {
-                if ($gradeable->getOpenDate() > $this->now) {
-                    $list[$gradeable->getId()] = $gradeable;
-                }
-            }
-            elseif($gradeable->getGradeStartDate() > $this->now){
-                $list[$gradeable->getId()] = $gradeable;
-            }
-        }
-        // only electronic gradeables have due_dates so future items must be sorted by the date grading begins
-        uasort($list, function(Gradeable $a, Gradeable $b) {
-            return $a->getGradeStartDate() < $b->getGradeStartDate();
-        });
-        return $list;
-    }
-    
 }

--- a/site/app/models/GradeableList.php
+++ b/site/app/models/GradeableList.php
@@ -179,8 +179,10 @@ class GradeableList {
     public function getGradingGradeables() {
         $list = array();
         foreach ($this->gradeables as $gradeable) {
-            if ($gradeable->getGradeStartDate() < $this->now
-                && $gradeable->getGradeReleasedDate() > $this->now) {
+            if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->useTAGrading()) {
+                continue;
+            }
+            if ($gradeable->getGradeStartDate() < $this->now && $gradeable->getGradeReleasedDate() > $this->now) {
                 $list[$gradeable->getId()] = $gradeable;
             }
         }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -52,11 +52,29 @@ HTML;
     <table class="gradeable_list" style="width:100%;">
 
 HTML;
-        $title_to_button_type_submission = array("FUTURE" => "btn-default", "OPEN" => "btn-primary" , "CLOSED" => "btn-danger",
-                                                 "ITEMS BEING GRADED" => "btn-default", "GRADED" => 'btn-success');
-        $title_to_button_type_grading = array("FUTURE" => "btn-default", "OPEN" => "btn-default" , "CLOSED" => "btn-default",
-                                                 "ITEMS BEING GRADED" => "btn-primary", "GRADED" => 'btn-danger');
-        $title_to_prefix = array("FUTURE" => "OPEN DATE", "OPEN" => "SUBMIT", "CLOSED" => "CLOSED", "ITEMS BEING GRADED" => "GRADING", "GRADED" => "GRADED");
+        $title_to_button_type_submission = array(
+            "FUTURE" => "btn-default",
+            "BETA" => "btn-default",
+            "OPEN" => "btn-primary" ,
+            "CLOSED" => "btn-danger",
+            "ITEMS BEING GRADED" => "btn-default",
+            "GRADED" => 'btn-success'
+        );
+        $title_to_button_type_grading = array(
+            "FUTURE" => "btn-default",
+            "BETA" => "btn-default",
+            "OPEN" => "btn-default" ,
+            "CLOSED" => "btn-default",
+            "ITEMS BEING GRADED" => "btn-primary",
+            "GRADED" => 'btn-danger');
+        $title_to_prefix = array(
+            "FUTURE" => "OPEN DATE",
+            "BETA" => "OPEN DATE",
+            "OPEN" => "SUBMIT",
+            "CLOSED" => "CLOSED",
+            "ITEMS BEING GRADED" => "GRADING",
+            "GRADED" => "GRADED"
+        );
 
         $found_assignment = false;
         foreach ($sections_to_list as $title => $gradeable_list) {
@@ -66,7 +84,7 @@ HTML;
             }
         }
 
-        if($found_assignment == false) {
+        if ($found_assignment == false) {
             $return .= <<<HTML
     <div class="container">
     <p>There are currently no assignments posted.  Please check back later.</p>
@@ -83,7 +101,7 @@ HTML;
 	    //  (released to graders for submission)
 	    //if ($title == "FUTURE" && !$this->core->getUser()->accessAdmin()) {
 
-            if ($title == "FUTURE" && !$this->core->getUser()->accessGrading()) {
+            if (($title === "FUTURE" || $title === "BETA") && !$this->core->getUser()->accessGrading()) {
                 continue;
             }
 
@@ -115,7 +133,7 @@ HTML;
 
                 if ($g_data->getType() == GradeableType::ELECTRONIC_FILE){
 
-                    $display_date = ($title=="FUTURE") ? $g_data->getOpenDate()->format("m/d/y{$time}") : "(due ".$g_data->getDueDate()->format("m/d/y{$time}").")";
+                    $display_date = ($title == "FUTURE" || $title == "BETA") ? $g_data->getOpenDate()->format("m/d/y{$time}") : "(due ".$g_data->getDueDate()->format("m/d/y{$time}").")";
                     $button_text = "{$title_to_prefix[$title]} {$display_date}";
                     if ($g_data->hasConfig()) {
                         $gradeable_open_range = <<<HTML

--- a/tests/e2e/test_navigation_page_non_student.py
+++ b/tests/e2e/test_navigation_page_non_student.py
@@ -11,7 +11,7 @@ class TestNavigationPageNonStudent(BaseTestCase):
         elements = self.driver.find_elements_by_class_name('nav-title-row')
         self.assertEqual(6, len(elements))
         self.assertEqual("future", elements[0].get_attribute('id'))
-        self.assertEqual(4, len(self.driver
+        self.assertEqual(3, len(self.driver
                          .find_element_by_id('future_tbody')
                          .find_elements_by_class_name("gradeable_row")))
         self.assertEquals("beta", elements[1].get_attribute('id'))

--- a/tests/e2e/test_navigation_page_non_student.py
+++ b/tests/e2e/test_navigation_page_non_student.py
@@ -9,24 +9,28 @@ class TestNavigationPageNonStudent(BaseTestCase):
     def test_instructor(self):
         self.log_in(user_id="instructor", user_password="instructor", user_name="Quinn")
         elements = self.driver.find_elements_by_class_name('nav-title-row')
-        self.assertEqual(5, len(elements))
+        self.assertEqual(6, len(elements))
         self.assertEqual("future", elements[0].get_attribute('id'))
-        self.assertEqual(6, len(self.driver
+        self.assertEqual(4, len(self.driver
                          .find_element_by_id('future_tbody')
                          .find_elements_by_class_name("gradeable_row")))
-        self.assertEqual("open", elements[1].get_attribute('id'))
+        self.assertEquals("beta", elements[1].get_attribute('id'))
+        self.assertEquals(3, len(self.driver
+                                 .find_element_by_id('beta_tbody')
+                                 .find_elements_by_class_name('gradeable_row')))
+        self.assertEqual("open", elements[2].get_attribute('id'))
         self.assertEqual(1, len(self.driver
-                         .find_element_by_id('open_tbody')
-                         .find_elements_by_class_name("gradeable_row")))
-        self.assertEqual("closed", elements[2].get_attribute('id'))
+                                .find_element_by_id('open_tbody')
+                                .find_elements_by_class_name("gradeable_row")))
+        self.assertEqual("closed", elements[3].get_attribute('id'))
         self.assertEqual(1, len(self.driver
                          .find_element_by_id('closed_tbody')
                          .find_elements_by_class_name("gradeable_row")))
-        self.assertEqual("items_being_graded", elements[3].get_attribute('id'))
+        self.assertEqual("items_being_graded", elements[4].get_attribute('id'))
         self.assertEqual(3, len(self.driver
                          .find_element_by_id('items_being_graded_tbody')
                          .find_elements_by_class_name("gradeable_row")))
-        self.assertEqual("graded", elements[4].get_attribute('id'))
+        self.assertEqual("graded", elements[5].get_attribute('id'))
         self.assertEqual(3, len(self.driver
                          .find_element_by_id('graded_tbody')
                          .find_elements_by_class_name("gradeable_row")))
@@ -37,9 +41,9 @@ class TestNavigationPageNonStudent(BaseTestCase):
         self.log_in(user_id="ta", user_password="ta", user_name="Jill")
         elements = self.driver.find_elements_by_class_name('nav-title-row')
         self.assertEqual(5, len(elements))
-        self.assertEqual("future", elements[0].get_attribute('id'))
+        self.assertEqual("beta", elements[0].get_attribute('id'))
         self.assertEqual(3, len(self.driver
-                                .find_element_by_id('future_tbody')
+                                .find_element_by_id('beta_tbody')
                                 .find_elements_by_class_name("gradeable_row")))
         self.assertEqual("open", elements[1].get_attribute('id'))
         self.assertEqual(1, len(self.driver


### PR DESCRIPTION
Closes #707 

Gradeables must be in only one category, and that there is a new beta test category for gradeables that are future, but viewable by TAs.

Also fix bug on creating electronic gradeable that doesn't use TA grading throwing datetime exception.

Fixes bug on creating/editing gradeable when there are no rotating section in a course