### PR TITLE
Improve handling of forcing refresh of JS/CSS files when updating site

### DIFF
--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -35,10 +35,10 @@ class NavigationController extends AbstractController {
 
     private function navigationPage() {
         $gradeables_list = new GradeableList($this->core);
-        $this->core->getOutput()->addCSS("https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700");
-        $this->core->getOutput()->addCSS("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic,700italic");
-        $this->core->getOutput()->addCSS("https://fonts.googleapis.com/css?family=PT+Sans:700,700italic");
-  		$this->core->getOutput()->addCSS("https://fonts.googleapis.com/css?family=Inconsolata");
+        $this->core->getOutput()->addCss("https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700");
+        $this->core->getOutput()->addCss("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic,700italic");
+        $this->core->getOutput()->addCss("https://fonts.googleapis.com/css?family=PT+Sans:700,700italic");
+        $this->core->getOutput()->addCss("https://fonts.googleapis.com/css?family=Inconsolata");
         
         $future_gradeables_list = $gradeables_list->getFutureGradeables();
         $beta_gradeables_list = $gradeables_list->getBetaGradeables();

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -664,7 +664,7 @@ class ElectronicGraderController extends AbstractController {
             $nameBreadCrumb .= $gradeable->getUser()->getId();
         }       
 
-        $this->core->getOutput()->addCSS($this->core->getConfig()->getBaseUrl()."/css/ta-grading.css");
+        $this->core->getOutput()->addInternalCss('ta-grading.css');
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'hwGradingPage', $gradeable, $progress, $prev_id, $next_id, $individual, $not_in_my_section);
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupStudents');
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupNewMark');

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -19,6 +19,7 @@ class Output {
     private $breadcrumbs = array();
     private $loaded_views = array();
     private $css = array();
+    private $js = array();
     
     private $use_header = true;
     private $use_footer = true;
@@ -33,6 +34,20 @@ class Output {
     public function __construct(Core $core) {
         $this->core = $core;
         $this->start_time = microtime(true);
+    }
+
+    public function setInternalResources() {
+        $this->addCss('https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
+        $this->addInternalCss('jquery-ui.min.css');
+        $this->addInternalCss('server.css');
+        $this->addInternalCss('bootstrap.css');
+        $this->addInternalCss('diff-viewer.css');
+        $this->addInternalCss('glyphicons-halflings.css');
+
+        $this->addInternalJs('jquery.min.js');
+        $this->addInternalJs('jquery-ui.min.js');
+        $this->addInternalJs('diff-viewer.js');
+        $this->addInternalJs('server.js');
     }
 
     /**
@@ -129,7 +144,12 @@ class Output {
     }
 
     private function renderHeader() {
-        return ($this->use_header) ? $this->renderTemplate('Global', 'header', implode(' > ', $this->breadcrumbs), $this->css) : "";
+        if ($this->use_header) {
+            return $this->renderTemplate('Global', 'header', implode(' > ', $this->breadcrumbs), $this->css, $this->js);
+        }
+        else {
+            return '';
+        }
     }
 
     private function renderFooter() {
@@ -209,12 +229,22 @@ class Output {
         return $errorPage;
     }
     
-    public function addInternalCSS($file) {
-        $this->addCSS($this->core->getConfig()->getBaseUrl()."/css/".$file);
+    public function addInternalCss($file) {
+        $timestamp = filemtime(FileUtils::joinPaths(__DIR__, '..', '..', 'public', 'css', $file));
+        $this->addCss($this->core->getConfig()->getBaseUrl()."css/".$file, $timestamp);
     }
  
-    public function addCSS($url) {
-        $this->css[] = $url;
+    public function addCss($url, $timestamp=0) {
+        $this->css[] = $url.(($timestamp !== 0) ? "?v={$timestamp}" : '');
+    }
+
+    public function addInternalJs($file) {
+        $timestamp = filemtime(FileUtils::joinPaths(__DIR__, '..', '..', 'public', 'js', $file));
+        $this->addJs($this->core->getConfig()->getBaseUrl()."js/".$file, $timestamp);
+    }
+
+    public function addJs($url, $timestamp=0) {
+        $this->js[] = $url.(($timestamp !== 0) ? "?v={$timestamp}" : '');
     }
     
     /**

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -3,12 +3,7 @@
 namespace app\views;
 
 class GlobalView extends AbstractView {
-    public function header($breadcrumbs, $css=array()) {
-        $extra = "";
-        if ($this->core->getConfig()->isDebug()) {
-            $extra = "?v=".time();
-        }
-
+    public function header($breadcrumbs, $css=array(), $js=array()) {
         $messages = <<<HTML
 <div id='messages'>
 
@@ -30,51 +25,42 @@ HTML;
 </div>
 HTML;
 
-        $override_css = '';
-        if ($this->core->getConfig()->isCourseLoaded() && file_exists($this->core->getConfig()->getCoursePath()."/config/override.css")) {
-            $override_css = "<style type='text/css'>".file_get_contents($this->core->getConfig()->getCoursePath()."/config/override.css")."</style>";
-        }
-
         $return = <<<HTML
 <!DOCTYPE html>
 <html lang="en">
 <head>
+
 HTML;
-    if($this->core->getConfig()->isCourseLoaded())
-    {
-        $return .= <<<HTML
+        if($this->core->getConfig()->isCourseLoaded()) {
+            $return .= <<<HTML
     <title>{$this->core->getFullCourseName()}</title>
+
 HTML;
-    }
-    else
-    {
-        $return .= <<<HTML
+        }
+        else {
+            $return .= <<<HTML
     <title>Submitty</title>
-HTML;
-    }
 
-    $return .= <<<HTML
-    <link rel="shortcut icon" href="{$this->core->getConfig()->getBaseUrl()}img/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css{$extra}" />
-    <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/jquery-ui.min.css{$extra}" />
-    <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/server.css{$extra}" />
-    <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/bootstrap.css{$extra}" />
-    <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/diff-viewer.css{$extra}" />
-    <link rel="stylesheet" type="text/css" href="{$this->core->getConfig()->getBaseUrl()}css/glyphicons-halflings.css{$extra}" />
 HTML;
+        }
 
-    foreach($css as $css_ref) {
         $return .= <<<HTML
-        <link rel="stylesheet" type="text/css" href="{$css_ref}{$extra}" />
-HTML;
-    }
+    <link rel="shortcut icon" href="{$this->core->getConfig()->getBaseUrl()}img/favicon.ico" type="image/x-icon" />
 
-    $return .= <<<HTML
-    {$override_css}
-    <script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}js/jquery.min.js{$extra}"></script>
-    <script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}js/jquery-ui.min.js{$extra}"></script>
-    <script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}js/diff-viewer.js{$extra}"></script>
-    <script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}js/server.js{$extra}"></script>
+HTML;
+
+        foreach($css as $css_ref) {
+            $return .= "    <link rel='stylesheet' type='text/css' href='{$css_ref}' />\n";
+        }
+
+        if ($this->core->getConfig()->isCourseLoaded() && file_exists($this->core->getConfig()->getCoursePath()."/config/override.css")) {
+            $return .= "    <style type='text/css'>\n".file_get_contents($this->core->getConfig()->getCoursePath()."/config/override.css")."\n    </style>\n";
+        }
+
+        foreach ($js as $js_ref) {
+            $return .= "    <script type='text/javascript' src='{$js_ref}'></script>\n";
+        }
+        $return .= <<<HTML
 </head>
 <script>var onAjaxInit;</script>
 <body onload="setSiteDetails('{$this->core->getConfig()->getSiteUrl()}', '{$this->core->getCsrfToken()}'); if (onAjaxInit) { onAjaxInit(); }">
@@ -85,9 +71,6 @@ HTML;
 
         if ($this->core->getConfig()->isCourseLoaded() && $this->core->userLoaded()) {
             if($this->core->getUser()->accessGrading()) {
-                $ta_base_url = $this->core->getConfig()->getTaBaseUrl();
-                $semester = $this->core->getConfig()->getSemester();
-                $course = $this->core->getConfig()->getCourse();
                 if($this->core->getUser()->accessAdmin()) {
                     $return .= <<<HTML
     <div id="nav">

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1577,10 +1577,13 @@ HTML;
 
 HTML;
         }
+
+        $this->core->getOutput()->addInternalJs('ta-grading.js');
+        $this->core->getOutput()->addInternalJs('ta-grading-mark.js');
+
         $return .= <<<HTML
 </div>
-<script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}/js/ta-grading.js"></script>
-<script type="text/javascript" src="{$this->core->getConfig()->getBaseUrl()}/js/ta-grading-mark.js"></script>
+
 <script type="text/javascript">
 window.onbeforeunload = function() {
     saveLastOpenedMark('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, '{$your_user_id}', '-1', false);

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -115,6 +115,8 @@ ExceptionHandler::setDisplayExceptions($core->getConfig()->isDebug());
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadDatabases();
 
+$core->getOutput()->setInternalResources();
+
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', 1);
 if($core->getConfig()->isDebug()) {


### PR DESCRIPTION
This makes it so that any internal JS/CSS files added to the Output class (which all should be) will be given a timestamp of when the file was last modified which will cause it the cache for any of these files to be refreshed anytime the site is re-installed.