### PR TITLE
Grader ui cleanup + consistency

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -371,6 +371,7 @@ table tr.table-header {
     border-radius: 3px;
     padding: 30px;
     margin: 15px;
+    flex-grow: 1;
 }
 
 .content h1 {
@@ -388,8 +389,12 @@ table tr.table-header {
 }
 
 #footer {
-    margin-top: 15px;
+    margin-top: -10px;
     z-index: 20;
+    width: 100%;
+    padding: 5px 0 10px 0;
+    text-align: center;
+    clear: both;
 }
 
 #push {
@@ -402,13 +407,6 @@ table tr.table-header {
 
 #footer a:hover {
     color: #4078c0;
-}
-
-#footer {
-    width: 100%;
-    padding: 5px 0;
-    text-align: center;
-    clear: both;
 }
 
 #footer #copyright {
@@ -933,6 +931,8 @@ table .instructor .two-options{
 #nav-positioner {
     margin-left: -30px;
     flex-grow: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 #nav-buttons {

--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -535,7 +535,8 @@ tr.is_publish {
 
 .gradeable .ta-rubric-table,
 .gradeable .received-marks-list {
-    padding: 8px;
+    padding: 8px 0px;
+    margin: 0 -5px;
 }
 
 .gradeable .done-container {
@@ -565,6 +566,12 @@ tr.is_publish {
 
 .gradeable .mark-container {
     min-height: 28px;
+    border-bottom: 1px solid #999;
+    padding: 3px;
+}
+
+.gradeable .mark-container:last-child {
+    border-bottom: none;
 }
 
 .gradeable .container.box-title {
@@ -578,7 +585,7 @@ tr.is_publish {
     border: 2px solid #000;
     border-radius: 4px;
     color: #888;
-    font-size: 10px;
+    font-size: 14px;
     font-family: 'Source Sans Pro', sans-serif;
     text-align: center;
 }
@@ -613,6 +620,10 @@ tr.is_publish {
     justify-content: flex-start;
 }
 
+.gradeable .mark-container input, .gradeable .mark-container textarea {
+    box-sizing: border-box;
+}
+
 .gradeable .mark-container span.mark-title textarea {
     width: 100%;
     resize: vertical;
@@ -632,7 +643,6 @@ tr.is_publish {
 
 .gradeable .mark-container.mark-publish {
     background-color: #bde;
-    border-radius: 4px;
 }
 
 .gradeable .mark-disabled span {

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -56,7 +56,7 @@ function calculateGradedComponentTotalScore(component, graded_component) {
     // Calculate the total
     let total = component.default;
     if (graded_component.custom_mark_selected) {
-        total += graded_component.custom_mark_selected ? graded_component.score : 0.0;
+        total += graded_component.custom_mark_selected && !isNaN(graded_component.score) ? graded_component.score : 0.0;
         markCount++;
     }
     component.marks.forEach(function (mark) {

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1325,8 +1325,10 @@ function getScoresFromDOM() {
 
     // Get the TA grading scores
     let scores = {
+        ta_grading_complete: getTaGradingComplete(),
         ta_grading_earned: getTaGradingEarned(),
-        ta_grading_total: getTaGradingTotal()
+        ta_grading_total: getTaGradingTotal(),
+        auto_grading_complete: false
     };
 
     // Then check if auto grading scorse exist before adding them
@@ -1334,6 +1336,7 @@ function getScoresFromDOM() {
     if (autoGradingTotal !== '') {
         scores.auto_grading_earned = parseInt(dataDOMElement.attr('data-auto_grading_earned'));
         scores.auto_grading_total = parseInt(autoGradingTotal);
+        scores.auto_grading_complete = true;
     }
 
     return scores;
@@ -1376,6 +1379,22 @@ function getTaGradingEarned() {
     }
     return total;
 }
+
+/**
+ * Gets if all components have a grade assigned
+ * @return {boolean} If all components have at least one mark checked
+ */
+function getTaGradingComplete() {
+    let anyIncomplete = false;
+    $('.graded-component-data').each(function () {
+        let pointsEarned = $(this).attr('data-total_score');
+        if (pointsEarned === '') {
+            anyIncomplete = true;
+        }
+    });
+    return !anyIncomplete;
+}
+
 
 /**
  * Gets the number of ta grading points that can be earned

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -512,38 +512,45 @@ registerKeyHandler({name: "Open Previous Component", code: 'ArrowUp'}, function(
 //-----------------------------------------------------------------------------
 // Selecting marks
 
-registerKeyHandler({name: "Select Mark 1", code: 'Digit1', locked: true}, function() {
+registerKeyHandler({name: "Select Full/No Credit Mark", code: 'Digit0', locked: true}, function() {
     checkOpenComponentMark(0);
 });
-registerKeyHandler({name: "Select Mark 2", code: 'Digit2', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 1", code: 'Digit1', locked: true}, function() {
     checkOpenComponentMark(1);
 });
-registerKeyHandler({name: "Select Mark 3", code: 'Digit3', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 2", code: 'Digit2', locked: true}, function() {
     checkOpenComponentMark(2);
 });
-registerKeyHandler({name: "Select Mark 4", code: 'Digit4', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 3", code: 'Digit3', locked: true}, function() {
     checkOpenComponentMark(3);
 });
-registerKeyHandler({name: "Select Mark 5", code: 'Digit5', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 4", code: 'Digit4', locked: true}, function() {
     checkOpenComponentMark(4);
 });
-registerKeyHandler({name: "Select Mark 6", code: 'Digit6', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 5", code: 'Digit5', locked: true}, function() {
     checkOpenComponentMark(5);
 });
-registerKeyHandler({name: "Select Mark 7", code: 'Digit7', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 6", code: 'Digit6', locked: true}, function() {
     checkOpenComponentMark(6);
 });
-registerKeyHandler({name: "Select Mark 8", code: 'Digit8', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 7", code: 'Digit7', locked: true}, function() {
     checkOpenComponentMark(7);
 });
-registerKeyHandler({name: "Select Mark 9", code: 'Digit9', locked: true}, function() {
+registerKeyHandler({name: "Select Mark 8", code: 'Digit8', locked: true}, function() {
     checkOpenComponentMark(8);
+});
+registerKeyHandler({name: "Select Mark 9", code: 'Digit9', locked: true}, function() {
+    checkOpenComponentMark(9);
 });
 
 function checkOpenComponentMark(index) {
     let component_id = getFirstOpenComponentId();
     if (component_id !== NO_COMPONENT_ID) {
         let mark_id = getMarkIdFromOrder(component_id, index);
+        //TODO: Custom mark id is zero as well, should use something unique
+        if (mark_id === CUSTOM_MARK_ID || mark_id === 0) {
+            return;
+        }
         toggleCommonMark(component_id, mark_id)
             .catch(function (err) {
                 console.error(err);

--- a/site/public/templates/grading/Component.twig
+++ b/site/public/templates/grading/Component.twig
@@ -32,7 +32,7 @@ Required Input:
     {# /Title bar #}
 
     {# Marks table #}
-    <div class="ta-rubric-table container" data-component_id="{{ component.id }}" {{ mark_list_visibility }}>
+    <div class="ta-rubric-table" data-component_id="{{ component.id }}" {{ mark_list_visibility }}>
         {# twig.js doens't support blocks inside of for loops ... ANNOYING #}
         {% block marks_block %}
         {% endblock %}

--- a/site/public/templates/grading/Functions.twig
+++ b/site/public/templates/grading/Functions.twig
@@ -1,15 +1,19 @@
 {#
 Function for getting the badge style for a given set of total and earned points
 #}
-{% macro getBadgeStyle(earned, total) %}
+{% macro getBadgeStyle(earned, total, complete) %}
     {% if earned is defined and total is defined %}
-        {% set percent = earned / total %}
-        {% if percent < 0.5 %}
-            red-background
-        {% elseif percent < 0.8 %}
-            yellow-background
+        {% if complete is defined and not complete %}
+            {# Nothing #}
         {% else %}
-            green-background
+            {% set percent = earned / total %}
+            {% if percent < 0.5 %}
+                red-background
+            {% elseif earned != total %}
+                yellow-background
+            {% else %}
+                green-background
+            {% endif %}
         {% endif %}
     {% endif %}
 {% endmacro %}

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -38,7 +38,6 @@ Required inputs:
                 <i><b>Note to Student: </b>{{ component.student_comment }}</i>
             </span>
         {% endif %}
-        <div class="row divider"></div>
     </div>
 {% endblock %}
 

--- a/site/public/templates/grading/GradingComponentHeader.twig
+++ b/site/public/templates/grading/GradingComponentHeader.twig
@@ -12,7 +12,7 @@
 <span class="col-no-gutters badge-container">
     <strong id="grading_total"
             class="badge {% if graded_component is defined %} {{ functions.getBadgeStyle(graded_component.total_score, component.max_value) }} {% endif %}">
-        {{ graded_component.total_score is defined ? graded_component.total_score|round(decimal_precision) : '-' }} / {{ component.max_value|round(decimal_precision) }}
+        {{ graded_component.total_score is defined ? graded_component.total_score|round(decimal_precision) : '&minus;' }} / {{ component.max_value|round(decimal_precision) }}
     </strong>
 </span>
 

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -24,7 +24,7 @@ Required Input:
         {# Keep the mark checkbox so we can keep graded data when in edit mode to automatically update the component points #}
         <span class="{{ is_checked ? 'mark-selected' : '' }} {{ edit_marks_enabled ? 'hidden' : '' }} mark-selector col-no-gutters"
               data-mark_id="{{ mark.id }}">
-            {{ mark.order + 1 }}
+            {{ mark.order }}
         </span>
     </span>
     <span class="col-no-gutters mark-points"

--- a/site/public/templates/grading/TotalScoreBox.twig
+++ b/site/public/templates/grading/TotalScoreBox.twig
@@ -10,16 +10,16 @@ Required Parameters:
 {% set show_total = auto_grading_total is defined and ta_grading_total is defined %}
 {% if auto_grading_total is defined %}
     <div class="box-title badge-container">
-        <strong id="autograding_total" class="badge {{ functions.getBadgeStyle(auto_grading_earned, ta_grading_total) }}">
-            {{ auto_grading_earned is defined ? auto_grading_earned|round(decimal_precision) : '-' }} / {{ auto_grading_total|round(decimal_precision) }}
+        <strong id="autograding_total" class="badge {{ functions.getBadgeStyle(auto_grading_earned, auto_grading_total, auto_grading_complete) }}">
+            {{ auto_grading_earned is defined ? auto_grading_earned|round(decimal_precision) : '&minus;' }} / {{ auto_grading_total|round(decimal_precision) }}
         </strong>
         <strong>Auto-Grading Total</strong>
     </div>
 {% endif %}
 {% if ta_grading_total is defined %}
     <div class="box-title badge-container">
-        <strong id="grading_total" class="badge {{ functions.getBadgeStyle(ta_grading_earned, ta_grading_total) }}">
-            {{ ta_grading_earned is defined ? ta_grading_earned|round(decimal_precision) : '-' }} / {{ ta_grading_total|round(decimal_precision) }}
+        <strong id="grading_total" class="badge {{ functions.getBadgeStyle(ta_grading_earned, ta_grading_total, ta_grading_complete) }}">
+            {{ ta_grading_earned is defined ? ta_grading_earned|round(decimal_precision) : '&minus;' }} / {{ ta_grading_total|round(decimal_precision) }}
         </strong>
         <strong>Manual Grading Total</strong>
     </div>
@@ -30,8 +30,8 @@ Required Parameters:
         {% set total_earned = ta_grading_earned|default(0) + auto_grading_earned|default(0) %}
     {% endif %}
     <div class="box-title badge-container">
-        <strong id="score_total" class="badge {{ functions.getBadgeStyle(total_earned, (ta_grading_total + auto_grading_total)) }}">
-            {{ total_earned is defined ? total_earned|round(decimal_precision) : '-' }} / {{ (ta_grading_total + auto_grading_total)|round(decimal_precision) }}
+        <strong id="score_total" class="badge {{ functions.getBadgeStyle(total_earned, (ta_grading_total + auto_grading_total), ta_grading_complete) }}">
+            {{ total_earned is defined ? total_earned|round(decimal_precision) : '&minus;' }} / {{ (ta_grading_total + auto_grading_total)|round(decimal_precision) }}
         </strong>
         <strong>Total</strong>
     </div>


### PR DESCRIPTION
Mostly minor changes, including:
- Starting mark indexes from zero
- Fix typing mark numbers that don't exist (closes #2873)
- Fix badge colors not being consistent with #2145 
- General style improvements with mark rows including borders and number sizing

More grader ui stuff to come later as I work my way around the new codebase

![](https://i.imgur.com/ysM1cFH.jpg)