### PR TITLE
Fix "download all files" when students can only download active version

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -289,12 +289,12 @@ class MiscController extends AbstractController {
 
         $folder_names = array();
         //See which directories we are allowed to read.
-        if ($this->core->getAccess()->canI("path.read.submissions", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version])) {
+        if ($this->core->getAccess()->canI("path.read.submissions", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
             //These two have the same check
             $folder_names[] = "submissions";
             $folder_names[] = "checkout";
         }
-        if ($this->core->getAccess()->canI("path.read.results", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version])) {
+        if ($this->core->getAccess()->canI("path.read.results", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
             $folder_names[] = "results";
         }
         //No results, no download

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -78,15 +78,15 @@ class Access {
     /** Check that the course status is such that the user can view the course */
     const CHECK_COURSE_STATUS           = 1 << 18;
 
-    /** If the current set of flags requires the "gradeable" argument */
+    /** If the current set of flags requires the "gradeable" (type Gradeable) argument */
     const REQUIRE_ARG_GRADEABLE         = 1 << 24;
-    /** If the current set of flags requires the "gradeable" argument */
+    /** If the current set of flags requires the "component" (type GradeableComponent) argument */
     const REQUIRE_ARG_COMPONENT         = 1 << 25;
-    /** If the current set of flags requires the "dir" and "path" arguments */
+    /** If the current set of flags requires the "dir" (type string) and "path" (type string) arguments */
     const REQUIRE_ARGS_DIR_PATH         = 1 << 26;
-    /** If the current set of flags requires the "gradeable_version" argument */
+    /** If the current set of flags requires the "gradeable_version" (type int) argument */
     const REQUIRE_ARG_VERSION           = 1 << 27;
-    /** If the current set of flags requires the "semester" and "course" arguments */
+    /** If the current set of flags requires the "semester" (type string) and "course" (type string) arguments */
     const REQUIRE_ARGS_SEMESTER_COURSE  = 1 << 28;
 
 


### PR DESCRIPTION
Was passing an AutoGradedVersion (object) to a function that was expecting an integer