### PR TITLE
Quick fix for various View All things

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -349,6 +349,7 @@ class ElectronicGraderController extends GradingController {
         //Checks to see if the Grader has access to all users in the course,
         //Will only show the sections that they are graders for if not TA or Instructor
         $show_all = isset($_GET['view']) && $_GET['view'] === "all" && $this->core->getAccess()->canI("grading.details.show_all");
+
         $students = array();
         //If we are peer grading, load in all students to be graded by this peer.
         if ($peer) {
@@ -376,8 +377,6 @@ class ElectronicGraderController extends GradingController {
         if ($show_all) {
             $students = $this->core->getQueries()->getAllUsers($section_key);
         }
-        else{
-        }
         if(!$peer) {
             $student_ids = array_map(function(User $student) { return $student->getId(); }, $students);
         }
@@ -398,6 +397,7 @@ class ElectronicGraderController extends GradingController {
                 }
             }
         }
+        
         $rows = $this->core->getQueries()->getGradeables($gradeable_id, $student_ids, $section_key);
         if ($gradeable->isTeamAssignment()) {
             // Rearrange gradeables arrray into form (sec 1 teams, sec 1 individuals, sec 2 teams, sec 2 individuals, etc...)

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -397,7 +397,7 @@ class ElectronicGraderController extends GradingController {
                 }
             }
         }
-        
+
         $rows = $this->core->getQueries()->getGradeables($gradeable_id, $student_ids, $section_key);
         if ($gradeable->isTeamAssignment()) {
             // Rearrange gradeables arrray into form (sec 1 teams, sec 1 individuals, sec 2 teams, sec 2 individuals, etc...)

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -349,7 +349,6 @@ class ElectronicGraderController extends GradingController {
         //Checks to see if the Grader has access to all users in the course,
         //Will only show the sections that they are graders for if not TA or Instructor
         $show_all = isset($_GET['view']) && $_GET['view'] === "all" && $this->core->getAccess()->canI("grading.details.show_all");
-
         $students = array();
         //If we are peer grading, load in all students to be graded by this peer.
         if ($peer) {
@@ -374,14 +373,10 @@ class ElectronicGraderController extends GradingController {
             }
             $graders = $this->core->getQueries()->getGradersForRotatingSections($gradeable->getId(), $sections);
         }
-
-        //If there are no sections, see if we should show all instead
-        if (count($sections) === 0) {
-            $show_all = $this->core->getAccess()->canI("grading.details.show_all_no_sections");
-        }
-
         if ($show_all) {
             $students = $this->core->getQueries()->getAllUsers($section_key);
+        }
+        else{
         }
         if(!$peer) {
             $student_ids = array_map(function(User $student) { return $student->getId(); }, $students);
@@ -403,7 +398,6 @@ class ElectronicGraderController extends GradingController {
                 }
             }
         }
-
         $rows = $this->core->getQueries()->getGradeables($gradeable_id, $student_ids, $section_key);
         if ($gradeable->isTeamAssignment()) {
             // Rearrange gradeables arrray into form (sec 1 teams, sec 1 individuals, sec 2 teams, sec 2 individuals, etc...)

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -74,7 +74,7 @@ class Access {
         $this->permissions["grading.status.full"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
         $this->permissions["grading.details"] = self::ALLOW_MIN_STUDENT | self::CHECK_GRADEABLE_MIN_GROUP;
         $this->permissions["grading.details.show_all"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
-        $this->permissions["grading.details.show_all_no_sections"] = self::ALLOW_MIN_INSTRUCTOR;
+        $this->permissions["grading.details.show_all_no_sections"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
         $this->permissions["grading.details.show_empty_teams"] = self::ALLOW_MIN_INSTRUCTOR;
         $this->permissions["grading.grade"] = self::ALLOW_MIN_STUDENT | self::CHECK_GRADEABLE_MIN_GROUP | self::CHECK_GRADING_SECTION_GRADER | self::CHECK_PEER_ASSIGNMENT_STUDENT;
         $this->permissions["grading.grade.if_no_sections_exist"] = self::ALLOW_MIN_INSTRUCTOR;

--- a/site/app/templates/admin/users/GraderList.twig
+++ b/site/app/templates/admin/users/GraderList.twig
@@ -27,11 +27,7 @@
                     <td style="text-align: left">{{ grader.getLastName() }}</td>
                     <td>{{ groups[grader.getGroup()].name }}</td>
                     <td>
-                    {% if groups[grader.getGroup()].all_sections %}
-                        All
-                    {% else %}
-                        {{ grader.getGradingRegistrationSections()|join(", ") }}
-                    {% endif %}
+                    {{ grader.getGradingRegistrationSections()|join(", ") }}
                     </td>
                     <td><a onclick="editUserForm('{{ grader.getId() }}');"><i class="fa fa-pencil" aria-hidden="true"></i></a></td>
                 </tr>

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -140,10 +140,17 @@
     {# Bottom buttons #}
     <div style="margin-top: 20px; vertical-align:bottom;">
         {% if graded_percentage != -1 or core.getUser().accessFullGrading() or peer %}
+            {% if core.getUser().accessAdmin() %}
+            <a class="btn btn-primary"
+               href="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action' :  'details', 'gradeable_id' :  gradeable.getId(), 'view' : 'all' }) }}">
+            Grading Details
+            </a>
+            {% else %}
             <a class="btn btn-primary"
                href="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action' :  'details', 'gradeable_id' :  gradeable.getId(), 'view' : percentage == -1 ? 'all' : null}) }}">
             Grading Details
             </a>
+            {% endif %}
             {% if core.getUser().getGradingRegistrationSections()|length != 0 %}
                 <a class="btn btn-primary"
                    href="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action': 'grade', 'gradeable_id': gradeable.getId()}) }}">


### PR DESCRIPTION
Couple quick things
Fixes the no View All for Full access grader with no sections bug ( closes #2484 )
Instructors do not display "All" for sections by default in graders tab
Instructors will be in View All mode by default on the Grading Details Page