### PR TITLE
Misc helper methods in new Gradeable model

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -146,31 +146,6 @@ class AdminGradeableController extends AbstractController {
         $default_late_days = $this->core->getConfig()->getDefaultHwLateDays();
         $vcs_base_url = $this->core->getConfig()->getVcsBaseUrl();
 
-
-        $num_text = 0;
-        $num_numeric = 0;
-        $pdf_page = false;
-        $pdf_page_student = false;
-        if ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
-            // Count text/numeric components if that is the gradeable type
-            foreach ($gradeable->getComponents() as $component) {
-                if ($component->isText()) {
-                    ++$num_text;
-                } else {
-                    ++$num_numeric;
-                }
-            }
-        } else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
-            // Get pdf page settings if electronic
-            foreach ($gradeable->getComponents() as $component) {
-                if ($component->getPage() !== 0) {
-                    $pdf_page = true;
-                    $pdf_page_student = $component->getPage() === -1;
-                }
-                break;
-            }
-        }
-
         $saved_config_path = $gradeable->getAutogradingConfigPath();
 
         // This helps determine which radio button to check when selecting config.
@@ -241,10 +216,10 @@ class AdminGradeableController extends AbstractController {
             //'inherit_teams_list' => $inherit_teams_list
             'default_late_days' => $default_late_days,
             'vcs_base_url' => $vcs_base_url,
-            'is_pdf_page' => $pdf_page,
-            'is_pdf_page_student' => $pdf_page_student,
-            'num_numeric' => $num_numeric,
-            'num_text' => $num_text,
+            'is_pdf_page' => $gradeable->isPdfUpload(),
+            'is_pdf_page_student' => $gradeable->isStudentPdfUpload(),
+            'num_numeric' => $gradeable->getNumNumeric(),
+            'num_text' => $gradeable->getNumText(),
             'type_string' => GradeableType::typeToString($gradeable->getType()),
             'show_edit_warning' => $gradeable->anyManualGrades(),
 

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -785,4 +785,64 @@ class Gradeable extends AbstractModel {
     public function isRotatingGraderSectionsModified() {
         return $this->rotating_grader_sections_modified;
     }
+
+    /**
+     * Gets if this gradeable is pdf-upload
+     * @return bool
+     */
+    public function isPdfUpload() {
+        foreach ($this->components as $component) {
+            if ($component->getPage() !== 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets if the students assign pages to components
+     * @return bool
+     */
+    public function isStudentPdfUpload() {
+        foreach ($this->components as $component) {
+            if ($component->getPage() === -1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets the number of numeric components if type is GradeableType::NUMERIC_TEXT
+     * @return int
+     */
+    public function getNumNumeric() {
+        if ($this->type !== GradeableType::NUMERIC_TEXT) {
+            return 0;
+        }
+        $count = 0;
+        foreach ($this->components as $component) {
+            if (!$component->isText()) {
+                ++$count;
+            }
+        }
+        return $count;
+    }
+
+    /**
+     * Gets the number of text components if type is GradeableType::NUMERIC_TEXT
+     * @return int
+     */
+    public function getNumText() {
+        if ($this->type !== GradeableType::NUMERIC_TEXT) {
+            return 0;
+        }
+        $count = 0;
+        foreach ($this->components as $component) {
+            if ($component->isText()) {
+                ++$count;
+            }
+        }
+        return $count;
+    }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -10,7 +10,7 @@ use app\libraries\Utils;
 use app\libraries\FileUtils;
 use app\libraries\Core;
 use app\models\AbstractModel;
-use app\models\GradeableComponent;
+use app\models\Team;
 
 /**
  * All data describing the configuration of a gradeable
@@ -92,8 +92,8 @@ class Gradeable extends AbstractModel {
     private $any_manual_grades = null;
     /** @property @var bool If any submissions exist */
     private $any_submissions = null;
-    /** @property @var bool If any teams have been formed */
-    private $any_teams = null;
+    /** @property @var Team[] Any teams that have been formed */
+    private $teams = null;
     /** @property @var string[][] Which graders are assigned to which rotating sections (empty if $grade_by_registration is true)
      *                          Array (indexed by grader id) of arrays of rotating section numbers
      */
@@ -751,21 +751,22 @@ class Gradeable extends AbstractModel {
     }
 
     /**
+     * Gets all of the teams formed for this gradeable
+     * @return Team[]
+     */
+    public function getTeams() {
+        if($this->teams === null) {
+            $this->teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
+        }
+        return $this->teams;
+    }
+
+    /**
      * Gets if this gradeable has any teams formed yet
      * @return bool
      */
     public function anyTeams() {
-        if($this->any_teams === null) {
-            // Unless we find a team, assume there are none
-            $this->any_teams = false;
-            if ($this->type === GradeableType::ELECTRONIC_FILE) {
-                $all_teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
-                if (!empty($all_teams)) {
-                    $this->any_teams = true;
-                }
-            }
-        }
-        return $this->any_teams;
+        return !empty($this->getTeams());
     }
 
     /**

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -792,7 +792,7 @@ class Gradeable extends AbstractModel {
      */
     public function isPdfUpload() {
         foreach ($this->components as $component) {
-            if ($component->getPage() !== 0) {
+            if ($component->getPage() !== Component::PDF_PAGE_NONE) {
                 return true;
             }
         }
@@ -805,7 +805,7 @@ class Gradeable extends AbstractModel {
      */
     public function isStudentPdfUpload() {
         foreach ($this->components as $component) {
-            if ($component->getPage() === -1) {
+            if ($component->getPage() === Component::PDF_PAGE_STUDENT) {
                 return true;
             }
         }


### PR DESCRIPTION
This changes are unrelated to any of the other PR's, so I'm putting them in their own, small PR...

I added helper methods in the new `Gradeable` class for getting the number of text/numeric components for `NUMERIC_TEXT` gradeables so the user doesn't need to count them every time.  Additionally, I added helper methods to check if the gradeable is (student) pdf upload and integrated them into the Admin Gradeable controller

Lastly, The Gradeable class lazy loads its teams instead of just its `anyTeams` status, which will be useful in the `ElectronicGraderController`.