### PR TITLE
Allow students access to grade inquiries if they made one before the deadline

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -101,7 +101,7 @@ class HomeworkView extends AbstractView {
             && $active_version !== 0) {
             $return .= $this->renderTAResultsBox($graded_gradeable, $regrade_available);
         }
-        if ($regrade_available) {
+        if ($regrade_available || $graded_gradeable->hasRegradeRequest()) {
             $return .= $this->renderRegradeBox($graded_gradeable);
         }
         return $return;


### PR DESCRIPTION
This PR will always show the grade inquiry discussion if an inquiry has been made on time before

Fixes #3199