### PR TITLE
[Bugfix] Better python multiple file warning

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -668,19 +668,30 @@ void parse_command_line(const std::string &cmd,
       my_args.push_back(" ");
       // because we don't want to run in interactive mode and wait for it to time out!
     } else if (my_args.size() > 1) {
+      // a common student error is to submit multiple .py files where
+      // only one is expected and we want to run 'python *.py'
       bool multiple_py_files = false;
-      for (int i = 1; i < my_args.size(); i++) {
-        if (my_args[i].find(".py") != std::string::npos) {
-          multiple_py_files = true;
-          std::cout << "WARNING!  .py file as arg " << my_args[i] << std::endl;
-          logfile << "WARNING!  .py file as arg " << my_args[i] << std::endl;
+      int python_file_count = 0;
+      for (int i = 0; i < my_args.size(); i++) {
+        std::string iterator itr = my_args[i].find(".py");
+        if (itr != std::string::npos &&
+            itr = my_args[i].end()-3) {
+          python_file_count++;
         }
       }
-      if (multiple_py_files == true) {
-        // FIXME: This might be an ok way to call the program...  (but
-        // not if multiple things matched a wildcard search *py)
-        std::cout << "WARNING!  RUNNING PYTHON WITH MULTIPLE ARGS" << std::endl;
-        logfile << "WARNING!  RUNNING PYTHON WITH MULTIPLE ARGS" << std::endl;
+      if (python_file_count == 0) {
+        std::cout << "WARNING!  RUNNING PYTHON WITH NO .py FILES" << std::endl;
+        logfile << "WARNING!  RUNNING PYTHON WITH NO .py FILES" << std::endl;
+      }
+      if (python_file_count > 1) {
+        std::cout << "WARNING!  RUNNING PYTHON WITH MULTIPLE .py FILES" << std::endl;
+        logfile << "WARNING!  RUNNING PYTHON WITH MULTIPLE .py FILES" << std::endl;
+      }
+      if (python_file_count != 1) {
+        for (int i = 0; i < my_args.size(); i++) {
+          logfile << my_args[i] << " ";
+        }
+        logfile << std::endl;
       }
     }
   }

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -670,7 +670,6 @@ void parse_command_line(const std::string &cmd,
     } else if (my_args.size() > 1) {
       // a common student error is to submit multiple .py files where
       // only one is expected and we want to run 'python *.py'
-      bool multiple_py_files = false;
       int python_file_count = 0;
       for (int i = 0; i < my_args.size(); i++) {
         unsigned int pos = my_args[i].find(".py");

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -673,9 +673,9 @@ void parse_command_line(const std::string &cmd,
       bool multiple_py_files = false;
       int python_file_count = 0;
       for (int i = 0; i < my_args.size(); i++) {
-        std::string iterator itr = my_args[i].find(".py");
-        if (itr != std::string::npos &&
-            itr = my_args[i].end()-3) {
+        unsigned int pos = my_args[i].find(".py");
+        if (pos != std::string::npos &&
+            pos == (my_args[i].size())-3) {
           python_file_count++;
         }
       }


### PR DESCRIPTION
Better logic to detect incorrect number of .py files on the python command line