### PR TITLE
Install script fix

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -545,11 +545,11 @@ if [ ${WORKER} == 0 ]; then
     su postgres -c "psql -c \"DO \\\$do\\\$ BEGIN IF NOT EXISTS ( SELECT FROM  pg_catalog.pg_roles WHERE  rolname = '${DB_USER}') THEN  CREATE ROLE ${DB_USER} LOGIN PASSWORD '${dbuser_password}'; END IF; END \\\$do\\\$;\""
 
     # check to see if a submitty master database exists
-    DB_EXISTS=`su -c 'psql -lqt | cut -d \| -f 1 | grep -w submitty' postgres`
+    DB_EXISTS=`su -c 'psql -lqt | cut -d \| -f 1 | grep -w submitty || true' postgres`
 
     if [ "$DB_EXISTS" == "" ]; then
 	echo "Submitty master database does not yet exist"
-	PGPASSWORD=${dbuser_password} psql -d postgres -h localhost -U ${DB_USER} -c "IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'submitty') THEN CREATE DATABASE submitty"
+	PGPASSWORD=${dbuser_password} psql -d postgres -h localhost -U ${DB_USER} -c "CREATE DATABASE submitty;"
 	python3 ${SUBMITTY_REPOSITORY}/migration/migrator.py -e master -e system migrate --initial
     else
 	echo "Submitty master database already exists"


### PR DESCRIPTION
On Vagrant 16.04 was getting an error due to grep returning 1 when results are empty, and then a syntax error on the `CREATE DATABASE` in the event that the `submitty` DB didn't yet exist.

This patches both those things; not sure what happens on live or 18.04