### PR TITLE
TA Grading Keyboard shortcuts

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1563,17 +1563,17 @@ HTML;
         $overallComment = htmlentities($gradeable->getOverallComment(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $return .= <<<HTML
                 <tr>
-                    <td id="title-general" colspan="4" onclick="{$break_onclick} saveLastOpenedMark('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}', {$question->getId()}); saveGeneralComment('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}); updateMarksOnPage({$c}, '', {$min}, {$max}, '{$precision}', '{$gradeable->getId()}', '{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}'); openClose(-2, {$num_questions});" data-changebg="true">
+                    <td id="title-general" colspan="4" onclick="{$break_onclick}; closeGeneralMessage(true);" data-changebg="true">
                         <b>General Comment</b>
                         <div style="float: right;">
                             <span id="save-mark-general" style="cursor: pointer;  display: none;" data-changedisplay1="true"> <i class="fa fa-check" style="color: green;" aria-hidden="true">Done</i> </span>
                         </div>
                     </td>
                     <td id="title-cancel-general" style="font-size: 12px; display: none; width: 5%" colspan="0" data-changebg="true" data-changedisplay1="true">
-                        <span id="cancel-mark-general" onclick="{$break_onclick} updateGeneralComment('{$gradeable->getId()}', '{$user->getAnonId()}'); openClose(-1, {$num_questions});" style="cursor: pointer; display: none; float: right;" data-changedisplay1="true"> <i class="fa fa-times" style="color: red;" aria-hidden="true">Cancel</i></span>
+                        <span id="cancel-mark-general" onclick="{$break_onclick}; closeGeneralMessage(false);" style="cursor: pointer; display: none; float: right;" data-changedisplay1="true"> <i class="fa fa-times" style="color: red;" aria-hidden="true">Cancel</i></span>
                     </td>
                 </tr>
-                <tr id="summary-general" style="" onclick="{$break_onclick} saveLastOpenedMark('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}', {$question->getId()}); saveGeneralComment('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}); updateMarksOnPage({$c}, '', {$min}, {$max}, '{$precision}', '{$gradeable->getId()}', '{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}'); openClose(-2, {$num_questions});" data-changedisplay2="true">
+                <tr id="summary-general" style="" onclick="{$break_onclick}; openGeneralMessage();" data-changedisplay2="true">
                     <td style="white-space:nowrap; vertical-align:middle; text-align:center" colspan="1">
                     </td>
                     <td style="width:98%;" colspan="3">

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1456,7 +1456,7 @@ HTML;
             }
             $return .= <<<HTML
                             <span id="graded-by-{$c}" style="font-style: italic; padding-right: 10px;">{$grader_id}</span>
-                            <span id="save-mark-{$c}" style="cursor: pointer;  display: none;" data-changedisplay1="true"> <i class="fa fa-check" style="color: green;" aria-hidden="true" onclick="{$break_onclick} saveLastOpenedMark('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}', {$question->getId()}); saveMark({$c},'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}', -1); updateMarksOnPage({$c}, '', {$min}, {$max}, '{$precision}', '{$gradeable->getId()}', '{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}'); openClose({$c}, {$num_questions});">Done</i> </span>
+                            <span id="save-mark-{$c}" style="cursor: pointer;  display: none;" data-changedisplay1="true"> <i class="fa fa-check" style="color: green;" aria-hidden="true" onclick="{$break_onclick}; closeMark({$c}, true);">Done</i> </span>
                         </div>
                         </span> <span id="ta_note-{$c}" style="display: none;" data-changedisplay1="true"> {$note}</span>
                         <span id="page-{$c}" style="display: none;">{$page}</span>
@@ -1470,7 +1470,7 @@ HTML;
                     </td>
                     <td id="title-cancel-{$c}" style="font-size: 12px; display: none; width: 5%;" colspan="0" data-changebg="true" data-changedisplay1="true">
                         <div>
-                            <span id="cancel-mark-{$c}" onclick="{$break_onclick} updateMarksOnPage({$c}, '', {$min}, {$max}, '{$precision}', '{$gradeable->getId()}', '{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}'); openClose(-1, {$num_questions});" style="cursor: pointer; float: right;"> <i class="fa fa-times" style="color: red;" aria-hidden="true">Cancel</i></span>
+                            <span id="cancel-mark-{$c}" onclick="{$break_onclick}; closeMark(${c}, false);" style="cursor: pointer; float: right;"> <i class="fa fa-times" style="color: red;" aria-hidden="true">Cancel</i></span>
                         </div>
                     </td>
                 </tr>
@@ -1503,7 +1503,7 @@ HTML;
             }
 
             $return .= <<<HTML
-                <tr id="summary-{$c}" style="{$graded_color}" onclick="switchOpenMark({$c});" data-changedisplay2="true" data-question_id="{$question->getId()}" data-min="{$min}" data-max="{$max}" data-precision="{$precision}">
+                <tr id="summary-{$c}" style="{$graded_color}" onclick="openMark({$c});" data-changedisplay2="true" data-question_id="{$question->getId()}" data-min="{$min}" data-max="{$max}" data-precision="{$precision}">
                     <td style="white-space:nowrap; vertical-align:middle; text-align:center; {$background}" colspan="1">
                         <strong><span id="grade-{$c}" name="grade-{$c}" class="grades" data-lower_clamp="{$question->getLowerClamp()}" data-default="{$question->getDefault()}" data-max_points="{$question->getMaxValue()}" data-upper_clamp="{$question->getUpperClamp()}"> {$question_points}</span> / {$question->getMaxValue()}</strong>
                     </td>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -945,20 +945,20 @@ HTML;
     }
     $return .= <<< HTML
 
-    <i title="Reset Rubric Panel Positions (Press R)" class="fa fa-refresh icon-header" onclick="handleKeyPress('KeyR');"></i>
-    <i title="Show/Hide Auto-Grading Testcases (Press A)" class="fa fa-list-alt icon-header" onclick="handleKeyPress('KeyA');"></i>
+    <i title="Reset Rubric Panel Positions (Press R)" class="fa fa-refresh icon-header" onclick="toggleAutograding(); updateCookies();"></i>
+    <i title="Show/Hide Auto-Grading Testcases (Press A)" class="fa fa-list-alt icon-header" onclick="toggleRubric(); updateCookies();"></i>
 HTML;
     if ($gradeable->useTAGrading()) {
             $return .= <<<HTML
-    <i title="Show/Hide Grading Rubric (Press G)" class="fa fa fa-pencil-square-o icon-header" onclick="handleKeyPress('KeyG');"></i>
+    <i title="Show/Hide Grading Rubric (Press G)" class="fa fa fa-pencil-square-o icon-header" onclick="toggleSubmissions(); updateCookies();"></i>
 HTML;
         }
         $return .= <<<HTML
-    <i title="Show/Hide Submission and Results Browser (Press O)" class="fa fa-folder-open icon-header" onclick="handleKeyPress('KeyO');"></i>
+    <i title="Show/Hide Submission and Results Browser (Press O)" class="fa fa-folder-open icon-header" onclick="toggleInfo(); updateCookies();"></i>
 HTML;
         if(!$peer) {
             $return .= <<<HTML
-    <i title="Show/Hide Student Information (Press S)" class="fa fa-user icon-header" onclick="handleKeyPress('KeyS');"></i>
+    <i title="Show/Hide Student Information (Press S)" class="fa fa-user icon-header" onclick="resetModules(); updateCookies();"></i>
 HTML;
         }
         $return .= <<<HTML

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -922,7 +922,7 @@ HTML;
     //If the student is in our section, add a clickable previous arrow, else add a grayed out one.
     if(!$studentNotInSection){
     $return .= <<< HTML
-        <a {$prev_href}><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>
+        <a {$prev_href} id="prev-student"><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>
 HTML;
     }
     else{
@@ -936,7 +936,7 @@ HTML;
     //If the student is in our section, add a clickable next arrow, else add a grayed out one.
     if(!$studentNotInSection){
     $return .= <<<HTML
-    <a {$next_href}><i title="Go to the next student" class="fa fa-chevron-right icon-header"></i></a>
+    <a {$next_href} id="next-student"><i title="Go to the next student" class="fa fa-chevron-right icon-header"></i></a>
 HTML;
     }
     else{

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -913,8 +913,8 @@ HTML;
         }
         $user = $gradeable->getUser();
         $your_user_id = $this->core->getUser()->getId();
-        $prev_href = "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$prev_id, 'individual'=>$individual))}\"";
-        $next_href = "href=\"{$this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$next_id, 'individual'=>$individual))}\"";
+        $prev_href = $this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$prev_id, 'individual'=>$individual));
+        $next_href = $this->core->buildUrl(array('component'=>'grading', 'page'=>'electronic', 'action'=>'grade', 'gradeable_id'=>$gradeable->getId(), 'who_id'=>$next_id, 'individual'=>$individual));
         $return = <<<HTML
 <div id="bar_wrapper" class="draggable">
 <div class="grading_toolbar">
@@ -922,7 +922,7 @@ HTML;
     //If the student is in our section, add a clickable previous arrow, else add a grayed out one.
     if(!$studentNotInSection){
     $return .= <<< HTML
-        <a {$prev_href} id="prev-student"><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>
+        <a href="javascript:void(0);" onclick="gotoPrevStudent();" data-href="{$prev_href}" id="prev-student"><i title="Go to the previous student" class="fa fa-chevron-left icon-header"></i></a>
 HTML;
     }
     else{
@@ -936,7 +936,7 @@ HTML;
     //If the student is in our section, add a clickable next arrow, else add a grayed out one.
     if(!$studentNotInSection){
     $return .= <<<HTML
-    <a {$next_href} id="next-student"><i title="Go to the next student" class="fa fa-chevron-right icon-header"></i></a>
+    <a href="javascript:void(0);" onclick="gotoNextStudent();" data-href="{$next_href}" id="next-student"><i title="Go to the next student" class="fa fa-chevron-right icon-header"></i></a>
 HTML;
     }
     else{

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -3,6 +3,7 @@
 namespace app\views\grading;
 
 use app\models\Gradeable;
+use app\models\GradeableComponent;
 use app\models\User;
 use app\models\LateDaysCalculation;
 use app\views\AbstractView;
@@ -905,7 +906,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage($gradeable, $progress, $prev_id, $next_id, $individual, $studentNotInSection=false, $canViewWholeGradeable=false) {
+    public function hwGradingPage(Gradeable $gradeable, float $progress, string $prev_id, string $next_id, string $individual, $studentNotInSection=false, $canViewWholeGradeable=false) {
         $peer = false;
         if($this->core->getUser()->getGroup()==4 && $gradeable->getPeerGrading()) {
             $peer = true;
@@ -1341,7 +1342,7 @@ HTML;
 
         $return .= <<<HTML
     <div style="margin:3px;">
-        <table class="ta-rubric-table ta-rubric-table-background" id="rubric-table" data-num_questions="{$num_questions}">
+        <table class="ta-rubric-table ta-rubric-table-background" id="rubric-table" data-gradeable_id="{$gradeable->getId()}" data-user_id="{$user->getAnonId()}" data-active_version="{$gradeable->getActiveVersion()}" data-num_questions="{$num_questions}" data-your_user_id="{$this->core->getUser()->getId()}">
             <tbody>
 HTML;
 
@@ -1353,6 +1354,7 @@ HTML;
         foreach ($gradeable->getComponents() as $component) {
             if($peer && !is_array($component)) continue;
             $question = null;
+            /* @var GradeableComponent $question */
             $show_graded_info = true;
             $num_peer_components = 0;
             if(is_array($component)) {
@@ -1501,7 +1503,7 @@ HTML;
             }
 
             $return .= <<<HTML
-                <tr id="summary-{$c}" style="{$graded_color}" onclick="saveLastOpenedMark('{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}', {$question->getId()}); saveMark({$c},'{$gradeable->getId()}' ,'{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}'); updateMarksOnPage({$c}, '', {$min}, {$max}, '{$precision}', '{$gradeable->getId()}', '{$user->getAnonId()}', {$gradeable->getActiveVersion()}, {$question->getId()}, '{$your_user_id}'); openClose({$c}, {$num_questions});" data-changedisplay2="true">
+                <tr id="summary-{$c}" style="{$graded_color}" onclick="switchOpenMark({$c});" data-changedisplay2="true" data-question_id="{$question->getId()}" data-min="{$min}" data-max="{$max}" data-precision="{$precision}">
                     <td style="white-space:nowrap; vertical-align:middle; text-align:center; {$background}" colspan="1">
                         <strong><span id="grade-{$c}" name="grade-{$c}" class="grades" data-lower_clamp="{$question->getLowerClamp()}" data-default="{$question->getDefault()}" data-max_points="{$question->getMaxValue()}" data-upper_clamp="{$question->getUpperClamp()}"> {$question_points}</span> / {$question->getMaxValue()}</strong>
                     </td>

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -803,6 +803,7 @@ function verifyMark(gradeable_id, component_id, user_id,verifyAll = false){
     })
 }
 
+//Open the given mark (if it's not open already), saving changes on any previous mark
 function openMark(id) {
     var rubric = $('#rubric-table')[0].dataset;
     var question = $('#summary-' + id)[0].dataset;
@@ -810,10 +811,20 @@ function openMark(id) {
     saveLastOpenedMark(rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id, question.question_id);
     saveMark(id, rubric.gradeable_id ,rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
     updateMarksOnPage(id, '', question.min, question.max, question.precision, rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
-    openClose(id, rubric.num_questions);
+
+    //If it's already open, then openClose() will close it
+    if (findCurrentOpenedMark() !== id) {
+        openClose(id, rubric.num_questions);
+    }
 }
 
+//Close the given mark (if it's open), optionally saving changes
 function closeMark(id, save) {
+    //Can't close a closed mark
+    if (findCurrentOpenedMark() !== id) {
+        return;
+    }
+
     var rubric = $('#rubric-table')[0].dataset;
     var question = $('#summary-' + id)[0].dataset;
 
@@ -825,16 +836,26 @@ function closeMark(id, save) {
     setMarkVisible(id, false);
 }
 
+//Open the general message input (if it's not open already), saving changes on any previous mark
 function openGeneralMessage() {
     var rubric = $('#rubric-table')[0].dataset;
 
     saveLastOpenedMark(rubric.gradeable_id ,rubric.user_id, rubric.active_version, '', rubric.your_user_id, '');
     saveGeneralComment(rubric.gradeable_id ,rubric.user_id, rubric.active_version);
-    updateMarksOnPage(-2, '', '', '', '', rubric.gradeable_id, rubric.user_id, rubric.active_version, '', rubric.your_user_id);
-    openClose(-2, rubric.num_questions);
+
+    //If it's already open, then openClose() will close it
+    if (findCurrentOpenedMark() !== -2) {
+        openClose(-2, rubric.num_questions);
+    }
 }
 
+//Close the general message input (if it's open), optionally saving changes
 function closeGeneralMessage(save) {
+    //Cannot save it if it is not being edited
+    if (findCurrentOpenedMark() !== -2) {
+        return;
+    }
+
     var rubric = $('#rubric-table')[0].dataset;
 
     if (save) {

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -481,19 +481,8 @@ function openClose(row_id, num_questions = -1) {
 
     //-2 means general comment, else open the row_id with the number
     var general_comment = $('#extra-general');
-    var general_comment_title = $('#title-general');
-    var general_comment_title_cancel = $('#title-cancel-general');
-    var gshow = (row_num === -2 && general_comment[0].style.display === 'none');
+    setGeneralVisible(row_num === -2 && general_comment[0].style.display === 'none');
 
-    // Updated all the background colors and displays of each element that has
-    //  the corresponding data tag for the general component
-    $("[id$='-general'][data-changebg='true']")      .css("background-color", (gshow ? "#e6e6e6" : "initial"));
-    $("[id$='-general'][data-changedisplay1='true']").css("display",          (gshow ? "" : "none"));
-    $("[id$='-general'][data-changedisplay2='true']").css("display",          (gshow ? "none" : ""));
-    
-    general_comment_title.attr('colspan', (gshow ? 3 : 4));
-    general_comment_title_cancel.attr('colspan', (gshow ? 1 : 0));
-    
     for (var x = 1; x <= total_num; x++) {
         var current_summary = $('#summary-' + x);
         setMarkVisible(x, x === row_num && current_summary[0].style.display === '');
@@ -502,6 +491,7 @@ function openClose(row_id, num_questions = -1) {
     updateCookies();
 }
 
+//Set if the mark at index X should be visible
 function setMarkVisible(x, show) {
     var page = ($('#page-' + x)[0]).innerHTML;
 
@@ -584,6 +574,23 @@ function setMarkVisible(x, show) {
 
     title.attr('colspan', (show ? 3 : 4));
     cancel_button.attr('colspan', (show ? 1 : 0));
+}
+
+//Set if the general comment box should be visible
+function setGeneralVisible(gshow) {
+    var general_comment = $('#extra-general');
+    var general_comment_title = $('#title-general');
+    var general_comment_title_cancel = $('#title-cancel-general');
+
+    // Updated all the background colors and displays of each element that has
+    //  the corresponding data tag for the general component
+    $("[id$='-general'][data-changebg='true']")      .css("background-color", (gshow ? "#e6e6e6" : "initial"));
+    $("[id$='-general'][data-changedisplay1='true']").css("display",          (gshow ? "" : "none"));
+    $("[id$='-general'][data-changedisplay2='true']").css("display",          (gshow ? "none" : ""));
+
+    general_comment_title.attr('colspan', (gshow ? 3 : 4));
+    general_comment_title_cancel.attr('colspan', (gshow ? 1 : 0));
+
 }
 
 // Saves the general comment
@@ -816,4 +823,25 @@ function closeMark(id, save) {
     }
     updateMarksOnPage(id, '', question.min, question.max, question.precision, rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
     setMarkVisible(id, false);
+}
+
+function openGeneralMessage() {
+    var rubric = $('#rubric-table')[0].dataset;
+
+    saveLastOpenedMark(rubric.gradeable_id ,rubric.user_id, rubric.active_version, '', rubric.your_user_id, '');
+    saveGeneralComment(rubric.gradeable_id ,rubric.user_id, rubric.active_version);
+    updateMarksOnPage(-2, '', '', '', '', rubric.gradeable_id, rubric.user_id, rubric.active_version, '', rubric.your_user_id);
+    openClose(-2, rubric.num_questions);
+}
+
+function closeGeneralMessage(save) {
+    var rubric = $('#rubric-table')[0].dataset;
+
+    if (save) {
+        saveLastOpenedMark(rubric.gradeable_id ,rubric.user_id, rubric.active_version, '', rubric.your_user_id, '');
+        saveGeneralComment(rubric.gradeable_id ,rubric.user_id, rubric.active_version);
+    } else {
+        updateGeneralComment(rubric.gradeable_id, rubric.user_id);
+    }
+    setGeneralVisible(false);
 }

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -792,3 +792,13 @@ function verifyMark(gradeable_id, component_id, user_id,verifyAll = false){
         }
     })
 }
+
+function switchOpenMark(id) {
+    var rubric = $('#rubric-table')[0].dataset;
+    var question = $('#summary-' + id)[0].dataset;
+
+    saveLastOpenedMark(rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id, question.question_id);
+    saveMark(id, rubric.gradeable_id ,rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
+    updateMarksOnPage(id, '', question.min, question.max, question.precision, rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
+    openClose(id, rubric.num_questions);
+}

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -39,7 +39,7 @@ function getMarkView(num, x, is_publish, checked, note, pointValue, precision, m
     return ' \
 <tr id="mark_id-'+num+'-'+x+'" name="mark_'+num+'" class="'+(is_publish ? 'is_publish' : '')+'"'+(is_new ? 'data-newmark="true"' : '')+'> \
     <td colspan="1" style="'+background+'; text-align: center;"> \
-        <span onclick="selectMark(this);"> \
+        <span id="mark_id-'+num+'-'+x+'-check" onclick="selectMark(this);"> \
             <i class="fa fa-square'+(checked ? '' : '-o')+' mark fa-lg" name="mark_icon_'+num+'_'+x+'" style="visibility: visible; cursor: pointer; position: relative; top: 2px;"></i> \
         </span> \
         <input name="mark_points_'+num+'_'+x+'" type="number" onchange="fixMarkPointValue(this);" step="'+precision+'" value="'+pointValue+'" min="'+min+'" max="'+max+'" style="width: 50%; resize:none; min-width: 50px;"> \

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -495,92 +495,95 @@ function openClose(row_id, num_questions = -1) {
     general_comment_title_cancel.attr('colspan', (gshow ? 1 : 0));
     
     for (var x = 1; x <= total_num; x++) {
-        var page = ($('#page-' + x)[0]).innerHTML;
-        
-        var title           = $('#title-' + x);
-        var cancel_button   = $('#title-cancel-' + x);
         var current_summary = $('#summary-' + x);
-
-        // Update the color if it is penalty or extra credit
-        var current_question_num = $('#grade-' + x);
-        var question_points = parseFloat(current_question_num[0].innerHTML);
-        if (question_points > parseFloat(current_question_num[0].dataset.max_points)) {
-            current_summary.children("td:first-of-type")[0].style.backgroundColor = "#D8F2D8";
-        } else if (question_points < 0) {
-            current_summary.children("td:first-of-type")[0].style.backgroundColor = "#FAD5D3";
-        } else {
-            current_summary.children("td:first-of-type")[0].style.backgroundColor = "initial";
-        }
-
-        var show = false;
-        if (x == row_num && current_summary[0].style.display === '') {
-            show = true;
-            updateProgressPoints(x);
-
-            // if the component has a page saved, open the PDF to that page
-            // opening directories/frames based off of code in openDiv and openFrame functions
-
-            // make sure submissions folder has files
-            var submissions = $('#div_viewer_1');
-            if (page > 0 && submissions.children().length > 0) {
-
-                    // find the first file that is a PDF
-                    var divs = $('#div_viewer_1 > div > div');
-                    var pdf_div = "";
-                    for (var i=0; i<divs.length; i++) {
-                        if ($(divs[i]).is('[data-file_url]')) {
-                            file_url = $(divs[i]).attr("data-file_url");
-                            if(file_url.substring(file_url.length - 3) == "pdf") {
-                                pdf_div = $($(divs[i]));
-                                break;
-                            }
-                        }
-                    }
-                    
-                    // only open submissions folder + PDF is a PDF file exists within the submissions folder
-                    if (pdf_div != "") {
-                        submissions.show();
-                        submissions.addClass('open');
-                        $($($(submissions.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-folder').addClass('fa-folder-open');
-
-                        var file_url = pdf_div.attr("data-file_url");
-                        var file_name = pdf_div.attr("data-file_name");
-                        if (!pdf_div.hasClass('open')) {
-                            openFrame(file_name,file_url,pdf_div.attr("id").substring(pdf_div.attr("id").lastIndexOf("_")+1));
-                        }
-                        var iframeId = pdf_div.attr("id") + "_iframe";
-                        directory = "submissions"; 
-                        src = $("#"+iframeId).prop('src');
-                        if (src.indexOf("#page=") === -1) {
-                            src = src + "#page=" + page;
-                        }
-                        else {
-                            src = src.slice(0,src.indexOf("#page=")) + "#page=" + page;
-                        }
-                        pdf_div.html("<iframe id='" + iframeId + "' src='" + src + "' width='95%' height='1200px' style='border: 0'></iframe>");
-
-                        if (!pdf_div.hasClass('open')) {
-                            pdf_div.addClass('open');
-                        }
-                        if (!pdf_div.hasClass('shown')) {
-                            pdf_div.show();
-                            pdf_div.addClass('shown');
-                        }
-                    }
-                }
-        }
-
-        // Updated all the background colors and displays of each element that has
-        //  the corresponding data tag
-        $("[id$='-"+x+"'][data-changebg='true']")      .css("background-color", (show ? "#e6e6e6" : "initial"));
-        $("[id$='-"+x+"'][data-changedisplay1='true']").css("display",          (show ? "" : "none"));
-        $("[id$='-"+x+"'][data-changedisplay2='true']").css("display",          (show ? "none" : ""));
-        
-        title.attr('colspan', (show ? 3 : 4));
-        cancel_button.attr('colspan', (show ? 1 : 0));
+        setMarkVisible(x, x === row_num && current_summary[0].style.display === '');
     }
 
     updateCookies();
+}
+
+function setMarkVisible(x, show) {
+    var page = ($('#page-' + x)[0]).innerHTML;
+
+    var title           = $('#title-' + x);
+    var cancel_button   = $('#title-cancel-' + x);
+    var current_summary = $('#summary-' + x);
+
+    // Update the color if it is penalty or extra credit
+    var current_question_num = $('#grade-' + x);
+    var question_points = parseFloat(current_question_num[0].innerHTML);
+    if (question_points > parseFloat(current_question_num[0].dataset.max_points)) {
+        current_summary.children("td:first-of-type")[0].style.backgroundColor = "#D8F2D8";
+    } else if (question_points < 0) {
+        current_summary.children("td:first-of-type")[0].style.backgroundColor = "#FAD5D3";
+    } else {
+        current_summary.children("td:first-of-type")[0].style.backgroundColor = "initial";
+    }
+
+    if (show) {
+        updateProgressPoints(x);
+
+        // if the component has a page saved, open the PDF to that page
+        // opening directories/frames based off of code in openDiv and openFrame functions
+
+        // make sure submissions folder has files
+        var submissions = $('#div_viewer_1');
+        if (page > 0 && submissions.children().length > 0) {
+
+            // find the first file that is a PDF
+            var divs = $('#div_viewer_1 > div > div');
+            var pdf_div = "";
+            for (var i=0; i<divs.length; i++) {
+                if ($(divs[i]).is('[data-file_url]')) {
+                    file_url = $(divs[i]).attr("data-file_url");
+                    if(file_url.substring(file_url.length - 3) == "pdf") {
+                        pdf_div = $($(divs[i]));
+                        break;
+                    }
+                }
+            }
+
+            // only open submissions folder + PDF is a PDF file exists within the submissions folder
+            if (pdf_div != "") {
+                submissions.show();
+                submissions.addClass('open');
+                $($($(submissions.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-folder').addClass('fa-folder-open');
+
+                var file_url = pdf_div.attr("data-file_url");
+                var file_name = pdf_div.attr("data-file_name");
+                if (!pdf_div.hasClass('open')) {
+                    openFrame(file_name,file_url,pdf_div.attr("id").substring(pdf_div.attr("id").lastIndexOf("_")+1));
+                }
+                var iframeId = pdf_div.attr("id") + "_iframe";
+                var directory = "submissions";
+                var src = $("#"+iframeId).prop('src');
+                if (src.indexOf("#page=") === -1) {
+                    src = src + "#page=" + page;
+                }
+                else {
+                    src = src.slice(0,src.indexOf("#page=")) + "#page=" + page;
+                }
+                pdf_div.html("<iframe id='" + iframeId + "' src='" + src + "' width='95%' height='1200px' style='border: 0'></iframe>");
+
+                if (!pdf_div.hasClass('open')) {
+                    pdf_div.addClass('open');
+                }
+                if (!pdf_div.hasClass('shown')) {
+                    pdf_div.show();
+                    pdf_div.addClass('shown');
+                }
+            }
+        }
+    }
+
+    // Updated all the background colors and displays of each element that has
+    //  the corresponding data tag
+    $("[id$='-"+x+"'][data-changebg='true']")      .css("background-color", (show ? "#e6e6e6" : "initial"));
+    $("[id$='-"+x+"'][data-changedisplay1='true']").css("display",          (show ? "" : "none"));
+    $("[id$='-"+x+"'][data-changedisplay2='true']").css("display",          (show ? "none" : ""));
+
+    title.attr('colspan', (show ? 3 : 4));
+    cancel_button.attr('colspan', (show ? 1 : 0));
 }
 
 // Saves the general comment
@@ -793,7 +796,7 @@ function verifyMark(gradeable_id, component_id, user_id,verifyAll = false){
     })
 }
 
-function switchOpenMark(id) {
+function openMark(id) {
     var rubric = $('#rubric-table')[0].dataset;
     var question = $('#summary-' + id)[0].dataset;
 
@@ -801,4 +804,16 @@ function switchOpenMark(id) {
     saveMark(id, rubric.gradeable_id ,rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
     updateMarksOnPage(id, '', question.min, question.max, question.precision, rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
     openClose(id, rubric.num_questions);
+}
+
+function closeMark(id, save) {
+    var rubric = $('#rubric-table')[0].dataset;
+    var question = $('#summary-' + id)[0].dataset;
+
+    if (save) {
+        saveLastOpenedMark(rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id, question.question_id);
+        saveMark(id, rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id, -1);
+    }
+    updateMarksOnPage(id, '', question.min, question.max, question.precision, rubric.gradeable_id, rubric.user_id, rubric.active_version, question.question_id, rubric.your_user_id);
+    setMarkVisible(id, false);
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -317,6 +317,30 @@ function unregisterKeyHandler(code, fn) {
     }
 }
 
+registerKeyHandler("KeyA", function() {
+	toggleAutograding();
+	updateCookies();
+});
+registerKeyHandler("KeyG", function() {
+	toggleRubric();
+	updateCookies();
+});
+registerKeyHandler("KeyO", function() {
+	toggleSubmissions();
+	updateCookies();
+});
+registerKeyHandler("KeyS", function() {
+	toggleInfo();
+	updateCookies();
+});
+registerKeyHandler("KeyR", function() {
+	resetModules();
+	updateCookies();
+});
+
+//-----------------------------------------------------------------------------
+// Panel show/hide
+
 function isAutogradingVisible() {
     return $("#autograding_results").is(":visible");
 }
@@ -390,27 +414,6 @@ function resetModules() {
 	deleteCookies();
 	updateCookies();
 }
-
-registerKeyHandler("KeyA", function() {
-	toggleAutograding();
-	updateCookies();
-});
-registerKeyHandler("KeyG", function() {
-	toggleRubric();
-	updateCookies();
-});
-registerKeyHandler("KeyO", function() {
-	toggleSubmissions();
-	updateCookies();
-});
-registerKeyHandler("KeyS", function() {
-	toggleInfo();
-	updateCookies();
-});
-registerKeyHandler("KeyR", function() {
-	resetModules();
-	updateCookies();
-});
 
 // expand all files in Submissions and Results section
 function openAll(click_class, class_modifier) {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -415,6 +415,45 @@ function resetModules() {
 	updateCookies();
 }
 
+//-----------------------------------------------------------------------------
+// Show/hide questions
+
+registerKeyHandler('Digit1', function() {
+    selectCurrentMarkCheck(0);
+});
+registerKeyHandler('Digit2', function() {
+    selectCurrentMarkCheck(1);
+});
+registerKeyHandler('Digit3', function() {
+    selectCurrentMarkCheck(2);
+});
+registerKeyHandler('Digit4', function() {
+    selectCurrentMarkCheck(3);
+});
+registerKeyHandler('Digit5', function() {
+    selectCurrentMarkCheck(4);
+});
+registerKeyHandler('Digit6', function() {
+    selectCurrentMarkCheck(5);
+});
+registerKeyHandler('Digit7', function() {
+    selectCurrentMarkCheck(6);
+});
+registerKeyHandler('Digit8', function() {
+    selectCurrentMarkCheck(7);
+});
+registerKeyHandler('Digit9', function() {
+    selectCurrentMarkCheck(8);
+});
+
+function selectCurrentMarkCheck(index) {
+	var opened = findCurrentOpenedMark();
+	if (opened !== -1) {
+		selectMark($("#mark_id-" + opened + "-" + index + "-check"));
+	}
+}
+
+
 // expand all files in Submissions and Results section
 function openAll(click_class, class_modifier) {
     $("."+click_class + class_modifier).each(function(){

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -416,7 +416,34 @@ function resetModules() {
 }
 
 //-----------------------------------------------------------------------------
-// Show/hide questions
+// Show/hide components
+
+registerKeyHandler('ArrowDown', function() {
+    var current = findCurrentOpenedMark();
+    var numQuestions = parseInt($('#rubric-table')[0].dataset.num_questions);
+    if (current === -1) {
+        switchOpenMark(1);
+    } else if (current === numQuestions) {
+        switchOpenMark(current);
+    } else {
+        switchOpenMark(current + 1);
+    }
+});
+
+registerKeyHandler('ArrowUp', function() {
+    var current = findCurrentOpenedMark();
+    var numQuestions = parseInt($('#rubric-table')[0].dataset.num_questions);
+    if (current === -1) {
+        switchOpenMark(numQuestions);
+    } else if (current === 1) {
+        switchOpenMark(current);
+    } else {
+        switchOpenMark(current - 1);
+    }
+});
+
+//-----------------------------------------------------------------------------
+// Selecting marks
 
 registerKeyHandler('Digit1', function() {
     selectCurrentMarkCheck(0);

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -431,11 +431,11 @@ registerKeyHandler('ArrowDown', function() {
     var current = findCurrentOpenedMark();
     var numQuestions = parseInt($('#rubric-table')[0].dataset.num_questions);
     if (current === -1) {
-        switchOpenMark(1);
+        openMark(1);
     } else if (current === numQuestions) {
-        switchOpenMark(current);
+        openMark(current);
     } else {
-        switchOpenMark(current + 1);
+        openMark(current + 1);
     }
 });
 
@@ -443,11 +443,11 @@ registerKeyHandler('ArrowUp', function() {
     var current = findCurrentOpenedMark();
     var numQuestions = parseInt($('#rubric-table')[0].dataset.num_questions);
     if (current === -1) {
-        switchOpenMark(numQuestions);
+        openMark(numQuestions);
     } else if (current === 1) {
-        switchOpenMark(current);
+        openMark(current);
     } else {
-        switchOpenMark(current - 1);
+        openMark(current - 1);
     }
 });
 

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -321,11 +321,25 @@ function unregisterKeyHandler(code, fn) {
 // Student navigation
 
 function gotoPrevStudent() {
-    window.location = $("#prev-student")[0].dataset.href;
+    var rubric = $('#rubric-table')[0].dataset;
+    saveLastOpenedMark(rubric.gradeable_id, rubric.user_id, rubric.active_version, rubric.your_user_id, false, function() {
+        window.location = $("#prev-student")[0].dataset.href;
+    }, function() {
+        if (confirm("Could not save last mark, change student anyway?")) {
+            window.location = $("#prev-student")[0].dataset.href;
+        }
+    });
 }
 
 function gotoNextStudent() {
-    window.location = $("#next-student")[0].dataset.href;
+    var rubric = $('#rubric-table')[0].dataset;
+    saveLastOpenedMark(rubric.gradeable_id, rubric.user_id, rubric.active_version, rubric.your_user_id, false, function() {
+        window.location = $("#next-student")[0].dataset.href;
+    }, function() {
+        if (confirm("Could not save last mark, change student anyway?")) {
+            window.location = $("#next-student")[0].dataset.href;
+        }
+    });
 }
 
 //Navigate to the prev / next student buttons

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -317,6 +317,7 @@ function unregisterKeyHandler(code, fn) {
     }
 }
 
+//Panel toggles
 registerKeyHandler("KeyA", function() {
     toggleAutograding();
     updateCookies();
@@ -336,6 +337,14 @@ registerKeyHandler("KeyS", function() {
 registerKeyHandler("KeyR", function() {
     resetModules();
     updateCookies();
+});
+
+//Navigate to the prev / next student buttons
+registerKeyHandler("ArrowLeft", function() {
+    window.location = $("#prev-student").attr("href");
+});
+registerKeyHandler("ArrowRight", function() {
+    window.location = $("#next-student").attr("href");
 });
 
 //-----------------------------------------------------------------------------

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -317,28 +317,6 @@ function unregisterKeyHandler(code, fn) {
     }
 }
 
-//Panel toggles
-registerKeyHandler("KeyA", function() {
-    toggleAutograding();
-    updateCookies();
-});
-registerKeyHandler("KeyG", function() {
-    toggleRubric();
-    updateCookies();
-});
-registerKeyHandler("KeyO", function() {
-    toggleSubmissions();
-    updateCookies();
-});
-registerKeyHandler("KeyS", function() {
-    toggleInfo();
-    updateCookies();
-});
-registerKeyHandler("KeyR", function() {
-    resetModules();
-    updateCookies();
-});
-
 //Navigate to the prev / next student buttons
 registerKeyHandler("ArrowLeft", function() {
     window.location = $("#prev-student").attr("href");
@@ -423,6 +401,28 @@ function resetModules() {
     deleteCookies();
     updateCookies();
 }
+
+
+registerKeyHandler("KeyA", function() {
+    toggleAutograding();
+    updateCookies();
+});
+registerKeyHandler("KeyG", function() {
+    toggleRubric();
+    updateCookies();
+});
+registerKeyHandler("KeyO", function() {
+    toggleSubmissions();
+    updateCookies();
+});
+registerKeyHandler("KeyS", function() {
+    toggleInfo();
+    updateCookies();
+});
+registerKeyHandler("KeyR", function() {
+    resetModules();
+    updateCookies();
+});
 
 //-----------------------------------------------------------------------------
 // Show/hide components

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -484,7 +484,7 @@ registerKeyHandler('Digit9', function() {
 
 function selectCurrentMarkCheck(index) {
     var opened = findCurrentOpenedMark();
-    if (opened !== -1) {
+    if (opened > 0) {
         selectMark($("#mark_id-" + opened + "-" + index + "-check"));
     }
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -317,12 +317,23 @@ function unregisterKeyHandler(code, fn) {
     }
 }
 
+//-----------------------------------------------------------------------------
+// Student navigation
+
+function gotoPrevStudent() {
+    window.location = $("#prev-student")[0].dataset.href;
+}
+
+function gotoNextStudent() {
+    window.location = $("#next-student")[0].dataset.href;
+}
+
 //Navigate to the prev / next student buttons
 registerKeyHandler("ArrowLeft", function() {
-    window.location = $("#prev-student").attr("href");
+    gotoPrevStudent();
 });
 registerKeyHandler("ArrowRight", function() {
-    window.location = $("#next-student").attr("href");
+    gotoNextStudent();
 });
 
 //-----------------------------------------------------------------------------

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -307,35 +307,35 @@ function registerKeyHandler(code, fn) {
 }
 
 function unregisterKeyHandler(code, fn) {
-	if (keymap.hasOwnProperty(code)) {
-		if (keymap[code].fns.indexOf(fn) !== -1) {
-		    //Delete the function from the list
-		    keymap[code].fns.splice(keymap[code].fns.indexOf(fn), 1);
-		}
-	} else {
-	    //Don't care if this key doesn't exist
+    if (keymap.hasOwnProperty(code)) {
+        if (keymap[code].fns.indexOf(fn) !== -1) {
+            //Delete the function from the list
+            keymap[code].fns.splice(keymap[code].fns.indexOf(fn), 1);
+        }
+    } else {
+        //Don't care if this key doesn't exist
     }
 }
 
 registerKeyHandler("KeyA", function() {
-	toggleAutograding();
-	updateCookies();
+    toggleAutograding();
+    updateCookies();
 });
 registerKeyHandler("KeyG", function() {
-	toggleRubric();
-	updateCookies();
+    toggleRubric();
+    updateCookies();
 });
 registerKeyHandler("KeyO", function() {
-	toggleSubmissions();
-	updateCookies();
+    toggleSubmissions();
+    updateCookies();
 });
 registerKeyHandler("KeyS", function() {
-	toggleInfo();
-	updateCookies();
+    toggleInfo();
+    updateCookies();
 });
 registerKeyHandler("KeyR", function() {
-	resetModules();
-	updateCookies();
+    resetModules();
+    updateCookies();
 });
 
 //-----------------------------------------------------------------------------
@@ -359,27 +359,27 @@ function isInfoVisible() {
 
 
 function setAutogradingVisible(visible) {
-	$('.fa-list-alt').toggleClass('icon-selected', visible);
-	$("#autograding_results").toggle(visible);
-	hideIfEmpty("#autograding_results");
+    $('.fa-list-alt').toggleClass('icon-selected', visible);
+    $("#autograding_results").toggle(visible);
+    hideIfEmpty("#autograding_results");
 }
 
 function setRubricVisible(visible) {
-	$('.fa-pencil-square-o').toggleClass('icon-selected', visible);
-	$("#grading_rubric").toggle(visible);
-	hideIfEmpty("#grading_rubric");
+    $('.fa-pencil-square-o').toggleClass('icon-selected', visible);
+    $("#grading_rubric").toggle(visible);
+    hideIfEmpty("#grading_rubric");
 }
 
 function setSubmissionsVisible(visible) {
-	$('.fa-folder-open.icon-header').toggleClass('icon-selected', visible);
-	$("#submission_browser").toggle(visible);
-	hideIfEmpty("#submission_browser");
+    $('.fa-folder-open.icon-header').toggleClass('icon-selected', visible);
+    $("#submission_browser").toggle(visible);
+    hideIfEmpty("#submission_browser");
 }
 
 function setInfoVisible(visible) {
-	$('.fa-user').toggleClass('icon-selected', visible);
-	$("#student_info").toggle(visible);
-	hideIfEmpty("#student_info");
+    $('.fa-user').toggleClass('icon-selected', visible);
+    $("#student_info").toggle(visible);
+    hideIfEmpty("#student_info");
 }
 
 
@@ -401,18 +401,18 @@ function toggleInfo() {
 
 
 function resetModules() {
-	$('.fa-list-alt').addClass('icon-selected');
-	$("#autograding_results").attr("style", "z-index:30; left:15px; top:175px; width:48%; height:37%; display:block;");
-	$('.fa-pencil-square-o').addClass('icon-selected');
-	$("#grading_rubric").attr("style", "right:15px; z-index:30; top:175px; width:48%; height:37%; display:block;");
-	$('.fa-folder-open').addClass('icon-selected');
-	$("#submission_browser").attr("style", "left:15px; z-index:30; bottom:40px; width:48%; height:30%; display:block;");
-	$('.fa-user').addClass('icon-selected');
-	$('#bar_wrapper').attr("style", "top: -90px;left: 45%; z-index:40;");
-	$("#student_info").attr("style", "right:15px; bottom:40px; z-index:30; width:48%; height:30%; display:block;");
-	hideIfEmpty(".rubric_panel");
-	deleteCookies();
-	updateCookies();
+    $('.fa-list-alt').addClass('icon-selected');
+    $("#autograding_results").attr("style", "z-index:30; left:15px; top:175px; width:48%; height:37%; display:block;");
+    $('.fa-pencil-square-o').addClass('icon-selected');
+    $("#grading_rubric").attr("style", "right:15px; z-index:30; top:175px; width:48%; height:37%; display:block;");
+    $('.fa-folder-open').addClass('icon-selected');
+    $("#submission_browser").attr("style", "left:15px; z-index:30; bottom:40px; width:48%; height:30%; display:block;");
+    $('.fa-user').addClass('icon-selected');
+    $('#bar_wrapper').attr("style", "top: -90px;left: 45%; z-index:40;");
+    $("#student_info").attr("style", "right:15px; bottom:40px; z-index:30; width:48%; height:30%; display:block;");
+    hideIfEmpty(".rubric_panel");
+    deleteCookies();
+    updateCookies();
 }
 
 //-----------------------------------------------------------------------------
@@ -447,10 +447,10 @@ registerKeyHandler('Digit9', function() {
 });
 
 function selectCurrentMarkCheck(index) {
-	var opened = findCurrentOpenedMark();
-	if (opened !== -1) {
-		selectMark($("#mark_id-" + opened + "-" + index + "-check"));
-	}
+    var opened = findCurrentOpenedMark();
+    if (opened !== -1) {
+        selectMark($("#mark_id-" + opened + "-" + index + "-check"));
+    }
 }
 
 
@@ -550,10 +550,10 @@ function downloadZip(grade_id, user_id) {
 function downloadFile(html_file, url_file) {
     var directory = "";
     if (url_file.includes("submissions")) {
-      directory = "submissions";
+        directory = "submissions";
     }
     else if (url_file.includes("results")) {
-      directory = "results";
+        directory = "results";
     }
     window.location = buildUrl({'component': 'misc', 'page': 'download_file', 'dir': directory, 'file': html_file, 'path': url_file});
     return false;


### PR DESCRIPTION
Will close #1492. Included as well is some cleanup to the TA grader JS: there were some long `onclick` functions that are now broken up into functions that can be used from other places.

Here is a list of shortcuts so far,
* A: autograding module
* G: grading rubric module
* O: file browser module
* S: student info module
* R: reset module positions
* Left Arrow: prev student
* Right Arrow: next student
* Up Arrow: prev component
* Down Arrow: next component
* 1 - 9: select/deselect rubric mark (of currently open component)