### PR TITLE
improve permissions for build_course & add '--clean' option

### DIFF
--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -10,6 +10,8 @@ function clean_homework {
     assignment=$3
     course_dir=$SUBMITTY_DATA_DIR/courses/$semester/$course
 
+    echo "clean old build: $course_dir $3"
+
     # cleanup all files associated with this assignment
     rm -rf $course_dir/test_input/${3}
     rm -rf $course_dir/test_output/${3}

--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -2,6 +2,25 @@
 # HELPER FUNCTION FOR INSTALLING INDIVIDUAL HOMEWORKS
 ##########################################################################
 
+function clean_homework {
+
+    # which assignment to cleanup
+    semester=$1
+    course=$2
+    assignment=$3
+    course_dir=$SUBMITTY_DATA_DIR/courses/$semester/$course
+
+    # cleanup all files associated with this assignment
+    rm -rf $course_dir/test_input/${3}
+    rm -rf $course_dir/test_output/${3}
+    rm -rf $course_dir/provided_code/${3}
+    rm -rf $course_dir/custom_validation_code/${3}
+    rm -rf $course_dir/build/${3}
+    rm -rf $course_dir/bin/${3}
+    rm -rf $course_dir/config/build/build_${3}.json
+    rm -rf $course_dir/config/complete_config/complete_config_${3}.json
+}
+
 
 function build_homework {
 
@@ -115,15 +134,23 @@ function build_homework {
     if [ -d $hw_build_path/custom_validation_code/ ]; then
 	rsync -ruz --delete $hw_build_path/custom_validation_code/    $course_dir/custom_validation_code/$assignment/
     fi
-    
+
+    # change permissions so other instructor users in this course & hwcron can re-run the build course script
+    find $course_dir/build/                   -type d -exec chmod -f ug+rwx,g+s,o= {} \;
+    find $course_dir/build/                   -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/build/                           -exec chgrp -f ${course_group} {} \;
     find $course_dir/provided_code/           -type d -exec chmod -f ug+rwx,g+s,o= {} \;
     find $course_dir/provided_code/           -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/provided_code/                   -exec chgrp -f ${course_group} {} \;
     find $course_dir/test_input/              -type d -exec chmod -f ug+rwx,g+s,o= {} \;
     find $course_dir/test_input/              -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/test_input/                      -exec chgrp -f ${course_group} {} \;
     find $course_dir/test_output/             -type d -exec chmod -f ug+rwx,g+s,o= {} \;
     find $course_dir/test_output/             -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/test_output/                     -exec chgrp -f ${course_group} {} \;
     find $course_dir/custom_validation_code/  -type d -exec chmod -f ug+rwx,g+s,o= {} \;
     find $course_dir/custom_validation_code/  -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/custom_validation_code/          -exec chgrp -f ${course_group} {} \;
 
     popd > /dev/null
 }

--- a/sbin/build_config_upload.py
+++ b/sbin/build_config_upload.py
@@ -17,13 +17,22 @@ import json
 def build_one(data):
     semester = data["semester"]
     course = data["course"]
-    gradeable = data["gradeable"]
 
+    # construct the paths for this course
     build_script = "/var/local/submitty/courses/" + semester + "/" + course + "/BUILD_" + course + ".sh"
     build_output = "/var/local/submitty/courses/" + semester + "/" + course + "/build_script_output.txt"
 
+    # construct the command line to build/rebuild/clean/delete the gradeable
+    build_args = [build_script]
+    if "gradeable" in data:
+        build_args.append(data["gradeable"])
+    if "clean" in data:
+        build_args.append("--clean")
+    if "no_build" in data:
+        build_args.append("--no_build")
+
     with open(build_output, "w") as open_file:
-        subprocess.call([build_script, gradeable], stdout=open_file, stderr=open_file)
+        subprocess.call(build_args, stdout=open_file, stderr=open_file)
 
 
 # ------------------------------------------------------------------------

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -564,6 +564,13 @@ class AdminGradeableController extends AbstractController {
                                    "course" => $course,
                                    "gradeable" =>  $_POST['gradeable_id']);
 
+
+        // FIXME/TODO: How to implement delete gradeable...
+        //$config_build_data = array("semester" => $semester,
+        //                           "course" => $course,
+        //                           "no_build" => true);
+
+
         if (file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false) {
           die("Failed to write file {$config_build_file}");
         }


### PR DESCRIPTION
Should fix permissions errors and allow all instructors in course & hwcron to run BUILD_XX.sh

new options:

BUILD_XX.sh --clean
(will delete all files associated with building all gradeables, then re-build all from scratch)

BUILD_XX.sh --clean --no_build
(will delete all files associated with building all gradeables)

BUILD_XX.sh hw1 hw3 --clean
(will delete files associated with specified gradeables & re-build them)

BUILD_XX.sh hw1 hw3
(re-builds the specified gradeables, should be a bit faster than the --clean version)

And every call to BUILD_XX.sh will search for gradeables that have been recently deleted (config/form/form_XX.json no longer exists), and run clean on those deleted gradeables.

Note that calling:
BUILD_XX.sh --no_build
Will only search for deleted gradeables (should run very fast -- should be called when a gradeable has been deleted to clean up all associated build files)

Should help implement #570 (delete gradeable)
May help fix #1420 (building gradeable when changed with/without parts)