### PR TITLE
Fixed team assignment version numbering bug

### DIFF
--- a/site/app/libraries/database/DatabaseQueriesPostgresql.php
+++ b/site/app/libraries/database/DatabaseQueriesPostgresql.php
@@ -387,10 +387,16 @@ LEFT JOIN (
   SELECT
     g_id,
     user_id,
+    team_id,
     count(*) as highest_version
   FROM electronic_gradeable_data
-  GROUP BY g_id, user_id
-) as egv ON g.g_id = egv.g_id AND u.user_id = egv.user_id";
+  GROUP BY g_id, user_id, team_id
+) AS egv ON g.g_id = egv.g_id AND (u.user_id = egv.user_id OR u.user_id IN (
+    SELECT
+      t.user_id
+    FROM gradeable_teams AS gt, teams AS t
+    WHERE g.g_id = gt.g_id AND gt.team_id = t.team_id AND t.team_id = egv.team_id AND t.state = 1)
+)";
         }
 
         $where = array();


### PR DESCRIPTION
Closes #1152 

Fixed bug in which the highest version of a team assignment is always zero, causing every new submission to be treated as version 1. The problem was in the last join in the SQL query in getGradeables(), which calculates the highest version.