### PR TITLE
New Gradeable model parameter fixes

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -960,12 +960,12 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
 
     /**
      * Generates the ORDER BY clause with the provided sorting keys
-     * @param string[] $sort_keys
+     * @param string[]|null $sort_keys
      * @param array $key_map A map from sort keys to arrays of expressions to sort by instead
      *          (see self::graded_gradeable_key_map for example)
      * @return string
      */
-    private static function generateOrderByClause(array $sort_keys, array $key_map) {
+    private static function generateOrderByClause($sort_keys, array $key_map) {
         if ($sort_keys !== null) {
             if (!is_array($sort_keys)) {
                 $sort_keys = [$sort_keys];

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -131,7 +131,7 @@ class TaGradedGradeable extends AbstractModel {
      * @return GradedComponent|null The graded component instance or null if not found
      * @throws \InvalidArgumentException If $grader is null and ($component is peer or $generate is true)
      */
-    public function getOrCreateGradedComponent(Component $component, User $grader, $generate = false) {
+    public function getOrCreateGradedComponent(Component $component, $grader, $generate = false) {
         $grades_exist = isset($this->graded_components[$component->getId()]);
         if ($grader === null) {
             // If the grader is null and its a peer component, we can't do anything useful

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -131,7 +131,7 @@ class TaGradedGradeable extends AbstractModel {
      * @return GradedComponent|null The graded component instance or null if not found
      * @throws \InvalidArgumentException If $grader is null and ($component is peer or $generate is true)
      */
-    public function getOrCreateGradedComponent(Component $component, $grader, $generate = false) {
+    public function getOrCreateGradedComponent(Component $component, $grader = null, $generate = false) {
         $grades_exist = isset($this->graded_components[$component->getId()]);
         if ($grader === null) {
             // If the grader is null and its a peer component, we can't do anything useful


### PR DESCRIPTION
These two parameters had cases when they could be null, but PHP type enforcement doesn't allow null values, so these would throw errors even though the functions were designed to handle the case when they were null.