### PR TITLE
Change "Max. late days allowed" column in late days table

### DIFF
--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -80,11 +80,19 @@ class LateDayInfo extends AbstractModel {
     }
 
     /**
+     * Gets the max number of late days the instructor allows for the gradeable
+     * @return int
+     */
+    public function getAssignmentAllowedLateDays() {
+        return $this->graded_gradeable->getGradeable()->getLateDays();
+    }
+
+    /**
      * Gets the number of days late the user may submit this gradeable and not be STATUS_BAD
      * @return int
      */
     public function getLateDaysAllowed() {
-        return min($this->graded_gradeable->getGradeable()->getLateDays(), $this->late_days_remaining) + $this->getLateDayException();
+        return min($this->getAssignmentAllowedLateDays(), $this->late_days_remaining) + $this->getLateDayException();
     }
 
     /**

--- a/site/app/templates/LateDaysTablePlugin.twig
+++ b/site/app/templates/LateDaysTablePlugin.twig
@@ -41,7 +41,7 @@
         <tr>
             <td {{ class }} style="padding:5px; border:thin solid black">{{ gradeable.getTitle() }}</td>
             <td {{ class }} align="center" style="padding:5px; border:thin solid black">{{ gradeable.getSubmissionDueDate()|date('m/d/Y') }}</td>
-            <td {{ class }} align="center" style="padding:5px; border:thin solid black">{{ late_day_info.getLateDaysAllowed() }}</td>
+            <td {{ class }} align="center" style="padding:5px; border:thin solid black">{{ late_day_info.getAssignmentAllowedLateDays() }}</td>
             <td {{ class }} align="center" style="padding:5px; border:thin solid black">{{ (late_day_info.getDaysLate() != 0) ? late_day_info.getDaysLate() : "" }}</td>
             <td {{ class }} align="center" style="padding:5px; border:thin solid black">{{ (late_day_info.getLateDayException() != 0) ? late_day_info.getLateDayException() : "" }}</td>
             <td {{ class }} {{ id }} align="center" style="padding:5px; border:thin solid black">{{ late_day_info.getStatusMessage() }}</td>


### PR DESCRIPTION
Changes "Maximum number of late days allowed for this assignment" column to display the number of late days allowed for _the gradeable_ , instead of the maximum number of late days a _given student_ can spend on the assignment. 

Fixes #3162