### PR TITLE
Forum full display name

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1753,13 +1753,13 @@ AND gc_id IN (
     public function getDisplayUserNameFromUserId($user_id){
       $this->course_db->query("SELECT user_firstname, user_preferred_firstname, user_lastname from users where user_id = ?", array($user_id));
       $name_rows = $this->course_db->rows()[0];
-      $last_name_initial =  " " . substr($name_rows["user_lastname"], 0, 1) . ".";
+      $last_name =  " " . $name_rows["user_lastname"];
       if(empty($name_rows["user_preferred_firstname"])){
         $name = $name_rows["user_firstname"];
       } else {
         $name = $name_rows["user_preferred_firstname"];
       }
-      $name .= $last_name_initial;
+      $name .= $last_name;
       return $name;
     }
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -36,6 +36,31 @@ class ForumThreadView extends AbstractView {
 		}
 		</script>
 
+HTML;
+	if($this->core->getUser()->getGroup() <= 2){
+		$return .= <<<HTML
+		<script>
+								function changeName(element, user, visible_username){
+									new_element = element.getElementsByTagName("strong")[0];
+									icon = element.getElementsByClassName("fa fa-eye");
+									if(icon.length == 0){
+										icon = element.getElementsByClassName("fa fa-eye-slash");
+									} icon = icon[0];
+									if(new_element.innerText == visible_username) {
+										new_element.innerText = user;
+										icon.className = "fa fa-eye-slash";
+										icon.title = "Hide full user information";
+									} else {
+										new_element.innerText = visible_username;
+										icon.className = "fa fa-eye";
+										icon.title = "Show full user information";
+									}
+									
+								}
+		</script>
+HTML;
+	}
+	$return .= <<<HTML
 		<div style="margin-top:5px;background-color:transparent; margin: !important auto;padding:0px;box-shadow: none;" class="content">
 
 		<div style="margin-top:10px; margin-bottom:10px; height:50px;  " id="forum_bar">
@@ -119,7 +144,7 @@ HTML;
 
 			$thread_id = -1;
 			$function_content = 'nl2br';
-			$userAccessToAnon = ($this->core->getUser()->getGroup() < 4) ? true : false;
+			$canToggleUser = ($this->core->getUser()->getGroup() < 4) ? true : false;
 			$title_html = '';
 			$return .= <<< HTML
 					</div>
@@ -156,26 +181,12 @@ HTML;
 						}
 						$date = date_create($post["timestamp"]);
 
-						if($post["anonymous"] == true){
-							if($userAccessToAnon){
-								$visible_username = "<a onClick=\"changeName(this, '{$post["author_user_id"]}')\" id=\"anonUser\">Anonymous</a>";
-								$return .= <<<HTML
-								<script>
-								function changeName(element, user){
-									if(element.innerHTML.indexOf("Anonymous") != -1) {
-										element.innerHTML = user;
-									} else {
-										element.innerHTML = 'Anonymous';
-									}
-									
-								}
-								</script>
-HTML;
-							} else {
-								$visible_username = "Anonymous";
-							}
+						$full_name = $this->core->getQueries()->getDisplayUserNameFromUserId($post["author_user_id"]);
+
+						if($post["anonymous"]){
+							$visible_username = "Anonymous";
 						} else {
-							$visible_username = $this->core->getQueries()->getDisplayUserNameFromUserId($post["author_user_id"]);
+							$visible_username = substr($full_name, 0, strpos($full_name, " ")+2) . ".";
 						}
 
 						$classes = "post_box";
@@ -197,10 +208,17 @@ HTML;
                         }
 
 						if($this->core->getUser()->getGroup() <= 2){
+							$info_name = $full_name . " (" . $post['author_user_id'] . ")";
 							$return .= <<<HTML
-							<a class="remove_post_button" style="position:relative; display:inline-block; color:red; float:right;" onClick="deletePost( {$post['thread_id']}, {$post['id']}, '{$post['author_user_id']}', '{$function_date($date,'m/d/Y g:i A')}' )" title="Remove post"><i class="fa fa-times" aria-hidden="true"></i></a>
+							<a class="remove_post_button" style="position:absolute; display:inline-block; color:red; float:right;" onClick="deletePost( {$post['thread_id']}, {$post['id']}, '{$post['author_user_id']}', '{$function_date($date,'m/d/Y g:i A')}' )" title="Remove post"><i class="fa fa-times" aria-hidden="true"></i></a>
+							<a class="remove_post_button" style="position:absolute; margin-right:18px;display:inline-block; color:black; float:right;" onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}'	)" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
+
 HTML;
-						}
+	
+								
+					
+							} 
+						
 						$return .= <<<HTML
 							<p class="post_content">{$function_content($post["content"])}</p>
 							
@@ -225,7 +243,7 @@ HTML;
 						}
 			$return .= <<<HTML
 			
-<h7 style="margin-top:5px;float:right;"><strong>{$visible_username}</a></strong> {$function_date($date,"m/d/Y g:i A")}</h7>
+<h7 style="margin-top:5px;float:right;"><strong id="post_user_id">{$visible_username}</strong> {$function_date($date,"m/d/Y g:i A")}</h7>
 </div>
 HTML;
 						

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -144,7 +144,6 @@ HTML;
 
 			$thread_id = -1;
 			$function_content = 'nl2br';
-			$canToggleUser = ($this->core->getUser()->getGroup() < 4) ? true : false;
 			$title_html = '';
 			$return .= <<< HTML
 					</div>

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -40,17 +40,25 @@ HTML;
 	if($this->core->getUser()->getGroup() <= 2){
 		$return .= <<<HTML
 		<script>
-								function changeName(element, user, visible_username){
+								function changeName(element, user, visible_username, anon){
 									new_element = element.getElementsByTagName("strong")[0];
 									icon = element.getElementsByClassName("fa fa-eye");
 									if(icon.length == 0){
 										icon = element.getElementsByClassName("fa fa-eye-slash");
 									} icon = icon[0];
 									if(new_element.innerText == visible_username) {
+										if(anon) {
+											new_element.style.color = "grey";
+											new_element.style.fontStyle = "italic";
+										}
 										new_element.innerText = user;
 										icon.className = "fa fa-eye-slash";
 										icon.title = "Hide full user information";
 									} else {
+										if(anon) {
+											new_element.style.color = "black";
+											new_element.style.fontStyle = "normal";
+										}
 										new_element.innerText = visible_username;
 										icon.className = "fa fa-eye";
 										icon.title = "Show full user information";
@@ -207,23 +215,28 @@ HTML;
                         }
 
 						if($this->core->getUser()->getGroup() <= 2){
-							$info_name = $full_name . " (" . $post['author_user_id'] . ")";
 							$return .= <<<HTML
 							<a class="post_button" style="position:absolute; display:inline-block; color:red; float:right;" onClick="deletePost( {$post['thread_id']}, {$post['id']}, '{$post['author_user_id']}', '{$function_date($date,'m/d/Y g:i A')}' )" title="Remove post"><i class="fa fa-times" aria-hidden="true"></i></a>
-							<a class="post_button" style="position:absolute; margin-right:18px;display:inline-block; color:black; float:right;" onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}'	)" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
-
 HTML;
-	
-								
-					
 							} 
 						
 						$return .= <<<HTML
 							<p class="post_content">{$function_content($post["content"])}</p>
 							
 							
-							<hr style="margin-bottom:3px;">
+							<hr style="margin-bottom:3px;"><span style="margin-top:5px;margin-left:10px;float:right;">
 							
+HTML;
+
+if($this->core->getUser()->getGroup() <= 2){
+						$info_name = $full_name . " (" . $post['author_user_id'] . ")";
+						$return .= <<<HTML
+						<a style=" margin-right:2px;display:inline-block; color:black; " onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}', {$post['anonymous']}	)" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
+HTML;
+}
+			$return .= <<<HTML
+			
+<h7><strong id="post_user_id">{$visible_username}</strong> {$function_date($date,"m/d/Y g:i A")}</h7></span>
 HTML;
 
 						if($post["has_attachment"]){
@@ -240,15 +253,14 @@ HTML;
 							}
 							
 						}
-			$return .= <<<HTML
-			
-<h7 style="margin-top:5px;float:right;"><strong id="post_user_id">{$visible_username}</strong> {$function_date($date,"m/d/Y g:i A")}</h7>
+						$return .= <<<HTML
 </div>
 HTML;
 						
 					}
 
 			$return .= <<<HTML
+			
 					<form style="margin:20px;" method="POST" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
 					<input type="hidden" name="thread_id" value="{$thread_id}" />
 	            	<br/>

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -209,8 +209,8 @@ HTML;
 						if($this->core->getUser()->getGroup() <= 2){
 							$info_name = $full_name . " (" . $post['author_user_id'] . ")";
 							$return .= <<<HTML
-							<a class="remove_post_button" style="position:absolute; display:inline-block; color:red; float:right;" onClick="deletePost( {$post['thread_id']}, {$post['id']}, '{$post['author_user_id']}', '{$function_date($date,'m/d/Y g:i A')}' )" title="Remove post"><i class="fa fa-times" aria-hidden="true"></i></a>
-							<a class="remove_post_button" style="position:absolute; margin-right:18px;display:inline-block; color:black; float:right;" onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}'	)" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
+							<a class="post_button" style="position:absolute; display:inline-block; color:red; float:right;" onClick="deletePost( {$post['thread_id']}, {$post['id']}, '{$post['author_user_id']}', '{$function_date($date,'m/d/Y g:i A')}' )" title="Remove post"><i class="fa fa-times" aria-hidden="true"></i></a>
+							<a class="post_button" style="position:absolute; margin-right:18px;display:inline-block; color:black; float:right;" onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}'	)" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
 
 HTML;
 	

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -721,10 +721,10 @@ table tr.table-header {
     margin-right: 40px;
 }
 
-.first_post .remove_post_button {
+.first_post .post_button {
 }
 
-.remove_post_button{
+.post_button {
     position: absolute;
     top: 5px;
     right: 5px;

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -717,6 +717,10 @@ table tr.table-header {
     margin-top: 10px;
 }
 
+.post_content {
+    margin-right: 40px;
+}
+
 .first_post .remove_post_button {
 }
 


### PR DESCRIPTION
This addresses the issue of uncovering anonymous posters not being intuitive by creating a button next to the delete post red X. It also shows full name and user id information for people who posted regularly. Please refer to the images attached below:

**Regular Post:**
![nonanonnottoggled](https://user-images.githubusercontent.com/16356240/36181292-37d92e92-10f2-11e8-9ecd-e6c620707304.png)
![nonanontoggled](https://user-images.githubusercontent.com/16356240/36181293-37eb0536-10f2-11e8-9d92-7bb24b9a1758.png)

**Anon Post:**
![not_toggled](https://user-images.githubusercontent.com/16356240/36181294-3815ab60-10f2-11e8-9c3d-7c14ed0b1f5f.png)
![toggled](https://user-images.githubusercontent.com/16356240/36181295-3824ef9e-10f2-11e8-84da-676aa7372a32.png)


Partial resolve of #1678. 