### PR TITLE
Fix New Gradable in Safari

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -252,7 +252,7 @@ What <a target=_blank href="http://submitty.org/instructor/rainbow_grades">sylla
         }
 
         if(!$('#radio_electronic_file').is(':checked')) {
-            $('input[name=scanned_exam').prop('checked', false);
+            $('input[name=scanned_exam]').prop('checked', false);
         }
 
         disableElementChildren('.electronic_file');


### PR DESCRIPTION
The missing bracket caused crashed in Safari, but didn't raise an error in the chrome dev console. Adding the bracket fixes the issue in Safari, and allows me to create gradables without an issue.
<img width="1440" alt="screenshot 2018-10-28 00 33 31" src="https://user-images.githubusercontent.com/6187282/47612071-61053880-da49-11e8-8817-c969ac5eff05.png">
closes #3028