### PR TITLE
Removed 'down_arrow.png' from styling

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -95,7 +95,7 @@ select {
     font-size: 16px;
     border: 1px solid #ccc;
     height: 34px;
-    background: #FFF url('../img/down_arrow.png') no-repeat right 10px center;
+    background: #FFF;
     background-size: 20px;
 }
 


### PR DESCRIPTION
This image does not exist, so it shouldn't be in the style sheet.  Since it doesn't exist, it causes an error on every page that uses server.css (all of the pages).  Now its gone...

I don't think there are any adverse effects of this, but someone else should try this out briefly before merging.