### PR TITLE
Bump up value of pm.max_children of PHP-FPM conf

### DIFF
--- a/.setup/php-fpm/pool.d/submitty.conf
+++ b/.setup/php-fpm/pool.d/submitty.conf
@@ -104,7 +104,7 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 5
+pm.max_children = 10
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'


### PR DESCRIPTION
This now matches the default value of proxy workers we've setup within Apache.

If this fixes things for students, we will have to add to the sysadmin installation instructions details about tuning these values (at least say that they should look at them, and link them to a resource that better explains what it means).

```
sudo cp /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/php-fpm/pool.d/submitty.conf /etc/php/#.#/fpm/pool.d/
sudo service php#.#-fpm restart
```

where `#.#` is either 7.0 (Ubuntu 16.04) or 7.2 (Ubuntu 18.04)