### PR TITLE
Fix custom mark not displaying properly in grading summary output

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -170,6 +170,7 @@ class ReportController extends AbstractController {
             }
 
             if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
+                $entry['overall_comment'] = $gradeable->getOverallComment();
                 $this->addLateDays($gradeable, $entry, $total_late_used);
             }
 

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -178,17 +178,15 @@ class ReportController extends AbstractController {
                 $inner = [
                     'title' => $component->getTitle()
                 ];
-                if (!$component->getIsText()) {
+
+                if ($component->getIsText()) {
+                    $inner['comment'] = $component->getComment();
+                }
+                else {
                     $inner['score'] = $component->getGradedTAPoints();
                     $inner['default_score'] = $component->getDefault();
                     $inner['upper_clamp'] = $component->getUpperClamp();
                     $inner['lower_clamp'] = $component->getLowerClamp();
-                }
-
-                // The text/score for an electronic file is a custom mark while
-                // for all other types it's the actual score/comment
-                if ($component->getIsText()) {
-                    $inner['comment'] = $component->getComment();
                 }
 
                 if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -176,8 +176,7 @@ class ReportController extends AbstractController {
             $entry['components'] = [];
             foreach ($gradeable->getComponents() as $component) {
                 $inner = [
-                    'title' => $component->getTitle(),
-                    'comment' => $component->getComment(),
+                    'title' => $component->getTitle()
                 ];
                 if (!$component->getIsText()) {
                     $inner['score'] = $component->getGradedTAPoints();
@@ -186,15 +185,24 @@ class ReportController extends AbstractController {
                     $inner['lower_clamp'] = $component->getLowerClamp();
                 }
 
-                if ($component->getHasMarks()) {
+                // The text/score for an electronic file is a custom mark while
+                // for all other types it's the actual score/comment
+                if ($component->getIsText()) {
+                    $inner['comment'] = $component->getComment();
+                }
+
+                if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
                     $marks = [];
-                    foreach ($component->getMarks() as $mark) {
-                        if ($mark->getHasMark()) {
-                            $marks[] = [
-                                'points' => $mark->getPoints(),
-                                'note' => $mark->getNote()
-                            ];
+                    if ($component->getHasMarks()) {
+                        foreach ($component->getMarks() as $mark) {
+                            if ($mark->getHasMark()) {
+                                $marks[] = ['points' => $mark->getPoints(), 'note' => $mark->getNote()];
+                            }
                         }
+                    }
+
+                    if (!empty($component->getComment()) || $component->getScore() != 0) {
+                        $marks[] = ['points' => $component->getScore(), 'note' => $component->getComment()];
                     }
                     $inner['marks'] = $marks;
                 }

--- a/site/app/models/GradeableComponentMark.php
+++ b/site/app/models/GradeableComponentMark.php
@@ -39,7 +39,7 @@ class GradeableComponentMark extends AbstractModel {
         }
         $this->id = $details['gcm_id'];
         $this->gc_id = $details['gc_id'];
-        $this->points = $details['gcm_points'];
+        $this->points = floatval($details['gcm_points']);
         $this->order = $details['gcm_order'];
         $this->note = $details['gcm_note'];
         $this->publish = $details['gcm_publish'];


### PR DESCRIPTION
This will show as the final mark in the the list of marks for a component.

For non-electronic gradeables, it'll then either show the score or a comment depending on if its a text field or not.