### PR TITLE
Allow vagrant to setup private networks

### DIFF
--- a/.setup/distro_setup/debian/setup_distro.sh
+++ b/.setup/distro_setup/debian/setup_distro.sh
@@ -54,18 +54,18 @@ if [ ${VAGRANT} == 1 ]; then
     # The VM’s host-only adapter provides a private connection to the VM,
     # but Ubuntu also needs to be configured to use this adapter.
 
-    echo "Binding static IPs to \"Host-Only\" virtual network interface."
+    # echo "Binding static IPs to \"Host-Only\" virtual network interface."
 
     # eth0 is auto-configured by Vagrant as NAT.  eth1 is a host-only adapter and
     # not auto-configured.  eth1 is manually set so that the host-only network
     # interface remains consistent among VM reboots as Vagrant has a bad habit of
     # discarding and recreating networking interfaces everytime the VM is restarted.
     # eth1 is statically bound to 192.168.56.101.
-    printf "auto eth1\niface eth1 inet static\naddress ${SUBMISSION_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
-    printf "auto eth1:1\niface eth1 inet static\naddress ${GIT_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
+    # printf "auto eth1\niface eth1 inet static\naddress ${SUBMISSION_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
+    # printf "auto eth1:1\niface eth1 inet static\naddress ${GIT_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/eth1.cfg
 
     # Turn them on.
-    ifup eth1 eth1:1
+    # ifup eth1 eth1:1
 
 
     rm /etc/motd

--- a/.setup/distro_setup/ubuntu/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/setup_distro.sh
@@ -37,7 +37,7 @@ if [ ${VAGRANT} == 1 ]; then
     # The VM’s host-only adapter provides a private connection to the VM,
     # but Ubuntu also needs to be configured to use this adapter.
 
-    echo "Binding static IPs to \"Host-Only\" virtual network interface."
+    # echo "Binding static IPs to \"Host-Only\" virtual network interface."
 
     # Note: Ubuntu 16.04 switched from the eth# scheme to ep0s# scheme.
     # enp0s3 is auto-configured by Vagrant as NAT.  enp0s8 is a host-only adapter and
@@ -45,11 +45,11 @@ if [ ${VAGRANT} == 1 ]; then
     # interface remains consistent among VM reboots as Vagrant has a bad habit of
     # discarding and recreating networking interfaces everytime the VM is restarted.
     # ep0s8 is statically bound to 192.168.56.101.
-    echo -e "auto enp0s8\niface enp0s8 inet static\naddress ${SUBMISSION_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/00-vagrant.cfg
-    echo -e "auto enp0s8:1\niface enp0s8:1 inet static\naddress ${GIT_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/00-vagrant.cfg
+    # echo -e "auto enp0s8\niface enp0s8 inet static\naddress ${SUBMISSION_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/00-vagrant.cfg
+    # echo -e "auto enp0s8:1\niface enp0s8:1 inet static\naddress ${GIT_URL:7}\nnetmask 255.255.255.0\n\n" >> /etc/network/interfaces.d/00-vagrant.cfg
 
     # Turn them on.
-    ifup enp0s8 enp0s8:1
+    # ifup enp0s8 enp0s8:1
 
     chmod -x /etc/update-motd.d/*
     chmod -x /usr/share/landscape/landscape-sysinfo.wrapper

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,13 +25,15 @@ Vagrant.configure(2) do |config|
   config.vm.define 'ubuntu', primary: true do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-16.04'
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 15432
-    ubuntu.vm.network 'private_network', ip: '192.168.56.101', auto_config: false
+    ubuntu.vm.network 'private_network', ip: '192.168.56.101'
+    ubuntu.vm.network 'private_network', ip: '192.168.56.102'
   end
 
   config.vm.define 'debian', autostart: false do |debian|
     debian.vm.box = 'bento/debian-8.8'
     debian.vm.network 'forwarded_port', guest: 5432, host: 25432
-    debian.vm.network 'private_network', ip: '192.168.56.102', auto_config: false
+    debian.vm.network 'private_network', ip: '192.168.56.201'
+    debian.vm.network 'private_network', ip: '192.168.56.202'
   end
 
   config.vm.provider 'virtualbox' do |vb|


### PR DESCRIPTION
Instead of having to manually configure the network adapters which at best was error-prone and would randomly break depending on your version of VirtualBox and Vagrant. As we only need the two IP addresses now (as we don't have a separate endpoint for submission, grading, cgi, etc.), we should be fine doing this.

I propose this instead of #1667