### PR TITLE
Blank Config Repository won't traverse entire course directory

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -190,14 +190,16 @@ class AdminGradeableController extends AbstractController {
 
         // Configs stored in a private repository (specified in course config)
         $config_repo_name = $this->core->getConfig()->getPrivateRepository();
-        $repository_config_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $config_repo_name);
-        $all_repository_configs = FileUtils::getAllFiles($repository_config_dir);
         $all_repository_config_paths = array();
-        foreach ($all_repository_configs as $file) {
-            $all_repository_config_paths[] = $file['path'];
-            // If this happens then select the third radio button 'Use Private Repository'
-            if ($file['path'] === $saved_config_path) {
-                $config_select_mode = 'repo';
+        if ($config_repo_name !== '') {
+            $repository_config_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $config_repo_name);
+            $all_repository_configs = FileUtils::getAllFiles($repository_config_dir);
+            foreach ($all_repository_configs as $file) {
+                $all_repository_config_paths[] = $file['path'];
+                // If this happens then select the third radio button 'Use Private Repository'
+                if ($file['path'] === $saved_config_path) {
+                    $config_select_mode = 'repo';
+                }
             }
         }
 


### PR DESCRIPTION
If the config repository is blank, php would attempt to traverse the entire course file structure since `<course-dir>/<repo-dir>` evaluated to `<course-dir>/`, which may be what is causing out-of-memory errors.  Now, this operation will only occur if there is a non-blank config repo name.