### PR TITLE
Activity Log

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -102,6 +102,7 @@ class AuthenticationController extends AbstractController {
                 }
             }
             $_SESSION['messages']['success'][] = "Successfully logged in as ".htmlentities($_POST['user_id']);
+            $redirect['success_login'] = "true";
             $this->core->redirect($this->core->buildUrl($redirect));
         }
         else {

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -2,6 +2,16 @@
 
 namespace app\libraries;
 
+/**
+ * Class Logger
+ *
+ * Static class which we can use to log various parts of the system. Primiarly, we log either errors (to *_error)
+ * or access (to *_access) logs which we can use to help debug certain issues people have with the system as well
+ * as use for certain effects like monitoring usage for people suspected of cheating or the like. Primarily, we
+ * always write to the *_error log for most of the methods here with only one method going to the *_access log.
+ *
+ * @package app\libraries
+ */
 class Logger {
 
     /**
@@ -22,8 +32,14 @@ class Logger {
     private function __clone() { }
 
 
+    /**
+     * Set the log path to be used by the logger, but only if the path is a valid one (otherwise ignore)
+     * @param string $path
+     */
     public static function setLogPath($path) {
-        static::$log_path = $path;
+        if (is_dir($path)) {
+            static::$log_path = $path;
+        }
     }
 
     /**
@@ -32,7 +48,7 @@ class Logger {
      * @param string $message
      */
     public static function debug($message="") {
-        Logger::log(Logger::DEBUG, $message);
+        Logger::logError(Logger::DEBUG, $message);
     }
 
     /**
@@ -41,7 +57,7 @@ class Logger {
      * @param string $message
      */
     public static function info($message="") {
-        Logger::log(Logger::INFO, $message);
+        Logger::logError(Logger::INFO, $message);
     }
 
     /**
@@ -50,7 +66,7 @@ class Logger {
      * @param string $message
      */
     public static function warn($message="") {
-        Logger::log(Logger::WARN, $message);
+        Logger::logError(Logger::WARN, $message);
     }
 
     /**
@@ -59,7 +75,7 @@ class Logger {
      * @param string $message
      */
     public static function error($message="") {
-        Logger::log(Logger::ERROR, $message);
+        Logger::logError(Logger::ERROR, $message);
     }
 
     /**
@@ -68,16 +84,24 @@ class Logger {
      * @param string $message
      */
     public static function fatal($message="") {
-        Logger::log(Logger::FATAL, $message);
+        Logger::logError(Logger::FATAL, $message);
     }
 
     /**
-     * Writes a message to a logfile (named for current date)
-     * assuming that we've defined the $log_path variable
+     * Returns the path that the logger is configured to use. If the logger has not been setup yet, this
+     * will return null.
      *
-     * We log a message as well as the calling URI if available.
-     * It's saved to $log_path/yyyymmdd.txt (yyyy is year, mm is month
-     * dd is day) with each log seperated by bunch of "=-".
+     * @return string
+     */
+    public static function getLogPath() {
+        return self::$log_path;
+    }
+
+    /**
+     * Writes a message to a logfile (named for current date) assuming that we've defined the $log_path variable
+     *
+     * We log a message as well as the calling URI if available. It's saved to $log_path/yyyymmdd.txt
+     * (yyyy is year, mm is month dd is day) with each log entry seperated by bunch of "=-".
      *
      * @param int $level: message level
      *     0. Debug
@@ -87,22 +111,13 @@ class Logger {
      *     4. Fatal Error
      * @param $message: message to log to the file
      */
-    private static function log($level=0, $message="") {
+    private static function logError($level=0, $message="") {
         if (static::$log_path === null) {
             return;
         }
-        
-        date_default_timezone_set("America/New_York");
 
-        FileUtils::createDir(static::$log_path);
-
-        $date = getdate(time());
-        $filename = $date['year']. Utils::pad($date['mon']) . Utils::pad($date['mday']);
-
-        $log_message = Utils::pad($date['mday']) ."/". Utils::pad($date['mon']) ."/".$date['year'];
-        $log_message .= " ";
-        $log_message .= Utils::pad($date['hours']) .":". Utils::pad($date['minutes']) .":";
-        $log_message .= Utils::pad($date['seconds']);
+        $filename = static::getFilename();
+        $log_message = static::getTimestamp();
         $log_message .= " - ";
         switch($level) {
             case 0:
@@ -130,12 +145,55 @@ class Logger {
         $log_message .= str_repeat("=-", 30)."="."\n";
 
         // Appends to the file using a locking mechanism, and supressing any potential error from this
-        if (file_put_contents(static::$log_path."/".$filename.".txt", $log_message, FILE_APPEND | LOCK_EX) === false) {
-            print "failure to log error";
-        }
+        @file_put_contents(FileUtils::joinPaths(static::$log_path, "{$filename}_error.log"), $log_message, FILE_APPEND | LOCK_EX);
     }
 
-    public static function getLogPath() {
-        return self::$log_path;
+    /**
+     * Internal method that constructs a filename for us to use based on the date so that we get a filename
+     * that is YYYYMMDD which we use as a prefix to our _error and _access log files.
+     *
+     * @return string
+     */
+    private static function getFilename() {
+        FileUtils::createDir(static::$log_path);
+        $date = getdate(time());
+        return $date['year']. Utils::pad($date['mon']) . Utils::pad($date['mday']);
+    }
+
+    /**
+     * Internal method that gives us a timestamp that we use as the beginning of any entry into the log files. The
+     * timestamp is in the form of HH:mm:SS DD/MM/YYYY.
+     * @return string
+     */
+    private static function getTimestamp() {
+        $date = getdate(time());
+        $log_message = Utils::pad($date['hours']).":".Utils::pad($date['minutes']).":".Utils::pad($date['seconds']);
+        $log_message .= " ";
+        $log_message .= Utils::pad($date['mon'])."/".Utils::pad($date['mday'])."/".$date['year'];
+        return $log_message;
+    }
+
+    /**
+     * This writes a one line message to the _access log file which we use to monitor what pages a user goes
+     * to (through a central point in the public/index.php file). This logs things in the fashion of:
+     *
+     * Timestamp | User ID | IP Adress | Action | User Agent
+     *
+     * where action is defined broadly as the page they're accessing and any other relevant information
+     * (so gradeable id for when they're submitting).
+     *
+     * @param $user_id
+     * @param $action
+     */
+    public static function logAccess($user_id, $action) {
+        $filename = static::getFilename();
+        $log_message[] = static::getTimestamp();
+        $log_message[] = $user_id;
+        $log_message[] = $_SERVER['REMOTE_ADDR'];
+        $log_message[] = $action;
+        //$log_message[] = $_SERVER['REQUEST_URI'];
+        $log_message[] = $_SERVER['HTTP_USER_AGENT'];
+        $log_message = implode(" | ", $log_message)."\n";
+        @file_put_contents(FileUtils::joinPaths(static::$log_path, "{$filename}_access.log"), $log_message, FILE_APPEND | LOCK_EX);
     }
 }

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -194,6 +194,7 @@ HTML;
         $(document).ready(function() {
             $("#submit").click(function(e){ // Submit button
                 handleSubmission("{$this->core->buildUrl(array('component' => 'student',
+                                                               'page' => 'submission',
                                                                'action' => 'upload',
                                                                'gradeable_id' => $gradeable->getId()))}",
                                  "{$this->core->buildUrl(array('component' => 'student',

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -141,6 +141,27 @@ if (!$logged_in) {
     }
 }
 
+if ($core->getUser() !== null) {
+    $log = false;
+    $action = "";
+    if ($_REQUEST['component'] === "authentication" && $_REQUEST['page'] === "logout") {
+        $log = true;
+        $action = "logout";
+    }
+    else if (in_array($_REQUEST['component'], array('student', 'submission')) && $_REQUEST['page'] === "submission" &&
+        $_REQUEST['action'] === "upload") {
+        $log = true;
+        $action = "submission:{$_REQUEST['gradeable_id']}";
+    }
+    else if (isset($_REQUEST['success_login']) && $_REQUEST['success_login'] === "true") {
+        $log = true;
+        $action = "login";
+    }
+    if ($log && $action !== "") {
+        Logger::logAccess($core->getUser()->getId(), $action);
+    }
+}
+
 switch($_REQUEST['component']) {
     case 'admin':
         $control = new app\controllers\AdminController($core);

--- a/tests/e2e/test_login.py
+++ b/tests/e2e/test_login.py
@@ -16,7 +16,8 @@ class TestLogin(BaseTestCase):
         you'll be taken to the login screen, and then once logged in,
         taken to that original page you had requested.
         """
-        url = "/index.php?semester=" + self.semester + "&course=csci1000&component=cpp_cats"
+        url = "/index.php?semester=" + self.semester + \
+              "&course=csci1000&component=cpp_cats&success_login=true"
         self.log_in(url)
         self.assertEqual(self.test_url + url, self.driver.current_url)
 

--- a/tests/unitTests/app/libraries/ExceptionHandlerTester.php
+++ b/tests/unitTests/app/libraries/ExceptionHandlerTester.php
@@ -40,14 +40,14 @@ class ExceptionHandlerTester extends \PHPUnit_Framework_TestCase {
         Logger::setLogPath($tmp_dir);
         date_default_timezone_set("America/New_York");
         $date = getdate(time());
-        $filename = $date['year'].Utils::pad($date['mon']).Utils::pad($date['mday']).".txt";
+        $filename = $date['year'].Utils::pad($date['mon']).Utils::pad($date['mday'])."_error.log";
         ExceptionHandler::setDisplayExceptions(false);
         ExceptionHandler::setLogExceptions(true);
         ExceptionHandler::handleException(new BaseException("test", array("test"=>"b", "test2"=>array('a','c'))));
         $file = FileUtils::joinPaths($tmp_dir, $filename);
         $this->assertFileExists($file);
         $actual = file_get_contents($file);
-        $this->assertRegExp('/[0-9]{2}\/[0-9]{2}\/[0-9]{4}\ [0-9]{2}\:[0-9]{2}\:[0-9]{2} \- FATAL ERROR\napp.+/', $actual);
+        $this->assertRegExp('/[0-9]{2}\:[0-9]{2}\:[0-9]{2}\ [0-9]{2}\/[0-9]{2}\/[0-9]{4} \- FATAL ERROR\napp.+/', $actual);
         $this->assertRegExp('/Extra Details:\n\ttest: b\n\ttest2:\n\t\ta\n\t\tc/', $actual);
         ExceptionHandler::setLogExceptions(false);
         $this->assertTrue(FileUtils::recursiveRmdir($tmp_dir));

--- a/tests/unitTests/app/libraries/LoggerTester.php
+++ b/tests/unitTests/app/libraries/LoggerTester.php
@@ -7,7 +7,8 @@ use \app\libraries\Utils;
 use \app\libraries\FileUtils;
 
 class LoggerTester extends \PHPUnit_Framework_TestCase {
-    private $file;
+    private $error;
+    private $access;
     private $directory;
 
     public static function setUpBeforeClass() {
@@ -28,8 +29,9 @@ class LoggerTester extends \PHPUnit_Framework_TestCase {
         $this->assertFileExists($this->directory);
         Logger::setLogPath($this->directory);
         $date = getdate(time());
-        $filename = $date['year'].Utils::pad($date['mon']).Utils::pad($date['mday']).".txt";
-        $this->file = FileUtils::joinPaths($this->directory, $filename);
+        $filename = $date['year'].Utils::pad($date['mon']).Utils::pad($date['mday']);
+        $this->error = FileUtils::joinPaths($this->directory, $filename."_error.log");
+        $this->access = FileUtils::joinPaths($this->directory, $filename."_access.log");
     }
 
     public function tearDown() {
@@ -37,47 +39,47 @@ class LoggerTester extends \PHPUnit_Framework_TestCase {
     }
 
     public function testLoggerDebug() {
-        $this->assertFileNotExists($this->file);
+        $this->assertFileNotExists($this->error);
         Logger::debug("Debug Message");
-        $this->assertFileExists($this->file);
+        $this->assertFileExists($this->error);
         $this->assertMessage("DEBUG", "Debug Message");
     }
 
     public function testLoggerInfo() {
-        $this->assertFileNotExists($this->file);
+        $this->assertFileNotExists($this->error);
         Logger::info("Info Message");
         $this->assertMessage("INFO", "Info Message");
     }
 
     public function testLoggerWarn() {
-        $this->assertFileNotExists($this->file);
+        $this->assertFileNotExists($this->error);
         Logger::warn("Warn Message");
         $this->assertMessage("WARN", "Warn Message");
     }
 
     public function testLoggerError() {
-        $this->assertFileNotExists($this->file);
+        $this->assertFileNotExists($this->error);
         Logger::error("Error Message");
         $this->assertMessage("ERROR", "Error Message");
     }
 
     public function testLoggerFatalError() {
-        $this->assertFileNotExists($this->file);
+        $this->assertFileNotExists($this->error);
         Logger::fatal("Fatal Message");
         $this->assertMessage("FATAL ERROR", "Fatal Message");
     }
 
     public function assertMessage($level, $message) {
         $current_date = getdate(time());
-        $file = file_get_contents($this->file);
+        $file = file_get_contents($this->error);
         $lines = explode("\n", $file);
         $this->assertCount(5, $lines);
         $first_line = explode(" - ", $lines[0]);
         $datetime = explode(" ", $first_line[0]);
-        $date = explode("/", $datetime[0]);
-        $time = explode(":", $datetime[1]);
-        $this->assertEquals(Utils::pad($current_date['mday']), $date[0], "Day is not right");
-        $this->assertEquals(Utils::pad($current_date['mon']), $date[1], "Month is not right");
+        $time = explode(":", $datetime[0]);
+        $date = explode("/", $datetime[1]);
+        $this->assertEquals(Utils::pad($current_date['mon']), $date[0], "Month is not right");
+        $this->assertEquals(Utils::pad($current_date['mday']), $date[1], "Day is not right");
         $this->assertEquals(Utils::pad($current_date['year']), $date[2], "Year is not right");
         $this->assertEquals(Utils::pad($current_date['hours']), $time[0], "Hours place is not right");
         $this->assertEquals(Utils::pad($current_date['minutes']), $time[1], "Minutes place is not right");
@@ -94,13 +96,37 @@ class LoggerTester extends \PHPUnit_Framework_TestCase {
         $this->assertEmpty($lines[4]);
     }
 
-    public static function generateMessage($level, $message) {
-        $date = getdate(time());
-        $return = Utils::pad($date['mday'])."/".Utils::pad($date['mon'])."/".Utils::pad($date['year']);
-        $return .= " ".Utils::pad($date['hours']).":".Utils::pad($date['minutes']).":";
-        $return .= Utils::pad($date['seconds'])." - ".$level."\n".$message."\n";
-        $return .= "URL: https://localhost/index.php?test=1\n";
-        $return .= "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
-        return $return;
+    public function testInvalidDirectory() {
+        $log_path = Logger::getLogPath();
+        Logger::setLogPath("/invalid");
+        $this->assertEquals($log_path, Logger::getLogPath());
+    }
+
+    public function testAccessLog() {
+        $current_date = getdate(time());
+        $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+        $_SERVER['HTTP_USER_AGENT'] = "PHPUnit";
+        Logger::logAccess("test", "action");
+        $file = file_get_contents($this->access);
+        $lines = explode("\n", $file);
+        $this->assertCount(2, $lines);
+        $this->assertEmpty($lines[1]);
+        $line = explode(" | ", $lines[0]);
+        $datetime = explode(" ", $line[0]);
+        $time = explode(":", $datetime[0]);
+        $date = explode("/", $datetime[1]);
+        $this->assertEquals(Utils::pad($current_date['mon']), $date[0], "Month is not right");
+        $this->assertEquals(Utils::pad($current_date['mday']), $date[1], "Day is not right");
+        $this->assertEquals(Utils::pad($current_date['year']), $date[2], "Year is not right");
+        $this->assertEquals(Utils::pad($current_date['hours']), $time[0], "Hours place is not right");
+        $this->assertEquals(Utils::pad($current_date['minutes']), $time[1], "Minutes place is not right");
+        $this->assertEquals(2, strlen($time[2]));
+        if (intval($time[2]) < 10) {
+            $this->assertStringStartsWith('0', $time[2]);
+        }
+        $this->assertEquals("test", $line[1]);
+        $this->assertEquals("127.0.0.1", $line[2]);
+        $this->assertEquals("action", $line[3]);
+        $this->assertEquals("PHPUnit", $line[4]);
     }
 }


### PR DESCRIPTION
Closes #848. 

I use the " | " as a seperator character (as the timestamp as a ":" in it which would make grepping that much harder).

Example log:

> 10:26:51 01/19/2017 | student | 192.168.56.1 | logout | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36
> 10:28:13 01/19/2017 | student | 192.168.56.1 | login | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36
> 11:29:12 01/19/2017 | student | 192.168.56.1 | submission:cpp_custom | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36