### PR TITLE
PDF scroll to page number

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -141,13 +141,13 @@
         return false;
     }
     //TODO: Name better
-    function expandFile(dir, path) {
+    function expandFile(name, path) {
         if($('#viewer').length != 0){
             $('#viewer').remove();
         }
-        let promise = loadFile(dir, path);
+        let promise = loadFile(name, path);
         $('#file_view').show();
-        $("#grading_file_name").html(dir);
+        $("#grading_file_name").html(name);
         let precision = $("#submission_browser").width()-$("#directory_view").width();
         let offset = $("#submission_browser").width()-precision;
         $("#directory_view").animate({'left': '+=' + -offset + 'px'}, 200);
@@ -156,8 +156,8 @@
         return promise;
     }
 
-    function loadFile(dir, path){
-        let extension = dir.split('.').pop();
+    function loadFile(name, path){
+        let extension = name.split('.').pop();
         if(extension == "pdf"){
             $('#pdf_annotation_bar').show();
             $('#save_status').show();
@@ -167,7 +167,7 @@
                 data: {
                     'gradeable_id': '{{ gradeable.getId() }}',
                     'user_id': '{{ gradeable.getUser().getId() }}',
-                    'filename': dir
+                    'filename': name
                 },
                 success: function(data){
                     $('#file_content').append(data);
@@ -179,9 +179,9 @@
             $("#file_viewer_full_panel").empty();
             $("#file_viewer_full_panel").attr("data-file_name", "");
             $("#file_viewer_full_panel").attr("data-file_url", "");
-            $("#file_viewer_full_panel").attr("data-file_name", dir);
+            $("#file_viewer_full_panel").attr("data-file_name", name);
             $("#file_viewer_full_panel").attr("data-file_url", path);
-            openFrame(dir, path, "full_panel");
+            openFrame(name, path, "full_panel");
         }
     }
 
@@ -190,7 +190,7 @@
         $("#file_viewer_full_panel").remove();
         $("#content-wrapper").remove();
         if($("#pdf_annotation_bar").is(":visible")){
-            $('#pdf_annotation_bar').hide();
+            $("#pdf_annotation_bar").hide();
         }
         $("#directory_view").show();
         var offset1 = $("#directory_view").css('left');

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -60,6 +60,9 @@ COUNT_DIRECTION_DOWN = -1;
 PDF_PAGE_NONE = 0;
 PDF_PAGE_STUDENT = -1;
 PDF_PAGE_INSTRUCTOR = -2;
+PDF_PAGE_HEIGHT = 841.89;
+PDF_BORDER_HEIGHT = 0;
+PDF_OFFSET = 0;
 
 /**
  * Whether ajax requests will be asynchronous or synchronous.  This
@@ -2335,11 +2338,40 @@ function openComponentGrading(component_id) {
         .then(function (graded_component) {
             // Set the global graded component list data for this component to detect changes
             OLD_GRADED_COMPONENT_LIST[component_id] = graded_component;
-
+            console.log()
             // Render the grading component with edit mode if enabled,
             //  and 'true' to show the mark list
             return injectGradingComponent(component_tmp, graded_component, isEditModeEnabled(), true);
+        })
+        .then(function () {
+            let page = getComponentPageNumber(component_id);
+            if(page){
+                scrollToPage(page);
+            }
         });
+}
+
+/**
+ * Scrolls the submission panel to the page number specified by the component
+ * TODO: This is currently very clunky, and only works with test files (aka upload.pdf).
+ * @param {int} page_num
+ * @return {void}
+ */
+function scrollToPage(page_num){
+    let files = $('.openable-element-submissions');
+    for(let i = 0; i < files.length; i++){
+        let zoom = localStorage.getItem('scale');
+        if(files[i].innerText.trim() == "upload.pdf"){
+            let scrollY = zoom*(page_num-1)*(PDF_PAGE_HEIGHT+PDF_OFFSET)+PDF_BORDER_HEIGHT;
+            if($("#file_view").is(":visible")){
+                $('#file_content').animate({scrollTop: scrollY}, 500);
+            } else {
+                expandFile("upload.pdf", files[i].getAttribute("file-url")).then(function(){
+                    $('#file_content').animate({scrollTop: scrollY}, 500);
+                });
+            }
+        }
+    }
 }
 
 /**

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -561,7 +561,6 @@ function openAll(click_class, class_modifier) {
 }
 function updateValue(obj, option1, option2) {
     // Switches the value of an element between option 1 and two
-    console.log('hi');
     obj.text(function(i, oldText){
         if(oldText.indexOf(option1) >= 0){
             newText = oldText.replace(option1, option2);


### PR DESCRIPTION
Somehow the features got lost. I think it's due to the major JS rewrite. Currently, the feature is still clunky and only works with upload.pdf. Also I don't think the components themselves specify which file the page belongs to. 
I also made sure that when a PDF is zoomed in, the scrolling scales with it. However, the behavior might be different with different resolution.