### PR TITLE
Let Full Access/Limited Graders upload for students

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -302,7 +302,7 @@ class SubmissionController extends AbstractController {
         }
 
         // make sure is admin
-        if (!$this->core->getUser()->accessAdmin()) {
+        if (!$this->core->getUser()->accessGrading()) {
             $msg = "You do not have access to that page.";
             $this->core->addErrorMessage($msg);
             return $this->uploadResult($msg, false);
@@ -339,9 +339,9 @@ class SubmissionController extends AbstractController {
         }
 
         $max_size = $gradeable->getMaxSize();
-	if ($max_size < 10000000) {
-	    $max_size = 10000000;
-	}
+        if ($max_size < 10000000) {
+            $max_size = 10000000;
+        }
         // Error checking of file name
         $file_size = 0;
         if (isset($uploaded_file)) {
@@ -468,8 +468,8 @@ class SubmissionController extends AbstractController {
             return $this->uploadResult("Invalid path.", false);
         }
 
-        // make sure is admin
-        if (!$this->core->getUser()->accessAdmin()) {
+        // make sure is grader
+        if (!$this->core->getUser()->accessGrading()) {
             $msg = "You do not have access to that page.";
             $this->core->addErrorMessage($msg);
             return $this->uploadResult($msg, false);
@@ -780,8 +780,8 @@ class SubmissionController extends AbstractController {
         // repo_id for VCS use
         $repo_id = $_POST['repo_id'];
 
-        // make sure is admin if the two ids do not match
-        if ($original_user_id !== $user_id && !$this->core->getUser()->accessAdmin()) {
+        // make sure is full grader if the two ids do not match
+        if ($original_user_id !== $user_id && !$this->core->getUser()->accessFullGrading()) {
             $msg = "You do not have access to that page.";
             $this->core->addErrorMessage($msg);
             return $this->uploadResult($msg, false);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -705,6 +705,13 @@ class SubmissionController extends AbstractController {
             return $this->uploadResult("Invalid path.", false);
         }
 
+        // make sure is grader
+        if (!$this->core->getUser()->accessGrading()) {
+            $msg = "You do not have access to that page.";
+            $this->core->addErrorMessage($msg);
+            return $this->uploadResult($msg, false);
+        }
+
         $gradeable_id = $_REQUEST['gradeable_id'];
         $gradeable = $gradeable_list[$gradeable_id];
         $gradeable->loadResultDetails();

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -262,7 +262,7 @@ HTML;
         <h2 class="upperinfo-right">Due: {$gradeable->getDueDate()->format("m/d/Y{$time}")}</h2>
     </div>
 HTML;
-            if ($this->core->getUser()->accessAdmin()) {
+            if ($this->core->getUser()->accessGrading()) {
                 $students = $this->core->getQueries()->getAllUsers();
                 $student_ids = array();
                 foreach ($students as $student) {
@@ -296,9 +296,13 @@ HTML;
         <div >
             <input type='radio' id="radio_normal" name="submission_type" checked="true"> 
                 Normal Submission
+HTML;
+                if($this->core->getUser()->accessFullGrading()) {
+                    $return .= <<<HTML
             <input type='radio' id="radio_student" name="submission_type">
                 Make Submission for a Student
 HTML;
+                }
                 if ($gradeable->getNumParts() == 1 && !$gradeable->useVcsCheckout()) {
                     $return .= <<<HTML
             <input type='radio' id="radio_bulk" name="submission_type">
@@ -730,7 +734,7 @@ HTML;
 </div>
 HTML;
         }
-        if ($this->core->getUser()->accessAdmin()) {
+        if ($this->core->getUser()->accessGrading()) {
 
             $all_directories = $gradeable->getUploadsFiles();
 


### PR DESCRIPTION
Gives full access graders permissions to upload for students, bulk upload, and upload split items.

Gives limited access graders permissions to bulk upload and upload split items.

Interfaces for each group changed accordingly so that they can see their options.

closes #1724 