### PR TITLE
Remove deprecated database_name field from course settings

### DIFF
--- a/site/config/course_template.ini
+++ b/site/config/course_template.ini
@@ -1,9 +1,6 @@
 [database_details]
 dbname=__CREATE_COURSE__FILLIN__TAGRADING_DATABASE_NAME__
 
-[hidden_details]
-database_name=__CREATE_COURSE__FILLIN__TAGRADING_DATABASE_NAME__
-
 [course_details]
 course_name=""
 course_home_url=""


### PR DESCRIPTION
We moved from using hidden_details.database_name to database_details.dbname in #1359 and left the original in as we moved the system over to using the new field in subsequent PRs. Given that those subsequent PRs have been since merged and this field is no longer ever used anywhere, we should just remove it from the `course_settings.ini` since having it both is potentially confusing.