### PR TITLE
Use release binaries for analysis tools by default

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -499,7 +499,7 @@ echo -e "Compile and install analysis tools"
 pushd ${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT_AnalysisTools
 
 # compile the tools
-stack --allow-different-user --no-terminal --install-ghc --copy-bins build
+./build.sh v0.2.1
 
 popd
 


### PR DESCRIPTION
I've added a small helper script, `build.sh`, to Submitty/AnalysisTools. This script will either install the binary releases of the specified version or will build the tools from source if no version (or the version `latest`) is specified.