### PR TITLE
Improved behavior of gradeable date getter function

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -947,7 +947,6 @@ class AdminGradeableController extends AbstractController {
             try {
                 $gradeable->setDates($dates);
                 $updated_properties = $gradeable->getDateStrings();
-                $updated_properties['late_days'] = $gradeable->getLateDays();
             } catch (ValidationException $e) {
                 $errors = array_merge($errors, $e->getDetails());
             }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -581,19 +581,20 @@ class Gradeable extends AbstractModel {
     }
 
     /**
-     * Gets all of the gradeable's date values indexed by property name
-     * @return \DateTime[]
+     * Gets all of the gradeable's date values indexed by property name (including late_days)
+     * @return mixed[]
      */
     public function getDates() {
         $dates = [];
         foreach(self::date_properties as $property) {
             $dates[$property] = $this->$property;
         }
+        $dates['late_days'] = $this->late_days;
         return $dates;
     }
 
     /**
-     * Gets all of the gradeable's date values as strings indexed by property name
+     * Gets all of the gradeable's date values as strings indexed by property name (including late_days)
      * @return string[]
      */
     public function getDateStrings() {
@@ -601,6 +602,7 @@ class Gradeable extends AbstractModel {
         foreach (self::date_properties as $property) {
             $dates[$property] = DateUtils::dateTimeToString($this->$property);
         }
+        $dates['late_days'] = strval($this->late_days);
         return $dates;
     }
 


### PR DESCRIPTION
You would expect that calling `gradeable->setDates(gradeable->getDates())` would result in no change of the gradeable state, but the current implementation of `getDates` does not include the `late_days` property, which is utilized in the `setDates` function.  This small PR simply adds `late_days` to the return of `getDates`.