### PR TITLE
More info for team history

### DIFF
--- a/site/app/models/Gradeable.php
+++ b/site/app/models/Gradeable.php
@@ -501,8 +501,8 @@ class Gradeable extends AbstractModel {
             $this->late_status = "Bad (too many late days used this term)";
             $late_flag = false;
         }
-        
-        if ($this->getActiveVersion() == 0) {
+
+        if ($this->getActiveVersion() <= 0) {
             if ($this->hasSubmitted()) {
                 $this->late_status = "Cancelled Submission";
             }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -919,22 +919,32 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
         team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="team_formation_date_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[0].time+ '" /><br />');
         team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="last_edit_left" readonly="readonly" value="Last edited on: " /><br />');
         team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="last_edit_date_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[team_history_len-1].time+ '" /><br />');
-        for (var i = 0; i < members.length; i++) {
-            for (var j = team_history_len-1; j >= 0; j--) {
-                if(user_assignment_setting_json.team_history[j].action == "admin_add_user"){
-                    if(user_assignment_setting_json.team_history[j].added_user == members[i]){
-                        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
-                        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
-                    }
-                }
-                else if(user_assignment_setting_json.team_history[j].action == "admin_create"){
-                    if(user_assignment_setting_json.team_history[j].first_user == members[i]){
+        for (var j = 0; j <=team_history_len-1; j++) {
+            if(user_assignment_setting_json.team_history[j].action == "admin_create"){
+                for (var i = 0; i < members.length; i++) {
+                    console.log(i);
+                    if(user_assignment_setting_json.team_history[j].first_user == members[i] || user_assignment_setting_json.team_history[j].added_user == members[i]){
                         team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
                         team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
                     }
                 }
             }
+            if(user_assignment_setting_json.team_history[j].action == "admin_add_user"){
+                for (var i = 0; i < members.length; i++) {
+                    if(user_assignment_setting_json.team_history[j].added_user == members[i]){
+                        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
+                        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+                    }
+                }
+            }
+            if(user_assignment_setting_json.team_history[j].action == "admin_remove_user"){
+
+                        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;"  readonly="readonly" value="'+user_assignment_setting_json.team_history[j].removed_user+ ' removed on: " /><br />');
+                        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;"  readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+
+            }
         }
+
     }
     var param = (new_team ? 3 : members.length+2);
     members_div.append('<span style="cursor: pointer;" onclick="addTeamMemberInput(this, '+param+');"><i class="fa fa-plus-square" aria-hidden="true"></i> \


### PR DESCRIPTION
Added more history information to "Edit Team" page. Now it looks like this.
![image](https://user-images.githubusercontent.com/30506009/48795136-fce13780-ecc9-11e8-8655-85f759b37e4b.png)
But I am not sure which information should be included so I include all of them this time(including all the adding and removing history). If there is any future feature change for this part, just let me know here and I will make appropriate changes. Thanks.