### PR TITLE
Fix ordering having system before master for migrations

### DIFF
--- a/migration/migrator.py
+++ b/migration/migrator.py
@@ -45,9 +45,13 @@ def parse_args():
     args = parser.parse_args()
     if args.environments is None:
         args.environments = ENVIRONMENTS
-    # make sure the order is of 'system', 'master', 'course' (which is reverse alphabetical)
-    args.environments.sort()
-    args.environments.reverse()
+    # make sure the order is of 'master', 'system', 'course' depending on what environments have been selected
+    # system must be run after master initially as system relies on master DB being setup for migration table
+    environments = []
+    for env in ['master', 'system', 'course']:
+        if env in args.environments:
+            environments.append(env)
+    args.envrionments = environments
     return args
 
 

--- a/migration/migrator.py
+++ b/migration/migrator.py
@@ -51,7 +51,7 @@ def parse_args():
     for env in ['master', 'system', 'course']:
         if env in args.environments:
             environments.append(env)
-    args.envrionments = environments
+    args.environments = environments
     return args
 
 

--- a/migration/migrator.py
+++ b/migration/migrator.py
@@ -19,7 +19,7 @@ import psycopg2
 VERSION = "1.1.0"
 DIR_PATH = Path(__file__).parent.resolve()
 MIGRATIONS_PATH = DIR_PATH / 'migrations'
-ENVIRONMENTS = [path.name for path in MIGRATIONS_PATH.iterdir()]
+ENVIRONMENTS = ['master', 'system', 'course']
 
 
 def parse_args():
@@ -48,7 +48,7 @@ def parse_args():
     # make sure the order is of 'master', 'system', 'course' depending on what environments have been selected
     # system must be run after master initially as system relies on master DB being setup for migration table
     environments = []
-    for env in ['master', 'system', 'course']:
+    for env in ENVIRONMENTS:
         if env in args.environments:
             environments.append(env)
     args.environments = environments
@@ -97,7 +97,7 @@ def handle_migration(args):
         database = json.load(open_file)
 
     for environment in args.environments:
-        if environment in ['system', 'master']:
+        if environment in ['master', 'system']:
             params = {
                 'dbname': 'submitty',
                 'host': database['database_host'],


### PR DESCRIPTION
Fix for build break in 9ba562103d7f7df4c09b7eef308d46d0ecfaaed6 where I messed up the ordering of the migrator environments. This is what I get for not waiting for Travis to finish for a "simple fix" that I tested against an already stood-up environment (bug was that --initial for system relies on master already being run for the migrations_system table to be created for us to record the system migrations in).