### PR TITLE
[Bugfix] Fixed the forum bar, change display, buttons 

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -16,14 +16,14 @@
 
 	{% if show_threads %}
 		<div style="margin-left:10px;display:inline-block;position:relative;top:3px;" class="btn-group btn-group-toggle" data-toggle="buttons">
-  			<label id="tree_label" for="radio" onclick="changeDisplayOptions('tree', {{ currentThread }})" class="btn btn-secondary">
+  			<label id="tree_label" for="radio" onclick="changeDisplayOptions('tree', {{ current_thread }})" class="btn btn-secondary">
     			<input type="radio" name="selectOption" id="tree" value="tree"> Hierarchical
   			</label>
-  			<label id="time_label" for="radio2" onclick="changeDisplayOptions('time', {{ currentThread }})" class="btn btn-secondary">
+  			<label id="time_label" for="radio2" onclick="changeDisplayOptions('time', {{ current_thread }})" class="btn btn-secondary">
     			<input type="radio" name="selectOption" id="time" value="time"> Chronological
   			</label>
 		{% if user_group <= 2 %}
-			<label id="alpha_label" for="radio3" onclick="changeDisplayOptions('alpha', {{ currentThread }})" class="btn btn-secondary">
+			<label id="alpha_label" for="radio3" onclick="changeDisplayOptions('alpha', {{ current_thread }})" class="btn btn-secondary">
     			<input type="radio" name="selectOption" id="alpha" value="alpha"> Alphabetical
   			</label>
   		{% endif %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1004,8 +1004,7 @@ HTML;
 	$return .= $this->core->getOutput()->renderTwigTemplate("forum/ForumBar.twig", [
 								"forum_bar_buttons" => $buttons,
 								"show_threads" => false,
-								"thread_exists" => $thread_exists,
-								"current_thread" => (isset($currentThread) ? $currentThread : -1)
+								"thread_exists" => $thread_exists
 	]);
 
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1005,7 +1005,7 @@ HTML;
 								"forum_bar_buttons" => $buttons,
 								"show_threads" => false,
 								"thread_exists" => $thread_exists,
-								"current_thread" => $currentThread
+								"current_thread" => (isset($currentThread) ? $currentThread : -1)
 	]);
 
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1004,7 +1004,8 @@ HTML;
 	$return .= $this->core->getOutput()->renderTwigTemplate("forum/ForumBar.twig", [
 								"forum_bar_buttons" => $buttons,
 								"show_threads" => false,
-								"thread_exists" => $thread_exists
+								"thread_exists" => $thread_exists,
+								"current_thread" => $currentThread
 	]);
 
 


### PR DESCRIPTION
The current thread id number was not being passed in when rendering the forum bar which made the 3 change display buttons default to a thread id of "undefined" and the page would then reload to the default top forum post instead of keeping the user on the current forum post.

I had already made a pull request which I closed because it had an error due to the current thread id variable not always existing, this one however fixes that issue.

This fixes half of issue #3218 however I don't have a fix for the other half, so I don't want this to automatically closed that issue. If this gets merged, I can put a comment on that issue to let people know what still needs to be fixed.