### PR TITLE
Fix Team Bulk Uploads

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -394,13 +394,18 @@ class SubmissionController extends AbstractController {
             $graded_gradeables[] = $gg;
         }
 
-        if (count($graded_gradeables) === 0) {
-            // No user was on a team
-            $msg = 'No user on a team';
-            $return = array('success' => false, 'message' => $msg);
-            $this->core->getOutput()->renderJson($return);
-            return $return;
-        } else if (count($graded_gradeables) > 1) {
+        // Below is true if no users are on a team. In this case, we later make the team automatically,
+        //   so this should not return a failure.
+        // if (count($graded_gradeables) === 0) {
+        //     // No user was on a team
+        //     $msg = 'No user on a team';
+        //     $return = array('success' => false, 'message' => $msg);
+        //     $this->core->getOutput()->renderJson($return);
+        //     return $return;
+        // } else 
+
+        //If the users are on multiple teams.
+        if (count($graded_gradeables) > 1) {
             // Not all users were on the same team
             $msg = "Inconsistent teams. One or more users are on different teams.";
             $return = array('success' => false, 'message' => $msg);
@@ -408,8 +413,11 @@ class SubmissionController extends AbstractController {
             return $return;
         }
 
-        $graded_gradeable = $graded_gradeables[0];
-        $highest_version = $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
+        $highest_version = -1;
+        if(count($graded_gradeables) > 0){
+            $graded_gradeable = $graded_gradeables[0];
+            $highest_version = $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
+        }
 
         //If there has been a previous submission, we tag it so that we can pop up a warning.
         $return = array('success' => true, 'highest_version' => $highest_version, 'previous_submission' => $highest_version > 0);
@@ -654,7 +662,15 @@ class SubmissionController extends AbstractController {
             else{
                 //If the team doesn't exist yet, we need to build a new one. (Note, we have already checked in ajaxvalidgradeable
                 //that all users are either on the same team or no team).
-                $members = $this->core->getQueries()->getUsersById($user_ids);
+
+                $leaderless = array();
+                foreach($user_ids as $i => $member){
+                    if($member !== $leader){
+                        $leaderless[] = $member;
+                    }
+                }
+
+                $members = $this->core->getQueries()->getUsersById($leaderless);
                 $leader_user = $this->core->getQueries()->getUserById($leader);
                 try {
                     $gradeable->createTeam($leader_user, $members);

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -56,8 +56,9 @@
                                 {% endif %}
                                 {% if team_assignment %}
                                     {# (size - 1) because twig loops are range inclusive #}
+                                    {% set outer_loop = loop %}
                                     {% for i in 1..(max_team_size - 1) %}
-                                        <input type="text" id="bulk_user_id_{{ loop.index }}[{{ i }}]" value =""/>
+                                        <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value =""/>
                                     {% endfor %}
                                 {% endif %}
                             </div>


### PR DESCRIPTION
Fixes team bulk uploads.

A check had been added which wouldn't allow a submission if the specified students were not on a team. The intended functionality is to generate a team this case rather than to fail. The new changes restore this functionality. Also fixed a bug in the submission twig which was causing teams to be improperly saved.