### PR TITLE
Added hwcron to the www-data group

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -118,6 +118,7 @@ fi
 
 adduser hwcron --gecos "First Last,RoomNumber,WorkPhone,HomePhone" --disabled-password
 adduser hwcron hwcronphp
+adduser hwcron www-data
 
 echo -e "\n# set by the .setup/install_system.sh script\numask 027" >> /home/hwcron/.profile
 

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -118,6 +118,7 @@ fi
 
 adduser hwcron --gecos "First Last,RoomNumber,WorkPhone,HomePhone" --disabled-password
 adduser hwcron hwcronphp
+# The VCS directories (/var/local/submitty/vcs) are owned root:www-data, and hwcron needs access to them for autograding
 adduser hwcron www-data
 
 echo -e "\n# set by the .setup/install_system.sh script\numask 027" >> /home/hwcron/.profile


### PR DESCRIPTION
This is necessary to get repo grading to work via local checkout as all repos are owned `root:www-data`.