### PR TITLE
Fix memory/time usage for grading summaries

### DIFF
--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -8,7 +8,7 @@ libpq-dev unzip valgrind zip libmagic-ocaml-dev common-lisp-controller libboost-
 javascript-common  \
 libfile-mmagic-perl libgnupg-interface-perl libbsd-resource-perl libarchive-zip-perl gcc g++ \
 g++-multilib jq libseccomp-dev libseccomp2 seccomp junit flex bison spim poppler-utils pdftk
-RUN apt-get install imagemagick
+RUN apt-get install -qqy imagemagick
 
 RUN mkdir -p /usr/local/submitty
 COPY drmemory /usr/local/submitty/drmemory

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -320,15 +320,9 @@ chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/make_assignments_txt_file.py
 # everyone needs to run this script
 chmod 555 ${SUBMITTY_INSTALL_DIR}/bin/killall.py
 
-
-# FIXME / WIP:  line below is temporary, to avoid error message if file does not exist
-touch ${SUBMITTY_INSTALL_DIR}/bin/clang.Dockerfile
-
-
 # hwcron only things
 chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/insert_database_version_data.py
 chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/grade_item.py
-chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/clang.Dockerfile
 chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/submitty_autograding_shipper.py
 chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/submitty_autograding_worker.py
 chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/grade_items_logging.py
@@ -336,7 +330,6 @@ chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/write_grade_history.py
 chown root:${HWCRON_USER} ${SUBMITTY_INSTALL_DIR}/bin/build_config_upload.py
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/insert_database_version_data.py
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/grade_item.py
-chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/clang.Dockerfile
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/submitty_autograding_shipper.py
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/submitty_autograding_worker.py
 chmod 550 ${SUBMITTY_INSTALL_DIR}/bin/grade_items_logging.py

--- a/.setup/bin/partial_reset.py
+++ b/.setup/bin/partial_reset.py
@@ -109,6 +109,9 @@ def main():
         with open(os.path.join(SUBMITTY_INSTALL_DIR,".setup","submitty_conf.json")) as submitty_config:
             submitty_config_json = json.load(submitty_config)
             os.environ['PGPASSWORD'] = submitty_config_json["database_password"]
+        os.system('psql -d postgres -U hsdbu -c "SELECT pg_terminate_backend(pg_stat_activity.pid) '
+                  'FROM pg_stat_activity WHERE pg_stat_activity.datname LIKE \'Submitty%\' AND '
+                  'pid <> pg_backend_pid();"')
         os.system("psql -U hsdbu --list | grep submitty* | awk '{print $1}' | "
                   "xargs -I \"@@\" dropdb -h localhost -U hsdbu \"@@\"")
         os.system('psql -d postgres -U hsdbu -c "CREATE DATABASE submitty"')

--- a/.setup/update_database.py
+++ b/.setup/update_database.py
@@ -101,5 +101,6 @@ for term in os.scandir(os.path.join(settings['submitty_data_dir'],"courses")):
         os.system("""PGPASSWORD='{}' psql --host={} --username={} --dbname={} -c 'ALTER TABLE seeking_team ADD CONSTRAINT seeking_team_pkey PRIMARY KEY (g_id, user_id)'""".format(settings['database_password'], settings['database_host'], settings['database_user'], db))
         os.system("""PGPASSWORD='{}' psql --host={} --username={} --dbname={} -c 'ALTER TABLE ONLY seeking_team ADD CONSTRAINT seeking_team_g_id_fkey FOREIGN KEY (g_id) REFERENCES gradeable(g_id) ON UPDATE CASCADE ON DELETE CASCADE'""".format(settings['database_password'], settings['database_host'], settings['database_user'], db))
 
+        os.system("""PGPASSWORD='{}' psql --host={} --username={} --dbname={} -c 'CREATE FUNCTION get_allowed_late_days(character varying, timestamp with time zone) RETURNS integer AS $$ SELECT allowed_late_days FROM late_days WHERE user_id = $1 AND since_timestamp <= $2 ORDER BY since_timestamp DESC LIMIT 1; $$ LANGUAGE SQL'""".format(settings['database_password'], settings['database_host'], settings['database_user'], db))
             
         print ("\n")

--- a/.setup/vagrant/sites-available/submitty.conf
+++ b/.setup/vagrant/sites-available/submitty.conf
@@ -14,7 +14,7 @@
         AddHandler php7-fcgi .php
         Action php7-fcgi /php7-fcgi
         Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
-        FastCgiExternalServer /usr/lib/cgi-bin/php7-fcgi -socket /var/run/php/php7.0-fpm-submitty.sock -pass-header Authorization
+        FastCgiExternalServer /usr/lib/cgi-bin/php7-fcgi -socket /var/run/php/php7.0-fpm-submitty.sock -idle-timeout 60 -pass-header Authorization
 
         <FilesMatch ".+\.ph(p[345]?|t|tml)$">
             SetHandler php7-fcgi

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -187,7 +187,7 @@ class ReportController extends AbstractController {
         $this->core->getOutput()->renderOutput(array('admin', 'Report'), 'showReportUpdates');
     }
 
-    private function addLateDays(Gradeable $gradeable, &$entry, $total_late_used) {
+    private function addLateDays(Gradeable $gradeable, &$entry, &$total_late_used) {
         $late_days_used = $gradeable->getLateDays() - $gradeable->getLateDayExceptions();
         $status = 'Good';
 
@@ -222,6 +222,7 @@ class ReportController extends AbstractController {
         else {
             $entry['days_late'] = 0;
         }
+        $total_late_used += $late_days_used;
     }
 
     private function addProblemScores(Gradeable $gradeable, &$entry) {

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -130,6 +130,7 @@ class ReportController extends AbstractController {
                     file_put_contents(FileUtils::joinPaths($base_path, $current_user.'_summary.json'), FileUtils::encodeJson($user));
                 }
                 $current_user = $gradeable->getUser()->getId();
+                $user = [];
                 $user['user_id'] = $gradeable->getUser()->getId();
                 $user['legal_first_name'] = $gradeable->getUser()->getFirstName();
                 $user['preferred_first_name'] = $gradeable->getUser()->getPreferredFirstName();
@@ -217,7 +218,6 @@ class ReportController extends AbstractController {
             $entry['days_after_deadline'] = $gradeable->getLateDays();
             $entry['extensions'] = $gradeable->getLateDayExceptions();
             $entry['days_charged'] = $late_days_used;
-
         }
         else {
             $entry['days_late'] = 0;

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -202,8 +202,10 @@ class ReportController extends AbstractController {
             $status = "Bad";
             $late_flag = false;
         }
-        //If late days used - extensions applied > allowed per term then status is "Bad..."
-        if ($late_days_used >  $gradeable->getStudentAllowedLateDays() - $total_late_used) {
+        // If late days used - extensions applied > allowed per term then status is "Bad..."
+        // Do a max(0, ...) to protect against the case where the student's late days goes down
+        // during the semester and they've already used late days
+        if ($late_days_used > max(0, $gradeable->getStudentAllowedLateDays() - $total_late_used)) {
             $status = "Bad";
             $late_flag = false;
         }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -221,7 +221,7 @@ class ReportController extends AbstractController {
         }
         $entry['status'] = $status;
 
-        if ($late_days_used > 0) {
+        if ($late_flag && $late_days_used > 0) {
 
             // TODO:  DEPRECATE THIS FIELD
             $entry['days_late'] = $late_days_used;

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -4,8 +4,10 @@ namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
 use app\libraries\Core;
+use app\libraries\FileUtils;
 use app\libraries\GradeableType;
 use app\libraries\Output;
+use app\models\Gradeable;
 use app\models\HWReport;
 use app\models\GradeSummary;
 use app\models\LateDaysCalculation;
@@ -115,10 +117,116 @@ class ReportController extends AbstractController {
     }
     
     public function generateGradeSummaries() {
-        $grade_summary = new GradeSummary($this->core);
-        $grade_summary->generateAllSummaries();
-        $this->core->addSuccessMessage("Successfully Generated GradeSummaries");
+        $curr_allowed_term =
+
+        $current_user = null;
+        $user = [];
+        $order_by = [
+            'g.g_gradeable_type',
+            'CASE WHEN eg.eg_submission_due_date IS NOT NULL THEN eg.eg_submission_due_date ELSE g.g_grade_released_date END'
+        ];
+        foreach ($this->core->getQueries()->getGradeablesIterator(null, true, 'registration_section', 'u.user_id', null, $order_by) as $gradeable) {
+            /** @var \app\models\Gradeable $gradeable */
+            if ($current_user !== $gradeable->getUser()->getId()) {
+                if ($current_user !== null) {
+                    file_put_contents(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "reports", $current_user.'_summary.json'), $user);
+                }
+                $current_user = $gradeable->getUser()->getId();
+                $user['user_id'] = $gradeable->getUser()->getId();
+                $user['legal_first_name'] = $gradeable->getUser()->getFirstName();
+                $user['preferred_first_name'] = $gradeable->getUser()->getPreferredFirstName();
+                $user['last_name'] = $gradeable->getUser()->getLastName();
+                $user['registration_section'] = $gradeable->getUser()->getRegistrationSection();
+                $user['default_allowed_late_days'] = $this->core->getConfig()->getDefaultHwLateDays();
+                $user['last_update'] = date("l, F j, Y");
+            }
+            $bucket = ucwords($gradeable->getBucket());
+            if (!isset($user[$bucket])) {
+                $user[$bucket] = [];
+            }
+
+            $autograding_score = $gradeable->getGradedAutoGraderPoints();
+            $ta_grading_score = $gradeable->getGradedTAPoints();
+
+            $entry = [
+                'id' => $gradeable->getId(),
+                'name' => $gradeable->getName(),
+                'grade_released_date' => $gradeable->getGradeReleasedDate()->format('Y-m-d H:i:s O'),
+            ];
+
+            if ($gradeable->validateVersions() || !$gradeable->useTAGrading()) {
+               $entry['score'] = max(0,floatval($autograding_score) + floatval($ta_grading_score));
+            }
+            else {
+                $entry['score'] = 0;
+                if ($gradeable->validateVersions(-1)) {
+                    $entry['note'] = 'This has not been graded yet.';
+                }
+                elseif ($gradeable->getActiveVersion() !== 0) {
+                    $entry['note'] = 'Score is set to 0 because there are version conflicts.';
+                }
+            }
+
+            switch ($gradeable->getType()) {
+                case GradeableType::ELECTRONIC_FILE:
+                    //$this->addLateDays($gradeable, $entry);
+                    $this->addText($gradeable, $entry);
+                    break;
+                case GradeableType::NUMERIC_TEXT:
+                    $this->addText($gradeable, $entry);
+                    $this->addProblemScores($gradeable, $entry);
+                    break;
+                case GradeableType::CHECKPOINTS:
+                    $this->addProblemScores($gradeable, $entry);
+                    break;
+            }
+            $user[$bucket][] = $entry;
+        }
+        $this->core->addSuccessMessage("Successfully Generated Grade Summaries");
         $this->core->getOutput()->renderOutput(array('admin', 'Report'), 'showReportUpdates');
+    }
+
+    private function addLateDays(Gradeable $gradeable, &$entry) {
+        $late_days = $gradeable->getLateDays();
+
+        if(substr($late_days['status'], 0, 3) == 'Bad') {
+            $this_g["score"] = 0;
+        }
+        $this_g['status'] = $late_days['status'];
+
+        if (array_key_exists('late_days_charged', $late_days) && $late_days['late_days_used'] > 0) {
+
+            // TODO:  DEPRECATE THIS FIELD
+            $this_g['days_late'] = $late_days['late_days_charged'];
+
+            // REPLACED BY:
+            $this_g['days_after_deadline'] = $late_days['late_days_used'];
+            $this_g['extensions'] = $late_days['extensions'];
+            $this_g['days_charged'] = $late_days['late_days_charged'];
+
+        }
+        else {
+            $this_g['days_late'] = 0;
+        }
+    }
+
+    private function addProblemScores(Gradeable $gradeable, &$entry) {
+        $component_scores = [];
+        foreach($gradeable->getComponents() as $component) {
+            $component_scores[] = [$component->getTitle() => $component->getScore()];
+        }
+        $entry["component_scores"] = $component_scores;
+    }
+
+    private function addText(Gradeable $gradeable, &$entry) {
+        $text_items = [];
+        foreach($gradeable->getComponents() as $component) {
+            $text_items[] = [$component->getTitle() => $component->getComment()];
+        }
+
+        if(count($text_items) > 0){
+            $entry["text"] = $text_items;
+        }
     }
     
     public function generateHWReports() {

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -227,6 +227,10 @@ class FileUtils {
         }
         return $json;
     }
+
+    public static function encodeJson($string) {
+        return json_encode($string, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
     
     /**
      * Given a file, returns its mimetype based on the file's so-called maagic bytes.
@@ -303,10 +307,6 @@ class FileUtils {
             }
         }
         return true;
-    }
-
-    public static function encodeJson($string) {
-        return json_encode($string, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -295,7 +295,18 @@ class DatabaseQueries {
         return $return;
     }
 
-    public function getGradeablesIterator($g_ids = null, $user_ids = null, $section_key="registration_section", $sort_key="u.user_id", $g_type = null) {
+    /** @noinspection PhpDocSignatureInspection */
+    /**
+     * @param null   $g_ids
+     * @param null   $user_ids
+     * @param string $section_key
+     * @param string $sort_key
+     * @param null   $g_type
+     * @parma array  $extra_order_by
+     *
+     * @return DatabaseRowIterator
+     */
+    public function getGradeablesIterator($g_ids = null, $user_ids = null, $section_key="registration_section", $sort_key="u.user_id", $g_type = null, $extra_order_by = []) {
         throw new NotImplementedException();
     }
 

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -146,8 +146,11 @@ WHERE semester=? AND course=? AND user_id=?", $params);
         }
     }
 
-    public function getGradeablesIterator($g_ids = null, $user_ids = null, $section_key="registration_section", $sort_key="u.user_id", $g_type = null) {
+    public function getGradeablesIterator($g_ids = null, $user_ids = null, $section_key="registration_section", $sort_key="u.user_id", $g_type = null, $extra_order_by = []) {
         $return = array();
+        if (!is_array($extra_order_by)) {
+            $extra_order_by = [];
+        }
         $g_ids_query = "";
         $users_query = "";
         $g_type_query = "";
@@ -164,7 +167,7 @@ WHERE semester=? AND course=? AND user_id=?", $params);
                 return $return;
             }
         }
-        if ($user_ids !== null) {
+        if ($user_ids !== null && $user_ids !== true) {
             if (!is_array($user_ids)) {
                 $user_ids = array($user_ids);
             }
@@ -281,7 +284,9 @@ SELECT";
   egd.autograding_hidden_non_extra_credit,
   egd.autograding_hidden_extra_credit,
   egd.submission_time,
-  egv.highest_version
+  egv.highest_version,
+  COALESCE(lde.late_day_exceptions, 0) AS late_day_exceptions,
+  GREATEST(0, CEIL((EXTRACT(EPOCH FROM(COALESCE(egd.submission_time, eg.eg_submission_due_date) - eg.eg_submission_due_date)) - (300*60))/86400)::integer) AS days_late
 FROM users AS u
 NATURAL JOIN gradeable AS g";
         }
@@ -414,14 +419,15 @@ LEFT JOIN (
       t.user_id
     FROM gradeable_teams AS gt, teams AS t
     WHERE g.g_id = gt.g_id AND gt.team_id = t.team_id AND t.team_id = egv.team_id AND t.state = 1)
-)";
+)
+LEFT JOIN late_day_exceptions AS lde ON g.g_id = lde.g_id AND u.user_id = lde.user_id";
         }
 
         $where = array();
         if ($g_ids !== null) {
             $where[] = "g.g_id IN ({$g_ids_query})";
         }
-        if ($user_ids !== null) {
+        if ($user_ids !== null && $user_ids !== true) {
             $where[] = "u.user_id IN ({$users_query})";
         }
         if ($g_type !== null) {
@@ -431,9 +437,15 @@ LEFT JOIN (
             $query .= "
 WHERE ".implode(" AND ", $where);
         }
+        $order_by = [];
         if ($user_ids !== null) {
+            $order_by[] = "u.{$section_key}";
+            $order_by[] = $sort_key;
+        }
+        $order_by = array_merge($order_by, $extra_order_by);
+        if (count($order_by) > 0) {
             $query .= "
-ORDER BY u.{$section_key}, {$sort_key}";
+ORDER BY ".implode(", ", $order_by);
         }
 
         return $this->course_db->queryIterator($query, $params, function ($row) {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -287,7 +287,7 @@ SELECT";
   egv.highest_version,
   COALESCE(lde.late_day_exceptions, 0) AS late_day_exceptions,
   GREATEST(0, CEIL((EXTRACT(EPOCH FROM(COALESCE(egd.submission_time, eg.eg_submission_due_date) - eg.eg_submission_due_date)) - (300*60))/86400)::integer) AS days_late,
-  ld.allowed_late_days AS student_allowed_late_days
+  get_allowed_late_days(u.user_id, eg.eg_submission_due_date) AS student_allowed_late_days
 FROM users AS u
 NATURAL JOIN gradeable AS g";
         }
@@ -418,8 +418,7 @@ LEFT JOIN (
     FROM gradeable_teams AS gt, teams AS t
     WHERE g.g_id = gt.g_id AND gt.team_id = t.team_id AND t.team_id = egv.team_id AND t.state = 1)
 )
-LEFT JOIN late_day_exceptions AS lde ON g.g_id = lde.g_id AND u.user_id = lde.user_id
-LEFT JOIN (SELECT * FROM late_days ORDER BY since_timestamp DESC) AS ld ON u.user_id = ld.user_id AND eg.eg_submission_due_date < ld.since_timestamp";
+LEFT JOIN late_day_exceptions AS lde ON g.g_id = lde.g_id AND u.user_id = lde.user_id";
         }
 
         $where = array();

--- a/site/app/models/Gradeable.php
+++ b/site/app/models/Gradeable.php
@@ -81,6 +81,9 @@ use app\libraries\Utils;
  * @method void setGdId(int $gd_id)
  * @method \DateTime getUserViewedDate()
  * @method float getTotalPeerGradingNonExtraCredit()
+ * @method int getLateDayExceptions()
+ * @method int getAllowedLateDays()
+ * @method int getLateDays()
  */
 class Gradeable extends AbstractModel {
     
@@ -155,7 +158,7 @@ class Gradeable extends AbstractModel {
     protected $subdirectory = "";
 
     /** @property @var int Number of days you can submit */
-    protected $late_days = 0;
+    protected $allowed_late_days = 0;
 
     /** @property @var string Url to any instructions for the gradeable for students */
     protected $instructions_url = "";
@@ -297,6 +300,12 @@ class Gradeable extends AbstractModel {
     /** @property @var int.*/
     protected $max_possible_grading_time = -1;
 
+    /** @property @var int */
+    protected $late_day_exceptions = 0;
+
+    /** @property @var int */
+    protected $late_days = 0;
+
     public function __construct(Core $core, $details=array(), User $user = null) {
         parent::__construct($core);
         if(!isset($details['g_id'])) {
@@ -321,7 +330,7 @@ class Gradeable extends AbstractModel {
         if ($this->type === GradeableType::ELECTRONIC_FILE) {
             $this->open_date = new \DateTime($details['eg_submission_open_date'], $timezone);
             $this->due_date = new \DateTime($details['eg_submission_due_date'], $timezone);
-            $this->late_days = $details['eg_late_days'];
+            $this->allowed_late_days = $details['eg_late_days'];
             $this->is_repository = $details['eg_is_repository'] === true;
             $this->subdirectory = $details['eg_subdirectory'];
             $this->point_precision = floatval($details['eg_precision']);
@@ -347,6 +356,8 @@ class Gradeable extends AbstractModel {
                 $this->graded_auto_hidden_non_extra_credit = floatval($details['autograding_hidden_non_extra_credit']);
                 $this->graded_auto_hidden_extra_credit = floatval($details['autograding_hidden_extra_credit']);
                 $this->submission_time = new \DateTime($details['submission_time'], $timezone);
+                $this->late_day_exceptions = $details['late_day_exceptions'];
+                $this->late_days = $details['days_late'];
             }
             
             if (isset($details['highest_version']) && $details['highest_version']!== null) {
@@ -478,7 +489,7 @@ class Gradeable extends AbstractModel {
             $this->incentive_message = Utils::prepareHtmlString($details['early_submission_incentive']['message']);
             $this->minimum_days_early = intval($details['early_submission_incentive']['minimum_days_early']);
             $this->minimum_points = intval($details['early_submission_incentive']['minimum_points']);
-	    $this->early_submission_test_cases = $details['early_submission_incentive']['test_cases'];
+            $this->early_submission_test_cases = $details['early_submission_incentive']['test_cases'];
         }
 
         $num_parts = 1;
@@ -816,10 +827,6 @@ class Gradeable extends AbstractModel {
     
     public function hasSubmitted() {
         return $this->getHighestVersion() > 0;
-    }
-
-    public function getAllowedLateDays() {
-        return $this->late_days;
     }
 
     public function getTotalNonHiddenNonExtraCreditPoints() {

--- a/site/app/models/Gradeable.php
+++ b/site/app/models/Gradeable.php
@@ -84,6 +84,7 @@ use app\libraries\Utils;
  * @method int getLateDayExceptions()
  * @method int getAllowedLateDays()
  * @method int getLateDays()
+ * @method int getStudentAllowedLateDays()
  */
 class Gradeable extends AbstractModel {
     
@@ -306,6 +307,9 @@ class Gradeable extends AbstractModel {
     /** @property @var int */
     protected $late_days = 0;
 
+    /** @property @var int */
+    protected $student_allowed_late_days = 0;
+
     public function __construct(Core $core, $details=array(), User $user = null) {
         parent::__construct($core);
         if(!isset($details['g_id'])) {
@@ -358,6 +362,7 @@ class Gradeable extends AbstractModel {
                 $this->submission_time = new \DateTime($details['submission_time'], $timezone);
                 $this->late_day_exceptions = $details['late_day_exceptions'];
                 $this->late_days = $details['days_late'];
+                $this->student_allowed_late_days = $details['student_allowed_late_days'] ?? $this->core->getConfig()->getDefaultStudentLateDays();
             }
             
             if (isset($details['highest_version']) && $details['highest_version']!== null) {

--- a/site/app/models/LateDaysCalculation.php
+++ b/site/app/models/LateDaysCalculation.php
@@ -145,7 +145,7 @@ class LateDaysCalculation extends AbstractModel {
                 $submission_latedays['remaining_days'] = $curr_remaining_late;
                 $submission_latedays['total_late_used'] = $total_late_used;
                 $submission_latedays['eg_submission_due_date'] = $submissions[$i]['eg_submission_due_date'];
-        $late_day_usage[$submissions[$i]['g_id']] = $submission_latedays;
+                $late_day_usage[$submissions[$i]['g_id']] = $submission_latedays;
             }
 
             $all_latedays[$student['user_id']] = $late_day_usage;

--- a/site/data/course_tables.sql
+++ b/site/data/course_tables.sql
@@ -46,6 +46,9 @@ BEGIN
 END;
 $_$;
 
+CREATE FUNCTION get_allowed_late_days(character varying, timestamp with time zone) RETURNS integer AS $$
+SELECT allowed_late_days FROM late_days WHERE user_id = $1 AND since_timestamp <= $2 ORDER BY since_timestamp DESC LIMIT 1;
+$$ LANGUAGE SQL;
 
 --
 -- Name: csv_to_numeric_gradeable(text[], text, text); Type: FUNCTION; Schema: public; Owner: -


### PR DESCRIPTION
This greatly simplifies the generate grading summaries page such that it only needs to iterate through gradeable models to generate the JSON file for each student.

Initial testing of this shows that it can generate ~740 students in sub-60 seconds compared to the current code which throws a 500 error (and then runs for several more minutes).