### PR TITLE
TA page cookies now save last opened componet, testcases, and folders.

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -579,6 +579,10 @@ class ElectronicGraderController extends AbstractController {
         $mark_modified = false;
 
         //makes sure only the users a grader is assigned to can be graded
+        if ($this->core->getUser()->getGroup() > $gradeable->getMinimumGradingGroup()) {
+            $_SESSION['messages']['error'][] = "You do not have permission to grade {$gradeable->getName()}";
+            return;
+        }
         if ($this->core->getUser()->getGroup() === 3) {
             if ($gradeable->isGradeByRegistration()) {
                 $sections = $this->core->getUser()->getGradingRegistrationSections();

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -543,12 +543,15 @@ HTML;
     <i title="Show/Hide Grading Rubric (Press G)" class="fa fa fa-pencil-square-o icon-header" onclick="handleKeyPress('KeyG');"></i>
     <i title="Show/Hide Submission and Results Browser (Press O)" class="fa fa-folder-open icon-header" onclick="handleKeyPress('KeyO');"></i>
     <i title="Show/Hide Student Information (Press S)" class="fa fa-user icon-header" onclick="handleKeyPress('KeyS');"></i>
+    <div> <input type="checkbox" id="autoscroll_id" onclick="updateCookies();"> Auto scroll / Auto open questions? </div>
 </div>
 
 <div class="progress_bar">
     <progress class="progressbar" max="100" value="{$progress}" style="width:80%; height: 100%;"></progress>
     <div class="progress-value" style="display:inline;"></div>
 </div>
+
+
 
 <div id="autograding_results" class="draggable rubric_panel" style="left:15px; top:170px; width:48%; height:36%;">
     <span class="grading_label">Auto-Grading Testcases</span>
@@ -573,11 +576,11 @@ HTML;
 
 <div id="submission_browser" class="draggable rubric_panel" style="left:15px; bottom:40px; width:48%; height:30%">
     <span class="grading_label">Submissions and Results Browser</span>
-    <button class="btn btn-default" onclick="openAll()">Expand All</button>
-    <button class="btn btn-default" onclick="closeAll()">Close All</button>
+    <button class="btn btn-default" onclick="openAll(); updateCookies();">Expand All</button>
+    <button class="btn btn-default" onclick="closeAll(); updateCookies();">Close All</button>
     <button class="btn btn-default" onclick="downloadZip('{$gradeable->getId()}','{$gradeable->getUser()->getId()}')">Download Zip File</button>
     <br />
-    <div class="inner-container">
+    <div class="inner-container" id="file-container">
 HTML;
         function add_files(&$files, $new_files, $start_dir_name) {
             $files[$start_dir_name] = array(); 
@@ -605,13 +608,13 @@ HTML;
                     $return .= <<<HTML
                 <div>
                     <div class="file-viewer">
-                        <a class='openAllFile' onclick='openFrame("{$dir}", "{$contents}", {$count})'>
+                        <a class='openAllFile' onclick='openFrame("{$dir}", "{$contents}", {$count}); updateCookies();'>
                             <span class="fa fa-plus-circle" style='vertical-align:text-bottom;'></span>
                         {$dir}</a> &nbsp;
                         <a onclick='openFile("{$dir}", "{$contents}")'><i class="fa fa-window-restore" aria-hidden="true" title="Pop up the file in a new window"></i></a>
                         <a onclick='downloadFile("{$dir}", "{$contents}")'><i class="fa fa-download" aria-hidden="true" title="Download the file"></i></a>
                     </div><br/>
-                    <div id="file_viewer_{$count}" style="margin-left:{$indent_offset}px"></div>
+                    <div id="file_viewer_{$count}" style="margin-left:{$indent_offset}px" data-file_name="{$dir}" data-file_url="{$contents}"></div>
                 </div>
 HTML;
                     $count++;
@@ -624,11 +627,11 @@ HTML;
                     $return .= <<<HTML
             <div>
                 <div class="div-viewer">
-                    <a class='openAllDiv' onclick='openDiv({$count});'>
+                    <a class='openAllDiv' onclick='openDiv({$count}); updateCookies();'>
                         <span class="fa fa-folder" style='vertical-align:text-top;'></span>
                     {$dir}</a> 
                 </div><br/>
-                <div id='div_viewer_{$count}' style='margin-left:15px; display: none'>
+                <div id='div_viewer_{$count}' style='margin-left:15px; display: none' data-file_name="{$dir}">
 HTML;
                     $count++;
                     display_files($contents, $count, $indent+1, $return);
@@ -763,15 +766,15 @@ HTML;
     <div class="red-message" style="text-align: center">Select the correct submission version to grade</div>
 HTML;
         }
+        $num_questions = count($gradeable->getComponents());
         $return .= <<<HTML
     <div style="margin:3px;">
-        <table class="rubric-table" id="rubric-table">
+        <table class="rubric-table" id="rubric-table" data-num_questions="{$num_questions}">
             <tbody>
 HTML;
 
         $c = 1;
         $precision = floatval($gradeable->getPointPrecision());
-        $num_questions = count($gradeable->getComponents());
 
         foreach ($gradeable->getComponents() as $question) {
             $type = 0; //0 is common deductable, 1 is common additive

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -755,7 +755,7 @@ HTML;
 </div>
 
 <div id="grading_rubric" class="draggable rubric_panel" style="right:15px; top:140px; width:48%; height:42%;">
-    <span class="grading_label">Grading Rubric</span> <span style="float: right; position: relative; top: 10px; right: 1%;"> Overwrite Grader: <input type='checkbox' id="overwrite-id" name='overwrite' value='1' /> </span>
+    <span class="grading_label">Grading Rubric</span> <span style="float: right; position: relative; top: 10px; right: 1%;"> Overwrite Grader: <input type='checkbox' id="overwrite-id" name='overwrite' value='1' onclick="updateCookies();" checked/> </span>
 HTML;
         $break_onclick = "";
         $disabled = '';

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -201,9 +201,14 @@ function selectMark(me, first_override = false) {
 }
 
 //closes all the questions except the one being opened
-function openClose(row_id, num_questions) {
+function openClose(row_id, num_questions = -1) {
     var row_num = parseInt(row_id);
-    var total_num = parseInt(num_questions);
+    var total_num = 0;
+    if (num_questions === -1) {
+        total_num = parseInt($('#rubric-table')[0].dataset.num_questions);
+    } else {
+        total_num = parseInt(num_questions);
+    }
     //-2 means general comment, else open the row_id with the number
     general_comment = document.getElementById('extra-general');
     general_comment_summary = document.getElementById('summary-general');
@@ -220,8 +225,7 @@ function openClose(row_id, num_questions) {
         general_comment_cancel_mark.style.display = 'none';
         general_comment_save_mark.style.display = 'none';
     }
-
-    for (var x = 1; x <= num_questions; x++) {
+    for (var x = 1; x <= total_num; x++) {
         var current = document.getElementById('extra-' + x);
         var current_summary = document.getElementById('summary-' + x);
         var ta_note = document.getElementById('ta_note-' + x);
@@ -229,7 +233,7 @@ function openClose(row_id, num_questions) {
         var progress_points = document.getElementById('progress_points-' + x);
         var cancel_mark = document.getElementById('cancel-mark-' + x);
         var save_mark = document.getElementById('save-mark-' + x);
-        if (x === row_num) {
+        if (x == row_num) {
             if (current.style.display === 'none') {
                 current.style.display = '';
                 current_summary.style.display = 'none';
@@ -258,6 +262,8 @@ function openClose(row_id, num_questions) {
             save_mark.style.display = 'none';
         }
     }
+
+    updateCookies();
 }
 
 function cancelMark(num, gradeable_id, user_id, gc_id) {
@@ -536,5 +542,33 @@ function saveMark(num, gradeable_id, user_id, active_version, gc_id = -1) {
                 console.log("Something went wront with saving marks...");
             }
         })
+    }
+}
+
+function findCurrentOpenedMark() {
+    var index = 1;
+    var found = false;
+    var doesExist = ($('#summary-' + index).length) ? true : false;
+    while(doesExist) {
+        if($('#summary-' + index).length) {
+            if ($('#summary-' + index)[0].style.display === 'none') {
+                found = true;
+                doesExist = false;
+                index--;
+            }
+        }
+        else{
+            doesExist = false;
+        }
+        index++;
+    }
+    if (found === true) {
+        return index;
+    } else {
+        if ($('#summary-general')[0].style.display === 'none') {
+            return -2;
+        } else {
+            return -1;
+        }
     }
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -98,6 +98,8 @@ function readCookies(){
     var status_height = document.cookie.replace(/(?:(?:^|.*;\s*)status_height\s*\=\s*([^;]*).*$)|^.*$/, "$1");
     var status_visible = document.cookie.replace(/(?:(?:^|.*;\s*)status_visible\s*\=\s*([^;]*).*$)|^.*$/, "$1");
 
+    var overwrite = document.cookie.replace(/(?:(?:^|.*;\s*)overwrite\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+
     var autoscroll = document.cookie.replace(/(?:(?:^|.*;\s*)autoscroll\s*\=\s*([^;]*).*$)|^.*$/, "$1");
     var opened_mark = document.cookie.replace(/(?:(?:^|.*;\s*)opened_mark\s*\=\s*([^;]*).*$)|^.*$/, "$1");
 
@@ -133,6 +135,8 @@ function readCookies(){
     (files_visible) ? ((files_visible) == "none" ? $(".fa-folder-open").removeClass("icon-selected") : $(".fa-folder-open").addClass("icon-selected")) : {};
     (rubric_visible) ? ((rubric_visible) == "none" ? $(".fa-pencil-square-o").removeClass("icon-selected") : $(".fa-pencil-square-o").addClass("icon-selected")) : {};
     (status_visible) ? ((status_visible) == "none" ? $(".fa-user").removeClass("icon-selected") : $(".fa-user").addClass("icon-selected")) : {};
+
+    (overwrite) ? ((overwrite) == "on" ? $('#overwrite-id').prop('checked', true) : $('#overwrite-id').prop('checked', false)) : {};
 
     (autoscroll) ? ((autoscroll) == "on" ? $('#autoscroll_id').prop('checked', true) : $('#autoscroll_id').prop('checked', false)) : {};
     if (autoscroll == "on") {
@@ -203,6 +207,14 @@ function updateCookies(){
     document.cookie = "status_width=" + $("#student_info").css("width") + "; path=/;";
     document.cookie = "status_height=" + $("#student_info").css("height") + "; path=/;";
     document.cookie = "status_visible=" + $("#student_info").css("display") + "; path=/;";
+
+    var overwrite = "on";
+    if ($('#overwrite-id').is(":checked")) {
+        overwrite = "on";
+    } else {
+        overwrite = "off";
+    }
+    document.cookie = "overwrite=" + overwrite + "; path=/;";
 
     var autoscroll = "on";
     if ($('#autoscroll_id').is(":checked")) {


### PR DESCRIPTION
The TA page now uses the cookies to save the last opened items. The checkbox for saving is defiantly out of place but I figured we should change that when we decide on the order of the icons.
I don't know if we want to closee #1238 since only half of it is technically finished. 
Also I misspelled "close" on purpose so GitHub doesn't auto close it.