### PR TITLE
Full access grader team submit nav page button displays properly if not on team

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -450,7 +450,7 @@ class NavigationView extends AbstractView {
                 if ($list_section > GradeableList::OPEN) {
                     $class = "btn-danger";
                     if ($this->core->getUser()->accessFullGrading()) {
-                        // team assignment, no team (admin)
+                        // team assignment, no team (full access grader)
                         $title = "OVERDUE SUBMISSION";
                         $disabled = false;
                     }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -443,11 +443,13 @@ class NavigationView extends AbstractView {
             // This means either the user isn't on a team, or has no submissions yet
             if ($gradeable->isTeamAssignment()) {
                 // team assignment, no team
-                $title = "MUST BE ON A TEAM TO SUBMIT";
-                $disabled = true;
+                if (!$this->core->getUser()->accessFullGrading()) {
+                    $title = "MUST BE ON A TEAM TO SUBMIT";
+                    $disabled = true;
+                }
                 if ($list_section > GradeableList::OPEN) {
                     $class = "btn-danger";
-                    if ($this->core->getUser()->accessAdmin()) {
+                    if ($this->core->getUser()->accessFullGrading()) {
                         // team assignment, no team (admin)
                         $title = "OVERDUE SUBMISSION";
                         $disabled = false;

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -440,7 +440,7 @@ class NavigationView extends AbstractView {
                 $title = "TA GRADE NOT AVAILABLE";
             }
         } else {
-            // This means either the user isn't on a team, or has no submissions yet
+            // This means either the user isn't on a team
             if ($gradeable->isTeamAssignment()) {
                 // team assignment, no team
                 if (!$this->core->getUser()->accessFullGrading()) {


### PR DESCRIPTION
If the user was a full access grader and was not on a team, the submit button indicated that they `MUST BE ON A TEAM TO SUBMIT` when they should get the same view as the instructor for `OVERDUE SUBMISSION` since full access graders can submit for students.