### PR TITLE
Team Gradeables without a due date won't crash the nav page

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1634,7 +1634,11 @@ class Gradeable extends AbstractModel {
            return false;
         }
         if (!$submitter->isTeam() && $this->isTeamAssignment()) {
-            $submitter = $this->core->getQueries()->getTeamByGradeableAndUser($this->getId(), $submitter->getId());
+            $team = $this->core->getQueries()->getTeamByGradeableAndUser($this->getId(), $submitter->getId());
+            if ($team === null) {
+                return false;
+            }
+            $submitter = new Submitter($this->core, $team);
         }
         return $this->core->getQueries()->getHasSubmission($this, $submitter);
     }


### PR DESCRIPTION
If any gradeable is a team assignemnt with `has due date` set to false, the nav page to fail to load for anyone accessing the course(Frog robot).  This fixes the improper handling of null values and types and prevents the crash.