### PR TITLE
Simplify and add tests for the breadcrumb model

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -416,8 +416,8 @@ class Output {
         $this->use_footer = $bool;
     }
     
-    public function addBreadcrumb($string, $url=null, $top=false, $icon=false) {
-        $this->breadcrumbs[] = new Breadcrumb($this->core, $string, $url, $top, $icon);
+    public function addBreadcrumb($string, $url=null, $external_link=false) {
+        $this->breadcrumbs[] = new Breadcrumb($this->core, $string, $url, $external_link);
     }
 
     public function addRoomTemplatesTwigPath() {

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -6,9 +6,17 @@ use app\libraries\Core;
 /**
  * Breadcrumb navigation item
  *
+ * These are used to give a user a sense of where they are in the hierarchy of
+ * the site. Each breadcrumb has a title, and then optionally a link and an
+ * external link. The links are used to provide an anchor tag on the title, while
+ * if there's an external link, then it shows a fa-external-link icon that has
+ * an anchor tag pointing to the external url.
+ *
+ * @link https://fontawesome.com/v4.7.0/icon/external-link
+ *
  * @method string getTitle()
  * @method string|null getUrl()
- * @method bool isExternalLink()
+ * @method string|null getExternalLink()
 */
 class Breadcrumb extends AbstractModel {
     /** @property string */

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -16,7 +16,7 @@ use app\libraries\Core;
  *
  * @method string getTitle()
  * @method string|null getUrl()
- * @method string|null getExternalLink()
+ * @method string|null getExternalUrl()
 */
 class Breadcrumb extends AbstractModel {
     /** @property string */

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -4,37 +4,32 @@ namespace app\models;
 use app\libraries\Core;
 
 /**
- * Breadcrumb header navigation item
+ * Breadcrumb navigation item
  *
- * @method string getString()
- * @method null getUrl()
- * @method bool isTop()
- * @method bool isIcon()
+ * @method string getTitle()
+ * @method string|null getUrl()
+ * @method bool isExternalLink()
 */
 class Breadcrumb extends AbstractModel {
-    /** @property string $title */
+    /** @property string */
     protected $title;
-    /** @property null $url */
+    /** @property string|null */
     protected $url = null;
-    /** @property bool $top */
-    protected $top = false;
-    /** @property bool $icon */
-    protected $icon = false;
+    /** @property string|null */
+    protected $external_url = false;
 
     /**
      * Breadcrumb constructor.
      * @param Core $core
      * @param string $title
-     * @param null $url
-     * @param bool $top
-     * @param bool $icon
+     * @param string|null $url
+     * @param string|null $external_url
      */
-    public function __construct(Core $core, string $title, $url = null, bool $top = false, bool $icon = false) {
+    public function __construct(Core $core, string $title, $url = null, $external_url = null) {
         parent::__construct($core);
         $this->title = $title;
         $this->url = $url;
-        $this->top = $top;
-        $this->icon = $icon;
+        $this->external_url = $external_url;
     }
 
 }

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -44,21 +44,16 @@
                     <div>
                         <h2>
                             {% for b in breadcrumbs %}
-                                {% if loop.index0 > 0 and not b.getIcon() %}
+                                {% if loop.index0 > 0 %}
                                     &gt;
                                 {% endif %}
-                                {% if b.getUrl() != null and b.getUrl() != "" %}
-                                    {% if b.getIcon() %}
-                                            <a class="external" href="{{ b.getUrl() }}" target="_blank"><i class="fa fa-external-link"></i></a>
-                                    {% else %}
-                                        {% if b.getTop() %}
-                                            <a target="_top" href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
-                                        {% else %}
-                                            <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
-                                        {% endif %}
-                                    {% endif %}
+                                {% if b.getUrl() is not empty %}
+                                    <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
                                 {% else %}
                                     {{ b.getTitle() }}
+                                {% endif %}
+                                {% if b.getExternalUrl() is not empty %}
+                                    <a class="external" href="{{ b.getExternalUrl() }}" target="_blank"><i class="fa fa-external-link"></i></a>
                                 {% endif %}
                             {% endfor %}
                         </h2>

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -96,13 +96,11 @@ $core->getOutput()->loadTwig();
 $core->loadGradingQueue();
 
 if($core->getConfig()->getInstitutionName() !== ""){
-    $core->getOutput()->addBreadcrumb($core->getConfig()->getInstitutionName(), "");
-    $core->getOutput()->addBreadcrumb("", $core->getConfig()->getInstitutionHomepage(),false, true);
+    $core->getOutput()->addBreadcrumb($core->getConfig()->getInstitutionName(), null, $core->getConfig()->getInstitutionHomepage());
 }
 $core->getOutput()->addBreadcrumb("Submitty", $core->getConfig()->getHomepageUrl());
 if($core->getConfig()->isCourseLoaded()){
-    $core->getOutput()->addBreadcrumb($core->getDisplayedCourseName(), $core->buildUrl());
-    $core->getOutput()->addBreadcrumb("", $core->getConfig()->getCourseHomeUrl(),false, true);
+    $core->getOutput()->addBreadcrumb($core->getDisplayedCourseName(), $core->buildUrl(), $core->getConfig()->getCourseHomeUrl());
 }
 
 date_default_timezone_set($core->getConfig()->getTimezone()->getName());

--- a/site/tests/app/models/BreadcrumbTester.php
+++ b/site/tests/app/models/BreadcrumbTester.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace app\models;
+
+
+use app\libraries\Core;
+
+class BreadcrumbTester extends \PHPUnit\Framework\TestCase {
+    public function testDefaults() {
+        $core = $this->createMock(Core::class);
+        $breadcrumb = new Breadcrumb($core, 'title');
+        $this->assertEquals('title', $breadcrumb->getTitle());
+        $this->assertNull($breadcrumb->getUrl());
+        $this->assertNull($breadcrumb->getExternalUrl());
+    }
+
+    public function testUrl() {
+        $core = $this->createMock(Core::class);
+        $breadcrumb = new Breadcrumb($core, "title", "link");
+        $this->assertEquals('title', $breadcrumb->getTitle());
+        $this->assertEquals('link', $breadcrumb->getUrl());
+        $this->assertNull($breadcrumb->getExternalUrl());
+    }
+
+    public function testExternalUrl() {
+        $core = $this->createMock(Core::class);
+        $breadcrumb = new Breadcrumb($core, 'title', null, 'link');
+        $this->assertEquals('title', $breadcrumb->getTitle());
+        $this->assertNull($breadcrumb->getUrl());
+        $this->assertEquals('link', $breadcrumb->getExternalUrl());
+    }
+
+    public function testUrlAndExternal() {
+        $core = $this->createMock(Core::class);
+        $breadcrumb = new Breadcrumb($core, 'title', 'internal_link', 'external_link');
+        $this->assertEquals('title', $breadcrumb->getTitle());
+        $this->assertEquals('internal_link', $breadcrumb->getUrl());
+        $this->assertEquals('external_link', $breadcrumb->getExternalUrl());
+    }
+}


### PR DESCRIPTION
Changes:
* Get rid of the unused `$top` variable on Breadcrumb items
* Rename the `$icon` variable to `$external_url` to better capture what it does (adds an external link)
* Simplify having external links on breadcrumbs by allowing specifying both internal and external urls

Previously to have an "external" following an "internal" breadcrumb, you'd have to define the normal breadcrumb and then define an "external" breadcrumb with a blank title, link, and a specific flag. This change allows you to define a breadcrumb that has an either/or internal or external link and then show the title with a link and if you specify an external url, then the external link icon will appear after that breadcrumb.

This also adds testcases for this model as well for functionality