### PR TITLE
Travis-CI removed Python 3.6, use 3.6 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,7 @@ before_install:
   - jdk_switcher use default
   # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
   - unset _JAVA_OPTIONS
-  - if [ ! $(pyenv versions | grep -oP "3.6.[0-9]") ]; then exit 1; fi;
-  - exit 1
+  - if [ $(pyenv versions | grep -oP "3.6.[0-9]") ]; then echo "Python 3.6 is back on Travis. Update the following line to use it or remove this one to keep using 3.5."; exit 1; fi;
   - PY_VERSION_3=$(pyenv versions | grep -oP "3.5.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,7 @@ before_install:
   - jdk_switcher use default
   # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
   - unset _JAVA_OPTIONS
-  - if [ $(pyenv versions | grep -oP "3.6.[0-9]") ]; then echo "Python 3.6 is back on Travis. Update the following line to use it or remove this one to keep using 3.5."; exit 1; fi;
-  - PY_VERSION_3=$(pyenv versions | grep -oP "3.5.[0-9]")
+  - PY_VERSION_3=$(pyenv versions | grep -oP "3.6.[0-9]" || pyenv versions | grep -oP "3.5.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
   - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ before_install:
   - jdk_switcher use default
   # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
   - unset _JAVA_OPTIONS
+  - ls -la /opt
+  - pyenv version
   - PY_VERSION_3=$(pyenv versions | grep -oP "3.6.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ before_install:
   - jdk_switcher use default
   # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
   - unset _JAVA_OPTIONS
-  - ls -la /opt/python
-  - pyenv versions
-  - PY_VERSION_3=$(pyenv versions | grep -oP "3.6.[0-9]")
+  - if [ ! $(pyenv versions | grep -oP "3.6.[0-9]") ]; then exit 1; fi;
+  - exit 1
+  - PY_VERSION_3=$(pyenv versions | grep -oP "3.5.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
   - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - jdk_switcher use default
   # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
   - unset _JAVA_OPTIONS
-  - PY_VERSION_3=$(ls /opt/python | grep "3.6.[0-9]")
+  - PY_VERSION_3=$(pyenv versions | grep -oP "3.6.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"
   - sudo sed -e "s?secure_path=\"?secure_path=\"/opt/python/${PY_VERSION_3}/bin:${PATH}:?g" --in-place /etc/sudoers

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ before_install:
   - jdk_switcher use default
   # we have to unset this as the JVM will print a message on STDERR on any execution if this is set because somehow that makes sense I guess
   - unset _JAVA_OPTIONS
-  - ls -la /opt
-  - pyenv version
+  - ls -la /opt/python
+  - pyenv versions
   - PY_VERSION_3=$(pyenv versions | grep -oP "3.6.[0-9]")
   - pyenv global ${PY_VERSION_3}
   - export PATH="$PATH:$HOME/.composer/vendor/bin:/usr/bin"


### PR DESCRIPTION
No idea why Travis all of a sudden removed several python versions (including 3.6). Added code to try and use 3.6, but fallback to 3.5 if that's unavailable.