### PR TITLE
Fix travis breaking on E2E tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
 install:
   - sudo add-apt-repository -y ppa:ondrej/php; sudo apt-get -qq update;
   - sudo apt-get -y install libapache2-mod-php7.0 php7.0-pgsql php7.0-curl; a2enmod php7.0;
-  - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip
+  - wget http://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chmod u+x chromedriver
   - sudo mv chromedriver /usr/bin/


### PR DESCRIPTION
For future reference, an error of:
```
selenium.common.exceptions.WebDriverException: Message: unknown error: missing or invalid 'entry.level'
  (Session info: chrome=63.0.3239.84)
  (Driver info: chromedriver=2.24.417424 (c5c5ea873213ee72e3d0929b47482681555340c3),platform=Linux 4.4.0-93-generic x86_64)
```
or 
```
ConnectionRefusedError: [Errno 111] Connection refused
```
or
```
http.client.RemoteDisconnected: Remote end closed connection without response
```
across all tests (or some mix of those errors across all tests) means that we've hit a version mismatch of Chrome and the associated chromedriver. Bumping the version of chromedriver should be all that is needed to fix this.