### PR TITLE
Fix limited access grader nav page button

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -417,7 +417,7 @@ class NavigationView extends AbstractView {
             if (!$gradeable->hasDueDate()) {
                 $display_date = "";
             }
-            if (!$gradeable->isStudentSubmit() && $this->core->getUser()->accessGrading()) {
+            if (!$gradeable->isStudentSubmit() && $this->core->getUser()->accessFullGrading()) {
                 // Student isn't submitting
                 $title = "BULK UPLOAD";
                 $class = "btn-primary";


### PR DESCRIPTION
It was saying "BULK UPLOAD" for limited access graders when only full access / instructors can bulk upload.