### PR TITLE
Course settings save again

### DIFF
--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -110,7 +110,7 @@ class ConfigurationController extends AbstractController {
             $entry = nl2br($entry);
         }
 
-        $config_ini = $this->core->getConfig()->readCourseIni();
+        $config_ini = $this->core->getConfig()->getCourseIni();
         if(!isset($config_ini['course_details'][$name])) {
             return $this->core->getOutput()->renderJsonFail('Not a valid config name');
         }

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -51,6 +51,7 @@ use app\libraries\Utils;
  * @method string getVcsType()
  * @method string getPrivateRepository()
  * @method string getRoomSeatingGradeableId()
+ * @method array getCourseIni()
  */
 
 class Config extends AbstractModel {


### PR DESCRIPTION
Fixed course settings not saving.  There is a function that was removed from `Config` and its usages were not updated.