### PR TITLE
Fixed expected file size comparison

### DIFF
--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -167,7 +167,7 @@ class DiffViewer {
                 $this->expected_file_image = $expected_file;
             }
             else{
-                 if(filesize($actual_file) < $size_limit){
+                 if(filesize($expected_file) < $size_limit){
                     $this->expected = file_get_contents($expected_file);
                     $this->has_expected = trim($this->expected) !== "" ? true : false;
                     $this->expected = explode("\n", $this->expected);


### PR DESCRIPTION
I was errantly using the size of the student's actual output file to determine whether or not the expected file was readable. 

This update makes it so that if the expected file is smaller than an upper-bound, the whole file is read, otherwise, the file is read up to the size limit. 