### PR TITLE
Remove Generate Homework Reports from UI

### DIFF
--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -94,7 +94,7 @@ HTML;
                 <a href="{$this->core->buildUrl(array('component' => 'admin', 'page' => 'late', 'action' => 'view_extension'))}">Excused Absence Extensions</a>
             </li>
             <li>
-                <a href="{$this->core->buildUrl(array('component' => 'admin', 'page' => 'reports', 'action' => 'reportpage'))}">HWReports, CSV Reports, and Grade Summaries</a>
+                <a href="{$this->core->buildUrl(array('component' => 'admin', 'page' => 'reports', 'action' => 'reportpage'))}">Grade Summaries / CSV Report</a>
             </li>
             <li>
                 <a href="{$this->core->buildUrl(array('component' => 'admin', 'page' => 'plagiarism'))}">Plagiarism Detection</a>

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -12,18 +12,6 @@ class ReportView extends AbstractView {
         <tbody>
             <tr>
                 <td width="50%">
-                    <p>Pushing this button will update or create Reports for all students for all Gradeables, regardless of grades. This happens on an individual basis whenever a TA or instructor enters a grade for a student. This action shouldn't be necessary, except to update late day information that effects other electronic gradeables.
-                    </p>
-                </td>
-                <td width="5%"> </td>
-                <td width="45%" style="position:relative">
-                    <button onclick="location.href='{$this->core->buildUrl(array('component' => 'admin', 'page' => 'reports', 'action' => 'hwreport'))}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Gradeable Reports</button>
-                <td>
-            </tr>
-            <tr class="bar"></tr>
-            <tr class="bar"></tr>
-            <tr>
-                <td width="50%">
                     <p> Pushing this button will update the grade summary data used to generate the rainbow grades reports, for all students in the class.
                     </p>
                 </td>
@@ -40,7 +28,7 @@ class ReportView extends AbstractView {
                 </td>
                 <td width="5%"> </td>
                 <td width="45%" style="position:relative">
-                    <button onclick="location.href='{$this->core->buildUrl(array('component' => 'admin', 'page' => 'reports', 'action' => 'csv'))}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Reports</button>
+                    <button onclick="location.href='{$this->core->buildUrl(array('component' => 'admin', 'page' => 'reports', 'action' => 'csv'))}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
                 </td>
             </tr>
         <tbody>


### PR DESCRIPTION
deprecated now that students see TA grading details directly from database and grade summaries contains more details.