### PR TITLE
Fix no submission check being backwards

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -960,7 +960,7 @@ class ElectronicGraderController extends GradingController {
             }
         }
 
-        if ($gradeable->getActiveVersion() > 0) {
+        if ($gradeable->getActiveVersion() <= 0) {
             $response = array('status' => 'failure');
             $this->core->getOutput()->renderJson($response);
             return $response;


### PR DESCRIPTION
It was only letting you grade if there was no submission, instead of the inverse.