### PR TITLE
Jsend output methods

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -123,6 +123,63 @@ class Output {
         $this->useFooter(false);
         $this->useHeader(false);
     }
+
+    /**
+     * Renders a json response for the "success" case
+     *  (see http://submitty.org/developer/json_responses)
+     * @param mixed|null $data Optional response data
+     */
+    public function renderJsonSuccess($data = null) {
+        $this->renderJson([
+            'status' => 'success',
+            'data' => $data
+        ]);
+    }
+
+    /**
+     * Renders a json response for the "fail" case
+     *  (see http://submitty.org/developer/json_responses)
+     * @param string $message A non-blank failure message
+     * @param mixed|null $data Optional response data
+     * @param array $extra Extra data merged into the response array
+     */
+    public function renderJsonFail($message, $data = null, $extra = []) {
+        $response = [
+            'status' => 'fail',
+            'message' => $message,
+        ];
+
+        if ($data !== null) {
+            $response['data'] = $data;
+        }
+
+        // Merge $response second so it overwrites conflicting keys in $extra
+        $response = array_merge($extra, $response);
+        $this->renderJson($response);
+    }
+
+    /**
+     * Renders a json response for the "error" case
+     *  (see http://submitty.org/developer/json_responses)
+     * @param string $message A non-blank error message
+     * @param mixed|null $data Optional response data
+     * @param int $code Code to identify error case
+     */
+    public function renderJsonError($message, $data = null, $code = null) {
+        $response = [
+            'status' => 'error',
+            'message' => $message,
+            'data' => $data
+        ];
+
+        if ($data !== null) {
+            $response['data'] = $data;
+        }
+        if ($code !== null) {
+            $response['code'] = $code;
+        }
+        $this->renderJson($response);
+    }
     
     public function renderString($string) {
         $this->output_buffer .= $string;

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -127,7 +127,7 @@ class Output {
     /**
      * Renders a json response for the "success" case
      *  (see http://submitty.org/developer/json_responses)
-     * @param mixed|null $data Optional response data
+     * @param mixed|null $data Response data
      */
     public function renderJsonSuccess($data = null) {
         $this->renderJson([
@@ -140,7 +140,7 @@ class Output {
      * Renders a json response for the "fail" case
      *  (see http://submitty.org/developer/json_responses)
      * @param string $message A non-blank failure message
-     * @param mixed|null $data Optional response data
+     * @param mixed|null $data Response data
      * @param array $extra Extra data merged into the response array
      */
     public function renderJsonFail($message, $data = null, $extra = []) {
@@ -162,7 +162,7 @@ class Output {
      * Renders a json response for the "error" case
      *  (see http://submitty.org/developer/json_responses)
      * @param string $message A non-blank error message
-     * @param mixed|null $data Optional response data
+     * @param mixed|null $data Response data
      * @param int $code Code to identify error case
      */
     public function renderJsonError($message, $data = null, $code = null) {


### PR DESCRIPTION
(see #2362).  All json routes manually create the response structure to comply with our modified JSend response structure, which means many of these routes don't actually comply to the spec.  These additional methods in Output construct the response from the required and optional parameters for each response type.  Moving forward, these should be used instead of `Output::renderJson`.