### PR TITLE
Improved variable scopes to fix assignment submission

### DIFF
--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -432,9 +432,9 @@ function validateUserId(csrf_token, gradeable_id, user_id, is_pdf, path, count, 
 * @param count
 */
 function submitSplitItem(csrf_token, gradeable_id, user_id, path, count, merge_previous=false) {
-    merge = (merge_previous ? "true" : "false");
-    url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload_split', 'gradeable_id': gradeable_id, "merge" : merge_previous});
-    return_url = buildUrl({'component': 'student','gradeable_id': gradeable_id});
+    var merge = (merge_previous ? "true" : "false");
+    var url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload_split', 'gradeable_id': gradeable_id, "merge" : merge_previous});
+    var return_url = buildUrl({'component': 'student','gradeable_id': gradeable_id});
 
     var formData = new FormData();
 
@@ -496,7 +496,7 @@ function submitSplitItem(csrf_token, gradeable_id, user_id, path, count, merge_p
 */
 function deleteSplitItem(csrf_token, gradeable_id, path, count) {
 
-    submit_url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'delete_split', 'gradeable_id': gradeable_id});
+    var submit_url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'delete_split', 'gradeable_id': gradeable_id});
 
     var formData = new FormData();
 
@@ -637,8 +637,8 @@ function handleBulk(gradeable_id, num_pages) {
 function handleSubmission(days_late, late_days_allowed, versions_used, versions_allowed, csrf_token, vcs_checkout, num_textboxes, gradeable_id, user_id, repo_id, student_page, num_components) {
     $("#submit").prop("disabled", true);
 
-    submit_url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload', 'gradeable_id': gradeable_id});
-    return_url = buildUrl({'component': 'student','gradeable_id': gradeable_id});
+    var submit_url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload', 'gradeable_id': gradeable_id});
+    var return_url = buildUrl({'component': 'student','gradeable_id': gradeable_id});
 
     var message = "";
     // check versions used

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -17,14 +17,13 @@ window.addEventListener("load", function() {
  * @returns {string} - Built up URL to use
  */
 function buildUrl(parts) {
-    url = document.body.dataset.siteUrl;
     var constructed = "";
     for (var part in parts) {
         if (parts.hasOwnProperty(part)) {
             constructed += "&" + part + "=" + parts[part];
         }
     }
-    return url + constructed;
+    return document.body.dataset.siteUrl + constructed;
 }
 
 function loadTestcaseOutput(div_name, gradeable_id, who_id, count){


### PR DESCRIPTION
Closes #1993 

An error in variable scopes was causing submissions to fail (submitting to the wrong url) with an obscure error.  Now, the `buildUrl` method is fixed to not leak any data into the global variables.

In addition to the contents of #1993 there were a few other places where variable scope was global instead of local, so now the variables that really should be local are now.