### PR TITLE
Fix issue with grade next student not working

### DIFF
--- a/bin/submitty_autograding_shipper.py
+++ b/bin/submitty_autograding_shipper.py
@@ -193,7 +193,7 @@ def prepare_job(my_name,which_machine,which_untrusted,next_directory,next_to_gra
     obj = grade_item.load_queue_file_obj(JOB_ID,next_directory,next_to_grade)
     partial_path = os.path.join(obj["gradeable"],obj["who"],str(obj["version"]))
     item_name = os.path.join(obj["semester"],obj["course"],"submissions",partial_path)
-    is_batch = obj["regrade"]
+    is_batch = "regrade" in obj and obj["regrade"]
     grade_items_logging.log_message(JOB_ID, jobname=item_name, which_untrusted=which_untrusted,
                                     is_batch=is_batch, message="Prepared job for " + which_machine)
     return True
@@ -207,7 +207,7 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
     obj = grade_item.load_queue_file_obj(JOB_ID,next_directory,next_to_grade)
     partial_path = os.path.join(obj["gradeable"],obj["who"],str(obj["version"]))
     item_name = os.path.join(obj["semester"],obj["course"],"submissions",partial_path)
-    is_batch = obj["regrade"]
+    is_batch = "regrade" in obj and obj["regrade"]
 
     # verify the hwcron user is running this script
     if not int(os.getuid()) == int(HWCRON_UID):

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -587,7 +587,7 @@ class ElectronicGraderController extends AbstractController {
                 $total = array_sum($this->core->getQueries()->getTotalUserCountByGradingSections($sections, 'rotating_section'));
             }
             else {
-                $users_to_grade = $this->core->getQueries()->getUsersByRegistrationSections($sections,$orderBy="rotating_section,user_id;");
+                $users_to_grade = $this->core->getQueries()->getUsersByRotatingSections($sections,$orderBy="rotating_section,user_id;");
                 $total = array_sum($this->core->getQueries()->getTotalUserCountByGradingSections($sections, 'rotating_section'));
             }
             $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'rotating_section'));


### PR DESCRIPTION
Should fix error which was causing TAs to report that the "grade next student" and ">" and "<" do not work anymore.

A typo was causing the buttons to always iterate over registration sections.