### PR TITLE
Create testcases for Course model

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -82,9 +82,8 @@ class HomePageController extends AbstractController {
      */
     public function showHomepage() {
         $user = $this->core->getUser();
-        $submitty_path = $this->core->getConfig()->getSubmittyPath();
-        $unarchived_courses = $this->core->getQueries()->getUnarchivedCoursesById($user->getId(), $submitty_path);
-        $archived_courses = $this->core->getQueries()->getArchivedCoursesById($user->getId(), $submitty_path);
+        $unarchived_courses = $this->core->getQueries()->getUnarchivedCoursesById($user->getId());
+        $archived_courses = $this->core->getQueries()->getArchivedCoursesById($user->getId());
 
         //Filter out any courses a student has dropped so they do not appear on the homepage.
         //Do not filter courses for non-students.

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2189,7 +2189,7 @@ ORDER BY gt.{$section_key}", $params);
 	 * @param string $submitty_path
 	 * @return array - unarchived courses (and their details) accessible by $user_id
 	 */
-    public function getUnarchivedCoursesById($user_id, $submitty_path) {
+    public function getUnarchivedCoursesById($user_id) {
         $this->submitty_db->query("
 SELECT u.semester, u.course
 FROM courses_users u
@@ -2208,7 +2208,7 @@ ORDER BY u.user_group ASC,
         $return = array();
         foreach ($this->submitty_db->rows() as $row) {
             $course = new Course($this->core, $row);
-            $course->loadDisplayName($submitty_path);
+            $course->loadDisplayName();
             $return[] = $course;
         }
         return $return;
@@ -2225,7 +2225,7 @@ ORDER BY u.user_group ASC,
      * @param string $submitty_path
      * @return array - archived courses (and their details) accessible by $user_id
      */
-    public function getArchivedCoursesById($user_id, $submitty_path) {
+    public function getArchivedCoursesById($user_id) {
         $this->submitty_db->query("
 SELECT u.semester, u.course
 FROM courses_users u
@@ -2244,7 +2244,7 @@ ORDER BY u.user_group ASC,
         $return = array();
         foreach ($this->submitty_db->rows() as $row) {
             $course = new Course($this->core, $row);
-            $course->loadDisplayName($submitty_path);
+            $course->loadDisplayName();
             $return[] = $course;
         }
         return $return;

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -10,6 +10,7 @@ use app\libraries\IniParser;
  * Holds basic information about courses. Used on homepage.
  * @method string getSemester()
  * @method string getTitle()
+ * @method string getDisplayName()
   */
 class Course extends AbstractModel {
      
@@ -33,23 +34,34 @@ class Course extends AbstractModel {
         $this->display_name = "";
     }
 
-    public function loadDisplayName($submitty_path){
-        $course_ini_path = FileUtils::joinPaths($submitty_path, "courses", $this->semester, $this->title, "config", "config.ini");
-        if (file_exists($course_ini_path) && is_readable ($course_ini_path)) {
+    public function loadDisplayName(){
+        $course_ini_path = FileUtils::joinPaths(
+            $this->core->getConfig()->getSubmittyPath(),
+            "courses",
+            $this->semester,
+            $this->title,
+            "config",
+            "config.ini"
+        );
+        if (file_exists($course_ini_path) && is_readable($course_ini_path)) {
             $config = IniParser::readFile($course_ini_path);
-            if (isset($config['course_details']['course_name'])) {
-                $this->display_name = $config['course_details']['course_name'];            
+            if (isset($config['course_details']) && isset($config['course_details']['course_name'])) {
+                $this->display_name = $config['course_details']['course_name'];
+                return true;
             }
         }
+        return false;
     }
 
     public function getLongSemester() {
         if (strlen($this->semester) == 3) {
-            if (strtolower($this->semester[0]) == 'f') {
+            if (strtolower($this->semester[0]) === 'f') {
                 return "Fall 20".substr($this->semester,1,2);
-            } else if (strtolower($this->semester[0]) == 's') {
+            }
+            elseif (strtolower($this->semester[0]) === 's') {
                 return "Spring 20".substr($this->semester,1,2);
-            } else if (strtolower($this->semester[0]) == 'u') {
+            }
+            elseif (strtolower($this->semester[0]) === 'u') {
                 return "Summer 20".substr($this->semester,1,2);
             }
         }

--- a/site/tests/app/models/CourseTester.php
+++ b/site/tests/app/models/CourseTester.php
@@ -20,6 +20,14 @@ class CourseTester extends BaseUnitTest {
         $this->assertEquals('csci1000', $course->getTitle());
         $this->assertEquals('CSCI1000', $course->getCapitalizedTitle());
         $this->assertEquals('', $course->getDisplayName());
+
+        $array = [
+            'semester' => 's18',
+            'title' => 'csci1000',
+            'display_name' => '',
+            'modified' => false
+        ];
+        $this->assertEquals($array, $course->toArray());
     }
 
     public function longSemesterDataProvider() {
@@ -68,6 +76,13 @@ class CourseTester extends BaseUnitTest {
             $course = new Course($this->createMockCore(['tmp_path' => $temp_dir]), $details);
             $this->assertTrue($course->loadDisplayName());
             $this->assertEquals('Test Course', $course->getDisplayName());
+            $array = [
+                'semester' => 's18',
+                'title' => 'csci1000',
+                'display_name' => 'Test Course',
+                'modified' => false
+            ];
+            $this->assertEquals($array, $course->toArray());
         }
         finally {
             FileUtils::recursiveRmdir($temp_dir);

--- a/site/tests/app/models/CourseTester.php
+++ b/site/tests/app/models/CourseTester.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace tests\app\models;
+
+use app\libraries\FileUtils;
+use app\libraries\IniParser;
+use app\libraries\Utils;
+use app\models\Course;
+use tests\BaseUnitTest;
+
+class CourseTester extends BaseUnitTest {
+    public function testCourse() {
+        $details = [
+            'semester' => 's18',
+            'course' => 'csci1000'
+        ];
+        $course = new Course($this->createMockCore(), $details);
+        $this->assertEquals('s18', $course->getSemester());
+        $this->assertEquals('Spring 2018', $course->getLongSemester());
+        $this->assertEquals('csci1000', $course->getTitle());
+        $this->assertEquals('CSCI1000', $course->getCapitalizedTitle());
+        $this->assertEquals('', $course->getDisplayName());
+    }
+
+    public function longSemesterDataProvider() {
+        return [
+            ['s18', 'Spring 2018'],
+            ['s22', 'Spring 2022'],
+            ['f18', 'Fall 2018'],
+            ['f32', 'Fall 2032'],
+            ['u18', 'Summer 2018'],
+            ['u12', 'Summer 2012'],
+            ['g18', 'g18'],
+            ['ss18', 'ss18'],
+            ['fs18', 'fs18'],
+            ['us18', 'us18']
+        ];
+    }
+
+    /**
+     * @dataProvider longSemesterDataProvider
+     * @param $short
+     * @param $expected_long
+     */
+    public function testLongSemester($short, $expected_long) {
+        $details = [
+            'semester' => $short,
+            'course' => 'csci0000'
+        ];
+        $course = new Course($this->createMockCore(), $details);
+        $this->assertEquals($short, $course->getSemester());
+        $this->assertEquals('csci0000', $course->getTitle());
+        $this->assertEquals($expected_long, $course->getLongSemester());
+    }
+
+    public function testLoadDisplayName() {
+        $temp_dir = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
+        $config_path = FileUtils::joinPaths($temp_dir, 'courses', 's18', 'csci1000', 'config');
+        FileUtils::createDir($config_path, null, true);
+        $config = [
+            'course_details' => [
+                'course_name' => 'Test Course',
+            ]
+        ];
+        IniParser::writeFile(FileUtils::joinPaths($config_path, 'config.ini'), $config);
+        $details = ['semester' => 's18', 'course' => 'csci1000'];
+        try {
+            $course = new Course($this->createMockCore(['tmp_path' => $temp_dir]), $details);
+            $this->assertTrue($course->loadDisplayName());
+            $this->assertEquals('Test Course', $course->getDisplayName());
+        }
+        finally {
+            FileUtils::recursiveRmdir($temp_dir);
+        }
+    }
+
+    public function testInvalidPath() {
+        $details = ['semester' => 's18', 'course' => 'csci1000'];
+        $course = new Course($this->createMockCore(['tmp_path' => '/invalid/path']), $details);
+        $this->assertFalse($course->loadDisplayName());
+        $this->assertEquals('', $course->getDisplayName());
+    }
+
+    public function testMissingSection() {
+        $temp_dir = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
+        $config_path = FileUtils::joinPaths($temp_dir, 'courses', 's18', 'csci1000', 'config');
+        FileUtils::createDir($config_path, null, true);
+        $config = [];
+        IniParser::writeFile(FileUtils::joinPaths($config_path, 'config.ini'), $config);
+        $details = ['semester' => 's18', 'course' => 'csci1000'];
+        try {
+            $course = new Course($this->createMockCore(['tmp_path' => $temp_dir]), $details);
+            $this->assertFalse($course->loadDisplayName());
+            $this->assertEquals('', $course->getDisplayName());
+        }
+        finally {
+            FileUtils::recursiveRmdir($temp_dir);
+        }
+    }
+
+    public function testMissingSetting() {
+        $temp_dir = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
+        $config_path = FileUtils::joinPaths($temp_dir, 'courses', 's18', 'csci1000', 'config');
+        FileUtils::createDir($config_path, null, true);
+        $config = ['course_details' => []];
+        IniParser::writeFile(FileUtils::joinPaths($config_path, 'config.ini'), $config);
+        $details = ['semester' => 's18', 'course' => 'csci1000'];
+        try {
+            $course = new Course($this->createMockCore(['tmp_path' => $temp_dir]), $details);
+            $this->assertFalse($course->loadDisplayName());
+            $this->assertEquals('', $course->getDisplayName());
+        }
+        finally {
+            FileUtils::recursiveRmdir($temp_dir);
+        }
+    }
+}


### PR DESCRIPTION
This also simplifies the loadDisplayName function to just use the stored reference to $Core to get the Submitty path instead of having it be passed in which was redundant.