### PR TITLE
Fix diff viewer indenting

### DIFF
--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -56,7 +56,6 @@
 .line_number {
     color: gray;
     border-right: 1px solid lightgrey;
-    float: left;
     text-align: right;
     width: auto;
 }


### PR DESCRIPTION
An extra `float: left` was causing the lines to float right when your resolution was too small. Closes #2194