### PR TITLE
Use window onload function to set global JS variables

### DIFF
--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -63,7 +63,7 @@ HTML;
         $return .= <<<HTML
 </head>
 <script>var onAjaxInit;</script>
-<body onload="setSiteDetails('{$this->core->getConfig()->getSiteUrl()}', '{$this->core->getCsrfToken()}'); if (onAjaxInit) { onAjaxInit(); }">
+<body data-site-url="{$this->core->getConfig()->getSiteUrl()}" data-csrf-token="{$this->core->getCsrfToken()}" onload="if (onAjaxInit) { onAjaxInit(); }">
 {$messages}
 <div id="container">
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1,10 +1,11 @@
 var siteUrl = undefined;
 var csrfToken = undefined;
 
-function setSiteDetails(url, setCsrfToken) {
-    siteUrl = url;
-    csrfToken = setCsrfToken;
-}
+window.addEventListener("load", function() {
+  for (const elem in document.body.dataset) {
+    window[elem] = document.body.dataset[elem];
+  }
+});
 
 /**
  * Acts in a similar fashion to Core->buildUrl() function within the PHP code


### PR DESCRIPTION
This makes it easier to reference the "global" JS variables in any JS script operating on the page as if desired, you can just pull it from `document.body.dataset`. Note, the naming scheme done by dataset is to convert any the data string such that it strips the `data-` and then converts the remainder to camelCase (dropping any - and uppercasing the following letter).