### PR TITLE
Fix ta scores not going negative

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -232,7 +232,7 @@ class Utils {
 
         if ($result > 1.0 && $clamp === true) {
             return 1.0;
-        } else if ($result < 0.0) {
+        } else if ($result < 0.0 && $clamp === true) {
             return 0.0;
         }
         return $result;


### PR DESCRIPTION
The TA subtotal in both the submission view and the ta grading view will properly show negative scores.