### PR TITLE
Allow Full Access Graders to delete posts/threads

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -161,7 +161,7 @@ class ForumController extends AbstractController {
     }
 
     public function deletePost(){
-        if($this->core->getUser()->accessAdmin()){
+        if($this->core->getUser()->getGroup() <= 2){
             $thread_id = $_POST["thread_id"];
             $post_id = $_POST["post_id"];
             $type = "";

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -187,7 +187,7 @@ HTML;
 						}
 
 
-						if($this->core->getUser()->accessAdmin()){
+						if($this->core->getUser()->getGroup() <= 2){
 							$return .= <<<HTML
 							<a style="position:relative; display:inline-block; color:red; float:right;" onClick="deletePost( {$post['thread_id']}, {$post['id']}, '{$post['author_user_id']}', '{$function_date($date,'m/d/Y g:i A')}' )" title="Remove post"><i class="fa fa-times" aria-hidden="true"></i></a>
 HTML;


### PR DESCRIPTION
Per our discussion with Professor Kuzmin on Wednesday, Full-Access graders now have the ability to delete threads/posts (in addition to instructors).