### PR TITLE
Fix bug with cleaning up after PAM and add tests

### DIFF
--- a/site/app/authentication/DatabaseAuthentication.php
+++ b/site/app/authentication/DatabaseAuthentication.php
@@ -15,6 +15,9 @@ namespace app\authentication;
 class DatabaseAuthentication extends AbstractAuthentication {
 
     public function authenticate() {
+        if ($this->user_id === null || $this->password === null) {
+            return false;
+        }
         $user = $this->core->getQueries()->getSubmittyUser($this->user_id);
         if ($user === null) {
             return false;

--- a/site/app/exceptions/CurlException.php
+++ b/site/app/exceptions/CurlException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace app\exceptions;
+
+class CurlException extends \RuntimeException {
+    public function __construct($curl_handle, $curl_return) {
+        if ($curl_return === false) {
+            parent::__construct("cURL error ".curl_error($curl_handle));
+        }
+        else {
+            $http_code = curl_getinfo($curl_handle, CURLINFO_RESPONSE_CODE);
+            parent::__construct("Invalid HTTP Code {$http_code}.");
+        }
+    }
+}

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -4,6 +4,7 @@ namespace app\libraries;
 
 use app\authentication\AbstractAuthentication;
 use app\exceptions\AuthenticationException;
+use app\exceptions\CurlException;
 use app\libraries\database\DatabaseFactory;
 use app\libraries\database\AbstractDatabase;
 use app\libraries\database\DatabaseQueries;
@@ -445,6 +446,33 @@ class Core {
      */
     public function getAccess() {
         return $this->access;
+    }
+
+    /**
+     * Given a string URL, sets up a CURL request to that URL, wherein it'll either return the response
+     * assuming that we
+     *
+     * @param string $url
+     *
+     * @return string
+     *
+     * @throws \app\exceptions\CurlException
+     */
+    public function curlRequest(string $url) {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        try {
+            $return = curl_exec($ch);
+            $http_code = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+            if (!curl_errno($ch) && $http_code === 200) {
+                return $return;
+            }
+            throw new CurlException($ch, $return);
+        }
+        finally {
+            curl_close($ch);
+        }
     }
 
     /**

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -66,12 +66,14 @@ class Utils {
      * as tokens and other things where uniqueness is of absolute importance. The generated
      * string is twice as long as the given number of bytes as the parameter.
      *
+     * @noinspection PhpDocMissingThrowsInspection
+     *
      * @param int $bytes
      *
      * @return string
-     * @throws \Exception
      */
     public static function generateRandomString($bytes = 16) {
+        /** @noinspection PhpUnhandledExceptionInspection */
         return bin2hex(random_bytes($bytes));
     }
     

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -10,7 +10,6 @@ use app\models\Config;
 use app\models\User;
 
 class BaseUnitTest extends \PHPUnit\Framework\TestCase {
-    /** @noinspection PhpDocMissingThrowsInspection */
     /** @noinspection PhpDocSignatureInspection */
     /**
      * Creates a mocked the Core object predefining things with known values so that we don't have to do this
@@ -24,7 +23,6 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
     protected function createMockCore($config_values=array(), $user_config=array()) {
         $core = $this->createMock(Core::class);
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         $config = $this->createMockModel(Config::class);
         if (isset($config_values['semester'])) {
             $config->method('getSemester')->willReturn($config_values['semester']);
@@ -83,7 +81,6 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
         else {
             $user->method('accessAdmin')->willReturn(false);
         }
-        
 
         $core->method('getUser')->willReturn($user);
 
@@ -103,11 +100,11 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
      * and does slow testing down some, but it's easier than having to manually update a list of needed functions
      * when mocking these things.
      *
+     * @noinspection PhpDocMissingThrowsInspection
+     *
      * @param string $class
      *
      * @return \PHPUnit\Framework\MockObject\MockObject
-     *
-     * @throws \ReflectionException
      */
     public function createMockModel($class) {
         $builder = $this->getMockBuilder($class)
@@ -116,6 +113,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes();
 
+        /** @noinspection PhpUnhandledExceptionInspection */
         $reflection = new \ReflectionClass($class);
         $methods = array();
         $matches = array();

--- a/site/tests/app/authentication/DatabaseAuthenticationTester.php
+++ b/site/tests/app/authentication/DatabaseAuthenticationTester.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace tests\app\authentication;
+
+use app\authentication\DatabaseAuthentication;
+use app\libraries\Core;
+use app\libraries\database\DatabaseQueries;
+use app\models\User;
+use tests\BaseUnitTest;
+
+class DatabaseAuthenticationTester extends BaseUnitTest {
+    public function testNoUsername() {
+        $core = $this->createMock(Core::class);
+        $auth = new DatabaseAuthentication($core);
+        $this->assertFalse($auth->authenticate());
+    }
+
+    public function testNoPassword() {
+        $core = $this->createMock(Core::class);
+        $auth = new DatabaseAuthentication($core);
+        $auth->setUserId('test');
+        $this->assertFalse($auth->authenticate());
+    }
+
+    public function testValidLogin() {
+        $user = $this->createMockModel(User::class);
+        $user->method('getPassword')->willReturn(password_hash('test', PASSWORD_DEFAULT));
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getSubmittyUser')->willReturn($user);
+        $core = $this->createMock(Core::class);
+        $core->method('getQueries')->willReturn($queries);
+
+        $auth = new DatabaseAuthentication($core);
+        $auth->setUserId('test');
+        $this->assertEquals('test', $auth->getUserId());
+        $auth->setPassword('test');
+        $this->assertTrue($auth->authenticate());
+
+    }
+
+    public function testInvalidUser() {
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getSubmittyUser')->willReturn(null);
+        $core = $this->createMock(Core::class);
+        $core->method('getQueries')->willReturn($queries);
+
+        $auth = new DatabaseAuthentication($core);
+        $auth->setUserId('test');
+        $auth->setPassword('test');
+        $this->assertFalse($auth->authenticate());
+    }
+}

--- a/site/tests/app/authentication/PamAuthenticationTester.php
+++ b/site/tests/app/authentication/PamAuthenticationTester.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace tests\app\authentication;
+
+use app\authentication\PamAuthentication;
+use app\exceptions\CurlException;
+use app\libraries\Core;
+use app\libraries\database\DatabaseQueries;
+use app\libraries\FileUtils;
+use app\libraries\Utils;
+use app\models\Config;
+use tests\BaseUnitTest;
+
+class PamAuthenticationTester extends BaseUnitTest {
+    /** @var string */
+    private $tmp_path;
+    public function setUp() {
+        $this->tmp_path = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
+        FileUtils::createDir(FileUtils::joinPaths($this->tmp_path, 'tmp', 'pam'), 0777, true);
+    }
+
+    /**
+     * We have to do this tearDown as a shutdown function due to the fact that the PamAuthentication
+     */
+    public function tearDown() {
+        FileUtils::recursiveChmod($this->tmp_path, 0777);
+        $iter = new \FilesystemIterator(FileUtils::joinPaths($this->tmp_path, 'tmp', 'pam'), \FilesystemIterator::SKIP_DOTS);
+        $this->assertEquals(0, iterator_count($iter));
+        $this->assertTrue(FileUtils::recursiveRmdir($this->tmp_path));
+    }
+
+    private function getMockCore($curl_response) {
+        $config = $this->createMockModel(Config::class);
+        $config->method('getSubmittyPath')->willReturn($this->tmp_path);
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getSubmittyUser')->willReturn(true);
+        $core = $this->createMock(Core::class);
+        $core->method('getConfig')->willReturn($config);
+        $core->method('getQueries')->willReturn($queries);
+        $core->method('curlRequest')->willReturn($curl_response);
+        return $core;
+    }
+
+    public function testSuccessfulPamAuthentication() {
+        $core = $this->getMockCore('{"authenticated": true}');
+
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $this->assertEquals('test', $pam->getUserId());
+        $pam->setPassword('test');
+        $this->assertTrue($pam->authenticate());
+    }
+
+
+    public function testFailedPamAuthentication() {
+        $core = $this->getMockCore('{"authenticated": false}');
+
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $this->assertFalse($pam->authenticate());
+    }
+
+    public function testNonBooleanAuthenticatedValue() {
+        $core = $this->getMockCore('{"authenticated": "string_value"}');
+
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $this->assertFalse($pam->authenticate());
+    }
+
+    public function testNoUserId() {
+        $core = $this->createMock(Core::class);
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $this->assertFalse($pam->authenticate());
+    }
+
+    public function testNoPassword() {
+        $core = $this->createMock(Core::class);
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $this->assertFalse($pam->authenticate());
+    }
+
+    public function testInvalidUserId() {
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getSubmittyUser')->willReturn(null);
+        $core = $this->createMock(Core::class);
+        $core->method('getQueries')->willReturn($queries);
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $this->assertFalse($pam->authenticate());
+    }
+
+    /**
+     * @expectedException \app\exceptions\AuthenticationException
+     * @expectedExceptionMessage Error attempting to authenticate against PAM: Invalid HTTP Code 0.
+     */
+    public function testCurlThrow() {
+        $config = $this->createMockModel(Config::class);
+        $config->method('getSubmittyPath')->willReturn($this->tmp_path);
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getSubmittyUser')->willReturn(true);
+        $core = $this->createMock(Core::class);
+        $core->method('getConfig')->willReturn($config);
+        $core->method('getQueries')->willReturn($queries);
+        $ch = curl_init();
+        $core->method('curlRequest')->willThrowException(new CurlException($ch, ''));
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $pam->authenticate();
+    }
+
+    /**
+     * @expectedException \app\exceptions\AuthenticationException
+     * @expectedExceptionMessage Could not create tmp user PAM file.
+     */
+    public function testCannotCreateFile() {
+        chmod(FileUtils::joinPaths($this->tmp_path, 'tmp', 'pam'), 0555);
+        $config = $this->createMockModel(Config::class);
+        $config->method('getSubmittyPath')->willReturn($this->tmp_path);
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getSubmittyUser')->willReturn(true);
+        $core = $this->createMock(Core::class);
+        $core->method('getConfig')->willReturn($config);
+        $core->method('getQueries')->willReturn($queries);
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $pam->authenticate();
+    }
+
+    /**
+     * @expectedException \app\exceptions\AuthenticationException
+     * @expectedExceptionMessage Error JSON response for PAM: Syntax error
+     */
+    public function testInvalidJsonResponse() {
+        $core = $this->getMockCore('{invalid_json: true}');
+
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $pam->authenticate();
+    }
+
+    /**
+     * @expectedException \app\exceptions\AuthenticationException
+     * @expectedExceptionMessage Missing response in JSON for PAM
+     */
+    public function testNoAuthenticatedKey() {
+        $core = $this->getMockCore('{"key": true}');
+
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('test');
+        $pam->authenticate();
+    }
+}


### PR DESCRIPTION
A bug was introduced where the tmp files that pam had created were not being properly cleaned up. Fixed that bug, and then added full test suite for the two authentication methods so that we don't have that bug again.