### PR TITLE
Add unique cookie identifier to site access logs

### DIFF
--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -183,12 +183,14 @@ class Logger {
      * (so gradeable id for when they're submitting).
      *
      * @param $user_id
+     * @param $token
      * @param $action
      */
-    public static function logAccess($user_id, $action) {
+    public static function logAccess($user_id, $token, $action) {
         $filename = static::getFilename();
         $log_message[] = static::getTimestamp();
         $log_message[] = $user_id;
+        $log_message[] = $token;
         $log_message[] = $_SERVER['REMOTE_ADDR'];
         $log_message[] = $action;
         //$log_message[] = $_SERVER['REQUEST_URI'];

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -69,9 +69,10 @@ class Utils {
      * @param int $bytes
      *
      * @return string
+     * @throws \Exception
      */
     public static function generateRandomString($bytes = 16) {
-        return bin2hex(openssl_random_pseudo_bytes($bytes));
+        return bin2hex(random_bytes($bytes));
     }
     
     /**
@@ -169,5 +170,33 @@ class Utils {
                 }
             } return true;
         } return false;
+    }
+
+    /**
+     * Generates a unique identifier v4 based on the RFC 4122 - Section 4.4 document.
+     * TODO: when we move to Composer inside of site, we should replace usage of this
+     * function with ramsey/uuid package.
+     *
+     * If for whatever reason random_butes fails, we fall back to uniqid which has a
+     * worse guarantee of being actually unique, but it's more important to not
+     * crash out here.
+     *
+     * @see http://tools.ietf.org/html/rfc4122#section-4.4
+     *
+     * @return string
+     */
+    public static function guidv4() {
+        try {
+            $data = random_bytes(16);
+
+            $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
+            $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
+
+            return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+        }
+        catch (\Exception $exc) {
+            return uniqid('', true);
+        }
+
     }
 }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -177,7 +177,7 @@ class Utils {
      * TODO: when we move to Composer inside of site, we should replace usage of this
      * function with ramsey/uuid package.
      *
-     * If for whatever reason random_butes fails, we fall back to uniqid which has a
+     * If for whatever reason random_bytes fails, we fall back to uniqid which has a
      * worse guarantee of being actually unique, but it's more important to not
      * crash out here.
      *

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -176,6 +176,9 @@ elseif ($core->getUser() === null) {
 }
 // Log the user action if they were logging in, logging out, or uploading something
 if ($core->getUser() !== null) {
+    if (empty($_COOKIE['submitty_token'])) {
+        Utils::setCookie('submitty_token', Utils::guidv4());
+    }
     $log = false;
     $action = "";
     if ($_REQUEST['component'] === "authentication" && $_REQUEST['page'] === "logout") {
@@ -195,7 +198,7 @@ if ($core->getUser() !== null) {
         if ($core->getConfig()->isCourseLoaded()) {
             $action = $core->getConfig()->getSemester().':'.$core->getConfig()->getCourse().':'.$action;
         }
-        Logger::logAccess($core->getUser()->getId(), $action);
+        Logger::logAccess($core->getUser()->getId(), $_COOKIE['submitty_token'], $action);
     }
 }
 

--- a/tests/unitTests/app/libraries/LoggerTester.php
+++ b/tests/unitTests/app/libraries/LoggerTester.php
@@ -108,7 +108,7 @@ class LoggerTester extends \PHPUnit_Framework_TestCase {
         $current_date = getdate(time());
         $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
         $_SERVER['HTTP_USER_AGENT'] = "PHPUnit";
-        Logger::logAccess("test", "action");
+        Logger::logAccess("test", "token", "action");
         $file = file_get_contents($this->access);
         $lines = explode("\n", $file);
         $this->assertCount(2, $lines);
@@ -127,8 +127,9 @@ class LoggerTester extends \PHPUnit_Framework_TestCase {
             $this->assertStringStartsWith('0', $time[2]);
         }
         $this->assertEquals("test", $line[1]);
-        $this->assertEquals("127.0.0.1", $line[2]);
-        $this->assertEquals("action", $line[3]);
-        $this->assertEquals("PHPUnit", $line[4]);
+        $this->assertEquals("token", $line[2]);
+        $this->assertEquals("127.0.0.1", $line[3]);
+        $this->assertEquals("action", $line[4]);
+        $this->assertEquals("PHPUnit", $line[5]);
     }
 }


### PR DESCRIPTION
Implements the latter part of #1937 in adding a unique identifier cookie for a user (if it doesn't exist) and writes that cookie to a log file within the access logs. The cookie should last indefinitely (depending on user's settings) for a given browser.

Added a TODO for later once we fold composer.json into the site folder and we can start to use third-party packages easier.