### PR TITLE
Fix nav page custom banner not being raw

### DIFF
--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -2,7 +2,7 @@
 
 {% if display_custom_message %}
     <div class="content">
-        {{ message_file_contents }}
+        {{ message_file_contents|raw }}
     </div>
 {% endif %}
 


### PR DESCRIPTION
Currently if you use custom html in the banner on the nav page it shows up escaped. So this will fix that.