### PR TITLE
Fix INSTALL_SUBMITTY_HELPER scripts not setting variables in Vagrant

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
@@ -7,7 +7,7 @@
 
 echo -e "Copy the user scripts"
 
-if [ -z ${SUBMITTY_INSTALL_DIR+x} ]; then
+if [ -z ${DAEMON_USER+x} ]; then
     CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../../../config
     SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
     SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)

--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -6,7 +6,7 @@
 
 echo -e "Copy the submission website"
 
-if [ -z ${SUBMITTY_INSTALL_DIR+x} ]; then
+if [ -z ${PHP_USER+x} ]; then
     # constants are not initialized,
     CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../../../config
     SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)


### PR DESCRIPTION
With #2421 being merged, the variables these two scripts were checking for are now always defined in Vagrant. This fixes it by checking for a different variable that isn't always set.