### PR TITLE
Badge Color buggy for Extra Credit points 

### DIFF
--- a/site/public/templates/grading/Functions.twig
+++ b/site/public/templates/grading/Functions.twig
@@ -9,10 +9,15 @@ Function for getting the badge style for a given set of total and earned points
             {% set percent = earned / total %}
             {% if percent < 0.5 %}
                 red-background
-            {% elseif earned != total %}
+            {% elseif percent < 1 %}
                 yellow-background
+            {# total = 0 means extra credit part and should be grey when earned =0 #}
+            {% elseif total == 0 and earned == 0%}
+                {# Nothing #}
+            {# should be green if you get 100% for earned/total or even more with extra credit#}
             {% else %}
                 green-background
+            }
             {% endif %}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Added a few rules to resolve the buggy color problem. Now it looks like this 
<img width="348" alt="screen shot 2018-10-28 at 10 28 12" src="https://user-images.githubusercontent.com/30506009/47617376-01d11380-da9d-11e8-8363-1c8589facefe.png">
<img width="351" alt="screen shot 2018-10-28 at 10 28 25" src="https://user-images.githubusercontent.com/30506009/47617375-01d11380-da9d-11e8-9551-72e040877ba2.png">
<img width="359" alt="screen shot 2018-10-28 at 10 28 31" src="https://user-images.githubusercontent.com/30506009/47617374-01d11380-da9d-11e8-8adf-0f8337e0b8fa.png">



