### PR TITLE
Ungraded Count-Down Component Has 0 Points

### DIFF
--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -162,7 +162,7 @@ class GradeableComponent extends AbstractModel {
     }
 
     public function getGradedTAPoints() {
-        if (!$this->getHasMarks() && $this->score == 0) {
+        if (!$this->getHasMarks() && $this->score == 0.0) {
             return 0.0; // No score if no points or marks are awarded.
         }
         $points = $this->default;

--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -162,7 +162,7 @@ class GradeableComponent extends AbstractModel {
     }
 
     public function getGradedTAPoints() {
-        if ($this->getHasMarks() && $this->score != 0.0) {
+        if (!$this->getHasMarks() && $this->score == 0) {
             return 0.0; // No score if no points or marks are awarded.
         }
         $points = $this->default;

--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -162,6 +162,9 @@ class GradeableComponent extends AbstractModel {
     }
 
     public function getGradedTAPoints() {
+        if ($this->getHasMarks() && $this->score != 0.0) {
+            return 0.0; // No score if no points or marks are awarded.
+        }
         $points = $this->default;
         foreach ($this->marks as $mark) {
             if ($mark->getHasMark()) {

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -164,7 +164,7 @@ class GradedComponent extends AbstractModel {
      * @return float
      */
     public function getTotalScore() {
-        if (count($this->marks) === 0 || $this->getScore() === 0.0) {
+        if (count($this->marks) === 0 && $this->getScore() == 0.0) {
             return 0.0; // Return no points if the user has no marks and no custom marks
         }
         // Be sure to add the default so count-down gradeables don't become negative

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -159,12 +159,20 @@ class GradedComponent extends AbstractModel {
     }
 
     /**
+     * Gets if the graded component has any marks assigned to it
+     * @return bool
+     */
+    public function anyMarks() {
+        return count($this->marks) !== 0;
+    }
+
+    /**
      * Gets the total number of points earned for this component
      *  (including mark points)
      * @return float
      */
     public function getTotalScore() {
-        if (count($this->marks) === 0 && $this->getScore() == 0.0) {
+        if (!$this->anyMarks() && $this->getScore() == 0.0) {
             return 0.0; // Return no points if the user has no marks and no custom marks
         }
         // Be sure to add the default so count-down gradeables don't become negative

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -46,7 +46,7 @@ class GradedComponent extends AbstractModel {
     protected $marks_modified = false;
 
     /** @property @var float The score for this component (or custom mark point value) */
-    protected $score = 0;
+    protected $score = 0.0;
     /** @property @var string The comment on this mark / custom mark description */
     protected $comment = "";
     /** @property @var string The Id of the grader who most recently updated the component's grade */
@@ -164,6 +164,9 @@ class GradedComponent extends AbstractModel {
      * @return float
      */
     public function getTotalScore() {
+        if (count($this->marks) === 0 || $this->getScore() === 0.0) {
+            return 0.0; // Return no points if the user has no marks and no custom marks
+        }
         // Be sure to add the default so count-down gradeables don't become negative
         $score = $this->component->getDefault();
         foreach($this->marks as $mark) {


### PR DESCRIPTION
This address the issue that @holzbh was experiencing with generating grade summaries showing incorrect scores for ungraded components.  Now, the logic that determines the grade for a component in both the new and the old model accounts for the count-down case properly, so a component must either have a mark assigned to it, or a custom mark to have a non-zero score.