### PR TITLE
Fix referencing wrong field name

### DIFF
--- a/site/app/libraries/database/DatabaseQueriesPostgresql.php
+++ b/site/app/libraries/database/DatabaseQueriesPostgresql.php
@@ -453,14 +453,14 @@ ORDER BY rotating_section", $params);
             $params = array_merge($params, $sections);
         }
         $this->database->query("
-SELECT count(u.*) as cnt, u.registration_section
+SELECT count(u.*) as cnt, u.rotating_section
 FROM users AS u
 INNER JOIN (
   SELECT * FROM gradeable_data WHERE g_id=? AND (gd_active_version >= 0 OR (gd_active_version = -1 AND gd_status = 0))
 ) AS gd ON u.user_id = gd.gd_user_id
 {$where}
-GROUP BY u.registration_section
-ORDER BY u.registration_section", $params);
+GROUP BY u.rotating_section
+ORDER BY u.rotating_section", $params);
         foreach ($this->database->rows() as $row) {
             if ($row['rotating_section'] === null) {
                 $row['rotating_section'] = "NULL";


### PR DESCRIPTION
The function `getGradedUserCountByRotatingSections` should reference rotating sections, not registration sections.