### PR TITLE
Mark 'publish' can be edited in the grading interface (by any grader)

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1773,11 +1773,6 @@ class ElectronicGraderController extends GradingController {
             return;
         }
 
-        // Restrict who can change the 'publish' property
-        if (!$this->core->getAccess()->canI('grading.electronic.save_mark_publish')) {
-            $publish = $mark->isPublish();
-        }
-
         try {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->saveMark($mark, $points, $title, $publish);

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -130,7 +130,6 @@ class Access {
         $this->permissions["grading.electronic.grade"] = self::ALLOW_MIN_STUDENT | self::CHECK_GRADEABLE_MIN_GROUP | self::CHECK_GRADING_SECTION_GRADER | self::CHECK_PEER_ASSIGNMENT_STUDENT;
         $this->permissions["grading.electronic.grade.if_no_sections_exist"] = self::ALLOW_MIN_INSTRUCTOR;
         $this->permissions["grading.electronic.save_mark"] = self::ALLOW_MIN_LIMITED_ACCESS_GRADER | self::CHECK_GRADING_SECTION_GRADER | self::CHECK_GRADEABLE_MIN_GROUP;
-        $this->permissions["grading.electronic.save_mark_publish"] = self::ALLOW_MIN_INSTRUCTOR;
         $this->permissions["grading.electronic.save_component"] = self::ALLOW_MIN_INSTRUCTOR;
         $this->permissions["grading.electronic.add_component"] = self::ALLOW_MIN_INSTRUCTOR;
         $this->permissions["grading.electronic.delete_component"] = self::ALLOW_MIN_INSTRUCTOR;

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2652,10 +2652,8 @@ function saveMarkList(component_id) {
  * @return {boolean}
  */
 function marksEqual(mark0, mark1) {
-    // publish settings only applies in instructor edit mode.  If a non-instructor
-    //  edits a mark, it doesn't overwrite the publish setting anyway.
     return mark0.points === mark1.points && mark0.title === mark1.title
-        && (!isInstructorEditEnabled() || mark0.publish === mark1.publish);
+        && mark0.publish === mark1.publish;
 }
 
 /**

--- a/site/public/templates/grading/ConflictMarks.twig
+++ b/site/public/templates/grading/ConflictMarks.twig
@@ -1,3 +1,11 @@
+{% import _self as s %}
+
+{% macro show_mark_info(mark) %}
+    <span class="col">
+        ({{ mark.points }}) {{ mark.title }} {{ mark.publish ? '-- <i>Show mark to all students</i>' : '' }}
+    </span>
+{% endmacro %}
+
 <div class="container mark-conflict-container">
     {% for conflict in conflict_marks %}
         <div id="mark-conflict-{{ conflict.domMark.id }}"
@@ -5,18 +13,14 @@
              data-mark_id="{{ conflict.domMark.id }}">
             <div class="col container">
                 <div class="row mark-resolve mark-resolve-old-server">
-                    <span class="col">
-                        ({{ conflict.oldServerMark.points }}) {{ conflict.oldServerMark.title }}
-                    </span>
+                    {{ s.show_mark_info(conflict.oldServerMark) }}
                     <span class="col-no-gutters button-container">
                         <input type="button" class="btn btn-default" value="Revert to Original"/>
                     </span>
                 </div>
                 <div class="row mark-resolve mark-resolve-server">
                     {% if conflict.serverMark != null %}
-                        <span class="col">
-                            ({{ conflict.serverMark.points }}) {{ conflict.serverMark.title }}
-                        </span>
+                        {{ s.show_mark_info(conflict.serverMark) }}
                         <span class="col-no-gutters button-container">
                             <input type="button" class="btn btn-primary" value="Ignore My Edits"/>
                         </span>
@@ -31,9 +35,7 @@
                 </div>
                 <div class="row mark-resolve mark-resolve-dom">
                     {% if not conflict.local_deleted %}
-                        <span class="col">
-                            ({{ conflict.domMark.points }}) {{ conflict.domMark.title }}
-                        </span>
+                        {{ s.show_mark_info(conflict.domMark) }}
                         <span class="col-no-gutters button-container">
                             <input type="button" class="btn btn-primary" value="Use My Edits"/>
                         </span>

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -43,6 +43,7 @@ Required inputs:
 {% endblock %}
 
 {% block marks_block %}
+    {% set show_publish = edit_marks_enabled %}
     {% for mark in component.marks %}
         {% set first_mark = loop.index0 == 0 %}
         {% set is_checked = mark.id in graded_component.mark_ids %}


### PR DESCRIPTION
Part of #2853

Previsouly, the 'publish' setting could only be edited in rubric tab of the edit gradeable page, but that restriction has been lifted.  Any grader can edit the 'publish' setting of any mark (except the first mark).  

Additionally, the mark conflict popup has been modified to expose the 'publish' values for the marks.  Overall this reduces complexity of the code and removes a few possible weird corner cases.