### PR TITLE
Fixed team invitation cancelling

### DIFF
--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -297,7 +297,7 @@ class TeamController extends AbstractController {
         $return_url = $this->core->buildUrl(array('component' => 'student', 'gradeable_id' => $gradeable_id, 'page' => 'team'));
 
         $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $user_id, false);
-        if ($graded_gradeable !== false) {
+        if ($graded_gradeable === false) {
             $this->core->addErrorMessage("You are not on a team");
             $this->core->redirect($return_url);
         }


### PR DESCRIPTION
Addresses part of #3085 
This only closes the title part of the issue.  It does not solve the multi-team users or the feature requests.

It looks like there was a not-equals that should have been an equals in the cancellation logic.