### PR TITLE
Fix dockerfile missing folder /usr/local/submitty

### DIFF
--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -9,6 +9,7 @@ javascript-common  \
 libfile-mmagic-perl libgnupg-interface-perl libbsd-resource-perl libarchive-zip-perl gcc g++ \
 g++-multilib jq libseccomp-dev libseccomp2 seccomp junit flex bison spim poppler-utils pdftk
 
+RUN mkdir -p /usr/local/submitty
 COPY drmemory /usr/local/submitty/drmemory
 COPY SubmittyAnalysisTools /usr/local/submitty/SubmittyAnalysisTools
 


### PR DESCRIPTION
To use:
```
git pull
vagrant ssh
sudo su
rm -rf /tmp/docker
mkdir /tmp/docker
cp /usr/local/submitty/GIT_CHECKOUT_Submitty/.setup/Dockerfile /tmp/docker
cp -R /usr/local/submitty/drmemory /tmp/docker
cp -R /usr/local/submitty/SubmittyAnalysisTools /tmp/docker
cd /tmp/docker
su hwcron
docker build -t ubuntu:custom .
```
You should then have a docker image. To initially test:
```
$ docker run ubuntu:custom /bin/ls -la /usr/local/submitty
total 16
drwxr-xr-x 1 root root 4096 Feb 17 11:29 .
drwxr-xr-x 1 root root 4096 Feb 14 17:39 ..
drwxr-xr-x 2 root root 4096 Feb 17 11:29 SubmittyAnalysisTools
drwxr-xr-x 9 root root 4096 Feb 17 11:29 drmemory
```