### PR TITLE
Displaying null section for view all

### DIFF
--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -22,7 +22,7 @@ class GradingSection extends AbstractModel {
      */
     protected $registration;
     /**
-     * @property @var string
+     * @property @var string|null
      */
     protected $name;
     /**
@@ -38,7 +38,7 @@ class GradingSection extends AbstractModel {
      */
     protected $teams;
 
-    public function __construct(Core $core, bool $registration, string $name, $graders, $users, $teams) {
+    public function __construct(Core $core, bool $registration, $name, $graders, $users, $teams) {
         parent::__construct($core);
         $this->registration = $registration;
         $this->name = $name;

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1424,6 +1424,7 @@ class Gradeable extends AbstractModel {
             foreach ($section_names as $i => $section) {
                 $section_names[$i] = $section['sections_registration_id'];
             }
+            $section_names[] = null; // add in the null section
             $graders = $this->core->getQueries()->getGradersForRegistrationSections($section_names);
         } else {
             if ($this->isTeamAssignment()) {
@@ -1443,6 +1444,7 @@ class Gradeable extends AbstractModel {
             foreach ($section_names as $i => $section) {
                 $section_names[$i] = $section['sections_rotating_id'];
             }
+            $section_names[] = null; // add in the null section
             $graders = $this->core->getQueries()->getGradersForRotatingSections($this->getId(), $section_names);
         }
 


### PR DESCRIPTION
Changes the way that grading sections are grabbed so that the null registration section is displayed after clicking view all.

closes #2818