### PR TITLE
Misc Gradeable Date Fixes

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -947,7 +947,6 @@ class AdminGradeableController extends AbstractController {
             try {
                 $gradeable->setDates($dates);
                 $updated_properties = $gradeable->getDateStrings();
-                $updated_properties['late_days'] = $gradeable->getLateDays();
             } catch (ValidationException $e) {
                 $errors = array_merge($errors, $e->getDetails());
             }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -597,11 +597,12 @@ class Gradeable extends AbstractModel {
      * @return string[]
      */
     public function getDateStrings() {
-        $dates = [];
-        foreach (self::date_properties as $property) {
-            $dates[$property] = DateUtils::dateTimeToString($this->$property);
+        $date_strings = [];
+        $now = new \DateTime('now', $this->core->getConfig()->getTimezone());
+        foreach ($this->getDates() as $date_prop => $date_val) {
+            $date_strings[$date_prop] = DateUtils::dateTimeToString($date_val ?? $now);
         }
-        return $dates;
+        return $date_strings;
     }
 
     /**

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -581,27 +581,29 @@ class Gradeable extends AbstractModel {
     }
 
     /**
-     * Gets all of the gradeable's date values indexed by property name
-     * @return \DateTime[]
+     * Gets all of the gradeable's date values indexed by property name (including late_days)
+     * @return mixed[]
      */
     public function getDates() {
         $dates = [];
-        foreach(self::date_properties as $property) {
+        foreach (self::date_properties as $property) {
             $dates[$property] = $this->$property;
         }
+        $dates['late_days'] = $this->late_days;
         return $dates;
     }
 
     /**
-     * Gets all of the gradeable's date values as strings indexed by property name
+     * Gets all of the gradeable's date values as strings indexed by property name (including late_days)
      * @return string[]
      */
     public function getDateStrings() {
         $date_strings = [];
         $now = new \DateTime('now', $this->core->getConfig()->getTimezone());
-        foreach ($this->getDates() as $date_prop => $date_val) {
-            $date_strings[$date_prop] = DateUtils::dateTimeToString($date_val ?? $now);
+        foreach (self::date_properties as $property) {
+            $date_strings[$property] = DateUtils::dateTimeToString($this->$property ?? $now);
         }
+        $date_strings['late_days'] = strval($this->late_days);
         return $date_strings;
     }
 

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -475,13 +475,13 @@ class Gradeable extends AbstractModel {
 
         // Check that the grades released date isn't before the 'max due date' (submission due date + late days)
         $submission_due_date = $dates['submission_due_date'];
-        if ($this->type === GradeableType::ELECTRONIC_FILE && $this->isStudentSubmit() && $submission_due_date !== null) {
+        if ($this->type === GradeableType::ELECTRONIC_FILE && $submission_due_date !== null) {
             $late_days = intval($dates['late_days'] ?? 0);
             /** @noinspection PhpUnhandledExceptionInspection */
             $max_due_date = (clone $submission_due_date)->add(new \DateInterval('P' . strval($late_days) . 'D'));
             if ($max_due_date > $dates['grade_released_date']) {
                 $errors['grade_released_date'] = self::date_display_names['grade_released_date'] . ' Date must be later than the ' .
-                    self::date_display_names['submission_due_date'] . ' + ' . self::date_display_names['late_days'];
+                    self::date_display_names['submission_due_date'] . ' Date + ' . self::date_display_names['late_days'];
             }
         }
 


### PR DESCRIPTION
Closes #2704

Fixes the error with null dates being stringified when the shouldn't have been. (#2704)

If the 'student submit' setting was changed to 'yes', the dates will fail validation if the late days extend after the grades released date, but not immediately.  It will fail the next time its loaded from the database, which will make the gradeable uneditable.  This fix just requires the due date + late days to be before the release date regardless of if students can submit.  We may want to change this behavior in the future, but this is important to fix now.