### PR TITLE
Multiple small but important bug fixes

### DIFF
--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -153,6 +153,12 @@ function build_homework {
     find $course_dir/custom_validation_code/  -type d -exec chmod -f ug+rwx,g+s,o= {} \;
     find $course_dir/custom_validation_code/  -type f -exec chmod -f ug+rw,o= {} \;
     find $course_dir/custom_validation_code/          -exec chgrp -f ${course_group} {} \;
+    find $course_dir/config/build/            -type d -exec chmod -f ug+rwx,g+s,o= {} \;
+    find $course_dir/config/build/            -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/config/build/            -exec chgrp -f ${course_group} {} \;
+    find $course_dir/config/complete_config/  -type d -exec chmod -f ug+rwx,g+s,o= {} \;
+    find $course_dir/config/complete_config/  -type f -exec chmod -f ug+rw,o= {} \;
+    find $course_dir/config/complete_config/  -exec chgrp -f ${course_group} {} \;
 
     popd > /dev/null
 }

--- a/bin/grading_done.py
+++ b/bin/grading_done.py
@@ -53,28 +53,37 @@ def main():
 
         # count the processes
         pid_list = psutil.pids()
-        num_procs=0
+        num_shippers=0
+        num_workers=0
         for pid in pid_list:
             try:
                 proc = psutil.Process(pid)
                 if DAEMON_USER == proc.username():
                     if (len(proc.cmdline()) >= 2 and
                         proc.cmdline()[1] == os.path.join(SUBMITTY_INSTALL_DIR,"sbin","submitty_autograding_shipper.py")):
-                        num_procs+=1
+                        num_shippers+=1
+                    if (len(proc.cmdline()) >= 2 and
+                        proc.cmdline()[1] == os.path.join(SUBMITTY_INSTALL_DIR,"sbin","submitty_autograding_worker.py")):
+                        num_workers+=1
             except psutil.NoSuchProcess:
                 pass
 
         # remove 1 from the count...  each worker is forked from the
         # initial process
-        num_procs-=1
+        num_shippers-=1
+        num_workers-=1
 
-        if num_procs <= 0:
+        if num_shippers <= 0:
             print ("WARNING: No matching submitty_autograding_shipper.py processes!")
-            num_procs = 0
+            num_shippers = 0
+        if num_workers <= 0:
+            print ("WARNING: No matching (local machine) submitty_autograding_worker.py processes!")
+            num_workers = 0
 
         done = True
 
-        print("GRADING PROCESSES:{:3d}       ".format(num_procs), end="")
+        print("SHIPPERS:{:3d}  ".format(num_shippers), end="")
+        print("WORKERS:{:3d}       ".format(num_workers), end="")
 
         if os.access(GRADING_QUEUE, os.R_OK):
             # most instructors do not have read access to the interactive queue

--- a/sbin/autograder/packer_unpacker.py
+++ b/sbin/autograder/packer_unpacker.py
@@ -139,15 +139,6 @@ def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_di
     waittime = (grading_began-queue_time).total_seconds()
     grade_items_logging.log_message(job_id,is_batch_job,"zip",item_name,"wait:",waittime,"")
 
-    # --------------------------------------------------------------------
-    # MAKE TEMPORARY DIRECTORY & COPY THE NECESSARY FILES THERE
-
-    tmp = tempfile.mkdtemp()
-    tmp_autograding = os.path.join(tmp,"TMP_AUTOGRADING")
-    os.mkdir(tmp_autograding)
-    tmp_submission = os.path.join(tmp,"TMP_SUBMISSION")
-    os.mkdir(tmp_submission)
-
     # --------------------------------------------------------
     # various paths
     provided_code_path = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"provided_code",obj["gradeable"])
@@ -157,6 +148,21 @@ def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_di
     bin_path = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"bin",obj["gradeable"])
     form_json_config = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"config","form","form_"+obj["gradeable"]+".json")
     complete_config = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"config","complete_config","complete_config_"+obj["gradeable"]+".json")
+
+    if not os.path.exists(form_json_config):
+        grade_items_logging.log_message(job_id,message="ERROR: the form json file does not exist " + form_json_config)
+        raise RuntimeError("ERROR: the form json file does not exist ",form_json_config)
+    if not os.path.exists(complete_config):
+        grade_items_logging.log_message(job_id,message="ERROR: the complete config file does not exist " + complete_config)
+        raise RuntimeError("ERROR: the complete config file does not exist ",complete_config)
+
+    # --------------------------------------------------------------------
+    # MAKE TEMPORARY DIRECTORY & COPY THE NECESSARY FILES THERE
+    tmp = tempfile.mkdtemp()
+    tmp_autograding = os.path.join(tmp,"TMP_AUTOGRADING")
+    os.mkdir(tmp_autograding)
+    tmp_submission = os.path.join(tmp,"TMP_SUBMISSION")
+    os.mkdir(tmp_submission)
 
     copytree_if_exists(provided_code_path,os.path.join(tmp_autograding,"provided_code"))
     copytree_if_exists(test_input_path,os.path.join(tmp_autograding,"test_input"))
@@ -194,7 +200,6 @@ def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_di
     # grab the submission time
     with open (os.path.join(submission_path,".submit.timestamp")) as submission_time_file:
         submission_string = submission_time_file.read().rstrip()
-    
     submission_datetime = dateutils.read_submitty_date(submission_string)
 
     # --------------------------------------------------------------------

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -318,8 +318,9 @@ class HomeworkView extends AbstractView {
 
         $highest_version = $graded_gradeable !== null ? $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : 0;
 
-        $my_team =  $graded_gradeable->getSubmitter()->getTeam();
-        $my_repository = $gradeable->getRepositoryPath($this->core->getUser(),$my_team);
+        // instructors can access this page even if they aren't on a team => don't create errors
+        $my_team = $graded_gradeable !== null ? $graded_gradeable->getSubmitter()->getTeam() : "";
+        $my_repository = $graded_gradeable !== null ? $gradeable->getRepositoryPath($this->core->getUser(),$my_team) : "";
 
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
             'gradeable_id' => $gradeable->getId(),


### PR DESCRIPTION
* When we fail to pack up a job (missing files), make sure we don't leave stuff behind in /tmp (we were filling it up)
* If we fail to pack up a job, just remove that job from the queue (it was spinning attempting to regrade and filling the log with duplicate errors)
* Don't error when an instructor without a team accesses the submission page
* Add to the list of permissions changes so that multiple users can run build autograding for a course without permissions errors