### PR TITLE
Allow Professors to Specify Network with Many to One Connections

### DIFF
--- a/.setup/bin/update_repos.sh
+++ b/.setup/bin/update_repos.sh
@@ -28,7 +28,7 @@ SUBMITTY_INSTALL_DIR=/usr/local/submitty
 min_AnalysisTools_version=v.18.06.00
 min_Lichen_version=v.18.07.04
 min_RainbowGrades_version=v.18.07.00
-min_Tutorial_version=v.18.08.02
+min_Tutorial_version=v.18.09.00
 
 ########################################################################
 # Helper function requires 2 args, the short name of the repository,

--- a/grading/execute.h
+++ b/grading/execute.h
@@ -46,4 +46,4 @@ bool delay_and_mem_check(float sleep_time_in_microseconds, int childPID, float& 
 
 std::string output_of_system_command(const char* cmd);
 
-void cin_reader(std::mutex* lock, std::queue<std::string>* input_queue);
+void cin_reader(std::mutex* lock, std::queue<std::string>* input_queue, bool* CHILD_NOT_TERMINATED);

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -56,8 +56,13 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
     whole_config["use_router"] = true;
   }
 
+  if (!whole_config["single_port_per_container"].is_boolean()){
+    whole_config["single_port_per_container"] = false; // connection
+  }
+
   bool use_router = whole_config["use_router"];
-  
+  bool single_port_per_container = whole_config["single_port_per_container"];
+
   nlohmann::json::iterator tc = whole_config.find("testcases");
   assert (tc != whole_config.end());
   
@@ -71,6 +76,9 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
       this_testcase["use_router"] = use_router;
     }
 
+    if (!this_testcase["single_port_per_container"].is_boolean()){
+      this_testcase["single_port_per_container"] = single_port_per_container;
+    }
 
     nlohmann::json commands = nlohmann::json::array();
     // if "command" exists in whole_config, we must wrap it in a container.

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -80,6 +80,8 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
       this_testcase["single_port_per_container"] = single_port_per_container;
     }
 
+    assert(!(single_port_per_container && use_router));
+
     nlohmann::json commands = nlohmann::json::array();
     // if "command" exists in whole_config, we must wrap it in a container.
     bool found_commands = false;

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -14,6 +14,8 @@ import random
 import socket
 import zipfile
 import sys
+import traceback
+from pwd import getpwnam
 
 from submitty_utils import dateutils, glob
 from . import grade_items_logging, grade_item_main_runner, write_grade_history, CONFIG_PATH
@@ -361,15 +363,38 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
                       stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
 
             if USE_DOCKER:
-                compilation_container = subprocess.check_output(['docker', 'run','-i', '-v', testcase_folder + ':' + testcase_folder,
-                                           '-w', testcase_folder,
-                                           container_image,
-                                           #The command to be run.
-                                           os.path.join(testcase_folder, 'my_compile.out'), queue_obj['gradeable'],
-                                           queue_obj['who'], str(queue_obj['version']), submission_string, str(testcase_num)],
-                                           stdout=logfile,
-                                           cwd=testcase_folder)
-                subprocess.call(['docker', 'rm', '-f', compilation_container])
+                try:
+                    #There can be only one container for a compilation step, so grab its container image
+                    #TODO: set default in load_config_json.cpp
+                    if my_testcases[testcase_num-1]['type'] == 'FileCheck':
+                        print("performing filecheck in default ubuntu:custom container")
+                        container_image = "ubuntu:custom"
+                    else:
+                        container_image = my_testcases[testcase_num-1]["containers"][0]["container_image"]
+                        print('creating a compilation container with image {0}'.format(container_image))
+                    untrusted_uid = str(getpwnam(which_untrusted).pw_uid)
+                    compilation_container = None
+                    compilation_container = subprocess.check_output(['docker', 'create','-i', 
+                                               '-v', tmp + ':' + tmp,
+                                               '-w', testcase_folder,
+                                               # '-u', untrusted_uid, 
+                                               '--network', 'none',
+                                               container_image,
+                                               #The command to be run.
+                                               os.path.join(testcase_folder, 'my_compile.out'), queue_obj['gradeable'],
+                                               queue_obj['who'], str(queue_obj['version']), submission_string, str(testcase_num)
+                                               ]).decode('utf8').strip()
+                    print("started container")
+                    compile_success = subprocess.call(['docker', 'start', '-i', compilation_container],
+                                                   stdout=logfile,
+                                                   cwd=testcase_folder)
+                except Exception as e:
+                    print('An error occurred when compiling with docker.')
+                    traceback.print_exc()
+                finally:
+                    if compilation_container != None:
+                        subprocess.call(['docker', 'rm', '-f', compilation_container])
+                        print("cleaned up compilation container.")
 
             else:
                 compile_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR, "sbin", "untrusted_execute"),

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -361,11 +361,16 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
                       stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
 
             if USE_DOCKER:
-                compile_success = subprocess.call(['docker', 'exec', '-w', testcase_folder, container,
-                                                   os.path.join(testcase_folder, 'my_compile.out'), queue_obj['gradeable'],
-                                                   queue_obj['who'], str(queue_obj['version']), submission_string, str(testcase_num)],
-                                                   stdout=logfile,
-                                                   cwd=testcase_folder)
+                compilation_container = subprocess.check_output(['docker', 'run','-i', '-v', testcase_folder + ':' + testcase_folder,
+                                           '-w', testcase_folder,
+                                           container_image,
+                                           #The command to be run.
+                                           os.path.join(testcase_folder, 'my_compile.out'), queue_obj['gradeable'],
+                                           queue_obj['who'], str(queue_obj['version']), submission_string, str(testcase_num)],
+                                           stdout=logfile,
+                                           cwd=testcase_folder)
+                subprocess.call(['docker', 'rm', '-f', compilation_container])
+
             else:
                 compile_success = subprocess.call([os.path.join(SUBMITTY_INSTALL_DIR, "sbin", "untrusted_execute"),
                                                    which_untrusted,

--- a/sbin/autograder/grade_item_main_runner.py
+++ b/sbin/autograder/grade_item_main_runner.py
@@ -60,6 +60,7 @@ def executeTestcases(complete_config_obj, tmp_logs, tmp_work, queue_obj, submiss
             if USE_DOCKER:
                 try:
                     use_router = testcases[testcase_num-1]['use_router']
+                    single_port_per_container = testcases[testcase_num-1]['single_port_per_container']
                     # returns a dictionary where container_name maps to outgoing connections and container image
                     container_info = find_container_information(testcases[testcase_num -1], testcase_num, use_router)
                     # Creates folders for each docker container if there are more than one. Otherwise, we grade in testcase_folder.
@@ -71,7 +72,7 @@ def executeTestcases(complete_config_obj, tmp_logs, tmp_work, queue_obj, submiss
                                          item_name,grading_began, queue_obj,submission_string,testcase_num)
                     # Networks containers together if there are more than one of them. Modifies container_info to store 'network'
                     #   The name of the docker network it is connected to.
-                    network_containers(container_info,os.path.join(tmp_work, "test_input"),which_untrusted,use_router)
+                    network_containers(container_info,os.path.join(tmp_work, "test_input"),which_untrusted,use_router,single_port_per_container)
                     print('NETWORKED CONTAINERS')
                     #The containers are now ready to execute.
 
@@ -315,7 +316,7 @@ def launch_container(container_name, container_image, mounted_directory,job_id,i
 
 
 
-def network_containers(container_info,test_input_folder,which_untrusted, use_router):
+def network_containers(container_info,test_input_folder,which_untrusted, use_router,single_port_per_container):
   if len(container_info) <= 1:
     return
 
@@ -324,7 +325,7 @@ def network_containers(container_info,test_input_folder,which_untrusted, use_rou
   else:
     network_containers_routerless(container_info,which_untrusted)
 
-  create_knownhosts_csv(container_info,test_input_folder)
+  create_knownhosts_csv(container_info,test_input_folder,single_port_per_container)
 
 def network_containers_routerless(container_info,which_untrusted):
   network_name = '{0}_routerless_network'.format(which_untrusted)
@@ -388,20 +389,33 @@ def network_containers_with_router(container_info,which_untrusted):
 
 
 
-def create_knownhosts_csv(container_info,test_input_folder):
+def create_knownhosts_csv(container_info,test_input_folder,single_port_per_container):
   tcp_connection_list = list()
   udp_connection_list = list()
   current_tcp_port = 9000
   current_udp_port = 15000
 
+  host_to_port = dict()
   for name, info in sorted(container_info.items()):
       for connected_machine in info['outgoing_connections']:
           if connected_machine == name:
               continue
-          tcp_connection_list.append([name, connected_machine, str(current_tcp_port)])
-          udp_connection_list.append([name, connected_machine, str(current_udp_port)])
-          current_tcp_port +=1
-          current_udp_port +=1
+          if single_port_per_container:
+            if not connected_machine in host_to_port:
+              host_to_port[connected_machine]['tcp_port'] = str(current_tcp_port)
+              host_to_port[connected_machine]['udp_port'] = str(current_udp_port)
+              current_tcp_port += 1
+              current_udp_port += 1
+            my_tcp_port = host_to_port[connected_machine]['tcp_port']
+            my_udp_port = host_to_port[connected_machine]['udp_port']
+          else:
+            my_tcp_port = current_tcp_port
+            my_udp_port = current_udp_port
+            current_tcp_port += 1
+            current_udp_port += 1
+          
+          tcp_connection_list.append([name, connected_machine,  my_tcp_port])
+          udp_connection_list.append([name, connected_machine,  my_udp_port])
 
   #writing complete knownhosts csvs to input directory
   knownhosts_location = os.path.join(test_input_folder, 'knownhosts_tcp.csv')

--- a/sbin/autograder/grade_item_main_runner.py
+++ b/sbin/autograder/grade_item_main_runner.py
@@ -412,6 +412,7 @@ def create_knownhosts_csv(container_info,test_input_folder,single_port_per_conta
               continue
           if single_port_per_container:
             if not connected_machine in host_to_port:
+              host_to_port[connected_machine] = dict()
               host_to_port[connected_machine]['tcp_port'] = str(current_tcp_port)
               host_to_port[connected_machine]['udp_port'] = str(current_udp_port)
               current_tcp_port += 1


### PR DESCRIPTION
This pull request allows professors to specify networks such that a single node listens on only a single port, on which it receives all of its messages. 

To this end, the PR adds the ```single_port_per_container``` boolean to the config.json both globally and per networked testcase.

This feature does not yet work with the router.

This PR also:
* fixes an issue with dispatcher actions that was causing main runner to crash.
* Allows compilation testcases to specify a container_image.