### PR TITLE
Use POST request to check pam authentication

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -282,11 +282,6 @@ mkdir -p ${SUBMITTY_DATA_DIR}/tmp
 chown root:root ${SUBMITTY_DATA_DIR}/tmp
 chmod 511 ${SUBMITTY_DATA_DIR}/tmp
 
-# tmp folder to hold files for PAM authentication. Needs to be writable by PHP_USER and only readable by CGI_USER
-mkdir -p ${SUBMITTY_DATA_DIR}/tmp/pam
-chown ${PHP_USER}:${CGI_USER} ${SUBMITTY_DATA_DIR}/tmp/pam
-chmod 750 ${SUBMITTY_DATA_DIR}/tmp/pam
-
 ########################################################################################################################
 ########################################################################################################################
 # RSYNC NOTES

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -453,15 +453,26 @@ class Core {
      * assuming that we
      *
      * @param string $url
+     * @param mixed $data
      *
      * @return string
      *
      * @throws \app\exceptions\CurlException
      */
-    public function curlRequest(string $url) {
+    public function curlRequest(string $url, $data = null) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        if (!empty($data)) {
+            if (is_array($data)) {
+                $data = http_build_query($data);
+            }
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [
+                'Content-Type: application/x-www-form-urlencoded; charset=utf-8',
+            ]);
+            curl_setopt($ch, CURLOPT_POST, 1);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        }
         try {
             $return = curl_exec($ch);
             $http_code = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);

--- a/site/cgi-bin/pam_check.cgi
+++ b/site/cgi-bin/pam_check.cgi
@@ -9,27 +9,11 @@ import cgi
 # If things are not working, then this should be enabled for better troubleshooting
 # import cgitb; cgitb.enable()
 import json
-import os
 import pam
 
 print("Content-type: text/html")
 print()
 
-current_dir = os.path.dirname(os.path.realpath(__file__))
-with open(os.path.join(current_dir, '..', '..', 'config', 'submitty.json'), 'r') as open_file:
-    info = json.load(open_file)
-tmp_path = os.path.join(info['submitty_data_dir'], 'tmp', 'pam')
-
-authenticated = False
-try:
-    arguments = cgi.FieldStorage()
-    # prevent a user from figuring out a way of passing a path instead of a filename
-    f = os.path.basename(arguments['file'].value)
-    with open(os.path.join(tmp_path, f), "r") as read_file:
-        j = json.loads(read_file.read())
-        p = pam.pam()
-        authenticated = p.authenticate(j['username'], j['password'])
-except:
-    pass
-
-print(json.dumps({"authenticated": authenticated}))
+arguments = cgi.FieldStorage(environ={'REQUEST_METHOD':'POST'})
+p = pam.pam()
+print(json.dumps({"authenticated": p.authenticate(arguments['username'].value, arguments['password'].value)}))

--- a/site/tests/app/authentication/PamAuthenticationTester.php
+++ b/site/tests/app/authentication/PamAuthenticationTester.php
@@ -12,30 +12,11 @@ use app\models\Config;
 use tests\BaseUnitTest;
 
 class PamAuthenticationTester extends BaseUnitTest {
-    /** @var string */
-    private $tmp_path;
-    public function setUp() {
-        $this->tmp_path = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
-        FileUtils::createDir(FileUtils::joinPaths($this->tmp_path, 'tmp', 'pam'), 0777, true);
-    }
-
-    /**
-     * We have to do this tearDown as a shutdown function due to the fact that the PamAuthentication
-     */
-    public function tearDown() {
-        FileUtils::recursiveChmod($this->tmp_path, 0777);
-        $iter = new \FilesystemIterator(FileUtils::joinPaths($this->tmp_path, 'tmp', 'pam'), \FilesystemIterator::SKIP_DOTS);
-        $this->assertEquals(0, iterator_count($iter));
-        $this->assertTrue(FileUtils::recursiveRmdir($this->tmp_path));
-    }
 
     private function getMockCore($curl_response) {
-        $config = $this->createMockModel(Config::class);
-        $config->method('getSubmittyPath')->willReturn($this->tmp_path);
         $queries = $this->createMock(DatabaseQueries::class);
         $queries->method('getSubmittyUser')->willReturn(true);
         $core = $this->createMock(Core::class);
-        $core->method('getConfig')->willReturn($config);
         $core->method('getQueries')->willReturn($queries);
         $core->method('curlRequest')->willReturn($curl_response);
         return $core;
@@ -105,35 +86,12 @@ class PamAuthenticationTester extends BaseUnitTest {
      * @expectedExceptionMessage Error attempting to authenticate against PAM: Invalid HTTP Code 0.
      */
     public function testCurlThrow() {
-        $config = $this->createMockModel(Config::class);
-        $config->method('getSubmittyPath')->willReturn($this->tmp_path);
         $queries = $this->createMock(DatabaseQueries::class);
         $queries->method('getSubmittyUser')->willReturn(true);
         $core = $this->createMock(Core::class);
-        $core->method('getConfig')->willReturn($config);
         $core->method('getQueries')->willReturn($queries);
         $ch = curl_init();
         $core->method('curlRequest')->willThrowException(new CurlException($ch, ''));
-        /** @noinspection PhpParamsInspection */
-        $pam = new PamAuthentication($core);
-        $pam->setUserId('test');
-        $pam->setPassword('test');
-        $pam->authenticate();
-    }
-
-    /**
-     * @expectedException \app\exceptions\AuthenticationException
-     * @expectedExceptionMessage Could not create tmp user PAM file.
-     */
-    public function testCannotCreateFile() {
-        chmod(FileUtils::joinPaths($this->tmp_path, 'tmp', 'pam'), 0555);
-        $config = $this->createMockModel(Config::class);
-        $config->method('getSubmittyPath')->willReturn($this->tmp_path);
-        $queries = $this->createMock(DatabaseQueries::class);
-        $queries->method('getSubmittyUser')->willReturn(true);
-        $core = $this->createMock(Core::class);
-        $core->method('getConfig')->willReturn($config);
-        $core->method('getQueries')->willReturn($queries);
         /** @noinspection PhpParamsInspection */
         $pam = new PamAuthentication($core);
         $pam->setUserId('test');

--- a/site/tests/app/authentication/PamAuthenticationTester.php
+++ b/site/tests/app/authentication/PamAuthenticationTester.php
@@ -14,9 +14,11 @@ use tests\BaseUnitTest;
 class PamAuthenticationTester extends BaseUnitTest {
 
     private function getMockCore($curl_response) {
+        $config = $this->createMockModel(Config::class);
         $queries = $this->createMock(DatabaseQueries::class);
         $queries->method('getSubmittyUser')->willReturn(true);
         $core = $this->createMock(Core::class);
+        $core->method('getConfig')->willReturn($config);
         $core->method('getQueries')->willReturn($queries);
         $core->method('curlRequest')->willReturn($curl_response);
         return $core;
@@ -86,9 +88,11 @@ class PamAuthenticationTester extends BaseUnitTest {
      * @expectedExceptionMessage Error attempting to authenticate against PAM: Invalid HTTP Code 0.
      */
     public function testCurlThrow() {
+        $config = $this->createMockModel(Config::class);
         $queries = $this->createMock(DatabaseQueries::class);
         $queries->method('getSubmittyUser')->willReturn(true);
         $core = $this->createMock(Core::class);
+        $core->method('getConfig')->willReturn($config);
         $core->method('getQueries')->willReturn($queries);
         $ch = curl_init();
         $core->method('curlRequest')->willThrowException(new CurlException($ch, ''));


### PR DESCRIPTION
This removes the need for writing user credentials to a file to do the PAM check which improves the overall security model, while simplifying the directory structure/permissions/needs.