### PR TITLE
Fix Travis-CI failures due to recent updates to their Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,6 @@ script:
   - if [ ${INTEGRATION_SUITE} = false ]; then vendor/bin/phpunit --configuration tests/phpunit.xml; fi
   - if [ ${INTEGRATION_SUITE} = false ]; then TEST_URL="http://localhost" nose2 -v --start-dir="tests/e2e"; fi
   - if [ ${INTEGRATION_SUITE} = true ]; then sudo /usr/local/submitty/test_suite/integrationTests/run.py; fi
-  - if [ ${INTEGRATION_SUITE} = true ]; then cat /usr/local/submitty/test_suite/integrationTests/tests/tutorial_10_java_coverage/*/test*_STDERR.txt; fi
 
 # Add more linters to the build process here
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,7 @@ addons:
       - libboost-all-dev
 
 before_install:
-  - ls -la /opt/python
-  - pyenv versions
   - PY_VERSION_3=$(ls /opt/python | grep "3.6.[0-9]")
-  - echo $PY_VERSION_3
   - jdk_switcher use default
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
@@ -73,19 +70,19 @@ install:
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/
   - travis_retry composer install --prefer-dist --no-interaction
-  - pip install -U pip
-  - pip install python-pam
-  - pip install PyYAML
-  - pip install psycopg2
-  - pip install sqlalchemy
-  - pip install pylint_runner
-  - pip install psutil
-  - pip install python-dateutil
-  - pip install watchdog
-  - pip install xlsx2csv
-  - pip install selenium
-  - pip install nose2
-  - pip install unittest2
+  - pip3 install -U pip
+  - pip3 install python-pam
+  - pip3 install PyYAML
+  - pip3 install psycopg2
+  - pip3 install sqlalchemy
+  - pip3 install pylint_runner
+  - pip3 install psutil
+  - pip3 install python-dateutil
+  - pip3 install watchdog
+  - pip3 install xlsx2csv
+  - pip3 install selenium
+  - pip3 install nose2
+  - pip3 install unittest2
   - pushd ${TRAVIS_BUILD_DIR}/python_submitty_utils
   - python3 setup.py install
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ addons:
       - libboost-all-dev
 
 before_install:
+  - ls -la /opt
+  - ls -la /opt/python
   - pip -V
   - python --version
   - python3 --verison

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,13 @@ addons:
       - libboost-all-dev
 
 before_install:
+  - pip -V
+  - python --version
+  - python3 --verison
   - jdk_switcher use default
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
-  - PY_VERSION_2="$(python2 -V 2>&1 | egrep -o '2.7.[0-9]{2,}')"
   - PY_VERSION_3="$(python3 -V 2>&1 | egrep -o '[0-9].[0-9].[0-9]{1,}')"
-  - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_2}/bin:/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers
+  - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH
 
@@ -70,19 +72,19 @@ install:
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/
   - travis_retry composer install --prefer-dist --no-interaction
-  - pip3 install -U pip
-  - pip3 install python-pam
-  - pip3 install PyYAML
-  - pip3 install psycopg2
-  - pip3 install sqlalchemy
-  - pip3 install pylint_runner
-  - pip3 install psutil
-  - pip3 install python-dateutil
-  - pip3 install watchdog
-  - pip3 install xlsx2csv
-  - pip3 install selenium
-  - pip3 install nose2
-  - pip3 install unittest2
+  - pip install -U pip
+  - pip install python-pam
+  - pip install PyYAML
+  - pip install psycopg2
+  - pip install sqlalchemy
+  - pip install pylint_runner
+  - pip install psutil
+  - pip install python-dateutil
+  - pip install watchdog
+  - pip install xlsx2csv
+  - pip install selenium
+  - pip install nose2
+  - pip install unittest2
   - pushd ${TRAVIS_BUILD_DIR}/python_submitty_utils
   - python3 setup.py install
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,10 @@ addons:
       - libboost-all-dev
 
 before_install:
-  - PY_VERSION_3=$(ls /opt/python | grep "3.6.[0-9]")
   - jdk_switcher use default
+  # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
+  - unset _JAVA_OPTIONS
+  - PY_VERSION_3=$(ls /opt/python | grep "3.6.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
   - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,15 +53,13 @@ addons:
       - libboost-all-dev
 
 before_install:
-  - ls -la /opt
   - ls -la /opt/python
-  - echo $PATH
-  - pip -V
-  - python --version
-  - python3 -V
+  - pyenv versions
+  - PY_VERSION_3=$(ls /opt/python | grep "3.6.[0-9]")
+  - echo $PY_VERSION_3
   - jdk_switcher use default
+  - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
-  - PY_VERSION_3="$(python3 -V 2>&1 | egrep -o '[0-9].[0-9].[0-9]{1,}')"
   - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,10 @@ addons:
 before_install:
   - ls -la /opt
   - ls -la /opt/python
+  - echo $PATH
   - pip -V
   - python --version
-  - python3 --verison
+  - python3 -V
   - jdk_switcher use default
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
   - PY_VERSION_3="$(python3 -V 2>&1 | egrep -o '[0-9].[0-9].[0-9]{1,}')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ script:
   - if [ ${INTEGRATION_SUITE} = false ]; then vendor/bin/phpunit --configuration tests/phpunit.xml; fi
   - if [ ${INTEGRATION_SUITE} = false ]; then TEST_URL="http://localhost" nose2 -v --start-dir="tests/e2e"; fi
   - if [ ${INTEGRATION_SUITE} = true ]; then sudo /usr/local/submitty/test_suite/integrationTests/run.py; fi
+  - if [ ${INTEGRATION_SUITE} = true ]; then cat /usr/local/submitty/test_suite/integrationTests/tests/tutorial_10_java_coverage/*/test*_STDERR.txt; fi
 
 # Add more linters to the build process here
 after_script:


### PR DESCRIPTION
Primarily, it seems that they now require using pyenv to set the python version (instead of adding python3 to the path) as well as  Travis now setting _JAVA_OPTIONS (which we have to unset).