### PR TITLE
Published marks get highlighted in TA grading interface

### DIFF
--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -630,6 +630,11 @@ tr.is_publish {
     border: none;
 }
 
+.gradeable .mark-container.mark-publish {
+    background-color: #bde;
+    border-radius: 4px;
+}
+
 .gradeable .mark-disabled span {
     cursor: not-allowed;
     opacity: 0.3;

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1232,7 +1232,7 @@ function getMarkFromDOM(mark_id) {
             points: parseFloat(domElement.find('input[type=number]').val()),
             title: domElement.find('input[type=text]').val(),
             deleted: domElement.hasClass('mark-deleted'),
-            publish: domElement.find('.mark-publish input[type=checkbox]').is(':checked')
+            publish: domElement.find('.mark-publish-container input[type=checkbox]').is(':checked')
         };
     } else {
         if (mark_id === 0) {
@@ -1242,7 +1242,7 @@ function getMarkFromDOM(mark_id) {
             id: parseInt(domElement.attr('data-mark_id')),
             points: parseFloat(domElement.find('.mark-points').attr('data-points')),
             title: domElement.find('.mark-title').attr('data-title'),
-            publish: domElement.attr('data-publish')
+            publish: domElement.attr('data-publish') === 'true',
         };
     }
 }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1972,6 +1972,14 @@ function onComponentPageNumberChange(me) {
 }
 
 /**
+ * Callback for changing the 'publish' setting of a mark
+ * @param me DOM element of the check box
+ */
+function onMarkPublishChange(me) {
+    getMarkJQuery(getMarkIdFromDOMElement(me)).toggleClass('mark-publish');
+}
+
+/**
  * Put all of the primary logic of the TA grading rubric here
  *
  */

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -9,7 +9,7 @@ Required Input:
     show_publish: True to show the 'publish' option
 #}
 <div id="mark-{{ mark.id }}"
-     class="mark-container row {{ first_mark ? 'mark-first' : '' }} {{ not edit_marks_enabled and mark_disabled ? 'mark-disabled' : '' }} {{ mark.deleted ? 'mark-deleted' : '' }}"
+     class="mark-container row {{ mark.publish ? 'mark-publish' : '' }} {{ first_mark ? 'mark-first' : '' }} {{ not edit_marks_enabled and mark_disabled ? 'mark-disabled' : '' }} {{ mark.deleted ? 'mark-deleted' : '' }}"
      data-component_id="{{ component.id }}"
      data-mark_id="{{ mark.id }}"
      data-publish="{{ mark.publish }}"

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -52,12 +52,8 @@ Required Input:
     </span>
     {% if show_publish %}
         {% if not first_mark %}
-            <span class="col-no-gutters mark-publish">
+            <span class="col-no-gutters mark-publish-container">
                 Show mark to all students: <input type="checkbox" {{ mark.publish ? 'checked' : '' }} onchange="onMarkPublishChange(this)"/>
-            </span>
-        {% else %}
-            <span class="mark-publish">
-                <input type="checkbox" {{ mark.publish ? 'checked' : '' }} hidden/>
             </span>
         {% endif %}
     {% endif %}

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -53,7 +53,7 @@ Required Input:
     {% if show_publish %}
         {% if not first_mark %}
             <span class="col-no-gutters mark-publish">
-                Show mark to all students: <input type="checkbox" {{ mark.publish ? 'checked' : '' }}/>
+                Show mark to all students: <input type="checkbox" {{ mark.publish ? 'checked' : '' }} onchange="onMarkPublishChange(this)"/>
             </span>
         {% else %}
             <span class="mark-publish">


### PR DESCRIPTION
part of #2853 

Marks that are 'published' get highlighted in the ta grading interface.  I think I chose a fairly inoffensive color, but I'm not attached to it.

![image](https://user-images.githubusercontent.com/3719964/46214447-38ced080-c309-11e8-9e1a-05da3773b84a.png)
