### PR TITLE
Fixed TA grading mark saving and custom mark errors

### DIFF
--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -1039,7 +1039,7 @@ function saveLastOpenedMark(sync, successCallback, errorCallback) {
 
     // Find open mark
     var index = 1;
-    var mark = $('#marks-parent-' + index);
+    var mark = $('#mark-table-' + index);
     while(mark.length > 0) {
         // If mark is open, then save it
         if (mark[0].style.display !== 'none') {
@@ -1047,7 +1047,7 @@ function saveLastOpenedMark(sync, successCallback, errorCallback) {
             saveMark(index, sync, successCallback, errorCallback);
             return;
         }
-        mark = $('#marks-parent-' + (++index));
+        mark = $('#mark-table-' + (++index));
     }
     // If no open mark was found, then save general comment
     saveGeneralComment(sync, successCallback, errorCallback);

--- a/site/public/js/ta-grading-mark.js
+++ b/site/public/js/ta-grading-mark.js
@@ -89,7 +89,7 @@ function updateCustomMarkText(me) {
 
 //if type == 0 number input, type == 1 textarea
 function checkIfSelected(me) {
-    var table_row = $(me.parentElement);
+    var table_row = $(me.parentElement.parentElement.parentElement);
     var is_selected = false;
     var icon = table_row.find(".mark");
     var number_input = table_row.find("input");


### PR DESCRIPTION
Closes #2677

I'm not sure why this error started happening, but these couple of line fixes appear to make grading and editing work as before.  The problem was that the selector used to check if a component was open was the `tbody` not the `table` and the `table` is what had the `display: none` style that was being checked against.  The custom mark issue is that the makeup of the custom mark cell may have been changed and `me.parentElement` did not evaluate to the `tr` element as expected, rather it evaluated to one of the other nested elements inside of the `td` that the custom mark message is in.