### PR TITLE
Fix zooming not saving problem

### DIFF
--- a/site/app/templates/grading/electronic/PDFAnnotationBar.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationBar.twig
@@ -11,7 +11,7 @@
         <a value="rotate" class="fa fa-rotate-right toolbar-action"></a>
         <a value="text" class="fa fa-font toolbar-item"></a>
         <a value="zoomin" class="fa fa-plus toolbar-action"></a>
-        <a value="zoomcustom" class="toolbar-action">100%</a>
+        <a value="zoomcustom" class="toolbar-action"></a>
         <a value="zoomout" class="fa fa-minus toolbar-action"></a>
         <a value="save" class="toolbar-action">Save</a>
         {#<a value="download" class="fa fa-download toolbar-action"></a>#}

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -68,6 +68,7 @@ function render(gradeable_id, user_id, grader_id, file_name, url = "") {
                         e.preventDefault();
                     }
                 });
+                $("a[value='zoomcustom']").text(parseInt(RENDER_OPTIONS.scale * 100) + "%");
                 viewer.innerHTML = '';
                 NUM_PAGES = pdf.pdfInfo.numPages;
                 for (let i=0; i<NUM_PAGES; i++) {

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -118,7 +118,7 @@ let GENERAL_INFORMATION = window.GENERAL_INFORMATION;
         $("a[value='zoomcustom']").text(parseInt(RENDER_OPTIONS.scale * 100) + "%");
         if(zoom_flag){
             localStorage.setItem('scale', RENDER_OPTIONS.scale);
-            render(GENERAL_INFORMATION.gradeable_id, GENERAL_INFORMATION.user_id, RENDER_OPTIONS.grader_id, GENERAL_INFORMATION.file_name);
+            render(GENERAL_INFORMATION.gradeable_id, GENERAL_INFORMATION.user_id, GENERAL_INFORMATION.grader_id, GENERAL_INFORMATION.file_name);
         }
     }
 


### PR DESCRIPTION
This fixes the problem discovered by @holzbh, where if you zoom in, the annotation won't save. Also fixed the zoom indicator so it's correct on start.