### PR TITLE
[Bugfix] system calls for clang++/sort & drmemory update on Ubuntu 18.04

### DIFF
--- a/.setup/bin/update_repos.sh
+++ b/.setup/bin/update_repos.sh
@@ -28,7 +28,7 @@ SUBMITTY_INSTALL_DIR=/usr/local/submitty
 min_AnalysisTools_version=v.18.06.00
 min_Lichen_version=v.18.07.04
 min_RainbowGrades_version=v.18.07.00
-min_Tutorial_version=v.18.08.00
+min_Tutorial_version=v.18.08.02
 
 ########################################################################
 # Helper function requires 2 args, the short name of the repository,

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -332,8 +332,8 @@ pushd /tmp > /dev/null
 
 echo "Getting DrMemory..."
 
-DRMEM_TAG=release_2.0.0_rc2
-DRMEM_VER=2.0.0-RC2
+DRMEM_TAG=release_2.0.1
+DRMEM_VER=2.0.1-2
 wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEM_TAG}/DrMemory-Linux-${DRMEM_VER}.tar.gz -o /dev/null > /dev/null 2>&1
 tar -xpzf DrMemory-Linux-${DRMEM_VER}.tar.gz
 rsync --delete -a /tmp/DrMemory-Linux-${DRMEM_VER}/ ${SUBMITTY_INSTALL_DIR}/drmemory

--- a/.setup/travis/autograder.sh
+++ b/.setup/travis/autograder.sh
@@ -22,8 +22,8 @@ cp -r grading/ ${SUBMITTY_INSTALL_DIR}/src/
 echo "Getting DrMemory..."
 mkdir -p ${SUBMITTY_INSTALL_DIR}/DrMemory
 pushd /tmp
-DRMEM_TAG=release_1.10.1
-DRMEM_VER=1.10.1-3
+DRMEM_TAG=release_2.0.1
+DRMEM_VER=2.0.1-2
 wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEM_TAG}/DrMemory-Linux-${DRMEM_VER}.tar.gz -o /dev/null > /dev/null 2>&1
 tar -xpzf DrMemory-Linux-${DRMEM_VER}.tar.gz -C ${SUBMITTY_INSTALL_DIR}/DrMemory
 ln -s ${SUBMITTY_INSTALL_DIR}/DrMemory/DrMemory-Linux-${DRMEM_VER} ${SUBMITTY_INSTALL_DIR}/drmemory

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,19 +34,19 @@ Vagrant.configure(2) do |config|
   # that one) as well as making sure all non-primary ones have "autostart: false" set
   # so that when we do "vagrant up", it doesn't spin up those machines.
 
-  # Our primary development target, this is what RPI runs Submitty on
-  config.vm.define 'ubuntu-16.04', primary: true do |ubuntu|
-    ubuntu.vm.box = 'bento/ubuntu-16.04'
-    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 15432
-    ubuntu.vm.network 'private_network', ip: '192.168.56.101'
-    ubuntu.vm.network 'private_network', ip: '192.168.56.102'
-  end
-
-  config.vm.define 'ubuntu-18.04', autostart: false do |ubuntu|
+  # Our primary development target, this is what RPI uses as of Fall 2018
+  config.vm.define 'ubuntu-18.04', primary: true do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-18.04'
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432
     ubuntu.vm.network 'private_network', ip: '192.168.56.111'
     ubuntu.vm.network 'private_network', ip: '192.168.56.112'
+  end
+
+  config.vm.define 'ubuntu-16.04', autostart: false do |ubuntu|
+    ubuntu.vm.box = 'bento/ubuntu-16.04'
+    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 15432
+    ubuntu.vm.network 'private_network', ip: '192.168.56.101'
+    ubuntu.vm.network 'private_network', ip: '192.168.56.102'
   end
 
   config.vm.define 'debian', autostart: false do |debian|

--- a/grading/main_validator.cpp
+++ b/grading/main_validator.cpp
@@ -204,13 +204,7 @@ double ValidateAutoCheck(const TestCase &my_testcase, int which_autocheck, nlohm
       if (my_testcase.isFileCheck() && num_messages > 0 && messages.size() > 0 && messages[0].second.find("README") != std::string::npos) {
         testcase_message = "README missing.";
       } else if (my_testcase.isCompilation() && num_messages > 0) {
-        if (result.hasError()) {
-          testcase_message = "Compilation Error(s).";
-        } else if (result.hasWarning() && testcase_message.find("ERROR") == std::string::npos) {
-          testcase_message = "Compilation Warning(s).";
-        } else {
-          testcase_message = "Compilation Error(s).";
-        }
+        testcase_message = "Compilation Errors and/or Warnings.";
       }
     }
   }

--- a/grading/seccomp_functions.cpp
+++ b/grading/seccomp_functions.cpp
@@ -175,6 +175,7 @@ int install_syscall_filter(bool is_32, const std::string &my_program, std::ofstr
     categories.insert("PROCESS_CONTROL_ADVANCED");
     categories.insert("PROCESS_CONTROL_NEW_PROCESS_THREAD");
     categories.insert("TGKILL");
+    categories.insert("COMMUNICATIONS_AND_NETWORKING_SIGNALS");
   }
 
   // ---------------------------------------------------------------

--- a/grading/seccomp_functions.cpp
+++ b/grading/seccomp_functions.cpp
@@ -287,6 +287,8 @@ int install_syscall_filter(bool is_32, const std::string &my_program, std::ofstr
   else if (my_program == "/usr/bin/sort") {
     categories.insert("PROCESS_CONTROL_NEW_PROCESS_THREAD");
     categories.insert("PROCESS_CONTROL_SCHEDULING");
+    categories.insert("FILE_MANAGEMENT_RARE");
+    categories.insert("PROCESS_CONTROL_ADVANCED");
   }
 
   // ---------------------------------------------------------------

--- a/migration/migrations/system/20180829105219_update_drmemory.py
+++ b/migration/migrations/system/20180829105219_update_drmemory.py
@@ -1,0 +1,26 @@
+import os
+import json
+from pathlib import Path
+
+
+def up(config):
+    
+    DRMEM_TAG="release_2.0.1"
+    DRMEM_VER="2.0.1-2"
+
+    drmemory_dir = str(Path(config.submitty['submitty_install_dir'], 'drmemory'))
+    course_builders_group = config.submitty_users['course_builders_group']
+    
+    os.system("rm -rf "+drmemory_dir)
+    os.makedirs(drmemory_dir)
+    os.chdir("/tmp")
+    os.system("wget https://github.com/DynamoRIO/drmemory/releases/download/"+DRMEM_TAG+"/DrMemory-Linux-"+DRMEM_VER+".tar.gz -o /dev/null > /dev/null 2>&1")
+    os.system("tar -xpzf DrMemory-Linux-"+DRMEM_VER+".tar.gz")
+    os.system("rsync --delete -a /tmp/DrMemory-Linux-"+DRMEM_VER+"/ "+drmemory_dir)
+    os.system("rm -rf /tmp/DrMemory*")
+    os.system("chown -R root:"+course_builders_group+" "+drmemory_dir)
+    os.system("chmod -R 755 "+drmemory_dir)
+
+
+def down(config):
+    pass

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_does_not_compile
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_does_not_compile
@@ -28,7 +28,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 1 Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_c
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_c
@@ -96,7 +96,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 5 C++ Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_cpp
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_cpp
@@ -80,7 +80,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 3 C Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_python2
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_python2
@@ -66,7 +66,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 3 C Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [
@@ -124,7 +124,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 5 C++ Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_python3
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_python3
@@ -66,7 +66,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 3 C Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [
@@ -124,7 +124,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 5 C++ Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/compile_error_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/compile_error_results.json
@@ -38,7 +38,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 2 Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [
@@ -68,7 +68,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 3 Dummy Compilation testing view_testcase_message",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/warning_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/warning_results.json
@@ -25,7 +25,7 @@
             ],
             "points_awarded": 3,
             "test_name": "Test 2 Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [
@@ -42,7 +42,7 @@
             ],
             "points_awarded": 2,
             "test_name": "Test 3 Dummy Compilation testing view_testcase_message",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/json/validation/results.json
+++ b/tests/integrationTests/tests/json/validation/results.json
@@ -32,7 +32,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 1 dummy compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_09_java_testing/validation/does_not_compile_results.json
+++ b/tests/integrationTests/tests/tutorial_09_java_testing/validation/does_not_compile_results.json
@@ -28,7 +28,7 @@
             ],
             "points_awarded": 0,
             "test_name": "Test 1 Java - Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [
@@ -58,7 +58,7 @@
             ],
             "points_awarded": 1,
             "test_name": "Test 2 Java - Instructor JUnit Test Compilation",
-            "testcase_message": "Compilation Error(s)."
+            "testcase_message": "Compilation Errors and/or Warnings."
         },
         {
             "autochecks": [


### PR DESCRIPTION
fixes #2528 
adds more to the system call whitelist for clang++ and sort
modifies the message for compilation errors/warnings
updates dr memory version for ubuntu 18.04
updates tutorial examples (for test case isolation & other minor tweaks)