### PR TITLE
Added new per-user gradeable model classes and DB queries

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -11,7 +11,10 @@ use app\libraries\GradeableType;
 use app\models\AdminGradeable;
 use app\models\Gradeable;
 use app\models\gradeable\Component;
+use app\models\gradeable\GradedComponent;
+use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\Mark;
+use app\models\gradeable\Submitter;
 use app\models\GradeableComponent;
 use app\models\GradeableComponentMark;
 use app\models\GradeableVersion;
@@ -2476,5 +2479,109 @@ AND gc_id IN (
         $gradeable->setComponents($this->getGradeableComponentConfigs($gradeable));
 
         return $gradeable;
+    }
+
+    /**
+     * Retrieves all GradedComponents for a given GradedGradeable
+     * @param GradedGradeable $graded_gradeable The gradeable associated with the components
+     * @return GradedComponent[]
+     * @throws \Exception If the database information is invalid
+     */
+    public function getGradeableComponentData(GradedGradeable $graded_gradeable) {
+        $query = "
+            SELECT
+                gc_id as comp_id,
+                gcd_score as score,
+                gcd_component_comment as comment,
+                gcd_grader_id AS grader_id,
+                gcd_graded_version AS graded_version,
+                gcd_grade_time AS grade_time
+            FROM gradeable_component_data
+            WHERE gd_id=?";
+        $this->course_db->query($query, array($graded_gradeable->getId()));
+
+        $component_data_raw = $this->course_db->rows();
+
+        $query = "
+            SELECT 
+                gc_id as comp_id,
+                gcm_id AS id
+            FROM gradeable_component_mark_data
+            WHERE gd_id=?";
+        $this->course_db->query($query, array($graded_gradeable->getId()));
+
+        $mark_data_raw = $this->course_db->rows();
+
+        // Construct an array of array of mark ids for easy construction of graded components
+        $marks_by_comp_id = [];
+        foreach ($mark_data_raw as $mark_data) {
+            if (isset($marks_by_comp_id[$mark_data['comp_id']])) {
+                $marks_by_comp_id[$mark_data['comp_id']][] = $mark_data['id'];
+            } else {
+                $marks_by_comp_id[$mark_data['comp_id']] = [$mark_data['id']];
+            }
+        }
+
+        // Construct all of the graded components with the provided marks
+        $graded_components = [];
+        foreach ($component_data_raw as $component_data) {
+            $graded_components[] = new GradedComponent($this->core,
+                $graded_gradeable,
+                $this->getUserById($component_data['grader_id']),
+                $component_data['comp_id'],
+                $marks_by_comp_id[$component_data['comp_id']] ?? [], // If no marks for this component, empty array
+                $component_data);
+        }
+
+        return $graded_components;
+    }
+
+    /**
+     * Retrieves a GradedGradeable instance from the database for a team/user.
+     *  Note: this internally calls getGradeableComponentData
+     * @param \app\models\gradeable\Gradeable $gradeable The gradeable associated with this grade
+     * @param string|null $user_id The user id to search for (or null if searching for a team)
+     * @param string|null $team_id The team id to search for (or null of searching for a user)
+     * @return GradedGradeable
+     * @throws \Exception If the database information is invalid
+     */
+    public function getGradeableData(\app\models\gradeable\Gradeable $gradeable, $user_id, $team_id = null) {
+
+        // Get the user/team FIRST so if they throw errors, we don't query anything else
+        $submitter = null;
+        if ($team_id !== null) {
+            $submitter = $this->getTeamById($team_id);
+        } else if ($user_id !== null) {
+            $submitter = $this->getUserById($user_id);
+        } else {
+            throw new \InvalidArgumentException('Must provide a non-null team or user id');
+        }
+
+        // Query for the gradeable data
+        $query = "
+            SELECT 
+                gd_id AS id,
+                gd_team_id AS team_id,
+                gd_overall_comment as overall_comment,
+                gd_user_viewed_date as user_viewed_date
+            FROM gradeable_data
+            WHERE g_id=? AND (gd_user_id=? OR gd_team_id=?)";
+        $this->course_db->query($query, array($gradeable->getId(), $user_id, $team_id));
+
+        // Throw an exception if the data was not found in the database.
+        //  Its better to throw that here instead of in the GradedGradeable constructor
+        //   so the stacktrace is more obvious
+        $details = $this->course_db->row();
+        if (count($details) === 0) {
+            throw new \InvalidArgumentException("Gradeable data did not exist!");
+        }
+
+        // Construct the graded gradeable
+        $graded_gradeable = new GradedGradeable($this->core, $gradeable, new Submitter($this->core, $submitter), $details);
+
+        // Query for the gradeable component data entries for this gradeable data
+        $graded_gradeable->setGradedComponents($this->getGradeableComponentData($graded_gradeable));
+
+        return $graded_gradeable;
     }
 }

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace app\models\gradeable;
+
+use app\models\AbstractModel;
+use app\libraries\Core;
+use app\libraries\DateUtils;
+use app\models\User;
+
+/**
+ * Class GradedComponent
+ * @package app\models\gradeable
+ *
+ * @method int getComponentId()
+ * @method float getScore()
+ * @method string getComment()
+ * @method void setComment($comment)
+ * @method string getGraderId()
+ * @method int getGradedVersion()
+ * @method void setGradedVersion($graded_version)
+ * @method \DateTime getGradeTime()
+ */
+class GradedComponent extends AbstractModel {
+    /** @var Component Reference to component */
+    private $component = null;
+    /** @var GradedGradeable Reference to the gradeable data */
+    private $graded_gradeable = null;
+    /** @property @var string Id of the component this grade is attached to */
+    protected $component_id = 0;
+
+    /** @var User The grader of this component */
+    private $grader = null;
+
+    /** @var Mark[] References to the marks this graded component received */
+    private $marks = array();
+
+    /** @property @var int[] The mark ids the submitter received for this component */
+    protected $mark_ids = array();
+
+    /** @property @var float The score for this component */
+    protected $score = 0;
+    /** @property @var string The comment on this mark / custom mark description */
+    protected $comment = "";
+    /** @property @var string The Id of the grader who most recently updated the component's grade */
+    protected $grader_id = "";
+    /** @property @var int The submission version this grade is for */
+    protected $graded_version = 0;
+    /** @property @var null The time which this grade was most recently updated */
+    protected $grade_time = null;
+
+    /**
+     * GradedComponent constructor.
+     * @param Core $core
+     * @param GradedGradeable $graded_gradeable The full graded gradeable associated with this component
+     * @param User $grader The user who graded this component
+     * @param int $component_id The component id associated with this grade
+     * @param int[] $mark_ids The mark ids this graded component received
+     * @param array $details any remaining properties
+     * @throws \Exception if the 'grade_time' value in the $details array is not a valid DateTime/date-string
+     */
+    public function __construct(Core $core, GradedGradeable $graded_gradeable, User $grader, $component_id, array $mark_ids, array $details) {
+        parent::__construct($core);
+
+        $this->setGradedGradeable($graded_gradeable);
+        $this->setComponent($graded_gradeable->getGradeable()->getComponent($component_id));
+        $this->setGrader($grader);
+
+        // This may seem redundant, but by fetching the marks from the component and calling setMarks, we
+        //  effectively filter out any of the invalid values in $mark_ids
+        $mark_objects = [];
+        foreach($this->component->getMarks() as $mark) {
+            if(in_array($mark->getId(), $mark_ids)) {
+                $mark_objects[] = $mark;
+            }
+        }
+        $this->setMarks($mark_objects);
+
+        $this->setComment($details['comment']);
+        $this->setGradedVersion($details['graded_version']);
+        $this->setGradeTime($details['grade_time']);
+
+        // Make sure the loaded score overrides the calculated
+        //  score if it exists / there aren't any marks
+        if (isset($details['score'])) {
+            $this->setScore($details['score']);
+        }
+    }
+
+    /**
+     * Gets the component associated with this component data
+     * @return Component
+     */
+    public function getComponent() {
+        return $this->component;
+    }
+
+    /**
+     * Gets the GradedGradeable this component belongs to
+     * @return GradedGradeable
+     */
+    public function getGradedGradeable() {
+        return $this->graded_gradeable;
+    }
+
+    /**
+     * Gets the user who graded this component
+     * @return User
+     */
+    public function getGrader() {
+        return $this->grader;
+    }
+
+    /**
+     * Gets references to the marks that the submitter received
+     * @return Mark[]
+     */
+    public function getMarks() {
+        return $this->marks;
+    }
+
+    /* Overridden setters with validation */
+
+    /**
+     * Sets the component reference for this data
+     * @param Component $component
+     */
+    private function setComponent(Component $component) {
+        if ($component === null) {
+            throw new \InvalidArgumentException('Component cannot be null');
+        }
+        $this->component = $component;
+        $this->component_id = $component->getId();
+    }
+
+    private function setGradedGradeable(GradedGradeable $graded_gradeable) {
+        if ($graded_gradeable === null) {
+            throw new \InvalidArgumentException('Graded gradeable cannot be null');
+        }
+        $this->graded_gradeable = $graded_gradeable;
+    }
+
+    /**
+     * Calculates the score the submitter received for this component
+     *  based on the $marks array
+     */
+    private function calculateScore() {
+        $total_points = 0.0;
+
+        foreach ($this->marks as $mark) {
+            $total_points += $mark->getPoints();
+        }
+        $this->setScore($total_points);
+    }
+
+    /**
+     * Sets the marks the submitter received for this component
+     * @param array $marks
+     */
+    public function setMarks(array $marks) {
+        $new_mark_ids = [];
+        foreach ($marks as $mark) {
+            if (!($mark instanceof Mark)) {
+                throw new \InvalidArgumentException('Object in marks array was not a mark');
+            }
+            $new_mark_ids[] = $mark->getId();
+        }
+        $this->marks = $marks;
+        $this->mark_ids = $new_mark_ids;
+
+        $this->calculateScore();
+    }
+
+    /**
+     * Sets the last time this component data was changed
+     * @param \DateTime|string $grade_time Either a \DateTime object, or a date-time string
+     * @throws \Exception if $grade_time is a string and failed to parse into a \DateTime object
+     */
+    public function setGradeTime($grade_time) {
+        if ($grade_time === null) {
+            $this->grade_time = null;
+        } else {
+            $this->grade_time = DateUtils::parseDateTime($grade_time, $this->core->getConfig()->getTimezone());
+        }
+    }
+
+    /**
+     * Sets the user who most recently changed the component data
+     * @param User $grader
+     */
+    public function setGrader(User $grader) {
+        $this->grader = $grader;
+        $this->grader_id = $this->grader !== null ? $grader->getId() : '';
+    }
+
+    /**
+     * Sets the score the submitter received for this component, clamped to be
+     *  between the lower and upper clamp of the associated component
+     * @param float $score
+     */
+    public function setScore($score) {
+        // clamp the score (no error if not in bounds)
+        //  min(max(a,b),c) will clamp the value 'b' in the range [a,c]
+        $this->score = min(max($this->component->getLowerClamp(), $score), $this->component->getUpperClamp());
+    }
+
+    /* Intentionally Unimplemented accessor methods */
+
+    /** @internal */
+    public function setComponentId() {
+        throw new \BadFunctionCallException('Cannot set component data\'s component Id');
+    }
+
+    /** @internal */
+    public function setGraderId() {
+        throw new \BadFunctionCallException('Cannot set grader Id');
+    }
+
+    /** @internal */
+    public function setMarkIds() {
+        throw new \BadFunctionCallException('Cannot set mark ids');
+    }
+}

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace app\models\gradeable;
+
+use app\libraries\Core;
+use app\libraries\DateUtils;
+use \app\models\AbstractModel;
+
+/**
+ * Class GradedGradeable
+ * @package app\models\gradeable
+ *
+ * @method string getGradeableId()
+ * @method GradedComponent[] getGradedComponents()
+ * @method Submitter getSubmitter()
+ * @method int getId()
+ * @method string getOverallComment()
+ * @method void setOverallComment($comment)
+ * @method \DateTime getUserViewedDate()
+ */
+class GradedGradeable extends AbstractModel {
+    /** @var Gradeable Reference to gradeable */
+    private $gradeable = null;
+    /** @property @var string Id of the gradeable this grade is attached to */
+    protected $gradeable_id = "";
+
+    /** @property @var int The id of this gradeable data */
+    protected $id = 0;
+    /** @property @var string The grader's overall comment */
+    protected $overall_comment = "";
+    /** @property @var \DateTime The date the user viewed their grade */
+    protected $user_viewed_date = null;
+
+    /** @property @var Submitter The submitter who received this graded gradeable */
+    protected $submitter = null;
+    /** @property @var GradedComponent[] The graded components */
+    protected $graded_components = array();
+
+
+    /**
+     * GradedGradeable constructor.
+     * @param Core $core
+     * @param Gradeable $gradeable The gradeable associated with this grade
+     * @param Submitter $submitter The user or team who submitted for this graded gradeable
+     * @param array $details A property-name-indexed array of values to construct with
+     * @throws \Exception If the 'user_viewed_date' in the $details array is an invalid DateTime/date-string
+     */
+    public function __construct(Core $core, Gradeable $gradeable, Submitter $submitter, array $details) {
+        parent::__construct($core);
+
+        $this->setGradeable($gradeable);
+        $this->setSubmitterInternal($submitter);
+
+        $this->setIdInternal($details['id']);
+        $this->setOverallComment($details['overall_comment']);
+        $this->setUserViewedDate($details['user_viewed_date']);
+    }
+
+    public function toArray() {
+        $details = parent::toArray();
+
+        // When serializing a graded gradeable, put the grader information into
+        //  the graded gradeable instead of each component so if one grader  grades
+        //  multiple components, their information only gets sent once
+        $details['graders'] = [];
+        foreach ($this->graded_components as $graded_component) {
+            if ($graded_component->getGrader() !== null) {
+                $details['graders'][$graded_component->getGrader()->getId()] = $graded_component->getGrader()->toArray();
+            }
+        }
+
+        return $details;
+    }
+
+    /**
+     * Gets the gradeable this grade data is associated with
+     * @return Gradeable the gradeable this grade data is associated with
+     */
+    public function getGradeable() {
+        return $this->gradeable;
+    }
+
+    /* Overridden setters with validation */
+
+    /**
+     * Sets the internal gradeable reference
+     * @param Gradeable $gradeable
+     */
+    private function setGradeable(Gradeable $gradeable) {
+        if ($gradeable === null) {
+            throw new \InvalidArgumentException('Gradeable cannot be null');
+        }
+        $this->gradeable = $gradeable;
+        $this->gradeable_id = $gradeable->getId();
+    }
+
+    /**
+     * Sets the submitter for this grade data
+     * @param Submitter $submitter
+     */
+    private function setSubmitterInternal(Submitter $submitter) {
+        if ($submitter === null) {
+            throw new \InvalidArgumentException('Submitter cannot be null');
+        }
+        $this->submitter = $submitter;
+    }
+
+    /**
+     * Sets the array of graded components for this gradeable data
+     * @param array $graded_components
+     */
+    public function setGradedComponents(array $graded_components) {
+        foreach ($graded_components as $graded_component) {
+            if (!($graded_component instanceof GradedComponent)) {
+                throw new \InvalidArgumentException('Graded Component array contained invalid type');
+            }
+        }
+        $this->graded_components = $graded_components;
+    }
+
+    /**
+     * Sets the date that the user viewed their grade
+     * @param string|\DateTime $user_viewed_date The date or date string of when the user viewed their grade
+     * @throws \Exception if $grade_time is a string and failed to parse into a \DateTime object
+     */
+    public function setUserViewedDate($user_viewed_date) {
+        if ($user_viewed_date === null) {
+            $this->user_viewed_date = null;
+        } else {
+            $this->user_viewed_date = DateUtils::parseDateTime($user_viewed_date, $this->core->getConfig()->getTimezone());
+        }
+    }
+
+    /**
+     * Sets the id of this grade data
+     * @param int $id
+     */
+    private function setIdInternal($id) {
+        if (is_int($id) || ctype_digit($id) && intval($id) >= 0) {
+            $this->id = intval($id);
+        } else {
+            throw new \InvalidArgumentException('Id must be a non-negative integer');
+        }
+    }
+
+    /* Intentionally Unimplemented accessor methods */
+
+    /** @internal */
+    public function setId($id) {
+        throw new \BadFunctionCallException('Cannot set id of gradeable data');
+    }
+
+    /** @internal */
+    public function setGradeableId($id) {
+        throw new \BadFunctionCallException('Cannot set id of gradeable associated with gradeable data');
+    }
+
+    /** @internal */
+    public function setSubmitter(Submitter $submitter) {
+        throw new \BadFunctionCallException('Cannot set gradeable submitter');
+    }
+}

--- a/site/app/models/gradeable/Submitter.php
+++ b/site/app/models/gradeable/Submitter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace app\models\gradeable;
+
+
+use app\libraries\Core;
+use app\models\AbstractModel;
+use app\models\Team;
+use app\models\User;
+
+/**
+ * Class Submitter
+ * @package app\models\gradeable
+ *
+ * A trivial wrapper around a Team or a User instance so the GradedGradeable can
+ *  have either and access it in a consistent way.
+ */
+class Submitter extends AbstractModel {
+
+    /** @var Team|User The internal team or user instance */
+    private $team_or_user;
+
+    /**
+     * Submitter constructor.
+     * @param Core $core
+     * @param Team|User $team_or_user The object for the submitter (team or user)
+     */
+    public function __construct(Core $core, $team_or_user) {
+        parent::__construct($core);
+
+        if($team_or_user === null) {
+            throw new \InvalidArgumentException('Team or user must not be null');
+        }
+
+        if($team_or_user instanceof Team || $team_or_user instanceof User) {
+            $this->team_or_user = $team_or_user;
+        } else {
+            throw new \InvalidArgumentException('Team or user must be a Team or a User');
+        }
+    }
+
+    public function toArray() {
+        return $this->team_or_user->toArray();
+    }
+
+    public function isTeam() {
+        return $this->team_or_user instanceof Team;
+    }
+
+    public function getObject() {
+        return $this->team_or_user;
+    }
+
+    public function getId() {
+        return $this->team_or_user->getId();
+    }
+
+}


### PR DESCRIPTION
The new green model classes (see #2107) and database methods to load them.  They are, once again, completely separate classes and not used anywhere else, so to test that they load propertly, you can insert the following lines:

```
$test_gradeable = $this->core->getQueries()->getGradeableConfig($admin_gradeable->getGId());
$gradeable_data = $this->core->getQueries()->getGradeableData($test_gradeable, 'aphacker', null);
$this->core->getOutput()->renderJson($gradeable_data->toArray());
return;
```

into the `AdminGradeableView` to short circuit it and dump the json representation to the client.