### PR TITLE
add config variable to migrator functions

### DIFF
--- a/migration/migrations/course/20180607070236_initial.py
+++ b/migration/migrations/course/20180607070236_initial.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
 
-def up(conn, semester, course):
+def up(config, conn, semester, course):
     with conn.cursor() as cursor:
         with Path(Path(__file__).parent.parent.parent, 'data', 'course_tables.sql').open() as open_file:
             cursor.execute(open_file.read())
 
 
-def down(conn, semester, course):
+def down(config, conn, semester, course):
     with conn.cursor() as cursor:
         cursor.execute("""
 DROP SCHEMA public CASCADE;

--- a/migration/migrations/course/20180611120540_regrade_request.py
+++ b/migration/migrations/course/20180611120540_regrade_request.py
@@ -1,4 +1,4 @@
-def up(conn, semester, course):
+def up(config, conn, semester, course):
     with conn.cursor() as cursor:
         cursor.execute("CREATE TABLE regrade_requests (id serial NOT NULL PRIMARY KEY, gradeable_id VARCHAR(255) NOT NULL, timestamp TIMESTAMP NOT NULL, student_id VARCHAR(255) NOT NULL, status INTEGER DEFAULT 0 NOT NULL)")
         cursor.execute("CREATE TABLE regrade_discussion (id serial NOT NULL PRIMARY KEY, regrade_id INTEGER NOT NULL, timestamp TIMESTAMP NOT NULL, user_id VARCHAR(255) NOT NULL, content TEXT, deleted BOOLEAN default FALSE NOT NULL)")
@@ -9,7 +9,8 @@ def up(conn, semester, course):
         cursor.execute("ALTER TABLE regrade_discussion ADD CONSTRAINT regrade_discussion_fk0 FOREIGN KEY (regrade_id) REFERENCES regrade_requests(id)")
         cursor.execute("ALTER TABLE regrade_discussion ADD CONSTRAINT regrade_discussion_fk1 FOREIGN KEY (user_id) REFERENCES users(user_id)")
 
-def down(conn, semester, course):
+
+def down(config, conn, semester, course):
     with conn.cursor() as cursor:
         cursor.execute("DROP TABLE regrade_discussion")
         cursor.execute("DROP TABLE regrade_requests")

--- a/migration/migrations/course/20180611125006_alphanumeric_sections.py
+++ b/migration/migrations/course/20180611125006_alphanumeric_sections.py
@@ -1,4 +1,4 @@
-def up(conn, semester, course):
+def up(config, conn, semester, course):
     with conn.cursor() as cursor:
         # drop foreign key contraints as the foreign keys also store type of columns in their definitions
         cursor.execute("ALTER TABLE ONLY grading_registration DROP CONSTRAINT grading_registration_sections_registration_id_fkey")
@@ -19,7 +19,7 @@ def up(conn, semester, course):
         cursor.execute("ALTER TABLE ONLY gradeable_teams ADD CONSTRAINT gradeable_teams_rotating_section_fkey FOREIGN KEY (rotating_section) REFERENCES sections_rotating(sections_rotating_id)")
 
 
-def down(conn, semester, course):
+def down(config, conn, semester, course):
     with conn.cursor() as cursor:
         # drop foreign key contraints while we typecast the columns
         cursor.execute("ALTER TABLE ONLY gradeable_teams DROP CONSTRAINT gradeable_teams_registration_section_fkey")

--- a/migration/migrations/course/20180618210747_forum_category_colors.py
+++ b/migration/migrations/course/20180618210747_forum_category_colors.py
@@ -1,11 +1,11 @@
-def up(conn, semester, course):
+def up(config, conn, semester, course):
     with conn.cursor() as cursor:
         cursor.execute("ALTER TABLE ONLY categories_list ADD COLUMN rank int")
         cursor.execute("ALTER TABLE ONLY categories_list ADD COLUMN color varchar DEFAULT '#000080' NOT NULL")
     pass
 
 
-def down(conn, semester, course):
+def down(config, conn, semester, course):
     with conn.cursor() as cursor:
         cursor.execute("ALTER TABLE ONLY categories_list DROP COLUMN rank")
         cursor.execute("ALTER TABLE ONLY categories_list DROP COLUMN color")

--- a/migration/migrations/course/20180627121504_lichen_directories.py
+++ b/migration/migrations/course/20180627121504_lichen_directories.py
@@ -1,28 +1,29 @@
 import os
 import grp
+from pathlib import Path
 
-def up(conn, semester, course):
 
-    course_dir          = os.path.join("/var/local/submitty/courses",semester,course)
-    lichen_dir          = os.path.join(course_dir,"lichen")
-    lichen_config_dir   = os.path.join(lichen_dir,"config")
-    lichen_provided_dir = os.path.join(lichen_dir,"provided_code")
+def up(config, conn, semester, course):
+    course_dir = Path(config.submitty['submitty_data_dir'], semester, course)
+    lichen_dir = course_dir / 'lichen'
+    lichen_config_dir = lichen_dir / 'config'
+    lichen_provided_dir = lichen_dir / 'provided_code'
 
     # create the directories
-    os.makedirs(lichen_dir, exist_ok=True)
-    os.makedirs(lichen_config_dir, exist_ok=True)
-    os.makedirs(lichen_provided_dir, exist_ok=True)
+    os.makedirs(str(lichen_dir), exist_ok=True)
+    os.makedirs(str(lichen_config_dir), exist_ok=True)
+    os.makedirs(str(lichen_provided_dir), exist_ok=True)
 
     # get course group
-    stat_info = os.stat(course_dir)
+    stat_info = os.stat(str(course_dir))
     course_group_id = stat_info.st_gid
     course_group = grp.getgrgid(course_group_id)[0]
 
     # set the owner/group/permissions
-    os.system("chown -R hwphp:"+course_group+" "+lichen_dir)
-    os.system("chmod -R u+rwx  "+lichen_dir)
-    os.system("chmod -R g+rwxs "+lichen_dir)
-    os.system("chmod -R o-rwx  "+lichen_dir)
+    os.system("chown -R hwphp:"+course_group+" "+str(lichen_dir))
+    os.system("chmod -R u+rwx  "+str(lichen_dir))
+    os.system("chmod -R g+rwxs "+str(lichen_dir))
+    os.system("chmod -R o-rwx  "+str(lichen_dir))
 
     pass
 

--- a/migration/migrations/master/20180607070236_initial.py
+++ b/migration/migrations/master/20180607070236_initial.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
 
-def up(conn):
+def up(config, conn):
     with conn.cursor() as cursor:
         with Path(Path(__file__).parent.parent.parent, 'data', 'submitty_db.sql').open() as open_file:
             cursor.execute(open_file.read())
 
 
-def down(conn):
+def down(config, conn):
     with conn.cursor() as cursor:
         cursor.execute("""
 DROP SCHEMA public CASCADE;

--- a/migration/migrations/master/20180611125006_alphanumeric_sections.py
+++ b/migration/migrations/master/20180611125006_alphanumeric_sections.py
@@ -1,11 +1,11 @@
-def up(conn):
+def up(config, conn):
     with conn.cursor() as cursor:
         cursor.execute('ALTER TABLE ONLY mapped_courses ALTER COLUMN registration_section SET DATA TYPE character varying(255) USING registration_section::varchar(255)')
         cursor.execute('ALTER TABLE ONLY mapped_courses ALTER COLUMN mapped_section SET DATA TYPE character varying(255) USING mapped_section::varchar(255)')
         cursor.execute('ALTER TABLE ONLY courses_users ALTER COLUMN registration_section SET DATA TYPE character varying(255) USING registration_section::varchar(255)')
 
 
-def down(conn):
+def down(config, conn):
     with conn.cursor() as cursor:
         cursor.execute('ALTER TABLE ONLY mapped_courses ALTER COLUMN registration_section SET DATA TYPE integer USING registration_section::integer')
         cursor.execute('ALTER TABLE ONLY mapped_courses ALTER COLUMN mapped_section SET DATA TYPE integer USING mapped_section::integer')

--- a/migration/migrations/master/20180622203658_auto_feed_registration_sections.py
+++ b/migration/migrations/master/20180622203658_auto_feed_registration_sections.py
@@ -1,4 +1,4 @@
-def up(conn):
+def up(config, conn):
     with conn.cursor() as cursor:
         cursor.execute("""
 CREATE TABLE public.courses_registration_sections (
@@ -34,7 +34,8 @@ $$ LANGUAGE plpgsql;""")
 
         cursor.execute('CREATE TRIGGER registration_sync_registration_id AFTER INSERT ON courses_registration_sections FOR EACH ROW EXECUTE PROCEDURE sync_registration_section();')
 
-def down(conn):
+
+def down(config, conn):
     with conn.cursor() as cursor:
         cursor.execute('DROP TRIGGER registration_sync_registration_id;')
         cursor.execute('DROP FUNCTION sync_registration_section();')

--- a/migration/migrations/system/20180607070236_initial.py
+++ b/migration/migrations/system/20180607070236_initial.py
@@ -1,6 +1,6 @@
-def up():
+def up(config):
     pass
 
 
-def down():
+def down(config):
     pass

--- a/migration/migrations/system/20180619110916_lichen_package_installation.py
+++ b/migration/migrations/system/20180619110916_lichen_package_installation.py
@@ -1,7 +1,7 @@
 import os
 
-def up():
 
+def up(config):
     # c/c++ tokenizer
     os.system("sudo apt-get -qqy install python-clang-3.8")
     os.system("sudo pip install clang")
@@ -18,5 +18,5 @@ def up():
     pass
 
 
-def down():
+def down(config):
     pass

--- a/migration/migrations/system/20180628235136_course_args.py
+++ b/migration/migrations/system/20180628235136_course_args.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 
-def _replace(old, new):
-    installed_migrations = Path(__file__).resolve().parent.parent.parent.parent.parent.parent / 'migrations' / 'course'
+def _replace(install_path, old, new):
+    installed_migrations = install_path / 'migrations' / 'course'
     if installed_migrations.is_dir():
         for entry in installed_migrations.iterdir():
             if entry.is_dir() or not entry.name.endswith('.py'):
@@ -15,9 +15,9 @@ def _replace(old, new):
                 open_file.truncate()
 
 
-def up():
-    _replace("(conn)", "(conn, semester, course)")
+def up(config):
+    _replace(Path(config.submitty['submitty_install_dir']), '(conn)', '(conn, semester, course)')
 
 
-def down():
-    _replace("(conn, semester, course)", "(conn)")
+def down(config):
+    _replace(Path(config.submitty['submitty_install_dir']), '(conn, semester, course)', '(conn)')

--- a/migration/migrations/system/20180629193000_config_arg.py
+++ b/migration/migrations/system/20180629193000_config_arg.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+def _replace(migration_path, old, new):
+    if migration_path.is_dir():
+        for entry in migration_path.iterdir():
+            if entry.is_dir() or not entry.name.endswith('.py'):
+                continue
+            with entry.open('r+') as open_file:
+                data = open_file.read()
+                data = data.replace(old, new)
+                open_file.seek(0)
+                open_file.write(data)
+                open_file.truncate()
+
+
+def up(config):
+    migration_path = Path(config.submitty['submitty_install_dir'], 'migrations')
+    _replace(migration_path /'system', 'up()', 'up(config)')
+    _replace(migration_path / 'system', 'down()', 'down(config)')
+    for folder in ('course', 'master'):
+        _replace(migration_path / folder, 'up(conn', 'up(config, conn')
+        _replace(migration_path / folder, 'down(conn', 'down(config, conn')
+
+
+def down(config):
+    migration_path = Path(config.submitty['submitty_install_dir'], 'migrations')
+    _replace(migration_path / 'system', 'up(config)', 'up()')
+    _replace(migration_path / 'system', 'down(config)', 'down()')
+    for folder in ('course', 'master'):
+        _replace(migration_path / folder, 'up(config, conn', 'up(conn')
+        _replace(migration_path / folder, 'down(config, conn', 'down(conn')


### PR DESCRIPTION
Fixes the necessity of hardcoding `/var/local/submitty` or other such paths and things into the a migration file. Will expand the config class with the other json files as necessary.