### PR TITLE
Link Fix

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -152,7 +152,7 @@ What is the unique id of this gradeable? (e.g., <kbd>hw01</kbd>, <kbd>lab_12</kb
 </fieldset>
 
 <!-- Gradeable bucket (read/write in all modes) -->
-What <a target=_blank href="http://submitty.org/instructor/rainbow_rainbow_grades">syllabus category</a> does this item belong to?:
+What <a target=_blank href="http://submitty.org/instructor/rainbow_grades">syllabus category</a> does this item belong to?:
 
 <select name="syllabus_bucket" class="auto_save" style="width: 170px;">
     {% for bucket in syllabus_buckets %}


### PR DESCRIPTION
A one-liner.
Fix the link on the General tab when creating a new gradeable (the link is the words "syllabus catagory") to point to the correct submitty.org page