### PR TITLE
iClicker Rainbow Grades Multifile Support / Misc. Improvements

### DIFF
--- a/RainbowGrades/MakefileHelper
+++ b/RainbowGrades/MakefileHelper
@@ -58,7 +58,7 @@ remove_json_comments: customization.json
 	cpp -xc++ $< | sed -e '/^#/d' > customization_no_comments.json
 	python $(GRADING_DIRECTORY)/json_syntax_checker.py customization_no_comments.json
 	grep '{"file":' customization_no_comments.json > iclicker_file_list.txt || true
-	python ${RAINBOW_GRADES_DIRECTORY}/parsexml.py iclicker_file_list.txt
+	${RAINBOW_GRADES_DIRECTORY}/parsexml.py iclicker_file_list.txt
 
 compile:  remove_json_comments
 	g++ -Wall ${flags} ${memory_flags} \

--- a/RainbowGrades/iclicker.cpp
+++ b/RainbowGrades/iclicker.cpp
@@ -133,21 +133,21 @@ std::string getItem(const std::string &line, int which) {
 }
 
 
-void AddClickerScores(std::vector<Student*> &students, std::vector<std::map<unsigned int, std::vector<iClickerQuestion> > > iclicker_questions) {
+void AddClickerScores(std::vector<Student*> &students, std::vector<std::vector<std::vector<iClickerQuestion> > > iclicker_questions) {
 
   for (unsigned int which_lecture = 0; which_lecture < iclicker_questions.size(); which_lecture++) {
     //std::cout << "which lecture = " << which_lecture << std::endl;
-    std::map<unsigned int, std::vector<iClickerQuestion> >& lecture = iclicker_questions[which_lecture];
+    std::vector<std::vector<iClickerQuestion> >& lecture = iclicker_questions[which_lecture];
     //for (unsigned int which_question = 0; which_question < lecture.size(); which_question++) {
-    for (std::map<unsigned int, std::vector<iClickerQuestion > >::iterator it = lecture.begin(); it != lecture.end(); it++){
-      unsigned int which_question = it->first;
+    for (std::size_t which_question = 0; which_question < lecture.size(); which_question++){
+      //unsigned int which_question = it->first;
       //iClickerQuestion& question = lecture[which_question];
 
       std::stringstream ss;
       ss << which_lecture << "." << which_question+1;
 
-      for(unsigned int i=0; i<it->second.size(); i++) {
-        iClickerQuestion &question = it->second[i];
+      for(unsigned int i=0; i<lecture[which_question].size(); i++) {
+        iClickerQuestion &question = lecture[which_question][i];
 
         if(i==0) {
           ICLICKER_QUESTION_NAMES.push_back(ss.str());

--- a/RainbowGrades/iclicker.cpp
+++ b/RainbowGrades/iclicker.cpp
@@ -133,81 +133,90 @@ std::string getItem(const std::string &line, int which) {
 }
 
 
-void AddClickerScores(std::vector<Student*> &students, std::vector<std::vector<iClickerQuestion> > iclicker_questions) {
+void AddClickerScores(std::vector<Student*> &students, std::vector<std::map<unsigned int, std::vector<iClickerQuestion> > > iclicker_questions) {
 
   for (unsigned int which_lecture = 0; which_lecture < iclicker_questions.size(); which_lecture++) {
     //std::cout << "which lecture = " << which_lecture << std::endl;
-    std::vector<iClickerQuestion>& lecture = iclicker_questions[which_lecture];
-    for (unsigned int which_question = 0; which_question < lecture.size(); which_question++) {
-      iClickerQuestion& question = lecture[which_question];
+    std::map<unsigned int, std::vector<iClickerQuestion> >& lecture = iclicker_questions[which_lecture];
+    //for (unsigned int which_question = 0; which_question < lecture.size(); which_question++) {
+    for (std::map<unsigned int, std::vector<iClickerQuestion > >::iterator it = lecture.begin(); it != lecture.end(); it++){
+      unsigned int which_question = it->first;
+      //iClickerQuestion& question = lecture[which_question];
 
       std::stringstream ss;
       ss << which_lecture << "." << which_question+1;
 
-      ICLICKER_QUESTION_NAMES.push_back(ss.str());
-      MAX_ICLICKER_TOTAL += 1.0;
+      for(unsigned int i=0; i<it->second.size(); i++) {
+        iClickerQuestion &question = it->second[i];
 
-      std::ifstream istr(question.getFilename());
-      if (!istr.good()) {
-        std::cerr << "ERROR: cannot open file: " << question.getFilename() << std::endl;
-      }
-
-      if (LECTURE_DATE_CORRESPONDENCES.find(which_lecture) ==
-          LECTURE_DATE_CORRESPONDENCES.end()) {
-        Date date = dateFromFilename(question.getFilename());
-        LECTURE_DATE_CORRESPONDENCES[which_lecture] = date;
-      }
-
-
-      char line_helper[5000];
-      while (istr.getline(line_helper,5000)) {
-
-        std::string line = line_helper;
-
-        // ignore lines that don't begin with a clicker id
-        // all clicker id's start with '#'
-        if (line[0] != '#') continue;
-
-        std::string remoteid = getItem(line,0);
-        std::string item = getItem(line,question.getColumn()-1);
-        bool participate = (item != "");
-        
-        if (!participate) continue;
-
-        //std::cout << "ITEM " << item << " " << item.size() << std::endl;
-        
-        assert (item.size() == 1);
-
-        //bool correct = question.participationQuestion() || question.isCorrectAnswer(item[0]);
-
-        //std::cout << "ITEM " << remoteid << " " << item << "  " << participate << " " << correct << std::endl;
-        std::map<std::string,std::string>::iterator itr = GLOBAL_CLICKER_MAP.find(remoteid);
-        if (itr == GLOBAL_CLICKER_MAP.end()) {
-          //std::cout << "UNKNOWN CLICKER: " << remoteid << "  " << std::endl;
-          std::cout << " " << remoteid;
-          continue;
+        if(i==0) {
+          ICLICKER_QUESTION_NAMES.push_back(ss.str());
+          MAX_ICLICKER_TOTAL += 1.0;
         }
-        assert (itr != GLOBAL_CLICKER_MAP.end());
-        std::string username = itr->second;
-        Student *s = GetStudent(students,username);
-        assert (s != NULL);
 
-        iclicker_answer_enum grade = ICLICKER_NOANSWER;
-        if (question.participationQuestion()) 
-          grade = ICLICKER_PARTICIPATED;
-        else {
-          if (question.isCorrectAnswer(item[0])) {
-            grade = ICLICKER_CORRECT;
-          } else {
-            grade = ICLICKER_INCORRECT;
+
+        std::ifstream istr(question.getFilename());
+        if (!istr.good()) {
+          std::cerr << "ERROR: cannot open file: " << question.getFilename() << std::endl;
+        }
+
+        if (LECTURE_DATE_CORRESPONDENCES.find(which_lecture) ==
+            LECTURE_DATE_CORRESPONDENCES.end()) {
+          Date date = dateFromFilename(question.getFilename());
+          LECTURE_DATE_CORRESPONDENCES[which_lecture] = date;
+        }
+
+
+        char line_helper[5000];
+        while (istr.getline(line_helper, 5000)) {
+
+          std::string line = line_helper;
+
+          // ignore lines that don't begin with a clicker id
+          // all clicker id's start with '#'
+          if (line[0] != '#') continue;
+
+          std::string remoteid = getItem(line, 0);
+          std::string item = getItem(line, question.getColumn() - 1);
+          bool participate = (item != "");
+
+          if (!participate) continue;
+
+          //std::cout << "ITEM " << item << " " << item.size() << std::endl;
+
+          assert(item.size() == 1);
+
+          //bool correct = question.participationQuestion() || question.isCorrectAnswer(item[0]);
+
+          //std::cout << "ITEM " << remoteid << " " << item << "  " << participate << " " << correct << std::endl;
+          std::map<std::string, std::string>::iterator itr = GLOBAL_CLICKER_MAP.find(remoteid);
+          if (itr == GLOBAL_CLICKER_MAP.end()) {
+            //std::cout << "UNKNOWN CLICKER: " << remoteid << "  " << std::endl;
+            std::cout << " " << remoteid;
+            continue;
           }
+          assert(itr != GLOBAL_CLICKER_MAP.end());
+          std::string username = itr->second;
+          Student *s = GetStudent(students, username);
+          assert(s != NULL);
+
+          iclicker_answer_enum grade = ICLICKER_NOANSWER;
+          if (question.participationQuestion())
+            grade = ICLICKER_PARTICIPATED;
+          else {
+            if (question.isCorrectAnswer(item[0])) {
+              grade = ICLICKER_CORRECT;
+            } else {
+              grade = ICLICKER_INCORRECT;
+            }
+          }
+
+          s->addIClickerAnswer(ss.str(), item[0], grade);
+          //s.seti
+
         }
-
-        s->addIClickerAnswer(ss.str(),item[0],grade);
-        //s.seti
-
+        std::cout << std::endl;
       }
-      std::cout << std::endl;
     }
   }
 }

--- a/RainbowGrades/iclicker.h
+++ b/RainbowGrades/iclicker.h
@@ -64,6 +64,6 @@ private:
 // ==========================================================
 
 void MatchClickerRemotes(std::vector<Student*> &students, const std::string &remotes_filename);
-void AddClickerScores(std::vector<Student*> &students, std::vector<std::vector<iClickerQuestion> > iclicker_questions);
+void AddClickerScores(std::vector<Student*> &students, std::vector<std::map<unsigned int, std::vector<iClickerQuestion> > > iclicker_questions);
 
 #endif

--- a/RainbowGrades/iclicker.h
+++ b/RainbowGrades/iclicker.h
@@ -64,6 +64,6 @@ private:
 // ==========================================================
 
 void MatchClickerRemotes(std::vector<Student*> &students, const std::string &remotes_filename);
-void AddClickerScores(std::vector<Student*> &students, std::vector<std::map<unsigned int, std::vector<iClickerQuestion> > > iclicker_questions);
+void AddClickerScores(std::vector<Student*> &students, std::vector<std::vector<std::vector<iClickerQuestion> > > iclicker_questions);
 
 #endif

--- a/RainbowGrades/main.cpp
+++ b/RainbowGrades/main.cpp
@@ -1206,7 +1206,7 @@ void processcustomizationfile(std::vector<Student*> &students) {
 
   std::string iclicker_remotes_filename;
   //std::vector<std::vector<iClickerQuestion> > iclicker_questions(MAX_LECTURES+1);
-  std::vector<std::map<unsigned int, std::vector<iClickerQuestion> > > iclicker_questions(MAX_LECTURES+1);
+  std::vector<std::vector<std::vector<iClickerQuestion> > > iclicker_questions(MAX_LECTURES+1);
 
   
   for (nlohmann::json::iterator itr = j.begin(); itr != j.end(); itr++) {
@@ -1351,16 +1351,20 @@ void processcustomizationfile(std::vector<Student*> &students) {
     for (nlohmann::json::iterator itr2 = (itr.value()).begin(); itr2 != (itr.value()).end(); itr2++) {
       std::string temp = itr2.key();
       std::vector<nlohmann::json> iclickerLectures = j[token][temp];
-      int which_line = 0;
+      int which_lecture = std::stoi(temp);
+
+      //Each step through this loop is one {} line inside a lecture, the naming of lecture vs lectures here is confusing
       for (std::size_t i = 0; i < iclickerLectures.size(); i++) {
         nlohmann::json iclickerLecture = iclickerLectures[i];
-        int which_lecture = std::stoi(temp);
+        iclicker_questions[which_lecture].push_back(std::vector<iClickerQuestion>());
+
+
         int which_column = iclickerLecture["column"].get<int>();
         std::string correct_answer = iclickerLecture["answer"].get<std::string>();
         assert (which_lecture >= 1 && which_lecture <= MAX_LECTURES);
 
-        //std::string clicker_file = iclickerLecture["file"].get<std::string>();
-        //TODO: Add code here to support multiple iClicker files. Should be exciting!
+
+        //Code to support multiple iClicker files for one question
         nlohmann::json j_filenames = iclickerLecture["file"];
         std::vector<std::string> filenames;
         for (std::size_t k = 0; k < j_filenames.size(); k++) {
@@ -1368,9 +1372,9 @@ void processcustomizationfile(std::vector<Student*> &students) {
         }
 
         for (std::size_t k=0; k<filenames.size(); k++) {
-          iclicker_questions[which_lecture][which_line].push_back(iClickerQuestion(filenames[k], which_column, correct_answer));
+          iclicker_questions[which_lecture].back().push_back(iClickerQuestion(filenames[k], which_column, correct_answer));
         }
-        which_line++;
+
       }
     }
   } else if (token == "audit") {

--- a/RainbowGrades/main.cpp
+++ b/RainbowGrades/main.cpp
@@ -1205,7 +1205,8 @@ void processcustomizationfile(std::vector<Student*> &students) {
   //float p_score,a_score,b_score,c_score,d_score;
 
   std::string iclicker_remotes_filename;
-  std::vector<std::vector<iClickerQuestion> > iclicker_questions(MAX_LECTURES+1);
+  //std::vector<std::vector<iClickerQuestion> > iclicker_questions(MAX_LECTURES+1);
+  std::vector<std::map<unsigned int, std::vector<iClickerQuestion> > > iclicker_questions(MAX_LECTURES+1);
 
   
   for (nlohmann::json::iterator itr = j.begin(); itr != j.end(); itr++) {
@@ -1350,6 +1351,7 @@ void processcustomizationfile(std::vector<Student*> &students) {
     for (nlohmann::json::iterator itr2 = (itr.value()).begin(); itr2 != (itr.value()).end(); itr2++) {
       std::string temp = itr2.key();
       std::vector<nlohmann::json> iclickerLectures = j[token][temp];
+      int which_line = 0;
       for (std::size_t i = 0; i < iclickerLectures.size(); i++) {
         nlohmann::json iclickerLecture = iclickerLectures[i];
         int which_lecture = std::stoi(temp);
@@ -1366,8 +1368,9 @@ void processcustomizationfile(std::vector<Student*> &students) {
         }
 
         for (std::size_t k=0; k<filenames.size(); k++) {
-          iclicker_questions[which_lecture].push_back(iClickerQuestion(filenames[k], which_column, correct_answer));
+          iclicker_questions[which_lecture][which_line].push_back(iClickerQuestion(filenames[k], which_column, correct_answer));
         }
+        which_line++;
       }
     }
   } else if (token == "audit") {

--- a/RainbowGrades/main.cpp
+++ b/RainbowGrades/main.cpp
@@ -1349,16 +1349,26 @@ void processcustomizationfile(std::vector<Student*> &students) {
   } else if (token == "iclicker") {
     for (nlohmann::json::iterator itr2 = (itr.value()).begin(); itr2 != (itr.value()).end(); itr2++) {
       std::string temp = itr2.key();
-    std::vector<nlohmann::json> iclickerLectures = j[token][temp];
-    for (std::size_t i = 0; i < iclickerLectures.size(); i++) {
-      nlohmann::json iclickerLecture = iclickerLectures[i];
-      int which_lecture = std::stoi(temp);
-      std::string clicker_file = iclickerLecture["file"].get<std::string>();
-      int which_column = iclickerLecture["column"].get<int>();
-      std::string correct_answer = iclickerLecture["answer"].get<std::string>();
-      assert (which_lecture >= 1 && which_lecture <= MAX_LECTURES);
-      iclicker_questions[which_lecture].push_back(iClickerQuestion(clicker_file,which_column,correct_answer));
-    }
+      std::vector<nlohmann::json> iclickerLectures = j[token][temp];
+      for (std::size_t i = 0; i < iclickerLectures.size(); i++) {
+        nlohmann::json iclickerLecture = iclickerLectures[i];
+        int which_lecture = std::stoi(temp);
+        int which_column = iclickerLecture["column"].get<int>();
+        std::string correct_answer = iclickerLecture["answer"].get<std::string>();
+        assert (which_lecture >= 1 && which_lecture <= MAX_LECTURES);
+
+        //std::string clicker_file = iclickerLecture["file"].get<std::string>();
+        //TODO: Add code here to support multiple iClicker files. Should be exciting!
+        nlohmann::json j_filenames = iclickerLecture["file"];
+        std::vector<std::string> filenames;
+        for (std::size_t k = 0; k < j_filenames.size(); k++) {
+          filenames.push_back(j_filenames[k].get<std::string>());
+        }
+
+        for (std::size_t k=0; k<filenames.size(); k++) {
+          iclicker_questions[which_lecture].push_back(iClickerQuestion(filenames[k], which_column, correct_answer));
+        }
+      }
     }
   } else if (token == "audit") {
     std::vector<nlohmann::json> audit_list = itr.value();

--- a/RainbowGrades/output.cpp
+++ b/RainbowGrades/output.cpp
@@ -1212,14 +1212,16 @@ void end_table(std::ofstream &ostr,  bool for_instructor, Student *s) {
     if (s != NULL) {
       ostr << "<b>Initial number of allowed late days: </b>" << s->getDefaultAllowedLateDays() <<  "<br>" << std::endl;
     }
-    ostr << "<b>Extra late days earned after iclicker points:</b> ";
-    for (std::size_t i = 0; i < GLOBAL_earned_late_days.size(); i++) {
-      ostr << GLOBAL_earned_late_days[i];
-      if (i < GLOBAL_earned_late_days.size()-1) {
-        ostr << ", ";
+    if(!GLOBAL_earned_late_days.empty()) {
+      ostr << "<b>Extra late days earned after iclicker points:</b> ";
+      for (std::size_t i = 0; i < GLOBAL_earned_late_days.size(); i++) {
+        ostr << GLOBAL_earned_late_days[i];
+        if (i < GLOBAL_earned_late_days.size() - 1) {
+          ostr << ", ";
+        }
       }
+      ostr << "<br>" << std::endl;
     }
-    ostr << "<br>" << std::endl;
     ostr << "</p>" << std::endl;
 
 

--- a/RainbowGrades/parsexml.py
+++ b/RainbowGrades/parsexml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import csv
 import xml.etree.ElementTree as ET
 import sys
@@ -137,8 +137,9 @@ if __name__ == '__main__':
     try:
         with open(sys.argv[1]) as json_file:
             for line in json_file:
-                # Extract just the filename of the session data
-                files.append(line.split(",")[0].split(":")[1].strip()[1:-1])
+                # Extract just the filenames of the session data
+                files += [x.strip()[1:-1] for x in line.split("[")[1].split("]")[0].split(",")]
+                print(files)
     except IOError as e:
         print("Error reading JSON excerpt: {}".format(e))
 

--- a/RainbowGrades/parsexml.py
+++ b/RainbowGrades/parsexml.py
@@ -139,7 +139,6 @@ if __name__ == '__main__':
             for line in json_file:
                 # Extract just the filenames of the session data
                 files += [x.strip()[1:-1] for x in line.split("[")[1].split("]")[0].split(",")]
-                print(files)
     except IOError as e:
         print("Error reading JSON excerpt: {}".format(e))
 


### PR DESCRIPTION
Addresses #1513 and #1660. This will change the `"iclicker":` syntax in customization.json slightly. After the pull request goes through I can update the documentation accordingly.

Changes:
* Multiple iClicker files can be associated with the same question in a given lecture. Currently the column numbers must match. A long-term goal would be an iClicker parsing overhaul and changing customization.json to also have the user specify which question a file/column was contributing to.
* The XML->CSV script now runs using Python 3 explicitly, and uses /usr/bin/env to figure out the right place to look
* The output in individual summaries that only makes sense to print when the `"earned_late_days"` field is present in customization.json will now only print when the field is present and not empty.

The support for multiple iClicker files for one question in one lecture is expressed as an array of filenames which technically could be separated into multiple lines. Right now this will cause problems in RainbowGrades/parsexml.py but the documentation can emphasize for the moment to keep the `file:` field on one line. I'm not sure if that's enough to stop this PR, though it warrants further testing and probably a new issue if there's a problem.