### PR TITLE
Correct gradeable version set when components are saved

### DIFF
--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -3,6 +3,7 @@
         {% if is_ta_grading %}
             <div id="rubric-container" class="container">
                 <div class="row row-wrap vertical-center">
+                    <span id="gradeable-version-container" data-gradeable_version="{{ display_version }}" hidden></span>
                     <span class="col grading_label">Grading Rubric</span>
                     {# Wrong version warnings #}
                     {% if not has_active_version %}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -641,6 +641,7 @@ class ElectronicGraderView extends AbstractView {
             "version_conflict" => $version_conflict,
             "show_silent_edit" => $show_silent_edit,
             "grader_id" => $this->core->getUser()->getId(),
+            "display_version" => $display_version,
         ]);
         return $return;
     }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -868,6 +868,14 @@ function isGradingDisabled() {
 }
 
 /**
+ * Gets the gradeable version being disaplyed
+ * @return {int}
+ */
+function getDisplayVersion() {
+    return parseInt($('#gradeable-version-container').attr('data-gradeable_version'));
+}
+
+/**
  * Gets the precision for component/mark point values
  * @returns {number}
  */
@@ -2700,8 +2708,11 @@ function gradedComponentsEqual(gcDOM, gcOLD) {
         return gcDOM.mark_ids.length === 0 && (!gcDOM.custom_mark_selected || (gcDOM.score === 0.0 && gcDOM.comment === ''));
     }
 
+    // If its not the same version, then we want to save
+    if (gcDOM.graded_version !== gcOLD.graded_version) return false;
+
     // Simple check, if the mark list isn't the same length
-    if (gcDOM.mark_ids.length !== gcDOM.mark_ids.length) return false;
+    if (gcDOM.mark_ids.length !== gcOLD.mark_ids.length) return false;
 
     // Check that they have the same marks assigned
     for (let i = 0; i < gcDOM.mark_ids.length; i++) {
@@ -2734,6 +2745,7 @@ function gradedComponentsEqual(gcDOM, gcOLD) {
 function saveGradedComponent(component_id) {
     let gradeable_id = getGradeableId();
     let gradedComponent = getGradedComponentFromDOM(component_id);
+    gradedComponent.graded_version = getDisplayVersion();
 
     // The grader didn't change the grade at all, so don't save (don't put our name on a grade we didn't contribute to)
     if (gradedComponentsEqual(gradedComponent, OLD_GRADED_COMPONENT_LIST[component_id])) {


### PR DESCRIPTION
Closes #2845

When a component is closed, the gradeable version that the grader is looking at gets saved into the graded component.  This prevents the 'Version Conflict' Issue on the grading list view and the submission page.