### PR TITLE
implement ability to send chunk of users to generate late day model

### DIFF
--- a/site/app/libraries/database/DatabaseQueriesPostgresql.php
+++ b/site/app/libraries/database/DatabaseQueriesPostgresql.php
@@ -548,10 +548,19 @@ ORDER BY egd.g_version", array($g_id, $user_id));
     // Moved from class LateDaysCalculation on port from TAGrading server.  May want to incorporate late day information into gradeable object rather than having a separate query 
     public function getLateDayUpdates($user_id) {
         if($user_id != null) {
-          $this->course_db->query("SELECT * FROM late_days WHERE user_id=?", array($user_id));
+            $query = "SELECT * FROM late_days WHERE user_id";
+            if (is_array($user_id)) {
+                $query .= ' IN ('.implode(',', array_fill(0, count($user_id), '?')).')';
+                $params = $user_id;
+            }
+            else {
+                $query .= '=?';
+                $params = array($user_id);
+            }
+            $this->course_db->query($query, $params);
         }
         else {
-          $this->course_db->query("SELECT * FROM late_days");
+            $this->course_db->query("SELECT * FROM late_days");
         }
         return $this->course_db->rows();
     }
@@ -618,8 +627,14 @@ ORDER BY egd.g_version", array($g_id, $user_id));
                       ON submissions.g_id = lde.g_id 
                       AND submissions.user_id = lde.user_id";
         if($user_id !== null) {
-          $query .= " WHERE submissions.user_id=?";
-          $params[] = $user_id;
+            if (is_array($user_id)) {
+                $query .= " WHERE submissions.user_id IN (".implode(", ", array_fill(0, count($user_id), '?')).")";
+                $params = array_merge($params, $user_id);
+            }
+            else {
+                $query .= " WHERE submissions.user_id=?";
+                $params[] = $user_id;
+            }
         }
         $this->course_db->query($query, $params);
         return $this->course_db->rows();

--- a/site/app/models/GradeSummary.php
+++ b/site/app/models/GradeSummary.php
@@ -149,7 +149,7 @@ class GradeSummary extends AbstractModel {
          * There isn't any memory advantage right now to doing smaller chunks of users, but
          * that isn't to say that there might not be a benefit in the future to user chunking.
          */
-        $size_of_user_id_chunks = count($user_ids);
+        $size_of_user_id_chunks = count($user_ids) / 2;
         $size_of_gradeable_id_chunks = 5;
 
         $student_output_json = array();
@@ -157,9 +157,9 @@ class GradeSummary extends AbstractModel {
         $gradeable_id_chunks = array_chunk($gradeable_ids,$size_of_gradeable_id_chunks);
         $user_id_chunks = array_chunk($user_ids,$size_of_user_id_chunks);
         foreach($user_id_chunks as $user_id_chunk) {
+            $ldu = new LateDaysCalculation($this->core, $user_id_chunk);
             foreach ($gradeable_id_chunks as $gradeable_id_chunk) {
                 $summary_data = $this->core->getQueries()->getGradeables($gradeable_id_chunk, $user_id_chunk);
-                $ldu = new LateDaysCalculation($this->core, $user_id_chunk);
                 //Logger::debug("Got gradeables " . implode(",", $gradeable_id_chunk) . " for users " . implode(",",$user_id_chunk));
                 $this->generateSummariesFromQueryResults($student_output_json, $buckets, $summary_data, $ldu);
                 //Logger::debug("Current memory usage: " . memory_get_usage(false) . " True memory usage: " . memory_get_usage(true));

--- a/site/app/models/GradeSummary.php
+++ b/site/app/models/GradeSummary.php
@@ -150,9 +150,8 @@ class GradeSummary extends AbstractModel {
          * that isn't to say that there might not be a benefit in the future to user chunking.
          */
         $size_of_user_id_chunks = count($user_ids);
-        $size_of_gradeable_id_chunks = 1; //5;
+        $size_of_gradeable_id_chunks = 5;
 
-        $ldu = new LateDaysCalculation($this->core);
         $student_output_json = array();
         $buckets = array();
         $gradeable_id_chunks = array_chunk($gradeable_ids,$size_of_gradeable_id_chunks);
@@ -160,6 +159,7 @@ class GradeSummary extends AbstractModel {
         foreach($user_id_chunks as $user_id_chunk) {
             foreach ($gradeable_id_chunks as $gradeable_id_chunk) {
                 $summary_data = $this->core->getQueries()->getGradeables($gradeable_id_chunk, $user_id_chunk);
+                $ldu = new LateDaysCalculation($this->core, $user_id_chunk);
                 //Logger::debug("Got gradeables " . implode(",", $gradeable_id_chunk) . " for users " . implode(",",$user_id_chunk));
                 $this->generateSummariesFromQueryResults($student_output_json, $buckets, $summary_data, $ldu);
                 //Logger::debug("Current memory usage: " . memory_get_usage(false) . " True memory usage: " . memory_get_usage(true));

--- a/site/app/models/GradeSummary.php
+++ b/site/app/models/GradeSummary.php
@@ -149,7 +149,7 @@ class GradeSummary extends AbstractModel {
          * There isn't any memory advantage right now to doing smaller chunks of users, but
          * that isn't to say that there might not be a benefit in the future to user chunking.
          */
-        $size_of_user_id_chunks = count($user_ids) / 2;
+        $size_of_user_id_chunks = ceil(count($user_ids) / 2);
         $size_of_gradeable_id_chunks = 5;
 
         $student_output_json = array();

--- a/site/app/models/HWReport.php
+++ b/site/app/models/HWReport.php
@@ -206,17 +206,20 @@ class HWReport extends AbstractModel {
     public function generateAllReports() {
         $students = $this->core->getQueries()->getAllUsers();
         $stu_ids = array_map(function($stu) {return $stu->getId();}, $students);
-        $gradeables = $this->core->getQueries()->getGradeables(null, $stu_ids, "registration_section", "u.user_id", 0);
-        $graders = $this->core->getQueries()->getAllGraders();
-        $ldu = new LateDaysCalculation($this->core);
-        foreach($gradeables as $gradeable) {
-            $this->generateReport($gradeable, $ldu);
+        $size_of_stu_id_chunks = ceil(count($stu_ids) / 2);
+        $stu_chunks = array_chunk($stu_ids, $size_of_stu_id_chunks);
+
+        foreach ($stu_chunks as $stu_chunk) {
+            $gradeables = $this->core->getQueries()->getGradeables(null, $stu_chunk, "registration_section");
+            $ldu = new LateDaysCalculation($this->core, $stu_chunk);
+            foreach($gradeables as $gradeable) {
+                $this->generateReport($gradeable, $ldu);
+            }
         }
     }
     
     public function generateSingleReport($student_id, $gradeable_id) {
-        $gradeables = $this->core->getQueries()->getGradeables($gradeable_id, $student_id, "registration_section", "u.user_id", 0);
-        $graders = $this->core->getQueries()->getAllGraders();
+        $gradeables = $this->core->getQueries()->getGradeables($gradeable_id, $student_id, "registration_section");
         $ldu = new LateDaysCalculation($this->core, $student_id);
         foreach($gradeables as $gradeable) {
             $this->generateReport($gradeable, $ldu);
@@ -226,17 +229,20 @@ class HWReport extends AbstractModel {
     public function generateAllReportsForGradeable($g_id) {
         $students = $this->core->getQueries()->getAllUsers();
         $stu_ids = array_map(function($stu) {return $stu->getId();}, $students);
-        $gradeables = $this->core->getQueries()->getGradeables($g_id, $stu_ids, "registration_section", "u.user_id", 0);
-        $graders = $this->core->getQueries()->getAllGraders();
-        $ldu = new LateDaysCalculation($this-core);
-        foreach($gradeables as $gradeable) {
-            $this->generateReport($gradeable, $ldu);
+        $size_of_stu_id_chunks = ceil(count($stu_ids) / 2);
+        $stu_chunks = array_chunk($stu_ids, $size_of_stu_id_chunks);
+
+        foreach ($stu_chunks as $stu_chunk) {
+            $gradeables = $this->core->getQueries()->getGradeables($g_id, $stu_chunk, "registration_section");
+            $ldu = new LateDaysCalculation($this->core, $stu_chunk);
+            foreach($gradeables as $gradeable) {
+                $this->generateReport($gradeable, $ldu);
+            }
         }
     }
     
     public function generateAllReportsForStudent($stu_id) {
         $gradeables = $this->core->getQueries()->getGradeables(null, $stu_id, "registration_section", "u.user_id", 0);
-        $graders = $this->core->getQueries()->getAllGraders();
         $ldu = new LateDaysCalculation($this->core, $stu_id);
         foreach($gradeables as $gradeable) {
             $this->generateReport($gradeable, $ldu);


### PR DESCRIPTION
This should (hopefully) fix the memory overflow when trying to generate the grade summaries. If that is not the case, you can continue to shrink the size of `$size_of_user_id_chunks` (and `$size_of_gradeable_id_chunks` as necessary) to hit a happy medium for now.