### PR TITLE
Status flag

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -355,7 +355,7 @@ ORDER BY {$section_key}", $params);
         }
         return $return;
     }
-    
+
     public function getTotalSubmittedUserCountByGradingSections($g_id, $sections, $section_key) {
         $return = array();
         $params = array();
@@ -470,13 +470,13 @@ ORDER BY gc_order
         }
         return $return;
     }
-    
+
     public function getAverageAutogradedScores($g_id, $section_key) {
         $this->course_db->query("
 SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) FROM(
    SELECT * FROM (
       SELECT (egv.autograding_non_hidden_non_extra_credit + egv.autograding_non_hidden_extra_credit + egv.autograding_hidden_non_extra_credit + egv.autograding_hidden_extra_credit) AS score
-      FROM electronic_gradeable_data AS egv 
+      FROM electronic_gradeable_data AS egv
       INNER JOIN users AS u ON u.user_id = egv.user_id
       WHERE egv.g_id=? AND u.{$section_key} IS NOT NULL
    )g
@@ -913,10 +913,10 @@ VALUES (?, ?, ?, ?, ?, ?, ?)", $params);
         $params = array($component->getScore(), $component->getComment(), $component->getGradedVersion(),
                         $component->getGradeTime()->format("Y-m-d H:i:s"), $grader_id, $component->getId(), $gd_id);
         $this->course_db->query("
-UPDATE gradeable_component_data 
-SET 
-  gcd_score=?, gcd_component_comment=?, gcd_graded_version=?, gcd_grade_time=?, 
-  gcd_grader_id=? 
+UPDATE gradeable_component_data
+SET
+  gcd_score=?, gcd_component_comment=?, gcd_graded_version=?, gcd_grade_time=?,
+  gcd_grader_id=?
 WHERE gc_id=? AND gd_id=?", $params);
     }
 
@@ -1500,7 +1500,7 @@ ORDER BY gt.{$section_key}", $params);
             VALUES(?,?,?)", array($user_id, $g_id, $days));
         }
     }
-    
+
     /**
      * Removes peer grading assignment if instructor decides to change the number of people each person grades for assignment
      * @param string $gradeable_id
@@ -1508,27 +1508,42 @@ ORDER BY gt.{$section_key}", $params);
     public function clearPeerGradingAssignments($gradeable_id) {
         $this->course_db->query("DELETE FROM peer_assign WHERE g_id=?", array($gradeable_id));
     }
-    
+
     /**
      * Adds an assignment for someone to grade another person for peer grading
      * @param string $student
      * @param string $grader
      * @param string $gradeable_id
-    */
+     */
     public function insertPeerGradingAssignment($grader, $student, $gradeable_id) {
         $this->course_db->query("INSERT INTO peer_assign(grader_id, user_id, g_id) VALUES (?,?,?)", array($grader, $student, $gradeable_id));
     }
 
+	/**
+	 * Retrieves all courses and their relevant details accessible by $user_id
+	 *
+	 * (u.user_id=? AND u.user_group=1) checks if $user_id is an instructor
+	 * Instructors may access all of their courses
+	 * (u.user_id=? AND c.status=1) checks if a course is active
+	 * An active course may be accessed by all users
+	 * Inactive courses may only be accessed by the instructor
+	 *
+	 * @param string $user_id
+	 * @param string $submitty_path
+	 * @return array courses (and details) accessible by $user_id
+	 */
     public function getStudentCoursesById($user_id, $submitty_path) {
         $this->submitty_db->query("
-SELECT semester, course
+SELECT u.semester, u.course
 FROM courses_users u
-WHERE u.user_id=? ORDER BY course", array($user_id));
-       $return = array();
+INNER JOIN courses c ON u.course=c.course AND u.semester=c.semester
+WHERE (u.user_id=? AND u.user_group=1) OR (u.user_id=? AND c.status=1)
+ORDER BY u.course", array($user_id, $user_id));
+        $return = array();
         foreach ($this->submitty_db->rows() as $row) {
-          $course = new Course($this->core, $row);
-          $course->loadDisplayName($submitty_path);
-          $return[] = $course;
+            $course = new Course($this->core, $row);
+            $course->loadDisplayName($submitty_path);
+            $return[] = $course;
         }
         return $return;
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -139,13 +139,18 @@ class DatabaseQueries {
         }
     }
 
-    /*  Gets the group that the user is in for a given class (used on homepage)
-     *  as the user isn't within a class yet.
-     *  @param $user_id - user id to be searched for
-     *  @return group of user in the given class
-    */
-    public function getGroupForUserInClass($course_name, $user_id){
-        $this->submitty_db->query("SELECT user_group FROM courses_users WHERE user_id = ? AND course = ?", array($user_id, $course_name));
+    /**
+     * Gets the group that the user is in for a given class (used on homepage)
+     *
+     * Classes are distinct for each semester *and* course
+     *
+     * @param string $semester - class's working semester
+     * @param string $course_name - class's course name
+     * @param string $user_id - user id to be searched for
+     * @return integer - group number of user in the given class
+     */
+    public function getGroupForUserInClass($semester, $course_name, $user_id) {
+        $this->submitty_db->query("SELECT user_group FROM courses_users WHERE user_id = ? AND course = ? AND semester = ?", array($user_id, $course_name, $semester));
         return intval($this->submitty_db->row()['user_group']);
     }
 
@@ -1520,7 +1525,7 @@ ORDER BY gt.{$section_key}", $params);
     }
 
 	/**
-	 * Retrieves all courses and their relevant details accessible by $user_id
+	 * Retrieves all courses (and details) that are accessible by $user_id
 	 *
 	 * (u.user_id=? AND u.user_group=1) checks if $user_id is an instructor
 	 * Instructors may access all of their courses
@@ -1530,7 +1535,7 @@ ORDER BY gt.{$section_key}", $params);
 	 *
 	 * @param string $user_id
 	 * @param string $submitty_path
-	 * @return array courses (and details) accessible by $user_id
+	 * @return array - courses (and their details) accessible by $user_id
 	 */
     public function getStudentCoursesById($user_id, $submitty_path) {
         $this->submitty_db->query("

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -107,15 +107,10 @@ HTML;
                         $rankWithCourse[$i] = array();
                     }
 
-                    
-                    foreach($courses as $course){
-
-                        $rank = $this->core->getQueries()->getGroupForUserInClass($course->getTitle(), $user->getId());
-
+                    foreach($courses as $course) {
+                        $rank = $this->core->getQueries()->getGroupForUserInClass($course->getSemester(), $course->getTitle(), $user->getId());
                         array_push($rankWithCourse[$rank], $course);
-
                         $pos++;
-
                     }
 
                     $pos = 0;
@@ -142,10 +137,10 @@ HTML;
                                         $header = "<h3>Student:</h3>";
                                 break;
                         }
-                            
+
                             $return .= <<<HTML
                         <tr>
-                            <td colspan="8">     
+                            <td colspan="8">
                                 {$header}
                             </td>
                         </tr>
@@ -156,9 +151,9 @@ HTML;
                             if($rankWithCourse[$i][$q]->getDisplayName() !== "") {
                                 $display_text .= " " . $rankWithCourse[$i][$q]->getDisplayName();
                             }
-                        
+
                         $return .= <<<HTML
-                        
+
                         <tr>
                             <td colspan="8">
                                 <a class="btn btn-primary btn-block" style="width:95%;white-space: normal;" href="{$this->core->buildUrl(array('component' => 'navigation', 'course' => $rankWithCourse[$i][$q]->getTitle(), 'semester' => $rankWithCourse[$i][$q]->getSemester()))}"> {$display_text}{$user->accessAdmin()}</a>


### PR DESCRIPTION
### Check status flag to filter courses displayed on homepage
* Instructors (group 1) may always see their courses
* All others may only see their active courses (status 1).
* This is filtered in SQL when DB is queried.

### Corrected intermittent bug where user ranking is incorrectly shown on homepage
Previously it was possible that a student associated with the same course in multiple semesters may not be listed as the correct rank for a course.  e.g. a student in a previous semester who is a TA later on may still be listed as a "student" under the course they are a grader.  This was caused by the rank search only checking course, although a class is distinct by course **and** semester.  The DB query has been fixed.