### PR TITLE
Autograding hidden cases display when grades release

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -33,14 +33,14 @@
         <div class="box">
             <div class="box-title">
                 {{ Badge.render(nonhidden_earned, nonhidden_max, false) }}
-                <h4>{{ is_ta_grading_complete ? "Autograding Subtotal" : "Total" }}</h4>
+                <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }}</h4>
             </div>
         </div>
         {% if display_hidden %}
             <div class="box">
                 <div class="box-title">
                     {{ Badge.render(hidden_earned, hidden_max, false) }}
-                    <h4>{{ is_ta_grading_complete ? "Autograding Subtotal" : "Total" }} <i>(With Hidden Points)</i></h4>
+                    <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }} <i>(With Hidden Points)</i></h4>
                 </div>
             </div>
         {% endif %}
@@ -69,7 +69,7 @@
                 {% else %}
                     <div class="badge">
                         Hidden
-                        {% if is_ta_grading_complete %}
+                        {% if is_ta_grade_released %}
                             <br>
                             {{ Badge.format_value(testcase.points, testcase.points_total, testcase.extra_credit) }}
                         {% endif %}

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -92,7 +92,7 @@ class AutoGradingView extends AbstractView {
             "display_hidden" => $display_hidden,
             "has_badges" => $has_badges,
             'testcases' => $testcase_array,
-            'is_ta_grading_complete' => $graded_gradeable->isTaGradingComplete(),
+            'is_ta_grade_released' => $gradeable->isTaGradeReleased(),
             "show_hidden" => $show_hidden,
             'display_version' => $version_instance->getVersion()
         ]);


### PR DESCRIPTION
The autograding hidden point values were displaying after ta grading was done, now they are only displaying after ta grades are released.

closes #2947