### PR TITLE
vagrant ssh as root by default

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -25,13 +25,19 @@ SUBMITTY_DATA_DIR=/var/local/submitty
 #################
 
 if [ "$1" == "--vagrant" ] || [ "$2" == "--vagrant" ]; then
-  echo "Non-interactive vagrant script..."
-  export VAGRANT=1
-  export DEBIAN_FRONTEND=noninteractive
-  shift
+    echo "Non-interactive vagrant script..."
+    export VAGRANT=1
+    export DEBIAN_FRONTEND=noninteractive
+    shift
+
+    # Setting it up to allow SSH as root by default
+    mkdir -m 700 /root/.ssh
+    cp /home/vagrant/.ssh/authorized_keys /root/.ssh
+
+    sed -i -e "s/PermitRootLogin prohibit-password/PermitRootLogin yes/g" /etc/ssh/sshd_config
 else
-  #TODO: We should get options for ./.setup/CONFIGURE_SUBMITTY.py script
-  export VAGRANT=0
+    #TODO: We should get options for ./.setup/CONFIGURE_SUBMITTY.py script
+    export VAGRANT=0
 fi
 
 if [ "$1" == "--worker" ] || [ "$2" == "--worker" ]; then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,4 +58,10 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT_Submitty', create: true, mount_options: ["dmode=775", "fmode=774"]
 
   config.vm.provision 'shell', inline: $script
+
+  if ARGV.include?('ssh')
+    config.ssh.username = 'root'
+    config.ssh.password = 'vagrant'
+    config.ssh.insert_key = 'true'
+  end
 end


### PR DESCRIPTION
This will make it when you `vagrant ssh`, you'll be logged in as root. The if statement is necessary around the new `config.ssh.*` lines as otherwise it'll break running `vagrant up`.

After merging this, you'll need to do `vagrant up --provision` to setup the SSH details.