### PR TITLE
Fix regrade request not being gradeable specific 

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1393,7 +1393,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
               ) AS ldet ON g.g_id=ldet.g_id AND ldet.team_id=team.team_id
               
               /* Join regrade request */
-              LEFT JOIN regrade_requests AS rr ON rr.user_id=gd.gd_user_id OR rr.team_id=gd.gd_team_id
+              LEFT JOIN regrade_requests AS rr ON (rr.user_id=gd.gd_user_id OR rr.team_id=gd.gd_team_id) AND rr.g_id=g.g_id
             WHERE $selector
             $order";
 


### PR DESCRIPTION
Fixes sql query to only get regrade requests specific to that gradeable.

Originally the sql query would try and get all regrade_requests made by a student instead of looking for a specific request. After a student has made 1 request, the query would then grab that request and attach it to every single gradeable for that student. Then submitty would think a regrade already existed for that gradeable and would prevent a student from ever opening another request.

This should prevent that first request (and any others) from showing up where they don't belong.
I don't think any data was lost while this bug was open, probably just got misplaced somewhere...

Fixes #2900