### PR TITLE
Fixed TA lab grading always failing

### DIFF
--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -53,6 +53,12 @@ class TaGradedGradeable extends AbstractModel {
         $this->setOverallComment($details['overall_comment'] ?? '');
         $this->setUserViewedDate($details['user_viewed_date'] ?? null);
         $this->graded_gradeable->getGradeable()->setJustRegraded($details['just_regraded'] ?? false);
+
+        // Default to all blank components
+        foreach ($graded_gradeable->getGradeable()->getComponents() as $component) {
+            $this->graded_component_containers[$component->getId()] = new GradedComponentContainer($core, $this, $component);
+        }
+
         $this->modified = false;
     }
 


### PR DESCRIPTION
The `TaGradedGradeable` doesn't initialize its `graded_component_containers` well.  It relies on being constructed from the postgres db query correctly, but in the case that no grades exist and the instance is generated as a blank, then the containers array isn't initialized.  This adds code to construct blank component containers.