### PR TITLE
Update Descriptions for Automatic Validators to be More Specific and Make Port Assignment Deterministic

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -357,7 +357,7 @@ void AddDefaultGrader(const std::string &command,
   j["method"] = "warnIfNotEmpty";
   j["actual_file"] = filename;
   if (filename.find("STDOUT") != std::string::npos) {
-    j["description"] = "Standard Output (STDOUT)";
+    j["description"] = "Standard Output ("+filename+")";
   } else if (filename.find("STDERR") != std::string::npos) {
     std::string program_name = get_program_name(command,whole_config);
     if (program_name == "/usr/bin/python") {
@@ -367,7 +367,7 @@ void AddDefaultGrader(const std::string &command,
     } else if (program_name == "/usr/bin/javac") {
       j["description"] = "syntax error output from running javac";
     } else {
-      j["description"] = "Standard Error (STDERR)";
+      j["description"] = "Standard Error ("+filename+")";
     }
   } else {
     j["description"] = "DEFAULTING TO "+filename;

--- a/sbin/autograder/grade_item_main_runner.py
+++ b/sbin/autograder/grade_item_main_runner.py
@@ -305,7 +305,7 @@ def network_containers(container_info,target_folder,test_input_folder,job_id,is_
   current_port = 9000
   connection_list = []
   router_connections = {}
-  for name, info in container_info.items():
+  for name, info in sorted(container_info.items()):
       my_name = "{0}_{1}".format(which_untrusted, name)
       network_name = "{0}_network".format(my_name)
       #pass in docker names by environment variables -e DOCKER_NAME={0}

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_does_not_compile
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_does_not_compile
@@ -51,7 +51,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR_0.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test02/STDERR_0.txt'",
@@ -61,7 +61,7 @@
                 },
                 {
                     "actual_file": "test02/STDERR_1.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR_1.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -93,7 +93,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test03/STDERR.txt'",
@@ -133,7 +133,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR_0.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test04/STDERR_0.txt'",
@@ -143,7 +143,7 @@
                 },
                 {
                     "actual_file": "test04/STDERR_1.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR_1.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -174,7 +174,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR_0.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test05/STDERR_0.txt'",
@@ -184,7 +184,7 @@
                 },
                 {
                     "actual_file": "test05/STDERR_1.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR_1.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_c
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_c
@@ -10,7 +10,7 @@
                 },
                 {
                     "actual_file": "test01/STDERR.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -36,7 +36,7 @@
                 },
                 {
                     "actual_file": "test02/STDERR.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -110,7 +110,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test06/STDERR.txt'",

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_cpp
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_cpp
@@ -10,7 +10,7 @@
                 },
                 {
                     "actual_file": "test01/STDERR.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -36,7 +36,7 @@
                 },
                 {
                     "actual_file": "test02/STDERR.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -94,7 +94,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test04/STDERR.txt'",

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_python2
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_python2
@@ -22,7 +22,7 @@
                 },
                 {
                     "actual_file": "test02/STDERR.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -80,7 +80,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test04/STDERR.txt'",
@@ -138,7 +138,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test06/STDERR.txt'",

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_python3
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_python3
@@ -10,7 +10,7 @@
                 },
                 {
                     "actual_file": "test01/STDERR.txt",
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "WARNING: This file should be empty",
@@ -80,7 +80,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test04/STDERR.txt'",
@@ -138,7 +138,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test06/STDERR.txt'",

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/compile_error_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/compile_error_results.json
@@ -82,7 +82,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test04/STDERR.txt'",
@@ -110,7 +110,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test05/STDERR.txt'",
@@ -138,7 +138,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test06/STDERR.txt'",
@@ -166,7 +166,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test07/STDERR.txt'",
@@ -194,7 +194,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Error (STDERR)",
+                    "description": "Standard Error (STDERR.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test08/STDERR.txt'",

--- a/tests/integrationTests/tests/json/assignment_config/config.json
+++ b/tests/integrationTests/tests/json/assignment_config/config.json
@@ -22,7 +22,7 @@
                 {
                     "method" : "diff",
                     "actual_file" : "STDOUT.txt",
-                    "description" : "Standard OUTPUT (STDOUT)",
+                    "description" : "Standard OUTPUT (STDOUT.txt)",
 		            "expected_file" : "test2_output.txt"
                 }
             ]

--- a/tests/integrationTests/tests/json/validation/results.json
+++ b/tests/integrationTests/tests/json/validation/results.json
@@ -21,7 +21,7 @@
                     ]
                 },
                 {
-                    "description": "Standard Output (STDOUT)",
+                    "description": "Standard Output (STDOUT.txt)",
                     "messages": [
                         {
                             "message": "ERROR!  Could not open student file: 'test01/STDOUT.txt'",
@@ -38,7 +38,7 @@
             "autochecks": [
                 {
                     "actual_file": "test02/STDOUT.txt",
-                    "description": "Standard OUTPUT (STDOUT)",
+                    "description": "Standard OUTPUT (STDOUT.txt)",
                     "difference_file": "test02/0_diff.json",
                     "expected_file": "test_output/testassignment/test2_output.txt"
                 }


### PR DESCRIPTION
closes #2749 

Makes it more clear to students which file they are looking at in their results. 

Also makes port assignment deterministic when grading networked programs, allowing prints involving port numbers to be diffed.