### PR TITLE
Fixed team and non-team gradeables not returning together

### DIFF
--- a/site/app/libraries/MultiIterator.php
+++ b/site/app/libraries/MultiIterator.php
@@ -64,6 +64,8 @@ class MultiIterator implements \Iterator {
         $this->seek();
         $this->key++;
         $this->curr_it->next();
+        // Seek after 'next' to be sure 'curr_it' is valid
+        $this->seek();
     }
 
     /**


### PR DESCRIPTION
Closes #3072

There was a bug in the `MultiIterator` that didn't seek to the next valid iterator _after_ next, so the iterator was terminating before any of the team gradeables were loaded.