### PR TITLE
Add special case for instructor not on team

### DIFF
--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -317,6 +317,6 @@ class User extends AbstractModel {
      */
     public function onTeam($gradeable_id) {
         $team = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable_id, $this->id);
-        return $team!==NULL;
+        return $team !== NULL;
     }
 }

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -308,4 +308,15 @@ class User extends AbstractModel {
 			trigger_error('User::validateUserData() called with unknown $field '.$field.' and $data '.$data, E_USER_ERROR);
     	}
     }
+
+    /**
+     * Checks if the user is on ANY team for the given assignment
+     *
+     * @param string gradable_id
+     * @return bool
+     */
+    public function onTeam($gradeable_id) {
+        $team = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable_id, $this->id);
+        return $team!==NULL;
+    }
 }

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -44,8 +44,12 @@ class HomeworkView extends AbstractView {
             $late_days_use = max(0, $gradeable->getWouldBeDaysLate() - $graded_gradeable->getLateDayException($this->core->getUser()));
         }
 
+        $is_admin = $this->core->getAccess()->canI('admin.wrapper', []);
+        $on_team = $this->core->getUser()->onTeam($gradeable->getId());
+
         // Only show the late banner if the submission has a due date
-        if (LateDays::filterCanView($this->core, $gradeable)) {
+        // Instructors shouldn't see this banner if they're not on a team (they won't have proper information)
+        if (LateDays::filterCanView($this->core, $gradeable) && !($is_admin && !$on_team)) {
             $late_days = LateDays::fromUser($this->core, $this->core->getUser());
             $return .= $this->renderLateDayMessage($late_days, $gradeable, $graded_gradeable);
         }


### PR DESCRIPTION
It looks like the crashes were caused by rendering the late day message when an instructor isn't on a team. I've added a check to avoid this in the special case that the user is an instructor and is not on a team.

fixes #3168