### PR TITLE
Fix Errant "Version Conflict" Message When a Submission is not Fully Graded

### DIFF
--- a/site/app/models/Gradeable.php
+++ b/site/app/models/Gradeable.php
@@ -996,6 +996,37 @@ class Gradeable extends AbstractModel {
         
     }
 
+    public function isFullyGraded()
+    {
+        if($this->peer_grading) {
+            foreach($this->components as $cmpt) {
+                if(is_array($cmpt)) {
+                    foreach($cmpt as $graded_by) {
+                        if($graded_by->getGradedVersion() == -1) {
+                            return false;
+                        }
+                    }
+                }
+                else {
+                    if($cmpt->getGradedVersion() == -1) {
+                        if($cmpt->getTitle() != "Grading Complete"){
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        else {
+            foreach($this->components as $component) {
+                if($component->getGradedVersion() == -1) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
     //save all the information in this gradeable and the gradeable components. Used in tests and text/numeric where the whole gradeable is saved at the same time rather than by component
     public function saveData() {
         $this->core->getCourseDB()->beginTransaction();

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -584,10 +584,15 @@ HTML;
                     $btn_class = "btn-default";
                     if($row->validateVersions()) {
                         $contents = "{$row->getGradedTAPoints()}&nbsp;/&nbsp;{$row->getTotalTANonExtraCreditPoints()}";
-			$graded += $row->getGradedTAPoints();
+			            $graded += $row->getGradedTAPoints();
                     }
                     else{
-                        $contents = "Version Conflict";
+                        if(!$row->isFullyGraded()){
+                            $contents = "Not Fully Graded";
+                        }
+                        else{
+                            $contents = "Version Conflict";
+                        }
                     }
                 }
                 else {

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -588,7 +588,7 @@ HTML;
                     }
                     else{
                         if(!$row->isFullyGraded()){
-                            $contents = "Not Fully Graded";
+                            $contents = "Grading Incomplete";
                         }
                         else{
                             $contents = "Version Conflict";


### PR DESCRIPTION
Addresses #1485

On the grading index page, if an assignment was only partially graded, the system was classifying it as experiencing a version conflict. This fix adds a function to evaluate whether a submission is actually in a version conflict or if it is just partially ungraded. If it is partially ungraded, the text "Not Fully Graded" is displayed instead of "Version Conflict." It would be trivial to change the text to something else (line 591 of ElectronicGraderView).