### PR TITLE
add check for empty post request

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -593,9 +593,13 @@ class SubmissionController extends AbstractController {
      * Function for uploading a submission to the server. This should be called via AJAX, saving the result
      * to the json_buffer of the Output object, returning a true or false on whether or not it suceeded or not.
      *
-     * @return boolean
+     * @return array
      */
     private function ajaxUploadSubmission() {
+        if (empty($_POST)) {
+            $max_size = ini_get('post_max_size');
+            return $this->uploadResult("Empty POST request. This may mean that the sum size of your files are greater than {$max_size}.", false);
+        }
         if (!isset($_POST['csrf_token']) || !$this->core->checkCsrfToken($_POST['csrf_token'])) {
             return $this->uploadResult("Invalid CSRF token.", false);
         }

--- a/tests/unitTests/app/controllers/submission/SubmissionControllerTester.php
+++ b/tests/unitTests/app/controllers/submission/SubmissionControllerTester.php
@@ -726,6 +726,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertFileExists(FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_interactive", $touch_file));
     }
 
+    public function testNoPost() {
+        $_POST = array();
+        $return = $this->runController();
+        $this->assertTrue($return['error']);
+        $this->assertRegExp("/Empty POST request. This may mean that the sum size of your files are greater than [0-9]*M./", $return['message']);
+        $this->assertFalse($return['success']);
+    }
+
     public function testErrorNotSetCsrfToken() {
         $_POST['csrf_token'] = null;
         $return = $this->runController();

--- a/tests/unitTests/app/controllers/submission/SubmissionControllerTester.php
+++ b/tests/unitTests/app/controllers/submission/SubmissionControllerTester.php
@@ -726,7 +726,7 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertFileExists(FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_interactive", $touch_file));
     }
 
-    public function testNoPost() {
+    public function testEmptyPost() {
         $_POST = array();
         $return = $this->runController();
         $this->assertTrue($return['error']);


### PR DESCRIPTION
Adds a better error message for when a student tries to upload way too large (or way too many) files that kills the `$_POST` superglobal.

Closes #1514