### PR TITLE
Use variable PHP version to restart FPM

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -707,11 +707,12 @@ fi
 # Restart php-fpm and apache
 if [ "${WORKER}" == 0 ]; then
     if [[ "$#" -ge 1 && $1 == "restart_web" ]]; then
-        echo -n "restarting php7.0-fpm..."
-        systemctl restart php7.0-fpm.service
+        PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
+        echo -n "restarting php${PHP_VERSION}-fpm..."
+        systemctl restart php${PHP_VERSION}-fpm
         echo "done"
         echo -n "restarting apache2..."
-        systemctl restart apache2.service
+        systemctl restart apache2
         echo "done"
     fi
 fi


### PR DESCRIPTION
#3010 reminded me that I had agreed to do this ages ago (sorry Barb).

This should better future-proof of us on whatever PHP version we're running for restarting the FPM service.