### PR TITLE
Replace psycopg2 with psycopg2-binary

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -128,7 +128,7 @@ usermod -aG docker hwcron
 pip3 install -U pip
 pip3 install python-pam
 pip3 install PyYAML
-pip3 install psycopg2
+pip3 install psycopg2-binary
 pip3 install sqlalchemy
 pip3 install pylint
 pip3 install psutil

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
   - pip3 install -U pip
   - pip3 install python-pam
   - pip3 install PyYAML
-  - pip3 install psycopg2
+  - pip3 install psycopg2-binary
   - pip3 install sqlalchemy
   - pip3 install pylint_runner
   - pip3 install psutil


### PR DESCRIPTION
The psycopg2 library is phasing out binaries from the primary pypi package and requiring people to build from source if using it as some people (not us) were having issues with the bundled version of libssl. We need to switch to their new binary only pypi package going forward, though this only requires changing the pypi package we install and no other changes.

See: http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/