### PR TITLE
Instructors can bulk upload 'view after grades'

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -286,8 +286,10 @@ class SubmissionController extends AbstractController {
         //if (!$gradeable->isSubmissionOpen() && !$this->core->getUser()->accessAdmin()) {
 
         // TEMPORARY - ALLOW LIMITED & FULL ACCESS GRADERS TO PRACTICE ALL FUTURE HOMEWORKS
-        if (!$gradeable->isSubmissionOpen() && !$this->core->getUser()->accessGrading()
-            || $gradeable->isStudentView() && $gradeable->isStudentViewAfterGrades() && !$gradeable->isTaGradeReleased()) {
+        if (!$this->core->getUser()->accessGrading() && (
+                !$gradeable->isSubmissionOpen()
+                || $gradeable->isStudentView() && $gradeable->isStudentViewAfterGrades() && !$gradeable->isTaGradeReleased()
+            )) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
             return array('error' => true, 'message' => 'No gradeable with that id.');
         }


### PR DESCRIPTION
This solves the issue that some instructors were having when choosing the scanned exam preset.  the preset set the 'view after grades' field to true, but when permission checks were being done to determine if a user can view the submission page, checks for 'grader' status were being done improperly.