### PR TITLE
Remove pip2 install clang installation line

### DIFF
--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -99,6 +99,6 @@ apt-key fingerprint 0EBFCD88
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
 apt-get install -qqy docker-ce
-systemctl status docker
+systemctl status docker | head -n 100
 
 apt-get -qqy autoremove

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -95,7 +95,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update -qqy
 apt-get install -qqy -y docker-ce
-systemctl status docker
+systemctl status docker | head -n 100
 
 
 if [ ${VAGRANT} == 1 ]; then

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -62,7 +62,7 @@ if [ "$1" == "--vagrant" ] || [ "$2" == "--vagrant" ]; then
     shift
 
     # Setting it up to allow SSH as root by default
-    mkdir -m 700 /root/.ssh
+    mkdir -p -m 700 /root/.ssh
     cp /home/vagrant/.ssh/authorized_keys /root/.ssh
 
     sed -i -e "s/PermitRootLogin prohibit-password/PermitRootLogin yes/g" /etc/ssh/sshd_config

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -188,8 +188,7 @@ pip3 install distro
 # for Lichen / Plagiarism Detection
 pip3 install parso
 
-# (yes, we need to run Python2 for clang tokenizer)
-pip2 install clang
+# Python3 implementation of python-clang bindings (may not work < 6.0)
 pip3 install clang
 
 sudo chmod -R 555 /usr/local/lib/python*/*


### PR DESCRIPTION
As it turns out, due to the installation order of python2 pip followed by python3 pip, `pip` was symlinked to `pip3` and so the change in #2387 to change `pip install clang` to `pip2 install clang` broke things in unexpected fashion.

Given that installation of `python-clang-#.#` installed the bindings anyway, it was redundant to try and install a second set for python2.