### PR TITLE
HTML decodes filename

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -56,7 +56,7 @@ class MiscController extends AbstractController {
         $gradeable_id = $_POST['gradeable_id'] ?? NULL;
         $id = $_POST['user_id'] ?? NULL;
         $file_name = $_POST['filename'] ?? NULL;
-
+        $file_name = html_entity_decode($file_name);
         $gradeable = $this->tryGetGradeable($gradeable_id);
         $submitter = $this->core->getQueries()->getSubmitterById($id);
         $graded_gradeable = $this->core->getQueries()->getGradedGradeableForSubmitter($gradeable, $submitter);

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -42,6 +42,7 @@ class PDFController extends AbstractController {
     private function showStudentPDF(){
         $gradeable_id = $_GET['gradeable_id'] ?? NULL;
         $filename = $_GET['file_name'] ?? NULL;
+        $filename = html_entity_decode($filename);
         $id = $this->core->getUser()->getId();
         $gradeable = $this->tryGetGradeable($gradeable_id);
         if($gradeable->isTeamAssignment()){
@@ -111,6 +112,7 @@ class PDFController extends AbstractController {
         //User can be a team
         $id = $_POST['user_id'] ?? NULL;
         $filename = $_POST['filename'] ?? NULL;
+        $filename = html_entity_decode($filename);
         $gradeable = $this->tryGetGradeable($gradeable_id);
         if($gradeable->isTeamAssignment()){
             $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, null, $id);


### PR DESCRIPTION
fixes #3096. Should fixes the problem with all html entities. I tested it with all the keyboard special characters, all of them works except for '/', which the issue says we can forbid. 