### PR TITLE
Make long request regrades wrap instead of scrolling

### DIFF
--- a/site/app/templates/submission/regrade/Discussion.twig
+++ b/site/app/templates/submission/regrade/Discussion.twig
@@ -34,7 +34,7 @@
         <h3>Regrade Request
             <script type="text/javascript">
                 toggleRegradeRequests();
-                document.getElementById("ShowRegradeRequestButton").style.display = 'none'
+                document.getElementById("ShowRegradeRequestButton").style.display = 'none';
             </script>
         <span>
             <span class="fa fa-hourglass" style="font-size: 16px; color: #af0000"></span> 
@@ -52,7 +52,7 @@
         <h3>Regrade Request
             <script type="text/javascript">
                 toggleRegradeRequests();
-                document.getElementById("ShowRegradeRequestButton").style.display = 'none'
+                document.getElementById("ShowRegradeRequestButton").style.display = 'none';
             </script>
         <span>
             <span class="fa fa-check" style="font-size: 16px; color: #008800"></span>  
@@ -69,7 +69,7 @@
 {% for post in posts %}
     <div style="margin-top: 20px;">
         <div class='{{ post.is_staff ? "post_box important" : "post_box" }} {{ loop.index0 == 0 ? "first_post" : "" }}' style="padding:20px;">
-            <p style='white-space:pre'>{{ post.content }}</p>
+            <p style='white-space:pre-wrap;'>{{ post.content }}</p>
             <hr>
             <div style="float:right">
                 <b>{{ post.name }}</b> &nbsp;

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -830,7 +830,9 @@ table tr.table-header {
     word-wrap: break-word;
     border-radius: 3px;
     background-color:white;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
+    width: 100%;
 }
 
 .post_box a {


### PR DESCRIPTION
The request regrade box in the TA screen will force the post content to wrap instead of adding a horizontal scroll bar.

![capture](https://user-images.githubusercontent.com/12129065/45920997-ea3db400-be7a-11e8-9f01-a56efd1f487b.PNG)

Fixes #2862