### PR TITLE
Fixed display of custom mark for student view of ta grading

### DIFF
--- a/site/app/templates/autograding/TAResultsNew.twig
+++ b/site/app/templates/autograding/TAResultsNew.twig
@@ -80,7 +80,7 @@
                                     </td>
                                 </tr>
                             {% endfor %}
-                            {% if component.total_score != 0 or component.comment != '' %}
+                            {% if component.custom_mark_score != 0 or component.comment != '' %}
                                 <tr>
                                     <td>
                                         <i class="fa fa-check-square-o fa-1g"></i>


### PR DESCRIPTION
Closes #2851

The custom mark was being displayed whenever the total score of the component is nonzero (i.e. full credit or no credit) instead of if the custom mark score is nonzero.