### PR TITLE
Fixed error on wrong login password

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -116,7 +116,7 @@ class AuthenticationController extends AbstractController {
             $this->core->addErrorMessage("Could not login using that user id or password");
             foreach ($_REQUEST as $key => $value) {
                 if (substr($key, 0, 4) == "old_") {
-                    $redirect[$key] = $_REQUEST['old'][$value];
+                    $redirect[substr($key, 4)] = $value;
                 }
             }
             $this->core->redirect($this->core->buildUrl($redirect));


### PR DESCRIPTION
Login page no longer crashes when given an invalid password.

closes #2436