### PR TITLE
Bulk upload "submit" & "delete" buttons fix

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -130,6 +130,7 @@
                 show_alert = true;
             } else {
                 validateUserId("{{ core.getCsrfToken() }}", "{{ gradeable_id }}", user_ids, true, path, count, "", makeSubmission);
+                btn.attr('disabled', false);
             }
             e.preventDefault();
             e.stopPropagation();

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -106,6 +106,7 @@
         });
         $("#bulkForm button").click(function(e) {
             var btn = $(document.activeElement);
+            btn.attr('disabled', true);
             var id = btn.attr("id");
             if(id == "bulk_submit_all" || id == "bulk_delete_all") return;
             console.log("deleting " + id);
@@ -119,6 +120,7 @@
                 if(show_alert){
                     message = "Are you sure you want to delete this submission?";
                     if (!confirm(message)) {
+                        btn.attr('disabled', false);
                         return;
                     }
                     $("bulk_delete_all").prop('disabled', true);


### PR DESCRIPTION
This (might) help the submit & delete buttons on production from throwing an alert even though the action went through fine.

closes #2957

