### PR TITLE
Fix autocomplete results being escaped and breaking things

### DIFF
--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -41,6 +41,6 @@
 </div>
 <script>
     $("#user_id").autocomplete({
-        source: {{ student_full }}
+        source: {{ student_full|raw }}
     });
 </script>

--- a/site/app/templates/admin/LateDays.twig
+++ b/site/app/templates/admin/LateDays.twig
@@ -51,6 +51,6 @@
 </div>
 <script>
     $("#user_id").autocomplete({
-        source: {{ student_full }}
+        source: {{ student_full|raw }}
     });
 </script>


### PR DESCRIPTION
Twig needed a `|raw` to not escape some json data