### PR TITLE
Reinitialize negative penalty to produce total_pts as zero

### DIFF
--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_penalty5_grade.txt
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_penalty5_grade.txt
@@ -7,6 +7,6 @@ Testcase  6: Error Checking: Frame Size 0                         0 /  2
 Testcase  7: Error Checking: Frame Size Negative                  0 /  2    [ HIDDEN ]
 Testcase  8: Error Checking: No Arguments                                 
 Testcase  9: Error Checking: Too Many Arguments                             [ HIDDEN ]
-Testcase 10: Submission Limit                                    -5 points
+Testcase 10: Submission Limit                                    -4 points
 Automatic grading total:                                          0 / 14
 Non-hidden automatic grading total:                               0 / 10

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_penalty5_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_penalty5_results.json
@@ -115,7 +115,7 @@
             "test_name": "Test 9 Error Checking: Too Many Arguments"
         },
         {
-            "points_awarded": -5,
+            "points_awarded": -4,
             "test_name": "Test 10 Submission Limit"
         }
     ]


### PR DESCRIPTION
Issue: #1324 
Configuration under `config.json`
```json
    "title" : "Forbidden Technique",
    "points" : -100
```
**Expected Output**
If _total_pts_ become negative because of heavy penalties, then reinitialize the negative alloted penalty scores such that _total_pts_ become _zero_. 

**Screenshot**
Result of normal sample submission
![forbiddentechnotused](https://user-images.githubusercontent.com/9819066/37534161-119079f8-296a-11e8-8c9c-6ca3ac846795.png)

Result of sample submission by using forbidden technique 
![forbiddentechused](https://user-images.githubusercontent.com/9819066/37534164-1274466a-296a-11e8-9bd9-b9607364a8a4.png)
