### PR TITLE
Remove late submission grace period

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -286,7 +286,7 @@ SELECT";
   egd.submission_time,
   egv.highest_version,
   COALESCE(lde.late_day_exceptions, 0) AS late_day_exceptions,
-  GREATEST(0, CEIL((EXTRACT(EPOCH FROM(COALESCE(egd.submission_time, eg.eg_submission_due_date) - eg.eg_submission_due_date)) - (300*60))/86400)::integer) AS days_late,
+  GREATEST(0, CEIL((EXTRACT(EPOCH FROM(COALESCE(egd.submission_time, eg.eg_submission_due_date) - eg.eg_submission_due_date)))/86400)::integer) AS days_late,
   get_allowed_late_days(u.user_id, eg.eg_submission_due_date) AS student_allowed_late_days
 FROM users AS u
 NATURAL JOIN gradeable AS g";

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -85,7 +85,12 @@ HTML;
           $error = true;
           if ($info != "") { $info .= "<br><br>"; }
           $info .= "Your active version was submitted {$active_days_late} " . $this->dayOrDays($active_days_late) . " after the deadline,"
-            . " but you only have XXX remaining late days.  Your grade for this assignment will be recorded as a zero.";
+            . " but you ";
+          if ($late_days_remaining == 0) {
+            $info .= "have no remaining late days.";
+          } else {
+            $info .= "only have {$late_days_remaining} remaining late " . $this->dayOrDays($late_days_remaining) . ".";
+          }
         }
 
         // BAD STATUS - AUTO ZERO BECAUSE TOO MANY LATE DAYS USED ON THIS ASSIGNMENT


### PR DESCRIPTION
It appears we had this set to 5 hours!?!?! when perhaps it was supposed to be 5 minutes.
Anyway, we agreed that the grace period should be 0.
When issue #1865 is complete, there will be no excuse for late submission.

If the instructor wishes to have a small grace period, they can adjust the deadline, but that exact date will be displayed to the students.