### PR TITLE
Display autochecks even if they lack an actual file

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -50,7 +50,7 @@ What is the unique id of this gradeable? (e.g., <kbd>hw01</kbd>, <kbd>lab_12</kb
 {% endif %}
 <div style="{{ action == 'edit' ? 'display:none' : '' }}">
     <input type='radio' id="radio_electronic_file" name="type" value="Electronic File"
-            {{ action != 'new' and gradeable.getType() == 0 ? 'checked' : '' }}> Electronic File
+            {{ action != 'new' and gradeable.getType() == 0 ? 'checked' : '' }}> Electronic File Upload
 
     <input type='radio' id="radio_checkpoints" name="type" value="Checkpoints"
             {{ action != 'new' and gradeable.getType() == 1 ? 'checked' : '' }}> Checkpoints
@@ -139,10 +139,10 @@ What is the unique id of this gradeable? (e.g., <kbd>hw01</kbd>, <kbd>lab_12</kb
         <input type="radio" id="repository_radio" name="vcs" value="true"
                 {{ action != 'new' and gradeable.isVcs() ? 'checked ' : '' }}/> Version Control System (VCS) Repository
     </div>
-
-    <br />
-
     <div id="repository">
+
+        <br />
+
         <h3>Path for the Version Control System (VCS) repository:</h3>
 
         VCS base URL (from Course Settings): <kbd>{{ vcs_base_url }}</kbd><br /><br />
@@ -192,7 +192,17 @@ What <a target=_blank href="http://submitty.org/instructor/rainbow_grades">sylla
 
 <br />
 {% if action == 'new' or action == 'template' %}
-    <button class="btn btn-primary" type="submit" style="margin-left:10px;">New Gradeable</button>
+   <br />
+   <em>Note: After pressing the "Create New Gradeable" button you may not change: <br />
+   <ul style="margin-left:10px">
+   <li style="margin-left:15px"> the unique id,</li>
+   <li style="margin-left:15px"> gradeable type (electronic file upload, checkpoints, or text), </li>
+   <li style="margin-left:15px"> whether the students will submit as individuals or team, and </li>
+   <li style="margin-left:15px"> whether the students will submit by directly uploading files or by version control. </li>
+   </ul>
+   All other settings for this gradeable may be edited.</em>
+   <br /><br />
+   <button class="btn btn-primary" type="submit" style="margin-left:10px;">Create New Gradeable</button>
 {% endif %}
 
 

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -8,14 +8,22 @@
         <iframe src="{{ core.buildUrl({"component": "misc", "page": "display_file", "dir": "results", "file": check.name, "path": check.path}) }}" width="95%" height="1200px" style="border: 0"></iframe>
     {% else %}
         <br>
+        {% if check.actual %}
         <div style="height:23px; float:right;">
             <a id="show_char_{{ index }}_{{ loop.index0 }}" class="btn btn-default" style="float:right;" onclick="changeDiffView('container_{{ index }}_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ who }}', '{{ display_version }}', '{{ index }}', '{{ loop.index0 }}', 'white_space_helper_{{ index }}')">Visualize whitespace characters</a>
         </div>
         <div><span style="margin-left: 20px" class="line_code" id='white_space_helper_{{ index }}'></span></div>
+        {% endif %}
+
         <div class="box-block">
 
-            {% if check.actual %}
-                {{ self.render_diff_element(check, check.actual, 0, popup_css_file, index, loop.index0) }}
+            {% if not check.actual %}
+               <h4 style="margin-bottom: 0">{{ check.description }}</h4>
+               <div>
+               {{ self.render_messages(check.messages) }}
+               </div>
+            {% else %}
+               {{ self.render_diff_element(check, check.actual, 0, popup_css_file, index, loop.index0) }}
             {% endif %}
             {% if check.expected %}
                 {{ self.render_diff_element(check, check.expected, 1, popup_css_file, index, loop.index0) }}
@@ -31,6 +39,7 @@
 
 {% macro render_diff_element(check, element, side, popup_css_file, index, check_index) %}
     <!-- Readded css here so the popups have the css -->
+
     <div class='diff-element'>
         <h4>
             {{ element.title }}
@@ -41,20 +50,21 @@
             {% endif %}
         </h4>
 
+        {% for message in check.messages %}
+              {% set type_class = "black-message" %}
+              {% if message['type'] == "information" %}
+                 {% set type_class = "blue-message" %}
+              {% elseif message['type'] == "success" %}
+                 {% set type_class = "green-message" %}
+              {% elseif message['type'] == "failure" %}
+                 {% set type_class = "red-message" %}
+              {% elseif message['type'] == "warning" %}
+                 {% set type_class = "yellow-message" %}
+              {% endif %}
+              <span class="{{ type_class }}">{{ message['message'] }}</span><br />
+        {% endfor %}
+
         <div id="container_{{ index }}_{{ check_index }}_{{ side }}">
-            {% for message in check.messages %}
-                {% set type_class = "black-message" %}
-                {% if message['type'] == "information" %}
-                    {% set type_class = "blue-message" %}
-                {% elseif message['type'] == "success" %}
-                    {% set type_class = "green-message" %}
-                {% elseif message['type'] == "failure" %}
-                    {% set type_class = "red-message" %}
-                {% elseif message['type'] == "warning" %}
-                    {% set type_class = "yellow-message" %}
-                {% endif %}
-                <span class="{{ type_class }}">{{ message['message'] }}</span><br />
-            {% endfor %}
             {% if element.type == "image" %}
                 <img src="{{ element.src }}" style="border:2px solid black">
             {% elseif element.type == "text" %}
@@ -65,3 +75,21 @@
         </div>
     </div>
 {% endmacro %}
+
+
+{% macro render_messages(messages) %}
+   {% for message in messages %}
+      {% set type_class = "black-message" %}
+      {% if message['type'] == "information" %}
+         {% set type_class = "blue-message" %}
+      {% elseif message['type'] == "success" %}
+         {% set type_class = "green-message" %}
+      {% elseif message['type'] == "failure" %}
+         {% set type_class = "red-message" %}
+      {% elseif message['type'] == "warning" %}
+         {% set type_class = "yellow-message" %}
+      {% endif %}
+      <span class="{{ type_class }}">{{ message['message'] }}</span><br />
+   {% endfor %}
+{% endmacro %}
+

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -189,9 +189,9 @@ class AutoGradingView extends AbstractView {
                 ];
             } else {
                 $check = [
-                    "messages" => $autocheck->getMessages()
+                    "messages" => $autocheck->getMessages(),
+                    "description" => $description
                 ];
-
                 $actual_title = "";
                 if ($diff_viewer->hasDisplayExpected() || $diff_viewer->getActualFilename() != "") {
                     $actual_title = "Student ";


### PR DESCRIPTION
fixes #2736 
This was broken a while ago, we stopped printing the autochecks that did not have an actual file.
This also tweaks the create/edit gradeable page.