### PR TITLE
Room templates bugfix

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -125,7 +125,7 @@ class NavigationView extends AbstractView {
                 if(is_file($seating_config_path)
                     && property_exists($user_seating_details, 'building')
                     && property_exists($user_seating_details, 'room')
-                    && is_file(FileUtils::joinPaths(dirname(dirname(dirname(__DIR__))), 'room_templates', $user_seating_details->building, $user_seating_details->room.'.twig'))) {
+                    && is_file(FileUtils::joinPaths(dirname(dirname(__DIR__)), 'room_templates', $user_seating_details->building, $user_seating_details->room.'.twig'))) {
                     $seating_config = file_get_contents($seating_config_path);
                 }
             }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -121,8 +121,11 @@ class NavigationView extends AbstractView {
 
                 $seating_config_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'uploads', 'seating',
                     $gradeable_id, $user_seating_details->building, $user_seating_details->room.'.json');
-                // if the report the instructor generated corresponds to a valid room config
-                if(is_file($seating_config_path)) {
+                // if the report the instructor generated corresponds to a valid room config and a valid room template
+                if(is_file($seating_config_path)
+                    && property_exists($user_seating_details, 'building')
+                    && property_exists($user_seating_details, 'room')
+                    && is_file(FileUtils::joinPaths(dirname(dirname(dirname(__DIR__))), 'room_templates', $user_seating_details->building, $user_seating_details->room.'.twig'))) {
                     $seating_config = file_get_contents($seating_config_path);
                 }
             }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -119,14 +119,14 @@ class NavigationView extends AbstractView {
             if(is_file($seating_user_path)) {
                 $user_seating_details = json_decode(file_get_contents($seating_user_path));
 
-                $seating_config_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'uploads', 'seating',
-                    $gradeable_id, $user_seating_details->building, $user_seating_details->room.'.json');
-                // if the report the instructor generated corresponds to a valid room config and a valid room template
-                if(is_file($seating_config_path)
-                    && property_exists($user_seating_details, 'building')
-                    && property_exists($user_seating_details, 'room')
-                    && is_file(FileUtils::joinPaths(dirname(dirname(__DIR__)), 'room_templates', $user_seating_details->building, $user_seating_details->room.'.twig'))) {
-                    $seating_config = file_get_contents($seating_config_path);
+                // if the user seating details have both a building and a room property
+                if(property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
+                    $seating_config_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'uploads', 'seating',
+                        $gradeable_id, $user_seating_details->building, $user_seating_details->room . '.json');
+                    // if the report the instructor generated corresponds to a valid room config and a valid room template
+                    if (is_file($seating_config_path) && is_file(FileUtils::joinPaths(dirname(dirname(__DIR__)), 'room_templates', $user_seating_details->building, $user_seating_details->room . '.twig'))) {
+                        $seating_config = file_get_contents($seating_config_path);
+                    }
                 }
             }
             else {


### PR DESCRIPTION
Minor fix for the room templates display: the page will opt for not displaying a room template instead of crashing when trying to display it anyways.

This still requires that the output sent to {$COURSE_DIR}/reports/seating/{$GRADEABLE_ID}/{$USER_ID}.json have "building" and "name" entries corresponding to a valid room template in the repository in order to properly display, but it just shouldn't crash if it isn't there.