### PR TITLE
fix bug where password could be set to something impossible to use

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -41,7 +41,7 @@ class HomePageController extends AbstractController {
 
     public function changePassword(){
         $user = $this->core->getUser();
-        if(isset($_POST['new_password']) && isset($_POST['confirm_new_password'])
+        if(!empty($_POST['new_password']) && !empty($_POST['confirm_new_password'])
             && $_POST['new_password'] == $_POST['confirm_new_password']) {
             $user->setPassword($_POST['new_password']);
             $this->core->getQueries()->updateUser($user);

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -133,7 +133,7 @@ class UsersController extends AbstractController {
             $error_message .= User::validateUserData('user_preferred_firstname', trim($_POST['user_preferred_firstname'])) ? "" : "Error in preferred first name: \"".strip_tags($_POST['user_preferred_firstname'])."\"<br>";
         }
         //Database password cannot be blank, no check on format
-        if ($use_database) {
+        if ($use_database && !empty($_POST['user_password'])) {
             $error_message .= User::validateUserData('user_password', $_POST['user_password']) ? "" : "Error must enter password for user<br>";
         }
 
@@ -164,7 +164,8 @@ class UsersController extends AbstractController {
 
         $user->setLastName(trim($_POST['user_lastname']));
         $user->setEmail(trim($_POST['user_email']));
-        if (isset($_POST['user_password'])) {
+
+        if (!empty($_POST['user_password'])) {
             $user->setPassword($_POST['user_password']);
         }
 

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -133,7 +133,7 @@ class UsersController extends AbstractController {
             $error_message .= User::validateUserData('user_preferred_firstname', trim($_POST['user_preferred_firstname'])) ? "" : "Error in preferred first name: \"".strip_tags($_POST['user_preferred_firstname'])."\"<br>";
         }
         //Database password cannot be blank, no check on format
-        if ($use_database && !empty($_POST['user_password'])) {
+        if ($use_database && (($_POST['edit_user'] == 'true' && !empty($_POST['user_password'])) || $_POST['edit_user'] != 'true')) {
             $error_message .= User::validateUserData('user_password', $_POST['user_password']) ? "" : "Error must enter password for user<br>";
         }
 

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -114,18 +114,23 @@ VALUES (?,?,?,?,?,?)", $params);
     }
 
     public function updateUser(User $user, $semester=null, $course=null) {
-        $array = array($user->getPassword(), $user->getFirstName(), $user->getPreferredFirstName(),
+        $params = array($user->getFirstName(), $user->getPreferredFirstName(),
                        $user->getLastName(), $user->getEmail(),
                        $this->submitty_db->convertBoolean($user->isUserUpdated()),
-                       $this->submitty_db->convertBoolean($user->isInstructorUpdated()),
-                       $user->getId());
+                       $this->submitty_db->convertBoolean($user->isInstructorUpdated()));
+        $extra = "";
+        if (!empty($user->getPassword())) {
+            $params[] = $user->getPassword();
+            $extra = ", user_password=?";
+        }
+        $params[] = $user->getId();
+
         $this->submitty_db->query("
 UPDATE users 
 SET 
-  user_password=?, user_firstname=?, user_preferred_firstname=?, user_lastname=?, 
-  user_email=?, user_updated=?, instructor_updated=?
-WHERE user_id=?", $array);
-
+  user_firstname=?, user_preferred_firstname=?, user_lastname=?, 
+  user_email=?, user_updated=?, instructor_updated=?{$extra}
+WHERE user_id=?", $params);
 
         if (!empty($semester) && !empty($course)) {
             $params = array($user->getGroup(), $user->getRegistrationSection(),

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -170,12 +170,14 @@ class User extends AbstractModel {
     }
 
     public function setPassword($password) {
-        $info = password_get_info($password);
-        if ($info['algo'] === 0) {
-            $this->password = password_hash($password, PASSWORD_DEFAULT);
-        }
-        else {
-            $this->password = $password;
+        if (!empty($password)) {
+            $info = password_get_info($password);
+            if ($info['algo'] === 0) {
+                $this->password = password_hash($password, PASSWORD_DEFAULT);
+            }
+            else {
+                $this->password = $password;
+            }
         }
     }
 


### PR DESCRIPTION
This should fix it where it's possible for a user to have `null` or `""` be set as their password (either directly in the DB as well as taking the password_hash of `null` `""`.