### PR TITLE
Prevent Students from adding students in null section

### DIFF
--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -182,7 +182,7 @@ class TeamController extends AbstractController {
         }
 
         if($this->core->getQueries()->getUserByID($invite_id)->getRegistrationSection() === null){
-            $this->core->addErrorMessage("Cannot invite {$invite_id}");
+            $this->core->addErrorMessage("User {$invite_id} does not exist");
             $this->core->redirect($return_url);
         }
 

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -181,6 +181,11 @@ class TeamController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
+        if($this->core->getQueries()->getUserByID($invite_id)->getRegistrationSection() === null){
+            $this->core->addErrorMessage("Cannot invite {$invite_id}");
+            $this->core->redirect($return_url);
+        }
+
         $invite_team = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable_id, $invite_id);
         if ($invite_team !== null) {
             $this->core->addErrorMessage("Did not send invitation, {$invite_id} is already on a team");

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -177,11 +177,15 @@ class TeamController extends AbstractController {
 
         $invite_id = $_POST['invite_id'];
         if ($this->core->getQueries()->getUserByID($invite_id) === null) {
+            // If a student with this id does not exist in the course...
             $this->core->addErrorMessage("User {$invite_id} does not exist");
             $this->core->redirect($return_url);
         }
 
         if($this->core->getQueries()->getUserByID($invite_id)->getRegistrationSection() === null){
+            // If a student with this id is in the null section...
+            // (make this look the same as a non-existant student so as not to
+            // reveal information about dropped students)
             $this->core->addErrorMessage("User {$invite_id} does not exist");
             $this->core->redirect($return_url);
         }

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -191,7 +191,7 @@
             {% elseif column.function == "team_members" %}
                 <td>
                     {{ user.getDisplayedFirstName() }}
-                    {{ user.getLastName() }}
+                    {{ user.getDisplayedLastName() }}
                 </td>
             {% elseif column.function == "total" %}
                 <td></td>

--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -138,10 +138,3 @@
         </table>
     </div>
 </div>
-{# /Users seeking team box #}
-
-<script>
-    $("#invite_id").autocomplete({
-        source: {{ student_full|raw }}
-    });
-</script>

--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -46,14 +46,6 @@ class TeamView extends AbstractView {
             $seekers[] = $this->core->getQueries()->getUserById($user_seeking_team);
         }
 
-        $students = $this->core->getQueries()->getAllUsers();
-        $student_full = array();
-        foreach ($students as $student) {
-            $student_full[] = array('value' => $student->getId(),
-                                    'label' => $student->getDisplayedFirstName().' '.$student->getDisplayedLastName().' <'.$student->getId().'>');
-        }
-        $student_full = json_encode($student_full);
-
         return $this->core->getOutput()->renderTwigTemplate("submission/Team.twig", [
             "gradeable" => $gradeable,
             "team" => $team,
@@ -62,8 +54,7 @@ class TeamView extends AbstractView {
             "members" => $members,
             "seekers" => $seekers,
             "invites_received" => $invites_received,
-            "seeking_partner" => $seeking_partner,
-            "student_full" => $student_full
+            "seeking_partner" => $seeking_partner
         ]);
     }
 }


### PR DESCRIPTION
Students can no longer invite students who are in the null section.
This PR also removes the autofill search for invite usernames so students will need to know the 
exact user_id before inviting people.

If a student tries to add a user in a null section they will receive an error saying "cannot invite {user_id}"

closes #3060