### PR TITLE
Reduce frequency of rebuild gradeable

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -815,8 +815,8 @@ class AdminGradeableController extends AbstractController {
             throw new \InvalidArgumentException('Request contained no properties, perhaps the name was blank?');
         }
 
-        // Trigger a rebuild if the config / due date changes
-        $trigger_rebuild_props = ['autograding_config_path', 'submission_due_date'];
+        // Trigger a rebuild if the config changes
+        $trigger_rebuild_props = ['autograding_config_path'];
         $trigger_rebuild = count(array_intersect($trigger_rebuild_props, array_keys($details))) > 0;
 
         $boolean_properties = [

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -146,6 +146,15 @@ $(document).ready(function () {
 });
 
 function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, errorCallback) {
+    let container = $('#container-rubric');
+    if (container.length === 0) {
+        alert("UPDATES DISABLED: no 'container-rubric' element!");
+        return;
+    }
+    // Don't process updates until the page is done loading
+    if (!container.is(':visible')) {
+        return;
+    }
     setGradeableUpdateInProgress();
     $.getJSON({
         type: "POST",


### PR DESCRIPTION
Closes #3100 

There are two things: first, the rebuild is only triggered by the button press or the config file change (as requested).  The noteworthy removal is that changes to dates (even the due date) will not trigger a rebuild.

The other change was to the client-side.  There were some premature requests sent to the server for updates that were just rebounds of the data loaded into the page causing the gradeable to be rebuilt on page load.  These events are now filtered out before being sent to the server.