### PR TITLE
Resolves issue with poor file name uploads

### DIFF
--- a/.setup/update_database.py
+++ b/.setup/update_database.py
@@ -18,6 +18,7 @@
 from datetime import datetime
 import json
 import os
+import urllib.parse
 
 usr_path = "/usr/local/submitty"
 
@@ -91,10 +92,8 @@ for term in os.scandir(os.path.join(settings['submitty_data_dir'],"courses")):
         else:
             #Legacy fix for spaces in attachment file names for the forum
             for root, dir_cur, files in os.walk(forum_dir):
-                files_with_space = list(filter(lambda x: " " in x, files))
-                for filename in files_with_space:
-                    filename_old = filename
-                    os.rename(os.path.join(root, filename_old), os.path.join(root, filename.replace(" ", "%20")));
+                for filename in files:
+                    os.rename(os.path.join(root, filename), os.path.join(root, urllib.parse.unquote(filename)));
 
 
             

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -40,8 +40,14 @@ class MiscController extends AbstractController {
         }
         // from this point on, is not a zip
         // do path and permissions checking
+
         $dir = $_REQUEST['dir'];
         $path = $_REQUEST['path'];
+
+        if(!empty($_GET['dir']) && !empty($_GET['path'])) {
+            $dir = $_GET['dir'];
+            $path = $_GET['path'];
+        }
 
         foreach (explode(DIRECTORY_SEPARATOR, $path) as $part) {
             if ($part == ".." || $part == ".") {
@@ -185,7 +191,7 @@ class MiscController extends AbstractController {
         $this->core->getOutput()->useFooter(false);
         if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
             header("Content-type: ".$mime_type);
-            header('Content-Disposition: inline; filename="' . basename(rawurldecode(htmlspecialchars_decode($_REQUEST['path']))) . '"');
+            header('Content-Disposition: inline; filename="' . basename(rawurldecode(htmlspecialchars_decode($_GET['path']))) . '"');
             readfile($corrected_name);
             $this->core->getOutput()->renderString($_REQUEST['path']);
         }
@@ -211,12 +217,14 @@ class MiscController extends AbstractController {
             $this->core->redirect($this->core->getConfig()->getSiteUrl());
         }
         
+        $filename = rawurldecode(htmlspecialchars_decode($_REQUEST['file']));
+
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         header('Content-Type: application/octet-stream');
         header("Content-Transfer-Encoding: Binary"); 
-        header("Content-disposition: attachment; filename=\"{$_REQUEST['file']}\"");
-        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_GET['path'])));
+        header("Content-disposition: attachment; filename=\"{$filename}\"");
+        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . basename(rawurldecode(htmlspecialchars_decode($_GET['path']))));
     }
 
     private function downloadZip() {

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -179,13 +179,13 @@ class MiscController extends AbstractController {
             return false;
         }
 
-        $corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_REQUEST['path']));
+        $corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" .  basename(rawurldecode(htmlspecialchars_decode($_GET['path'])));
         $mime_type = FileUtils::getMimeType($corrected_name);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
             header("Content-type: ".$mime_type);
-            header('Content-Disposition: inline; filename="' . basename($_REQUEST['path']) . '"');
+            header('Content-Disposition: inline; filename="' . basename(rawurldecode(htmlspecialchars_decode($_REQUEST['path']))) . '"');
             readfile($corrected_name);
             $this->core->getOutput()->renderString($_REQUEST['path']);
         }
@@ -216,7 +216,7 @@ class MiscController extends AbstractController {
         header('Content-Type: application/octet-stream');
         header("Content-Transfer-Encoding: Binary"); 
         header("Content-disposition: attachment; filename=\"{$_REQUEST['file']}\"");
-        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_REQUEST['path'])));
+        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_GET['path'])));
     }
 
     private function downloadZip() {

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -41,13 +41,8 @@ class MiscController extends AbstractController {
         // from this point on, is not a zip
         // do path and permissions checking
 
-        $dir = $_REQUEST['dir'];
-        $path = $_REQUEST['path'];
-
-        if(!empty($_GET['dir']) && !empty($_GET['path'])) {
-            $dir = $_GET['dir'];
-            $path = $_GET['path'];
-        }
+        $dir = $_GET['dir'];
+        $path = $_GET['path'];
 
         foreach (explode(DIRECTORY_SEPARATOR, $path) as $part) {
             if ($part == ".." || $part == ".") {

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -116,7 +116,7 @@ class ForumController extends AbstractController {
                 FileUtils::createDir($post_dir);
 
                 for($i = 0; $i < count($_FILES["file_input"]["name"]); $i++){
-                    $target_file = $post_dir . "/" . basename(rawurlencode($_FILES["file_input"]["name"][$i]));
+                    $target_file = $post_dir . "/" . basename($_FILES["file_input"]["name"][$i]);
                     move_uploaded_file($_FILES["file_input"]["tmp_name"][$i], $target_file);
                 }
                 
@@ -145,7 +145,7 @@ class ForumController extends AbstractController {
                 $post_dir = FileUtils::joinPaths($thread_dir, $post_id);
                 FileUtils::createDir($post_dir);
                 for($i = 0; $i < count($_FILES["file_input"]["name"]); $i++){
-                    $target_file = $post_dir . "/" . basename(rawurlencode($_FILES["file_input"]["name"][$i]));
+                    $target_file = $post_dir . "/" . basename($_FILES["file_input"]["name"][$i]);
                     move_uploaded_file($_FILES["file_input"]["tmp_name"][$i], $target_file);
                 }
             }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -514,6 +514,8 @@ class SubmissionController extends AbstractController {
         $uploaded_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
             $gradeable->getId(), $path);
 
+        $uploaded_file = rawurldecode(htmlspecialchars_decode($uploaded_file));
+
         // copy over the uploaded file
         if (isset($uploaded_file)) {
             if (!@copy($uploaded_file, FileUtils::joinPaths($version_path,"upload.pdf"))) {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -511,6 +511,8 @@ class SubmissionController extends AbstractController {
 
         $max_size = $gradeable->getMaxSize();
 
+        $path = rawurldecode(htmlspecialchars_decode($path));
+
         $uploaded_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
             $gradeable->getId(), $path);
 
@@ -641,10 +643,12 @@ class SubmissionController extends AbstractController {
         $gradeable_id = $_REQUEST['gradeable_id'];
         $gradeable = $gradeable_list[$gradeable_id];
         $gradeable->loadResultDetails();
-        $path = $_POST['path'];
+        $path = rawurldecode(htmlspecialchars_decode($_POST['path']));
 
         $uploaded_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
             $gradeable->getId(), $path);
+
+        $uploaded_file = rawurldecode(htmlspecialchars_decode($uploaded_file));
 
         if (!@unlink($uploaded_file)) {
             return $this->uploadResult("Failed to delete the uploaded file {$uploaded_file} from temporary storage.", false);

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -279,8 +279,8 @@ HTML;
 							$post_dir = FileUtils::joinPaths($thread_dir, $post["id"]);
 							$files = FileUtils::getAllFiles($post_dir);
 							foreach($files as $file){
-								$path = rawurlencode(htmlspecialchars($file['path']));
-								$name = rawurlencode(htmlspecialchars($file['name']));
+								$path = rawurlencode($file['path']);
+								$name = rawurlencode($file['name']);
 								$name_display = htmlentities(rawurldecode($file['name']), ENT_QUOTES | ENT_HTML5, 'UTF-8');
 								$return .= <<<HTML
 							<a href="#" style="text-decoration:none;display:inline-block;white-space: nowrap;" class="btn-default btn-sm" onclick="openFile('forum_attachments', '{$name}', '{$path}')" > {$name_display} </a>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1028,8 +1028,8 @@ HTML;
             foreach ($files as $dir => $path) {
                 if (!is_array($path)) {
                     $name = htmlentities($dir);
-                    $dir = urlencode(htmlspecialchars($dir));
-                    $path = urlencode(htmlspecialchars($path));
+                    $dir = rawurlencode(htmlspecialchars($dir));
+                    $path = rawurlencode(htmlspecialchars($path));
                     $indent_offset = $indent * -15;
                     $return .= <<<HTML
                 <div>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -870,8 +870,8 @@ HTML;
                 }
             </script>
 HTML;
-                        $filename = urlencode($file['relative_name']);
-                        $filepath = urlencode($file['path']);
+                        $filename = rawurlencode($file['relative_name']);
+                        $filepath = rawurlencode($file['path']);
                         $return .= <<< HTML
             <a onclick='downloadFile("{$filename}","{$filepath}")'><i class="fa fa-download" aria-hidden="true" title="Download the file"></i></a>
             <br />

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -870,10 +870,10 @@ HTML;
                 }
             </script>
 HTML;
-                        $filename = $file['relative_name'];
-                        $filepath = $file['path'];
+                        $filename = urlencode($file['relative_name']);
+                        $filepath = urlencode($file['path']);
                         $return .= <<< HTML
-            <a onclick="downloadFile('$filename','$filepath')"><i class="fa fa-download" aria-hidden="true" title="Download the file"></i></a>
+            <a onclick='downloadFile("{$filename}","{$filepath}")'><i class="fa fa-download" aria-hidden="true" title="Download the file"></i></a>
             <br />
 HTML;
                     }

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -477,10 +477,12 @@ HTML;
     <script type="text/javascript">
         function makeSubmission(user_id, highest_version, is_pdf, path, count, repo_id) {
             // submit the selected pdf
+            path = decodeURIComponent(path);
             if (is_pdf) {
                 submitSplitItem("{$this->core->getCsrfToken()}", "{$gradeable->getId()}", user_id, path, count);
                 moveNextInput(count);
             }
+            
             // otherwise, this is a regular submission of the uploaded files
             else if (user_id == "") {
                 handleSubmission({$late_days_use},
@@ -591,14 +593,15 @@ HTML;
 
                     foreach ($files as $filename => $details) {
                         $clean_timestamp = str_replace("_", " ", $timestamp);
-                        $path = $details["path"];
+                        $path = rawurlencode(htmlspecialchars($details["path"]));
                         if (strpos($filename, "cover") === false) {
                             continue;
                         }
                         // get the full filename for PDF popout
                         // add "timestamp / full filename" to count_array so that path to each filename is to the full PDF, not the cover
+                        $filename = rawurlencode(htmlspecialchars($filename));
                         $url = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename."&path=".$path."&ta_grading=false";
-                        $filename_full = str_replace("_cover.pdf", ".pdf", rawurldecode( $filename) );
+                        $filename_full = str_replace("_cover.pdf", ".pdf",  $filename );
                         $path_full = str_replace("_cover.pdf", ".pdf", $path);
                         $url_full = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename_full."&path=".$path_full."&ta_grading=false";
                         $count_array[$count] = FileUtils::joinPaths($timestamp, rawurlencode( $filename_full) );
@@ -658,7 +661,7 @@ HTML;
             var user_ids = [];
             $("input[id^='"+name+"']").each(function(){ user_ids.push(this.value); }); 
             var js_count_array = $count_array_json;
-            var path = js_count_array[count];
+            var path = decodeURIComponent(js_count_array[count]);
             if (id.includes("delete")) {
                 message = "Are you sure you want to delete this submission?";
                 if (!confirm(message)) {

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -561,9 +561,7 @@ function handleBulk(gradeable_id, num_pages) {
                 alert("ERROR! You may not use angle brackets in your filename: " + file_array[i][j].name);
                 return;
             }
-            var newName = file_array[i][j].name;
-            newName = newName.split('+').join(' ');
-            formData.append('files' + (i + 1) + '[]', file_array[i][j], encodeURIComponent(newName).replace(/\!/g, "%21").replace(/\(/g, "%28").replace(/\)/g, "%29"));
+            formData.append('files' + (i + 1) + '[]', file_array[i][j], file_array[i][j].name);
         }
     }
 
@@ -680,8 +678,7 @@ function handleSubmission(days_late, late_days_allowed, versions_used, versions_
                     alert("ERROR! You may not use angle brackets in your filename: " + file_array[i][j].name);
                     return;
                 }
-                formData.append('files' + (i + 1) + '[]', file_array[i][j], encodeURIComponent(file_array[i][j].name).replace(/\!/g, "%21").replace(/\(/g, "%28").replace(/\)/g, "%29"));
-            }
+            formData.append('files' + (i + 1) + '[]', file_array[i][j], file_array[i][j].name);            }
         }
         // Files from previous submission
         formData.append('previous_files', JSON.stringify(previous_files));


### PR DESCRIPTION
This should resolve the issue of a user inputting a poor filename, and not renaming or having issues displaying the poorly named file. All filenames are also preserved. Refer to the screenshots below.
Collaborated with @shailpatels to complete this PR.

*.pdf also works. Tested frame_buggy.cpp to ensure that it doesn't break with normal file names.

![screenshot from 2018-03-05 02-12-22](https://user-images.githubusercontent.com/16356240/36962044-e94e323e-201b-11e8-8b4f-c52189d9a4f6.png)


![screenshot from 2018-03-05 02-13-25](https://user-images.githubusercontent.com/16356240/36962032-e0594a60-201b-11e8-90b2-5096662f1af5.png)

![screenshot from 2018-03-05 02-15-44](https://user-images.githubusercontent.com/16356240/36962058-f8110094-201b-11e8-96a9-2d30e8137655.png)

![screenshot from 2018-03-05 02-20-23](https://user-images.githubusercontent.com/16356240/36962063-fd034ba2-201b-11e8-9a94-d15d13923887.png)

![screenshot from 2018-03-05 02-24-00](https://user-images.githubusercontent.com/16356240/36962128-4c99b57a-201c-11e8-9233-07931c012329.png)


