### PR TITLE
'Verify' button won't show up before closing component on first grade

### DIFF
--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -191,7 +191,7 @@ function renderGradingComponentHeader(grader_id, component, graded_component, gr
         resolve(Twig.twig({ref: "GradingComponentHeader"}).render({
             'component': component,
             'graded_component': graded_component,
-            'show_verify_grader': canVerifyGraders && graded_component !== undefined && grader_id !== graded_component.grader_id,
+            'show_verify_grader': canVerifyGraders && showVerifyComponent(graded_component, grader_id),
             'show_mark_list': showMarkList,
             'grading_disabled': grading_disabled,
             'decimal_precision': DECIMAL_PRECISION,

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -816,6 +816,16 @@ function ajaxVerifyAllComponents(gradeable_id, anon_id) {
 }
 
 /**
+ * Gets if the 'verify' button should show up for a component
+ * @param {Object} graded_component
+ * @param {string} grader_id
+ * @returns {boolean}
+ */
+function showVerifyComponent(graded_component, grader_id) {
+    return graded_component !== undefined && graded_component.grader_id !== '' && grader_id !== graded_component.grader_id
+}
+
+/**
  * Put all DOM accessing methods here to abstract the DOM from the other function
  *  of the interface
  */

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -11,7 +11,7 @@ Required inputs:
      {{ functions.getBadgeStyle(graded_component.total_score, component.max_value) }}
 #}
 
-{% set show_verify_grader = can_verify_graders and graded_component is defined and grader_id != graded_component.grader_id %}
+{% set show_verify_grader = can_verify_graders and graded_component is defined and graded_component.grader_id|length != 0 and grader_id != graded_component.grader_id %}
 
 {% block component_click %}
     {{ grading_disabled ? '' : 'onClickComponent(this)' }}

--- a/site/public/templates/grading/GradingGradeable.twig
+++ b/site/public/templates/grading/GradingGradeable.twig
@@ -15,7 +15,7 @@
             {% include "GradingComponent.twig" with {
                 'precision': gradeable.precision,
                 'show_mark_list': false,
-                'component_version_conflict': graded_component.graded_version != display_version,
+                'component_version_conflict': graded_gradeable.graded_version != display_version,
             } %}
         </div>
     {% endfor %}

--- a/site/public/templates/grading/GradingGradeable.twig
+++ b/site/public/templates/grading/GradingGradeable.twig
@@ -15,7 +15,7 @@
             {% include "GradingComponent.twig" with {
                 'precision': gradeable.precision,
                 'show_mark_list': false,
-                'component_version_conflict': graded_gradeable.graded_version != display_version,
+                'component_version_conflict': graded_component.graded_version != display_version,
             } %}
         </div>
     {% endfor %}


### PR DESCRIPTION
When opening a component for the first time as a full access grader or above, clicking a mark to grade would cause the 'verify' button to appear.  Now, the 'verify' button won't show up unless another grader has already graded the component (as it should).