### PR TITLE
Allow instructor to specify number of ports listened to by a container

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -109,6 +109,15 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
     whole_config["single_port_per_container"] = false; // connection
   }
 
+  if (!whole_config["ports_per_container"].is_number()){
+    whole_config["ports_per_container"] = 1;
+  }
+
+  int ports_per_container = whole_config["ports_per_container"];
+  assert(ports_per_container > 0);
+  assert(ports_per_container <= 100);
+
+
   bool use_router = whole_config["use_router"];
   bool single_port_per_container = whole_config["single_port_per_container"];
 
@@ -130,6 +139,14 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
     }
 
     assert(!(single_port_per_container && use_router));
+
+    if (!this_testcase["ports_per_container"].is_number()){
+      this_testcase["ports_per_container"] = ports_per_container;
+    }
+    
+    int testcase_ports_per_container = this_testcase["ports_per_container"];
+    assert(testcase_ports_per_container > 0);
+    assert(testcase_ports_per_container <= 100);
 
     nlohmann::json commands = nlohmann::json::array();
     // if "command" exists in whole_config, we must wrap it in a container.


### PR DESCRIPTION
Added ```ports_per_container``` field both globally and per testcase to the assignment configuration json.

This number defaults to 1, and must range between 1 and 100. It specifies the number of ports allocated to a container in the knownhosts files. Router integration is left for later.

This PR should not require a rebuild of any existing gradeables. All existing gradeables will be assumed to use 1 as the number of ports per container.