### PR TITLE
enforce submissions to have files submitted in only one part

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ addons:
     sources:
       - sourceline: "deb http://archive.ubuntu.com/ubuntu trusty multiverse"
       - sourceline: "deb http://archive.ubuntu.com/ubuntu trusty-updates multiverse"
+    # You cannot put just any Ubuntu trusty package here and expect to install them and that
+    # they must be in this list: https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-trusty
+    # otherwise you'll have to install it via "sudo apt-get install ..." in the before_install section
     packages:
       - apache2
       - libapache2-mod-fastcgi
@@ -54,6 +57,7 @@ addons:
       - unzip
       - google-chrome-stable
       - libpam-passwdqc
+      - libboost-all-dev
 
 before_install:
    - jdk_switcher use default
@@ -77,7 +81,6 @@ install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then sudo apt-get -y install libapache2-mod-php5 php5-pgsql php5-curl; a2enmod php5; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then sudo apt-get -y install libapache2-mod-php5.6 php5.6-pgsql php5.6-curl; a2enmod php5.6; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then sudo apt-get -y install libapache2-mod-php7.0 php7.0-pgsql php7.0-curl; a2enmod php7.0; fi
-  - sudo apt-get install libboost-all-dev
   - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ addons:
       - unzip
       - google-chrome-stable
       - libpam-passwdqc
-      - libboost-dev
 
 before_install:
    - jdk_switcher use default
@@ -78,6 +77,7 @@ install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then sudo apt-get -y install libapache2-mod-php5 php5-pgsql php5-curl; a2enmod php5; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then sudo apt-get -y install libapache2-mod-php5.6 php5.6-pgsql php5.6-curl; a2enmod php5.6; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then sudo apt-get -y install libapache2-mod-php7.0 php7.0-pgsql php7.0-curl; a2enmod php7.0; fi
+  - sudo apt-get install libboost-all-dev
   - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ addons:
       - unzip
       - google-chrome-stable
       - libpam-passwdqc
+      - libboost-dev
 
 before_install:
    - jdk_switcher use default

--- a/grading/CMakeLists.txt
+++ b/grading/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(submitty_grading
 
 ###################################################################################
 
-target_link_libraries(submitty_grading seccomp)
+target_link_libraries(submitty_grading seccomp boost_system boost_filesystem)
 
 set_property(TARGET submitty_grading APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
 

--- a/grading/Sample_CMakeLists.txt
+++ b/grading/Sample_CMakeLists.txt
@@ -153,13 +153,13 @@ add_executable(validate.out
 
 ###################################################################################
 
-target_link_libraries(custom_functions seccomp)
+target_link_libraries(custom_functions seccomp boost_system boost_filesystem)
 set_property(TARGET custom_functions APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
 
-target_link_libraries(configure.out  ${GRADINGLIB}  seccomp  custom_functions)
-target_link_libraries(compile.out    ${GRADINGLIB}  seccomp  custom_functions)
-target_link_libraries(run.out        ${GRADINGLIB}  seccomp  custom_functions)
-target_link_libraries(validate.out   ${GRADINGLIB}  seccomp  custom_functions)
+target_link_libraries(configure.out  ${GRADINGLIB}  seccomp  custom_functions boost_system boost_filesystem)
+target_link_libraries(compile.out    ${GRADINGLIB}  seccomp  custom_functions boost_system boost_filesystem)
+target_link_libraries(run.out        ${GRADINGLIB}  seccomp  custom_functions boost_system boost_filesystem)
+target_link_libraries(validate.out   ${GRADINGLIB}  seccomp  custom_functions boost_system boost_filesystem)
 
 set_property(TARGET configure.out APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
 set_property(TARGET compile.out   APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")

--- a/grading/main_compile.cpp
+++ b/grading/main_compile.cpp
@@ -17,6 +17,64 @@
 
 #define DIR_PATH_MAX 1000
 
+#include "boost/filesystem/operations.hpp"
+#include "boost/filesystem/path.hpp"
+
+// =====================================================================
+// =====================================================================
+
+
+void CleanUpMultipleParts() {
+
+  std::cout << "Clean up multiple parts" << std::endl;
+  boost::filesystem::path top( boost::filesystem::current_path() );
+
+  // collect the part directories that have files
+  std::set<boost::filesystem::path> non_empty_parts;
+
+  // loop over all of the part directories 
+  // NOTE: not necessarily sorted.  OS dependent.  Put in std::set to sort!
+  boost::filesystem::directory_iterator end_iter;
+  for (boost::filesystem::directory_iterator top_itr( top ); top_itr != end_iter; ++top_itr) {
+    boost::filesystem::path part_path = top_itr->path();
+    if (!is_directory(part_path)) {
+      continue;
+    }
+    int count = 0;
+    for (boost::filesystem::directory_iterator part_itr( part_path ); part_itr != end_iter; ++part_itr) {
+      count++;
+    }
+    std::cout << "part: " << part_path.string() << " " << count << std::endl;
+    if (count > 0) {
+      non_empty_parts.insert(part_path);
+    }
+  }
+
+  if (non_empty_parts.size() > 1) {
+
+    std::cout << "ERROR!  Student submitted to multiple parts in violation of instructions.\nRemoving files from all but first non empty part." << std::endl;
+
+    // collect files to remove
+    std::vector<boost::filesystem::path> remove_this;
+
+    std::set<boost::filesystem::path>::iterator itr = non_empty_parts.begin();
+    // skip (keep contents of) first part directory
+    itr++;
+    while (itr != non_empty_parts.end()) {
+      for (boost::filesystem::directory_iterator part_itr( *itr ); part_itr != end_iter; ++part_itr) {
+	remove_this.push_back(part_itr->path());
+      }
+      itr++;
+    }
+
+    // remove those files
+    for (int i = 0; i < remove_this.size(); i++) {
+      std::cout << "REMOVE: " << remove_this[i].string() << std::endl;
+      boost::filesystem::remove(remove_this[i]);
+    }
+  }
+}
+
 
 // =====================================================================
 // =====================================================================
@@ -60,6 +118,15 @@ int main(int argc, char *argv[]) {
   system("find . -type f -exec ls -sh {} +");
 
   CustomizeAutoGrading(rcsid,config_json);
+
+
+  // if it's a "one part only" assignment, check if student
+  // submitted to multiple parts
+  bool one_part_only = config_json.value("one_part_only",false);
+  if (one_part_only) {
+    CleanUpMultipleParts();
+  }
+  
 
   // Run each COMPILATION TEST
   nlohmann::json::iterator tc = config_json.find("testcases");


### PR DESCRIPTION
When a gradeable provides multiple drop zones, but students are instructed to submit files to only one part, this commit enforces the "only one part" requirement by remove files from all but the first non empty part (files are removed only from the tmp compilation directory, not the archived submission directory)