### PR TITLE
Date parsing for new gradeable accepts years > 9999

### DIFF
--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -5,7 +5,6 @@ namespace app\libraries;
 use \DateTime;
 use \DateTimeZone;
 use \DateInterval;
-use http\Exception\InvalidArgumentException;
 
 /**
  * Class DateUtils
@@ -108,8 +107,8 @@ class DateUtils {
      */
     private static function parseDateTimeCustom(string $date_time, $default_date_time) {
         $matches = [];
-        if (!preg_match('/^([0-9]{4,5})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2})(\.[0-9]+)?([-|+]?[0-9]{2,4})?$/', $date_time, $matches)) {
-            throw new InvalidArgumentException('Invalid DateTime Format');
+        if (!preg_match('/^([0-9]{4,5})-([0-9]{2})-([0-9]{2})[ |T]([0-9]{2}):([0-9]{2}):([0-9]{2})(\.[0-9]+)?([-|+]?[0-9]{2})?/', $date_time, $matches)) {
+            throw new \InvalidArgumentException('Invalid DateTime Format');
         }
 
         $ms = $matches[7] ?? '';

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -100,6 +100,8 @@ class DateUtils {
 
     /**
      * Parses a date string into a \DateTime object using regex.  This allows dates to be year >9999
+     * Format YYYYY-MM-DD HH:mm:ssZ
+     * 
      * @param string $date_time
      * @param \DateTimeZone|null $default_date_time The default timezone to use if none provided
      * @return DateTime

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -91,7 +91,7 @@ class DateUtils {
         if ($date instanceof \DateTime) {
             return $date;
         } else if (gettype($date) === 'string') {
-            return self::parseDateTimeCustom($date, $default_time_zone);
+            return new \DateTime($date, $default_time_zone);
         } else {
             throw new \InvalidArgumentException('Passed object was not a DateTime object or a date string');
         }
@@ -99,15 +99,16 @@ class DateUtils {
 
     /**
      * Parses a date string into a \DateTime object using regex.  This allows dates to be year >9999
+     * Note: This is designed so that dates larger than year 9999 can be loaded from the db without exception.
      * Format YYYYY-MM-DD HH:mm:ssZ
      * 
      * @param string $date_time
-     * @param \DateTimeZone|null $default_date_time The default timezone to use if none provided
+     * @param \DateTimeZone|null $default_time_zone The default timezone to use if none provided
      * @return DateTime
      */
-    private static function parseDateTimeCustom(string $date_time, $default_date_time) {
+    public static function parseDateTimeLong(string $date_time, $default_time_zone = null) {
         $matches = [];
-        if (!preg_match('/^([0-9]{4,5})-([0-9]{2})-([0-9]{2})[ |T]([0-9]{2}):([0-9]{2}):([0-9]{2})(\.[0-9]+)?([-|+]?[0-9]{2})?/', $date_time, $matches)) {
+        if (!preg_match('/^([0-9]{4,5})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2})(\.[0-9]+)?([-|+]?[0-9]{2})?/', $date_time, $matches)) {
             throw new \InvalidArgumentException('Invalid DateTime Format');
         }
 
@@ -117,7 +118,7 @@ class DateUtils {
             $ms = 0;
         }
 
-        $date = new \DateTime('now', ($timezone !== '') ? new DateTimeZone($timezone) : $default_date_time);
+        $date = new \DateTime('now', ($timezone !== '') ? new DateTimeZone($timezone) : $default_time_zone);
         $date->setDate($matches[1], $matches[2], $matches[3]);
         $date->setTime($matches[4], $matches[5], $matches[6], $ms);
         return $date;

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -116,15 +116,10 @@ class DateUtils {
             throw new \InvalidArgumentException('Invalid DateTime Format');
         }
 
-        $ms = $matches[7] ?? '';
         $timezone = $matches[8] ?? '';
-        if ($ms === '') {
-            $ms = 0;
-        }
-
         $date = new \DateTime('now', ($timezone !== '') ? new DateTimeZone($timezone) : $default_time_zone);
         $date->setDate($matches[1], $matches[2], $matches[3]);
-        $date->setTime($matches[4], $matches[5], $matches[6], $ms);
+        $date->setTime($matches[4], $matches[5], $matches[6]);
         return $date;
     }
 

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -83,15 +83,19 @@ class DateUtils {
      * Parses a date string into a \DateTime object, or does nothing if $date is already a \DateTime object
      *
      * @param \DateTime|string $date The date to parse
-     * @param \DateTimeZone|null $default_time_zone The time zone to use if none specified in $date
+     * @param \DateTimeZone $time_zone
      * @return \DateTime The parsed date
-     * @throws \InvalidArgumentException If $date is not a string or a \DateTime, or not a valid \DateTime
+     * @throws \InvalidArgumentException If $date is not a string or a \DateTime, or not a valid \DateTime string
      */
-    public static function parseDateTime($date, $default_time_zone = null) {
+    public static function parseDateTime($date, \DateTimeZone $time_zone) {
         if ($date instanceof \DateTime) {
             return $date;
         } else if (gettype($date) === 'string') {
-            return new \DateTime($date, $default_time_zone);
+            try {
+                return new \DateTime($date, $time_zone);
+            } catch (\Exception) {
+                throw new \InvalidArgumentException('Invalid DateTime Format');
+            }
         } else {
             throw new \InvalidArgumentException('Passed object was not a DateTime object or a date string');
         }
@@ -101,7 +105,7 @@ class DateUtils {
      * Parses a date string into a \DateTime object using regex.  This allows dates to be year >9999
      * Note: This is designed so that dates larger than year 9999 can be loaded from the db without exception.
      * Format YYYYY-MM-DD HH:mm:ssZ
-     * 
+     *
      * @param string $date_time
      * @param \DateTimeZone|null $default_time_zone The default timezone to use if none provided
      * @return DateTime

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -93,7 +93,7 @@ class DateUtils {
         } else if (gettype($date) === 'string') {
             try {
                 return new \DateTime($date, $time_zone);
-            } catch (\Exception) {
+            } catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
         } else {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -4,6 +4,7 @@ namespace app\libraries\database;
 
 use app\exceptions\DatabaseException;
 use app\exceptions\ValidationException;
+use app\libraries\DateUtils;
 use app\libraries\Utils;
 use \app\libraries\GradeableType;
 use app\models\Gradeable;
@@ -1676,6 +1677,12 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         $gradeable_constructor = function($row) {
             if (!isset($row['eg_g_id']) && $row['type'] === GradeableType::ELECTRONIC_FILE) {
                 throw new DatabaseException("Electronic gradeable didn't have an entry in the electronic_gradeable table!");
+            }
+
+            // TODO: remove this once there are db constraints preventing dates this large in the db
+            // Parse the date properties using a method that will accept dates larger than year 9999 (since the DB may be in that state)
+            foreach(\app\models\gradeable\Gradeable::date_properties as $property) {
+                $row[$property] = $row[$property] !== null ? DateUtils::parseDateTimeLong($row[$property]) : null;
             }
 
             // Finally, create the gradeable

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -459,11 +459,7 @@ class AutoGradedVersion extends AbstractModel {
      */
     private function setSubmissionTimeInternal($submission_time) {
         if ($submission_time !== null) {
-            try {
-                $this->submission_time = DateUtils::parseDateTime($submission_time, $this->core->getConfig()->getTimezone());
-            } catch(\Exception $e) {
-                throw new \InvalidArgumentException('Graded version submission time format invalid');
-            }
+            $this->submission_time = DateUtils::parseDateTime($submission_time, $this->core->getConfig()->getTimezone());
         } else {
             throw new \InvalidArgumentException('Graded version submission time must not be null');
         }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -380,7 +380,7 @@ class Gradeable extends AbstractModel {
         foreach (self::date_properties as $date) {
             if (isset($dates[$date]) && $dates[$date] !== null) {
                 try {
-                    $parsedDates[$date] = DateUtils::parseDateTime($dates[$date], $this->core->getConfig()->getTimezone());
+                    $parsedDates[$date] = DateUtils::parseDateTime($dates[$date]);
                 } catch (\Exception $e) {
                     $parsedDates[$date] = null;
                 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -380,7 +380,7 @@ class Gradeable extends AbstractModel {
         foreach (self::date_properties as $date) {
             if (isset($dates[$date]) && $dates[$date] !== null) {
                 try {
-                    $parsedDates[$date] = DateUtils::parseDateTime($dates[$date]);
+                    $parsedDates[$date] = DateUtils::parseDateTime($dates[$date], $this->core->getConfig()->getTimezone());
                 } catch (\Exception $e) {
                     $parsedDates[$date] = null;
                 }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -115,7 +115,7 @@
                         $( "<button>", {
                             text: "Infinity",
                             click: function() {
-                                $.datepicker._curInst.input.datepicker('setDate', "9999-12-31 23:59:59-0400").datepicker('hide');
+                                $.datepicker._curInst.input.datepicker('setDate', "9999-1-1 23:59:59").datepicker('hide');
                             }
                         }).appendTo( buttonPane ).addClass("ui-datepicker-clear ui-state-default ui-priority-primary ui-corner-all");
                     }, 1 );


### PR DESCRIPTION
The default php date parsing method does not accept years > 9999, so this new method accepts years with 5 digits, but is stricter.  It accepts the format the database returns and the format from the Edit Gradeable interface.  For good measure, I changed 'infinity' to be towards the beginning of the year 9999 so this is less of a potential issue in the future for code that doesn't use this date parsing method.

The method requires years, months, days, hours, minutes, seconds, and optional sub-second and time zone.