### PR TITLE
Removed artificial restriction on team regrade requests

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -72,8 +72,6 @@ class HomeworkView extends AbstractView {
         }
 
         $regrade_available = $this->core->getConfig()->isRegradeEnabled()
-            // FIXME: remove this check once regrade requests support team assignments
-            && !$gradeable->isTeamAssignment()
             && $gradeable->isTaGradeReleased()
             && $gradeable->isTaGrading()
             && $graded_gradeable !== null


### PR DESCRIPTION
Closes #2914 

This is an artifact of when the old gradeable model was being used for regrade requests and it didn't support team regrade requests.

I tested the entire lifecycle of a gradeable with regrade requests and teams and it all seems to work as expected.  However, until #2970 gets merged,  the `Grade` button on the `Details` page for the team that has a regrade request doesn't turn into `REGRADE`.  It still displays the score as if no regrade request existed.