### PR TITLE
Fixed wacky file list on Firefox on macOS

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1174,7 +1174,7 @@ HTML;
                         {$name}</a> &nbsp;
                         <a onclick='openFile("{$dir}", "{$path}")'><i class="fa fa-window-restore" aria-hidden="true" title="Pop up the file in a new window"></i></a>
                         <a onclick='downloadFile("{$dir}", "{$path}")'><i class="fa fa-download" aria-hidden="true" title="Download the file"></i></a>
-                    </div><br/>
+                    </div>
                     <div id="file_viewer_{$count}" style="margin-left:{$indent_offset}px" data-file_name="{$dir}" data-file_url="{$path}"></div>
                 </div>
 HTML;

--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -197,7 +197,6 @@ progress::-webkit-progress-value {
 }
 
 .file-viewer{
-    float: left;
     margin-right: 10px;
     cursor: pointer;
 }


### PR DESCRIPTION
Closes #1451. Ended up being a simple CSS fix.