### PR TITLE
Removed Mark Note Url Encoding from Model and put in View

### DIFF
--- a/site/app/models/GradeableComponentMark.php
+++ b/site/app/models/GradeableComponentMark.php
@@ -10,6 +10,8 @@ use app\libraries\Core;
  * @method int getGcId()
  * @method int getOrder()
  * @method float getPoints()
+ * @method string getNote()
+ * @method void setNote($note)
  * @method boolean getPublish()
  * @method boolean getHasMark()
  */
@@ -74,17 +76,10 @@ class GradeableComponentMark extends AbstractModel {
             return $this->core->getQueries()->deleteGradeableComponentMark($this);
         }
     }
-    public function setNote($temp_note) {
-        $this->note = urlencode($temp_note);
-    }
 
     //use this when inserting into the database
     public function getNoteNoDecode(){
         return ($this->note);
-    }
-
-    public function getNote() {
-        return(urldecode($this->note));
     }
 
     /**
@@ -110,7 +105,7 @@ class GradeableComponentMark extends AbstractModel {
     public function getGradedData() {
         return [
             "id" => $this->id,
-            "name" => $this->getNote(),
+            "name" => $this->note,
             "order" => $this->order,
             "points" => $this->points,
             "publish" => $this->publish,

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -52,7 +52,7 @@
                 data-component_index="{{ c_index }}"
                 data-mark_index="{{ m_id }}"
                 class="mark-note {% if not editable %} mark-uneditable {% endif %}"
-            >{{ mark.name }}</textarea>
+            >{{ mark.name|escape }}</textarea>
             <span id="mark_info_id-{{ c_index }}-{{ m_id }}" onclick="saveMark('{{ c_index }}' ); showMarklist(this); event.stopPropagation();">
                 <i class="fa fa-users icon-got-this-mark"></i>
             </span>
@@ -79,7 +79,7 @@
                 data-component_index="{{ c_index }}"
                 data-mark_index="{{ m_id }}"
                 class="mark-note {% if not editable %} mark-uneditable {% endif %}"
-            >{{ mark.name }}</textarea>
+            >{{ mark.name|escape }}</textarea>
             <span id="mark_info_id-{{ c_index }}-{{ m_id }}" onclick="saveMark('{{ c_index }}' ); showMarklist(this); event.stopPropagation();">
                 <i class="fa fa-users icon-got-this-mark"></i>
             </span>


### PR DESCRIPTION
In the old model, marks were url encoded before saved to the database.  The new model saves the original text in the database, so I updated the old gradeable to do the same.  The string escaping is now done in the view layer (twig.js in this case)

This should actually fix the issues @KCony has with mark names being url encoded.  Any existing names will need to be fixed, but the grading interface won't break the names anymore.