### PR TITLE
Fix missing reference warning when a grader with no sections looks at the grade list

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -140,6 +140,7 @@ class ElectronicGraderController extends GradingController {
         $num_submitted = array();
         $num_unsubmitted = 0 ;
         $total_indvidual_students = 0;
+        $viewed_grade = 0;
         if ($peer) {
             $peer_grade_set = $gradeable->getPeerGradeSet();
             $total_users = $this->core->getQueries()->getTotalUserCountByGradingSections($sections, 'registration_section');


### PR DESCRIPTION
Forgot to initialize a variable and it was unset in one case.