### PR TITLE
Custom Mark Improvements

### DIFF
--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -654,6 +654,11 @@ tr.is_publish {
     background: #FFAAAA
 }
 
+.gradeable .custom-mark-error {
+    border-color: #F00;
+    background-color: #FEE;
+}
+
 .gradeable .mark-deleted span.delete-mark-container {
     display: none;
 }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1691,6 +1691,23 @@ function getComponentVersionConflict(graded_component) {
     return graded_component !== undefined && graded_component.graded_version !== getDisplayVersion();
 }
 
+/**
+ * Sets the error state of the custom mark message
+ * @param {int} component_id
+ * @param {boolean} show_error
+ */
+function setCustomMarkError(component_id, show_error) {
+    let jquery = getComponentJQuery(component_id).find('textarea.mark-note-custom');
+    let c = 'custom-mark-error';
+    if (show_error) {
+        jquery.addClass(c);
+        jquery.prop('title', 'Custom mark cannot be blank!');
+    } else {
+        jquery.removeClass(c);
+        jquery.prop('title', '');
+    }
+}
+
 
 /**
  * DOM Callback methods
@@ -1903,6 +1920,11 @@ function onCustomMarkChange(me) {
  */
 function onToggleCustomMark(me) {
     let component_id = getComponentIdFromDOMElement(me);
+    let graded_component = getGradedComponentFromDOM(component_id);
+    if (graded_component.comment === '') {
+        setCustomMarkError(component_id, true);
+        return;
+    }
     toggleDOMCustomMark(component_id);
     toggleCustomMark(component_id)
         .catch(function (err) {

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2528,6 +2528,14 @@ function closeComponentGrading(component_id, saveChanges) {
                     component_tmp = component;
                 });
         } else {
+            // The grader unchecked the custom mark, but didn't delete the text.  This shouldn't happen too often,
+            //  so prompt the grader if this is what they really want since it will delete the text / score.
+            let gradedComponent = getGradedComponentFromDOM(component_id);
+            if (gradedComponent.comment !== '' && !gradedComponent.custom_mark_selected) {
+                if (!confirm("Are you sure you want to delete the custom mark?")) {
+                    return sequence;
+                }
+            }
             // We're in grade mode, so save the graded component
             sequence = sequence
                 .then(function () {
@@ -2560,9 +2568,12 @@ function closeComponentGrading(component_id, saveChanges) {
 function closeComponent(component_id, saveChanges = true) {
     setComponentInProgress(component_id);
     // Achieve polymorphism in the interface using this `isInstructorEditEnabled` flag
-    return isInstructorEditEnabled()
+    return (isInstructorEditEnabled()
         ? closeComponentInstructorEdit(component_id, saveChanges)
-        : closeComponentGrading(component_id, saveChanges)
+        : closeComponentGrading(component_id, saveChanges))
+        .then(function () {
+            setComponentInProgress(component_id, false);
+        });
 }
 
 /**


### PR DESCRIPTION
Closes #2678 

The 'checked' state of the custom mark will continue to update automatically based on the presence or absence of text in the 'message' input.  

If you try to check the custom mark without any text in the 'message' input, the 'message' input will turn red and get a on-hover tooltip that prompts the user that they need a non-blank message.  
![image](https://user-images.githubusercontent.com/3719964/46928282-d6174d80-d007-11e8-86fa-92f01d35c71e.png)

Additionally, if the custom mark does have 'message' text, but the grader unchecks the custom mark, they will be prompted to confirm their decision to delete the custom mark since the message / point value will be lost when the component is saved.
![image](https://user-images.githubusercontent.com/3719964/46957491-b6167700-d065-11e8-9d45-782b0bf8dcd3.png)
