### PR TITLE
Add ability to show system message

### DIFF
--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -131,6 +131,9 @@ class Config extends AbstractModel {
      */
     protected $username_change_text = "";
 
+    /** @property @var string Text shown to all users for system announcement */
+    protected $system_message = '';
+
     /** @property @var array */
     protected $submitty_database_params = array();
 
@@ -246,6 +249,10 @@ class Config extends AbstractModel {
 
         if (isset($submitty_json['username_change_text'])) {
             $this->username_change_text = $submitty_json['username_change_text'];
+        }
+
+        if (isset($submitty_json['system_message'])) {
+            $this->system_message = strval($submitty_json['system_message']);
         }
 
         $this->timezone = new \DateTimeZone($this->timezone);

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -75,6 +75,11 @@
                     <img id="logo-submitty" src="../img/submitty_logo.png" alt="Submitty Logo">
                 </a>
             </div>
+            {% if system_message is not null and system_message|length > 0 %}
+            <div class="row system_message">
+                <span>{{ system_message }}</span>
+            </div>
+            {% endif %}
             <div class="row" id="push" {{ row_height }}>
                 {% if sidebar_buttons|length > 0 %}
                     <div class="col-md-auto" id="sidebar">

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -32,7 +32,8 @@ class GlobalView extends AbstractView {
             "notifications_info" => $notifications_info,
             "wrapper_enabled" => $this->core->getConfig()->wrapperEnabled(),
             "wrapper_urls" => $wrapper_urls,
-            "fixed_height" => $fixed_height
+            "fixed_height" => $fixed_height,
+            "system_message" => $this->core->getConfig()->getSystemMessage()
         ]);
      }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1724,11 +1724,8 @@ end of styles used in the admin gradeable page
 }
 
 .noscript {
-    width: 100%;
-    text-align: center;
     background: #f2dede;
     color: #b94a48;
-    height: 2em;
 }
 
 .noscript span,

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1710,3 +1710,16 @@ end of styles used in the admin gradeable page
 .courses-table .btn {
     margin-bottom: 3px;
 }
+
+.system_message {
+    width: 100%;
+    background: #fff3cd;
+    color: #856404;
+    height: 2em;
+}
+
+.system_message span {
+    text-align: center;
+    margin: auto;
+    font-size: 1em;
+}

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -75,8 +75,9 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             "vcs_url" => "",
             "cgi_url" => "http://example.com/cgi-bin",
             "institution_name" => "RPI",
-            "username_change_text" => "Submitty welcomes individuals of all ages, backgrounds, citizenships, disabilities, sex, education, ethnicities, family statuses, genders, gender identities, geographical locations, languages, military experience, political views, races, religions, sexual orientations, socioeconomic statuses, and work experiences. In an effort to create an inclusive environment, you may specify a preferred name to be used instead of what was provided on the registration roster.",
+            "username_change_text" => "Submitty welcomes all students.",
             "institution_homepage" => "https://rpi.edu",
+            'system_message' => "Some system message"
         ];
         $config = array_replace($config, $extra);
         FileUtils::writeJsonFile(FileUtils::joinPaths($this->config_path, "submitty.json"), $config);
@@ -149,6 +150,10 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($db_params, $config->getSubmittyDatabaseParams());
         $this->assertEquals("PamAuthentication", $config->getAuthentication());
         $this->assertEquals("America/Chicago", $config->getTimezone()->getName());
+        $this->assertEquals("RPI", $config->getInstitutionName());
+        $this->assertEquals("https://rpi.edu", $config->getInstitutionHomepage());
+        $this->assertEquals("Submitty welcomes all students.", $config->getUsernameChangeText());
+        $this->assertEquals("Some system message", $config->getSystemMessage());
 
         $config->loadCourseIni($this->course_ini_path);
         $this->assertEquals(array_merge($db_params, array('dbname' => 'submitty_s17_csci0000')), $config->getCourseDatabaseParams());
@@ -233,9 +238,10 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'private_repository' => '',
             'regrade_enabled' => false,
             'room_seating_gradeable_id' => '',
-            'username_change_text' => 'Submitty welcomes individuals of all ages, backgrounds, citizenships, disabilities, sex, education, ethnicities, family statuses, genders, gender identities, geographical locations, languages, military experience, political views, races, religions, sexual orientations, socioeconomic statuses, and work experiences. In an effort to create an inclusive environment, you may specify a preferred name to be used instead of what was provided on the registration roster.',
+            'username_change_text' => 'Submitty welcomes all students.',
             'vcs_url' => 'http://example.com/{$vcs_type}/',
-            'wrapper_files' => []
+            'wrapper_files' => [],
+            'system_message' => 'Some system message'
         );
         $actual = $config->toArray();
 


### PR DESCRIPTION
Closes #1415.

You can add a `system_message` to the `config/submitty.json` file that it will show on every page of the system. If the field is missing or blank, then it's not shown. I'm not sure where we want to surface configuration of this (do we want to add a new page on explanation of the config files on submitty.org?).

![screenshot 2019-01-30 17 02 01](https://user-images.githubusercontent.com/1845314/52015811-d0f3e680-24b0-11e9-884d-3ba15294db92.png)
