### PR TITLE
Upload User List bug fixes

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -408,7 +408,7 @@ class UsersController extends AbstractController {
 
             //Database password cannot be blank, no check on format
             if ($use_database) {
-                $error_message .= (isset($vals[5]) && ($vals[5] != "")) ? "" : "Error in password column, row #{$row_num}: cannot be blank," . PHP_EOL;
+                $error_message .= $vals[5] != "" ? "" : "Error in password column, row #{$row_num}: cannot be blank," . PHP_EOL;
             }
 
             $graders_data[] = $vals;
@@ -529,7 +529,7 @@ class UsersController extends AbstractController {
 
             //Database password cannot be blank, no check on format
             if ($use_database) {
-                $error_message .= (isset($vals[5]) && ($vals[5] != "")) ? "" : "Error in password column, row #{$row_num}: cannot be blank," . PHP_EOL;
+                $error_message .= $vals[5] != "" ? "" : "Error in password column, row #{$row_num}: cannot be blank," . PHP_EOL;
             }
 
             $students_data[] = $vals;

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -92,6 +92,7 @@ class UsersController extends AbstractController {
             $this->core->addErrorMessage("Invalid CSRF token.");
             $this->core->redirect($return_url);
         }
+        $use_database = $this->core->getAuthentication() instanceof DatabaseAuthentication;
 
         $error_message = "";
         //Username must contain only lowercase alpha, numbers, underscores, hyphens
@@ -101,6 +102,14 @@ class UsersController extends AbstractController {
         $error_message .= preg_match("~^[a-zA-Z.'`\- ]+$~", trim($_POST['user_lastname'])) ? "" : "Error in last name: {$_POST['user_lastname']}," . PHP_EOL;
         //Check email address for format "address@domain".
         $error_message .= preg_match("~.+@{1}[a-zA-Z0-9:\.\-\[\]]+$~", trim($_POST['user_email'])) ? "" : "Error in email: {$_POST['user_email']}," . PHP_EOL;
+        //Preferred first name must be alpha characters, white-space, or certain punctuation.
+        if (isset($_POST['user_preferred_firstname'])) {
+            $error_message .= preg_match("~^[a-zA-Z.'`\- ]+$~", trim($_POST['user_preferred_firstname'])) ? "" : "Error in preferred first name: {$_POST['user_preferred_firstname']}," . PHP_EOL;
+        }
+        //Database password cannot be blank, no check on format
+        if ($use_database) {
+            $error_message .= $_POST['user_password'] != "" ? "" : "Error must enter password for user" . PHP_EOL;
+        }
 
         if (!empty($error_message)) {
             $this->core->addErrorMessage($error_message." Contact your sysadmin if this should not cause an error.");
@@ -354,6 +363,7 @@ class UsersController extends AbstractController {
 
     public function uploadGraderList() {
         $return_url = $this->core->buildUrl(array('component'=>'admin', 'page'=>'users', 'action'=>'graders'));
+        $use_database = $this->core->getAuthentication() instanceof DatabaseAuthentication;
 
         if (!$this->core->checkCsrfToken($_POST['csrf_token'])) {
             $this->core->addErrorMessage("Invalid CSRF token");
@@ -368,6 +378,7 @@ class UsersController extends AbstractController {
         $contents = $this->getCsvOrXlsxData($_FILES['upload']['name'], $_FILES['upload']['tmp_name'], $return_url);
 
         //Validation and error checking.
+        $pref_name_idx = $use_database ? 6 : 5;
         $error_message = "";
         $row_num = 0;
         $graders_data = array();
@@ -389,6 +400,16 @@ class UsersController extends AbstractController {
 
             //grader-level check is a digit between 1 - 4.
             $error_message .= preg_match("~[1-4]{1}~", $vals[4]) ? "" : "Error in grader-level column, row #{$row_num}: {$vals[4]}," . PHP_EOL;
+
+            //Preferred first name must be alpha characters, white-space, or certain punctuation.
+            if (isset($vals[$pref_name_idx]) && ($vals[$pref_name_idx] != "")) {
+                $error_message .= preg_match("~^[a-zA-Z.'`\- ]+$~", $vals[$pref_name_idx]) ? "" : "Error in first name column, row #{$row_num}: {$vals[$pref_name_idx]}," . PHP_EOL;
+            }
+
+            //Database password cannot be blank, no check on format
+            if ($use_database) {
+                $error_message .= (isset($vals[5]) && ($vals[5] != "")) ? "" : "Error in password column, row #{$row_num}: cannot be blank," . PHP_EOL;
+            }
 
             $graders_data[] = $vals;
         }
@@ -430,6 +451,12 @@ class UsersController extends AbstractController {
             $grader->setLastName($grader_data[2]);
             $grader->setEmail($grader_data[3]);
             $grader->setGroup($grader_data[4]);
+            if (isset($grader_data[$pref_name_idx]) && ($grader_data[$pref_name_idx] != "")) {
+                $grader->setPreferredFirstName($grader_data[$pref_name_idx]);
+            }
+            if ($use_database) {
+                $grader->setPassword($grader_data[5]);
+            }
             if ($this->core->getQueries()->getSubmittyUser($grader_data[0]) === null) {
                 $this->core->getQueries()->insertSubmittyUser($grader);
             }
@@ -449,6 +476,7 @@ class UsersController extends AbstractController {
 
     public function uploadClassList() {
         $return_url = $this->core->buildUrl(array('component'=>'admin', 'page'=>'users', 'action'=>'students'));
+        $use_database = $this->core->getAuthentication() instanceof DatabaseAuthentication;
 
         if (!$this->core->checkCsrfToken($_POST['csrf_token'])) {
             $this->core->addErrorMessage("Invalid CSRF token");
@@ -464,6 +492,7 @@ class UsersController extends AbstractController {
 
         //Validation and error checking.
         $num_reg_sections = count($this->core->getQueries()->getRegistrationSections());
+        $pref_name_idx = $use_database ? 6 : 5;
         $error_message = "";
         $row_num = 0;
         $students_data = array();
@@ -492,6 +521,16 @@ class UsersController extends AbstractController {
 
             //Student section must be greater than zero (intval($str) returns zero when $str is not integer)
             $error_message .= (($vals[4] > 0 && $vals[4] <= $num_reg_sections) || $vals[4] === null) ? "" : "Error in student section column, row #{$row_num}: {$vals[4]}," . PHP_EOL;
+
+            //Preferred first name must be alpha characters, white-space, or certain punctuation.
+            if (isset($vals[$pref_name_idx]) && ($vals[$pref_name_idx] != "")) {
+                $error_message .= preg_match("~^[a-zA-Z.'`\- ]+$~", $vals[$pref_name_idx]) ? "" : "Error in first name column, row #{$row_num}: {$vals[$pref_name_idx]}," . PHP_EOL;
+            }
+
+            //Database password cannot be blank, no check on format
+            if ($use_database) {
+                $error_message .= (isset($vals[5]) && ($vals[5] != "")) ? "" : "Error in password column, row #{$row_num}: cannot be blank," . PHP_EOL;
+            }
 
             $students_data[] = $vals;
         }
@@ -534,6 +573,12 @@ class UsersController extends AbstractController {
             $student->setEmail($student_data[3]);
             $student->setRegistrationSection($student_data[4]);
             $student->setGroup(4);
+            if (isset($student_data[$pref_name_idx]) && ($student_data[$pref_name_idx] != "")) {
+                $student->setPreferredFirstName($student_data[$pref_name_idx]);
+            }
+            if ($use_database) {
+                $student->setPassword($student_data[5]);
+            }
             if ($this->core->getQueries()->getSubmittyUser($student_data[0]) === null) {
                 $this->core->getQueries()->insertSubmittyUser($student);
             }

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -25,7 +25,7 @@ class Course extends AbstractModel {
      * @param Core  $core
      * @param array $details
      */
-    public function __construct(Core $core, $details, $submitty_path) {
+    public function __construct(Core $core, $details) {
         parent::__construct($core);
 
         $this->semester = $details['semester'];

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -13,7 +13,7 @@ class HomePageView extends AbstractView {
     /*
     *@param List of courses the student is in.
     */
-    public function showHomePage($user, $courses = array(), $changeNameText, $course_display_name) {
+    public function showHomePage($user, $courses = array(), $changeNameText) {
         $displayedFirstName = $user->getDisplayedFirstName();
         $return = <<< HTML
 <div class="content">

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -392,14 +392,14 @@ HTML;
         return $return;
     }
 
-    public function graderListForm() {
+    public function graderListForm($use_database) {
         $return = <<<HTML
 <div class="popup-form" id="grader-list-form">
     <h2>Upload Grader List</h2>
     <p>&emsp;</p>
     <p>
         Format your grader data as an .xlsx or .csv file with 5 columns:<br>
-        &emsp;username, LastName, FirstName, email, GraderGroup<br>
+        &emsp;username, FirstName, LastName, email, GraderGroup<br>
     </p>
     <p>&emsp;</p>
     <p>
@@ -429,14 +429,22 @@ HTML;
         return $return;
     }
 
-    public function classListForm() {
+    public function classListForm($use_database) {
+        if ($use_database) {
+            $num_cols = 7;
+            $password_col = "password, ";
+        }
+        else {
+            $num_cols = 6;
+            $password_col = "";
+        }
         $return = <<<HTML
 <div class="popup-form" id="class-list-form">
     <h2>Upload Classlist</h2>
     <p>&emsp;</p>
     <p>
-        Format your class list as an .xlsx or .csv file with 5 columns:<br>
-        &emsp;username, LastName, FirstName, email, RegistrationSection<br>
+        Format your class list as an .xlsx or .csv file with {$num_cols} columns:<br>
+        &emsp;username, first name, last name, email, registration section, {$password_col}preferred first name<br>
     </p>
     <p>&emsp;</p>
     <p>

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -393,13 +393,21 @@ HTML;
     }
 
     public function graderListForm($use_database) {
+        if ($use_database) {
+            $num_cols = 7;
+            $password_col = "password, ";
+        }
+        else {
+            $num_cols = 6;
+            $password_col = "";
+        }
         $return = <<<HTML
 <div class="popup-form" id="grader-list-form">
     <h2>Upload Grader List</h2>
     <p>&emsp;</p>
     <p>
-        Format your grader data as an .xlsx or .csv file with 5 columns:<br>
-        &emsp;username, FirstName, LastName, email, GraderGroup<br>
+        Format your grader data as an .xlsx or .csv file with {$num_cols} columns:<br>
+        &emsp;username, first name, last name, email, grader group, {$password_col}preferred first name<br>
     </p>
     <p>&emsp;</p>
     <p>
@@ -411,6 +419,7 @@ HTML;
     </p>
     <p>&emsp;</p>
     <p>
+        Preferred first name is optional.<br>
         Do not use a header row.<br>
     </p>
     <br />
@@ -448,6 +457,7 @@ HTML;
     </p>
     <p>&emsp;</p>
     <p>
+        Preferred first name is optional.<br>
         Registration section can be null.<br>
         Do not use a header row.<br>
     </p>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -104,8 +104,6 @@ function newGraderListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#grader-list-form");
     form.css("display", "block");
-    form.css("width", "500px");
-    form.css("margin-left", "-250px");
     $('[name="upload"]', form).val(null);
 }
 
@@ -113,8 +111,6 @@ function newClassListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#class-list-form");
     form.css("display", "block");
-    form.css("width", "500px");
-    form.css("margin-left", "-250px");
     $('[name="move_missing"]', form).prop('checked', false);
     $('[name="upload"]', form).val(null);
 }


### PR DESCRIPTION
Closes #1417 
Usernames are now checked to only contain lowercase alpha characters, underscore and hyphen. No spaces. This is checked when uploading a grader list or class list csv or when creating a user manually through the new student form.

Closes #1423 
There is now a 6th column expected in the grader/class list csv when the course uses database passwords. No restrictions on the format of the passwords but it can not be left blank. There is also an optional column (6th or 7th depending on if database passwords are used) for preferred first name.

Closes #1425 
Leading and trailing spaces are trimmed off of user_id, first name, last name, email, preferred first name when uploading users via csv or the new user form. Spaces are allowed within names, not in user_id or email.