### PR TITLE
Fixed gradeable build handling and unwritable file handling

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1053,7 +1053,7 @@ class AdminGradeableController extends AbstractController {
         ];
 
         $fp = $this->core->getConfig()->getCoursePath() . '/config/form/form_' . $gradeable->getId() . '.json';
-        if (file_put_contents($fp, json_encode($jsonProperties, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) === false) {
+        if (!is_writable($fp) || file_put_contents($fp, json_encode($jsonProperties, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) === false) {
             return "Failed to write to file {$fp}";
         }
         return null;
@@ -1073,7 +1073,7 @@ class AdminGradeableController extends AbstractController {
             "gradeable" => $g_id
         ];
 
-        if (file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false) {
+        if (!is_writable($config_build_file) || file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false) {
             return "Failed to write to file {$config_build_file}";
         }
         return null;

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -938,6 +938,10 @@ class AdminGradeableController extends AbstractController {
             return $errors;
         }
 
+        // Trigger a rebuild if the config / due date changes
+        $trigger_rebuild_props = ['autograding_config_path', 'submission_due_date'];
+        $trigger_rebuild = count(array_intersect($trigger_rebuild_props, array_keys($details))) > 0;
+
         $boolean_properties = [
             'grade_by_registration',
             'ta_grading',
@@ -989,9 +993,7 @@ class AdminGradeableController extends AbstractController {
             }
         }
 
-        // Trigger a rebuild if the config / due date changes
-        $trigger_rebuild = ['autograding_config_path', 'submission_due_date'];
-        if (count(array_intersect($trigger_rebuild, array_keys($details))) > 0) {
+        if ($trigger_rebuild) {
             $result = $this->enqueueBuild($gradeable);
             if ($result !== null) {
                 // TODO: what key should this get?


### PR DESCRIPTION
The gradeable config actually gets rebuilt on due date changes now.  Second, if the course is archived and the files/folders are not writable, there is no longer a warning emitted from `file_put_contents` and the error message properly gets sent back to the client.