### PR TITLE
[WIP] Diffviewer monospace problem

### DIFF
--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -64,7 +64,8 @@
     vertical-align: top;
     max-height: 20px !important;
     height: 20px !important;
-    font-family: 'Inconsolata', monospace !important;
+    /*Somehow this is causing bunch of problems*/
+    /*font-family: 'Inconsolata', monospace !important;*/
     font-size: 16px;
     line-height: 20px !important;
     padding: 0 5px 0 5px;

--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -64,8 +64,7 @@
     vertical-align: top;
     max-height: 20px !important;
     height: 20px !important;
-    /*Somehow this is causing bunch of problems*/
-    /*font-family: 'Inconsolata', monospace !important;*/
+    font-family: "Courier New", Courier, monospace;
     font-size: 16px;
     line-height: 20px !important;
     padding: 0 5px 0 5px;


### PR DESCRIPTION
Closes #2863. This is a weird one. I literally just commented out the font-family css rule and everything seems to be in monospace. All the bang importants are a bit hard to find the root of the problem. Here is a before/after comparison.
Before
![capture](https://user-images.githubusercontent.com/7075286/46249526-c806e180-c3f8-11e8-8946-fb1508733d13.PNG)
After
![capture](https://user-images.githubusercontent.com/7075286/46249530-dc4ade80-c3f8-11e8-9262-1da9bea816ca.PNG)

I tested a bunch of lines from the sample file provided, and they all seem to work. Do we still need to find a new font?
