### PR TITLE
Deleted component notification fixes

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -495,7 +495,7 @@ class ForumController extends AbstractController {
             $post_author = $post['author_user_id'];
             $notification = new Notification($this->core, array('component' => 'forum', 'type' => 'deleted', 'thread_id' => $thread_id, 'post_content' => $post['content'], 'reply_to' => $post_author));
             $this->core->getQueries()->pushNotification($notification);
-            $this->core->getQueries()->removeNotificationsFromParent($post_id);
+            $this->core->getQueries()->removeNotificationsPost($post_id);
             $this->core->getOutput()->renderJson($response = array('type' => $type));
             return $response;
         } else if($modifyType == 2) { //undelete post or thread

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -478,14 +478,13 @@ class ForumController extends AbstractController {
      * @param integer(0/1/2) $modifyType - 0 => delete, 1 => edit content, 2 => undelete
      */
     public function alterPost($modifyType){
+        $post_id = $_POST["post_id"] ?? $_POST["edit_post_id"];
+        if(!($this->checkPostEditAccess($post_id))) {
+                $this->core->addErrorMessage("You do not have permissions to do that.");
+                return;
+        }
         if($modifyType == 0) { //delete post or thread
-            if(!($this->core->getUser()->getGroup() <= 2)) {
-                $error = "You do not have permissions to do that.";
-                $this->core->getOutput()->renderJson($response = array('error' => $error));
-                return $response;
-            }
             $thread_id = $_POST["thread_id"];
-            $post_id = $_POST["post_id"];
             $type = "";
             if($this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 1)){
                 $type = "thread";
@@ -496,16 +495,11 @@ class ForumController extends AbstractController {
             $post_author = $post['author_user_id'];
             $notification = new Notification($this->core, array('component' => 'forum', 'type' => 'deleted', 'thread_id' => $thread_id, 'post_content' => $post['content'], 'reply_to' => $post_author));
             $this->core->getQueries()->pushNotification($notification);
+            $this->core->getQueries()->removeNotificationsFromParent($post_id);
             $this->core->getOutput()->renderJson($response = array('type' => $type));
             return $response;
         } else if($modifyType == 2) { //undelete post or thread
-            if(!($this->core->getUser()->getGroup() <= 2)) {
-                $error = "You do not have permissions to do that.";
-                $this->core->getOutput()->renderJson($response = array('error' => $error));
-                return $response;
-            }
             $thread_id = $_POST["thread_id"];
-            $post_id = $_POST["post_id"];
             $type = "";
             $result = $this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 0);
             if(is_null($result)) {
@@ -523,11 +517,6 @@ class ForumController extends AbstractController {
             return $response;
         } else if($modifyType == 1) { //edit post or thread
             $thread_id = $_POST["edit_thread_id"];
-            $post_id = $_POST["edit_post_id"];
-            if(!($this->checkPostEditAccess($post_id))) {
-                $this->core->addErrorMessage("You do not have permissions to do that.");
-                return;
-            }
             $status_edit_thread = $this->editThread();
             $status_edit_post   = $this->editPost();
             $any_changes = false;

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -327,8 +327,11 @@ class DatabaseQueries {
         return $this->course_db->rows()[0];
     }
 
-    public function removeNotificationsFromParent($post_id) {
+    public function removeNotificationsPost($post_id) {
+        //Deletes all children notifications i.e. this posts replies
         $this->course_db->query("DELETE FROM notifications where metadata::json->>1 = ?", array($post_id));
+        //Deletes parent notification i.e. this post is a reply
+        $this->course_db->query("DELETE FROM notifications where metadata::json->>2 = ?", array($post_id));
     }
 
     public function isStaffPost($author_id){

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -327,7 +327,9 @@ class DatabaseQueries {
         return $this->course_db->rows()[0];
     }
 
-
+    public function removeNotificationsFromParent($post_id) {
+        $this->course_db->query("DELETE FROM notifications where metadata::json->>1 = ?", array($post_id));
+    }
 
     public function isStaffPost($author_id){
         $this->course_db->query("SELECT user_group FROM users WHERE user_id=?", array($author_id));

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -185,7 +185,7 @@ class Notification extends AbstractModel {
     }
 
     private function actAsForumDeletedNotification($thread_id, $post_content, $target){
-        $this->setNotifyMetadata(json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id))));
+        $this->setNotifyMetadata(json_encode(array()));
         $this->setNotifyContent("Deleted: Your thread/post '".$this->textShortner($post_content)."' was deleted by ".Utils::getDisplayNameForum(false, $this->core->getQueries()->getDisplayUserInfoFromUserId($this->getCurrentUser())));
         $this->setNotifySource($this->getCurrentUser());
         $this->setNotifyTarget($target);
@@ -211,6 +211,10 @@ class Notification extends AbstractModel {
             $message = substr($message, 0, $max_length - 3) . "...";
         }
         return $message;
+    }
+
+    public function hasEmptyMetadata() {
+        return count(json_decode($this->getNotifyMetadata())) == 0;
     }
 
     /**

--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -20,6 +20,7 @@
                 </tr>
                 <tbody style="text-align: left;">
                     {% for notification in notifications %}
+                        {% set hasLink = not notification.hasEmptyMetadata() %}
                         <tr>
                             <td colspan="1">
                                 {% if notification.getComponent() == "forum" %}
@@ -27,11 +28,15 @@
                                 {% endif %}
                             </td>
                             <td colspan="4">
-                                <a href="{{ core.buildUrl({"component": "navigation", "page": "notifications", "action": "open_notification", "nid": notification.getId(), "seen": notification.isSeen() }) }}">
+                                {% if hasLink %}
+                                    <a href="{{ core.buildUrl({"component": "navigation", "page": "notifications", "action": "open_notification", "nid": notification.getId(), "seen": notification.isSeen() }) }}">
+                                {% endif %}
                                     <div style="height: 100%; width: 100%;">
                                         {{ notification.getNotifyContent() }}
                                     </div>
-                                </a>
+                                {% if hasLink %}
+                                    </a>
+                                {% endif %}
                             </td>
                             <td colspan="2">
                                 {{ notification.getNotifyTime() }}

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -523,7 +523,7 @@ input[type="button"].btn-block {
   padding: .2em .6em .3em;
   font-size: 65%;
   font-weight: bold;
-  line-height: 1;
+  line-height: 2.5;
   color: #fff;
   text-align: center;
   white-space: nowrap;


### PR DESCRIPTION
This PR addresses: 
- If there is a thread/post that is deleted the corresponding notifications for this component is also deleted (this includes all notifications where this post is a parent, and notifications where this post is a reply). 
- The notification to the user that is generated when their thread/post is deleted no longer is a link to the deleted thread.
- Fixes forum label visual display overlapping with post preview content

Visual explanation:

User gets two replies:
![notifyexample](https://user-images.githubusercontent.com/16356240/46387181-8180e380-c693-11e8-9c6c-56dac21b96d2.png)

One of the replies to the user is deleted:
![deleteone](https://user-images.githubusercontent.com/16356240/46387183-847bd400-c693-11e8-9f1a-e1a8c0187ad8.png)

The thread/post of the user is deleted:
![deleteuserthread](https://user-images.githubusercontent.com/16356240/46387187-8776c480-c693-11e8-9290-541a4ff8daa8.png)


Closes #2787.