### PR TITLE
Display Student Preferred Name Throughout the System

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -963,13 +963,13 @@ HTML;
                 foreach ($gradeable->getTeam()->getMembers() as $team_member) {
                     $team_member = $this->core->getQueries()->getUserById($team_member);
                     $return .= <<<HTML
-                &emsp;{$team_member->getFirstName()} {$team_member->getLastName()} ({$team_member->getId()})<br/>
+                &emsp;{$team_member->getDisplayedFirstName()} {$team_member->getLastName()} ({$team_member->getId()})<br/>
 HTML;
                 }
             }
             else {
                 $return .= <<<HTML
-                <b>{$user->getFirstName()} {$user->getLastName()} ({$user->getId()})<br/>
+                <b>{$user->getDisplayedFirstName()} {$user->getLastName()} ({$user->getId()})<br/>
 HTML;
             }
 

--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -54,7 +54,7 @@ HTML;
         foreach ($team->getMembers() as $teammate) {
             $teammate = $this->core->getQueries()->getUserById($teammate);
             $return .= <<<HTML
-        <span>&emsp;{$teammate->getFirstName()} {$teammate->getLastName()} ({$teammate->getId()}) - {$teammate->getEmail()}</span> <br />
+        <span>&emsp;{$teammate->getDisplayedFirstName()} {$teammate->getLastName()} ({$teammate->getId()}) - {$teammate->getEmail()}</span> <br />
 HTML;
         }
         //Team invitations status


### PR DESCRIPTION
Addresses Issue #1563

This change updates the last places in the php code where a student's legal name is being displayed rather than their preferred name. To the best of my knowledge, this has been addressed everywhere in the main Submitty system.