### PR TITLE
Archiving files / displaying .jpg / (temporarily) comment out broken late days

### DIFF
--- a/bin/grade_item.py
+++ b/bin/grade_item.py
@@ -466,9 +466,6 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
         shutil.move(os.path.join(tmp,"OLD_RESULTS"),
                     os.path.join(results_path,"OLD"))
 
-    shutil.copytree(tmp_logs,os.path.join(results_path,"logs"))
-    shutil.copy(os.path.join(tmp_work,"results.json"),results_path)
-    shutil.copy(os.path.join(tmp_work,"grade.txt"),results_path)
     os.makedirs(os.path.join(results_path,"details"))
 
     patterns_work_to_details = complete_config_obj["autograding"]["work_to_details"]
@@ -483,6 +480,9 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
         
     grading_finished = dateutils.get_current_time()
 
+    shutil.copy(os.path.join(tmp_work,"results.json"),results_path)
+    shutil.copy(os.path.join(tmp_work,"grade.txt"),results_path)
+
     # -------------------------------------------------------------
     # create/append to the results history
 
@@ -496,9 +496,7 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
     grading_began_longstring = dateutils.write_submitty_date(grading_began)
     grading_finished_longstring = dateutils.write_submitty_date(grading_finished)
 
-
     gradingtime = int((grading_finished-grading_began).total_seconds())
-
 
     write_grade_history.just_write_grade_history(history_file,
                                                  gradeable_deadline_longstring,
@@ -529,14 +527,17 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
     grade_items_logging.log_message(is_batch_job,which_untrusted,submission_path,"grade:",gradingtime,grade_result)
 
     with open(os.path.join(tmp_logs,"overall.txt"),'a') as f:
-        f.write("finished")
-            
-            
+        f.write("FINISHED GRADING!")
+
+    # save the logs!
+    shutil.copytree(tmp_logs,os.path.join(results_path,"logs"))
+
+
     # --------------------------------------------------------------------
     # REMOVE TEMP DIRECTORY
     shutil.rmtree(tmp)
 
-    
+
 # ==================================================================================
 # ==================================================================================
 if __name__ == "__main__":

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -100,9 +100,12 @@ class DiffViewer {
         }
         else if ($actual_file != "") {
             // TODO: fix this hacky way to deal with images
-	        if (substr($actual_file,strlen($actual_file)-4,4) == ".png") {
-	            $this->actual_file_image = $actual_file;
-            }
+	    if ( (substr($actual_file,strlen($actual_file)-4,4) == ".png") ||
+		 (substr($actual_file,strlen($actual_file)-4,4) == ".jpg") ||
+		 (substr($actual_file,strlen($actual_file)-4,4) == ".jpeg") )
+	      {
+		$this->actual_file_image = $actual_file;
+	      }
             else {
                 $this->actual = file_get_contents($actual_file);
                 $this->has_actual = trim($this->actual) !== "" ? true: false;
@@ -116,9 +119,12 @@ class DiffViewer {
         }
         else if ($expected_file != "") {
             //TODO: fix this hacky way to deal with images.
-            if (substr($expected_file,strlen($expected_file)-4,4) == ".png") {
+            if ( (substr($expected_file,strlen($expected_file)-4,4) == ".png") ||
+		 (substr($expected_file,strlen($expected_file)-4,4) == ".jpg") ||
+		 (substr($expected_file,strlen($expected_file)-4,4) == ".jpeg") )
+	      {
                 $this->expected_file_image = $expected_file;
-            }
+	      }
             else{
                 $this->expected = file_get_contents($expected_file);
                 $this->has_expected = trim($this->expected) !== "" ? true : false;
@@ -132,9 +138,11 @@ class DiffViewer {
         }
         else if ($image_difference != "") {
             //TODO: fix this hacky way to deal with images.
-            if (substr($image_difference,strlen($image_difference)-4,4) == ".png") {
-                $this->difference_file_image = $image_difference;
-            }
+	  if ( (substr($image_difference,strlen($image_difference)-4,4) == ".png") ||
+	       (substr($image_difference,strlen($image_difference)-4,4) == ".jpg") ||
+	       (substr($image_difference,strlen($image_difference)-4,4) == ".jpeg") ){
+	    $this->difference_file_image = $image_difference;
+	  }
         }
 
         if (!file_exists($diff_file) && $diff_file != "") {

--- a/site/app/models/GradeSummary.php
+++ b/site/app/models/GradeSummary.php
@@ -150,7 +150,7 @@ class GradeSummary extends AbstractModel {
          * that isn't to say that there might not be a benefit in the future to user chunking.
          */
         $size_of_user_id_chunks = count($user_ids);
-        $size_of_gradeable_id_chunks = 5;
+        $size_of_gradeable_id_chunks = 1; //5;
 
         $ldu = new LateDaysCalculation($this->core);
         $student_output_json = array();

--- a/site/app/models/HWReport.php
+++ b/site/app/models/HWReport.php
@@ -88,10 +88,10 @@ class HWReport extends AbstractModel {
                 $student_output_text_main .= "  Contact your TA or instructor if you believe this is an error".$nl.$nl;
             }
             if($late_days['late_days_charged'] > 0) {
-                $student_output_text_main .= "Number of late days used for this homework: " . $late_days['late_days_charged'] . $nl;
+//                $student_output_text_main .= "Number of late days used for this homework: " . $late_days['late_days_charged'] . $nl;
             }
-            $student_output_text_main .= "Total late days used this semester: " . $late_days['total_late_used'] . " (up to and including this assignment)" . $nl;
-            $student_output_text_main .= "Late days remaining for the semester: " . $late_days['remaining_days'] . " (as of the due date of this homework)" . $nl;
+//            $student_output_text_main .= "Total late days used this semester: " . $late_days['total_late_used'] . " (up to and including this assignment)" . $nl;
+//            $student_output_text_main .= "Late days remaining for the semester: " . $late_days['remaining_days'] . " (as of the due date of this homework)" . $nl;
             
             $student_output_text_main .= "----------------------------------------------------------------------" . $nl;
 

--- a/site/app/models/HWReport.php
+++ b/site/app/models/HWReport.php
@@ -77,22 +77,28 @@ class HWReport extends AbstractModel {
             // TODO: add functionality to choose who regrade requests will be sent to
             $student_output_text_main .= $nl;
             $student_output_text_main .= "Any regrade requests are due within 7 days of posting to: ".$name_and_emails.$nl;
-            if($gradeable->getDaysLate() > 0) {
-                $student_output_text_main .= "This submission was submitted ".$gradeable->getDaysLate()." day(s) after the due date.".$nl;
-            }
+//            if($gradeable->getDaysLate() > 0) {
+//                $student_output_text_main .= "This submission was submitted ".$gradeable->getDaysLate()." day(s) after the due date.".$nl;
+//            }
+
+//	    $student_output_text_main .= "DEBUGGING LATE DAYS..  THE INFORMATION BELOW MAY BE INCORRECT - PLEASE CHECK BACK LATER".$nl;
+    	    $student_output_text_main .= "DEBUGGING LATE DAYS..   PLEASE CHECK BACK LATER".$nl;
+
             if($late_days['extensions'] > 0) {
-                $student_output_text_main .= "You have a ".$late_days['extensions']." day extension on this assignment.".$nl;
+//                $student_output_text_main .= "You have a ".$late_days['extensions']." day extension on this assignment.".$nl;
             }
             if(substr($late_days['status'], 0, 3) == 'Bad') {
                 $student_output_text_main .= "NOTE: THIS ASSIGNMENT WILL BE RECORDED AS ZERO".$nl;
                 $student_output_text_main .= "  Contact your TA or instructor if you believe this is an error".$nl.$nl;
             }
-            if($late_days['late_days_charged'] > 0) {
+//            if($late_days['late_days_charged'] > 0) {
 //                $student_output_text_main .= "Number of late days used for this homework: " . $late_days['late_days_charged'] . $nl;
-            }
+//            }
 //            $student_output_text_main .= "Total late days used this semester: " . $late_days['total_late_used'] . " (up to and including this assignment)" . $nl;
 //            $student_output_text_main .= "Late days remaining for the semester: " . $late_days['remaining_days'] . " (as of the due date of this homework)" . $nl;
-            
+
+//	    $student_output_text_main .= "END DEBUGGING LATE DAYS".$nl;
+
             $student_output_text_main .= "----------------------------------------------------------------------" . $nl;
 
             if($gradeable->validateVersions()) {


### PR DESCRIPTION
Archiving of files from autograding was buggy.
Autograding log files were incomplete (copied before they were done).
Now we display .jpg images (previously only .png) to the students and graders.
Late days on hw reports are buggy, comment them out until they are debugged.