### PR TITLE
Remove datepicker from Edit Gradeable page

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -225,7 +225,7 @@ class AdminGradeableController extends AbstractController {
             'nav_tab' => $nav_tab,
             'semester' => $semester,
             'course' => $course,
-            'date_format' => 'Y-m-d H:i:sO',
+            'date_format' => 'Y-m-d H:i:s',
             'syllabus_buckets' => self::syllabus_buckets,
             'gradeable_components_enc' => json_encode($gradeable_components_enc),
             'regrade_allowed' => $gradeable->isRegradeAllowed(),
@@ -957,7 +957,7 @@ class AdminGradeableController extends AbstractController {
         if ($date_set) {
             try {
                 $gradeable->setDates($dates);
-                $updated_properties = $gradeable->getDateStrings();
+                $updated_properties = $gradeable->getDateStrings(false);
             } catch (ValidationException $e) {
                 $errors = array_merge($errors, $e->getDetails());
             }

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -92,7 +92,9 @@ class DateUtils {
             return $date;
         } else if (gettype($date) === 'string') {
             try {
-                return new \DateTime($date, $time_zone);
+                $date_time = new \DateTime($date, $time_zone);
+                $date_time->setTimezone($time_zone);
+                return $date_time;
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
@@ -127,10 +129,11 @@ class DateUtils {
      * Converts a \DateTime object to a string in one place so if we change the format
      *  here, it changes everywhere
      *
-     * @param $date \DateTime The date to format
+     * @param \DateTime  $date The date to format
+     * @param bool $add_utc_offset If the UTC offset should be part of the output
      * @return string The formatted date
      */
-    public static function dateTimeToString(DateTime $date) {
-        return $date->format('Y-m-d H:i:sO');
+    public static function dateTimeToString(DateTime $date, bool $add_utc_offset = true) {
+        return $date->format('Y-m-d H:i:s' . ($add_utc_offset ? 'O' : ''));
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -583,13 +583,14 @@ class Gradeable extends AbstractModel {
 
     /**
      * Gets all of the gradeable's date values as strings indexed by property name (including late_days)
+     * @param bool $add_utc_offset True to add the UTC offset to the output strings
      * @return string[]
      */
-    public function getDateStrings() {
+    public function getDateStrings(bool $add_utc_offset = true) {
         $date_strings = [];
         $now = new \DateTime('now', $this->core->getConfig()->getTimezone());
         foreach (self::date_properties as $property) {
-            $date_strings[$property] = DateUtils::dateTimeToString($this->$property ?? $now);
+            $date_strings[$property] = DateUtils::dateTimeToString($this->$property ?? $now, $add_utc_offset);
         }
         $date_strings['late_days'] = strval($this->late_days);
         return $date_strings;

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -97,33 +97,4 @@
         onLateSubmissionAllowedChanged();
     }
 
-    $(document).ready(function() {
-        $(function() {
-            $( ".date_picker" ).datetimepicker({
-                dateFormat: 'yy-mm-dd',
-                timeFormat: "HH:mm:ssz",
-                showButtonPanel: true,
-                showTimezone: false,
-                showMillisec: false,
-                showMicrosec: false,
-                beforeShow: function( input ) {
-                    setTimeout(function() {
-                        var buttonPane = $( input )
-                            .datepicker( "widget" )
-                            .find( ".ui-datepicker-buttonpane" );
-
-                        $( "<button>", {
-                            text: "Infinity",
-                            click: function() {
-                                $.datepicker._curInst.input.datepicker('setDate', "9999-1-1 23:59:59").datepicker('hide');
-                            }
-                        }).appendTo( buttonPane ).addClass("ui-datepicker-clear ui-state-default ui-priority-primary ui-corner-all");
-                    }, 1 );
-                }
-            });
-        });
-
-        updateDateDisplay();
-    });
-
 </script>


### PR DESCRIPTION
This removes the date-time picker from the edit gradeable page since it was not handling time zones very well (very poorly actually) and, among other things, was causing very frustrating behavior to the user.

We need to investigate other date-time picker options that _do_ handle time zones (and daylight savings time) well.