### PR TITLE
Graders cannot view hidden testcase details from submission page

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1882,6 +1882,7 @@ class ElectronicGraderController extends GradingController {
         if (!$this->core->getAccess()->canI("autograding.load_checks", ["gradeable" => $graded_gradeable])) {
             // TODO: streamline permission error strings
             $this->core->getOutput()->renderJsonFail('You have insufficient permissions to access this command');
+            return;
         }
 
         try {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -327,7 +327,7 @@ class SubmissionController extends AbstractController {
                 // FIXME: remove this 'old_gradeable' once none of the HomeworkView relies on it
                 $old_gradeable = $this->core->getQueries()->getGradeable($gradeable_id, $this->core->getUser()->getId());
                 $this->core->getOutput()->renderOutput(array('submission', 'Homework'),
-                                                       'showGradeable', $gradeable, $graded_gradeable, $old_gradeable, $version, $late_days_use, $extensions, $show_hidden);
+                                                       'showGradeable', $gradeable, $graded_gradeable, $old_gradeable, $version, $late_days_use, $extensions, $show_hidden, false);
             }
         }
         return array('id' => $gradeable_id, 'error' => $error);

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -38,13 +38,17 @@
 
 {% for testcase in testcases if testcase.can_view %}
     {% set can_view = (not testcase.hidden or show_hidden) %}
+    {% set can_view_details = (not testcase.hidden or show_hidden_details) %}
     <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#D3D3D3;'" : "" }}>
         <div id='tc_{{ loop.index0 }}' class="box-title"
-                {{ testcase.has_extra_results and can_view ? "style='cursor: pointer;'" : "" }}
-             onclick="loadTestcaseOutput('testcase_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ submitter_id }}', '{{ loop.index0 }}', {{ display_version }});">
+                {% if can_view_details %}
+                    {{ testcase.has_extra_results ? "style='cursor: pointer;'" : "" }}
+                    onclick="loadTestcaseOutput('testcase_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ submitter_id }}', '{{ loop.index0 }}', {{ display_version }});"
+                {% endif %}
+        >
 
             {# Details button #}
-            {% if testcase.has_extra_results and can_view %}
+            {% if testcase.has_extra_results and can_view_details %}
                 <div style="float:right; color: #0000EE; text-decoration: underline">
                     Details
                 </div>

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -38,7 +38,7 @@
 
 {% for testcase in testcases if testcase.can_view %}
     {% set can_view = (not testcase.hidden or show_hidden) %}
-    {% set can_view_details = (not testcase.hidden or show_hidden_details) %}
+    {% set can_view_details = (not testcase.hidden or show_hidden_details and show_hidden) %}
     <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#D3D3D3;'" : "" }}>
         <div id='tc_{{ loop.index0 }}' class="box-title"
                 {% if can_view_details %}

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -41,8 +41,8 @@
     {% set can_view_details = (not testcase.hidden or show_hidden_details and show_hidden) %}
     <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#D3D3D3;'" : "" }}>
         <div id='tc_{{ loop.index0 }}' class="box-title"
-                {% if can_view_details %}
-                    {{ testcase.has_extra_results ? "style='cursor: pointer;'" : "" }}
+                {% if can_view_details and testcase.has_extra_results %}
+                    style="cursor: pointer"
                     onclick="loadTestcaseOutput('testcase_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ submitter_id }}', '{{ loop.index0 }}', {{ display_version }});"
                 {% endif %}
         >

--- a/site/app/templates/grading/electronic/AutogradingPanel.twig
+++ b/site/app/templates/grading/electronic/AutogradingPanel.twig
@@ -7,7 +7,7 @@
             {% if version_instance is null %}
                 <h4>No Submission</h4>
             {% else %}
-                {{ render_template('AutoGrading', 'showResults', version_instance, show_hidden_cases) }}
+                {{ render_template('AutoGrading', 'showResults', version_instance, show_hidden_cases, true) }}
             {% endif %}
         </div>
     </div>

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -18,10 +18,11 @@ class AutoGradingView extends AbstractView {
 
     /**
      * @param AutoGradedVersion $version_instance
-     * @param bool $show_hidden
+     * @param bool $show_hidden True to show the scores of hidden testcases
+     * @param bool $show_hidden_details True to show the details of hidden testcases
      * @return string
      */
-    public function showResults(AutoGradedVersion $version_instance, bool $show_hidden = false) {
+    public function showResults(AutoGradedVersion $version_instance, bool $show_hidden = false, bool $show_hidden_details = false) {
         $graded_gradeable = $version_instance->getGradedGradeable();
         $gradeable = $graded_gradeable->getGradeable();
         $autograding_config = $gradeable->getAutogradingConfig();
@@ -101,6 +102,7 @@ class AutoGradingView extends AbstractView {
             "hidden_earned" => $hidden_earned,
             "hidden_max" => $hidden_max,
             "show_hidden" => $show_hidden,
+            "show_hidden_details" => $show_hidden_details,
             "has_badges" => $has_badges,
             'testcases' => $testcase_array,
             'is_ta_grade_released' => $gradeable->isTaGradeReleased(),


### PR DESCRIPTION
Fixes regressive bug where graders could view hidden test case details in the submission page.  The 'Details' button no longer shows up and the testcase no longer appears clickable.