### PR TITLE
Fixed nav page Gradeable order

### DIFF
--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -102,8 +102,8 @@ class GradeableList extends AbstractModel {
         $sort_array = array(
             'future_gradeables' => 'getGradeStartDate',
             'beta_gradeables' => 'getGradeStartDate',
-            'open_gradeables' => 'getDueDate',
-            'closed_gradeables' => 'getDueDate',
+            'open_gradeables' => 'getSubmissionDueDate',
+            'closed_gradeables' => 'getSubmissionDueDate',
             'grading_gradeables' => 'getGradeStartDate',
             'graded_gradeables' => 'getGradeReleasedDate'
         );


### PR DESCRIPTION
The `GradeableList` was still using the date getters from the old model when sorting.  This updates the names of the date getters to match the new model.  This was causing the order `beta` and `open` gradeables appeared to not match the nav page before the refactor.