### PR TITLE
Student grade interface update

### DIFF
--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -184,11 +184,16 @@ class GradeableComponent extends AbstractModel {
         return $points;
     }
 
-    public function getGradedTAComments($nl, $show_students) {
+    public function getGradedTAComments($nl, $show_students,$show_ascii=true) {
         $text = "";
         $first_text = true;
-        $checkedBox = '<i class="fa fa-check-square-o fa-1g"></i> ';
-        $box = '<i class="fa fa-square-o"></i> ';
+        if(!$show_ascii){
+            $checkedBox = '<i class="fa fa-check-square-o fa-1g"></i> ';
+            $box = '<i class="fa fa-square-o"></i> ';
+        }else{
+            $checkedBox = '(*)';
+            $box = '( )';
+        }
         foreach ($this->marks as $mark) {
             $points_string = "    ";
             if ($mark->getPoints() != 0) {

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -76,11 +76,16 @@ HTML;
 HTML;
             }
             else {
+                //check if instructor grades exist and change title, display hidden points when TA grades are released
+                $totalTitle = ($gradeable->hasGradeFile()) ? "Autograding Subtotal" : "Total";
+                $autoGradingPoints = $current_version->getNonHiddenTotal();
+                if($gradeable->taGradesReleased())
+                    $autoGradingPoints += $current_version->getHiddenTotal();
                 $return .= <<<HTML
 <div class="box" style="display: {$display_total};">
     <div class="box-title">
-        <span class="badge {$background}">{$current_version->getNonHiddenTotal()} / {$gradeable->getNormalPoints()}</span>
-        <h4>Total</h4>
+        <span class="badge {$background}">{$autoGradingPoints} / {$gradeable->getNormalPoints()}</span>
+        <h4>{$totalTitle}</h4>
     </div>
 </div>
 HTML;
@@ -113,8 +118,14 @@ HTML;
             }
             if ($testcase->hasPoints()) {
                 if ($testcase->isHidden() && !$show_hidden) {
+                    if($gradeable->taGradesReleased()){
+                        $hiddenPoints = ($testcase->isExtraCredit()) ? '<br/>+'. $testcase->getPointsAwarded() : '<br>'.$testcase->getPointsAwarded() . " / " . $testcase->getPoints();
+                    }else{
+                        $hiddenPoints = "";
+                    }
+                    
                     $return .= <<<HTML
-        <div class="badge">Hidden</div>
+        <div class="badge">Hidden {$hiddenPoints} </div>
 HTML;
                 }
                 else {
@@ -432,6 +443,13 @@ HTML;
 HTML;
             return $return;
         }
+        if($gradeable->getCurrentVersionNumber() != $gradeable->getActiveVersion()){
+            $return = <<<HTML
+            <br>
+            <h3>The version you have selected above does not match the version graded by your TA/instructor, please contact TA/instructor if necessary to resolve the problem.</h3>
+HTML;
+            return $return;
+        }
         foreach ($gradeable->getComponents() as $component) {
             if(!$component->getGrader()){
                 $return = <<<HTML
@@ -455,6 +473,7 @@ HTML;
         }
         //get total score and max possible score
         $score = $gradeable->getGradedTAPoints();
+        $totalInstructorPointsEarned = $score;
         $maxScore = $gradeable->getTotalTANonExtraCreditPoints();
         if($score >= $maxScore){
             $background = "green-background";
@@ -467,6 +486,17 @@ HTML;
         //late day data
         $ldu = new LateDaysCalculation($this->core, $gradeable->getUser()->getId());
         $lateDayData = $ldu->getGradeable($gradeable->getUser()->getId(), $gradeable->getId());
+        //change title if autograding exists or not
+        //display a sum of autograding and instructor points if both exist
+        $totalTitle = "Total";
+        $displayTotal = "none";
+        foreach ($gradeable->getTestcases() as $testcase) {
+            if ($testcase->viewTestcase()){
+                $totalTitle = "TA / Instructor grading Subtotal";
+                $displayTotal = "block";
+                break;
+            }
+        }
         $return = <<<HTML
         <div class = "sub">
             <div class="box half" style="padding: 10px; width: 40%;">
@@ -485,7 +515,7 @@ HTML;
             <div class = "box">
                 <div class="box-title">
                     <span class="badge {$background}" style="float: left">{$score} / {$maxScore}</span>
-                    <h4>Total</h4>
+                    <h4>{$totalTitle}</h4>
                 </div>
             </div>
 HTML;
@@ -512,12 +542,35 @@ HTML;
                 <div class="box-title">
                     <span class="badge {$background}">{$score}</span>
                     <h4>{$component->getTitle()} <i>{$componentGrader}</i></h4>
-                    <p style="float:left;">{$component->getGradedTAComments('<br>',true)}</p>
+                    <p style="float:left;">{$component->getGradedTAComments('<br>',true,false)}</p>
                 </div>
             </div>
 HTML;
         }
+        //add total points if both autograding and instructor grading exist
+        $display = "none";
+        $current = $gradeable->getCurrentVersion();
+        $totalPointsEarned = $current->getNonHiddenTotal() + $current->getHiddenTotal() + $totalInstructorPointsEarned;
+        $maxPossiblePoints = $gradeable->getNormalPoints() + $maxScore;
+        $background = "";
+        if($totalPointsEarned >= $maxPossiblePoints){
+            $background = "green-background";
+        }else if($totalPointsEarned > $maxPossiblePoints * 0.5){
+            $background = "yellow-background";
+        }else{
+            $background = "red-background";
+        }
         $return .= <<<HTML
+            <div style="display: {$displayTotal}" class="box">
+                <div class="box-title" style="padding-top: 15px; padding-bottom: 15px;">
+                    <span class="badge {$background}"> {$totalPointsEarned}/{$maxPossiblePoints}</span>
+                    <h4>Total</h4>
+                </div>
+            </div>
+        </div>
+        <h3>Grade File</h3>
+        <div class="sub">
+            <pre class="box">{$gradeable->getGradeFile()}</pre>
         </div>
 HTML;
     return $return;

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1025,7 +1025,7 @@ HTML;
 HTML;
     }
         if ($gradeable->taGradesReleased()) {
-            $return .= <<<HTML
+                $return .= <<<HTML
 <div class="content">
 HTML;
             if ($gradeable->hasGradeFile()) {


### PR DESCRIPTION
Added:

- Changed titles to say "Total" or "Subtotal" depending if autograding and instructor grading both exist
- Hidden autograding points are now displayed under autograding once grades have been released
-Total/Subtotal points add hidden points when grades have been released
- Checks for incomplete grading, version conflicts
- Total displayed at bottom of instructor grades if both sections exist
- Gradefile now displayed under new TA/Instructor grading view
- Fixed bug where ascii art was replaced with code in Gradefiles

Ta only grading:
![tagrading](https://user-images.githubusercontent.com/12129065/38749644-5b4adbd0-3f20-11e8-8cf7-ae2b9c8c976a.png)

Autograding Only:
![autogradingonly](https://user-images.githubusercontent.com/12129065/38749658-68b4bf66-3f20-11e8-9a92-03ce1c190d18.png)

Autograding with hidden points/ hidden extra credit points
![autototal](https://user-images.githubusercontent.com/12129065/38750143-0662a5d8-3f22-11e8-9973-6e9e3710f176.PNG)

TA/Instructor view with total
![total png](https://user-images.githubusercontent.com/12129065/38749723-a22eb0e4-3f20-11e8-8ed9-7009a25c0b10.PNG)

GradeFile now shown at bottom
![capturegradefile](https://user-images.githubusercontent.com/12129065/38749780-dd9ebf34-3f20-11e8-99ba-a0772c306d44.PNG)

Version conflict error:
![error1](https://user-images.githubusercontent.com/12129065/38749798-e9371382-3f20-11e8-91d0-6deb5926d03b.PNG)

Grading not complete error:
![notgraded](https://user-images.githubusercontent.com/12129065/38749799-e954f136-3f20-11e8-9c82-428f057c85d7.PNG)



