### PR TITLE
fix bugs with new summary page

### DIFF
--- a/site/app/libraries/database/DatabaseQueriesPostgresql.php
+++ b/site/app/libraries/database/DatabaseQueriesPostgresql.php
@@ -383,7 +383,8 @@ LEFT JOIN (
   SELECT *
   FROM users
 ) AS u ON u.user_id = g.user_id
-{$where}", $params);
+{$where}
+ORDER BY g.sections_registration_id, g.user_id", $params);
         $user_store = array();
         foreach ($this->database->rows() as $row) {
             if ($row['sections_registration_id'] === null) {
@@ -485,7 +486,8 @@ LEFT JOIN (
   SELECT *
   FROM users
 ) AS u ON u.user_id = g.user_id
-WHERE g.g_id=? {$where}", $params);
+WHERE g.g_id=? {$where}
+ORDER BY g.sections_rotating_id, g.user_id", $params);
         $user_store = array();
         foreach ($this->database->rows() as $row) {
             if ($row['sections_rotating_id'] === null) {

--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -47,7 +47,8 @@ class GradeableAutocheck {
         }
         
         $actual_file = $expected_file = $difference_file = "";
-	if(isset($details["actual_file"]) && file_exists($result_path . "/" . $details["actual_file"])) {
+
+        if(isset($details["actual_file"]) && file_exists($result_path . "/" . $details["actual_file"])) {
             $actual_file = $result_path . "/" . $details["actual_file"];
         }
     

--- a/site/app/models/GradeableVersion.php
+++ b/site/app/models/GradeableVersion.php
@@ -14,6 +14,7 @@ class GradeableVersion {
     private $hidden_extra_credit = 0;
     private $submission_time;
     private $active = false;
+    private $days_late = 0;
 
     /**
      * GradeableVersion constructor.

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -51,7 +51,7 @@ HTML;
                 continue;
             }
             if (count($section['graders']) > 0) {
-                $graders = implode(", ", array_map(function($grader) { $grader->getId(); }, $section['graders']));
+                $graders = implode(", ", array_map(function($grader) { return $grader->getId(); }, $section['graders']));
             }
             else {
                 $graders = "Nobody";
@@ -81,10 +81,9 @@ HTML;
     /**
      * @param Gradeable   $gradeable
      * @param Gradeable[] $rows
-     * @param string      $section_key
      * @return string
      */
-    public function summaryPage($gradeable, $rows, $section_key="registration_section") {
+    public function summaryPage($gradeable, $rows) {
         $return = <<<HTML
 <div class="content">
     <h2>Summary Page for {$gradeable->getName()}</h2>
@@ -119,11 +118,11 @@ HTML;
             foreach ($rows as $row) {
                 $total_possible = $row->getTotalAutograderNonExtraCreditPoints() + $row->getTotalTANonExtraCreditPoints();
                 $graded = $row->getGradedAutograderPoints() + $row->getGradedTAPoints();
-                if ($section_key === "rotating_section") {
-                    $section = $row->getUser()->getRotatingSection();
+                if ($gradeable->isGradeByRegistration()) {
+                    $section = $row->getUser()->getRegistrationSection();
                 }
                 else {
-                    $section = $row->getUser()->getRegistrationSection();
+                    $section = $row->getUser()->getRotatingSection();
                 }
                 $display_section = ($section === null) ? "NULL" : $section;
                 if ($section !== $last_section) {
@@ -167,6 +166,7 @@ HTML;
                 <td>{$graded} / {$total_possible}</td>
             </tr>
 HTML;
+                $count++;
             }
             $return .= <<<HTML
         </tbody>


### PR DESCRIPTION
This fixes the following bugs with the new index and summary page:
1) Properly display the list of graders for each section (index page)
2) Properly display students in rotating sections for an assignment (summary page)

The new summary page can be gotten to directly by appending the following:
`&component=grading&page=electronic&action=summary&gradeable_id=open_homework`

to any URL that utilizes the main URL (and not the old hwgrading). Change `gradeable_id` to whatever gradeable you have.