### PR TITLE
Fix PHPUnit issuing warnings for some number of tests

### DIFF
--- a/site/app/models/Gradeable.php
+++ b/site/app/models/Gradeable.php
@@ -33,16 +33,15 @@ use app\libraries\Utils;
  * @method float getNormalPoints() Returns the total number of points for testcases that are not hidden nor are extra credit
  * @method bool setTeamAssignment()
  * @method bool getTeamAssignment()
- * @method setTaViewDate()
- * @method getOpenDate()
- * @method setOpenDate()
- * @method getDueDate()
- * @method getGradeStartDate()
- * @method setGradeStartDate(Date $datetime)
- * @method getGradeReleasedDate()
- * @method setGradeReleasedDate(Datetime $datetime)
+ * @method setTaViewDate(\DateTime $datetime)
+ * @method \DateTime getOpenDate(\DateTime $datetime)
+ * @method setOpenDate(\DateTime $datetime)
+ * @method \DateTime getDueDate()
+ * @method \DateTime getGradeStartDate()
+ * @method setGradeStartDate(\DateTime $datetime)
+ * @method \DateTime getGradeReleasedDate()
+ * @method setGradeReleasedDate(\DateTime $datetime)
  * @method bool getGradeByRegistration()
- * @method getOpenDate()
  * @method array getSubmittedFiles()
  * @method array getSvnFiles()
  * @method array getTestcases()
@@ -68,7 +67,7 @@ use app\libraries\Utils;
  * @method string getBucket()
  * @method int|null getGdId()
  * @method void setGdId(int $gd_id)
- * @method getUserViewedDate()
+ * @method \DateTime getUserViewedDate()
  */
 class Gradeable extends AbstractModel {
     

--- a/tests/unitTests/BaseUnitTest.php
+++ b/tests/unitTests/BaseUnitTest.php
@@ -110,7 +110,7 @@ class BaseUnitTest extends \PHPUnit_Framework_TestCase {
                 $methods[] = $method->getName();
             }
         }
-        $builder->setMethods($methods);
+        $builder->setMethods(array_unique($methods));
         return $builder->getMock();
     }
 }


### PR DESCRIPTION
Someone inserted the same `@method` twice in the header of Gradeable and it was causing all tests that mocked that object to just issue a warning, but not necessarily complete. Fixed that and prevented the issue of multiple `@method`s from happening again.