### PR TITLE
fix single quotes being used on filenames

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -195,7 +195,7 @@ class MiscController extends AbstractController {
         $this->core->getOutput()->useFooter(false);
         header('Content-Type: application/octet-stream');
         header("Content-Transfer-Encoding: Binary"); 
-        header("Content-disposition: attachment; filename='{$_REQUEST['file']}'");
+        header("Content-disposition: attachment; filename=\"{$_REQUEST['file']}\"");
         readfile($_REQUEST['path']);
     }
 


### PR DESCRIPTION
As per the spec on content-disposition, on the filename attribute, single-quotes are thought to be part of the actual filename, and not act as boundaries except on Chrome, where they're stripped (see [relevant bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=179825)).

This should fix it so that all browsers now download the file with its name as-is.

Closes #1538