### PR TITLE
Fix check off all checkpoints at once

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -486,6 +486,10 @@ function setupCheckboxCells() {
             var lastScore = null;
             var setFull = false;
             parent.children(".cell-grade").each(function() {
+                updateCheckpointCell(this, setFull);
+                elems.push(this);
+            });
+            parent.children(".cell-grade").each(function() {
                 if (lastScore === null) {
                     lastScore = $(this).data("score");
                 }
@@ -493,10 +497,6 @@ function setupCheckboxCells() {
                     setFull = true;
                 }
                 scores[$(this).data('id')] = $(this).data('score');
-            });
-            parent.children(".cell-grade").each(function() {
-                updateCheckpointCell(this, setFull);
-                elems.push(this);
             });
         }
         else {


### PR DESCRIPTION
This should fix it. I think before we were updating the color and score after putting it in an array to save. If full points were given, then it would appear to not save upon refresh.
closes #1428