### PR TITLE
Fixed nav page exception with cancelled submission

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1387,11 +1387,9 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
                 $graded_gradeable->setTaGradedGradeable($ta_graded_gradeable);
             }
 
-            // This will be false if autograding hasn't run yet, or if the gradeable isn't electronic
-            if (isset($row['active_version'])) {
-                $auto_graded_gradeable = new AutoGradedGradeable($this->core, $graded_gradeable, $row);
-                $graded_gradeable->setAutoGradedGradeable($auto_graded_gradeable);
-            }
+            // Always construct an instance even if there is no data
+            $auto_graded_gradeable = new AutoGradedGradeable($this->core, $graded_gradeable, $row);
+            $graded_gradeable->setAutoGradedGradeable($auto_graded_gradeable);
 
             $graded_components = [];
             $graded_versions = [];

--- a/site/app/models/gradeable/AutoGradedGradeable.php
+++ b/site/app/models/gradeable/AutoGradedGradeable.php
@@ -140,7 +140,7 @@ class AutoGradedGradeable extends AbstractModel {
      * Gets if the autograding is finished for the active version (if one)
      * @return bool
      */
-    public function isAutogradingComplete() {
+    public function isAutoGradingComplete() {
         return $this->hasActiveVersion() && $this->getActiveVersionInstance()->isAutogradingComplete();
     }
 

--- a/site/app/models/gradeable/AutoGradedGradeable.php
+++ b/site/app/models/gradeable/AutoGradedGradeable.php
@@ -38,7 +38,7 @@ class AutoGradedGradeable extends AbstractModel {
     public function __construct(Core $core, GradedGradeable $graded_gradeable, array $details) {
         parent::__construct($core);
 
-        $this->setActiveVersion($details['active_version']);
+        $this->setActiveVersion($details['active_version'] ?? 0);
         if($graded_gradeable === null) {
             throw new \InvalidArgumentException('Graded gradeable cannot be null');
         }

--- a/site/app/models/gradeable/AutoGradedGradeable.php
+++ b/site/app/models/gradeable/AutoGradedGradeable.php
@@ -128,6 +128,22 @@ class AutoGradedGradeable extends AbstractModel {
         return $instance->getTotalPercent($clamp);
     }
 
+    /**
+     * Gets if the submitter has a version selected for grading
+     * @return bool
+     */
+    public function hasActiveVersion() {
+        return $this->active_version > 0;
+    }
+
+    /**
+     * Gets if the autograding is finished for the active version (if one)
+     * @return bool
+     */
+    public function isAutogradingComplete() {
+        return $this->hasActiveVersion() && $this->getActiveVersionInstance()->isAutogradingComplete();
+    }
+
     /* Queue status access methods */
 
     /**

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -105,15 +105,6 @@ class GradedGradeable extends AbstractModel {
         return $this->hasTaGradingInfo() && $this->ta_graded_gradeable->getPercentGraded() == 1;
     }
 
-    /**
-     * Gets whether the Auto grading has been completed for this submitter/gradeable for
-     *  the active version
-     * @return bool
-     */
-    public function isAutoGradingComplete() {
-        return $this->auto_graded_gradeable->getActiveVersion() > 0;
-    }
-
     /* Intentionally Unimplemented accessor methods */
 
     /** @internal */

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -11,7 +11,7 @@ use \app\models\AbstractModel;
  * @package app\models\gradeable
  *
  * @method string getGradeableId()
- * @method AutoGradedGradeable|null getAutoGradedGradeable()
+ * @method AutoGradedGradeable getAutoGradedGradeable()
  * @method TaGradedGradeable|null getTaGradedGradeable()
  * @method Submitter getSubmitter()
  */
@@ -106,21 +106,12 @@ class GradedGradeable extends AbstractModel {
     }
 
     /**
-     * Gets whether any Auto grading information exists for this submitter/gradeable
-     * Note: this will be false if the student's submission is in queue
-     * @return bool
-     */
-    public function hasAutoGradingInfo() {
-        return $this->auto_graded_gradeable !== null;
-    }
-
-    /**
      * Gets whether the Auto grading has been completed for this submitter/gradeable for
-     *  at least one submission
+     *  the active version
      * @return bool
      */
     public function isAutoGradingComplete() {
-        return $this->hasAutoGradingInfo() && $this->auto_graded_gradeable->getActiveVersion() > 0;
+        return $this->auto_graded_gradeable->getActiveVersion() > 0;
     }
 
     /* Intentionally Unimplemented accessor methods */

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -389,7 +389,7 @@ class NavigationView extends AbstractView {
             }
 
             // Submitted, currently after grade released date
-            if ($graded_gradeable->getAutoGradedGradeable()->isAutogradingComplete() &&
+            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
                 $list_section == GradeableList::GRADED) {
                 if ($gradeable->isTaGrading()) {
                     if (!$graded_gradeable->isTaGradingComplete()) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -368,13 +368,13 @@ class NavigationView extends AbstractView {
 
 
             //If the button is autograded and has been submitted once, give a progress bar.
-            if (!is_nan($points_percent) &&  $graded_gradeable->isAutoGradingComplete() &&
+            if (!is_nan($points_percent) &&  $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
                 ($list_section == GradeableList::CLOSED || $list_section == GradeableList::OPEN)) {
                 $progress = $points_percent * 100;
             }
 
             // Not submitted or cancelled, after submission deadline
-            if (!$graded_gradeable->isAutoGradingComplete() &&
+            if (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
                 ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
                 //You forgot to submit
                 $class = "btn-danger";
@@ -389,7 +389,7 @@ class NavigationView extends AbstractView {
             }
 
             // Submitted, currently after grade released date
-            if ($graded_gradeable->isAutoGradingComplete() &&
+            if ($graded_gradeable->getAutoGradedGradeable()->isAutogradingComplete() &&
                 $list_section == GradeableList::GRADED) {
                 if ($gradeable->isTaGrading()) {
                     if (!$graded_gradeable->isTaGradingComplete()) {
@@ -402,24 +402,24 @@ class NavigationView extends AbstractView {
                 }
             }
 
-            if ($graded_gradeable->isAutoGradingComplete() &&
+            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
                 $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() != 0 && $points_percent >= 0.5 &&
                 $list_section == GradeableList::CLOSED) {
                 $class = "btn-default";
             }
 
-            if ($graded_gradeable->isAutoGradingComplete() &&
+            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
                 ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
                 $display_date = "";
             }
 
-            if ($graded_gradeable->isAutoGradingComplete() && $list_section == GradeableList::OPEN) {
+            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::OPEN) {
                 //if the user submitted something on time
                 $title = "RESUBMIT";
-            } else if ($graded_gradeable->isAutoGradingComplete() && $list_section == GradeableList::CLOSED) {
+            } else if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::CLOSED) {
                 //if the user submitted something past time
                 $title = "LATE RESUBMIT";
-            } else if (!$graded_gradeable->isAutoGradingComplete() && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
+            } else if (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
                 //to change the text to overdue submission if nothing was submitted on time
                 $title = "OVERDUE SUBMISSION";
             } else if ($gradeable->isTaGrading() && !$graded_gradeable->isTaGradingComplete() && $list_section == GradeableList::GRADED) {


### PR DESCRIPTION
If a student has submissions for a gradeable, but no active version, the database method constructing the `GradedGradeable` will fail.  To remediate this, the `GradedGradeable` always has an `AutoGradedGradeable` even if there are no versions (empty array) and no active version (active version set to 0).  Going on the assumption that there will always be this instance also simplifies use of this class.