### PR TITLE
Remove Unnecessary References to Grace Period

### DIFF
--- a/TAGradingServer/models/ElectronicGradeable.php
+++ b/TAGradingServer/models/ElectronicGradeable.php
@@ -445,7 +445,7 @@ ORDER BY gc_order ASC
                 // TODO: Convert this to using DateTime and DateTimeInterval objects
                 $date_submission = strtotime($timestamp);
                 $details['submission_time'] = $timestamp;
-                $date_due = strtotime($this->eg_details["eg_submission_due_date"]) + 1 + __SUBMISSION_GRACE_PERIOD_SECONDS__;
+                $date_due = strtotime($this->eg_details["eg_submission_due_date"]) + 1;
                 $days_late = round((($date_submission - $date_due) / (60 * 60 * 24)) + .5, 0);
                 $this->days_late = ($days_late < 0) ? 0 : $days_late;
             }

--- a/TAGradingServer/models/LateDaysCalculation.php
+++ b/TAGradingServer/models/LateDaysCalculation.php
@@ -151,7 +151,6 @@ class LateDaysCalculation
                         late_day_exceptions AS lde 
                       ON submissions.g_id = lde.g_id 
                       AND submissions.user_id = lde.user_id";
-        array_push($params, __SUBMISSION_GRACE_PERIOD_SECONDS__);
 
         //Query database and return results.
         Database::query($query, $params);

--- a/TAGradingServer/toolbox/configs/master_template.php
+++ b/TAGradingServer/toolbox/configs/master_template.php
@@ -5,7 +5,6 @@ define("__BASE_URL__", "__INSTALL__FILLIN__TAGRADING_URL__");
 define("__DATABASE_HOST__", "__INSTALL__FILLIN__DATABASE_HOST__");
 define("__DATABASE_USER__", "__INSTALL__FILLIN__DATABASE_USER__");
 define("__DATABASE_PASSWORD__", "__INSTALL__FILLIN__DATABASE_PASSWORD__");
-define("__SUBMISSION_GRACE_PERIOD_SECONDS__", 5 * 60);
 define("__OUTPUT_MAX_LENGTH__", 100000);
 define("__DEBUG__", false);
 define("__LOG_EXCEPTIONS__", true);

--- a/TAGradingServer/toolbox/functions.php
+++ b/TAGradingServer/toolbox/functions.php
@@ -49,7 +49,6 @@ else {
 $base_url = $a['site_details']['base_url'];
 $ta_base_url = $a['site_details']['ta_base_url'];
 define("__CGI_URL__", $a['site_details']['cgi_url']);
-define("__SUBMISSION_GRACE_PERIOD_SECONDS__", 5 * 60);
 define("__OUTPUT_MAX_LENGTH__", 100000);
 define("__DATABASE_HOST__", $a['database_details']['database_host']);
 define("__DATABASE_USER__", $a['database_details']['database_user']);

--- a/site/app/models/LateDaysCalculation.php
+++ b/site/app/models/LateDaysCalculation.php
@@ -15,9 +15,6 @@ class LateDaysCalculation extends AbstractModel {
     /** @var array */
     protected $students;
 
-    /* Holds grace period in seconds (300 seconds = 5 minutes)*/
-    protected $SUBMISSION_GRACE_PERIOD = 300;
-
     function __construct(Core $core, $user_id = null) {
         parent::__construct($core);
         $this->students = $this->parseStudents($user_id);


### PR DESCRIPTION
`SUBMISSION_GRACE_PERIOD` and ` __SUBMISSION_GRACE_PERIOD_SECONDS__` don't seem to change the submission behavior at all, and can be removed to avoid further confusion. 

When an assignment is submitted shortly after the official due date, a javascript alert warns the student that they will be charged one late day, but no late days are actually charged.
![image](https://user-images.githubusercontent.com/6187282/38781073-15100fca-40ae-11e8-8aba-dc31cec42c89.png)
![image](https://user-images.githubusercontent.com/6187282/38781075-215c18d2-40ae-11e8-8797-ed57dd8f95bf.png)

After removing these lines, the same behavior occurs:
![due_date_no_grace](https://user-images.githubusercontent.com/6187282/38781133-fd894096-40ae-11e8-96c4-348a742dab26.jpeg)
![late_day_use_no_grace](https://user-images.githubusercontent.com/6187282/38781134-ff6215aa-40ae-11e8-9728-9a9053dfb6cb.jpeg)

