### PR TITLE
Added popup for extension view (For teams)

### DIFF
--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -3,6 +3,7 @@
     <h2>Excused Absence Extensions</h2>
     <form id="excusedAbsenceForm" method="post" enctype="multipart/form-data" action="" onsubmit="return updateHomeworkExtensions($(this));">
         <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="option" value="-1" />
         <div class="panel">
             <div class="option">
                 <p> Use this form to grant an extension (e.g., for an excused absence) to a user on a specific assignment.<br><br><br></p>
@@ -44,3 +45,4 @@
         source: {{ student_full|raw }}
     });
 </script>
+{% include('admin/users/MoreExtensions.twig')%}

--- a/site/app/templates/admin/users/MoreExtensions.twig
+++ b/site/app/templates/admin/users/MoreExtensions.twig
@@ -1,0 +1,17 @@
+<div class="popup-form" id="more_extension_popup">
+    <h3>This student has one or more teammates, should the extension apply to them as well?</h3>
+    <p>Team member list: </p>
+    {% for id, user in member_list %}
+        <p>{{ user }} ({{ id }})</p>
+    {% endfor %}
+    <script>
+        function confirmExtension(option){
+            $('.popup-form').css('display', 'none');
+            $('input[name="option"]').val(option);
+            $('#excusedAbsenceForm').submit();
+            $('input[name="option"]').val(-1);
+        }
+    </script>
+    <a class="btn btn-primary" onclick="confirmExtension(1)">Yes</a>
+    <a class="btn btn-default" onclick="confirmExtension(0)">No</a>
+</div>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -129,6 +129,13 @@ function newUserForm() {
     $("[name='grading_registration_section[]']").prop('checked', false);
 }
 
+function extensionPopup(json){
+    $('.popup-form').css('display', 'none');
+    var form = $('#more_extension_popup');
+    form[0].outerHTML = json['popup'];
+    $('#more_extension_popup').css('display', 'block');
+}
+
 function newDownloadForm() {
     $('.popup-form').css('display', 'none');
     var form = $('#download-form');
@@ -2061,6 +2068,10 @@ function updateHomeworkExtensions(data) {
             if(json['error']){
                 var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fa fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fa fa-times-circle"></i>' + json['error'] + '</div>';
                 $('#messages').append(message);
+                return;
+            }
+            if(json['is_team']){
+                extensionPopup(json);
                 return;
             }
             var form = $("#load-homework-extensions");


### PR DESCRIPTION
As discussed in the meeting, I added a popup for when adding an extension to team assignments.  Now, if the instructor decides to grant an extension to a student who's in a team, a popup will appear and ask if the same extension should be granted to other members. If the instructor chooses "No", then only the student selected will be granted the extension. (This extension will carry on even if he switches teams).

Closes #1725