### PR TITLE
Cleanup subprocess calls & adjust autograding daemon

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -501,8 +501,24 @@ rsync -rtz  ${SUBMITTY_REPOSITORY}/.setup/submitty_grading_scheduler.service   /
 chown -R hwcron:hwcron /etc/systemd/system/submitty_grading_scheduler.service
 chmod 444 /etc/systemd/system/submitty_grading_scheduler.service
 
-systemctl restart submitty_grading_scheduler
-echo -e "\n(Re)Started Submitty Grading Scheduler Daemon\n"
+systemctl is-active --quiet submitty_grading_scheduler
+is_active_before=$?
+
+# if the daemon is currently running, restart it now
+systemctl try-restart submitty_grading_scheduler
+
+systemctl is-active --quiet submitty_grading_scheduler
+is_active_after=$?
+
+if [[ $is_active_before -ne 0 ]]; then
+    echo -e "NOTE: Submitty Grading Scheduler Daemon is not currently running\n"
+    echo -e "To start the daemon, run:\n   systemctl start submitty_grading_scheduler\n"
+else
+    if [[ $is_active_after -ne 0 ]]; then
+        echo -e "\nERROR!  Failed to restart Submitty Grading Scheduler Daemon\n"
+    fi
+    echo -e "Restarted Submitty Grading Scheduler Daemon\n"
+fi
 
 
 ################################################################################################################

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -512,7 +512,12 @@ else
 fi
 
 source ${SUBMITTY_INSTALL_DIR}/.setup/INSTALL_SUBMITTY.sh clean
-#source ${SUBMITTY_INSTALL_DIR}/.setup/INSTALL_SUBMITTY.sh clean test
+
+# (re)start the submitty grading scheduler daemon
+systemctl restart submitty_grading_scheduler
+# also, set it to automatically start on boot
+sudo systemctl enable submitty_grading_scheduler
+
 
 mkdir -p ${SUBMITTY_DATA_DIR}/instructors
 mkdir -p ${SUBMITTY_DATA_DIR}/bin

--- a/bin/grade_item.py
+++ b/bin/grade_item.py
@@ -19,6 +19,8 @@ import tzlocal
 
 import submitty_utils
 import grade_items_logging
+import write_grade_history
+import insert_database_version_data
 
 # these variables will be replaced by INSTALL_SUBMITTY.sh
 SUBMITTY_INSTALL_DIR = "__INSTALL__FILLIN__SUBMITTY_INSTALL_DIR__"
@@ -437,31 +439,29 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
     gradingtime=int((grading_finished-grading_began).total_seconds())
 
 
-
-    subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","write_grade_history.py"),
-                     history_file,
-                     gradeable_deadline_longstring,
-                     submission_longstring,
-                     str(seconds_late),
-                     queue_time_longstring,
-                     is_batch_job_string,
-                     grading_began_longstring,
-                     str(waittime),
-                     grading_finished_longstring,
-                     str(gradingtime),
-                     grade_result])
+    write_grade_history.just_write_grade_history(history_file,
+                                                 gradeable_deadline_longstring,
+                                                 submission_longstring,
+                                                 seconds_late,
+                                                 queue_time_longstring,
+                                                 is_batch_job_string,
+                                                 grading_began_longstring,
+                                                 waittime,
+                                                 grading_finished_longstring,
+                                                 gradingtime,
+                                                 grade_result)
 
     #---------------------------------------------------------------------
     # WRITE OUT VERSION DETAILS
-    subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","insert_database_version_data.py"),
-                     obj["semester"],
-                     obj["course"],
-                     obj["gradeable"],
-                     obj["user"],
-                     obj["team"],
-                     obj["who"],
-                     "true" if obj["is_team"] else "false",
-                     str(obj["version"])])
+    insert_database_version_data.insert_to_database(
+        obj["semester"],
+        obj["course"],
+        obj["gradeable"],
+        obj["user"],
+        obj["team"],
+        obj["who"],
+        "true" if obj["is_team"] else "false",
+        str(obj["version"]))
 
     print ("pid",my_pid,"finished grading ", next_to_grade, " in ", gradingtime, " seconds")
 

--- a/bin/insert_database_version_data.py
+++ b/bin/insert_database_version_data.py
@@ -36,98 +36,30 @@ DATA_DIR = "__INSTALL__FILLIN__SUBMITTY_DATA_DIR__"
 def str2bool(v):
   return v.lower() in ("yes", "true", "t", "1")
 
-def parse_arguments():
-    """
-    Parse the arguments coming from argparse
-    :return: parsed arguments from argparse
-    """
-    parser = argparse.ArgumentParser(
-        description="Insert details about a version of a submission into the database. This can "
-                    "be used either in conjunction with loading the submission information from "
-                    "files or can pass the details directly into the script.")
-    parser.add_argument("semester", type=str, help="")
-    parser.add_argument("course", type=str, help="")
-    parser.add_argument("gradeable_id", type=str, help="")
-    parser.add_argument("user_id", type=str, help="")
-    parser.add_argument("team_id", type=str, help="")
-    parser.add_argument("who_id", type=str, help="")
-    parser.add_argument("is_team", type=str, help="")  # converted to boolean below
-    parser.add_argument("version", type=int, help="")
 
-    parser.add_argument("-n", "--no-file", action="store_true", dest="no_file", default=False,
-                        help="do not load any data from files")
+def insert_to_database(semester,course,gradeable_id,user_id,team_id,who_id,is_team,version):
 
-    parser.add_argument("-a", "--autograding_non_hidden_non_extra_credit", type=float, default=None,
-                        dest="autograding_non_hidden_non_extra_credit",
-                        help="score from autograder on non-hidden non-extra credit autochecks. "
-                             "setting this will overwrite any data gotten from the files. "
-                             "default to 0, only if -n is set")
-    parser.add_argument("-b", "--autograding_non_hidden_extra_credit", type=float, default=None,
-                        dest="autograding_non_hidden_extra_credit",
-                        help="score from autograder on non-hidden extra credit autochecks. "
-                             "setting this will overwrite any data gotten from the files. "
-                             "default to 0, only if -n is set")
-    parser.add_argument("-c", "--autograding_hidden_non_extra_credit", type=float, default=None,
-                        dest="autograding_hidden_non_extra_credit",
-                        help="score from autograder on hidden, non-extra credit autochecks. "
-                             "setting this will overwrite any data gotten from the files. "
-                             "default to 0, only if -n is set")
-    parser.add_argument("-d", "--autograding_hidden_extra_credit", type=float, default=None,
-                        dest="autograding_hidden_extra_credit",
-                        help="score from autograder on hidden, extra credit autochecks. "
-                             "setting this will overwrite any data gotten from the files. "
-                             "default to 0, only if -n is set")
-    parser.add_argument("-e", "--submission_time", type=str, default=None,
-                        dest="submission_time",
-                        help="submission timestamp for the assignment in the format YYYY-MM-DD "
-                             "HH:MM:SS. setting this will overwrite any data gotten from the "
-                             "files. default to current timestamp, only if -n is set")
-    return parser.parse_args()
+    non_hidden_non_ec = 0
+    non_hidden_ec = 0
+    hidden_non_ec = 0
+    hidden_ec = 0
 
+    testcases = get_testcases(semester, course, gradeable_id)
+    results = get_result_details(semester, course, gradeable_id, who_id, version)
+    if not len(testcases) == len(results['testcases']):
+      print ("ERROR!  mismatched # of testcases ",len(testcases)," != ",len(results['testcases']))
+    for i in range(len(testcases)):
+      if testcases[i]['hidden'] and testcases[i]['extra_credit']:
+        hidden_ec += results['testcases'][i]['points']
+      elif testcases[i]['hidden']:
+        hidden_non_ec += results['testcases'][i]['points']
+      elif testcases[i]['extra_credit']:
+        non_hidden_ec += results['testcases'][i]['points']
+      else:
+        non_hidden_non_ec += results['testcases'][i]['points']
+    submission_time = results['submission_time']
 
-def main():
-    """
-    Program execution
-    """
-
-    args = parse_arguments()
-
-    semester = args.semester
-    course = args.course
-    gradeable_id = args.gradeable_id
-    user_id = args.user_id
-    team_id = args.team_id
-    who_id = args.who_id
-    is_team = str2bool(args.is_team)
-    version = args.version
-
-    if not args.no_file:
-        non_hidden_non_ec = 0
-        non_hidden_ec = 0
-        hidden_non_ec = 0
-        hidden_ec = 0
-        testcases = get_testcases(semester, course, gradeable_id)
-        results = get_result_details(semester, course, gradeable_id, who_id, version)
-        if not len(testcases) == len(results['testcases']):
-            print ("ERROR!  mismatched # of testcases ",len(testcases)," != ",len(results['testcases']))
-        for i in range(len(testcases)):
-            if testcases[i]['hidden'] and testcases[i]['extra_credit']:
-                hidden_ec += results['testcases'][i]['points']
-            elif testcases[i]['hidden']:
-                hidden_non_ec += results['testcases'][i]['points']
-            elif testcases[i]['extra_credit']:
-                non_hidden_ec += results['testcases'][i]['points']
-            else:
-                non_hidden_non_ec += results['testcases'][i]['points']
-        submission_time = results['submission_time']
-    else:
-        non_hidden_non_ec = parse_default_int(args.autograding_non_hidden_non_extra_credit)
-        non_hidden_ec = parse_default_int(args.autograding_non_hidden_extra_credit)
-        hidden_non_ec = parse_default_int(args.autograding_hidden_non_extra_credit)
-        hidden_ec = parse_default_int(args.autograding_hidden_extra_credit)
-        submission_time = parse_default_time(args.submission_time)
-
-    db_name = "submitty_{}_{}".format(args.semester, args.course)
+    db_name = "submitty_{}_{}".format(semester, course)
 
     # If using a UNIX socket, have to specify a slightly different connection string
     if os.path.isdir(DB_HOST):
@@ -149,7 +81,7 @@ def main():
                             .where(data_table.c.g_id == bindparam('g_id'))
                             .where(data_table.c.team_id == bindparam('team_id'))
                             .where(data_table.c.g_version == bindparam('g_version')),
-                            g_id=args.gradeable_id,  team_id=args.team_id, g_version=args.version)
+                            g_id=gradeable_id,  team_id=team_id, g_version=version)
         row = result.fetchone()
         query_type = data_table.insert()
         if row[0] > 0:
@@ -173,9 +105,9 @@ def main():
             # update. Passing this as an argument to db.execute doesn't cause any issue when we
             # use the insert query (that doesn't have u_g_id)
         db.execute(query_type,
-                   g_id=args.gradeable_id, u_g_id=args.gradeable_id,
-                   team_id=args.team_id, u_team_id=args.team_id,
-                   g_version=args.version, u_g_version=args.version,
+                   g_id=gradeable_id, u_g_id=gradeable_id,
+                   team_id=team_id, u_team_id=team_id,
+                   g_version=version, u_g_version=version,
                    autograding_non_hidden_non_extra_credit=non_hidden_non_ec,
                    autograding_non_hidden_extra_credit=non_hidden_ec,
                    autograding_hidden_non_extra_credit=hidden_non_ec,
@@ -187,7 +119,7 @@ def main():
                             .where(data_table.c.g_id == bindparam('g_id'))
                             .where(data_table.c.user_id == bindparam('user_id'))
                             .where(data_table.c.g_version == bindparam('g_version')),
-                            g_id=args.gradeable_id, user_id=args.user_id, g_version=args.version)
+                            g_id=gradeable_id, user_id=user_id, g_version=version)
         row = result.fetchone()
         query_type = data_table.insert()
         if row[0] > 0:
@@ -211,36 +143,14 @@ def main():
             # update. Passing this as an argument to db.execute doesn't cause any issue when we
             # use the insert query (that doesn't have u_g_id)
         db.execute(query_type,
-                   g_id=args.gradeable_id, u_g_id=args.gradeable_id,
-                   user_id=args.user_id, u_user_id=args.user_id,
-                   g_version=args.version, u_g_version=args.version,
+                   g_id=gradeable_id, u_g_id=gradeable_id,
+                   user_id=user_id, u_user_id=user_id,
+                   g_version=version, u_g_version=version,
                    autograding_non_hidden_non_extra_credit=non_hidden_non_ec,
                    autograding_non_hidden_extra_credit=non_hidden_ec,
                    autograding_hidden_non_extra_credit=hidden_non_ec,
                    autograding_hidden_extra_credit=hidden_ec,
                    submission_time=submission_time)
-
-
-def parse_default_int(arg):
-    """
-    Defaults value to 0 for numeric argument if the argument is not set (None)
-    :param arg:
-    :return: 0 if arg isn't None, but otherwise return arg
-    """
-    return 0 if arg is None else arg
-
-
-def parse_default_time(arg):
-    """
-    Defaults value to the current date and time if argument is not set (None), otherwise return arg
-    :param arg:
-    :return:
-    """
-    if arg is None:
-        a = datetime.now()
-        arg = '{}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}' .format(a.year, a.month, a.day, a.hour,
-                                                          a.minute, a.second)
-    return arg
 
 
 def get_testcases(semester, course, g_id):
@@ -301,5 +211,3 @@ def get_result_details(semester, course, g_id, who_id, version):
     return result_details
 
 
-if __name__ == "__main__":
-    main()

--- a/bin/write_grade_history.py
+++ b/bin/write_grade_history.py
@@ -13,71 +13,83 @@ import json
 import os
 import collections
 
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Writes out grading details to the "
+                                     "history.json file which is ordered by when "
+                                     "the grade was done (with newest grading being last "
+                                     "in the list)")
+    parser.add_argument("json_file", type=str, help="location of the history.json file")
+    parser.add_argument("assignment_deadline", type=str, help="deadline for the gradeable submission")
+    parser.add_argument("submission_time", type=str, help="time that submission happened by student")
+    parser.add_argument("seconds_late", type=int, help="how many seconds late was the submission? "
+                        "This is difference between submission_time "
+                        "and assignment_deadline (with minimum value "
+                        "of 0")
+    parser.add_argument("queue_time", type=str, help="when did the file enter the queue")
+    parser.add_argument("batch_regrade", type=str, help="was this a regrade of homework or not")
+    parser.add_argument("grading_began", type=str, help="what time did the grading begin on submission")
+    parser.add_argument("wait_time", type=int, help="how long did submission wait before it started "
+                        "to be graded")
+    parser.add_argument("grading_finished", type=str, help="when did grading finish running for "
+                        "submission")
+    parser.add_argument("grade_time", type=int, help="how long was spent between when grading started "
+                        "and when it finished")
+    parser.add_argument("autograde_total", type=str, help="String that should be of the format "
+                        "'Automatic grading total: # /  #')' which "
+                        "we can split to get the first # as the "
+                        "autograding total. If it's not of that "
+                        "format, we don't write out an "
+                        "autograde_total")
+    return parser.parse_args()
 
-parser = argparse.ArgumentParser(description="Writes out grading details to the "
-                                             "history.json file which is ordered by when "
-                                             "the grade was done (with newest grading being last "
-                                             "in the list)")
-parser.add_argument("json_file", type=str, help="location of the history.json file")
-parser.add_argument("assignment_deadline", type=str, help="deadline for the gradeable submission")
-parser.add_argument("submission_time", type=str, help="time that submission happened by student")
-parser.add_argument("seconds_late", type=int, help="how many seconds late was the submission? "
-                                                   "This is difference between submission_time "
-                                                   "and assignment_deadline (with minimum value "
-                                                   "of 0")
-parser.add_argument("queue_time", type=str, help="when did the file enter the queue")
-parser.add_argument("batch_regrade", type=str, help="was this a regrade of homework or not")
-parser.add_argument("grading_began", type=str, help="what time did the grading begin on submission")
-parser.add_argument("wait_time", type=int, help="how long did submission wait before it started "
-                                                "to be graded")
-parser.add_argument("grading_finished", type=str, help="when did grading finish running for "
-                                                       "submission")
-parser.add_argument("grade_time", type=int, help="how long was spent between when grading started "
-                                                 "and when it finished")
-parser.add_argument("autograde_total", type=str, help="String that should be of the format "
-                                                      "'Automatic grading total: # /  #')' which "
-                                                      "we can split to get the first # as the "
-                                                      "autograding total. If it's not of that "
-                                                      "format, we don't write out an "
-                                                      "autograde_total")
-args = parser.parse_args()
+
+def just_write_grade_history(json_file,assignment_deadline,submission_time,
+                             seconds_late,queue_time,batch_regrade,grading_began,
+                             wait_time,grading_finished,grade_time,autograde_total):
+
+    #####################################
+    # LOAD THE PREVIOUS HISTORY
+    if os.path.isfile(json_file):
+        with open(json_file, 'r') as infile:
+            obj = json.load(infile, object_pairs_hook=collections.OrderedDict)
+    else:
+        obj = []
+
+    #####################################
+    # CREATE THE NEWEST INFO BLOB
+    blob = collections.OrderedDict()
+    blob["assignment_deadline"] = assignment_deadline
+    blob["submission_time"] = submission_time
+    seconds_late = seconds_late
+    if seconds_late > 0:
+        minutes_late = int((seconds_late+60-1) / 60)
+        hours_late = int((seconds_late+60*60-1) / (60*60))
+        days_late = int((seconds_late+60*60*24-1) / (60*60*24))
+        blob["days_late_before_extensions"] = days_late
+    blob["queue_time"] = queue_time
+    blob["batch_regrade"] = True if batch_regrade == "BATCH" else False
+    blob["grading_began"] = grading_began
+    blob["wait_time"] = wait_time
+    blob["grading_finished"] = grading_finished
+    blob["grade_time"] = grade_time
+    blob["autograde_result"] = autograde_total
+    autograde_array = str.split(autograde_total)
+    if len(autograde_array) > 0 and autograde_array[0] == "Automatic":
+        blob["autograde_total"] = int(autograde_array[3])
+        if len(autograde_array) == 6:
+            blob["autograde_max_possible"] = int(autograde_array[5])
+
+
+    #####################################
+    #  ADD IT TO THE HISTORY
+    obj.append(blob)
+    with open(json_file, 'w') as outfile:
+        json.dump(obj, outfile, indent=4, separators=(',', ': '))
+
 
 #####################################
-# LOAD THE PREVIOUS HISTORY
-json_file = args.json_file
-if os.path.isfile(json_file):
-    with open(json_file, 'r') as infile:
-        obj = json.load(infile, object_pairs_hook=collections.OrderedDict)
-else:
-    obj = []
-
-#####################################
-# CREATE THE NEWEST INFO BLOB
-blob = collections.OrderedDict()
-blob["assignment_deadline"] = args.assignment_deadline
-blob["submission_time"] = args.submission_time
-seconds_late = args.seconds_late
-if seconds_late > 0:
-    minutes_late = int((seconds_late+60-1) / 60)
-    hours_late = int((seconds_late+60*60-1) / (60*60))
-    days_late = int((seconds_late+60*60*24-1) / (60*60*24))
-    blob["days_late_before_extensions"] = days_late
-blob["queue_time"] = args.queue_time
-blob["batch_regrade"] = True if args.batch_regrade == "BATCH" else False
-blob["grading_began"] = args.grading_began
-blob["wait_time"] = args.wait_time
-blob["grading_finished"] = args.grading_finished
-blob["grade_time"] = args.grade_time
-blob["autograde_result"] = args.autograde_total
-autograde_array = str.split(args.autograde_total)
-if len(autograde_array) > 0 and autograde_array[0] == "Automatic":
-    blob["autograde_total"] = int(autograde_array[3])
-    if len(autograde_array) == 6:
-        blob["autograde_max_possible"] = int(autograde_array[5])
-
-
-#####################################
-#  ADD IT TO THE HISTORY 
-obj.append(blob)
-with open(json_file, 'w') as outfile:
-    json.dump(obj, outfile, indent=4, separators=(',', ': '))
+if __name__ == "__main__":
+    args = parse_arguments()
+    just_write_grade_history(args.json_file,args.assigment_deadline,args.submission_time,
+                             args.seconds_late,args.queue_time,args.batch_regrade,args.grading_begun,
+                             args.wait_time,args.grading_finished,args.grade_time,args.autograde_total)


### PR DESCRIPTION
eliminated a few subprocess.call between python scripts (now just function calls).

removed some command line argument parsing flexibility (that wasn't being used anyway).  Question:  Is there any reason to keep it (it needs repair)?  For future testing?  

Question:  Should the clutter of small python scripts be combined?  (submitty_grading_scheduler.py, grade_item.py, write_grade_history.py, insert_database_version_data.py)  Either in a single file or in a subfolder?   What's "pythonic"?  The current file structure is an artifact of development, not conscious design.