### PR TITLE
No Due Date / Not Student Submit can't have 'bad' status in reports/summaries

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -204,6 +204,12 @@ class ReportController extends AbstractController {
     }
 
     private function addLateDays(Gradeable $gradeable, &$entry, &$total_late_used) {
+        // If there is no due date or not student submit, short circuit the late day calculation
+        if (!$gradeable->getStudentSubmit() || !$gradeable->getHasDueDate()) {
+            $entry['status'] = 'Good';
+            $entry['days_late'] = 0;
+            return;
+        }
         $late_days_used = $gradeable->getLateDays() - $gradeable->getLateDayExceptions();
         $status = 'Good';
         $late_flag = false;


### PR DESCRIPTION
Fixes #3112 

If the gradeable doesn't have student submission enabled or doesn't have a due date, then late days don't make sense.  This fix makes the late day calculation in the reports controller more consistent with the late day calculation in the Gradeable model.  This inconsistency will be resolved when the reports controller uses the new gradeable model (in progress).