### PR TITLE
Fix full height cutting off sidebar

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -32,7 +32,7 @@
 </head>
 <script>var onAjaxInit;</script>
 <body data-site-url="{{ site_url }}" data-csrf-token="{{ core.getCsrfToken() }}" onload="if (onAjaxInit) { onAjaxInit(); }">
-<div id="container" {{ container_class }}>
+<div id="container">
     {% if wrapper_urls['top_bar.html'] != null %}
         {# uploaded homepage redirect can go here? #}
         <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="top_bar" src="{{ wrapper_urls['top_bar.html'] }}" frameborder="0"></iframe>
@@ -75,7 +75,7 @@
                     <img id="logo-submitty" src="../img/submitty_logo.png" alt="Submitty Logo">
                 </a>
             </div>
-            <div class="row" id="push" {{ row_height }}>
+            <div class="row {{ header_class  }}" id="push">
                 {% if sidebar_buttons|length > 0 %}
                     <div class="col-md-auto" id="sidebar">
                         <div id="nav-buttons-visible">


### PR DESCRIPTION
This fix should resolve the issue when the sidebar overflows the height of the display content. This creates an extra scrollbar when viewing content, but this expands the view to maximize the amount of content that is visible (scrolling hides the top breadcrumbs as shown below). We can discuss if this is the right approach to solve this problem. 

Top of scroll:
![top](https://user-images.githubusercontent.com/16356240/51570614-7386e680-1e6d-11e9-98f5-ddb208480244.png)

Bottom of scroll:
![full page display](https://user-images.githubusercontent.com/16356240/51570316-bbf1d480-1e6c-11e9-921e-1c83fb900c5d.png)
