### PR TITLE
Remove hard dependency of clang-3.8

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -88,14 +88,22 @@ ${DISTRO_LINE}
 fi
 
 
-# We don't want to install pip via the system as we get an old version
-# and upgrading it is not recommended
-if [ ! -x "$(command -v pip)" ]; then
+if [ ! -x "$(command -v pip2)" ] || [ ! -x "$(command -v pip3)" ]; then
     wget --tries=5 https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
+fi
+
+if [ ! -x "$(command -v pip2)" ]; then
     python2 /tmp/get-pip.py
-    python3 /tmp/get-pip.py
-    rm -f /tmp/get-pip.py
 else
     pip2 install -U pip
+fi
+
+if [ ! -x "$(command -v pip3)" ]; then
+    python3 /tmp/get-pip.py
+else
     pip3 install -U pip
+fi
+
+if [ -f /tmp/get-pip.py ]; then
+    rm -f /tmp/get-pip.py
 fi

--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -82,6 +82,9 @@ apt-get install -qqy ninja-build
 echo "installing cmake"
 apt-get install -qqy cmake
 
+# for Lichen (Plagiarism Detection)
+apt-get install -qqy python-clang-6.0
+
 # Install Oracle 8 Non-Interactively
 echo "installing java8"
 apt-get install -qqy oracle-java8-installer > /dev/null 2>&1

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -183,7 +183,6 @@ pip3 install pause
 pip3 install paramiko
 pip3 install tzlocal
 pip3 install PyPDF2
-pip3 install distro
 
 # for Lichen / Plagiarism Detection
 pip3 install parso

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -183,12 +183,13 @@ pip3 install pause
 pip3 install paramiko
 pip3 install tzlocal
 pip3 install PyPDF2
+pip3 install distro
 
 # for Lichen / Plagiarism Detection
 pip3 install parso
 
 # (yes, we need to run Python2 for clang tokenizer)
-pip install clang
+pip2 install clang
 pip3 install clang
 
 sudo chmod -R 555 /usr/local/lib/python*/*
@@ -460,7 +461,7 @@ if [ ! -d "${clangsrc}" ]; then
     # initial cmake for llvm tools (might take a bit of time)
     mkdir -p ${clangbuild}
     pushd ${clangbuild}
-    cmake -G Ninja ../src/llvm -DCMAKE_INSTALL_PREFIX=${clanginstall} -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=/usr/bin/clang-3.8 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-3.8
+    cmake -G Ninja ../src/llvm -DCMAKE_INSTALL_PREFIX=${clanginstall} -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
     popd > /dev/null
 
     # add build targets for our tools (src to be installed in INSTALL_SUBMITTY_HELPER.sh)

--- a/migration/migrations/system/20180619110916_lichen_package_installation.py
+++ b/migration/migrations/system/20180619110916_lichen_package_installation.py
@@ -1,10 +1,16 @@
 import os
+import subprocess
 
 
 def up(config):
     # c/c++ tokenizer
-    os.system("sudo apt-get -qqy install python-clang-3.8")
-    os.system("sudo pip install clang")
+    p1 = subprocess.Popen(['clang', '--version'], stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(['grep', '-o', '[0-9]\.[0-9]\{1,\}'], stdin=p1.stdout, stdout=subprocess.PIPE)
+    p3 = subprocess.Popen(['head', '-1'], stdin=p2.stdout, stdout=subprocess.PIPE, universal_newlines=True)
+    clang_ver = p3.communicate()[0].strip()
+
+    os.system("sudo apt-get -qqy install python-clang-{}".format(clang_ver))
+    os.system("sudo pip2 install clang")
     os.system("sudo pip3 install clang")
 
     # python tokenzier


### PR DESCRIPTION
`/usr/bin/clang` and `/usr/bin/clang-#.#` both symlink to the same place: `../lib/llvm-#.#/bin/clang` (clang++ has the same structure).

We want to use the former as it allows us to have the same line on both Ubuntu 16.04 (which uses 3.8) and 18.04 (which uses 6.0).

Due to the error being related in the build process, PR also improves handling of installation of pip for python2 and python3 as well as explicitly installing the python bindings for python2 by using pip2.