### PR TITLE
Use json_agg when loading from the model, prevent \ issues

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -318,36 +318,36 @@ LEFT JOIN electronic_gradeable AS eg ON eg.g_id=g.g_id
 LEFT JOIN (
   SELECT
     g_id,
-    array_agg(gc_is_peer) as array_gc_is_peer,
-    array_agg(gc_id) as array_gc_id,
-    array_agg(gc_title) AS array_gc_title,
-    array_agg(gc_ta_comment) AS array_gc_ta_comment,
-    array_agg(gc_student_comment) AS array_gc_student_comment,
-    array_agg(gc_lower_clamp) AS array_gc_lower_clamp,
-    array_agg(gc_default) AS array_gc_default,
-    array_agg(gc_max_value) AS array_gc_max_value,
-    array_agg(gc_upper_clamp) AS array_gc_upper_clamp,
-    array_agg(gc_is_text) AS array_gc_is_text,
-    array_agg(gc_order) AS array_gc_order,
-    array_agg(gc_page) AS array_gc_page,
-    array_agg(array_gcm_id) AS array_array_gcm_id,
-    array_agg(array_gc_id) AS array_array_gc_id,
-    array_agg(array_gcm_points) AS array_array_gcm_points,
-    array_agg(array_gcm_note) AS array_array_gcm_note,
-    array_agg(array_gcm_publish) AS array_array_gcm_publish,
-    array_agg(array_gcm_order) AS array_array_gcm_order
+    json_agg(gc_is_peer) as array_gc_is_peer,
+    json_agg(gc_id) as array_gc_id,
+    json_agg(gc_title) AS array_gc_title,
+    json_agg(gc_ta_comment) AS array_gc_ta_comment,
+    json_agg(gc_student_comment) AS array_gc_student_comment,
+    json_agg(gc_lower_clamp) AS array_gc_lower_clamp,
+    json_agg(gc_default) AS array_gc_default,
+    json_agg(gc_max_value) AS array_gc_max_value,
+    json_agg(gc_upper_clamp) AS array_gc_upper_clamp,
+    json_agg(gc_is_text) AS array_gc_is_text,
+    json_agg(gc_order) AS array_gc_order,
+    json_agg(gc_page) AS array_gc_page,
+    json_agg(array_gcm_id) AS array_array_gcm_id,
+    json_agg(array_gc_id) AS array_array_gc_id,
+    json_agg(array_gcm_points) AS array_array_gcm_points,
+    json_agg(array_gcm_note) AS array_array_gcm_note,
+    json_agg(array_gcm_publish) AS array_array_gcm_publish,
+    json_agg(array_gcm_order) AS array_array_gcm_order
   FROM
   (SELECT gc.*, gcm.array_gcm_id, gcm.array_gc_id, gcm.array_gcm_points, array_gcm_note, array_gcm_publish, array_gcm_order
   FROM gradeable_component AS gc
   LEFT JOIN(
     SELECT
       gc_id,
-      array_to_string(array_agg(gcm_id), ',') as array_gcm_id,
-      array_to_string(array_agg(gc_id), ',') as array_gc_id,
-      array_to_string(array_agg(gcm_points), ',') as array_gcm_points,
-      array_to_string(array_agg(gcm_note), ',') as array_gcm_note,
-      array_to_string(array_agg(gcm_publish), ',') as array_gcm_publish,
-      array_to_string(array_agg(gcm_order), ',') as array_gcm_order
+      json_agg(gcm_id) as array_gcm_id,
+      json_agg(gc_id) as array_gc_id,
+      json_agg(gcm_points) as array_gcm_points,
+      json_agg(gcm_note) as array_gcm_note,
+      json_agg(gcm_publish) as array_gcm_publish,
+      json_agg(gcm_order) as array_gcm_order
     FROM gradeable_component_mark
     GROUP BY gc_id
   ) AS gcm
@@ -377,25 +377,25 @@ LEFT JOIN (
   LEFT JOIN (
     SELECT
       gcd.gd_id,
-      array_agg(gc_id) AS array_gcd_gc_id,
-      array_agg(gcd_score) AS array_gcd_score,
-      array_agg(gcd_component_comment) AS array_gcd_component_comment,
-      array_agg(gcd_grader_id) AS array_gcd_grader_id,
-      array_agg(gcd_graded_version) AS array_gcd_graded_version,
-      array_agg(gcd_grade_time) AS array_gcd_grade_time,
-      array_agg(array_gcm_mark) AS array_array_gcm_mark,
-      array_agg(u.user_id) AS array_gcd_user_id,
-      array_agg(u.anon_id) AS array_gcd_anon_id,
-      array_agg(u.user_firstname) AS array_gcd_user_firstname,
-      array_agg(u.user_preferred_firstname) AS array_gcd_user_preferred_firstname,
-      array_agg(u.user_lastname) AS array_gcd_user_lastname,
-      array_agg(u.user_email) AS array_gcd_user_email,
-      array_agg(u.user_group) AS array_gcd_user_group
+      json_agg(gc_id) AS array_gcd_gc_id,
+      json_agg(gcd_score) AS array_gcd_score,
+      json_agg(gcd_component_comment) AS array_gcd_component_comment,
+      json_agg(gcd_grader_id) AS array_gcd_grader_id,
+      json_agg(gcd_graded_version) AS array_gcd_graded_version,
+      json_agg(gcd_grade_time) AS array_gcd_grade_time,
+      json_agg(array_gcm_mark) AS array_array_gcm_mark,
+      json_agg(u.user_id) AS array_gcd_user_id,
+      json_agg(u.anon_id) AS array_gcd_anon_id,
+      json_agg(u.user_firstname) AS array_gcd_user_firstname,
+      json_agg(u.user_preferred_firstname) AS array_gcd_user_preferred_firstname,
+      json_agg(u.user_lastname) AS array_gcd_user_lastname,
+      json_agg(u.user_email) AS array_gcd_user_email,
+      json_agg(u.user_group) AS array_gcd_user_group
     FROM(
         SELECT gcd.* , gcmd.array_gcm_mark
         FROM gradeable_component_data AS gcd
         LEFT JOIN (
-          SELECT gc_id, gd_id, gcd_grader_id, array_to_string(array_agg(gcm_id), ',') as array_gcm_mark
+          SELECT gc_id, gd_id, gcd_grader_id, json_agg(gcm_id) as array_gcm_mark
           FROM gradeable_component_mark_data AS gcmd
           GROUP BY gc_id, gd_id, gd_id, gcd_grader_id
         ) as gcmd
@@ -482,7 +482,7 @@ ORDER BY ".implode(", ", $order_by);
                 $bools = array('gc_is_text', 'gc_is_peer');
                 foreach ($fields as $key) {
                     if (isset($row['array_' . $key])) {
-                        $row['array_' . $key] = $this->core->getCourseDB()->fromDatabaseToPHPArray($row['array_' . $key], in_array($key, $bools));
+                        $row['array_' . $key] = json_decode($row['array_' . $key], true);
                     }
                 }
             }

--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -137,13 +137,6 @@ class GradeableComponent extends AbstractModel {
         if (isset($details['array_gcm_id'])) {
             $mark_fields = array('gcm_id', 'gc_id', 'gcm_points', 'gcm_publish',
                                     'gcm_note', 'gcm_order');
-            foreach ($mark_fields as $key) {
-                $details["array_{$key}"] = explode(',', $details["array_{$key}"]);
-            }
-
-            if (isset($details['array_gcm_mark'])) {
-                $details['array_gcm_mark'] = explode(',', $details['array_gcm_mark']);
-            }
             for ($i = 0; $i < count($details['array_gcm_id']); $i++) {
                 $mark_details = array();
                 foreach ($mark_fields as $key) {

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -31,6 +31,9 @@ function getComponent(c_index) {
  * @returns Object Mark data
  */
 function getMark(c_index, m_id){
+    //FIXME: This hurts me deep inside
+    c_index = parseInt(c_index);
+    m_id = parseInt(m_id);
     var marks = grading_data.gradeable.components[c_index-1].marks;
     for(var i=0; i<marks.length; i++){
         if(marks[i].id === m_id){


### PR DESCRIPTION
Currently, if a mark note ends in a backslash, the entire page breaks. This is because `fromDatabaseToPHPArray` cannot handle backslashes nor the large majority of weird escaped strings. To fix, I swapped array_agg with json_agg because JSON is capable of data (de)serialization without errors.