### PR TITLE
Fix count function trying to read a nonarray

### DIFF
--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -449,7 +449,7 @@ class AutoGradingView extends AbstractView {
         $precision_parts = explode('.', strval($gradeable->getPrecision()));
         if (count($precision_parts) > 1) {
             // TODO: this hardcoded value will mean a weird precision value (like 1/3) won't appear ridiculous
-            $num_decimals = min(3, count($precision_parts[1]));
+            $num_decimals = min(3, count($precision_parts));
         }
 
         $component_data = array_map(function (Component $component) use ($ta_graded_gradeable) {


### PR DESCRIPTION
Small bugfix when finding the precision, gets rid of this error that appeared in some sample submissions.

![error](https://user-images.githubusercontent.com/12129065/45267353-c3be5880-b438-11e8-8eb3-212d32a2cf50.PNG)

fixes #2828