### PR TITLE
Java 8 Package Fix

### DIFF
--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -85,7 +85,28 @@ apt-get install -qqy python-clang-6.0
 
 # Install Oracle 8 Non-Interactively
 echo "installing java8"
-apt-get install -qqy oracle-java8-installer > /dev/null 2>&1
+
+# Try to install Java.... But sometimes they release new security updates faster
+# than the package managers
+
+# Run this in a subshell so it doesn't crash the script when Java fails to install
+GOT_JAVA=$(bash -c 'apt-get install -qqy oracle-java8-installer > /dev/null 2>&1; echo $?')
+# If it didn't work, our package manager is out of date so we need to 
+# patch in the updated version 
+if [ $GOT_JAVA -ne 0 ]; then
+    pushd .
+    # https://askubuntu.com/a/996986
+    cd /var/lib/dpkg/info
+    sed -i 's|JAVA_VERSION=8u171|JAVA_VERSION=8u181|' oracle-java8-installer.*
+    sed -i 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' oracle-java8-installer.*
+    sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' oracle-java8-installer.*
+    sed -i 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' oracle-java8-installer.*
+    popd
+    # Try again! If this fails then someone needs to update the above for whatever
+    # new version of Java has come out. 
+    apt-get install -qqy oracle-java8-installer > /dev/null 2>&1
+fi
+
 apt-get install -qqy oracle-java8-set-default
 
 # Install Image Magick for image comparison, etc.

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -109,7 +109,6 @@ fi
 
 apt-get install -qqy oracle-java8-set-default
 
-
 # Install Image Magick for image comparison, etc.
 apt-get install -qqy imagemagick
 

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -83,6 +83,15 @@ apt-get install -qqy cmake
 # for Lichen (Plagiarism Detection)
 apt-get -qqy install python-clang-3.8
 
+# https://askubuntu.com/a/996986
+pushd .
+cd /var/lib/dpkg/info
+sed -i 's|JAVA_VERSION=8u171|JAVA_VERSION=8u181|' oracle-java8-installer.*
+sed -i 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' oracle-java8-installer.*
+sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' oracle-java8-installer.*
+sed -i 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' oracle-java8-installer.*
+popd
+
 # Install Oracle 8 Non-Interactively
 echo "installing java8"
 apt-get install -qqy oracle-java8-installer > /dev/null 2>&1

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -86,7 +86,13 @@ apt-get -qqy install python-clang-3.8
 # Install Oracle 8 Non-Interactively
 echo "installing java8"
 
+# Try to install Java.... But sometimes they release new security updates faster
+# than the package managers
+
+# Run this in a subshell so it doesn't crash the script when Java fails to install
 GOT_JAVA=$(bash -c 'apt-get install -qqy oracle-java8-installer > /dev/null 2>&1; echo $?')
+# If it didn't work, our package manager is out of date so we need to 
+# patch in the updated version 
 if [ $GOT_JAVA -ne 0 ]; then
     pushd .
     # https://askubuntu.com/a/996986
@@ -96,6 +102,8 @@ if [ $GOT_JAVA -ne 0 ]; then
     sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' oracle-java8-installer.*
     sed -i 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' oracle-java8-installer.*
     popd
+    # Try again! If this fails then someone needs to update the above for whatever
+    # new version of Java has come out. 
     apt-get install -qqy oracle-java8-installer > /dev/null 2>&1
 fi
 

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -83,10 +83,10 @@ apt-get install -qqy cmake
 # for Lichen (Plagiarism Detection)
 apt-get -qqy install python-clang-3.8
 
-
 # Install Oracle 8 Non-Interactively
 echo "installing java8"
-GOT_JAVA=$(apt-get install -qqy oracle-java8-installer > /dev/null 2>&1)
+
+GOT_JAVA=$(bash -c 'apt-get install -qqy oracle-java8-installer > /dev/null 2>&1; echo $?')
 if [ $GOT_JAVA -ne 0 ]; then
     pushd .
     # https://askubuntu.com/a/996986
@@ -98,7 +98,9 @@ if [ $GOT_JAVA -ne 0 ]; then
     popd
     apt-get install -qqy oracle-java8-installer > /dev/null 2>&1
 fi
+
 apt-get install -qqy oracle-java8-set-default
+
 
 # Install Image Magick for image comparison, etc.
 apt-get install -qqy imagemagick

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -83,18 +83,21 @@ apt-get install -qqy cmake
 # for Lichen (Plagiarism Detection)
 apt-get -qqy install python-clang-3.8
 
-# https://askubuntu.com/a/996986
-pushd .
-cd /var/lib/dpkg/info
-sed -i 's|JAVA_VERSION=8u171|JAVA_VERSION=8u181|' oracle-java8-installer.*
-sed -i 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' oracle-java8-installer.*
-sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' oracle-java8-installer.*
-sed -i 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' oracle-java8-installer.*
-popd
 
 # Install Oracle 8 Non-Interactively
 echo "installing java8"
-apt-get install -qqy oracle-java8-installer > /dev/null 2>&1
+GOT_JAVA=$(apt-get install -qqy oracle-java8-installer > /dev/null 2>&1)
+if [ $GOT_JAVA -ne 0 ]; then
+    pushd .
+    # https://askubuntu.com/a/996986
+    cd /var/lib/dpkg/info
+    sed -i 's|JAVA_VERSION=8u171|JAVA_VERSION=8u181|' oracle-java8-installer.*
+    sed -i 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' oracle-java8-installer.*
+    sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' oracle-java8-installer.*
+    sed -i 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' oracle-java8-installer.*
+    popd
+    apt-get install -qqy oracle-java8-installer > /dev/null 2>&1
+fi
 apt-get install -qqy oracle-java8-set-default
 
 # Install Image Magick for image comparison, etc.


### PR DESCRIPTION
Webupd8 hasn't updated their java package yet and it's causing vagrant to fail. This is a janky (but hopefully functional) fix for that.