### PR TITLE
Fixed twig footer escaping db queries

### DIFF
--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -17,11 +17,11 @@
         Runtime: {{ runtime }}<br /><br />
         <h3>Site Details</h3>
         Total Submitty Details: {{ core.getSubmittyDB().getQueryCount() }}<br /><br />
-        Submitty Queries:<br /> {{ core.getSubmittyDB().getPrintQueries() }}
+        Submitty Queries:<br /> {{ core.getSubmittyDB().getPrintQueries()|raw }}
 
         <h3>Course Details</h3>
         Total Course Queries: {{ core.getCourseDB().getQueryCount() }}<br /><br />
-        Course Queries: <br /> {{ core.getCourseDB().getPrintQueries() }}
+        Course Queries: <br /> {{ core.getCourseDB().getPrintQueries()|raw }}
     </div>
 {% endif %}
 </body>


### PR DESCRIPTION
The new twig template was escaping the db queries text, which contained html line breaks.  I removed this escaping so the text displays on multiple lines as intended.