### PR TITLE
Autograding total/subtotal display bug

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1755,16 +1755,28 @@ class SubmissionController extends AbstractController {
 
         // Don't load the graded gradeable, since that may not exist yet
         $submitter_id = $this->core->getUser()->getId();
+        $user_id = $submitter_id;
+        $team_id = null;
         if ($gradeable !== null && $gradeable->isTeamAssignment()) {
             $team = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable_id, $submitter_id);
+
             if ($team !== null) {
                 $submitter_id = $team->getId();
+                $team_id = $submitter_id;
+                $user_id = null;
             }
         }
 
-        $path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "results", $gradeable_id,
-            $submitter_id, $version);
-        if (file_exists($path."/results.json")) {
+        $filepath = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "results", $gradeable_id,
+            $submitter_id, $version, "results.json");
+
+        $results_json_exists = file_exists($filepath);
+
+        // if the results json exists, check the database to make sure that the autogradingresults are done.
+        $has_results = $results_json_exists && $this->core->getQueries()->getGradeableVersionHasAutogradingResults(
+            $gradeable_id, $version, $user_id, $team_id);
+
+        if ($has_results) {
             $refresh_string = "REFRESH_ME";
             $refresh_bool = true;
         }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -710,6 +710,20 @@ ORDER BY egd.g_version", array($g_id, $user_id));
         return $return;
     }
 
+    public function getGradeableVersionHasAutogradingResults($g_id, $version, $user_id, $team_id) {
+        $query = "SELECT * FROM electronic_gradeable_data WHERE g_id=? AND g_version=? AND ";
+        if($user_id === null) {
+            $query .= "team_id=?";
+            $params = [$g_id, $version, $team_id];
+        }
+        else {
+            $query .= "user_id=?";
+            $params = [$g_id, $version, $user_id];
+        }
+        $this->course_db->query($query, $params);
+        return count($this->course_db->rows()) > 0 && $this->course_db->rows()[0]['autograding_complete'] === true;
+    }
+
 
     // Moved from class LateDaysCalculation on port from TAGrading server.  May want to incorporate late day information into gradeable object rather than having a separate query
     public function getLateDayUpdates($user_id) {

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -35,11 +35,11 @@ class AutoGradingView extends AbstractView {
         $display_hidden = false;
         $num_visible_testcases = 0;
 
-        // FIXME: This variable should be false if autograding results
+        // This variable should be false if autograding results
         // (files/database values) exist, but true if the assignment
         // is in the queue or something went wrong with autograding
         // (it crashed, files were corrupted, etc)
-        $incomplete_autograding = true;
+        $incomplete_autograding = !$version_instance->isAutogradingComplete();
 
         $testcase_array = array_map(function (AutoGradedTestcase $testcase) {
             $testcase_config = $testcase->getTestcase();
@@ -81,9 +81,6 @@ class AutoGradingView extends AbstractView {
             }
         }
         foreach ($version_instance->getTestcases() as $testcase) {
-
-            // FIXME: I don't know if this is the right check
-            $incomplete_autograding = false;
 
             if ($testcase->canView()) {
                 $num_visible_testcases++;


### PR DESCRIPTION
The submission page now checks to make sure that the autograding results are filled in in the database before refreshing the page.
Also, if the user refreshes the page before the autograding results are filled in to the database, it will also wait to display results.

However, I was unable to do extensive testing on whether or not this works, as the issue was hard to replicate on my local machine.

closes #2882