### PR TITLE
Allow Merging of Bulk Submissions

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -284,6 +284,7 @@ if not args.worker:
     config['institution_name'] = INSTITUTION_NAME
     config['username_change_text'] = USERNAME_TEXT
     config['institution_homepage'] = INSTITUTION_HOMEPAGE
+    config['debugging_enabled'] = DEBUGGING_ENABLED
 
     config['site_log_path'] = TAGRADING_LOG_PATH
 

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -139,14 +139,14 @@ echo -e "Make top level directores & set permissions"
 
 mkdir -p ${SUBMITTY_DATA_DIR}
 
-if [ ${WORKER} == 1 ]; then
+if [ "${WORKER}" == 1 ]; then
     echo -e "INSTALLING SUBMITTY IN WORKER MODE"
 else
     echo -e "INSTALLING PRIMARY SUBMITTY"
 fi
 
 #Make a courses and checkouts directory if not in worker mode.
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     mkdir -p ${SUBMITTY_DATA_DIR}/courses
     mkdir -p ${SUBMITTY_DATA_DIR}/vcs
 fi
@@ -155,7 +155,7 @@ mkdir -p ${SUBMITTY_DATA_DIR}/logs
 mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding
 
 #Make site logging directories if not in worker mode.
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/site_errors
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/access
 fi
@@ -165,7 +165,7 @@ chown  root:${COURSE_BUILDERS_GROUP}              ${SUBMITTY_DATA_DIR}
 chmod  751                                        ${SUBMITTY_DATA_DIR}
 
 #Set up courses and version control ownership if not in worker mode
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     chown  root:${COURSE_BUILDERS_GROUP}              ${SUBMITTY_DATA_DIR}/courses
     chmod  751                                        ${SUBMITTY_DATA_DIR}/courses
     chown  root:www-data                              ${SUBMITTY_DATA_DIR}/vcs
@@ -173,7 +173,7 @@ if [ ${WORKER} == 0 ]; then
 fi
 
 #Set up permissions on the logs directory. If in worker mode, hwphp does not exist.
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     chown  -R ${HWPHP_USER}:${COURSE_BUILDERS_GROUP}  ${SUBMITTY_DATA_DIR}/logs
     chmod  -R u+rwx,g+rxs,o+x                         ${SUBMITTY_DATA_DIR}/logs
 else
@@ -185,7 +185,7 @@ chown  -R ${HWCRON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/auto
 chmod  -R u+rwx,g+rxs                             ${SUBMITTY_DATA_DIR}/logs/autograding
 
 #Set up shipper grading directories if not in worker mode.
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     # remove the old versions of the queues
     rm -rf $SUBMITTY_DATA_DIR/to_be_graded_interactive
     rm -rf $SUBMITTY_DATA_DIR/to_be_graded_batch
@@ -255,7 +255,7 @@ find ${SUBMITTY_INSTALL_DIR}/src -type f -exec chmod 444 {} \;
 
 
 #Set up sample files if not in worker mode.
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     ########################################################################################################################
     ########################################################################################################################
     # COPY THE SAMPLE FILES FOR COURSE MANAGEMENT
@@ -408,7 +408,7 @@ popd > /dev/null
 ################################################################################################################
 ################################################################################################################
 # COPY THE TA GRADING WEBSITE IF NOT IN WORKER MODE
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     echo -e "Copy the ta grading website"
 
     mkdir -p ${SUBMITTY_INSTALL_DIR}/site/public/hwgrading
@@ -447,7 +447,7 @@ fi
 ################################################################################################################
 ################################################################################################################
 # COPY THE 1.0 Grading Website if not in worker mode
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     echo -e "Copy the submission website"
 
     # copy the website from the repo
@@ -582,7 +582,7 @@ chmod -R 555 /usr/local/lib/python*/*
 chmod 555 /usr/lib/python*/dist-packages
 
 #Set up pam if not in worker mode.
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     sudo chmod 500   /usr/local/lib/python*/dist-packages/pam.py*
     sudo chown hwcgi /usr/local/lib/python*/dist-packages/pam.py*
 fi
@@ -745,7 +745,7 @@ fi
 ################################################################################################################
 ################################################################################################################
 # INSTALL TEST SUITE if not in worker mode
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     # one optional argument installs & runs test suite
     if [[ "$#" -ge 1 && $1 == "test" ]]; then
 
@@ -772,7 +772,7 @@ fi
 ################################################################################################################
 ################################################################################################################
 # INSTALL RAINBOW GRADES TEST SUITE if not in worker mode
-if [ ${WORKER} == 0 ]; then
+if [ "${WORKER}" == 0 ]; then
     # one optional argument installs & runs test suite
     if [[ "$#" -ge 1 && $1 == "test_rainbow" ]]; then
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -406,6 +406,13 @@ class SubmissionController extends AbstractController {
         if (!isset($_POST['csrf_token']) || !$this->core->checkCsrfToken($_POST['csrf_token'])) {
             return $this->uploadResult("Invalid CSRF token.", false);
         }
+
+        $merge_previous = false;
+        if(isset($_REQUEST['merge'])){
+            if($_REQUEST['merge']  === "true"){
+                $merge_previous = true;
+            }
+        }
     
         $gradeable_list = $this->gradeables_list->getSubmittableElectronicGradeables();
         
@@ -528,6 +535,24 @@ class SubmissionController extends AbstractController {
             }
             if (!@unlink(str_replace(".pdf", "_cover.pdf", $uploaded_file))) {
                 return $this->uploadResult("Failed to delete the uploaded file {$uploaded_file} from temporary storage.", false);
+            }
+            //if we are merging in the previous submission (TODO check folder support)
+            if($merge_previous && $new_version !== 1){
+                $old_version = $new_version -1;
+                $old_version_path = FileUtils::joinPaths($user_path, $old_version);
+                $to_search = FileUtils::joinPaths($old_version_path, "*.*");
+                $files = glob($to_search);
+                foreach($files as $file){
+                  $file_base_name = basename($file);
+                  if (strpos($file_base_name, 'version') === false) {
+                    $parts = explode(".", $file_base_name);
+                    $file_base_name = $parts[0] . "_version_" . $old_version . "." . $parts[1];    
+                  }
+                  $move_here = FileUtils::joinPaths($version_path, $file_base_name);
+                  if (!copy($file, $move_here)){
+                    return $this->uploadResult("Failed to merge previous version.", false);
+                  }
+                }
             }
         }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -475,11 +475,11 @@ HTML;
 
             $return .= <<<HTML
     <script type="text/javascript">
-        function makeSubmission(user_id, highest_version, is_pdf, path, count, repo_id) {
+        function makeSubmission(user_id, highest_version, is_pdf, path, count, repo_id, merge_previous=false) {
             // submit the selected pdf
             path = decodeURIComponent(path);
             if (is_pdf) {
-                submitSplitItem("{$this->core->getCsrfToken()}", "{$gradeable->getId()}", user_id, path, count);
+                submitSplitItem("{$this->core->getCsrfToken()}", "{$gradeable->getId()}", user_id, path, count, merge_previous=merge_previous);
                 moveNextInput(count);
             }
             

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -380,7 +380,6 @@ function validateUserId(csrf_token, gradeable_id, user_id, is_pdf, path, count, 
             try {
                 data = JSON.parse(data);
                 if (data['success']) {
-                    var submission_status = "";
                     if(data['previous_submission']){
                         $(function() {
                             var dialog = $('<p>One or more users you are submitting for had a previous submission. Do you wish to continue?</p>').dialog({

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -370,7 +370,6 @@ function validateUserId(csrf_token, gradeable_id, user_id, is_pdf, path, count, 
     formData.append('user_id', user_id);
 
     var url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'verify', 'gradeable_id': gradeable_id});
-
     $.ajax({
         url: url,
         data: formData,
@@ -381,11 +380,31 @@ function validateUserId(csrf_token, gradeable_id, user_id, is_pdf, path, count, 
             try {
                 data = JSON.parse(data);
                 if (data['success']) {
-                    var make_submission = true;
+                    var submission_status = "";
                     if(data['previous_submission']){
-                        var make_submission = confirm("One or more users you are submitting for had a previous submission. Do you wish to continue?")
+                        $(function() {
+                            var dialog = $('<p>One or more users you are submitting for had a previous submission. Do you wish to continue?</p>').dialog({
+                                open: function(event, ui) {
+                                    $(".ui-dialog-titlebar-close", ui.dialog | ui).hide();
+                                },
+                                buttons: {
+                                    "Yes": function() {
+                                        makeSubmission(user_id, data['highest_version'], is_pdf, path, count, repo_id);
+                                        dialog.dialog('close');
+
+                                    },
+                                    "No":  function() {
+                                        dialog.dialog('close');
+                                    },
+                                    "Merge":  function() {
+                                        makeSubmission(user_id, data['highest_version'], is_pdf, path, count, repo_id, merge_previous=true);
+                                        dialog.dialog('close');
+                                    }
+                                }
+                            });
+                        });
                     }
-                    if(make_submission){
+                    else{
                         makeSubmission(user_id, data['highest_version'], is_pdf, path, count, repo_id);
                     }
                 }
@@ -413,9 +432,9 @@ function validateUserId(csrf_token, gradeable_id, user_id, is_pdf, path, count, 
 * @param path
 * @param count
 */
-function submitSplitItem(csrf_token, gradeable_id, user_id, path, count) {
-
-    url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload_split', 'gradeable_id': gradeable_id});
+function submitSplitItem(csrf_token, gradeable_id, user_id, path, count, merge_previous=false) {
+    merge = (merge_previous ? "true" : "false");
+    url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload_split', 'gradeable_id': gradeable_id, "merge" : merge_previous});
     return_url = buildUrl({'component': 'student','gradeable_id': gradeable_id});
 
     var formData = new FormData();


### PR DESCRIPTION
Closes #1871 

Made the changes necessary to allow bulk submissions to be merged with the previously submitted version. Now, when a professor attempts to bulk upload to a student that has a previous submission, they are presented with a dialog box asking if they still want to upload, which has the options yes, no, and merge. If yes is clicked, a new submission is made for the student with the new file. If no is clicked, no submission is made. If merge is clicked, a new version is made with both the newly uploaded and previous version files. Previous version files have the text _version_# appended to their base names, unless the text "version" is already present (this is safe, as bulk uploads are always generically named "upload.pdf"). 

This pull request also fixes a minor bug in install submitty which was causing some if statements to improperly evaluate and another in configure_submitty which was causing the debug option to not be set.