### PR TITLE
allow instructors to see hw grading pages even with no manual grading set

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -380,139 +380,134 @@ HTML;
 							}
 						}
                         //This code is taken from the ElectronicGraderController, it used to calculate the TA percentage.
-                        if ($g_data->useTAGrading()) {
-                            $gradeable_core = $this->core->getQueries()->getGradeable($gradeable);
-                            $gradeable_id = $gradeable_core->getId();
+                        $gradeable_core = $this->core->getQueries()->getGradeable($gradeable);
+                        $gradeable_id = $gradeable_core->getId();
 
-                            $total_users = array();
-                            $no_team_users = array();
-                            $graded_components = array();
-                            $graders = array();
-                            if ($gradeable_core->isGradeByRegistration()) {
-                                if(!$this->core->getUser()->accessFullGrading()){
-                                    $sections = $this->core->getUser()->getGradingRegistrationSections();
-                                }
-                                else {
-                                    $sections = $this->core->getQueries()->getRegistrationSections();
-                                    foreach ($sections as $i => $section) {
-                                        $sections[$i] = $section['sections_registration_id'];
-                                    }
-                                }
-                                $section_key='registration_section';
-                                if (count($sections) > 0) {
-                                    $graders = $this->core->getQueries()->getGradersForRegistrationSections($sections);
-                                }
+                        $total_users = array();
+                        $no_team_users = array();
+                        $graded_components = array();
+                        $graders = array();
+                        if ($gradeable_core->isGradeByRegistration()) {
+                            if(!$this->core->getUser()->accessFullGrading()){
+                                $sections = $this->core->getUser()->getGradingRegistrationSections();
                             }
                             else {
-                                if(!$this->core->getUser()->accessFullGrading()){
-                                    $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id, $this->core->getUser()->getId());
-                                }
-                                else {
-                                    $sections = $this->core->getQueries()->getRotatingSections();
-                                    foreach ($sections as $i => $section) {
-                                        $sections[$i] = $section['sections_rotating_id'];
-                                    }
-                                }
-                                $section_key='rotating_section';
-                                if (count($sections) > 0) {
-                                    $graders = $this->core->getQueries()->getGradersForRotatingSections($gradeable_id, $sections);
+                                $sections = $this->core->getQueries()->getRegistrationSections();
+                                foreach ($sections as $i => $section) {
+                                    $sections[$i] = $section['sections_registration_id'];
                                 }
                             }
+                            $section_key='registration_section';
                             if (count($sections) > 0) {
-                                if ($gradeable_core->isTeamAssignment()) {
-                                    $total_users = $this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, $section_key);
-                                    $no_team_users = $this->core->getQueries()->getUsersWithoutTeamByGradingSections($gradeable_id, $sections, $section_key);
-                                    $graded_components = $this->core->getQueries()->getGradedComponentsCountByTeamGradingSections($gradeable_id, $sections, $section_key);
-                                }
-                                else {
-                                    $total_users = $this->core->getQueries()->getTotalUserCountByGradingSections($sections, $section_key);
-                                    $no_team_users = array();
-                                    $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key);
-                                }
-                            }
-                            
-                            $num_components = $this->core->getQueries()->getTotalComponentCount($gradeable_id);
-                            $sections = array();
-                            if (count($total_users) > 0) {
-                                foreach ($total_users as $key => $value) {
-                                    $sections[$key] = array(
-                                        'total_components' => $value * $num_components,                        
-                                        'graded_components' => 0,
-                                        'graders' => array()
-                                    );
-                                    if ($gradeable_core->isTeamAssignment()) {
-                                        $sections[$key]['no_team'] = $no_team_users[$key];
-                                    }
-                                    if (isset($graded_components[$key])) {
-                                        $sections[$key]['graded_components'] = intval($graded_components[$key]);
-                                    }
-                                    if (isset($graders[$key])) {
-                                        $sections[$key]['graders'] = $graders[$key];
-                                    }
-                                }
-                            }
-
-                            $components_graded = 0;
-                            $components_total = 0;
-                            foreach ($sections as $key => $section) {
-                                if ($key === "NULL") {
-                                    continue;
-                                }
-                                $components_graded += $section['graded_components'];
-                                $components_total += $section['total_components']; 
-                            }
-                            $TA_percent = 0;
-                            if ($components_total == 0) { $TA_percent = 0; }
-                            else {
-                                $TA_percent = $components_graded / $components_total;
-                                $TA_percent = $TA_percent * 100;
-                            }
-                            //if $TA_percent is 100, change the text to REGRADE
-                            if ($TA_percent == 100 && $title_save=='ITEMS BEING GRADED') {
-                                $gradeable_grade_range = <<<HTML
-                                <a class="btn btn-default btn-nav" \\
-                                href="{$this->core->buildUrl(array('component' => 'grading', 'page' => 'electronic', 'gradeable_id' => $gradeable))}">
-                                {$temp_regrade_text}</a>
-HTML;
-                            } else if ($TA_percent == 100 && $title_save=='GRADED') {
-                                $gradeable_grade_range = <<<HTML
-                                <a class="btn btn-default btn-nav" \\
-                                href="{$this->core->buildUrl(array('component' => 'grading', 'page' => 'electronic', 'gradeable_id' => $gradeable))}">
-                                REGRADE</a>
-HTML;
-                            } else {
-                                $gradeable_grade_range = <<<HTML
-                                <a class="btn {$title_to_button_type_grading[$title_save]} btn-nav" \\
-                                href="{$this->core->buildUrl(array('component' => 'grading', 'page' => 'electronic', 'gradeable_id' => $gradeable))}">
-                                {$gradeable_grade_range}</a>
-HTML;
-                            }                           
-                            //Give the TAs a progress bar too                        
-                            if (($title_save == "GRADED" || $title_save == "ITEMS BEING GRADED") && $components_total != 0) {
-                                $gradeable_grade_range .= <<<HTML
-                                <style type="text/css"> 
-                                    .meter3 { 
-                                        height: 10px; 
-                                        position: relative;
-                                        background: rgb(224,224,224);
-                                        padding: 0px;
-                                    }
-
-                                    .meter3 > span {
-                                        display: block;
-                                        height: 100%;
-                                        background-color: rgb(92,184,92);
-                                        position: relative;
-                                    }
-                                </style>    
-                                <div class="meter3">
-                                    <span style="width: {$TA_percent}%"></span>
-                                </div>               
-HTML;
+                                $graders = $this->core->getQueries()->getGradersForRegistrationSections($sections);
                             }
                         }
                         else {
-                            $gradeable_grade_range = "";
+                            if(!$this->core->getUser()->accessFullGrading()){
+                                $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id, $this->core->getUser()->getId());
+                            }
+                            else {
+                                $sections = $this->core->getQueries()->getRotatingSections();
+                                foreach ($sections as $i => $section) {
+                                    $sections[$i] = $section['sections_rotating_id'];
+                                }
+                            }
+                            $section_key='rotating_section';
+                            if (count($sections) > 0) {
+                                $graders = $this->core->getQueries()->getGradersForRotatingSections($gradeable_id, $sections);
+                            }
+                        }
+                        if (count($sections) > 0) {
+                            if ($gradeable_core->isTeamAssignment()) {
+                                $total_users = $this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, $section_key);
+                                $no_team_users = $this->core->getQueries()->getUsersWithoutTeamByGradingSections($gradeable_id, $sections, $section_key);
+                                $graded_components = $this->core->getQueries()->getGradedComponentsCountByTeamGradingSections($gradeable_id, $sections, $section_key);
+                            }
+                            else {
+                                $total_users = $this->core->getQueries()->getTotalUserCountByGradingSections($sections, $section_key);
+                                $no_team_users = array();
+                                $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key);
+                            }
+                        }
+                        
+                        $num_components = $this->core->getQueries()->getTotalComponentCount($gradeable_id);
+                        $sections = array();
+                        if (count($total_users) > 0) {
+                            foreach ($total_users as $key => $value) {
+                                $sections[$key] = array(
+                                    'total_components' => $value * $num_components,                        
+                                    'graded_components' => 0,
+                                    'graders' => array()
+                                );
+                                if ($gradeable_core->isTeamAssignment()) {
+                                    $sections[$key]['no_team'] = $no_team_users[$key];
+                                }
+                                if (isset($graded_components[$key])) {
+                                    $sections[$key]['graded_components'] = intval($graded_components[$key]);
+                                }
+                                if (isset($graders[$key])) {
+                                    $sections[$key]['graders'] = $graders[$key];
+                                }
+                            }
+                        }
+
+                        $components_graded = 0;
+                        $components_total = 0;
+                        foreach ($sections as $key => $section) {
+                            if ($key === "NULL") {
+                                continue;
+                            }
+                            $components_graded += $section['graded_components'];
+                            $components_total += $section['total_components']; 
+                        }
+                        $TA_percent = 0;
+                        if ($components_total == 0) { $TA_percent = 0; }
+                        else {
+                            $TA_percent = $components_graded / $components_total;
+                            $TA_percent = $TA_percent * 100;
+                        }
+                        //if $TA_percent is 100, change the text to REGRADE
+                        if ($TA_percent == 100 && $title_save=='ITEMS BEING GRADED') {
+                            $gradeable_grade_range = <<<HTML
+                            <a class="btn btn-default btn-nav" \\
+                            href="{$this->core->buildUrl(array('component' => 'grading', 'page' => 'electronic', 'gradeable_id' => $gradeable))}">
+                            {$temp_regrade_text}</a>
+HTML;
+                        } else if ($TA_percent == 100 && $title_save=='GRADED') {
+                            $gradeable_grade_range = <<<HTML
+                            <a class="btn btn-default btn-nav" \\
+                            href="{$this->core->buildUrl(array('component' => 'grading', 'page' => 'electronic', 'gradeable_id' => $gradeable))}">
+                            REGRADE</a>
+HTML;
+                        } else {
+                            $gradeable_grade_range = <<<HTML
+                            <a class="btn {$title_to_button_type_grading[$title_save]} btn-nav" \\
+                            href="{$this->core->buildUrl(array('component' => 'grading', 'page' => 'electronic', 'gradeable_id' => $gradeable))}">
+                            {$gradeable_grade_range}</a>
+HTML;
+                        }                           
+                        //Give the TAs a progress bar too                        
+                        if (($title_save == "GRADED" || $title_save == "ITEMS BEING GRADED") && $components_total != 0) {
+                            $gradeable_grade_range .= <<<HTML
+                            <style type="text/css"> 
+                                .meter3 { 
+                                    height: 10px; 
+                                    position: relative;
+                                    background: rgb(224,224,224);
+                                    padding: 0px;
+                                }
+
+                                .meter3 > span {
+                                    display: block;
+                                    height: 100%;
+                                    background-color: rgb(92,184,92);
+                                    position: relative;
+                                }
+                            </style>    
+                            <div class="meter3">
+                                <span style="width: {$TA_percent}%"></span>
+                            </div>               
+HTML;
                         }
                     }
                     else {

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -976,9 +976,16 @@ HTML;
             $span_style = '';
             $checked = 'checked';
         }
+        $empty = "";
+        if(!$gradeable->useTAGrading()) {
+            $empty = "empty";
+        }
         $return .= <<<HTML
-<div id="grading_rubric" class="draggable rubric_panel" style="right:15px; top:140px; width:48%; height:42%;">
+<div id="grading_rubric" class="draggable rubric_panel {$empty}" style="right:15px; top:140px; width:48%; height:42%;">
     <span class="grading_label">Grading Rubric</span>
+HTML;
+        if($gradeable->useTAGrading()) {
+        $return .= <<<HTML
     <div style="float: right; float: right; position: relative; top: 10px; right: 1%;">
         <span style="padding-right: 10px"> <input type="checkbox" id="autoscroll_id" onclick="updateCookies();"> Auto scroll / Auto open </span>
         <span {$span_style}> <input type='checkbox' id="overwrite-id" name='overwrite' value='1' onclick="updateCookies();" {$checked}/> Overwrite Grader </span>
@@ -1336,7 +1343,10 @@ HTML;
         </div>
     </form>
     </div>
-</div>
+HTML;
+        }
+        $return .= <<<HTML
+</div> 
 <script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}/js/ta-grading.js"></script>
 <script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}/js/ta-grading-mark.js"></script>
 <script type="text/javascript">

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -701,6 +701,9 @@ function saveMark(num, gradeable_id, user_id, active_version, gc_id = -1, your_u
 
 //finds what mark is currently open
 function findCurrentOpenedMark() {
+    if($('#grading_rubric').hasClass('empty')) {
+        return -3;
+    }
     var index = 1;
     var found = false;
     var doesExist = ($('#summary-' + index).length) ? true : false;

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -232,7 +232,6 @@ function updateCookies(){
     }
     document.cookie = "autoscroll=" + autoscroll + "; path=/;";
     document.cookie = "opened_mark=" + findCurrentOpenedMark() + "; path=/;";
-
     if (findCurrentOpenedMark() > 0 || findCurrentOpenedMark() == -2) {
         if (findCurrentOpenedMark() == -2) {
             var current_mark = document.getElementById('title-general');


### PR DESCRIPTION
- see title
- not sure how to set the permissions to set a TA to see grading since those permissions are set in the TA section of the rubric which doesn't show up in this use case. Leaving it be for now
- the changes to the navigation page is just the removal of an if-else block and then a fix to the indentation
closes #1357 