### PR TITLE
Changed manual grading page to say "View" instead of "Grade"

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -221,8 +221,11 @@
                 {% endif %}
             {% endif %}
         {% endif %}
-    {% else %}
+    {% elseif gradeable.isTaGrading() %}
         {% set contents = "Grade" %}
+        {% set btn_class = "btn-primary" %}
+    {% else %}
+        {% set contents = "View" %}
         {% set btn_class = "btn-primary" %}
     {% endif %}
     {% set who_id = (gradeable.isTeamAssignment() ? gradeable.getTeam().getId() : gradeable.getUser().getId()) %}


### PR DESCRIPTION
For gradeables with no manual grading, the index page of all students no longer has buttons that say "Grade", but rather "View"

closes #2414 