### PR TITLE
Fix autograding score for version list

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -450,6 +450,9 @@ class HomeworkView extends AbstractView {
             ];
         }, $auto_graded_gradeable->getAutoGradedVersions());
 
+        //sort array by version number after values have been mapped
+        ksort($version_data);
+
         $param = [];
         $show_testcases = false;
         $show_incentive_message = false;


### PR DESCRIPTION
Fixes autograding scores in the drop-down menu for versions. Previously the array wasn't sorted correctly and versions would show a score for a different submission.

fixes #2785
fixes #2416
 
