### PR TITLE
Removed out-of-place code from new model

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -68,7 +68,6 @@ use app\models\User;
  * @method float getPrecision()
  * @method void setPrecision($grading_precision)
  * @method Component[] getComponents()
- * @method bool getJustRegraded()
  */
 class Gradeable extends AbstractModel {
     /* Properties for all types of gradeables */
@@ -171,8 +170,6 @@ class Gradeable extends AbstractModel {
     protected $submission_due_date = null;
     /** @property @var int The number of late days allowed */
     protected $late_days = 0;
-    /** @property @var boolean Has the gradeable been regraded recently (the student hasn't yet viewed the result*/
-    protected $just_regraded = false;
     /**
      * Gradeable constructor.
      * @param Core $core
@@ -849,9 +846,6 @@ class Gradeable extends AbstractModel {
             }
         }
         return $count;
-    }
-    public function setJustRegraded($bool) {
-        $this->just_regraded=$bool;
     }
 
     /**

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -52,7 +52,6 @@ class TaGradedGradeable extends AbstractModel {
         $this->setIdFromDatabase($details['id'] ?? 0);
         $this->setOverallComment($details['overall_comment'] ?? '');
         $this->setUserViewedDate($details['user_viewed_date'] ?? null);
-        $this->graded_gradeable->getGradeable()->setJustRegraded($details['just_regraded'] ?? false);
 
         // Default to all blank components
         foreach ($graded_gradeable->getGradeable()->getComponents() as $component) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -405,11 +405,10 @@ class NavigationView extends AbstractView {
 
             // TA grading enabled, the gradeable is fully graded, and the user hasn't viewed it
             if ($gradeable->isTaGrading() && $graded_gradeable->isTaGradingComplete() &&
-                ($ta_graded_gradeable->getUserViewedDate() === null || $gradeable->getJustRegraded() === true) &&
+                $ta_graded_gradeable->getUserViewedDate() === null &&
                 $list_section === GradeableList::GRADED) {
                 //Graded and you haven't seen it yet
                 $class = "btn-success";
-                $gradeable->setJustRegraded(false);
             }
             // Submitted, currently after grade released date
             if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&


### PR DESCRIPTION
There was a `just_regraded` field added to the `Gradeable` class (both versions).  I do not know what the plans are for this variable, but it doesn't belong in the `gradeable\Gradeable` class.  As described in the class-doc, this class is only for the configuration of a gradeable.

It appears like this variable is being used to notify the user if they have new regrade messages, but this should be done using a notification system shared (at least somewhat) with the forum, et al.  Since notifications need to be per-user, not per submitter, it probably should not be in the GradedGradeable model either.