### PR TITLE
Fix Hangs When Grading

### DIFF
--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -182,6 +182,13 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
     os.chdir(SUBMITTY_DATA_DIR)
     tmp = os.path.join("/var/local/submitty/autograding_tmp/",which_untrusted,"tmp")
 
+    if os.path.exists(tmp):
+        untrusted_grant_rwx_access(which_untrusted, tmp)
+        add_permissions_recursive(tmp,
+                  stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH,
+                  stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH,
+                  stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
+
     # clean up old usage of this directory
     shutil.rmtree(tmp,ignore_errors=True)
     os.mkdir(tmp)

--- a/sbin/autograder/packer_unpacker.py
+++ b/sbin/autograder/packer_unpacker.py
@@ -90,6 +90,8 @@ def unzip_queue_file(zipfilename):
         raise RuntimeError("ERROR: zip file does not exist '", zipfilename, "'")
     zip_ref = zipfile.ZipFile(zipfilename,'r')
     names = zip_ref.namelist()
+    if 'failure.txt' in names:
+        return None
     if not 'queue_file.json' in names:
         raise RuntimeError("ERROR: zip file does not contain queue file '", zipfilename, "'")
     # remember the current directory
@@ -278,6 +280,10 @@ def unpack_grading_results_zip(which_machine,which_untrusted,my_results_zip_file
 
     queue_obj = unzip_queue_file(my_results_zip_file)
 
+    if queue_obj is None:
+        return False
+
+
     job_id = queue_obj["job_id"]
     partial_path = os.path.join(queue_obj["gradeable"],queue_obj["who"],str(queue_obj["version"]))
     item_name = os.path.join(queue_obj["semester"],queue_obj["course"],"submissions",partial_path)
@@ -311,6 +317,7 @@ def unpack_grading_results_zip(which_machine,which_untrusted,my_results_zip_file
     print (which_machine,which_untrusted,"unzip",item_name, " in ", int(gradingtime), " seconds")
 
     grade_items_logging.log_message(job_id,is_batch_job,"unzip",item_name,"grade:",gradingtime,grade_result)
+    return True
 
 
 # ==================================================================================

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -14,6 +14,7 @@ import operator
 import paramiko
 import tempfile
 import socket
+import traceback
 
 from autograder import grade_items_logging
 from autograder import grade_item
@@ -303,6 +304,7 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
         packer_unpacker.unpack_grading_results_zip(which_machine,which_untrusted,local_results_zip)
     except:
         grade_items_logging.log_message(JOB_ID,jobname=item_name,message="ERROR: Exception when unpacking zip")
+        traceback.print_exc()
         with contextlib.suppress(FileNotFoundError):
             os.remove(local_results_zip)
 

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -301,16 +301,19 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
                 return False
     # archive the results of grading
     try:
-        packer_unpacker.unpack_grading_results_zip(which_machine,which_untrusted,local_results_zip)
+        success = packer_unpacker.unpack_grading_results_zip(which_machine,which_untrusted,local_results_zip)
     except:
         grade_items_logging.log_message(JOB_ID,jobname=item_name,message="ERROR: Exception when unpacking zip")
-        traceback.print_exc()
         with contextlib.suppress(FileNotFoundError):
             os.remove(local_results_zip)
+        success = False
 
     with contextlib.suppress(FileNotFoundError):
         os.remove(local_done_queue_file)
-    grade_items_logging.log_message(JOB_ID, jobname=item_name, which_untrusted=which_untrusted, is_batch=is_batch, message="Unpacked job from " + which_machine)
+
+    msg = "Unpacked job from " + which_machine if success else "ERROR: failure returned from worker machine"
+    print(msg)
+    grade_items_logging.log_message(JOB_ID, jobname=item_name, which_untrusted=which_untrusted, is_batch=is_batch, message=msg)
     return True
 
 

--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -9,6 +9,8 @@ from submitty_utils import dateutils
 import multiprocessing
 import contextlib
 import traceback
+import tempfile
+import zipfile
 
 from autograder import grade_items_logging
 from autograder import grade_item
@@ -71,6 +73,25 @@ def worker_process(which_machine,address,which_untrusted,my_server):
                     os.remove(autograding_zip)
                 with contextlib.suppress(FileNotFoundError):
                     os.remove(submission_zip)
+
+                #Respond with a failure zip file.
+                results_zip = os.path.join(SUBMITTY_DATA_DIR,"autograding_DONE",servername_workername+"_"+which_untrusted+"_results.zip")
+                tmp_dir = tempfile.mkdtemp()
+                with open(os.path.join(tmp_dir, 'failure.txt'), 'w') as outfile:
+                    outfile.write("grading failed.\n")
+
+                results_zip_tmp = zipfile.ZipFile(results_zip, 'w')
+                results_zip_tmp.write(os.path.join(tmp_dir, 'failure.txt'))
+                results_zip_tmp.close()
+
+                shutil.rmtree(tmp_dir)
+                done_queue_file = os.path.join(SUBMITTY_DATA_DIR,"autograding_DONE",servername_workername+"_"+which_untrusted+"_queue.json")
+                with open(todo_queue_file, 'r') as infile:
+                    queue_obj = json.load(infile)
+                    queue_obj["done_time"]=dateutils.write_submitty_date(microseconds=True)
+                with open(done_queue_file, 'w') as outfile:
+                    json.dump(queue_obj, outfile, sort_keys=True, indent=4)
+
             with contextlib.suppress(FileNotFoundError):
                 os.remove(todo_queue_file)
             counter = 0


### PR DESCRIPTION
Fixes bug which was causing the shipper process to hang on worker failure (as the worker would never respond).  On failure, the worker now sends a zip file back to the shipper containing the file failure.txt. Upon finding this, the shipper gives up on the gradeable, and the student receives the "error, something went wrong during autograding"

Fixes bug which caused worker to fail when a file owned by an untrusted user was left in autograding_tmp.