### PR TITLE
Removed length limit for instruction URL

### DIFF
--- a/migration/data/course_tables.sql
+++ b/migration/data/course_tables.sql
@@ -190,7 +190,7 @@ CREATE TABLE electronic_gradeable_version (
 CREATE TABLE gradeable (
     g_id character varying(255) NOT NULL,
     g_title character varying(255) NOT NULL,
-    g_instructions_url character varying(255) NOT NULL,
+    g_instructions_url character varying NOT NULL,
     g_overall_ta_instructions character varying NOT NULL,
     g_gradeable_type integer NOT NULL,
     g_grade_by_registration boolean NOT NULL,

--- a/migration/migrations/course/20180919150904_remove_instruction_url_limit.py
+++ b/migration/migrations/course/20180919150904_remove_instruction_url_limit.py
@@ -1,0 +1,7 @@
+def up(config, conn, semester, course):
+    with conn.cursor() as cursor:
+        cursor.execute("ALTER TABLE gradeable ALTER COLUMN g_instructions_url TYPE VARCHAR")
+
+
+def down(config, conn, semester, course):
+    pass


### PR DESCRIPTION
Closes #2856 

Since the instruction URL had a maximum length (255 characters), longer urls (especially those with url-encoded characters) would go beyond this limit and would cause a database exception to be thrown.  This PR adds a migration to remove this hard limit.