### PR TITLE
Instructor Team Editing Bug Fix

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -490,18 +490,19 @@ HTML;
                     if ($this->core->getUser()->accessAdmin()) {
                         $return .= <<<HTML
 
-                <td><a onclick='adminTeamForm(true, "{$row->getUser()->getId()}", "{$display_section}", [], {$gradeable->getMaxTeamSize()});'>
-                    <i class="fa fa-pencil" aria-hidden="true"></i></a></td>
 HTML;
                         if($row->getTeam()=== null) {
                             $return .= <<<HTML
-
+                <td><a onclick='adminTeamForm(true, "{$row->getUser()->getId()}", "{$display_section}", [], {$gradeable->getMaxTeamSize()});'>
+                    <i class="fa fa-pencil" aria-hidden="true"></i></a></td>
                 <td></td>
 HTML;
                         }
                         else {
+                            $members = json_encode($row->getTeam()->getMembers());
                             $return .= <<<HTML
-
+                <td><a onclick='adminTeamForm(false, "{$row->getTeam()->getId()}", "{$display_section}", {$members}, {$gradeable->getMaxTeamSize()});'>
+                    <i class="fa fa-pencil" aria-hidden="true"></i></a></td>
                 <td>{$row->getTeam()->getId()}</td>
 HTML;
                         }


### PR DESCRIPTION
A bug got introduced somewhere along the line causing instructor team editing to attempt to create a new team for one of the team members rather than editing their current one. Small fix.