### PR TITLE
add way to disable output buffer and echo output more immediately

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -94,6 +94,7 @@ class SubmissionController extends AbstractController {
                 $loc = array('component' => 'student',
                              'gradeable_id' => $gradeable->getId());
                 $this->core->getOutput()->addBreadcrumb($gradeable->getName(), $this->core->buildUrl($loc));
+                $this->core->getOutput()->disableBuffer();
                 if (!$gradeable->hasConfig()) {
                     $this->core->getOutput()->renderOutput(array('submission', 'Homework'),
                                                            'showGradeableError', $gradeable);

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -10,6 +10,14 @@ namespace app\libraries;
  * HTML or plain-text)
  */
 class DiffViewer {
+
+    private $actual_file;
+    private $expected_file;
+    private $diff_file;
+    private $image_difference;
+
+    private $built = false;
+
     /**
      * @var bool
      */
@@ -79,7 +87,6 @@ class DiffViewer {
         $this->diff = array();
         $this->add = array();
         $this->link = array();
-        $this->id = "id";
     }
     
     /**
@@ -89,26 +96,45 @@ class DiffViewer {
      * @param $actual_file
      * @param $expected_file
      * @param $diff_file
+     * @param $image_difference
      * @param $id_prepend
      *
      * @throws \Exception
      */
     public function __construct($actual_file, $expected_file, $diff_file, $image_difference, $id_prepend="id") {
+        $this->id = rtrim($id_prepend, "_")."_";
+        $this->actual_file = $actual_file;
+        $this->expected_file = $expected_file;
+        $this->diff_file = $diff_file;
+        $this->image_difference = $image_difference;
+    }
+
+    public function destroyViewer() {
         $this->reset();
-        $this->id = rtrim($id_prepend,"_")."_";
+        $this->built = false;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function buildViewer() {
+        if ($this->built) {
+            return;
+        }
+        $actual_file = $this->actual_file;
+        $expected_file = $this->expected_file;
+        $diff_file = $this->diff_file;
+        $image_difference = $this->image_difference;
         if (!file_exists($actual_file) && $actual_file != "") {
             throw new \Exception("'{$actual_file}' could not be found.");
         }
         else if ($actual_file != "") {
             // TODO: fix this hacky way to deal with images
-	    if ( (substr($actual_file,strlen($actual_file)-4,4) == ".png") ||
-		 (substr($actual_file,strlen($actual_file)-4,4) == ".jpg") ||
-		 (substr($actual_file,strlen($actual_file)-4,4) == ".jpeg") )
-	      {
-		$this->actual_file_image = $actual_file;
-	      }
+            if (Utils::isImage($actual_file)) {
+                $this->actual_file_image = $actual_file;
+            }
             else {
-		$this->actual_file_name = $actual_file;
+                $this->actual_file_name = $actual_file;
                 $this->actual = file_get_contents($actual_file);
                 $this->has_actual = trim($this->actual) !== "" ? true: false;
                 $this->actual = explode("\n", $this->actual);
@@ -120,13 +146,9 @@ class DiffViewer {
             throw new \Exception("'{$expected_file}' could not be found.");
         }
         else if ($expected_file != "") {
-            //TODO: fix this hacky way to deal with images.
-            if ( (substr($expected_file,strlen($expected_file)-4,4) == ".png") ||
-		 (substr($expected_file,strlen($expected_file)-4,4) == ".jpg") ||
-		 (substr($expected_file,strlen($expected_file)-4,4) == ".jpeg") )
-	      {
+            if (Utils::isImage($expected_file)) {
                 $this->expected_file_image = $expected_file;
-	      }
+            }
             else{
                 $this->expected = file_get_contents($expected_file);
                 $this->has_expected = trim($this->expected) !== "" ? true : false;
@@ -139,12 +161,9 @@ class DiffViewer {
             throw new \Exception("'{$expected_file}' could not be found.");
         }
         else if ($image_difference != "") {
-            //TODO: fix this hacky way to deal with images.
-	  if ( (substr($image_difference,strlen($image_difference)-4,4) == ".png") ||
-	       (substr($image_difference,strlen($image_difference)-4,4) == ".jpg") ||
-	       (substr($image_difference,strlen($image_difference)-4,4) == ".jpeg") ){
-	    $this->difference_file_image = $image_difference;
-	  }
+            if (Utils::isImage($image_difference)) {
+                $this->difference_file_image = $image_difference;
+            }
         }
 
         if (!file_exists($diff_file) && $diff_file != "") {
@@ -210,15 +229,18 @@ class DiffViewer {
                 }
             }
         }
+        $this->built = true;
     }
-    
+
     /**
      * @return bool
+     * @throws \Exception
      */
     public function hasDisplayActual() {
+        $this->buildViewer();
         return $this->display_actual;
     }
-    
+
     /**
      * Boolean flag to indicate whether or not the actual file had any contents to display (or was
      * blank/empty lines). Assuming we do not have a difference file, we can use this flag to indicate
@@ -226,24 +248,30 @@ class DiffViewer {
      * empty in most cases).
      *
      * @return bool
+     * @throws \Exception
      */
     public function hasActualOutput() {
+        $this->buildViewer();
         return $this->has_actual;
     }
     
     /**
      * Was there a given expected file and were we able to successfully read from it
      * @return bool
+     * @throws \Exception
      */
     public function hasDisplayExpected() {
+        $this->buildViewer();
         return $this->display_expected;
     }
     
     /**
      * Returns boolean indicating whether or not there is any input in the expected.
      * @return bool
+     * @throws \Exception
      */
     public function hasExpectedOutput() {
+        $this->buildViewer();
         return $this->has_expected;
     }
 
@@ -251,8 +279,10 @@ class DiffViewer {
      * Return the output HTML for the actual display
      *
      * @return string actual html
+     * @throws \Exception
      */
     public function getDisplayActual() {
+        $this->buildViewer();
         if ($this->display_actual) {
             return $this->getDisplay($this->actual, "actual");
         }
@@ -263,21 +293,38 @@ class DiffViewer {
     }
 
     /**
-     * @return the file name for a non-image.
+     * @return string the file name for a non-image.
+     * @throws \Exception
      */
     public function getActualFilename() {
-    	return $this->actual_file_name;
+        $this->buildViewer();
+        return $this->actual_file_name;
     }
 
+    /**
+     * @return string
+     * @throws \Exception
+     */
     public function getActualImageFilename() {
+        $this->buildViewer();
     	return $this->actual_file_image;
     }
 
+    /**
+     * @return string
+     * @throws \Exception
+     */
     public function getExpectedImageFilename() {
+        $this->buildViewer();
         return $this->expected_file_image;
     }
 
+    /**
+     * @return string
+     * @throws \Exception
+     */
     public function getDifferenceFilename() {
+        $this->buildViewer();
         return $this->difference_file_image;
     }
 
@@ -285,8 +332,10 @@ class DiffViewer {
      * Return the HTML for the expected display
      *
      * @return string expected html
+     * @throws \Exception
      */
     public function getDisplayExpected() {
+        $this->buildViewer();
         if ($this->display_expected) {
             return $this->getDisplay($this->expected, "expected");
         }
@@ -306,8 +355,10 @@ class DiffViewer {
      * @param string $type which diff we use while printing
      *
      * @return string html to be displayed to user
+     * @throws \Exception
      */
     private function getDisplay($lines, $type="expected") {
+        $this->buildViewer();
         $start = null;
         $html = "<div class='diff-container'><div class='diff-code'>\n";
 
@@ -415,8 +466,10 @@ class DiffViewer {
      * return false
      *
      * @return bool
+     * @throws \Exception
      */
     public function existsDifference() {
+        $this->buildViewer();
         $return = false;
         foreach(array("expected", "actual") as $key) {
             if(count($this->diff[$key]) > 0 || count($this->add[$key]) > 0) {

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -143,4 +143,18 @@ class Utils {
         $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && $_SERVER['HTTPS'] !== 'off';
         return setcookie($name, $data, $expire, "/", "", $secure);
     }
+
+    /**
+     * Given a filename, determine if it is an image.
+     * TOOD: Make this a stronger check than just on the appended file extension to the naem
+     *
+     * @param string $filename
+     *
+     * @return bool true if filename references an image else false
+     */
+    public static function isImage($filename) {
+        return (substr($filename,strlen($filename)-4,4) == ".png") ||
+            (substr($filename,strlen($filename)-4,4) == ".jpg") ||
+            (substr($filename,strlen($filename)-4,4) == ".jpeg");
+    }
 }

--- a/site/app/models/Gradeable.php
+++ b/site/app/models/Gradeable.php
@@ -58,7 +58,7 @@ use app\libraries\Utils;
  * @method bool getGradeByRegistration()
  * @method array getSubmittedFiles()
  * @method array getVcsFiles()
- * @method array getTestcases()
+ * @method GradeableTestcase[] getTestcases()
  * @method bool getIsRepository()
  * @method string getSubdirectory()
  * @method string getConfigPath()

--- a/site/app/models/GradeableTestcase.php
+++ b/site/app/models/GradeableTestcase.php
@@ -27,6 +27,7 @@ use app\libraries\Utils;
  * @method string getTestcaseMessage()
  */
 class GradeableTestcase extends AbstractModel {
+    /** @var Core */
     protected $core;
 
     /** @property @var string */
@@ -99,14 +100,15 @@ class GradeableTestcase extends AbstractModel {
             $this->points_awarded = floatval($testcase['points_awarded']);
             if ($this->points > 0) {
                 // POSITIVE POINTS TESTCASE
+                // TODO: ADD ERROR
+                /*
                 if ($this->points_awarded < 0) {
-                  // TODO: ADD ERROR
-                  //$this->points_awarded = 0;
+                  $this->points_awarded = 0;
                 }
                 if ($this->points_awarded > $this->points) {
-                  // TODO: ADD ERROR
-                  //$this->points_awarded = $this->points;
+                  $this->points_awarded = $this->points;
                 }
+                */
             }
             else if ($this->points < 0) {
                 // PENALTY TESTCASE

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -7,8 +7,14 @@ use app\views\AbstractView;
 use app\libraries\FileUtils;
 
 class AutogradingView extends AbstractView {
-
-    public function showResults($gradeable, $show_hidden=false) {
+    /**
+     * @param Gradeable $gradeable
+     * @param bool      $show_hidden
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public function showResults(Gradeable $gradeable, $show_hidden=false) {
         $return = "";
         $current_version = $gradeable->getCurrentVersion();
         $popup_css_file = "{$this->core->getConfig()->getBaseUrl()}css/diff-viewer.css";
@@ -356,6 +362,7 @@ HTML;
         <div class="clear"></div>
 HTML;
                     }
+                    $diff_viewer->destroyViewer();
                 }
                 $return .= <<<HTML
     </div>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -938,7 +938,15 @@ HTML;
                             }
                         //}
                     }
+                    if (!$this->core->getOutput()->bufferOutput()) {
+                        echo $return;
+                        $return = "";
+                    }
                     $return .= $this->core->getOutput()->renderTemplate('AutoGrading', 'showResults', $gradeable);
+                    if (!$this->core->getOutput()->bufferOutput()) {
+                        echo $return;
+                        $return = "";
+                    }
                 }
                 $return .= <<<HTML
     </div>

--- a/tests/unitTests/app/libraries/DiffViewerTester.php
+++ b/tests/unitTests/app/libraries/DiffViewerTester.php
@@ -48,6 +48,7 @@ class DiffViewerTester extends \PHPUnit_Framework_TestCase {
      */
     public function testActualException() {
         $diff = new DiffViewer("file_that_doesnt_exist", "", "", "");
+        $diff->buildViewer();
     }
 
     /**
@@ -56,6 +57,7 @@ class DiffViewerTester extends \PHPUnit_Framework_TestCase {
     public function testExpectedException() {
         $diff = new DiffViewer(__TEST_DATA__."/diffs/diff_test_01/input_actual.txt",
                                "file_that_doesnt_exist", "", "");
+        $diff->buildViewer();
     }
 
     /**
@@ -64,7 +66,7 @@ class DiffViewerTester extends \PHPUnit_Framework_TestCase {
     public function testDifferencesException() {
         $diff = new DiffViewer(__TEST_DATA__."/diffs/diff_test_01/input_actual.txt",
                                __TEST_DATA__."/diffs/diff_test_01/input_expected.txt",
-                               "file_that_doesnt_exist",
-                               "");
+                               "file_that_doesnt_exist", "");
+        $diff->buildViewer();
     }
 }


### PR DESCRIPTION
This should improve the memory usage of the homework page in two ways:
1. Don't buffer the output of all testcases into memory at once. Instead, we echo the output as we go per testcase which should incur a smaller footprint
2. Build the DiffViewer's output the first time we use a function that requires it, and destroy it after we're done with it.

I've tested this and it appears to work for normal testcases in the sample course on Vagrant, but I did not test it on a testcase that was previously causing memory errors or hangs. 