### PR TITLE
Sample data team rotating sections

### DIFF
--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -1039,7 +1039,7 @@ class Course(object):
                              team_id=unique_team_id,
                              g_id=gradeable.id,
                              registration_section=str(reg_section),
-                             rotation_section=None)
+                             rotating_section=str(random.randint(1, self.rotating_sections)))
                 self.conn.execute(teams_table.insert(),
                              team_id=unique_team_id, 
                              user_id=user.get_detail(self.code, "id"),

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -335,7 +335,7 @@ class ElectronicGraderView extends AbstractView {
             if ($row->isTeamAssignment()) {
                 if ($row->getTeam() === null) {
                     $reg_section = ($row->getUser()->getRegistrationSection() === null) ? "NULL" : $row->getUser()->getRegistrationSection();
-                    $rot_section = ($row->getUser()->getRotatingSection() === null) ? "NULL" : $row->getUser()->getRegistrationSection();
+                    $rot_section = ($row->getUser()->getRotatingSection() === null) ? "NULL" : $row->getUser()->getRotatingSection();
                     $info["team_edit_onclick"] = "adminTeamForm(true, '{$row->getUser()->getId()}', '{$reg_section}', '{$rot_section}', [], [], {$gradeable->getMaxTeamSize()});";
                 } else {
                     $user_assignment_setting_json = json_encode($row->getTeam()->getAssignmentSettings($gradeable));

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -825,6 +825,8 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
                 source: student_full
             });
         }
+        members_div.find('[name="reg_section"]').val(reg_section);
+        members_div.find('[name="rot_section"]').val(rot_section);
     }
     else {
         $('[name="new_team_user_id"]', form).val("");


### PR DESCRIPTION
Add rotating sections to teams in the sample data.
~~Remaining is making the instructor create team button on the grading page default to the rotating section of the student.~~

closes #2359 and closes #2345