### PR TITLE
TA Grading Team Name Fix

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -601,10 +601,7 @@ HTML;
                                 $member_list = $member_list . ", ";
                             }
  	 
-                            $first_name = $this->core->getQueries()->getUserById($team_member)->getPreferredFirstName();
-                            if ($first_name === "") {
-                                $first_name = $this->core->getQueries()->getUserById($team_member)->getFirstName();
-                            }
+                            $first_name = $this->core->getQueries()->getUserById($team_member)->getDisplayedFirstName();
                             $last_name = $this->core->getQueries()->getUserById($team_member)->getLastName();
 
                             $member_list = $member_list . $first_name . " " . $last_name;

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -593,10 +593,25 @@ HTML;
                 <td>{$row->getUser()->getId()}</td>
 HTML;
                     }
-                    else {
-                        $return .= <<<HTML
+                    // Construct a string containing the names of all team members
+                     else {
+                        $member_list = "";
+                        foreach($row->getTeam()->getMembers() as $team_member) {
+                            if ($member_list !== "") {
+                                $member_list = $member_list . ", ";
+                            }
+ 	 
+                            $first_name = $this->core->getQueries()->getUserById($team_member)->getPreferredFirstName();
+                            if ($first_name === "") {
+                                $first_name = $this->core->getQueries()->getUserById($team_member)->getFirstName();
+                            }
+                            $last_name = $this->core->getQueries()->getUserById($team_member)->getLastName();
 
-                <td>{$row->getTeam()->getMemberList()}</td>
+                            $member_list = $member_list . $first_name . " " . $last_name;
+                        }
+                        $return .= <<<HTML
+                <td>{$member_list}</td>
+        
 HTML;
                     }
                 }


### PR DESCRIPTION
closes #1594, where team names consisted of list of user IDs, not full names