### PR TITLE
TA/Instructor Grading View Update 

### DIFF
--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -184,11 +184,16 @@ class GradeableComponent extends AbstractModel {
         return $points;
     }
 
-    public function getGradedTAComments($nl, $show_students) {
+    public function getGradedTAComments($nl, $show_students, $use_ascii = true) {
         $text = "";
         $first_text = true;
-        $checkedBox = '<i class="fa fa-check-square-o fa-1g"></i> ';
-        $box = '<i class="fa fa-square-o"></i> ';
+        if(!$use_ascii){
+            $checkedBox = '<i class="fa fa-check-square-o fa-1g"></i> ';
+            $box = '<i class="fa fa-square-o"></i> ';
+        }else{
+            $checkedBox = '(*)';
+            $box = '( )';
+        }
         foreach ($this->marks as $mark) {
             $points_string = "    ";
             if ($mark->getPoints() != 0) {

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -225,10 +225,10 @@ HTML;
 HTML;
                         }
                         else {
-                $percentage = 0;
+			    $percentage = 0;
                             if($gradeable->getTotalAutograderNonExtraCreditPoints() != 0) {
                                 $percentage = round($autograded_average->getAverageScore()/$gradeable->getTotalAutograderNonExtraCreditPoints()*100);
-                }
+			    }
                             $return .= <<<HTML
                 Average: {$autograded_average->getAverageScore()} / {$gradeable->getTotalAutograderNonExtraCreditPoints()} ({$percentage}%)<br/>
                 Standard Deviation: {$autograded_average->getStandardDeviation()} <br/>
@@ -253,8 +253,8 @@ HTML;
                             $overall_score += $comp->getAverageScore();
                             $overall_max += $comp->getMaxValue();
                             $percentage = 0;
-                            if ($comp->getMaxValue() != 0) {
-                                $percentage = round($comp->getAverageScore() / $comp->getMaxValue() * 100);
+			                if ($comp->getMaxValue() != 0) {
+			                    $percentage = round($comp->getAverageScore() / $comp->getMaxValue() * 100);
                             }
                             $average_string = ($comp->getMaxValue() > 0 ? "{$comp->getAverageScore()} / {$comp->getMaxValue()} ({$percentage}%)" : "{$comp->getAverageScore()}");
                             $return .= <<<HTML
@@ -603,7 +603,7 @@ HTML;
                             if ($member_list !== "") {
                                 $member_list = $member_list . ", ";
                             }
-     
+ 	 
                             $first_name = $this->core->getQueries()->getUserById($team_member)->getDisplayedFirstName();
                             $last_name = $this->core->getQueries()->getUserById($team_member)->getLastName();
 
@@ -686,7 +686,7 @@ HTML;
                     if($row->validateVersions()) {
                         $btn_class = "btn-default";
                         $contents = "{$row->getGradedTAPoints()}&nbsp;/&nbsp;{$row->getTotalTANonExtraCreditPoints()}";
-                        $graded += $row->getGradedTAPoints();
+			            $graded += $row->getGradedTAPoints();
                     }
                     else{
                         $btn_class = "btn-primary";
@@ -716,7 +716,7 @@ HTML;
 
                 //prints the graded questions
                 foreach ($row->getComponents() as $component) {
-                    $first = true;
+                	$first = true;
                     if(is_array($component)) {
                         foreach($component as $cmpt) {
                             if($cmpt->getGrader() == null) {
@@ -737,16 +737,16 @@ HTML;
                     }
                     if($question->getGrader() === null || $question === null) {
                     } else {
-                        if ($first == true) {
-                            $first = false;
-                            $return .= <<<HTML
+                    	if ($first == true) {
+                    		$first = false;
+                    		$return .= <<<HTML
                             {$temp_counter}
 HTML;
-                        } else {
-                            $return .= <<<HTML
+                    	} else {
+                    		$return .= <<<HTML
                            , {$temp_counter}
 HTML;
-                        }
+                    	}
                     }
                     $temp_counter++;
                 }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -225,10 +225,10 @@ HTML;
 HTML;
                         }
                         else {
-			    $percentage = 0;
+                $percentage = 0;
                             if($gradeable->getTotalAutograderNonExtraCreditPoints() != 0) {
                                 $percentage = round($autograded_average->getAverageScore()/$gradeable->getTotalAutograderNonExtraCreditPoints()*100);
-			    }
+                }
                             $return .= <<<HTML
                 Average: {$autograded_average->getAverageScore()} / {$gradeable->getTotalAutograderNonExtraCreditPoints()} ({$percentage}%)<br/>
                 Standard Deviation: {$autograded_average->getStandardDeviation()} <br/>
@@ -253,8 +253,8 @@ HTML;
                             $overall_score += $comp->getAverageScore();
                             $overall_max += $comp->getMaxValue();
                             $percentage = 0;
-			                if ($comp->getMaxValue() != 0) {
-			                    $percentage = round($comp->getAverageScore() / $comp->getMaxValue() * 100);
+                            if ($comp->getMaxValue() != 0) {
+                                $percentage = round($comp->getAverageScore() / $comp->getMaxValue() * 100);
                             }
                             $average_string = ($comp->getMaxValue() > 0 ? "{$comp->getAverageScore()} / {$comp->getMaxValue()} ({$percentage}%)" : "{$comp->getAverageScore()}");
                             $return .= <<<HTML
@@ -603,7 +603,7 @@ HTML;
                             if ($member_list !== "") {
                                 $member_list = $member_list . ", ";
                             }
- 	 
+     
                             $first_name = $this->core->getQueries()->getUserById($team_member)->getDisplayedFirstName();
                             $last_name = $this->core->getQueries()->getUserById($team_member)->getLastName();
 
@@ -686,7 +686,7 @@ HTML;
                     if($row->validateVersions()) {
                         $btn_class = "btn-default";
                         $contents = "{$row->getGradedTAPoints()}&nbsp;/&nbsp;{$row->getTotalTANonExtraCreditPoints()}";
-			            $graded += $row->getGradedTAPoints();
+                        $graded += $row->getGradedTAPoints();
                     }
                     else{
                         $btn_class = "btn-primary";
@@ -716,7 +716,7 @@ HTML;
 
                 //prints the graded questions
                 foreach ($row->getComponents() as $component) {
-                	$first = true;
+                    $first = true;
                     if(is_array($component)) {
                         foreach($component as $cmpt) {
                             if($cmpt->getGrader() == null) {
@@ -737,16 +737,16 @@ HTML;
                     }
                     if($question->getGrader() === null || $question === null) {
                     } else {
-                    	if ($first == true) {
-                    		$first = false;
-                    		$return .= <<<HTML
+                        if ($first == true) {
+                            $first = false;
+                            $return .= <<<HTML
                             {$temp_counter}
 HTML;
-                    	} else {
-                    		$return .= <<<HTML
+                        } else {
+                            $return .= <<<HTML
                            , {$temp_counter}
 HTML;
-                    	}
+                        }
                     }
                     $temp_counter++;
                 }

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1034,7 +1034,6 @@ HTML;
 HTML;
                 $return .= $this->core->getOutput()->renderTemplate('AutoGrading', 'showTAResults', $gradeable);
                 $return .= <<<HTML
-    <pre>{$gradeable->getGradeFile()}</pre>
 HTML;
             } else {
                 $return .= <<<HTML


### PR DESCRIPTION
Added:

- Changed titles to say "Total" or "Subtotal" depending if autograding and instructor grading both exist
- Hidden autograding points are now displayed under autograding once grades have been released
- Total/Subtotal points add hidden points when grades have been released
- Checks for incomplete grading, version conflicts
- Total displayed at bottom of instructor grades if both sections exist
- Gradefile now displayed under new TA/Instructor grading view
- Fixed bug where ascii art was replaced with code in Gradefiles
-Fixed capitalizations

TA/Instructor
![capture1](https://user-images.githubusercontent.com/12129065/38832040-4fb57dea-418f-11e8-9f2b-cfee6e19eb46.PNG)

Auto
![capture2](https://user-images.githubusercontent.com/12129065/38832045-520d9276-418f-11e8-9910-c30b29848381.PNG)
