### PR TITLE
Clears related notifications if thread is viewed

### DIFF
--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -136,10 +136,11 @@ class NavigationController extends AbstractController {
         $user_id = $this->core->getUser()->getId();
         if(!empty($_GET['action'])) {
             if($_GET['action'] == 'open_notification' && !empty($_GET['nid']) && is_numeric($_GET['nid']) && $_GET['nid'] >= 1) {
-                if(!$_GET['seen']) {
-                    $this->core->getQueries()->markNotificationAsSeen($user_id, $_GET['nid']);
-                }
                 $metadata = $this->core->getQueries()->getNotificationInfoById($user_id, $_GET['nid'])['metadata'];
+                if(!$_GET['seen']) {
+                    $thread_id = Notification::getThreadIdIfExists($metadata);
+                    $this->core->getQueries()->markNotificationAsSeen($user_id, $_GET['nid'], $thread_id);
+                }
                 $this->core->redirect(Notification::getUrl($this->core, $metadata));
             } else if($_GET['action'] == 'mark_as_seen' && !empty($_GET['nid']) && is_numeric($_GET['nid']) && $_GET['nid'] >= 1) {
                 $this->core->getQueries()->markNotificationAsSeen($user_id, $_GET['nid']);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -687,6 +687,7 @@ class ForumController extends AbstractController {
         $option = ($this->core->getUser()->getGroup() <= 2 || $option != 'alpha') ? $option : 'tree';
         if(!empty($_REQUEST["thread_id"])){
             $thread_id = (int)$_REQUEST["thread_id"];
+            $this->core->getQueries()->markNotificationAsSeen($user, -2, (string)$thread_id);
             $thread = $this->core->getQueries()->getThread($thread_id);
             if(!empty($thread)) {
                 $thread = $thread[0];

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2741,10 +2741,13 @@ AND gc_id IN (
      * @param sting $user_id
      * @param int $notification_id  if $notification_id != -1 then marks corresponding as seen else mark all notifications as seen
      */
-    public function markNotificationAsSeen($user_id, $notification_id){
+    public function markNotificationAsSeen($user_id, $notification_id, $thread_id = -1){
         $parameters = array();
         $parameters[] = $user_id;
-        if($notification_id == -1) {
+        if($thread_id != -1) {
+        	$id_query = "metadata::json->0->>'thread_id' = ?";
+        	$parameters[] = $thread_id;
+        } else if($notification_id == -1) {
             $id_query = "true";
         } else {
             $id_query = "id = ?";

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -116,6 +116,15 @@ class Notification extends AbstractModel {
         return $core->buildUrl($parts, $hash);
     }
 
+    public static function getThreadIdIfExists($metadata_json) {
+        $metadata = json_decode($metadata_json, true);
+        if(is_null($metadata)) {
+            return null;
+        }
+        $thread_id = array_key_exists('thread_id', $metadata[0]) ? $metadata[0]['thread_id'] : -1;
+        return $thread_id;
+    }
+
     /**
      * Handles notifications related to forum
      *


### PR DESCRIPTION
This PR closes #3108, which will mark unseen notifications as viewed when viewing the corresponding thread.