### PR TITLE
Fix permissions on scripts when running just the HELPER_BIN

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
@@ -81,3 +81,14 @@ else
 fi
 chmod 750 ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils
 chmod 550 ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils/*
+
+# set the permissions here in the case we JUST run this script or else things will break
+if [ -f ${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute ]; then
+    chgrp ${DAEMON_GROUP}  ${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute
+    chmod 4550             ${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute
+fi
+
+if [ -f ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out ]; then
+    chown root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out
+    chmod 550                           ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out
+fi


### PR DESCRIPTION
Creation/installation of these two scripts belong in the primary "SUBMITTY_INSTALL_HELPER" as at least the case of the second one, it requires running the "fillin_variables" function which I didn't want to fully import for these smaller quick scripts, but I at least don't want the permissions to break when just running them one-off. I do dislike that I've duplicated the chown/chmod from the primary script to here, though I'm not sure what the better solution might be.