### PR TITLE
Enabled MPI on Submitty

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -108,6 +108,8 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     { "timeout",                 "/usr/bin/timeout" },
     { "mpicc.openmpi",           "/usr/bin/mpicc.openmpi" },
     { "mpirun.openmpi",          "/usr/bin/mpirun.openmpi" },
+    { "mpirun"        ,          "/usr/bin/mpirun"},
+    { "mpicc",                   "/usr/bin/mpicc"},
 
     // for LLVM / Compiler class
     { "lex",                     "/usr/bin/lex" },

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -108,7 +108,7 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     { "timeout",                 "/usr/bin/timeout" },
     { "mpicc.openmpi",           "/usr/bin/mpicc.openmpi" },
     { "mpirun.openmpi",          "/usr/bin/mpirun.openmpi" },
-    { "mpirun"        ,          "/usr/bin/mpirun"},
+    { "mpirun",                  "/usr/bin/mpirun"},
     { "mpicc",                   "/usr/bin/mpicc"},
 
     // for LLVM / Compiler class

--- a/grading/execute_limits.cpp
+++ b/grading/execute_limits.cpp
@@ -45,7 +45,7 @@ const std::vector<int> limit_names = {
 const std::map<int,rlim_t> system_limits = 
   { 
     { RLIMIT_CPU,        600              }, // 10 minutes per test
-    { RLIMIT_FSIZE,      100*1000*1000    }, // 100 MB created file size
+    { RLIMIT_FSIZE,      400*1000*1000    }, // 100 MB created file size
     { RLIMIT_DATA,       RLIM_INFINITY    }, // heap                // 1 GB
     { RLIMIT_STACK,      RLIM_INFINITY    }, // stack size          // 50 MB
     { RLIMIT_CORE,       RLIM_INFINITY    }, // allow core files?   // FIXME: 0
@@ -207,7 +207,6 @@ void enable_all_setrlimit(const std::string &program_name,
   
   // loop over all of the limits
   for (int i = 0; i < limit_names.size(); i++) {
-
     // get the current limit values
     success = getrlimit(limit_names[i], &current_rl);
     assert (success == 0);


### PR DESCRIPTION
Set up mpi for use in Parallel. This only required adding mpi to the list of enabled system programs and increasing the max RLIMIT_FSIZE from 100mb to 400mb.