### PR TITLE
Began Work on Docker Network Integration Test

### DIFF
--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/__init__.py
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/__init__.py
@@ -1,0 +1,56 @@
+# Necessary imports. Provides library functions to ease writing tests.
+from lib import prebuild, testcase, SUBMITTY_TUTORIAL_DIR
+
+import subprocess
+import os
+import glob
+import shutil
+
+
+############################################################################
+# COPY THE ASSIGNMENT FROM THE SAMPLE ASSIGNMENTS DIRECTORIES
+
+SAMPLE_ASSIGNMENT_CONFIG = SUBMITTY_TUTORIAL_DIR + "/examples/16_docker_network_python/config"
+SAMPLE_SUBMISSIONS = SUBMITTY_TUTORIAL_DIR + "/examples/16_docker_network_python/submissions/"
+
+@prebuild
+def initialize(test):
+    try:
+        os.mkdir(os.path.join(test.testcase_path, "assignment_config"))
+    except OSError:
+        pass
+
+    subprocess.call(["cp",
+                     os.path.join(SAMPLE_ASSIGNMENT_CONFIG, "config.json"),
+                     os.path.join(test.testcase_path, "assignment_config")])
+
+
+############################################################################
+
+
+def cleanup(test):
+    data_path = os.path.join(test.testcase_path, "data")
+    if os.path.isdir(data_path):
+        shutil.rmtree(data_path)
+    os.mkdir(data_path)
+    
+    subprocess.call(["cp", "-r",
+        os.path.join(SAMPLE_ASSIGNMENT_CONFIG, "test_input"),
+        os.path.join(data_path)])
+    subprocess.call(["cp"] +
+                     glob.glob(os.path.join(SAMPLE_ASSIGNMENT_CONFIG, "test_output","*")) +
+                     [os.path.join(test.testcase_path, "data")])
+
+
+#This test is not possible until lib.py starts using grade_item_main_runner.
+@testcase
+def correct(test):
+  pass
+    # cleanup(test)
+    # subprocess.call(["cp",os.path.join(SAMPLE_SUBMISSIONS, "correct","server.py"),
+    #                  os.path.join(test.testcase_path, "data")])
+    # test.run_compile()
+    # test.run_run()
+    # test.run_validator()
+    # test.diff("grade.txt","correct_grade.txt","-b")
+    # test.json_diff("results.json","correct_results.json")

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/correct_grade.txt
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/correct_grade.txt
@@ -1,0 +1,8 @@
+Testcase  1: Ping Pong                                            5 /  5  
+Testcase  2: Ping Pong, Ping Pong                                 5 /  5  
+Testcase  3: Not Ping                                             5 /  5  
+Testcase  4: Not Ping, Ping, Ping                                 5 /  5  
+Testcase  5: UDP Test                                            +2 points
+Testcase  6: Submission Limit                                             
+Automatic grading total:                                         22 / 20
+Non-hidden automatic grading total:                              22 / 20

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/correct_results.json
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/correct_results.json
@@ -1,0 +1,159 @@
+{
+    "testcases": [
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test01/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test01/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_0.txt"
+                },
+                {
+                    "actual_file": "test01/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test01/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_0.txt"
+                },
+                {
+                    "actual_file": "test01/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 1 Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test02/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test02/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_1.txt"
+                },
+                {
+                    "actual_file": "test02/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test02/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_1.txt"
+                },
+                {
+                    "actual_file": "test02/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 2 Ping Pong, Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test03/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test03/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test03/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 3 Not Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test04/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test04/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_3.txt"
+                },
+                {
+                    "actual_file": "test04/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test04/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_3.txt"
+                },
+                {
+                    "actual_file": "test04/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 4 Not Ping, Ping, Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test05/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test05/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_4.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/server/STDOUT.txt",
+                    "description": "Standard Output (server/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 5 UDP Test"
+        },
+        {
+            "points_awarded": 0,
+            "test_name": "Test 6 Submission Limit",
+            "view_testcase": false
+        }
+    ]
+}

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/incorrect_grade.txt
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/incorrect_grade.txt
@@ -1,0 +1,8 @@
+Testcase  1: Ping Pong                                            3 /  5  
+Testcase  2: Ping Pong, Ping Pong                                 3 /  5  
+Testcase  3: Not Ping                                             3 /  5  
+Testcase  4: Not Ping, Ping, Ping                                 3 /  5  
+Testcase  5: UDP Test                                            +2 points
+Testcase  6: Submission Limit                                             
+Automatic grading total:                                         14 / 20
+Non-hidden automatic grading total:                              14 / 20

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/incorrect_results.json
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/incorrect_results.json
@@ -1,0 +1,207 @@
+{
+    "testcases": [
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test01/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test01/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_0.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test01/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_0.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 3,
+            "test_name": "Test 1 Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test02/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test02/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_1.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test02/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_1.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 3,
+            "test_name": "Test 2 Ping Pong, Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test03/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test03/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_2.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test03/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test03/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_2.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test03/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 3,
+            "test_name": "Test 3 Not Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test04/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test04/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test04/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 3,
+            "test_name": "Test 4 Not Ping, Ping, Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test05/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test05/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_4.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/server/STDOUT.txt",
+                    "description": "Standard Output (server/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 5 UDP Test"
+        },
+        {
+            "points_awarded": 0,
+            "test_name": "Test 6 Submission Limit",
+            "view_testcase": false
+        }
+    ]
+}

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/infinite_response_grade.txt
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/infinite_response_grade.txt
@@ -1,0 +1,8 @@
+Testcase  1: Ping Pong                                            2 /  5  
+Testcase  2: Ping Pong, Ping Pong                                 1 /  5  
+Testcase  3: Not Ping                                             5 /  5  
+Testcase  4: Not Ping, Ping, Ping                                 1 /  5  
+Testcase  5: UDP Test                                            +2 points
+Testcase  6: Submission Limit                                             
+Automatic grading total:                                         11 / 20
+Non-hidden automatic grading total:                              11 / 20

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/infinite_response_results.json
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/infinite_response_results.json
@@ -1,0 +1,237 @@
+{
+    "testcases": [
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test01/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test01/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_0.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Student file too large for grader",
+                            "type": "failure"
+                        },
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test01/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_0.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 1 Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test02/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test02/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_1.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Student file too large for grader",
+                            "type": "failure"
+                        },
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test02/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_1.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 1,
+            "test_name": "Test 2 Ping Pong, Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test03/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test03/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test03/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 3 Not Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test04/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test04/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Student file too large for grader",
+                            "type": "failure"
+                        },
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test04/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 1,
+            "test_name": "Test 4 Not Ping, Ping, Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test05/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test05/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_4.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/server/STDOUT.txt",
+                    "description": "Standard Output (server/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 5 UDP Test"
+        },
+        {
+            "points_awarded": 0,
+            "test_name": "Test 6 Submission Limit",
+            "view_testcase": false
+        }
+    ]
+}

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/large_response_grade.txt
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/large_response_grade.txt
@@ -1,0 +1,8 @@
+Testcase  1: Ping Pong                                            3 /  5  
+Testcase  2: Ping Pong, Ping Pong                                 2 /  5  
+Testcase  3: Not Ping                                             4 /  5  
+Testcase  4: Not Ping, Ping, Ping                                 3 /  5  
+Testcase  5: UDP Test                                            +2 points
+Testcase  6: Submission Limit                                             
+Automatic grading total:                                         14 / 20
+Non-hidden automatic grading total:                              14 / 20

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/large_response_results.json
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/large_response_results.json
@@ -1,0 +1,261 @@
+{
+    "testcases": [
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test01/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test01/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_0.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test01/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_0.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test01/router/STDERR.txt",
+                    "description": "Standard Error (router/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 3,
+            "test_name": "Test 1 Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test02/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test02/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_1.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test02/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_1.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test02/router/STDERR.txt",
+                    "description": "Standard Error (router/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 2 Ping Pong, Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test03/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test03/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_2.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test03/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test03/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 4,
+            "test_name": "Test 3 Not Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test04/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test04/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test04/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/router/STDERR.txt",
+                    "description": "Standard Error (router/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 3,
+            "test_name": "Test 4 Not Ping, Ping, Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test05/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test05/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_4.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/server/STDOUT.txt",
+                    "description": "Standard Output (server/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 5 UDP Test"
+        },
+        {
+            "points_awarded": 0,
+            "test_name": "Test 6 Submission Limit",
+            "view_testcase": false
+        }
+    ]
+}

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/syntax_error_grade.txt
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/syntax_error_grade.txt
@@ -1,0 +1,8 @@
+Testcase  1: Ping Pong                                            5 /  5  
+Testcase  2: Ping Pong, Ping Pong                                 5 /  5  
+Testcase  3: Not Ping                                             2 /  5  
+Testcase  4: Not Ping, Ping, Ping                                 1 /  5  
+Testcase  5: UDP Test                                            +2 points
+Testcase  6: Submission Limit                                             
+Automatic grading total:                                         15 / 20
+Non-hidden automatic grading total:                              15 / 20

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/syntax_error_results.json
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/syntax_error_results.json
@@ -1,0 +1,203 @@
+{
+    "testcases": [
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test01/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test01/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_0.txt"
+                },
+                {
+                    "actual_file": "test01/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test01/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_0.txt"
+                },
+                {
+                    "actual_file": "test01/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 1 Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test02/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test02/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_1.txt"
+                },
+                {
+                    "actual_file": "test02/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test02/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_1.txt"
+                },
+                {
+                    "actual_file": "test02/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 2 Ping Pong, Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test03/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test03/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_2.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test03/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test03/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_2.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test03/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test03/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 3 Not Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test04/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test04/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test04/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_3.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/server/STDERR.txt",
+                    "description": "Standard Error (server/STDERR.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test04/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 1,
+            "test_name": "Test 4 Not Ping, Ping, Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test05/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test05/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_4.txt",
+                    "messages": [
+                        {
+                            "message": "ERROR: Your code did not match the expected output.",
+                            "type": "failure"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/server/STDOUT.txt",
+                    "description": "Standard Output (server/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 2,
+            "test_name": "Test 5 UDP Test"
+        },
+        {
+            "points_awarded": 0,
+            "test_name": "Test 6 Submission Limit",
+            "view_testcase": false
+        }
+    ]
+}

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/udp_correct_grade.txt
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/udp_correct_grade.txt
@@ -1,0 +1,8 @@
+Testcase  1: Ping Pong                                            5 /  5  
+Testcase  2: Ping Pong, Ping Pong                                 5 /  5  
+Testcase  3: Not Ping                                             5 /  5  
+Testcase  4: Not Ping, Ping, Ping                                 5 /  5  
+Testcase  5: UDP Test                                            +5 points
+Testcase  6: Submission Limit                                             
+Automatic grading total:                                         25 / 20
+Non-hidden automatic grading total:                              25 / 20

--- a/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/udp_correct_results.json
+++ b/tests/integrationTests/tests/tutorial_16_docker_network_python/validation/udp_correct_results.json
@@ -1,0 +1,153 @@
+{
+    "testcases": [
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test01/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test01/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_0.txt"
+                },
+                {
+                    "actual_file": "test01/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test01/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_0.txt"
+                },
+                {
+                    "actual_file": "test01/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 1 Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test02/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test02/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_1.txt"
+                },
+                {
+                    "actual_file": "test02/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test02/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_1.txt"
+                },
+                {
+                    "actual_file": "test02/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 2 Ping Pong, Ping Pong"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test03/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test03/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test03/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_2.txt"
+                },
+                {
+                    "actual_file": "test03/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 3 Not Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test04/server/STDOUT.txt",
+                    "description": "server/STDOUT.txt",
+                    "difference_file": "test04/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_server_output_3.txt"
+                },
+                {
+                    "actual_file": "test04/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test04/1_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_3.txt"
+                },
+                {
+                    "actual_file": "test04/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 4 Not Ping, Ping, Ping"
+        },
+        {
+            "autochecks": [
+                {
+                    "actual_file": "test05/client/STDOUT_1.txt",
+                    "description": "client/STDOUT_1.txt",
+                    "difference_file": "test05/0_diff.json",
+                    "expected_file": "test_output/integration_test/expected_client_output_4.txt"
+                },
+                {
+                    "actual_file": "test05/server/STDOUT.txt",
+                    "description": "Standard Output (server/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                },
+                {
+                    "actual_file": "test05/router/STDOUT.txt",
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "messages": [
+                        {
+                            "message": "WARNING: This file should be empty",
+                            "type": "warning"
+                        }
+                    ]
+                }
+            ],
+            "points_awarded": 5,
+            "test_name": "Test 5 UDP Test"
+        },
+        {
+            "points_awarded": 0,
+            "test_name": "Test 6 Submission Limit",
+            "view_testcase": false
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds the skeleton of a integration test of Tutorial 16. 

However, it will be unable to run until lib.py executes the docker network creation code found in grade_item_main_runner.py. This work is tabled for now, but should be pursued in the future per #2757