### PR TITLE
Fixes TA grading tiles hiding behind header

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -29,8 +29,8 @@ $(document).ready(function(){
     }
 
     $('body').css({'position':'fixed', 'width':'100%'});
-    $('#header').css({'position':'fixed', 'z-index':'1'});
-    $('#footer').css({'position':'fixed', 'z-index':'1'});
+    $('#header').css({'position':'fixed', 'z-index':'-1'});
+    $('#footer').css({'position':'fixed', 'z-index':'-1'});
 
     calculatePercentageTotal();
     var progressbar = $(".progressbar"),


### PR DESCRIPTION
[ partially addresses ] #1493, the tiles no longer hide behind the header when advancing or returning to a student using the arrow buttons. Should revisit if there is a better location to where the grading_toolbar should be put. 