### PR TITLE
Upload Images Part 2

### DIFF
--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -19,8 +19,13 @@ class ImagesController extends AbstractController {
 
     public function viewImagesPage() {
         $user_group = $this->core->getUser()->getGroup();
-        if ($user_group === 4) { // student has no permissions to view image page
+        $images_course_path = $this->core->getConfig()->getCoursePath();
+        $images_path = Fileutils::joinPaths($images_course_path,"uploads/student_images");
+        $any_images_files = FileUtils::getAllFiles($images_path);
+        if ($user_group === 4 || (($user_group === 2 || $user_group === 3) && count($any_images_files) === 0)) { // student has no permissions to view image page
             $this->core->addErrorMessage("You have no permissions to see images.");
+            $this->core->redirect($this->core->getConfig()->getSiteUrl());
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')));
             return;
         }
         $grader_sections = $this->core->getUser()->getGradingRegistrationSections();

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -21,7 +21,7 @@ class ImagesController extends AbstractController {
         $user_group = $this->core->getUser()->getGroup();
         $images_course_path = $this->core->getConfig()->getCoursePath();
         $images_path = Fileutils::joinPaths($images_course_path,"uploads/student_images");
-        $any_images_files = FileUtils::getAllFiles($images_path);
+        $any_images_files = FileUtils::getAllFiles($images_path, array(), true);
         if ($user_group === 4 || (($user_group === 2 || $user_group === 3) && count($any_images_files) === 0)) { // student has no permissions to view image page
             $this->core->addErrorMessage("You have no permissions to see images.");
             $this->core->redirect($this->core->getConfig()->getSiteUrl());

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -110,27 +110,26 @@ class NavigationView extends AbstractView {
 	      // ======================================================================================
         // IMAGES BUTTON -- visible to limited access graders and up
         // ======================================================================================
-               $images_course_path = $this->core->getConfig()->getCoursePath();
-                $images_path = Fileutils::joinPaths($images_course_path,"uploads/student_images");
-               $any_images_files = FileUtils::getAllFiles($images_path);
-                //$this->core->addErrorMessage(count($any_images_files));
-               if ($this->core->getUser()->getGroup()=== 1 && count($any_images_files)===0) {
-                   $top_buttons[] = new Button($this->core, [
-                       "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
-                       "title" => "Upload Student Photos",
-                       "class" => "btn btn-primary"
+        $images_course_path = $this->core->getConfig()->getCoursePath();
+        $images_path = Fileutils::joinPaths($images_course_path,"uploads/student_images");
+        $any_images_files = FileUtils::getAllFiles($images_path, array(), true);
+        if ($this->core->getUser()->getGroup()=== 1 && count($any_images_files)===0) {
+            $top_buttons[] = new Button($this->core, [
+                "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
+                "title" => "Upload Student Photos",
+                "class" => "btn btn-primary"
+            ]);
+        }
+        else if (count($any_images_files)!==0 && $this->core->getUser()->accessGrading()) {
+            $sections = $this->core->getUser()->getGradingRegistrationSections();
+                if (!empty($sections) || $this->core->getUser()->getGroup() !== 3) {
+                    $top_buttons[] = new Button($this->core, [
+                        "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
+                        "title" => "View Student Photos",
+                        "class" => "btn btn-primary"
                     ]);
-               }
-               else if (!empty($any_images_files) && $this->core->getUser()->accessGrading()) {
-                     $sections = $this->core->getUser()->getGradingRegistrationSections();
-                         if (!empty($sections) || $this->core->getUser()->getGroup() !== 3) {
-                             $top_buttons[] = new Button($this->core, [
-                               "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
-                               "title" => "View Student Photos",
-                               "class" => "btn btn-primary"
-                            ]);
-                       }
-              }
+                }
+        }
 
         // ======================================================================================
         // CREATE NEW GRADEABLE BUTTON -- only visible to instructors

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -122,13 +122,13 @@ class NavigationView extends AbstractView {
         }
         else if (count($any_images_files)!==0 && $this->core->getUser()->accessGrading()) {
             $sections = $this->core->getUser()->getGradingRegistrationSections();
-                if (!empty($sections) || $this->core->getUser()->getGroup() !== 3) {
-                    $top_buttons[] = new Button($this->core, [
-                        "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
-                        "title" => "View Student Photos",
-                        "class" => "btn btn-primary"
-                    ]);
-                }
+            if (!empty($sections) || $this->core->getUser()->getGroup() !== 3) {
+                $top_buttons[] = new Button($this->core, [
+                    "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
+                    "title" => "View Student Photos",
+                    "class" => "btn btn-primary"
+                ]);
+            }
         }
 
         // ======================================================================================

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -110,16 +110,27 @@ class NavigationView extends AbstractView {
 	      // ======================================================================================
         // IMAGES BUTTON -- visible to limited access graders and up
         // ======================================================================================
-        if ($this->core->getUser()->accessGrading()) {
-            $sections = $this->core->getUser()->getGradingRegistrationSections();
-                if (!empty($sections) || $this->core->getUser()->getGroup() !== 3) {
-                    $top_buttons[] = new Button($this->core, [
-                        "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
-                        "title" => "View Student Photos",
-                        "class" => "btn btn-primary"
+               $images_course_path = $this->core->getConfig()->getCoursePath();
+                $images_path = Fileutils::joinPaths($images_course_path,"uploads/student_images");
+               $any_images_files = FileUtils::getAllFiles($images_path);
+                //$this->core->addErrorMessage(count($any_images_files));
+               if ($this->core->getUser()->getGroup()=== 1 && count($any_images_files)===0) {
+                   $top_buttons[] = new Button($this->core, [
+                       "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
+                       "title" => "Upload Student Photos",
+                       "class" => "btn btn-primary"
                     ]);
-                }
-        }
+               }
+               else if (!empty($any_images_files) && $this->core->getUser()->accessGrading()) {
+                     $sections = $this->core->getUser()->getGradingRegistrationSections();
+                         if (!empty($sections) || $this->core->getUser()->getGroup() !== 3) {
+                             $top_buttons[] = new Button($this->core, [
+                               "href" => $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')),
+                               "title" => "View Student Photos",
+                               "class" => "btn btn-primary"
+                            ]);
+                       }
+              }
 
         // ======================================================================================
         // CREATE NEW GRADEABLE BUTTON -- only visible to instructors

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -14,6 +14,7 @@ class ImagesView extends AbstractView {
      * @return string
      */
     public function listStudentImages($students, $grader_sections, $instructor_permission) {
+        $this->core->getOutput()->addBreadcrumb("Student Photos", $this->core->buildUrl(array('component' => 'grading', 'page' => 'images', 'action' => 'view_images_page')));
         //Assemble students into sections if they are in grader_sections based on the registration section.
         $sections = [];
         foreach ($students as $student) {
@@ -23,7 +24,7 @@ class ImagesView extends AbstractView {
             }
         }
 
-		
+
         //$images_data_array to contain base64_encoded image urls
         $images_data_array = array();
         //$images_names_array to contain the names of the images (rcs ids)
@@ -32,7 +33,7 @@ class ImagesView extends AbstractView {
 
         //Get the expected images path and png files to loop through
         $expected_images_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "student_images");
-	
+
         $dir = new \DirectoryIterator($expected_images_path);
         foreach ($dir as $fileinfo) {
             if (!$fileinfo->isDot() && $fileinfo->getExtension() === "png") {


### PR DESCRIPTION
Closes #2508 
Upload button changes in the above issue. Added a breadcrumb for student photos. Fixed some permissions preventing students from getting into instructor link of student photos as well as full-access graders and limited-access grader when appropriate (no student photos).