### PR TITLE
Scrolling fix for pdf grading

### DIFF
--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -71,7 +71,15 @@ class PDFController extends AbstractController {
                 }
             }
         }
-        $this->core->getOutput()->renderOutput(array('PDF'), 'showPDFEmbedded', $gradeable_id, $id, $filename, $annotation_jsons, true);
+        $params = [
+            "gradeable_id" => $gradeable_id,
+            "id" => $id,
+            "file_name" => $filename,
+            "annotation_jsons" => $annotation_jsons,
+            "is_student" => true,
+            "page_num" => 1
+        ];
+        $this->core->getOutput()->renderOutput(array('PDF'), 'showPDFEmbedded', $params);
     }
 
     private function savePDFAnnotation(){
@@ -112,6 +120,7 @@ class PDFController extends AbstractController {
         //User can be a team
         $id = $_POST['user_id'] ?? NULL;
         $filename = $_POST['filename'] ?? NULL;
+        $page_num = $_POST['page_num'] ?? NULL;
         $filename = html_entity_decode($filename);
         $gradeable = $this->tryGetGradeable($gradeable_id);
         if($gradeable->isTeamAssignment()){
@@ -141,7 +150,15 @@ class PDFController extends AbstractController {
                 }
             }
         }
-        $this->core->getOutput()->renderOutput(array('PDF'), 'showPDFEmbedded', $gradeable_id, $id, $filename, $annotation_jsons, false);
+        $params = [
+            "gradeable_id" => $gradeable_id,
+            "id" => $id,
+            "file_name" => $filename,
+            "annotation_jsons" => $annotation_jsons,
+            "is_student" => false,
+            "page_num" => $page_num
+        ];
+        $this->core->getOutput()->renderOutput(array('PDF'), 'showPDFEmbedded', $params);
     }
 
     private function showGraderPDFFullpage(){

--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -37,6 +37,6 @@
     {% if student_popup %}
     render_student("{{ gradeable_id }}", "{{ user_id }}", "{{ filename }}", "{{ pdf_url_base | raw}}");
     {% else %}
-    render("{{ gradeable_id }}", "{{ user_id }}", "{{ grader_id }}", '{{ filename }}');
+    render("{{ gradeable_id }}", "{{ user_id }}", "{{ grader_id }}", '{{ filename }}', {{ page_num }});
     {% endif %}
 </script>

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -137,12 +137,12 @@
         return false;
     }
     //TODO: Name better
-    function expandFile(name, path) {
+    function expandFile(name, path, page_num = 0) {
         // debugger;
         if($('#viewer').length != 0){
             $('#viewer').remove();
         }
-        let promise = loadFile(name, path);
+        let promise = loadFile(name, path, page_num);
         $('#file_view').show();
         $("#grading_file_name").html(name);
         let precision = $("#submission_browser").width()-$("#directory_view").width();
@@ -153,7 +153,7 @@
         return promise;
     }
 
-    function loadFile(name, path){
+    function loadFile(name, path, page_num = 0){
         let extension = name.split('.').pop();
         if(extension == "pdf"){
             $('#pdf_annotation_bar').show();
@@ -164,7 +164,8 @@
                 data: {
                     'gradeable_id': '{{ gradeable_id }}',
                     'user_id': '{{ submitter_id }}',
-                    'filename': name
+                    'filename': name,
+                    'page_num': page_num
                 },
                 success: function(data){
                     $('#file_content').append(data);

--- a/site/app/views/PDFView.php
+++ b/site/app/views/PDFView.php
@@ -11,17 +11,18 @@ class PDFView extends AbstractView {
      *
      * @return a twig output of either student view or grader view.
      */
-    public function showPDFEmbedded($gradeable_id, $user_id, $filename, $annotation_jsons, $is_student){
+    public function showPDFEmbedded($params){
         $this->core->getOutput()->useFooter(false);
         $this->core->getOutput()->useHeader(false);
         $pdf_url = $this->core->buildUrl(array('component' => 'misc', 'page' => 'base64_encode_pdf'));
         return $this->core->getOutput()->renderTwigOutput('grading/electronic/PDFAnnotationEmbedded.twig', [
-            'gradeable_id' => $gradeable_id,
-            'user_id' => $user_id,
+            'gradeable_id' => $params["gradeable_id"],
+            'user_id' => $params["id"],
             'grader_id' => $this->core->getUser()->getId(),
-            'filename' => $filename,
-            'annotation_jsons' => json_encode($annotation_jsons),
-            'student_popup' => $is_student,
+            'filename' => $params["file_name"],
+            'annotation_jsons' => json_encode($params["annotation_jsons"]),
+            'student_popup' => $params["is_student"],
+            'page_num' => $params["page_num"],
             'pdf_url_base' => $pdf_url
         ]);
     }

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -25,10 +25,10 @@ let NUM_PAGES = 0;
 //For the student popup window, buildURL doesn't work because the context switched. Therefore, we need to pass in the url
 //as a parameter.
 function render_student(gradeable_id, user_id, file_name, pdf_url){
-    render(gradeable_id, user_id, "", file_name, pdf_url)
+    render(gradeable_id, user_id, "", file_name, 1, pdf_url)
 }
 
-function render(gradeable_id, user_id, grader_id, file_name, url = "") {
+function render(gradeable_id, user_id, grader_id, file_name, page_num, url = "") {
     window.GENERAL_INFORMATION = {
         grader_id: grader_id,
         user_id: user_id,
@@ -79,6 +79,7 @@ function render(gradeable_id, user_id, grader_id, file_name, url = "") {
                     UI.renderPage(page_id, window.RENDER_OPTIONS).then(([pdfPage, annotations]) => {
                         let viewport = pdfPage.getViewport(window.RENDER_OPTIONS.scale, window.RENDER_OPTIONS.rotate);
                         PAGE_HEIGHT = viewport.height;
+                        $('#file_content').animate({scrollTop: page_num*PAGE_HEIGHT}, 500);
                     }).then(function(){
                         document.getElementById('pageContainer'+page_id).addEventListener('mousedown', function(){
                             //Makes sure the panel don't move when writing on it.

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2439,9 +2439,7 @@ function scrollToPage(page_num){
             if($("#file_view").is(":visible")){
                 $('#file_content').animate({scrollTop: scrollY}, 500);
             } else {
-                expandFile("upload.pdf", files[i].getAttribute("file-url")).then(function(){
-                    $('#file_content').animate({scrollTop: scrollY}, 500);
-                });
+                expandFile("upload.pdf", files[i].getAttribute("file-url"), page_num-1);
             }
         }
     }


### PR DESCRIPTION
This will be changed in the future, but right now a variable is being passed all over the place and it's messy. Because I first need to make an async request to get the PDF grading page, then I need to wait for the PDF.js to render, it's a whole mess :(. But this PR should fix the scrolling problem. After test grading is finished I'll refactor Submissionpanel.twig which will make the code much cleaner. I tested it with multiple pdfs, and they all seem to work. But someone else should test it also.