### PR TITLE
Fixed blank course throwing nav page exception

### DIFF
--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -80,9 +80,10 @@ class NavigationController extends AbstractController {
 
         // Get the user data for each gradeable
         $graded_gradeables = [];
-        // FIXME: Add sorting when that PR gets merged
-        foreach($this->core->getQueries()->getGradedGradeables($visible_gradeables, $user->getId()) as $gg) {
-            $graded_gradeables[$gg->getGradeableId()] = $gg;
+        if (count($visible_gradeables) !== 0) {
+            foreach ($this->core->getQueries()->getGradedGradeables($visible_gradeables, $user->getId()) as $gg) {
+                $graded_gradeables[$gg->getGradeableId()] = $gg;
+            }
         }
 
         $this->core->getOutput()->renderOutput('Navigation', 'showGradeables', $sections_to_lists, $graded_gradeables);


### PR DESCRIPTION
Getting `GradedGradeable`s from the database checks first that the requested array of `Gradeable`s isn't blank and throws an exception if it is.  The nav page was not checking that the array of `Gradeable`s it was passing wasn't blank before requesting the `GradedGradeables`.  Now it properly does this check.