### PR TITLE
Fix checking out another's repo using grading permissions

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -178,10 +178,10 @@ class AuthenticationController extends AbstractController {
             $this->core->getOutput()->renderJsonFail($msg);
             return false;
         }
-        else if (!$user->accessFullGrading()) {
-            $msg = "This user cannot check out that repo.";
-            $this->core->getOutput()->renderJsonFail($msg);
-            return false;
+        else if ($user->accessFullGrading()) {
+            $msg = "Successfully logged in as {$_POST['user_id']}";
+            $this->core->getOutput()->renderJsonSuccess(['message' => $msg, 'authenticated' => true]);
+            return true;
         }
 
         $gradeable = $this->core->getQueries()->getGradeableConfig($_POST['gradeable_id']);
@@ -193,7 +193,9 @@ class AuthenticationController extends AbstractController {
             }
         }
         elseif ($_POST['user_id'] !== $_POST['id']) {
-            return true;
+            $msg = "This user cannot check out that repo.";
+            $this->core->getOutput()->renderJsonFail($msg);
+            return false;
         }
 
         $msg = "Successfully logged in as {$_POST['user_id']}";


### PR DESCRIPTION
Fixes allowing instructor to checkout anyone's repos. The authentication process should be tied more into the Access library that Glen wrote at some point for better checking of "is this something you're allowed to see based on having to grade it?", but this at least keeps the functionality equivalent to what it was last semester.

I think the next step for this is to create proper unit testing of all conditions and then go from there for using the access class.