### PR TITLE
Vcs zip fix

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -315,97 +315,81 @@ class MiscController extends AbstractController {
         $temp_name = uniqid($this->core->getUser()->getId(), true);
         $zip_name = $temp_dir . "/" . $temp_name . ".zip";
         $gradeable = $this->core->getQueries()->getGradeable($_REQUEST['gradeable_id']);
-        $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
-            $gradeable->getId());
+        $paths = ['submissions'];
+        if ($gradeable->useVcsCheckout()) {
+          $paths[] = 'checkout';
+        }
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        if($type === "all") {
+        foreach ($paths as $path) {
+          $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $path,
+              $gradeable->getId());
+          if($type === "all") {
+              $zip->addEmptyDir($path);
               $files = new \RecursiveIteratorIterator(
                   new \RecursiveDirectoryIterator($gradeable_path),
                   \RecursiveIteratorIterator::LEAVES_ONLY
               );
-            foreach ($files as $name => $file)
-            {
-                // Skip directories (they would be added automatically)
-                if (!$file->isDir())
-                {
-                    // Get real and relative path for current file
-                    $filePath = $file->getRealPath();
-                    $relativePath = substr($filePath, strlen($gradeable_path) + 1);
-                    // Add current file to archive
-                    $zip->addFile($filePath, $relativePath);
-                    }
-            }
-            if ($gradeable->useVcsCheckout())
-            {
-                $zip -> addEmptyDir("ALL_SUBMITTED_FILES");
-                $gradeable_checkout_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "checkout",
-                    $gradeable->getId());
-                $checkout_files = new \RecursiveIteratorIterator(
-                    new \RecursiveDirectoryIterator($gradeable_checkout_path),
-                    \RecursiveIteratorIterator::LEAVES_ONLY
+              foreach ($files as $name => $file)
+              {
+                  // Skip directories (they would be added automatically)
+                  if (!$file->isDir())
+                  {
+                      // Get real and relative path for current file
+                      $filePath = $file->getRealPath();
+                      $relativePath = substr($filePath, strlen($gradeable_path) + 1);
+                      // Add current file to archive
+                      $zip->addFile($filePath, $path . "/" . $relativePath);
+                  }
+              }
+           } else {
+               //gets the students that are part of the sections
+               if ($gradeable->isGradeByRegistration()) {
+                   $section_key = "registration_section";
+                   $sections = $this->core->getUser()->getGradingRegistrationSections();
+                   $students = $this->core->getQueries()->getUsersByRegistrationSections($sections);
+               }
+               else {
+                   $section_key = "rotating_section";
+                   $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id,
+                       $this->core->getUser()->getId());
+                   $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
+               }
+               $students_array = array();
+               foreach($students as $student) {
+                   $students_array[] = $student->getId();
+               }
+               $files = scandir($gradeable_path);
+               $arr_length = count($students_array);
+               foreach($files as $file) {
+                   for ($x = 0; $x < $arr_length; $x++) {
+                       if ($students_array[$x] === $file) {
+                           $temp_path = $gradeable_path . "/" . $file;
+                           $files_in_folder = new \RecursiveIteratorIterator(
+                               new \RecursiveDirectoryIterator($temp_path),
+                               \RecursiveIteratorIterator::LEAVES_ONLY
+                           );
 
-                );
-                foreach ($checkout_files as $name => $file)
-                {
-                    // Skip directories (they would be added automatically)
-                    if (!$file->isDir())
-                    {
-                        // Get real and relative path for current file
-                        $filePath = $file->getRealPath();
-                        $relativePath = substr($filePath, strlen($gradeable_checkout_path) + 1);
-                        // Add current file to archive
-                        $zip->addFile($filePath, "ALL_SUBMITTED_FILES" . "/" . $relativePath);
-                    }
-                }
-            }
-         } else {
-             //gets the students that are part of the sections
-             if ($gradeable->isGradeByRegistration()) {
-                 $section_key = "registration_section";
-                 $sections = $this->core->getUser()->getGradingRegistrationSections();
-                 $students = $this->core->getQueries()->getUsersByRegistrationSections($sections);
-             }
-             else {
-                 $section_key = "rotating_section";
-                 $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id,
-                     $this->core->getUser()->getId());
-                 $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
-             }
-             $students_array = array();
-             foreach($students as $student) {
-                 $students_array[] = $student->getId();
-             }
-             $files = scandir($gradeable_path);
-             $arr_length = count($students_array);
-             foreach($files as $file) {
-                 for ($x = 0; $x < $arr_length; $x++) {
-                     if ($students_array[$x] === $file) {
-                         $temp_path = $gradeable_path . "/" . $file;
-                         $files_in_folder = new \RecursiveIteratorIterator(
-                             new \RecursiveDirectoryIterator($temp_path),
-                             \RecursiveIteratorIterator::LEAVES_ONLY
-                         );
+                           //makes a new directory in the zip to add the files in
+                           $zip -> addEmptyDir($file);
 
-                         //makes a new directory in the zip to add the files in
-                         $zip -> addEmptyDir($file);
-
-                         foreach ($files_in_folder as $name => $file_in_folder)
-                         {
-                             // Skip directories (they would be added automatically)
-                             if (!$file_in_folder->isDir())
-                             {
-                                 // Get real and relative path for current file
-                                 $filePath = $file_in_folder->getRealPath();
-                                 $relativePath = substr($filePath, strlen($temp_path) + 1);
-                                 // Add current file to archive
-                                 $zip->addFile($filePath, $file . "/" . $relativePath);
-                             }
-                         }
-                         $x = $arr_length; //cuts the for loop early when found
-                    }
-                }
-            }
+                           foreach ($files_in_folder as $name => $file_in_folder)
+                           {
+                               // Skip directories (they would be added automatically)
+                               if (!$file_in_folder->isDir())
+                               {
+                                   // Get real and relative path for current file
+                                   $filePath = $file_in_folder->getRealPath();
+                                   $relativePath = substr($filePath, strlen($temp_path) + 1);
+                                   // Add current file to archive
+                                   $zip->addFile($filePath, $file . "/" . $relativePath);
+                               }
+                           }
+                           $x = $arr_length; //cuts the for loop early when found
+                      }
+                  }
+              }
+           }
         }
         // Zip archive will be created only after closing object
         $zip->close();

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -40,9 +40,8 @@ class MiscController extends AbstractController {
         }
         // from this point on, is not a zip
         // do path and permissions checking
-
-        $dir = $_GET['dir'];
-        $path = $_GET['path'];
+        $dir = $_REQUEST['dir'];
+        $path = $_REQUEST['path'];
 
         foreach (explode(DIRECTORY_SEPARATOR, $path) as $part) {
             if ($part == ".." || $part == ".") {
@@ -50,7 +49,7 @@ class MiscController extends AbstractController {
                  return false;
             }
         }
-        
+
         if (!FileUtils::isValidFileName($path)) {
             $error_string="not valid filename";
             return false;
@@ -180,13 +179,13 @@ class MiscController extends AbstractController {
             return false;
         }
 
-        $corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" .  basename(rawurldecode(htmlspecialchars_decode($_GET['path'])));
+        $corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_REQUEST['path']));
         $mime_type = FileUtils::getMimeType($corrected_name);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
             header("Content-type: ".$mime_type);
-            header('Content-Disposition: inline; filename="' . basename(rawurldecode(htmlspecialchars_decode($_GET['path']))) . '"');
+            header('Content-Disposition: inline; filename="' . basename($_REQUEST['path']) . '"');
             readfile($corrected_name);
             $this->core->getOutput()->renderString($_REQUEST['path']);
         }
@@ -203,7 +202,7 @@ class MiscController extends AbstractController {
     }
 
     private function downloadFile() {
-        
+
         // security check
         $error_string="";
         if (!$this->checkValidAccess(false,$error_string)) {
@@ -211,15 +210,13 @@ class MiscController extends AbstractController {
             $this->core->addErrorMessage($message);
             $this->core->redirect($this->core->getConfig()->getSiteUrl());
         }
-        
-        $filename = rawurldecode(htmlspecialchars_decode($_REQUEST['file']));
 
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         header('Content-Type: application/octet-stream');
-        header("Content-Transfer-Encoding: Binary"); 
-        header("Content-disposition: attachment; filename=\"{$filename}\"");
-        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . basename(rawurldecode(htmlspecialchars_decode($_GET['path']))));
+        header("Content-Transfer-Encoding: Binary");
+        header("Content-disposition: attachment; filename=\"{$_REQUEST['file']}\"");
+        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_REQUEST['path'])));
     }
 
     private function downloadZip() {
@@ -260,7 +257,7 @@ class MiscController extends AbstractController {
                     new \RecursiveDirectoryIterator($paths[$x]),
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 );
-                $zip -> addEmptyDir($folder_names[$x]); 
+                $zip -> addEmptyDir($folder_names[$x]);
                 foreach ($files as $name => $file)
                 {
                     // Skip directories (they would be added automatically)
@@ -274,20 +271,20 @@ class MiscController extends AbstractController {
                         $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
                     }
                 }
-            }    
+            }
         }
 
         $zip->close();
-        header("Content-type: application/zip"); 
+        header("Content-type: application/zip");
         header("Content-Disposition: attachment; filename=$zip_file_name");
         header("Content-length: " . filesize($zip_name));
-        header("Pragma: no-cache"); 
-        header("Expires: 0"); 
+        header("Pragma: no-cache");
+        header("Expires: 0");
         readfile("$zip_name");
         unlink($zip_name); //deletes the random zip file
     }
 
-    private function downloadAssignedZips() { 
+    private function downloadAssignedZips() {
         // security check
         if (!($this->core->getUser()->accessGrading())) {
             $message = "You do not have access to that page.";
@@ -315,85 +312,181 @@ class MiscController extends AbstractController {
         $temp_name = uniqid($this->core->getUser()->getId(), true);
         $zip_name = $temp_dir . "/" . $temp_name . ".zip";
         $gradeable = $this->core->getQueries()->getGradeable($_REQUEST['gradeable_id']);
-        $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
-            $gradeable->getId());
-        $zip = new \ZipArchive();
-        $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        if($type === "all") {
-            $files = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($gradeable_path),
-                \RecursiveIteratorIterator::LEAVES_ONLY
-            );
 
-            foreach ($files as $name => $file)
-            {
-                // Skip directories (they would be added automatically)
-                if (!$file->isDir())
-                {
-                    // Get real and relative path for current file
-                    $filePath = $file->getRealPath();
-                    $relativePath = substr($filePath, strlen($gradeable_path) + 1);
+        //IF FILE IS NOT A VCS
+        if (!$gradeable->useVcsCheckout()) {
+          $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
+              $gradeable->getId());
 
-                    // Add current file to archive
-                    $zip->addFile($filePath, $relativePath);
-                }
-            }
-        } else {
-                //gets the students that are part of the sections
-            if ($gradeable->isGradeByRegistration()) {
-                $section_key = "registration_section";
-                $sections = $this->core->getUser()->getGradingRegistrationSections();
-                $students = $this->core->getQueries()->getUsersByRegistrationSections($sections);
-            }
-            else {
-                $section_key = "rotating_section";
-                $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id,
-                    $this->core->getUser()->getId());
-                $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
-            }
-            $students_array = array();
-            foreach($students as $student) {
-                $students_array[] = $student->getId();
-            }
-            $files = scandir($gradeable_path);
-            $arr_length = count($students_array); 
-            foreach($files as $file) {
-                for ($x = 0; $x < $arr_length; $x++) {
-                    if ($students_array[$x] === $file) {
-                        $temp_path = $gradeable_path . "/" . $file;
-                        $files_in_folder = new \RecursiveIteratorIterator(
-                            new \RecursiveDirectoryIterator($temp_path),
-                            \RecursiveIteratorIterator::LEAVES_ONLY
-                        );
+          $zip = new \ZipArchive();
+          $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+          if($type === "all") {
+                $files = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($gradeable_path),
+                    \RecursiveIteratorIterator::LEAVES_ONLY
+                );
+              foreach ($files as $name => $file)
+              {
+                  // Skip directories (they would be added automatically)
+                  if (!$file->isDir())
+                  {
+                      // Get real and relative path for current file
+                      $filePath = $file->getRealPath();
+                      $relativePath = substr($filePath, strlen($gradeable_path) + 1);
+                      // Add current file to archive
+                      $zip->addFile($filePath, $relativePath);
+                      }
+                  }
+             } else {
+                     //gets the students that are part of the sections
+                 if ($gradeable->isGradeByRegistration()) {
+                     $section_key = "registration_section";
+                     $sections = $this->core->getUser()->getGradingRegistrationSections();
+                     $students = $this->core->getQueries()->getUsersByRegistrationSections($sections);
+                 }
+                 else {
+                     $section_key = "rotating_section";
+                     $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id,
+                         $this->core->getUser()->getId());
+                     $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
+                 }
+                 $students_array = array();
+                 foreach($students as $student) {
+                     $students_array[] = $student->getId();
+                 }
+                 $files = scandir($gradeable_path);
+                 $arr_length = count($students_array);
+                 foreach($files as $file) {
+                     for ($x = 0; $x < $arr_length; $x++) {
+                         if ($students_array[$x] === $file) {
+                             $temp_path = $gradeable_path . "/" . $file;
+                             $files_in_folder = new \RecursiveIteratorIterator(
+                                 new \RecursiveDirectoryIterator($temp_path),
+                                 \RecursiveIteratorIterator::LEAVES_ONLY
+                             );
 
-                        //makes a new directory in the zip to add the files in
-                        $zip -> addEmptyDir($file); 
+                             //makes a new directory in the zip to add the files in
+                             $zip -> addEmptyDir($file);
 
-                        foreach ($files_in_folder as $name => $file_in_folder)
-                        {
-                            // Skip directories (they would be added automatically)
-                            if (!$file_in_folder->isDir())
-                            {
-                                // Get real and relative path for current file
-                                $filePath = $file_in_folder->getRealPath();
-                                $relativePath = substr($filePath, strlen($temp_path) + 1);
-                                // Add current file to archive
-                                $zip->addFile($filePath, $file . "/" . $relativePath);
-                            }
-                        }
-                        $x = $arr_length; //cuts the for loop early when found 
-                    }
-                } 
-            }
+                             foreach ($files_in_folder as $name => $file_in_folder)
+                             {
+                                 // Skip directories (they would be added automatically)
+                                 if (!$file_in_folder->isDir())
+                                 {
+                                     // Get real and relative path for current file
+                                     $filePath = $file_in_folder->getRealPath();
+                                     $relativePath = substr($filePath, strlen($temp_path) + 1);
+                                     // Add current file to archive
+                                     $zip->addFile($filePath, $file . "/" . $relativePath);
+                                 }
+                             }
+                             $x = $arr_length; //cuts the for loop early when found
+                         }
+                     }
+                 }
+             }
+        } else {      //IF FILE IS A VCS
+          $gradeable_checkout_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "checkout",
+              $gradeable->getId());
+          $gradeable_submission_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
+              $gradeable->getId());
+
+          $zip = new \ZipArchive();
+          $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+          $zip -> addEmptyDir("submissions");
+          $zip -> addEmptyDir("checkout");
+          if($type === "all") {
+                $checkout_files = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($gradeable_checkout_path),
+                    \RecursiveIteratorIterator::LEAVES_ONLY
+
+                );
+                $submission_files = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($gradeable_submission_path),
+                    \RecursiveIteratorIterator::LEAVES_ONLY
+
+                );
+              foreach ($submission_files as $name => $file)
+              {
+                  // Skip directories (they would be added automatically)
+                  if (!$file->isDir())
+                  {
+                      // Get real and relative path for current file
+                      $filePath = $file->getRealPath();
+                      $relativePath = substr($filePath, strlen($gradeable_submission_path) + 1);
+                      // Add current file to archive
+                      $zip->addFile($filePath,"submissions" . "/" . $relativePath);
+                  }
+              }
+              foreach ($checkout_files as $name => $file)
+              {
+                  // Skip directories (they would be added automatically)
+                  if (!$file->isDir())
+                  {
+                      // Get real and relative path for current file
+                      $filePath = $file->getRealPath();
+                      $relativePath = substr($filePath, strlen($gradeable_checkout_path) + 1);
+                      // Add current file to archive
+                      $zip->addFile($filePath, "checkout" . "/" . $relativePath);
+                  }
+              }
+          } else {
+                  //gets the students that are part of the sections
+              if ($gradeable->isGradeByRegistration()) {
+                  $section_key = "registration_section";
+                  $sections = $this->core->getUser()->getGradingRegistrationSections();
+                  $students = $this->core->getQueries()->getUsersByRegistrationSections($sections);
+              }
+              else {
+                  $section_key = "rotating_section";
+                  $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id,
+                      $this->core->getUser()->getId());
+                  $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
+              }
+              $students_array = array();
+              foreach($students as $student) {
+                  $students_array[] = $student->getId();
+              }
+              $files = scandir($gradeable_path);
+              $arr_length = count($students_array);
+              foreach($files as $file) {
+                  for ($x = 0; $x < $arr_length; $x++) {
+                      if ($students_array[$x] === $file) {
+                          $temp_path = $gradeable_path . "/" . $file;
+                          $files_in_folder = new \RecursiveIteratorIterator(
+                              new \RecursiveDirectoryIterator($temp_path),
+                              \RecursiveIteratorIterator::LEAVES_ONLY
+                          );
+
+                          //makes a new directory in the zip to add the files in
+                          $zip -> addEmptyDir($file);
+
+                          foreach ($files_in_folder as $name => $file_in_folder)
+                          {
+                              // Skip directories (they would be added automatically)
+                              if (!$file_in_folder->isDir())
+                              {
+                                  // Get real and relative path for current file
+                                  $filePath = $file_in_folder->getRealPath();
+                                  $relativePath = substr($filePath, strlen($temp_path) + 1);
+                                  // Add current file to archive
+                                  $zip->addFile($filePath, $file . "/" . $relativePath);
+                              }
+                          }
+                          $x = $arr_length; //cuts the for loop early when found
+                      }
+                  }
+              }
+           }
         }
-        
+
         // Zip archive will be created only after closing object
         $zip->close();
-        header("Content-type: application/zip"); 
+        header("Content-type: application/zip");
         header("Content-Disposition: attachment; filename=$zip_file_name");
         header("Content-length: " . filesize($zip_name));
-        header("Pragma: no-cache"); 
-        header("Expires: 0"); 
+        header("Pragma: no-cache");
+        header("Expires: 0");
         readfile("$zip_name");
         unlink($zip_name); //deletes the random zip file
     }

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -386,6 +386,7 @@ class MiscController extends AbstractController {
                  }
              }
         } else {      //IF FILE IS A VCS
+          //get checkout files and submissions
           $gradeable_checkout_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "checkout",
               $gradeable->getId());
           $gradeable_submission_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
@@ -393,6 +394,7 @@ class MiscController extends AbstractController {
 
           $zip = new \ZipArchive();
           $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+          //make two directorys in zip folder
           $zip -> addEmptyDir("submissions");
           $zip -> addEmptyDir("checkout");
           if($type === "all") {

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -40,8 +40,9 @@ class MiscController extends AbstractController {
         }
         // from this point on, is not a zip
         // do path and permissions checking
-        $dir = $_REQUEST['dir'];
-        $path = $_REQUEST['path'];
+
+        $dir = $_GET['dir'];
+        $path = $_GET['path'];
 
         foreach (explode(DIRECTORY_SEPARATOR, $path) as $part) {
             if ($part == ".." || $part == ".") {
@@ -179,13 +180,13 @@ class MiscController extends AbstractController {
             return false;
         }
 
-        $corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_REQUEST['path']));
+        $corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" .  basename(rawurldecode(htmlspecialchars_decode($_GET['path'])));
         $mime_type = FileUtils::getMimeType($corrected_name);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
             header("Content-type: ".$mime_type);
-            header('Content-Disposition: inline; filename="' . basename($_REQUEST['path']) . '"');
+            header('Content-Disposition: inline; filename="' . basename(rawurldecode(htmlspecialchars_decode($_GET['path']))) . '"');
             readfile($corrected_name);
             $this->core->getOutput()->renderString($_REQUEST['path']);
         }
@@ -211,12 +212,14 @@ class MiscController extends AbstractController {
             $this->core->redirect($this->core->getConfig()->getSiteUrl());
         }
 
+        $filename = rawurldecode(htmlspecialchars_decode($_REQUEST['file']));
+
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         header('Content-Type: application/octet-stream');
         header("Content-Transfer-Encoding: Binary");
-        header("Content-disposition: attachment; filename=\"{$_REQUEST['file']}\"");
-        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_REQUEST['path'])));
+        header("Content-disposition: attachment; filename=\"{$filename}\"");
+        readfile(pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . basename(rawurldecode(htmlspecialchars_decode($_GET['path']))));
     }
 
     private function downloadZip() {

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -203,7 +203,6 @@ class MiscController extends AbstractController {
     }
 
     private function downloadFile() {
-
         // security check
         $error_string="";
         if (!$this->checkValidAccess(false,$error_string)) {
@@ -211,9 +210,7 @@ class MiscController extends AbstractController {
             $this->core->addErrorMessage($message);
             $this->core->redirect($this->core->getConfig()->getSiteUrl());
         }
-
         $filename = rawurldecode(htmlspecialchars_decode($_REQUEST['file']));
-
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         header('Content-Type: application/octet-stream');
@@ -230,7 +227,6 @@ class MiscController extends AbstractController {
             $this->core->addErrorMessage($message);
             $this->core->redirect($this->core->getConfig()->getSiteUrl());
         }
-
         $zip_file_name = $_REQUEST['gradeable_id'] . "_" . $_REQUEST['user_id'] . "_" . date("m-d-Y") . ".zip";
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
@@ -317,31 +313,32 @@ class MiscController extends AbstractController {
         $gradeable = $this->core->getQueries()->getGradeable($_REQUEST['gradeable_id']);
         $paths = ['submissions'];
         if ($gradeable->useVcsCheckout()) {
-          $paths[] = 'checkout';
+            //VCS submissions are stored in the checkout directory
+            $paths[] = 'checkout';
         }
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
         foreach ($paths as $path) {
-          $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $path,
-              $gradeable->getId());
-          if($type === "all") {
-              $zip->addEmptyDir($path);
-              $files = new \RecursiveIteratorIterator(
-                  new \RecursiveDirectoryIterator($gradeable_path),
-                  \RecursiveIteratorIterator::LEAVES_ONLY
-              );
-              foreach ($files as $name => $file)
-              {
-                  // Skip directories (they would be added automatically)
-                  if (!$file->isDir())
-                  {
-                      // Get real and relative path for current file
-                      $filePath = $file->getRealPath();
-                      $relativePath = substr($filePath, strlen($gradeable_path) + 1);
-                      // Add current file to archive
-                      $zip->addFile($filePath, $path . "/" . $relativePath);
-                  }
-              }
+            $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $path,
+                $gradeable->getId());
+            if($type === "all") {
+                $zip->addEmptyDir($path);
+                $files = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($gradeable_path),
+                    \RecursiveIteratorIterator::LEAVES_ONLY
+                );
+                foreach ($files as $name => $file)
+                {
+                    // Skip directories (they would be added automatically)
+                    if (!$file->isDir())
+                    {
+                        // Get real and relative path for current file
+                        $filePath = $file->getRealPath();
+                        $relativePath = substr($filePath, strlen($gradeable_path) + 1);
+                        // Add current file to archive
+                        $zip->addFile($filePath, $path . "/" . $relativePath);
+                    }
+                }
            } else {
                //gets the students that are part of the sections
                if ($gradeable->isGradeByRegistration()) {
@@ -386,10 +383,10 @@ class MiscController extends AbstractController {
                                }
                            }
                            $x = $arr_length; //cuts the for loop early when found
-                      }
-                  }
-              }
-           }
+                        }
+                    }
+                }
+            }
         }
         // Zip archive will be created only after closing object
         $zip->close();


### PR DESCRIPTION
Fix for version control system zip downloads. The actual submission files were not in the zip.
New zip folder should contain two top directories each containing a folder for each student. One directory should contain the students actual submissions and the other should contain submission info. 

Will need to be tested on live server due to a lack of ability to test VCS on local machine.