### PR TITLE
Added Gradeable Date Constraints to DB/PHP

### DIFF
--- a/migration/data/course_tables.sql
+++ b/migration/data/course_tables.sql
@@ -142,7 +142,10 @@ CREATE TABLE electronic_gradeable (
     eg_precision numeric NOT NULL,
     eg_regrade_allowed boolean DEFAULT true NOT NULL,
     eg_regrade_request_date timestamp(6) with time zone NOT NULL,
-    CONSTRAINT eg_submission_date CHECK ((eg_submission_open_date <= eg_submission_due_date))
+    CONSTRAINT eg_submission_date CHECK ((eg_submission_open_date <= eg_submission_due_date)),
+    CONSTRAINT eg_team_lock_date_max CHECK ((eg_team_lock_date <= '9999-03-01 00:00:00.000000')),
+    CONSTRAINT eg_submission_due_date_max CHECK ((eg_submission_due_date <= '9999-03-01 00:00:00.000000')),
+    CONSTRAINT eg_regrade_request_date_max CHECK ((eg_regrade_request_date <= '9999-03-01 00:00:00.000000'))
 );
 
 
@@ -201,7 +204,8 @@ CREATE TABLE gradeable (
     CONSTRAINT g_ta_view_start_date CHECK ((g_ta_view_start_date <= g_grade_start_date)),
     CONSTRAINT g_grade_start_date CHECK ((g_grade_start_date <= g_grade_due_date)),
     CONSTRAINT g_grade_due_date CHECK ((g_grade_due_date <= g_grade_released_date)),
-    CONSTRAINT g_grade_released_date CHECK ((g_grade_released_date <= g_grade_locked_date))
+    CONSTRAINT g_grade_released_date CHECK ((g_grade_released_date <= g_grade_locked_date)),
+    CONSTRAINT g_grade_locked_date_max CHECK ((g_grade_locked_date <= '9999-03-01 00:00:00.000000'))
 );
 
 

--- a/migration/migrations/course/20180904185348_max_date_constraint.py
+++ b/migration/migrations/course/20180904185348_max_date_constraint.py
@@ -1,16 +1,16 @@
 def up(config, conn, semester, course):
     with conn.cursor() as cursor:
         # First, re-clamp the dates similar to the "clamp_dates" migration
-        cursor.execute("UPDATE gradeable SET g_ta_view_start_date = LEAST(g_ta_view_start_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE gradeable SET g_grade_start_date = LEAST(g_grade_start_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE gradeable SET g_grade_due_date = LEAST(g_grade_due_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE gradeable SET g_grade_released_date = LEAST(g_grade_released_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE gradeable SET g_grade_locked_date = LEAST(g_grade_locked_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_ta_view_start_date = LEAST(g_ta_view_start_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_start_date = LEAST(g_grade_start_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_due_date = LEAST(g_grade_due_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_released_date = LEAST(g_grade_released_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_locked_date = LEAST(g_grade_locked_date, '9999-02-01 00:00:00.000000')")
 
-        cursor.execute("UPDATE electronic_gradeable SET eg_team_lock_date = LEAST(eg_team_lock_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE electronic_gradeable SET eg_submission_open_date = LEAST(eg_submission_open_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE electronic_gradeable SET eg_submission_due_date = LEAST(eg_submission_due_date, '9999-03-01 00:00:00.000000')")
-        cursor.execute("UPDATE electronic_gradeable SET eg_regrade_request_date = LEAST(eg_regrade_request_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_team_lock_date = LEAST(eg_team_lock_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_submission_open_date = LEAST(eg_submission_open_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_submission_due_date = LEAST(eg_submission_due_date, '9999-02-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_regrade_request_date = LEAST(eg_regrade_request_date, '9999-02-01 00:00:00.000000')")
 
         # Now, add constraints to prevent them from being this high again
         # Note: due to existing constraints, only a few of the columns need the new constraint

--- a/migration/migrations/course/20180904185348_max_date_constraint.py
+++ b/migration/migrations/course/20180904185348_max_date_constraint.py
@@ -1,0 +1,30 @@
+def up(config, conn, semester, course):
+    with conn.cursor() as cursor:
+        # First, re-clamp the dates similar to the "clamp_dates" migration
+        cursor.execute("UPDATE gradeable SET g_ta_view_start_date = LEAST(g_ta_view_start_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_start_date = LEAST(g_grade_start_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_due_date = LEAST(g_grade_due_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_released_date = LEAST(g_grade_released_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE gradeable SET g_grade_locked_date = LEAST(g_grade_locked_date, '9999-03-01 00:00:00.000000')")
+
+        cursor.execute("UPDATE electronic_gradeable SET eg_team_lock_date = LEAST(eg_team_lock_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_submission_open_date = LEAST(eg_submission_open_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_submission_due_date = LEAST(eg_submission_due_date, '9999-03-01 00:00:00.000000')")
+        cursor.execute("UPDATE electronic_gradeable SET eg_regrade_request_date = LEAST(eg_regrade_request_date, '9999-03-01 00:00:00.000000')")
+
+        # Now, add constraints to prevent them from being this high again
+        # Note: due to existing constraints, only a few of the columns need the new constraint
+        cursor.execute("ALTER TABLE gradeable ADD CONSTRAINT g_grade_locked_date_max CHECK(g_grade_locked_date <= '9999-03-01 00:00:00.000000')")
+
+        cursor.execute("ALTER TABLE electronic_gradeable ADD CONSTRAINT eg_team_lock_date_max CHECK(eg_team_lock_date <= '9999-03-01 00:00:00.000000')")
+        cursor.execute("ALTER TABLE electronic_gradeable ADD CONSTRAINT eg_submission_due_date_max CHECK(eg_submission_due_date <= '9999-03-01 00:00:00.000000')")
+        cursor.execute("ALTER TABLE electronic_gradeable ADD CONSTRAINT eg_regrade_request_date_max CHECK(eg_regrade_request_date <= '9999-03-01 00:00:00.000000')")
+
+
+def down(config, conn, semester, course):
+    with conn.cursor() as cursor:
+        cursor.execute("ALTER TABLE gradeable DROP CONSTRAINT g_grade_locked_date_max")
+
+        cursor.execute("ALTER TABLE electronic_gradeable DROP CONSTRAINT eg_team_lock_date_max")
+        cursor.execute("ALTER TABLE electronic_gradeable DROP CONSTRAINT eg_submission_due_date_max")
+        cursor.execute("ALTER TABLE electronic_gradeable DROP CONSTRAINT eg_regrade_request_date_max")

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -803,6 +803,10 @@ class AdminGradeableController extends AbstractController {
             if (isset($details[$date_property])) {
                 $dates[$date_property] = $details[$date_property];
 
+                if ($dates[$date_property] > DateUtils::MAX_TIME) {
+                    $errors[$date_property] = Gradeable::date_display_names[$date_property] . ' Date is higher than the max allowed date! (' . DateUtils::MAX_TIME . ')';
+                }
+
                 // Unset dates so we don't try and use it in the other loop
                 unset($details[$date_property]);
                 $date_set = true;

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -78,6 +78,7 @@ class DateUtils {
         return true;
     }
 
+    const MAX_TIME = '9999-02-01 00:00:00.000000';
 
     /**
      * Parses a date string into a \DateTime object, or does nothing if $date is already a \DateTime object
@@ -88,19 +89,19 @@ class DateUtils {
      * @throws \InvalidArgumentException If $date is not a string or a \DateTime, or not a valid \DateTime string
      */
     public static function parseDateTime($date, \DateTimeZone $time_zone) {
-        if ($date instanceof \DateTime) {
-            return $date;
-        } else if (gettype($date) === 'string') {
+        if (gettype($date) === 'string') {
             try {
-                $date_time = new \DateTime($date, $time_zone);
-                $date_time->setTimezone($time_zone);
-                return $date_time;
+                $date = new \DateTime($date, $time_zone);
+                $date->setTimezone($time_zone);
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
         } else {
             throw new \InvalidArgumentException('Passed object was not a DateTime object or a date string');
         }
+
+        // Make sure we don't go above our range
+        return min($date, new \DateTime(self::MAX_TIME, $time_zone));
     }
 
     /**

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -78,10 +78,12 @@ class DateUtils {
         return true;
     }
 
+    /** @var string The php-limit for dates.  Note that the database limit is later */
     const MAX_TIME = '9999-02-01 00:00:00.000000';
 
     /**
      * Parses a date string into a \DateTime object, or does nothing if $date is already a \DateTime object
+     * Note: This will clamp the date to be earlier than MAX_TIME
      *
      * @param \DateTime|string $date The date to parse
      * @param \DateTimeZone $time_zone

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -96,7 +96,7 @@ class DateUtils {
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
-        } else {
+        } else if (!($date instanceof \DateTime)) {
             throw new \InvalidArgumentException('Passed object was not a DateTime object or a date string');
         }
 

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -79,7 +79,7 @@ class DateUtils {
     }
 
     /** @var string The php-limit for dates.  Note that the database limit is later */
-    const MAX_TIME = '9999-02-01 00:00:00.000000';
+    const MAX_TIME = '9999-02-01 00:00:00';
 
     /**
      * Parses a date string into a \DateTime object, or does nothing if $date is already a \DateTime object

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1679,12 +1679,6 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
                 throw new DatabaseException("Electronic gradeable didn't have an entry in the electronic_gradeable table!");
             }
 
-            // TODO: remove this once there are db constraints preventing dates this large in the db
-            // Parse the date properties using a method that will accept dates larger than year 9999 (since the DB may be in that state)
-            foreach(\app\models\gradeable\Gradeable::date_properties as $property) {
-                $row[$property] = $row[$property] !== null ? DateUtils::parseDateTimeLong($row[$property]) : null;
-            }
-
             // Finally, create the gradeable
             $gradeable = new \app\models\gradeable\Gradeable($this->core, $row);
 


### PR DESCRIPTION
Closes #2772, #2771

Added constraints to the database so that the maximum date allowed is March 1, 9999.  In PHP, these dates will be clamped (no error / warning) to be at most February 1, 9999 so that we can still load the dates if the db dates are later than the soft limit.  I figure when we redo the date-picker, we can tell the user this is invalid then or not let them do it at all.  The error message now for the date being too large appears similarly to how the other date errors are displayed (red background + tooltip)