### PR TITLE
Mark text wrapping + alignment

### DIFF
--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -45,9 +45,11 @@
             {# Todo: This is heinous #}
             {% set extra_credit = component.getTitle()|lower|trim == "extra credit" %}
 
-            <div class="box">
-                <div class="box-title">
+            <div class="box grade-results">
+                <div class="box-badge">
                     {{ Badge.render(component.getGradedTAPoints(), component.getMaxValue(), extra_credit) }}
+                </div>
+                <div class="box-info">
                     <h4>{{ component.getTitle() }}
                         {# Grader only shows up if they are not peer and full access #}
                         {% if not gradeable.getPeerGrading() and component.getGrader().accessFullGrading() %}
@@ -67,7 +69,7 @@
                                                 <i class="fa fa-square-o fa-1g"></i>
                                             {% endif %}
                                         </td>
-                                        <td style="text-align: right">
+                                        <td class="mark-score">
                                             {{ mark.getPoints()|number_format(num_decimals) }}
                                         </td>
                                         <td>
@@ -80,7 +82,7 @@
                                         <td>
                                             <i class="fa fa-check-square-o fa-1g"></i>
                                         </td>
-                                        <td style="text-align: right">
+                                        <td class="mark-score">
                                             {{ component.getScore()|number_format(num_decimals) }}
                                         </td>
                                         <td>

--- a/site/app/templates/autograding/TAResultsNew.twig
+++ b/site/app/templates/autograding/TAResultsNew.twig
@@ -64,7 +64,7 @@
                         {% endif %}
                     </h4>
                     <div style="float:left; word-break: break-word;">
-                        <p style="padding-bottom: 10px;">{{ component.student_comment }}</p>
+                        <p style="padding-bottom: 10px;">{{ component.student_comment|nl2br }}</p>
                         <p>
                         <table class="gradeable_comment">
                             {% for mark in component.marks if mark.show_mark %}

--- a/site/app/templates/autograding/TAResultsNew.twig
+++ b/site/app/templates/autograding/TAResultsNew.twig
@@ -53,9 +53,11 @@
 
         {# Component boxes #}
         {% for component in components %}
-            <div class="box">
-                <div class="box-title">
+            <div class="box grade-results">
+                <div class="box-badge">
                     {{ Badge.render(component.total_score, component.points_possible, component.extra_credit) }}
+                </div>
+                <div class="box-info">
                     <h4>{{ component.title }}
                         {% if not is_peer and component.graders|length != 0 %}
                             <i>(Graded by: {{ component.graders|join(' / ') }})</i>
@@ -74,7 +76,7 @@
                                             <i class="fa fa-square-o fa-1g"></i>
                                         {% endif %}
                                     </td>
-                                    <td style="text-align: right">
+                                    <td class="mark-score">
                                         {{ mark.points|number_format(num_decimals) }}
                                     </td>
                                     <td>
@@ -87,7 +89,7 @@
                                     <td>
                                         <i class="fa fa-check-square-o fa-1g"></i>
                                     </td>
-                                    <td style="text-align: right">
+                                    <td class="mark-score">
                                         {{ component.custom_mark_score|number_format(num_decimals) }}
                                     </td>
                                     <td>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -698,9 +698,9 @@ table tr.table-header {
 }
 
 .no-badge {
-    width: 85px;
+    width: 70px;
     height: 10px;
-    margin-right: 20px;
+    margin-right: 10px;
     margin-left: 10px;
     float: left;
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -641,6 +641,11 @@ table tr.table-header {
     margin-left: 20px;
 }
 
+.grade-results {
+    display: flex;
+    flex-direction: row;
+}
+
 .box > h4 {
     margin-bottom: 10px;
     margin-left: 10px;
@@ -689,7 +694,7 @@ table tr.table-header {
     background-color: #999;
     border-radius: 10px;
     margin-left: 10px;
-    margin-right: 20px;
+    margin-right: 10px;
 }
 
 .no-badge {
@@ -746,6 +751,11 @@ table tr.table-header {
 
 .gradeable_comment td {
     padding: 0 4px;
+}
+
+.gradeable_comment td.mark-score {
+    text-align: right;
+    white-space: nowrap;
 }
 
 #search_wrapper{

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -30,12 +30,12 @@ Required inputs:
         {% endif %}
         {% if show_ta_comment %}
             <span class="row ta-student-comment">
-                <i><b>Note to TA: </b>{{ component.ta_comment }}</i>
+                <i><b>Note to TA: </b>{{ component.ta_comment|nl2br }}</i>
             </span>
         {% endif %}
         {% if show_student_comment %}
             <span class="row ta-student-comment">
-                <i><b>Note to Student: </b>{{ component.student_comment }}</i>
+                <i><b>Note to Student: </b>{{ component.student_comment|nl2br }}</i>
             </span>
         {% endif %}
     </div>


### PR DESCRIPTION
- Closes #2504 
- Fixes an issue where the point values were being wrapped on every char if the mark was too long
- Fixes ta/student comment not having newlines when displayed