### PR TITLE
Fix grading checking current version instead of active version

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -960,7 +960,7 @@ class ElectronicGraderController extends GradingController {
             }
         }
 
-        if ($gradeable->getCurrentVersion() === null) {
+        if ($gradeable->getActiveVersion() > 0) {
             $response = array('status' => 'failure');
             $this->core->getOutput()->renderJson($response);
             return $response;


### PR DESCRIPTION
Current version is some variable about which version is being viewed, active version is the real "have they submitted" check.