### PR TITLE
Add killall script for user who runs it

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -314,6 +314,9 @@ chown ${HWCRON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/bin/make_a
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/build_homework_function.sh
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/make_assignments_txt_file.py
 
+# everyone needs to run this script
+chmod 555 ${SUBMITTY_INSTALL_DIR}/bin/killall.py
+
 
 # FIXME / WIP:  line below is temporary, to avoid error message if file does not exist
 touch ${SUBMITTY_INSTALL_DIR}/bin/clang.Dockerfile

--- a/bin/grade_item.py
+++ b/bin/grade_item.py
@@ -395,22 +395,35 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
                               stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH,
                               stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
 
+
+
     # raise SystemExit()
     # run the run.out as the untrusted user
     with open(os.path.join(tmp_logs,"runner_log.txt"), 'w') as logfile:
-        if USE_DOCKER:
-            runner_success = subprocess.call(['docker', 'exec', '-w', tmp_work, container,
-                                              os.path.join(tmp_work, 'my_runner.out'), obj['gradeable'],
-                                              obj['who'], str(obj['version']), submission_string], stdout=logfile)
-        else:
-            runner_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","untrusted_execute"),
-                                              which_untrusted,
-                                              os.path.join(tmp_work,"my_runner.out"),
-                                              obj["gradeable"],
-                                              obj["who"],
-                                              str(obj["version"]),
-                                              submission_string],
-                                              stdout=logfile)
+        print ("LOGGING BEGIN my_runner.out",file=logfile)
+        logfile.flush()
+
+        try:
+            if USE_DOCKER:
+                runner_success = subprocess.call(['docker', 'exec', '-w', tmp_work, container,
+                                                  os.path.join(tmp_work, 'my_runner.out'), obj['gradeable'],
+                                                  obj['who'], str(obj['version']), submission_string], stdout=logfile)
+            else:
+                runner_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","untrusted_execute"),
+                                                  which_untrusted,
+                                                  os.path.join(tmp_work,"my_runner.out"),
+                                                  obj["gradeable"],
+                                                  obj["who"],
+                                                  str(obj["version"]),
+                                                  submission_string],
+                                                 stdout=logfile)
+            logfile.flush()
+        except Exception as e:
+            print ("ERROR caught runner.out exception={0}".format(str(e.args[0])).encode("utf-8"),file=logfile)
+            logfile.flush()
+
+        print ("LOGGING END my_runner.out",file=logfile)
+        logfile.flush()
 
     if runner_success == 0:
         print ("pid",my_pid,"RUNNER OK")

--- a/bin/grade_item.py
+++ b/bin/grade_item.py
@@ -27,7 +27,6 @@ BATCH_QUEUE = os.path.join(SUBMITTY_DATA_DIR, "to_be_graded_batch")
 
 USE_DOCKER = False
 WRITE_DATABASE = True
-#WRITE_DATABASE = False
 
 # ==================================================================================
 def parse_args():
@@ -426,13 +425,18 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
         print ("LOGGING END my_runner.out",file=logfile)
         logfile.flush()
 
-        runner_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","untrusted_execute"),
-                                          which_untrusted,
-                                          os.path.join(SUBMITTY_INSTALL_DIR,"bin","killall.py")],
-                                         stdout=logfile)
+        killall_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","untrusted_execute"),
+                                           which_untrusted,
+                                           os.path.join(SUBMITTY_INSTALL_DIR,"bin","killall.py")],
+                                          stdout=logfile)
 
         print ("KILLALL COMPLETE my_runner.out",file=logfile)
         logfile.flush()
+
+        if killall_success != 0:
+            msg='RUNNER ERROR: had to kill {} process(es)'.format(killall_success)
+            print ("pid",my_pid,msg)
+            grade_items_logging.log_message(is_batch_job,which_untrusted,submission_path,"","",msg)
 
     if runner_success == 0:
         print ("pid",my_pid,"RUNNER OK")

--- a/bin/grade_item.py
+++ b/bin/grade_item.py
@@ -27,6 +27,7 @@ BATCH_QUEUE = os.path.join(SUBMITTY_DATA_DIR, "to_be_graded_batch")
 
 USE_DOCKER = False
 WRITE_DATABASE = True
+#WRITE_DATABASE = False
 
 # ==================================================================================
 def parse_args():
@@ -423,6 +424,14 @@ def just_grade_item(next_directory,next_to_grade,which_untrusted):
             logfile.flush()
 
         print ("LOGGING END my_runner.out",file=logfile)
+        logfile.flush()
+
+        runner_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR,"bin","untrusted_execute"),
+                                          which_untrusted,
+                                          os.path.join(SUBMITTY_INSTALL_DIR,"bin","killall.py")],
+                                         stdout=logfile)
+
+        print ("KILLALL COMPLETE my_runner.out",file=logfile)
         logfile.flush()
 
     if runner_success == 0:

--- a/bin/killall.py
+++ b/bin/killall.py
@@ -7,14 +7,25 @@ Script that will kill all processes owned by the user who runs this script.
 import os
 import pwd
 import psutil
+import sys
 
 current_pid = os.getpid()
+
+count=0
+
 for proc in psutil.process_iter():
     try:
         pinfo = proc.as_dict(attrs=['name', 'pid', 'username'])
         if pinfo['username'] == pwd.getpwuid(os.getuid())[0]:
-            print ("a process to kill (except if its this script)", proc)
+            print ("a process to kill (except if its this script) proc=", proc, " count=",count)
             if pinfo['pid'] != current_pid:
+                count+=1
                 proc.kill()
     except psutil.NoSuchProcess:
         pass
+
+if count>0:
+    print ("ERROR: killall.py had to kill ",count," process(es)")
+    sys.exit(count)  # non-zero exit code means that many things had to be killed
+
+sys.exit(100)  # zero exit code means nothing had to be killed

--- a/bin/killall.py
+++ b/bin/killall.py
@@ -12,7 +12,9 @@ current_pid = os.getpid()
 for proc in psutil.process_iter():
     try:
         pinfo = proc.as_dict(attrs=['name', 'pid', 'username'])
-        if pinfo['pid'] != current_pid and pinfo['username'] == pwd.getpwuid(os.getuid())[0]:
-            proc.kill()
+        if pinfo['username'] == pwd.getpwuid(os.getuid())[0]:
+            print ("a process to kill (except if its this script)", proc)
+            if pinfo['pid'] != current_pid:
+                proc.kill()
     except psutil.NoSuchProcess:
         pass

--- a/bin/killall.py
+++ b/bin/killall.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+"""
+Script that will kill all processes owned by the user who runs this script.
+"""
+
+import os
+import pwd
+import psutil
+
+current_pid = os.getpid()
+for proc in psutil.process_iter():
+    try:
+        pinfo = proc.as_dict(attrs=['name', 'pid', 'username'])
+        if pinfo['pid'] != current_pid and pinfo['username'] == pwd.getpwuid(os.getuid())[0]:
+            proc.kill()
+    except psutil.NoSuchProcess:
+        pass


### PR DESCRIPTION
Testing it:
In one terminal:
```
$ vagrant ssh
vagrant@vagrant:~$ sudo su
root@vagrant:/home/vagrant# su untrusted00
untrusted00@vagrant:/home/vagrant$ python -c "import time; time.sleep(1000)"
root@vagrant:/home/vagrant#
```

and in another terminal:
```
$ vagrant ssh
vagrant@vagrant:~$ sudo su
root@vagrant:/home/vagrant# cd /usr/local/submitty/GIT_CHECKOUT_Submitty/bin/
root@vagrant:/usr/local/submitty/bin# su untrusted00
untrusted00@vagrant:/usr/local/submitty/bin$ ./killall.py
root@vagrant:/usr/local/submitty/bin#
```

The long running python script as well as both bash shells will be killed.

----
Still need to hook this up to the grade_item.py script.