### PR TITLE
Regrade requests table supports teams

### DIFF
--- a/migration/data/course_tables.sql
+++ b/migration/data/course_tables.sql
@@ -1068,6 +1068,7 @@ ALTER TABLE "viewed_responses" ADD CONSTRAINT "viewed_responses_fk1" FOREIGN KEY
 
 ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk0" FOREIGN KEY ("g_id") REFERENCES "gradeable"("g_id");
 ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk1" FOREIGN KEY ("user_id") REFERENCES "users"("user_id");
+ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk2" FOREIGN KEY ("team_id") REFERENCES "gradeable_teams"("team_id");
 
 ALTER TABLE "regrade_discussion" ADD CONSTRAINT "regrade_discussion_fk0" FOREIGN KEY ("regrade_id") REFERENCES "regrade_requests"("id");
 ALTER TABLE "regrade_discussion" ADD CONSTRAINT "regrade_discussion_fk1" FOREIGN KEY ("user_id") REFERENCES "users"("user_id");

--- a/migration/data/course_tables.sql
+++ b/migration/data/course_tables.sql
@@ -479,9 +479,10 @@ CREATE TABLE teams (
 --
 CREATE TABLE regrade_requests (
     id serial NOT NULL PRIMARY KEY,
-    gradeable_id VARCHAR(255) NOT NULL,
+    g_id VARCHAR(255) NOT NULL,
     timestamp TIMESTAMP NOT NULL,
-    student_id VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255),
+    team_id VARCHAR(255),
     status INTEGER DEFAULT 0 NOT NULL
 );
 
@@ -1065,8 +1066,8 @@ ALTER TABLE "student_favorites" ADD CONSTRAINT "student_favorites_fk1" FOREIGN K
 ALTER TABLE "viewed_responses" ADD CONSTRAINT "viewed_responses_fk0" FOREIGN KEY ("thread_id") REFERENCES "threads"("id");
 ALTER TABLE "viewed_responses" ADD CONSTRAINT "viewed_responses_fk1" FOREIGN KEY ("user_id") REFERENCES "users"("user_id");
 
-ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk0" FOREIGN KEY ("gradeable_id") REFERENCES "gradeable"("g_id");
-ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk1" FOREIGN KEY ("student_id") REFERENCES "users"("user_id");
+ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk0" FOREIGN KEY ("g_id") REFERENCES "gradeable"("g_id");
+ALTER TABLE "regrade_requests" ADD CONSTRAINT "regrade_requests_fk1" FOREIGN KEY ("user_id") REFERENCES "users"("user_id");
 
 ALTER TABLE "regrade_discussion" ADD CONSTRAINT "regrade_discussion_fk0" FOREIGN KEY ("regrade_id") REFERENCES "regrade_requests"("id");
 ALTER TABLE "regrade_discussion" ADD CONSTRAINT "regrade_discussion_fk1" FOREIGN KEY ("user_id") REFERENCES "users"("user_id");
@@ -1079,6 +1080,12 @@ ALTER TABLE ONLY thread_categories
 
 ALTER TABLE ONLY student_favorites
     ADD CONSTRAINT user_and_thread_unique UNIQUE (user_id, thread_id);
+
+ALTER TABLE ONLY regrade_requests
+    ADD CONSTRAINT gradeable_user_unique UNIQUE(g_id, user_id);
+
+ALTER TABLE ONLY regrade_requests
+    ADD CONSTRAINT gradeable_team_unique UNIQUE(g_id, team_id);
 
 -- End Forum Key relationships
 

--- a/migration/migrations/course/20180730032400_regrade_request_teams.py
+++ b/migration/migrations/course/20180730032400_regrade_request_teams.py
@@ -1,0 +1,23 @@
+def up(config, conn, semester, course):
+    with conn.cursor() as cursor:
+        cursor.execute('ALTER TABLE regrade_requests RENAME COLUMN gradeable_id TO g_id')
+        cursor.execute('ALTER TABLE regrade_requests RENAME COLUMN student_id TO user_id')
+
+        cursor.execute("SELECT * FROM regrade_requests LIMIT 0")
+        colnames = [desc[0] for desc in cursor.description]
+
+        if 'team_id' not in colnames:
+            cursor.execute('ALTER TABLE regrade_requests ADD COLUMN team_id VARCHAR(255)')
+
+        cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT gradeable_user_unique UNIQUE(g_id, user_id)')
+        cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT gradeable_team_unique UNIQUE(g_id, team_id)')
+
+
+
+def down(config, conn, semester, course):
+    with conn.cursor() as cursor:
+        cursor.execute('ALTER TABLE regrade_requests RENAME COLUMN g_id TO gradeable_id')
+        cursor.execute('ALTER TABLE regrade_requests RENAME COLUMN user_id TO student_id')
+
+        cursor.execute('ALTER TABLE regrade_requests DROP CONSTRAINT gradeable_user_unique')
+        cursor.execute('ALTER TABLE regrade_requests DROP CONSTRAINT gradeable_team_unique;')

--- a/migration/migrations/course/20180730032400_regrade_request_teams.py
+++ b/migration/migrations/course/20180730032400_regrade_request_teams.py
@@ -11,6 +11,7 @@ def up(config, conn, semester, course):
 
         cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT gradeable_user_unique UNIQUE(g_id, user_id)')
         cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT gradeable_team_unique UNIQUE(g_id, team_id)')
+        cursor.execute('ALTER TABLE regrade_requests ALTER COLUMN user_id DROP NOT NULL')
 
 
 
@@ -20,4 +21,4 @@ def down(config, conn, semester, course):
         cursor.execute('ALTER TABLE regrade_requests RENAME COLUMN user_id TO student_id')
 
         cursor.execute('ALTER TABLE regrade_requests DROP CONSTRAINT gradeable_user_unique')
-        cursor.execute('ALTER TABLE regrade_requests DROP CONSTRAINT gradeable_team_unique;')
+        cursor.execute('ALTER TABLE regrade_requests DROP CONSTRAINT gradeable_team_unique')

--- a/migration/migrations/course/20180730032400_regrade_request_teams.py
+++ b/migration/migrations/course/20180730032400_regrade_request_teams.py
@@ -8,6 +8,7 @@ def up(config, conn, semester, course):
 
         if 'team_id' not in colnames:
             cursor.execute('ALTER TABLE regrade_requests ADD COLUMN team_id VARCHAR(255)')
+            cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT regrade_requests_fk2 FOREIGN KEY (team_id) REFERENCES gradeable_teams(team_id)')
 
         cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT gradeable_user_unique UNIQUE(g_id, user_id)')
         cursor.execute('ALTER TABLE regrade_requests ADD CONSTRAINT gradeable_team_unique UNIQUE(g_id, team_id)')

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2402,15 +2402,15 @@ AND gc_id IN (
         return $this->submitty_db->row()['active'];
 
     }
-    public function getRegradeRequestStatus($student_id, $gradeable_id){
-        $row = $this->course_db->query("SELECT * FROM regrade_requests WHERE student_id = ? AND gradeable_id = ? ", array($student_id, $gradeable_id));
+    public function getRegradeRequestStatus($user_id, $gradeable_id){
+        $row = $this->course_db->query("SELECT * FROM regrade_requests WHERE user_id = ? AND g_id = ? ", array($user_id, $gradeable_id));
         $result = ($this->course_db->row()) ? $row['status'] : 0;
         return $result;
     }
     public function insertNewRegradeRequest($gradeable_id, $student_id,$content){
         $params = array($gradeable_id, $student_id, -1);
         try{
-            $this->course_db->query("INSERT INTO regrade_requests(gradeable_id, timestamp, student_id, status) VALUES (?, current_timestamp, ?, ?)", $params);
+            $this->course_db->query("INSERT INTO regrade_requests(g_id, timestamp, user_id, status) VALUES (?, current_timestamp, ?, ?)", $params);
             $regrade_id = $this->getRegradeRequestID($gradeable_id,$student_id);
             $this->insertNewRegradePost($regrade_id,$gradeable_id,$student_id,$content);
             return true;
@@ -2420,7 +2420,7 @@ AND gc_id IN (
         }
     }
     public function getNumberRegradeRequests($gradeable_id){
-        $this->course_db->query("SELECT COUNT(*) AS cnt FROM regrade_requests WHERE gradeable_id = ? AND status = -1", array($gradeable_id));
+        $this->course_db->query("SELECT COUNT(*) AS cnt FROM regrade_requests WHERE g_id = ? AND status = -1", array($gradeable_id));
         return ($this->course_db->row()['cnt']); 
     }
     public function getRegradeDiscussion($regrade_id){
@@ -2432,7 +2432,7 @@ AND gc_id IN (
         return $result;
     }
     public function getRegradeRequestID($gradeable_id,$student_id){
-        $row = $this->course_db->query("SELECT id FROM regrade_requests WHERE gradeable_id = ? AND student_id = ?", array($gradeable_id,$student_id));
+        $row = $this->course_db->query("SELECT id FROM regrade_requests WHERE g_id = ? AND user_id = ?", array($gradeable_id,$student_id));
         $result = ($this->course_db->row()) ? $row['id'] : -1;
         return $result;
     }


### PR DESCRIPTION
Closes #2370.

Added a migration to allow the `regrade_requests` table to support teams as well as users (symmetric to how `gradeable_data` supports teams/users).  Also updated the database queries that access these fields.

The  motivation behind this is to associate a regrade request with a submitter, so it can be associated with a `GradedGradeable` in a way symmetric to how the rest of the new model functions.

Tested: migrate->rollback->migrate without any errors.
The regrade request ecosystem seems to also be working as before