### PR TITLE
Add additional fields to grade summary output and fix score always being 0

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -152,6 +152,8 @@ class ReportController extends AbstractController {
                 'id' => $gradeable->getId(),
                 'name' => $gradeable->getName(),
                 'grade_released_date' => $gradeable->getGradeReleasedDate()->format('Y-m-d H:i:s O'),
+                'autograding_score' => $autograding_score,
+                'tagrading_score' => $ta_grading_score
             ];
 
             if ($gradeable->validateVersions() || !$gradeable->useTAGrading()) {
@@ -173,11 +175,17 @@ class ReportController extends AbstractController {
 
             $entry['components'] = [];
             foreach ($gradeable->getComponents() as $component) {
-                $inner = ['title' => $component->getTitle()];
+                $inner = [
+                    'title' => $component->getTitle(),
+                    'comment' => $component->getComment(),
+                ];
                 if (!$component->getIsText()) {
-                    $inner['score'] = $component->getScore();
+                    $inner['score'] = $component->getGradedTAPoints();
+                    $inner['default_score'] = $component->getDefault();
+                    $inner['upper_clamp'] = $component->getUpperClamp();
+                    $inner['lower_clamp'] = $component->getLowerClamp();
                 }
-                $inner['comment'] = $component->getComment();
+
                 if ($component->getHasMarks()) {
                     $marks = [];
                     foreach ($component->getMarks() as $mark) {

--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -174,16 +174,8 @@ class GradeableComponent extends AbstractModel {
                 $points += $mark->getPoints();
             }
         }
-
         $points += $this->score;
-
-        if($points < $this->lower_clamp) {
-            $points = $this->lower_clamp;
-        }
-        if($points > $this->upper_clamp) {
-            $points = $this->upper_clamp;
-        }
-        return $points;
+        return min(max($points, $this->lower_clamp), $this->upper_clamp);
     }
 
     public function getGradedTAComments($nl, $show_students, $use_ascii = true) {


### PR DESCRIPTION
Example of homework:
```
        {
            "id": "closed_homework",
            "name": "Closed Homework",
            "grade_released_date": "9998-12-31 23:59:59 -0500",
            "autograding_score": 0,
            "tagrading_score": 11,
            "score": 11,
            "status": "Good",
            "days_late": 0,
            "components": [
                {
                    "title": "Read Me",
                    "comment": "",
                    "score": 1,
                    "default_score": 2,
                    "upper_clamp": 2,
                    "lower_clamp": 0,
                    "marks": [
                        {
                            "points": "-1",
                            "note": "Minor errors in Read Me"
                        }
                    ]
                },
                {
                    "title": "Coding Style",
                    "comment": "",
                    "score": 5,
                    "default_score": 5,
                    "upper_clamp": 5,
                    "lower_clamp": 0,
                    "marks": [
                        {
                            "points": "0",
                            "note": "Full Credit"
                        }
                    ]
                },
                {
                    "title": "Documentation",
                    "comment": "",
                    "score": 5,
                    "default_score": 5,
                    "upper_clamp": 5,
                    "lower_clamp": 0,
                    "marks": [
                        {
                            "points": "0",
                            "note": "Full Credit"
                        }
                    ]
                },
                {
                    "title": "Extra Credit",
                    "comment": "",
                    "score": 0,
                    "default_score": 0,
                    "upper_clamp": 5,
                    "lower_clamp": 0,
                    "marks": [
                        {
                            "points": "0",
                            "note": "No Credit"
                        }
                    ]
                }
            ]
        },
```

New fields are:
At gradeable scope:
* autograding_score
* tagrading_score

At component scope:
* default_score
* upper_clamp
* lower_clamp