### PR TITLE
drop PHP 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,14 @@ dist: trusty
 
 matrix:
   include:
-    - php: 5.5
-      env: AUTH_METHOD=DatabaseAuthentication INTEGRATION_SUITE=false
-    - php: 5.5
-      env: AUTH_METHOD=DatabaseAuthentication INTEGRATION_SUITE=true
     - php: 5.6
       env: AUTH_METHOD=DatabaseAuthentication INTEGRATION_SUITE=false
     - php: 7.0
       env: AUTH_METHOD=DatabaseAuthentication INTEGRATION_SUITE=false
     - php: 7.0
       env: AUTH_METHOD=PamAuthentication INTEGRATION_SUITE=false
+    - php: 7.0
+      env: AUTH_METHOD=DatabaseAuthentication INTEGRATION_SUITE=true
 
 cache:
   pip: true
@@ -58,13 +56,11 @@ addons:
 
 before_install:
   - jdk_switcher use default
-  - if [[ "$TRAVIS_PHP_VERSION" = "5.5" ]]; then mv composer_55.json composer.json; fi
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
   - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/2.7.12/bin:/opt/python/3.5.2/bin:${PATH}:?g" --in-place /etc/sudoers
 
 install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.5" ]]; then sudo add-apt-repository -y ppa:ondrej/php; sudo apt-get -qq update; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then sudo apt-get -y install libapache2-mod-php5 php5-pgsql php5-curl; a2enmod php5; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then sudo apt-get -y install libapache2-mod-php5.6 php5.6-pgsql php5.6-curl; a2enmod php5.6; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then sudo apt-get -y install libapache2-mod-php7.0 php7.0-pgsql php7.0-curl; a2enmod php7.0; fi
   - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip

--- a/composer_55.json
+++ b/composer_55.json
@@ -1,8 +1,0 @@
-{
-    "name": "submitty/submitty",
-    "require-dev": {
-        "phpunit/phpunit": "4.*",
-        "phpunit/phpunit-selenium": "1.*",
-        "satooshi/php-coveralls": "1.*"
-    }
-}


### PR DESCRIPTION
Closes #1053.

Removes support for PHP 5.5. We will no longer run any Travis test suites against PHP 5.5 and will start using features available in PHP 5.6 in the code base. PHP 5.6 is currently supported at this time.