### PR TITLE
Hidden testcases only visible for graded version

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -317,7 +317,7 @@ class SubmissionController extends AbstractController {
                     $this->core->getQueries()->saveTaGradedGradeable($graded_gradeable->getTaGradedGradeable());
                 }
 
-                // Only show hidden test cases if the display version is the graded version
+                // Only show hidden test cases if the display version is the graded version (and grades are released)
                 $show_hidden = $version == $graded_gradeable->getOrCreateTaGradedGradeable()->getGradedVersion(false) && $gradeable->isTaGradeReleased();
 
                 // If we get here, then we can safely construct the old model w/o checks

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -316,13 +316,15 @@ class SubmissionController extends AbstractController {
                     $graded_gradeable->getOrCreateTaGradedGradeable()->setUserViewedDate($now);
                     $this->core->getQueries()->saveTaGradedGradeable($graded_gradeable->getTaGradedGradeable());
                 }
-                $canViewWholeGradeable = false;
+
+                // Only show hidden test cases if the display version is the graded version
+                $show_hidden = $version == $graded_gradeable->getOrCreateTaGradedGradeable()->getGradedVersion(false) && $gradeable->isTaGradeReleased();
 
                 // If we get here, then we can safely construct the old model w/o checks
                 // FIXME: remove this 'old_gradeable' once none of the HomeworkView relies on it
                 $old_gradeable = $this->core->getQueries()->getGradeable($gradeable_id, $this->core->getUser()->getId());
                 $this->core->getOutput()->renderOutput(array('submission', 'Homework'),
-                                                       'showGradeable', $gradeable, $graded_gradeable, $old_gradeable, $version, $late_days_use, $extensions, $canViewWholeGradeable);
+                                                       'showGradeable', $gradeable, $graded_gradeable, $old_gradeable, $version, $late_days_use, $extensions, $show_hidden);
             }
         }
         return array('id' => $gradeable_id, 'error' => $error);

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -41,7 +41,7 @@
                 <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }}</h4>
             </div>
         </div>
-        {% if display_hidden %}
+        {% if any_visible_hidden and show_hidden %}
             <div class="box">
                 <div class="box-title">
                     {{ Badge.render(hidden_earned, hidden_max, false) }}
@@ -56,11 +56,11 @@
     {% set can_view = (not testcase.hidden or show_hidden) %}
     <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#D3D3D3;'" : "" }}>
         <div id='tc_{{ loop.index0 }}' class="box-title"
-                {{ testcase.has_extra_results and can_view ? "style='cursor: pointer;'" : "" }}
+                {{ testcase.has_extra_results and not testcase.hidden ? "style='cursor: pointer;'" : "" }}
              onclick="loadTestcaseOutput('testcase_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ submitter_id }}', '{{ loop.index0 }}', {{ display_version }});">
 
             {# Details button #}
-            {% if testcase.has_extra_results and can_view %}
+            {% if testcase.has_extra_results and not testcase.hidden %}
                 <div style="float:right; color: #0000EE; text-decoration: underline">
                     Details
                 </div>
@@ -69,15 +69,11 @@
 
             {# Badge #}
             {% if testcase.has_points %}
-                {% if can_view %}
+                {% if not testcase.hidden or show_hidden %}
                     {{ Badge.render(testcase.points, testcase.points_total, testcase.extra_credit) }}
                 {% else %}
                     <div class="badge">
                         Hidden
-                        {% if is_ta_grade_released %}
-                            <br>
-                            {{ Badge.format_value(testcase.points, testcase.points_total, testcase.extra_credit) }}
-                        {% endif %}
                     </div>
                 {% endif %}
             {% elseif has_badges %}
@@ -86,7 +82,7 @@
             {# /Badge #}
 
             <h4>
-                {% if testcase.hidden and show_hidden %}
+                {% if testcase.hidden %}
                     HIDDEN:
                 {% endif %}
                 {{ testcase.name }}

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -40,11 +40,11 @@
     {% set can_view = (not testcase.hidden or show_hidden) %}
     <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#D3D3D3;'" : "" }}>
         <div id='tc_{{ loop.index0 }}' class="box-title"
-                {{ testcase.has_extra_results and not testcase.hidden ? "style='cursor: pointer;'" : "" }}
+                {{ testcase.has_extra_results and can_view ? "style='cursor: pointer;'" : "" }}
              onclick="loadTestcaseOutput('testcase_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ submitter_id }}', '{{ loop.index0 }}', {{ display_version }});">
 
             {# Details button #}
-            {% if testcase.has_extra_results and not testcase.hidden %}
+            {% if testcase.has_extra_results and can_view %}
                 <div style="float:right; color: #0000EE; text-decoration: underline">
                     Details
                 </div>

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -18,37 +18,21 @@
 {% endif %}
 
 {% if num_visible_testcases > 1 %}
+    {# check if instructor grades exist and change title, display hidden points when TA grades are released (if hidden tests exist) #}
+
+    <div class="box">
+        <div class="box-title">
+            {{ Badge.render(nonhidden_earned, nonhidden_max, false) }}
+            <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }} {% if show_hidden_breakdown %} <i>(Without Hidden Points)</i>{% endif %}</h4>
+        </div>
+    </div>
     {% if show_hidden_breakdown %}
         <div class="box">
             <div class="box-title">
-                {{ Badge.render(nonhidden_earned, nonhidden_max, false) }}
-                <h4>Total (No Hidden Points)</h4>
-            </div>
-        </div>
-
-        <div class="box" style="background-color:#D3D3D3;">
-            <div class="box-title">
                 {{ Badge.render(hidden_earned, hidden_max, false) }}
-                <h4>Total (With Hidden Points)</h4>
+                <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }} <i>(With Hidden Points)</i></h4>
             </div>
         </div>
-    {% else %}
-        {# check if instructor grades exist and change title, display hidden points when TA grades are released (if hidden tests exist) #}
-
-        <div class="box">
-            <div class="box-title">
-                {{ Badge.render(nonhidden_earned, nonhidden_max, false) }}
-                <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }}</h4>
-            </div>
-        </div>
-        {% if any_visible_hidden and show_hidden %}
-            <div class="box">
-                <div class="box-title">
-                    {{ Badge.render(hidden_earned, hidden_max, false) }}
-                    <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }} <i>(With Hidden Points)</i></h4>
-                </div>
-            </div>
-        {% endif %}
     {% endif %}
 {% endif %}
 

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -32,7 +32,7 @@ class AutoGradingView extends AbstractView {
         $hidden_earned = 0;
         $hidden_max = 0;
         $show_hidden_breakdown = false;
-        $display_hidden = false;
+        $any_visible_hidden = false;
         $num_visible_testcases = 0;
 
         // FIXME: This variable should be false if autograding results
@@ -69,12 +69,11 @@ class AutoGradingView extends AbstractView {
 
             $show_hidden_breakdown = ($version_instance->getNonHiddenNonExtraCredit() + $version_instance->getHiddenNonExtraCredit() > $autograding_config->getTotalNonHiddenNonExtraCredit()) && $show_hidden;
 
-            $display_hidden = false;
             if ($gradeable->isTaGradeReleased()) {
                 foreach ($version_instance->getTestcases() as $testcase) {
                     if (!$testcase->canView()) continue;
                     if ($testcase->getTestcase()->isHidden()) {
-                        $display_hidden = true;
+                        $any_visible_hidden = true;
                         break;
                     }
                 }
@@ -100,11 +99,11 @@ class AutoGradingView extends AbstractView {
             "nonhidden_max" => $nonhidden_max,
             "hidden_earned" => $hidden_earned,
             "hidden_max" => $hidden_max,
-            "display_hidden" => $display_hidden,
+            "show_hidden" => $show_hidden,
+            "any_visible_hidden" => $any_visible_hidden,
             "has_badges" => $has_badges,
             'testcases' => $testcase_array,
             'is_ta_grade_released' => $gradeable->isTaGradeReleased(),
-            "show_hidden" => $show_hidden,
             'display_version' => $version_instance->getVersion()
         ]);
     }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -67,8 +67,6 @@ class AutoGradingView extends AbstractView {
             $hidden_earned = $version_instance->getTotalPoints();
             $hidden_max = $autograding_config->getTotalNonExtraCredit();
 
-            $show_hidden_breakdown = ($version_instance->getNonHiddenNonExtraCredit() + $version_instance->getHiddenNonExtraCredit() > $autograding_config->getTotalNonHiddenNonExtraCredit()) && $show_hidden;
-
             if ($gradeable->isTaGradeReleased()) {
                 foreach ($version_instance->getTestcases() as $testcase) {
                     if (!$testcase->canView()) continue;
@@ -78,6 +76,9 @@ class AutoGradingView extends AbstractView {
                     }
                 }
             }
+
+            $show_hidden_breakdown = $any_visible_hidden && $show_hidden &&
+                ($version_instance->getNonHiddenNonExtraCredit() + $version_instance->getHiddenNonExtraCredit() > $autograding_config->getTotalNonHiddenNonExtraCredit());
         }
         foreach ($version_instance->getTestcases() as $testcase) {
 
@@ -100,7 +101,6 @@ class AutoGradingView extends AbstractView {
             "hidden_earned" => $hidden_earned,
             "hidden_max" => $hidden_max,
             "show_hidden" => $show_hidden,
-            "any_visible_hidden" => $any_visible_hidden,
             "has_badges" => $has_badges,
             'testcases' => $testcase_array,
             'is_ta_grade_released' => $gradeable->isTaGradeReleased(),

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -29,10 +29,10 @@ class HomeworkView extends AbstractView {
      * @param int $display_version
      * @param int $late_days_use
      * @param int $extensions
-     * @param bool $canViewWholeGradeable
+     * @param bool $show_hidden_testcases
      * @return string
      */
-    public function showGradeable(Gradeable $gradeable, $graded_gradeable, \app\models\Gradeable $old_gradeable, int $display_version, int $late_days_use, int $extensions, bool $canViewWholeGradeable = false) {
+    public function showGradeable(Gradeable $gradeable, $graded_gradeable, \app\models\Gradeable $old_gradeable, int $display_version, int $late_days_use, int $extensions, bool $show_hidden_testcases = false) {
         $return = '';
 
         $this->core->getOutput()->addInternalJs('drag-and-drop.js');
@@ -68,7 +68,7 @@ class HomeworkView extends AbstractView {
         if ($submission_count === 0) {
             $return .= $this->renderNoSubmissionBox($graded_gradeable);
         } else {
-            $return .= $this->renderVersionBox($graded_gradeable, $version_instance, $canViewWholeGradeable);
+            $return .= $this->renderVersionBox($graded_gradeable, $version_instance, $show_hidden_testcases);
         }
 
         $regrade_available = $this->core->getConfig()->isRegradeEnabled()

--- a/site/tests/app/controllers/submission/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/submission/SubmissionControllerTester.php
@@ -8,6 +8,7 @@ use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\AutogradingConfig;
 use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\Submitter;
+use app\models\gradeable\TaGradedGradeable;
 use \ZipArchive;
 use app\controllers\student\SubmissionController;
 use app\exceptions\IOException;
@@ -1167,8 +1168,12 @@ class SubmissionControllerTester extends BaseUnitTest {
         $gradeable->method('isSubmissionOpen')->willReturn(true);
         $core->getQueries()->method('getGradeableConfig')->with('test')->willReturn($gradeable);
 
+        $ta_graded_gradeable = $this->createMockModel(TaGradedGradeable::class);
+        $ta_graded_gradeable->method('getGradedVersion')->willReturn(0);
+
         $graded_gradeable = $this->createMockGradedGradeable();
         $graded_gradeable->method('getSubmitter')->willReturn($this->createMockSubmitter('testUser'));
+        $graded_gradeable->method('getOrCreateTaGradedGradeable')->willReturn($ta_graded_gradeable);
         $core->getQueries()->method('getGradedGradeable')->willReturn($graded_gradeable);
 
         $return = $this->runController($core);


### PR DESCRIPTION
Closes #2994 

The hidden test cases are only visible for the version that the TA graded.

Graded version:
![image](https://user-images.githubusercontent.com/3719964/47246013-aaaaaf00-d3c9-11e8-8510-e3784790a5cf.png)

Other Version:
![image](https://user-images.githubusercontent.com/3719964/47246038-c1510600-d3c9-11e8-92b3-d0e0a18c3c4a.png)
