### PR TITLE
Knownhosts Refactor

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <iostream>
 #include <cassert>
+#include <algorithm>
+#include <ctype.h>
+
 
 #include "TestCase.h"
 #include "load_config_json.h"
@@ -132,6 +135,10 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
         //pad this out correctly?
         this_testcase["containers"][container_num]["container_name"] = "container" + std::to_string(container_num); 
       }
+
+      std::string container_name = this_testcase["containers"][container_num]["container_name"];
+
+      assert(std::find_if(container_name.begin(), container_name.end(), isspace) == container_name.end());
 
       if(this_testcase["containers"][container_num]["outgoing_connections"].is_null()){
         this_testcase["containers"][container_num]["outgoing_connections"] = nlohmann::json::array();


### PR DESCRIPTION
___This pull request is accompanied by another in the tutorial repo.___

This PR changes knownhosts files from comma delimited csv to space delimited text files. As a result, the ```container_name``` variable for a container is now constrained to not include spaces.

Knownhost files now take the form:
```
sender recipient port_number
```

When ```single_port_per_container``` is specified in the assignment configuration, knownhost files are shortened to the form:

```
recipient port_number
```

In a future PR, all knownhost files will be moved to the simplified form, and an ```overlay.txt``` file will be specified, which will define which nodes on the network can communicate.