### PR TITLE
Small Forum Tweaks

### DIFF
--- a/.setup/update_database.py
+++ b/.setup/update_database.py
@@ -88,6 +88,14 @@ for term in os.scandir(os.path.join(settings['submitty_data_dir'],"courses")):
             os.chown(forum_dir,uid,gid)
             os.chmod(forum_dir,0o770)
             print ("created directory:" + forum_dir)
+        else:
+            #Legacy fix for spaces in attachment file names for the forum
+            for root, dir_cur, files in os.walk(forum_dir):
+                files_with_space = list(filter(lambda x: " " in x, files))
+                for filename in files_with_space:
+                    filename_old = filename
+                    os.rename(os.path.join(root, filename_old), os.path.join(root, filename.replace(" ", "%20")));
+
 
             
         print ("\n")

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -116,7 +116,7 @@ class ForumController extends AbstractController {
                 FileUtils::createDir($post_dir);
 
                 for($i = 0; $i < count($_FILES["file_input"]["name"]); $i++){
-                    $target_file = $post_dir . "/" . basename($_FILES["file_input"]["name"][$i]);
+                    $target_file = $post_dir . "/" . basename(rawurlencode($_FILES["file_input"]["name"][$i]));
                     move_uploaded_file($_FILES["file_input"]["tmp_name"][$i], $target_file);
                 }
                 
@@ -145,7 +145,7 @@ class ForumController extends AbstractController {
                 $post_dir = FileUtils::joinPaths($thread_dir, $post_id);
                 FileUtils::createDir($post_dir);
                 for($i = 0; $i < count($_FILES["file_input"]["name"]); $i++){
-                    $target_file = $post_dir . "/" . basename($_FILES["file_input"]["name"][$i]);
+                    $target_file = $post_dir . "/" . basename(rawurlencode($_FILES["file_input"]["name"][$i]));
                     move_uploaded_file($_FILES["file_input"]["tmp_name"][$i], $target_file);
                 }
             }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -276,9 +276,9 @@ HTML;
 							$post_dir = FileUtils::joinPaths($thread_dir, $post["id"]);
 							$files = FileUtils::getAllFiles($post_dir);
 							foreach($files as $file){
-								$path = urlencode(htmlspecialchars($file['path']));
-								$name = urlencode(htmlspecialchars($file['name']));
-								$name_display = htmlentities($file['name'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+								$path = rawurlencode(htmlspecialchars($file['path']));
+								$name = rawurlencode(htmlspecialchars('"'.$file['name'].'"'));
+								$name_display = htmlentities(rawurldecode($file['name']), ENT_QUOTES | ENT_HTML5, 'UTF-8');
 								$return .= <<<HTML
 							<a href="#" style="text-decoration:none;display:inline-block;white-space: nowrap;" class="btn-default btn-sm" onclick="openFile('forum_attachments', '{$name}', '{$path}')" > {$name_display} </a>
 HTML;

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -141,8 +141,8 @@ HTML;
 						$first_post_content = str_replace("&lbrack;&sol;code&rsqb;", "", str_replace("&lbrack;code&rsqb;", "", strip_tags($first_post["content"])));
 						$sizeOfContent = strlen($first_post_content);
 						$contentDisplay = substr($first_post_content, 0, ($sizeOfContent < 80) ? $sizeOfContent : strpos($first_post_content, " ", 70));
-						
-						$titleDisplay = substr($thread["title"], 0, 30);
+						$titleLength = strlen($thread['title']);
+						$titleDisplay = substr($thread["title"], 0, ($titleLength < 30) ? $titleLength : strpos($thread['title'], " ", 29));
 						if(strlen($first_post["content"]) > 80){
 							$contentDisplay .= "...";
 						}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -47,6 +47,7 @@ class ForumThreadView extends AbstractView {
 
 			$( document ).ready(function() {
 			    enableTabsInTextArea('post_content');
+			    saveScrollLocationOnRefresh('thread_list');
 			});
 
 		</script>
@@ -261,8 +262,9 @@ HTML;
 
 if($this->core->getUser()->getGroup() <= 2){
 						$info_name = $full_name . " (" . $post['author_user_id'] . ")";
+						$jscriptAnonFix = $post['anonymous'] ? 'true' : 'false' ;
 						$return .= <<<HTML
-						<a style=" margin-right:2px;display:inline-block; color:black; " onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}', {$post['anonymous']}	)" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
+						<a style=" margin-right:2px;display:inline-block; color:black; " onClick="changeName(this.parentNode, '{$info_name}', '{$visible_username}', {$jscriptAnonFix})" title="Show full user information"><i class="fa fa-eye" aria-hidden="true"></i></a>
 HTML;
 }
 			$return .= <<<HTML
@@ -313,7 +315,7 @@ HTML;
 					</span>
 
 	            	<div style="margin-bottom:20px;float:right;" class="form-group row">
-	            		<label style="display:inline-block;" for="Anon">Anonymous?</label> <input type="checkbox" style="margin-right:15px;display:inline-block;" name="Anon" value="Anon" /><input type="submit" style="display:inline-block;" name="post" value="Reply" class="btn btn-primary" />
+	            		<label style="display:inline-block;" for="Anon">Anonymous (to class)?</label> <input type="checkbox" style="margin-right:15px;display:inline-block;" name="Anon" value="Anon" /><input type="submit" style="display:inline-block;" name="post" value="Reply" class="btn btn-primary" />
 	            	</div>
 	            	</form>
 	            	<br/>
@@ -393,7 +395,7 @@ HTML;
 			</div>
 		</div>
 
-		<div style="padding-left:20px;padding-top:1vh;height:69vh;border-radius:3px;box-shadow: 0 2px 15px -5px #888888;padding-right:20px;background-color: #E9EFEF;" id="forum_wrapper">
+		<div style="padding-left:20px;padding-top:1vh; padding-bottom: 10px;height:69vh;border-radius:3px;box-shadow: 0 2px 15px -5px #888888;padding-right:20px;background-color: #E9EFEF;" id="forum_wrapper">
 
 		<h3> Create Thread </h3>
 
@@ -407,7 +409,7 @@ HTML;
             		<button type="button" title="Insert a link" onclick="addBBCode(1, '#thread_content')" style="margin-right:10px;" class="btn btn-primary">Link <i class="fa fa-link fa-1x"></i></button><button title="Insert a code segment" type="button" onclick="addBBCode(0, '#thread_content')" class="btn btn-primary">Code <i class="fa fa-code fa-1x"></i></button>
             	</div>
             	<div class="form-group row">
-            		<textarea name="thread_content" id="thread_content" style="resize:none;min-height:45vh;overflow:hidden;width:100%;" rows="10" cols="30" placeholder="Enter your post here..." required></textarea>
+            		<textarea name="thread_content" id="thread_content" style="resize:none;min-height:40vmin;overflow:hidden;width:100%;" rows="10" cols="30" placeholder="Enter your post here..." required></textarea>
             	</div>
 
             	<br/>
@@ -423,7 +425,7 @@ HTML;
 				</span>
 
 				<span style="display:inline-block;float:right;">
-            	<label for="Anon">Anonymous?</label> <input type="checkbox" style="margin-right:15px;display:inline-block;" name="Anon" value="Anon" />
+            	<label for="Anon">Anonymous (to class)?</label> <input type="checkbox" style="margin-right:15px;display:inline-block;" name="Anon" value="Anon" />
 HTML;
 				
 				if($this->core->getUser()->getGroup() <= 2){

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -863,7 +863,7 @@ function saveScrollLocationOnRefresh(className){
     $(document).ready(function() {
         if(sessionStorage.scrollTop != "undefined"){
 
-            //This can be used in stead of the animation: 
+            //This can be used instead of the animation: 
             //$(element).scrollTop(sessionStorage.scrollTop);
 
             $(element).animate({

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -862,7 +862,13 @@ function saveScrollLocationOnRefresh(className){
     });
     $(document).ready(function() {
         if(sessionStorage.scrollTop != "undefined"){
-            $(element).scrollTop(sessionStorage.scrollTop);
+
+            //This can be used in stead of the animation: 
+            //$(element).scrollTop(sessionStorage.scrollTop);
+
+            $(element).animate({
+                scrollTop: sessionStorage.scrollTop
+            });
         }
     });
 }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -868,7 +868,7 @@ function saveScrollLocationOnRefresh(className){
 
             $(element).animate({
                 scrollTop: sessionStorage.scrollTop
-            });
+            }, 300);
         }
     });
 }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -837,7 +837,7 @@ function enableTabsInTextArea(id){
     var t = document.getElementById(id);
 
     $(t).on('input', function() {
-        $(this).outerHeight(20).outerHeight(this.scrollHeight);
+        $(this).outerHeight(38).outerHeight(this.scrollHeight);
     });
     $(t).trigger('input');
         t.onkeydown = function(t){
@@ -853,6 +853,18 @@ function enableTabsInTextArea(id){
             }
         };
 
+}
+
+function saveScrollLocationOnRefresh(className){
+    var element = document.getElementsByClassName(className);
+    $(element).scroll(function() {
+        sessionStorage.scrollTop = $(this).scrollTop();
+    });
+    $(document).ready(function() {
+        if(sessionStorage.scrollTop != "undefined"){
+            $(element).scrollTop(sessionStorage.scrollTop);
+        }
+    });
 }
 
 function deletePost(thread_id, post_id, author, time){


### PR DESCRIPTION
We have discussed a few things in the last couple of days and some of the fixes for those are included in this PR. Including:

- Thread list scroll bar saving location on refresh (this is animated and can be changed to be slower, faster, or not animated)

- Full name and user_id clickable for ta & instructor forum view should be fixed. I can't re-create the issue that was mentioned but I believe my fix addresses the error

- There was an error where htmlentities would display in the thread_list for titles of threads 

- Text area size change for create thread as it seemed to overflow in some cases 

- A fix for making files with spaces being able to be displayed, this doesn't effect ones that already have been uploaded with a space in the file name, but rather future uploads. To fix attachments that have already been uploaded with a space you need to run the `update_database.py` file (goes through and converts spaces in file names to their corresponding rawurlencode value --> %20)
