### PR TITLE
Fix one_part_only flag to properly prune excess parts

### DIFF
--- a/grading/main_compile.cpp
+++ b/grading/main_compile.cpp
@@ -20,65 +20,6 @@
 #include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
 
-// =====================================================================
-// =====================================================================
-
-void CleanUpMultipleParts() {
-
-  std::cout << "Clean up multiple parts" << std::endl;
-  boost::filesystem::path top( boost::filesystem::current_path() );
-
-  // collect the part directories that have files
-  std::set<boost::filesystem::path> non_empty_parts;
-
-  // loop over all of the part directories 
-  // NOTE: not necessarily sorted.  OS dependent.  Put in std::set to sort!
-  boost::filesystem::directory_iterator end_iter;
-  for (boost::filesystem::directory_iterator top_itr( top ); top_itr != end_iter; ++top_itr) {
-    boost::filesystem::path part_path = top_itr->path();
-    if (!is_directory(part_path)) {
-      continue;
-    }
-    std::string path_name = part_path.string();
-    if (path_name.find("part") == std::string::npos) {
-      continue;
-    }
-
-    int count = 0;
-    for (boost::filesystem::directory_iterator part_itr( part_path ); part_itr != end_iter; ++part_itr) {
-      count++;
-    }
-    std::cout << "part: " << part_path.string() << " " << count << std::endl;
-    if (count > 0) {
-      non_empty_parts.insert(part_path);
-    }
-  }
-
-  if (non_empty_parts.size() > 1) {
-
-    std::cout << "ERROR!  Student submitted to multiple parts in violation of instructions.\nRemoving files from all but first non empty part." << std::endl;
-
-    // collect files to remove
-    std::vector<boost::filesystem::path> remove_this;
-
-    std::set<boost::filesystem::path>::iterator itr = non_empty_parts.begin();
-    // skip (keep contents of) first part directory
-    itr++;
-    while (itr != non_empty_parts.end()) {
-      for (boost::filesystem::directory_iterator part_itr( *itr ); part_itr != end_iter; ++part_itr) {
-        remove_this.push_back(part_itr->path());
-      }
-      itr++;
-    }
-
-    // remove those files
-    for (int i = 0; i < remove_this.size(); i++) {
-      std::cout << "REMOVE: " << remove_this[i].string() << std::endl;
-      boost::filesystem::remove(remove_this[i]);
-    }
-  }
-}
-
 
 // =====================================================================
 // =====================================================================
@@ -117,14 +58,6 @@ int main(int argc, char *argv[]) {
   std::cout << "Compiling User Code..." << std::endl;
 
   system("find . -type f -exec ls -sh {} +");
-
-  // if it's a "one part only" assignment, check if student
-  // submitted to multiple parts
-  bool one_part_only = config_json.value("one_part_only",false);
-  if (one_part_only) {
-    CleanUpMultipleParts();
-  }
-  
 
   // Run each COMPILATION TEST
   nlohmann::json::iterator tc = config_json.find("testcases");

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -132,6 +132,47 @@ def unzip_this_file(zipfilename,path):
     zip_ref.close()
 
 
+def clean_parts(path, log_path=os.devnull):
+    """
+    Given a path to a directory, iterate through the directory and detect folders that start with
+    "part". If there is more than one and they have files, then delete all of the part folders except
+    for the first one that has files.
+
+    An example would be if you had the folder structure:
+    part1/
+        test.py
+    part2/
+        test.cpp
+
+    Then the part2 folder would be deleted, leaving just the part1 folder.
+
+    :param path: string filepath to directory to scan for parts in
+    :param log_path: string filepath to file to write print statements to
+    """
+    if not os.path.isdir(path):
+        return
+    with open(log_path, 'a') as log:
+        clean_directories = []
+        print('Clean up multiple parts', file=log)
+        for entry in sorted(os.listdir(path)):
+            full_path = os.path.join(path, entry)
+            if not os.path.isdir(full_path) or not entry.startswith('part'):
+                continue
+            count = len(os.listdir(full_path))
+            print('{}: {}'.format(entry, count), file=log)
+            if count > 0:
+                clean_directories.append(full_path)
+
+        if len(clean_directories) > 1:
+            print("ERROR!  Student submitted to multiple parts in violation of instructions.\n"
+                  "Removing files from all but first non empty part.", file=log)
+
+            for i in range(1, len(clean_directories)):
+                print("REMOVE: {}".format(clean_directories[i]), file=log)
+                for entry in os.listdir(clean_directories[i]):
+                    print("  -> {}".format(entry), file=log)
+                shutil.rmtree(clean_directories[i])
+
 
 # ==================================================================================
 # ==================================================================================
@@ -177,6 +218,33 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
         grading_began_longstring = f.read()
     grading_began = dateutils.read_submitty_date(grading_began_longstring)
 
+    submission_path = os.path.join(tmp_submission, "submission")
+    checkout_path = os.path.join(tmp_submission, "checkout")
+
+    provided_code_path = os.path.join(tmp_autograding, "provided_code")
+    test_input_path = os.path.join(tmp_autograding, "test_input")
+    test_output_path = os.path.join(tmp_autograding, "test_output")
+    custom_validation_code_path = os.path.join(tmp_autograding, "custom_validation_code")
+    bin_path = os.path.join(tmp_autograding, "bin")
+    form_json_config = os.path.join(tmp_autograding, "form.json")
+    complete_config = os.path.join(tmp_autograding, "complete_config.json")
+
+    with open(form_json_config, 'r') as infile:
+        gradeable_config_obj = json.load(infile)
+    gradeable_deadline_string = gradeable_config_obj["date_due"]
+
+    with open(complete_config, 'r') as infile:
+        complete_config_obj = json.load(infile)
+
+    is_vcs = gradeable_config_obj["upload_type"] == "repository"
+    checkout_subdirectory = complete_config_obj["autograding"].get("use_checkout_subdirectory","")
+    checkout_subdir_path = os.path.join(checkout_path, checkout_subdirectory)
+
+    if complete_config_obj.get('one_part_only', False):
+        clean_parts(submission_path, os.path.join(tmp_logs, "overall.txt"))
+        if is_vcs:
+            clean_parts(checkout_subdir_path, os.path.join(tmp_logs, "overall.txt"))
+
     # --------------------------------------------------------------------
     # START DOCKER
 
@@ -205,30 +273,8 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
     os.mkdir(tmp_compilation)
     os.chdir(tmp_compilation)
 
-    submission_path = os.path.join(tmp_submission,"submission")
-    checkout_path = os.path.join(tmp_submission,"checkout")
-
-    provided_code_path = os.path.join(tmp_autograding,"provided_code")
-    test_input_path = os.path.join(tmp_autograding,"test_input")
-    test_output_path = os.path.join(tmp_autograding,"test_output")
-    custom_validation_code_path = os.path.join(tmp_autograding,"custom_validation_code")
-    bin_path = os.path.join(tmp_autograding,"bin")
-    form_json_config = os.path.join(tmp_autograding,"form.json")
-    complete_config = os.path.join(tmp_autograding,"complete_config.json")
-
-
-    with open(form_json_config, 'r') as infile:
-        gradeable_config_obj = json.load(infile)
-    gradeable_deadline_string = gradeable_config_obj["date_due"]
-    
-    with open(complete_config, 'r') as infile:
-        complete_config_obj = json.load(infile)
     patterns_submission_to_compilation = complete_config_obj["autograding"]["submission_to_compilation"]
     pattern_copy("submission_to_compilation",patterns_submission_to_compilation,submission_path,tmp_compilation,tmp_logs)
-
-    is_vcs = gradeable_config_obj["upload_type"]=="repository"
-    checkout_subdirectory = complete_config_obj["autograding"].get("use_checkout_subdirectory","")
-    checkout_subdir_path = os.path.join(checkout_path,checkout_subdirectory)
 
     if is_vcs:
         pattern_copy("checkout_to_compilation",patterns_submission_to_compilation,checkout_subdir_path,tmp_compilation,tmp_logs)
@@ -239,7 +285,7 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
     subprocess.call(['ls', '-lR', '.'], stdout=open(tmp_logs + "/overall.txt", 'a'))
 
     # copy compile.out to the current directory
-    shutil.copy (os.path.join(bin_path,"compile.out"),os.path.join(tmp_compilation,"my_compile.out"))
+    shutil.copy(os.path.join(bin_path, "compile.out"), os.path.join(tmp_compilation, "my_compile.out"))
 
     # give the untrusted user read/write/execute permissions on the tmp directory & files
     add_permissions_recursive(tmp_compilation,


### PR DESCRIPTION
Closes #2727 and #2721 

Changes the output of the cleanup process slightly which makes it a bit easier to read in my opinion, but I can change it back if so wanted.

```
Clean up multiple parts
part1: 1
part2: 1
part3: 1
part4: 1
ERROR!  Student submitted to multiple parts in violation of instructions.
Removing files from all but first non empty part.
REMOVE: /var/local/submitty/autograding_tmp/untrusted00/tmp/TMP_SUBMISSION/submission/part2
  -> python3.py
REMOVE: /var/local/submitty/autograding_tmp/untrusted00/tmp/TMP_SUBMISSION/submission/part3
  -> c.c
REMOVE: /var/local/submitty/autograding_tmp/untrusted00/tmp/TMP_SUBMISSION/submission/part4
  -> cpp.cpp
```