### PR TITLE
Course settings page allows blank course name

### DIFF
--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -42,9 +42,6 @@ class ConfigurationController extends AbstractController {
             'room_seating_gradeable_id'      => $this->core->getConfig()->getRoomSeatingGradeableId()
         );
 
-        // this is not displaying the value being stored in the config, should be fixed (also default value needs to be fixed)
-        $fields['course_name'] = $this->core->getDisplayedCourseName();
-
         if (isset($_SESSION['request'])) {
             foreach (array('upload_message', 'course_email', 'regrade_message') as $key) {
                 if (isset($_SESSION['request'][$key])) {
@@ -88,12 +85,7 @@ class ConfigurationController extends AbstractController {
         }
         $entry = $_POST['entry'];
 
-        if($name === "course_name") {
-            if($entry === "") {
-                return $this->core->getOutput()->renderJsonFail('Course name cannot be blank');
-            }
-        }
-        else if($name === "room_seating_gradeable_id") {
+        if($name === "room_seating_gradeable_id") {
             $gradeable_seating_options = $this->getGradeableSeatingOptions();
             $gradeable_ids = array();
             foreach($gradeable_seating_options as $option) {

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -1,13 +1,13 @@
 <div class="content">
     <h2>Course Settings</h2>
-    <form id="configForm" method="post" action="{{ core.buildUrl({'component': 'admin', 'page': 'configuration', 'action': 'update'}) }}">
+    <div id="config">
         <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
         <div class="panel">
             <div class="option">
-                <div class="option-input"><input class="required" type="text" name="course_name" value="{{ fields['course_name']|raw }}" placeholder="(Required)" /></div>
+                <div class="option-input"><input type="text" name="course_name" value="{{ fields['course_name']|raw }}" /></div>
                 <div class="option-desc">
-                    <div class="option-title">Course Name</div>
-                    <div class="option-alt">Input the course name that should appear in the header of the site</div>
+                    <div class="option-title">Full Course Name</div>
+                    <div class="option-alt">Input the course name that should appear in the header of the site (your course code is {{ core.getConfig().getCourse() }})</div>
                 </div>
             </div>
 
@@ -165,5 +165,5 @@
                 </div>
             </div>
         </div>
-    </form>
+    </div>
 </div>


### PR DESCRIPTION
The course settings page was not allowed to accept a blank course name previously, but now it will.

Also, it is displaying the proper value for the course name instead of the displayed course name (which was causing it to display the course code for courses with blank names).

closes #2637 
