### PR TITLE
Hide limited access graders

### DIFF
--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -563,8 +563,8 @@ HTML;
                 }
                 $score = $score . " / " . $component->getMaxValue();
             }
-            //add grader's name if not peer grading
-            $componentGrader = ($gradeable->getPeerGrading())? "" :" (Graded by: " . $component->getGrader()->getLastName().")";
+            //add grader's name if not peer grading and is a full access grader
+            $componentGrader = ($gradeable->getPeerGrading() || !$component->getGrader()->accessFullGrading())? "" :" (Graded by: " . $component->getGrader()->getLastName().")";
             $return .= <<<HTML
             <div class="box">
                 <div class="box-title">

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -579,7 +579,7 @@ HTML;
         $display = "none";
         $current = $gradeable->getCurrentVersion();
         $totalPointsEarned = $current->getNonHiddenTotal() + $current->getHiddenTotal() + $totalInstructorPointsEarned;
-        $maxPossiblePoints = $gradeable->getTotalAutograderNonExtraCreditPoints() + $maxScore;
+        $maxPossiblePoints = $gradeable->getNormalPoints() + $maxScore;
         $background = "";
         if($totalPointsEarned >= $maxPossiblePoints){
             $background = "green-background";

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -579,7 +579,7 @@ HTML;
         $display = "none";
         $current = $gradeable->getCurrentVersion();
         $totalPointsEarned = $current->getNonHiddenTotal() + $current->getHiddenTotal() + $totalInstructorPointsEarned;
-        $maxPossiblePoints = $gradeable->getNormalPoints() + $maxScore;
+        $maxPossiblePoints = $gradeable->getTotalAutograderNonExtraCreditPoints() + $maxScore;
         $background = "";
         if($totalPointsEarned >= $maxPossiblePoints){
             $background = "green-background";


### PR DESCRIPTION
Prevents limited access graders from displaying on the TA/Instructor grade view.
Instead of a grader name, it'll just be blank - this shouldn't be an issue when the verify grader feature is implemented.

Fixes #1908 
