### PR TITLE
Updated license year and fixed the AUTHORS.md file link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, [Submitty team](https://github.com/Submitty/Submitty/blob/master/AUTHORS.md)  
+Copyright (c) 2017-2018, [Submitty Team](AUTHORS.md)  
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
### Description of the Change

Changed the license year line from

```
Copyright (c) 2017, [Submitty team](https://github.com/Submitty/Submitty/blob/master/AUTHORS.md)
```
to
```
Copyright (c) 2017-2018, [Submitty Team](AUTHORS.md)
```

also updated how AUTHORS.md file was linked to the file, which wouldn't work as expected in a forked repository. This would link back to the base repo under Submitty.

### Benefits

The new range of license year states the proper year of development of the open source project.

### Possible Drawbacks

None

### Verification Process

Now LICENSE.md displays the right year.

All the repos from GitHub contain a range of years instead of a single year as it better states when the software was developed.
Ref on how to manage license year is [here](https://github.com/github/choosealicense.com)

### Applicable Issues

Fixes #1797 

