### PR TITLE
Add test suite for VCS login method

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -14,6 +14,9 @@ use app\models\Breadcrumb;
  */
 
 class Output {
+    /** @var bool */
+    private $render = true;
+
     /** @var bool Should we  */
     private $buffer_output = true;
 
@@ -44,6 +47,15 @@ class Output {
         $this->core = $core;
         $this->start_time = microtime(true);
         $this->controller = new GlobalController($core);
+    }
+
+    /**
+     * Disables the render functions that call in a file/Twig, causing them to return null
+     * immediately. This allows us to not have to mock out this class when we're using
+     * it for the JSON response stuff.
+     */
+    public function disableRender() {
+        $this->render = false;
     }
 
     public function loadTwig() {
@@ -92,6 +104,10 @@ class Output {
      * rendering another View
      */
     public function renderOutput() {
+        if (!$this->render) {
+            return null;
+        }
+
         if ($this->buffer_output) {
             $this->output_buffer .= call_user_func_array('self::renderTemplate', func_get_args());
         }
@@ -117,6 +133,10 @@ class Output {
      * @return string
      */
     public function renderTemplate() {
+        if (!$this->render) {
+            return null;
+        }
+
         if (func_num_args() < 2) {
             throw new \InvalidArgumentException("Render requires at least two parameters (View, Function)");
         }
@@ -193,7 +213,6 @@ class Output {
         $response = [
             'status' => 'error',
             'message' => $message,
-            'data' => $data
         ];
 
         if ($data !== null) {

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -18,10 +18,11 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
      *
      * @param array $config_values
      * @param array $user_config
+     * @param array $queries
      *
      * @return Core
      */
-    protected function createMockCore($config_values=array(), $user_config=array()) {
+    protected function createMockCore($config_values=array(), $user_config=array(), $queries=array()) {
         $core = $this->createMock(Core::class);
 
         $config = $this->createMockModel(Config::class);
@@ -31,6 +32,10 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
 
         if (isset($config_values['course'])) {
             $config->method('getCourse')->willReturn($config_values['course']);
+        }
+
+        if (isset($config_values['semester']) && isset($config_values['course'])) {
+            $config->method('isCourseLoaded')->willReturn(true);
         }
 
         if (isset($config_values['tmp_path'])) {
@@ -58,8 +63,11 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
             $core->method('isTesting')->willReturn(true);
         }
 
-        $queries = $this->createMock(DatabaseQueries::class);
-        $core->method('getQueries')->willReturn($queries);
+        $mock_queries = $this->createMock(DatabaseQueries::class);
+        foreach ($queries as $method => $value) {
+            $mock_queries->method($method)->willReturn($value);
+        }
+        $core->method('getQueries')->willReturn($mock_queries);
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $user = $this->createMockModel(User::class);
@@ -85,7 +93,10 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
 
         $core->method('getUser')->willReturn($user);
 
-        $output = $this->createMock(Output::class);
+        /** @noinspection PhpParamsInspection */
+        $output = new Output($core);
+        $output->disableRender();
+
         $core->method('getOutput')->willReturn($output);
 
         /** @noinspection PhpIncompatibleReturnTypeInspection */

--- a/site/tests/app/controllers/AuthenticationControllerTester.php
+++ b/site/tests/app/controllers/AuthenticationControllerTester.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace tests\app\controllers;
+
+use app\authentication\AbstractAuthentication;
+use app\controllers\AuthenticationController;
+use app\models\Team;
+use app\models\User;
+use app\models\gradeable\Gradeable;
+use tests\BaseUnitTest;
+
+class AuthenticationControllerTester extends BaseUnitTest {
+
+    private function getAuthenticationCore($authenticate=false, $queries=[]) {
+        $core = $this->createMockCore(['semester' => 'f18', 'course' => 'test'], null, $queries);
+        $auth = $this->createMock(AbstractAuthentication::class);
+        $auth->method('setUserId')->willReturn(null);
+        $auth->method('setPassword')->willReturn(null);
+        $core->method('authenticate')->willReturn($authenticate);
+        $core->method('getAuthentication')->willReturn($auth);
+        return $core;
+    }
+
+    public function testVcsLoginMissingUserId() {
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $core = $this->createMockCore();
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'error', 'message' => 'Missing value for one of the fields'], $response);
+    }
+
+    public function testVcsLoginMissingPassword() {
+        $_POST['user_id'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $core = $this->createMockCore();
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'error', 'message' => 'Missing value for one of the fields'], $response);
+    }
+
+    public function testVcsLoginMissingGradeableId() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['id'] = 'test';
+        $core = $this->createMockCore();
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'error', 'message' => 'Missing value for one of the fields'], $response);
+    }
+
+    public function testVcsLoginMissingId() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $core = $this->createMockCore();
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'error', 'message' => 'Missing value for one of the fields'], $response);
+    }
+
+
+    public function testVcsLoginCourseNotLoaded() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $core = $this->createMockCore();
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'error', 'message' => 'Missing value for one of the fields'], $response);
+    }
+
+    public function testVcsLoginAuthenticationFail() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $core = $this->getAuthenticationCore();
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'fail', 'message' => 'Could not login using that user id or password'], $response);
+    }
+
+    public function testVcsLoginUserNotInCourse() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $core = $this->getAuthenticationCore(true, ['getUserById' => null]);
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(['status' => 'fail', 'message' => 'Could not find that user for that course'], $response);
+    }
+
+    public function testVcsLoginUserAccessGrading() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $user = $this->createMockModel(User::class);
+        $user->method('accessFullGrading')->willReturn(true);
+        $core = $this->getAuthenticationCore(true, ['getUserById' => $user]);
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(
+            [
+                'status' => 'success',
+                'data' => [
+                    'message' => 'Successfully logged in as test',
+                    'authenticated' => true
+                ]
+            ],
+            $response
+        );
+    }
+
+    public function testVcsLoginNullGradeableWrongId() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'not_test';
+        $user = $this->createMockModel(User::class);
+        $core = $this->getAuthenticationCore(true, ['getUserById' => $user]);
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'This user cannot check out that repository.'
+            ],
+            $response
+        );
+    }
+
+    public function testVcsLoginTeamGradeableFail() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockModel(Gradeable::class);
+        $gradeable->method('isTeamAssignment')->willReturn(true);
+        $team = $this->createMockModel(Team::class);
+        $team->method('hasMember')->with($this->equalTo('test'))->willReturn(false);
+        $core = $this->getAuthenticationCore(
+            true,
+            [
+                'getUserById' => $user,
+                'getGradeableConfig' => $gradeable,
+                'getTeamById' => $team,
+            ]
+        );
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'This user is not a member of that team.'
+            ],
+            $response
+        );
+    }
+
+    public function testVcsLoginTeamGradeableSuccess() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'not_test';
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockModel(Gradeable::class);
+        $gradeable->method('isTeamAssignment')->willReturn(true);
+        $team = $this->createMockModel(Team::class);
+        $team->method('hasMember')->with($this->equalTo('test'))->willReturn(true);
+        $core = $this->getAuthenticationCore(
+            true,
+            [
+                'getUserById' => $user,
+                'getGradeableConfig' => $gradeable,
+                'getTeamById' => $team,
+            ]
+        );
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(
+            [
+                'status' => 'success',
+                'data' => [
+                    'message' => 'Successfully logged in as test',
+                    'authenticated' => true
+                ],
+            ],
+            $response
+        );
+    }
+}

--- a/site/tests/app/controllers/AuthenticationControllerTester.php
+++ b/site/tests/app/controllers/AuthenticationControllerTester.php
@@ -123,13 +123,34 @@ class AuthenticationControllerTester extends BaseUnitTest {
         $_POST['gradeable_id'] = 'test';
         $_POST['id'] = 'not_test';
         $user = $this->createMockModel(User::class);
-        $core = $this->getAuthenticationCore(true, ['getUserById' => $user]);
+        $core = $this->getAuthenticationCore(true, ['getUserById' => $user, 'getGradeableConfig' => null]);
         $controller = new AuthenticationController($core);
         $response = $controller->vcsLogin();
         $this->assertEquals(
             [
                 'status' => 'fail',
                 'message' => 'This user cannot check out that repository.'
+            ],
+            $response
+        );
+    }
+
+    public function testVcsLoginNullGradeableRightId() {
+        $_POST['user_id'] = 'test';
+        $_POST['password'] = 'test';
+        $_POST['gradeable_id'] = 'test';
+        $_POST['id'] = 'test';
+        $user = $this->createMockModel(User::class);
+        $core = $this->getAuthenticationCore(true, ['getUserById' => $user, 'getGradeableConfig' => null]);
+        $controller = new AuthenticationController($core);
+        $response = $controller->vcsLogin();
+        $this->assertEquals(
+            [
+                'status' => 'success',
+                'data' => [
+                    'message' => 'Successfully logged in as test',
+                    'authenticated' => true
+                ],
             ],
             $response
         );


### PR DESCRIPTION
Adds the following tests of the VCS login method:
* Test not having a user_id (error)
* Test not having a password (error)
* Test not having a gradeable id (error)
* Test not having a fourth ID paramter (error)
* Test the course not loading (error)
* Test authentication failed (fail)
* Test user not in course (fail)
* Test user having grading success (success)
* Test null gradeable and different fourth id from first id (fail)
* Test null gradeable and same fourth id as first id (success)
* Test team gradeable and user not in team (fail)
* Test team gradeable and user in team (success)