### PR TITLE
Modify MultiIterator to operate on normal iterators

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1111,7 +1111,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
      * Gets all GradedGradeable's associated with each Gradeable.  If
      *  both $users and $teams are null, then everyone will be retrieved.
      *  Note: The users' teams will be included in the search
-     * @param \app\models\gradeable\Gradeable[] The gradeable(s) to retrieve data for
+     * @param \app\models\gradeable\Gradeable[] $gradeables The gradeable(s) to retrieve data for
      * @param string[]|string|null $users The id(s) of the user(s) to get data for
      * @param string[]|string|null $teams The id(s) of the team(s) to get data for
      * @param string[]|string|null $sort_keys An ordered list of keys to sort by (i.e. `user_id` or `g_id DESC`)
@@ -1122,21 +1122,17 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         $non_team_gradeables = [];
         $team_gradeables = [];
         foreach ($gradeables as $gradeable) {
-            /** @var \app\models\gradeable\Gradeable $gradeable */
             if ($gradeable->isTeamAssignment()) {
                 $team_gradeables[] = $gradeable;
             } else {
                 $non_team_gradeables[] = $gradeable;
             }
         }
-        // Make one call to each teams and users.  This is because doing a JOIN on a team OR a user is REALLY expensive
-        $non_team_it = function () use ($non_team_gradeables, $users, $teams, $sort_keys) {
-            return $this->getGradedGradeablesUserOrTeam($non_team_gradeables, $users, $teams, $sort_keys, false);
-        };
-        $team_it = function () use ($team_gradeables, $users, $teams, $sort_keys) {
-            return $this->getGradedGradeablesUserOrTeam($team_gradeables, $users, $teams, $sort_keys, true);
-        };
-        return new MultiIterator([[$non_team_it, $this], [$team_it, $this]]);
+
+        return new MultiIterator(
+            $this->getGradedGradeablesUserOrTeam($non_team_gradeables, $users, $teams, $sort_keys, false),
+            $this->getGradedGradeablesUserOrTeam($team_gradeables, $users, $teams, $sort_keys, true)
+        );
     }
 
     /**
@@ -1636,12 +1632,14 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             return $graded_gradeable;
         };
 
-        return $this->course_db->queryIterator($query,
+        return $this->course_db->queryIterator(
+            $query,
             array_merge(
                 $param,
                 array_keys($gradeables_by_id)
             ),
-            $constructGradedGradeable);
+            $constructGradedGradeable
+        );
     }
 
     /**

--- a/site/tests/app/libraries/MultiIteratorTester.php
+++ b/site/tests/app/libraries/MultiIteratorTester.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace tests\app\libraries;
+
+use app\libraries\FileUtils;
+use \app\libraries\MultiIterator;
+use app\libraries\Utils;
+
+class MultiIteratorTester extends \PHPUnit\Framework\TestCase {
+    public function testIterator() {
+        $temp_dir1 = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
+        $temp_dir2 = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
+
+        try {
+            FileUtils::createDir($temp_dir1);
+            touch(FileUtils::joinPaths($temp_dir1, 'file_1'));
+            touch(FileUtils::joinPaths($temp_dir1, 'file_2'));
+
+            FileUtils::createDir($temp_dir2);
+            touch(FileUtils::joinPaths($temp_dir2, 'file_3'));
+            touch(FileUtils::joinPaths($temp_dir2, 'file_4'));
+
+            $multi_iterator = new MultiIterator(
+                new \FilesystemIterator($temp_dir1, \RecursiveDirectoryIterator::SKIP_DOTS),
+                new \FilesystemIterator($temp_dir2, \RecursiveDirectoryIterator::SKIP_DOTS)
+            );
+
+            $files = [
+                'file_1',
+                'file_2',
+                'file_3',
+                'file_4'
+            ];
+
+            $count = 0;
+            foreach ($multi_iterator as $item) {
+                $this->assertEquals($count, $multi_iterator->key());
+                $this->assertEquals($files[$count], $item->getFilename());
+                $count++;
+            }
+
+            $this->assertNull($multi_iterator->current());
+
+            $count = 0;
+            foreach ($multi_iterator as $item) {
+                $this->assertEquals($count, $multi_iterator->key());
+                $this->assertEquals($files[$count], $item->getFilename());
+                $count++;
+            }
+        }
+        finally {
+            if (file_exists($temp_dir1)) {
+                FileUtils::recursiveRmdir($temp_dir1);
+            }
+            if (file_exists($temp_dir2)) {
+                FileUtils::recursiveRmdir($temp_dir2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
PDO allows for multiple statements to be active at the same time without having to first go through the whole result set of a particular statement first before going into the next statement (you could also do this to interweave the result sets of queries). Additionally, as we're already using DatabaseRowIterator under the hood here, there's little cost to PHP itself to have two open statements.

As such, we can simplify the implementation of the MultiIterator such that we can use it for any type of iterator, not just databases, which eases the implementation and testing of it.

After this change, I saw no affect in:
* Submitting assignment
* Viewing grading summary for individual assignment
* Grading individual assignment
* Viewing grading summary for team assignment
* Grading team assignment