### PR TITLE
Better handling for double posts

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -131,7 +131,7 @@ class ForumController extends AbstractController {
             $result["error"] = "You do not have permissions to do that.";
 		}
         $this->core->getOutput()->renderJson($result);
-		return $result;
+		return $this->core->getOutput()->getOutput();
 	}
 
     private function checkGoodAttachment($isThread, $thread_id, $file_post){
@@ -216,7 +216,7 @@ class ForumController extends AbstractController {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
-        return $result;
+        return $this->core->getOutput()->getOutput();
     }
 
     public function deleteCategory(){
@@ -242,7 +242,7 @@ class ForumController extends AbstractController {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
-        return $result;
+        return $this->core->getOutput()->getOutput();
     }
 
     public function editCategory(){
@@ -277,7 +277,7 @@ class ForumController extends AbstractController {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
-        return $result;
+        return $this->core->getOutput()->getOutput();
     }
 
     public function reorderCategories(){
@@ -304,7 +304,7 @@ class ForumController extends AbstractController {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
-        return $result;
+        return $this->core->getOutput()->getOutput();
     }
 
     //CODE WILL BE CONSOLIDATED IN FUTURE
@@ -358,7 +358,7 @@ class ForumController extends AbstractController {
             }
         }
         $this->core->getOutput()->renderJson($result);
-        return $result;
+        return $this->core->getOutput()->getOutput();
     }
 
     private function search(){
@@ -414,7 +414,7 @@ class ForumController extends AbstractController {
             }
         }
         $this->core->getOutput()->renderJson($result);
-        return $result;
+        return $this->core->getOutput()->getOutput();
     }
 
     public function alterAnnouncement($type){
@@ -436,7 +436,7 @@ class ForumController extends AbstractController {
         $this->core->getQueries()->addPinnedThread($current_user, $thread_id, $type);
         $response = array('user' => $current_user, 'thread' => $thread_id, 'type' => $type);
         $this->core->getOutput()->renderJson($response);
-        return $response;
+        return $this->core->getOutput()->getOutput();
     }
 
     private function checkPostEditAccess($post_id) {
@@ -494,7 +494,7 @@ class ForumController extends AbstractController {
             $this->core->getQueries()->pushNotification($notification);
             $this->core->getQueries()->removeNotificationsPost($post_id);
             $this->core->getOutput()->renderJson($response = array('type' => $type));
-            return $response;
+            return $this->core->getOutput()->getOutput();
         } else if($modifyType == 2) { //undelete post or thread
             $thread_id = $_POST["thread_id"];
             $type = "";
@@ -511,7 +511,7 @@ class ForumController extends AbstractController {
                 $this->core->getQueries()->pushNotification($notification);
                 $this->core->getOutput()->renderJson($response = array('type' => $type));
             }
-            return $response;
+            return $this->core->getOutput()->getOutput();
         } else if($modifyType == 1) { //edit post or thread
             $thread_id = $_POST["edit_thread_id"];
             $status_edit_thread = $this->editThread();
@@ -766,7 +766,7 @@ class ForumController extends AbstractController {
             $output['error'] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($output);
-        return $output;
+        return $this->core->getOutput()->getOutput();
     }
 
     public function getEditPostContent(){
@@ -782,10 +782,10 @@ class ForumController extends AbstractController {
                 $this->getThreadContent($_POST["thread_id"], $output);
             }
             $this->core->getOutput()->renderJson($output);
-            return $output;
         } else {
             $this->core->getOutput()->renderJson(array('error' => "You do not have permissions to do that."));
         }
+        return $this->core->getOutput()->getOutput();
     }
 
     private function getThreadContent($thread_id, &$output){

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -860,8 +860,8 @@ HTML;
 				<a class="expand btn btn-default btn-sm" style="float:right; text-decoration:none; margin-top: -8px" onClick="hidePosts(this, {$post['id']})"></a>
 HTML;
 		}
-		if($this->core->getUser()->getGroup() <= 2) {
-			if($deleted){
+		if($this->core->getUser()->getGroup() <= 2 || $post['author_user_id'] === $current_user) {
+			if($deleted && $this->core->getUser()->getGroup() <= 2){
 				$ud_toggle_status = "false";
 				$ud_button_title = "Undelete post";
 				$ud_button_icon = "fa-undo";

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -486,7 +486,7 @@ HTML;
 
 			<hr style="border-top:1px solid #999;margin-bottom: 5px;" />
 			
-					<form style="margin-right:17px;" class="post_reply_from" method="POST" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
+					<form style="margin-right:17px;" class="post_reply_from" method="POST" onsubmit='post.disabled=true; post.value="Submitting post..."; return true;' action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
 						<input type="hidden" name="thread_id" value="{$thread_id}" />
 						<input type="hidden" name="parent_id" value="{$first_post_id}" />
 						<input type="hidden" name="display_option" value="{$display_option}" />
@@ -920,7 +920,7 @@ HTML;
 						$return .= <<<HTML
 </div>
 
-           	<form class="reply-box post_reply_from" id="$post_id-reply" style="margin-left:{$offset}px" method="POST" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
+					<form class="reply-box post_reply_from" id="$post_id-reply" onsubmit='post.disabled=true; post.value="Submitting post..."; return true;' style="margin-left:{$offset}px" method="POST" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
 						<input type="hidden" name="thread_id" value="{$thread_id}" />
 						<input type="hidden" name="parent_id" value="{$post_id}" />
 	            		<br/>

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -486,7 +486,7 @@ HTML;
 
 			<hr style="border-top:1px solid #999;margin-bottom: 5px;" />
 			
-					<form style="margin-right:17px;" class="post_reply_from" method="POST" onsubmit='post.disabled=true; post.value="Submitting post..."; return true;' action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
+					<form style="margin-right:17px;" class="post_reply_from" method="POST" onsubmit="post.disabled=true; post.value='Submitting post...'; return true;" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
 						<input type="hidden" name="thread_id" value="{$thread_id}" />
 						<input type="hidden" name="parent_id" value="{$first_post_id}" />
 						<input type="hidden" name="display_option" value="{$display_option}" />
@@ -920,7 +920,7 @@ HTML;
 						$return .= <<<HTML
 </div>
 
-					<form class="reply-box post_reply_from" id="$post_id-reply" onsubmit='post.disabled=true; post.value="Submitting post..."; return true;' style="margin-left:{$offset}px" method="POST" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
+					<form class="reply-box post_reply_from" id="$post_id-reply" onsubmit="post.disabled=true; post.value='Submitting post...'; return true;" style="margin-left:{$offset}px" method="POST" action="{$this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_post'))}" enctype="multipart/form-data">
 						<input type="hidden" name="thread_id" value="{$thread_id}" />
 						<input type="hidden" name="parent_id" value="{$post_id}" />
 	            		<br/>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1417,7 +1417,9 @@ function publishFormWithAttachments(form, test_category, error_message) {
             window.location.href = json['next_page'];
         },
         error: function(){
-            window.alert(error_message);
+            var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fa fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fa fa-times-circle"></i>' + error_message + '</div>';
+            $('#messages').append(message);
+            return;
         }
     });
     return false;
@@ -1834,6 +1836,7 @@ function showHistory(post_id) {
                 }
                 $("#popup-post-history").show();
                 $("#popup-post-history .post_box.history_box").remove();
+                $("#popup-post-history .form-body").css("padding", "5px");
                 var dummy_box = $($("#popup-post-history .post_box")[0]);
                 for(var i = json.length - 1 ; i >= 0 ; i -= 1) {
                     var post = json[i];


### PR DESCRIPTION
PR includes:

- Helps prevent double form submission by disabling button when form is submitted. 
- The return json object for forum function will ensure json_encoding which should prevent the javascript from failing to decode in some cases. 
- Add extra padding to version history popup
- Users can now delete their own threads/posts without having to be a ta/instructor