### PR TITLE
No syntax highlighting on text/plain MIME type files

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -157,9 +157,9 @@ class MiscController extends AbstractController {
         }
         else {
             $contents = htmlentities(file_get_contents($_REQUEST['path']), ENT_SUBSTITUTE);
-            if ($_REQUEST['dir'] === "submissions" && $mime_type != "text/plain") {
+            if ($_REQUEST['ta_grading'] === "true") {
                 $filename = htmlentities($_REQUEST['file'], ENT_SUBSTITUTE);
-                $this->core->getOutput()->renderOutput('Misc', 'displayCode', $filename, $contents);
+                $this->core->getOutput()->renderOutput('Misc', 'displayCode', $mime_type, $filename, $contents);
             }
             else {
                 $this->core->getOutput()->renderOutput('Misc', 'displayFile', $contents);

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -157,7 +157,7 @@ class MiscController extends AbstractController {
         }
         else {
             $contents = htmlentities(file_get_contents($_REQUEST['path']), ENT_SUBSTITUTE);
-            if ($_REQUEST['dir'] === "submissions") {
+            if ($_REQUEST['dir'] === "submissions" && $mime_type != "text/plain") {
                 $filename = htmlentities($_REQUEST['file'], ENT_SUBSTITUTE);
                 $this->core->getOutput()->renderOutput('Misc', 'displayCode', $filename, $contents);
             }

--- a/site/app/views/MiscView.php
+++ b/site/app/views/MiscView.php
@@ -12,10 +12,10 @@ class MiscView extends AbstractView {
 HTML;
     }
 
-    private function sourceSettingsJS($filename, $number) {
+    private function sourceSettingsJS($mime_type, $filename, $number) {
         $type = FileUtils::getContentType($filename);
         $number = intval($number);
-        return <<<HTML
+        $return = <<<HTML
     <script>
         var editor{$number} = CodeMirror.fromTextArea(document.getElementById('code{$number}'), {
             lineNumbers: true,
@@ -32,8 +32,15 @@ HTML;
 	        editor{$number}.setSize("100%", "auto");
 	    }
 	    editor{$number}.setOption("theme", "eclipse");
-	    editor{$number}.setOption("mode", "{$type}");
-
+HTML;
+        
+        if ($mime_type != "text/plain") {
+            $return .= <<<HTML
+        editor{$number}.setOption("mode", "{$type}");
+HTML;
+        }
+        
+        $return .= <<<HTML
 	    $("#myTab").find("a").click(function (e) {
 	        e.preventDefault();
 	        $(this).tab("show");
@@ -41,9 +48,10 @@ HTML;
 	    });
     </script>
 HTML;
+        return $return;
     }
 
-    public function displayCode($filename, $file_contents) {
+    public function displayCode($mime_type, $filename, $file_contents) {
         $return = <<<HTML
 <!doctype html>
 <html>
@@ -69,7 +77,7 @@ HTML;
         $return .= <<<HTML
     </textarea>
 HTML;
-		$return .= $this->sourceSettingsJS($filename, 0);
+		$return .= $this->sourceSettingsJS($mime_type, $filename, 0);
         $return .= <<<HTML
 </body>
 </html>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1344,10 +1344,10 @@ HTML;
             else if (url_file.includes("results")) directory = "results";  
             // handle pdf
             if(url_file.substring(url_file.length - 3) == "pdf") {
-                iframe.html("<iframe id='" + iframeId + "' src='{$this->core->getConfig()->getSiteUrl()}&component=misc&page=display_file&dir=" + directory + "&file=" + html_file + "&path=" + url_file + "' width='95%' height='600px' style='border: 0'></iframe>");
+                iframe.html("<iframe id='" + iframeId + "' src='{$this->core->getConfig()->getSiteUrl()}&component=misc&page=display_file&dir=" + directory + "&file=" + html_file + "&path=" + url_file + "&ta_grading=true' width='95%' height='600px' style='border: 0'></iframe>");
             }
             else {
-                iframe.html("<iframe id='" + iframeId + "' onload='resizeFrame(\"" + iframeId + "\");' src='{$this->core->getConfig()->getSiteUrl()}&component=misc&page=display_file&dir=" + directory + "&file=" + html_file + "&path=" + url_file + "' width='95%' style='border: 0'></iframe>");
+                iframe.html("<iframe id='" + iframeId + "' onload='resizeFrame(\"" + iframeId + "\");' src='{$this->core->getConfig()->getSiteUrl()}&component=misc&page=display_file&dir=" + directory + "&file=" + html_file + "&path=" + url_file + "&ta_grading=true' width='95%' style='border: 0'></iframe>");
             }
             iframe.addClass('open');
         }
@@ -1383,7 +1383,7 @@ HTML;
         directory = "";
         if (url_file.includes("submissions")) directory = "submissions";
         else if (url_file.includes("results")) directory = "results";
-        window.open("{$this->core->getConfig()->getSiteUrl()}&component=misc&page=display_file&dir=" + directory + "&file=" + html_file + "&path=" + url_file,"_blank","toolbar=no,scrollbars=yes,resizable=yes, width=700, height=600");
+        window.open("{$this->core->getConfig()->getSiteUrl()}&component=misc&page=display_file&dir=" + directory + "&file=" + html_file + "&path=" + url_file + "&ta_grading=true","_blank","toolbar=no,scrollbars=yes,resizable=yes, width=700, height=600");
         return false;
     }
 </script>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -552,10 +552,10 @@ HTML;
                         }
                         // get the full filename for PDF popout
                         // add "timestamp / full filename" to count_array so that path to each filename is to the full PDF, not the cover
-                        $url = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename."&path=".$path;
+                        $url = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename."&path=".$path."&ta_grading=true";
                         $filename_full = str_replace("_cover.pdf", ".pdf", $filename);
                         $path_full = str_replace("_cover.pdf", ".pdf", $path);
-                        $url_full = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename_full."&path=".$path_full;
+                        $url_full = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename_full."&path=".$path_full."&ta_grading=true";
                         $count_array[$count] = FileUtils::joinPaths($timestamp, $filename_full);
                         $return .= <<<HTML
             <tr class="tr tr-vertically-centered">

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -552,10 +552,10 @@ HTML;
                         }
                         // get the full filename for PDF popout
                         // add "timestamp / full filename" to count_array so that path to each filename is to the full PDF, not the cover
-                        $url = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename."&path=".$path."&ta_grading=true";
+                        $url = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename."&path=".$path."&ta_grading=false";
                         $filename_full = str_replace("_cover.pdf", ".pdf", $filename);
                         $path_full = str_replace("_cover.pdf", ".pdf", $path);
-                        $url_full = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename_full."&path=".$path_full."&ta_grading=true";
+                        $url_full = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename_full."&path=".$path_full."&ta_grading=false";
                         $count_array[$count] = FileUtils::joinPaths($timestamp, $filename_full);
                         $return .= <<<HTML
             <tr class="tr tr-vertically-centered">


### PR DESCRIPTION
Closes #1447 

No syntax highlighting will be enabled when viewing files with a MIME type of "text/plain" in the submissions and results browser on the TA grading page.