### PR TITLE
Ungraded count-down component checks comment instead of score

### DIFF
--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -162,7 +162,7 @@ class GradeableComponent extends AbstractModel {
     }
 
     public function getGradedTAPoints() {
-        if (!$this->getHasMarks() && $this->comment === '') {
+        if (!$this->getHasMarks() && $this->score == 0.0 && $this->comment === '') {
             return 0.0; // Return no points if the user has no marks and no custom mark
         }
         $points = $this->default;

--- a/site/app/models/GradeableComponent.php
+++ b/site/app/models/GradeableComponent.php
@@ -162,8 +162,8 @@ class GradeableComponent extends AbstractModel {
     }
 
     public function getGradedTAPoints() {
-        if (!$this->getHasMarks() && $this->score == 0.0) {
-            return 0.0; // No score if no points or marks are awarded.
+        if (!$this->getHasMarks() && $this->comment === '') {
+            return 0.0; // Return no points if the user has no marks and no custom mark
         }
         $points = $this->default;
         foreach ($this->marks as $mark) {

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -171,7 +171,7 @@ class GradedComponent extends AbstractModel {
      * @return bool
      */
     public function hasCustomMark() {
-        return $this->getComment() !== '' && $this->getScore() != 0.0;
+        return $this->getComment() !== '' || $this->getScore() != 0.0;
     }
 
     /**

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -171,7 +171,7 @@ class GradedComponent extends AbstractModel {
      * @return bool
      */
     public function hasCustomMark() {
-        return !($this->getComment() == '' && $this->getScore() == 0.0);
+        return $this->getComment() !== '' && $this->getScore() != 0.0;
     }
 
     /**

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -171,7 +171,7 @@ class GradedComponent extends AbstractModel {
      * @return bool
      */
     public function hasCustomMark() {
-        return $this->getComment() !== '';
+        return !($this->getComment() == '' && $this->getScore() == 0.0);
     }
 
     /**

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -159,11 +159,19 @@ class GradedComponent extends AbstractModel {
     }
 
     /**
-     * Gets if the graded component has any marks assigned to it
+     * Gets if the graded component has any common marks assigned to it
      * @return bool
      */
     public function anyMarks() {
         return count($this->marks) !== 0;
+    }
+
+    /**
+     * Gets if the graded component has a custom mark
+     * @return bool
+     */
+    public function hasCustomMark() {
+        return $this->getComment() !== '';
     }
 
     /**
@@ -172,7 +180,7 @@ class GradedComponent extends AbstractModel {
      * @return float
      */
     public function getTotalScore() {
-        if (!$this->anyMarks() && $this->getComment() === '') {
+        if (!$this->anyMarks() && !$this->hasCustomMark()) {
             return 0.0; // Return no points if the user has no marks and no custom mark
         }
         // Be sure to add the default so count-down gradeables don't become negative

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -172,8 +172,8 @@ class GradedComponent extends AbstractModel {
      * @return float
      */
     public function getTotalScore() {
-        if (!$this->anyMarks() && $this->getScore() == 0.0) {
-            return 0.0; // Return no points if the user has no marks and no custom marks
+        if (!$this->anyMarks() && $this->getComment() === '') {
+            return 0.0; // Return no points if the user has no marks and no custom mark
         }
         // Be sure to add the default so count-down gradeables don't become negative
         $score = $this->component->getDefault();


### PR DESCRIPTION
Count down components with a custom mark will not have any common marks.  The custom mark may have a 0.0 score to indicate full credit, but it will have text.  The recently-changed logic would show the student that they received 0 points for the component instead of full credit.  This PR changes the logic to look at the custom mark text instead of the score.