### PR TITLE
Save grading info when responding to a regrade request

### DIFF
--- a/site/app/templates/submission/regrade/Discussion.twig
+++ b/site/app/templates/submission/regrade/Discussion.twig
@@ -97,7 +97,7 @@
             {{ self.bbcode_buttons() }}
         {% elseif btn_type == 'admin_open' %}
             {# Admin, request is open #}
-            <input type="submit" value="Respond and Resolve Regrade Request" class="btn btn-primary" style="margin-top: 15px; float: right" onclick="$('#status').val(0);">
+            <input type="submit" value="Respond and Resolve Regrade Request" class="btn btn-primary" style="margin-top: 15px; float: right" onclick="closeAllComponents();$('#status').val(0);">
             {{ self.bbcode_buttons() }}
             <input type="submit" class="btn btn-default" id="extraInfoRegrade" value="Request Additional Information" style="margin-top: 15px; float: right" onclick="$('#status').val(-1);">
             <input type="button" class="btn btn-default" id="cancelRegrade" value="Resolve Regrade Request Without Response" style="margin-top: 15px; float: right" onclick="changeRegradeStatus({{ thread_id }}, '{{ gradeable_id}}', '{{ submitter_id }}', 0);">


### PR DESCRIPTION
When a grader changes a student's grade and then goes and responds to a regrade request, any changes to the grade will now be saved.

closes #3016 
