### PR TITLE
Decrease load time when grading successive students

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -514,14 +514,12 @@ class ElectronicGraderController extends AbstractController {
         }
         else if ($gradeable->isGradeByRegistration()) {
             $section_key = "registration_section";
+            $sections = $this->core->getUser()->getGradingRegistrationSections();
             if ($this->core->getUser()->accessAdmin() && $sections == null) {
                 $sections = $this->core->getQueries()->getRegistrationSections();
                 for ($i = 0; $i < count($sections); $i++) {
                     $sections[$i] = $sections[$i]['sections_registration_id'];
                 }
-            }
-            else{
-                $sections = $this->core->getUser()->getGradingRegistrationSections();
             }
             $users_to_grade = $this->core->getQueries()->getUsersByRegistrationSections($sections,$orderBy="registration_section,user_id;");
             $total = array_sum($this->core->getQueries()->getTotalUserCountByGradingSections($sections, 'registration_section'));
@@ -529,14 +527,12 @@ class ElectronicGraderController extends AbstractController {
         }
         else {
             $section_key = "rotating_section";
+            $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id, $this->core->getUser()->getId());
             if ($this->core->getUser()->accessAdmin() && $sections == null) {
                 $sections = $this->core->getQueries()->getRotatingSections();
                 for ($i = 0; $i < count($sections); $i++) {
                     $sections[$i] = $sections[$i]['sections_rotating_id'];
                 }
-            }
-            else{
-                $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id, $this->core->getUser()->getId());
             }
             $users_to_grade = $this->core->getQueries()->getUsersByRotatingSections($sections,$orderBy="rotating_section,user_id;");
             $total = array_sum($this->core->getQueries()->getTotalUserCountByGradingSections($sections, 'rotating_section'));

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -327,6 +327,15 @@ ORDER BY egd.g_version", array($g_id, $user_id));
         return $return;
     }
 
+    public function getUsersInNullSection($orderBy="user_id"){
+      $return = array();
+      $this->course_db->query("SELECT * FROM users AS u WHERE registration_section IS NULL ORDER BY {$orderBy}");
+      foreach ($this->course_db->rows() as $row) {
+        $return[] = new User($this->core, $row);
+      }
+      return $return;
+    }
+
     public function getTotalUserCountByGradingSections($sections, $section_key) {
         $return = array();
         $params = array();

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -797,7 +797,7 @@ HTML;
     }
     else{
         $return .= <<< HTML
-        <i title="Go to the previous student" class="fa fa-step-backward icon-header"></i>
+        <i title="Go to the previous student" class="fa fa-chevron-left icon-header" style="color:grey"></i>
 HTML;
     }
     $return .= <<< HTML
@@ -811,7 +811,7 @@ HTML;
     }
     else{
         $return .= <<< HTML
-        <i title="Go to the next student" class="fa fa-step-forward icon-header"></i>
+        <i title="Go to the next student" class="fa fa-chevron-right icon-header" style="color:grey"></i>
 HTML;
     }
     $return .= <<< HTML

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -783,7 +783,7 @@ HTML;
         $user = $gradeable->getUser();
         $your_user_id = $this->core->getUser()->getId();
         $prev_href = $prev_id == '' ? '' : "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$prev_id, 'individual'=>$individual))}\"";
-        $next_href = $next_id == '' ? '' : "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$next_id, 'individual'=>$individual))}\"";
+        $next_href = "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$next_id, 'individual'=>$individual))}\"";
         $return = <<<HTML
 <div class="grading_toolbar">
     <a onclick="saveMark(-2,'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, '{$your_user_id}', '-1', false);" {$prev_href}><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -775,20 +775,47 @@ HTML;
         return $return;
     }
 
-    public function hwGradingPage($gradeable, $progress, $prev_id, $next_id, $individual) {
+    //The student not in section variable indicates that an full access grader is viewing a student that is not in their
+    //assigned section.
+    public function hwGradingPage($gradeable, $progress, $prev_id, $next_id, $individual, $studentNotInSection=false) {
         $peer = false;
         if($this->core->getUser()->getGroup()==4 && $gradeable->getPeerGrading()) {
             $peer = true;
         }
         $user = $gradeable->getUser();
         $your_user_id = $this->core->getUser()->getId();
-        $prev_href = $prev_id == '' ? '' : "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$prev_id, 'individual'=>$individual))}\"";
+        $prev_href = "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$prev_id, 'individual'=>$individual))}\"";
         $next_href = "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$next_id, 'individual'=>$individual))}\"";
         $return = <<<HTML
 <div class="grading_toolbar">
-    <a onclick="saveMark(-2,'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, '{$your_user_id}', '-1', false);" {$prev_href}><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>
+HTML;
+    //If the student is in our section, add a clickable previous arrow, else add a grayed out one.
+    if(!$studentNotInSection){
+    $return .= <<< HTML
+        <a onclick="saveMark(-2,'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, '{$your_user_id}', '-1', false);" {$prev_href}><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>
+HTML;
+    }
+    else{
+        $return .= <<< HTML
+        <i title="Go to the previous student" class="fa fa-step-backward icon-header"></i>
+HTML;
+    }
+    $return .= <<< HTML
     <a onclick="saveMark(-2,'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, '{$your_user_id}', '-1', false);" href="{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'details', 'gradeable_id'=>$gradeable->getId()))}"><i title="Go to the main page" class="fa fa-home icon-header" ></i></a>
+HTML;
+    //If the student is in our section, add a clickable next arrow, else add a grayed out one.
+    if(!$studentNotInSection){
+    $return .= <<<HTML
     <a onclick="saveMark(-2,'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, '{$your_user_id}', '-1', false);" {$next_href}><i title="Go to the next student" class="fa fa-chevron-right icon-header"></i></a>
+HTML;
+    }
+    else{
+        $return .= <<< HTML
+        <i title="Go to the next student" class="fa fa-step-forward icon-header"></i>
+HTML;
+    }
+    $return .= <<< HTML
+
     <i title="Reset Rubric Panel Positions (Press R)" class="fa fa-refresh icon-header" onclick="handleKeyPress('KeyR');"></i>
     <i title="Show/Hide Auto-Grading Testcases (Press A)" class="fa fa-list-alt icon-header" onclick="handleKeyPress('KeyA');"></i>
     <i title="Show/Hide Grading Rubric (Press G)" class="fa fa fa-pencil-square-o icon-header" onclick="handleKeyPress('KeyG');"></i>


### PR DESCRIPTION
Closes #1534

Improves loading time when iterating to the next student from the TA grading page. 

Fixed the TA grading page's next button so that when you're on the last student in your assigned section, and you press the "go to next student", it takes you back to the index page, or the status page. 

Fixed the TA grading page's next button so that it does not work on sections that are not assigned to you.