### PR TITLE
Disable OPCache for vagrant

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -555,6 +555,9 @@ sudo chown -R www-data:www-data /usr/lib/cgi-bin
 apache2ctl -t
 
 if [[ ${VAGRANT} == 1 ]]; then
+    # Disable OPCache for development purposes as we don't care about the efficiency as much
+    echo "opcache.enable=0" >> /etc/php/7.0/fpm/conf.d/10-opcache.ini
+
     rm -r ${SUBMITTY_DATA_DIR}/autograding_logs
     rm -r ${SUBMITTY_REPOSITORY}/.vagrant/autograding_logs
     mkdir ${SUBMITTY_REPOSITORY}/.vagrant/autograding_logs


### PR DESCRIPTION
Having it enabled requires potentially having to restart php7.0-fpm after creating courses (or tearing down/creating) as the config.ini file's existance (or lack thereof) was getting cached and then not being found properly. We don't need the efficiency gains from the OPCache on vagrant for development, so we do want it enabled for production server (though maybe mention somewhere that if you're getting a missing file error on the config.ini file, you need to restart php7.0-fpm).