### PR TITLE
Make Test Notes Upload configs More Tolerant of PDFs

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -783,7 +783,7 @@ else
         chmod -R g+r ${SUBMITTY_REPOSITORY}
 
         # Update any foreign worker machines
-        echo -e Updating worker machines
+        echo -e -n "Updating worker machines\n\n"
         sudo -H -u ${DAEMON_USER} ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils/update_and_install_workers.py
     fi
 fi

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -14,33 +14,46 @@
 extern const char *GLOBAL_config_json_string;  // defined in json_generated.cpp
 
 void AddAutogradingConfiguration(nlohmann::json &whole_config) {
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.cpp");
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.cxx");
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.c");
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.h");
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.hpp");
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.hxx");
-  whole_config["autograding"]["submission_to_compilation"].push_back("**/*.java");
 
-  whole_config["autograding"]["submission_to_runner"].push_back("**/*.py");
-  whole_config["autograding"]["submission_to_runner"].push_back("**/*.pdf");
+  if (whole_config["autograding"].find("submission_to_compilation") == whole_config["autograding"].end()) {
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.cpp");
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.cxx");
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.c");
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.h");
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.hpp");
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.hxx");
+    whole_config["autograding"]["submission_to_compilation"].push_back("**/*.java");
+  }
 
-  whole_config["autograding"]["compilation_to_runner"].push_back("**/*.out");
-  whole_config["autograding"]["compilation_to_runner"].push_back("**/*.class");
+  if (whole_config["autograding"].find("submission_to_runner") == whole_config["autograding"].end()) {
+    whole_config["autograding"]["submission_to_runner"].push_back("**/*.py");
+    whole_config["autograding"]["submission_to_runner"].push_back("**/*.pdf");
+  }
 
-  whole_config["autograding"]["compilation_to_validation"].push_back("test*/STDOUT*.txt");
-  whole_config["autograding"]["compilation_to_validation"].push_back("test*/STDERR*.txt");
+  if (whole_config["autograding"].find("compilation_to_runner") == whole_config["autograding"].end()) {
+    whole_config["autograding"]["compilation_to_runner"].push_back("**/*.out");
+    whole_config["autograding"]["compilation_to_runner"].push_back("**/*.class");
+  }
 
-  whole_config["autograding"]["submission_to_validation"].push_back("**/README.txt");
-  whole_config["autograding"]["submission_to_validation"].push_back("textbox_*.txt");
-  whole_config["autograding"]["submission_to_validation"].push_back("**/*.pdf");
+  if (whole_config["autograding"].find("compilation_to_validation") == whole_config["autograding"].end()) {
+    whole_config["autograding"]["compilation_to_validation"].push_back("test*/STDOUT*.txt");
+    whole_config["autograding"]["compilation_to_validation"].push_back("test*/STDERR*.txt");
+  }
 
-  whole_config["autograding"]["work_to_details"].push_back("test*/*.txt");
-  whole_config["autograding"]["work_to_details"].push_back("test*/*_diff.json");
-  whole_config["autograding"]["work_to_details"].push_back("**/README.txt");
-  whole_config["autograding"]["work_to_details"].push_back("textbox_*.txt");
-  //todo check up on how this works.
-  whole_config["autograding"]["work_to_details"].push_back("test*/textbox_*.txt");
+  if (whole_config["autograding"].find("submission_to_validation") == whole_config["autograding"].end()) {
+    whole_config["autograding"]["submission_to_validation"].push_back("**/README.txt");
+    whole_config["autograding"]["submission_to_validation"].push_back("textbox_*.txt");
+    whole_config["autograding"]["submission_to_validation"].push_back("**/*.pdf");
+  }
+
+  if (whole_config["autograding"].find("work_to_details") == whole_config["autograding"].end()) {
+    whole_config["autograding"]["work_to_details"].push_back("test*/*.txt");
+    whole_config["autograding"]["work_to_details"].push_back("test*/*_diff.json");
+    whole_config["autograding"]["work_to_details"].push_back("**/README.txt");
+    whole_config["autograding"]["work_to_details"].push_back("textbox_*.txt");
+    //todo check up on how this works.
+    whole_config["autograding"]["work_to_details"].push_back("test*/textbox_*.txt");
+  }
 
   if (whole_config["autograding"].find("use_checkout_subdirectory") == whole_config["autograding"].end()) {
     whole_config["autograding"]["use_checkout_subdirectory"] = "";

--- a/more_autograding_examples/test_notes_upload/config/config.json
+++ b/more_autograding_examples/test_notes_upload/config/config.json
@@ -7,13 +7,13 @@
     },
 
     "autograding" : {
-	"submission_to_compilation" : [ "*.pdf" ],
-	"submission_to_runner" : [ "*.pdf" ],
-	"submission_to_validation" : [ "*.pdf" ],
+	"submission_to_compilation" : [ ],
+	"submission_to_runner" : [ *.pdf ],
+	"submission_to_validation" : [ ],
 	"work_to_details" : [
-	    "**/*.pdf", "*test_template.pdf", "*student_file.pdf" ],
+            "test01/student_file.pdf", "test02/test_template.pdf" ],
         "work_to_public" : [
-	    "**/*.pdf", "*test_template.pdf", "*student_file.pdf" ]
+            "test01/student_file.pdf", "test02/test_template.pdf" ]
     },
 
     "assignment_message" : "Prepare a 2 page, black & white, 8.5x11”, portrait orientation, max size = 2MB .pdf of notes you would like to have during the test.<br><br>Be sure to inspect the produced sample test pdf to make sure that your notes are successfully attached to the back and that they will be legible when printed.",
@@ -28,14 +28,14 @@
 		{
                     "actual_file": "student_file.pdf",
                     "deduction": 1.0,
-                    "description": "uploaded file",
+                    "description": "Student's uploaded .pdf file",
                     "method": "fileExists",
                     "show_actual": "always",
                     "show_message": "on_failure",
-				    "failure_message": "Either could not find a .pdf file or found multiple .pdf files. Please submit exactly one PDF file."
+		    "failure_message": "Looks like you either did not submit a .pdf file or you submitted multiple .pdf files. Please submit exactly one PDF file."
                 },
-                { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
-                { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDOUT.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDERR.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
 	    ]
 	},
@@ -50,6 +50,8 @@
 		}
 	    ],
 	    "command" : [
+                // Just in case the student named a submission file 'test_template.pdf'
+                "mv test_template.pdf student_test_template.pdf",
                 // BUILD the simple blank page latex file
                 "pdflatex blank_page.tex",
                 // SEPARATE the pages of the students submitted .pdf
@@ -67,11 +69,11 @@
                 {
                     "actual_file": "test_template.pdf",
                     "deduction": 1.0,
-                    "description": "Test with your notes attached at the back",
+                    "description": "Test template with student notes attached at the back",
                     "method": "fileExists",
                     "show_actual": "always",
                     "show_message": "on_failure",
-					"failure_message": "Failed to attach submission to sample test. This could be because the .pdf file submitted was not a valid PDF. This could happen if you renamed another file type (such as .txt, .odt, .docx, .jpg) to .pdf instead of saving/exporting a file in PDF format."
+		    "failure_message": "We failed to attach your .pdf submission to the sample test. This could be because the .pdf file you submitted was not a valid PDF.  This could happen if you renamed another file type (such as .txt, .odt, .docx, .jpg) to .pdf instead of saving/exporting a file in PDF format."
                 },
                 { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
@@ -79,6 +81,8 @@
                 { "actual_file": "STDERR_1.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDOUT_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDOUT_3.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDERR_3.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
 
 	    ]

--- a/more_autograding_examples/test_notes_upload/config/config.json
+++ b/more_autograding_examples/test_notes_upload/config/config.json
@@ -20,7 +20,7 @@
 
     "testcases" : [
 	{
-	    "title" : "Did you submit .pdf file?",
+	    "title" : "Did you submit a .pdf file?",
             // NOTE: This command will fail if the student no .pdf files or submits multiple .pdf files.
 	    "command" : [ "mv *.pdf student_file.pdf" ],
 	    "points" : 1,
@@ -31,8 +31,12 @@
                     "description": "uploaded file",
                     "method": "fileExists",
                     "show_actual": "always",
-                    "show_message": "always"
-                }
+                    "show_message": "on_failure",
+				    "failure_message": "Either could not find a .pdf file or found multiple .pdf files. Please submit exactly one PDF file."
+                },
+                { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
 	    ]
 	},
         {
@@ -66,14 +70,17 @@
                     "description": "Test with your notes attached at the back",
                     "method": "fileExists",
                     "show_actual": "always",
-                    "show_message": "always"
+                    "show_message": "on_failure",
+					"failure_message": "Failed to attach submission to sample test. This could be because the .pdf file submitted was not a valid PDF. This could happen if you renamed another file type (such as .txt, .odt, .docx, .jpg) to .pdf instead of saving/exporting a file in PDF format."
                 },
                 { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDOUT_1.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_1.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDOUT_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
-                { "actual_file": "STDERR_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
+                { "actual_file": "STDERR_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
+
 	    ]
 	}
     ] 

--- a/more_autograding_examples/test_notes_upload/config/test_input/separate_pages.py
+++ b/more_autograding_examples/test_notes_upload/config/test_input/separate_pages.py
@@ -4,7 +4,7 @@ import sys
 from PyPDF2 import PdfFileWriter, PdfFileReader
 from shutil import copyfile
 
-inputpdf = PdfFileReader(open("student_file.pdf", "rb"))
+inputpdf = PdfFileReader(open("student_file.pdf", "rb"), strict=False)
 
 # separate the pages of the student input file
 for i in range(inputpdf.numPages):

--- a/more_autograding_examples/test_notes_upload_3page/config/config.json
+++ b/more_autograding_examples/test_notes_upload_3page/config/config.json
@@ -20,7 +20,7 @@
 
     "testcases" : [
 	{
-	    "title" : "Did you submit .pdf file?",
+	    "title" : "Did you submit a .pdf file?",
             // NOTE: This command will fail if the student no .pdf files or submits multiple .pdf files.
 	    "command" : [ "mv *.pdf student_file.pdf" ],
 	    "points" : 1,
@@ -31,8 +31,13 @@
                     "description": "uploaded file",
                     "method": "fileExists",
                     "show_actual": "always",
-                    "show_message": "always"
-                }
+                    "show_message": "on_failure",
+					"failure_message": "Either could not find a .pdf file or found multiple .pdf files. Please submit exactly one PDF file."
+        },
+        { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+        { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+        { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
+
 	    ]
 	},
         {
@@ -66,14 +71,16 @@
                     "description": "Test with your notes attached at the back",
                     "method": "fileExists",
                     "show_actual": "always",
-                    "show_message": "always"
+                    "show_message": "on_failure",
+					"failure_message": "Failed to attach submission to sample test. This could be because the .pdf file submitted was not a valid PDF. This could happen if you renamed another file type (such as .txt, .odt, .docx, .jpg) to .pdf instead of saving/exporting a file in PDF format."
                 },
                 { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDOUT_1.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_1.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDOUT_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
-                { "actual_file": "STDERR_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
+                { "actual_file": "STDERR_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
 	    ]
 	}
     ] 

--- a/more_autograding_examples/test_notes_upload_3page/config/config.json
+++ b/more_autograding_examples/test_notes_upload_3page/config/config.json
@@ -11,9 +11,9 @@
 	"submission_to_runner" : [ "*.pdf" ],
 	"submission_to_validation" : [ "*.pdf" ],
 	"work_to_details" : [
-	    "**/*.pdf", "*test_template.pdf", "*student_file.pdf" ],
+            "test01/student_file.pdf", "test02/test_template.pdf" ],
         "work_to_public" : [
-	    "**/*.pdf", "*test_template.pdf", "*student_file.pdf" ]
+            "test01/student_file.pdf", "test02/test_template.pdf" ]
     },
 
     "assignment_message" : "Prepare a 3 page, black & white, 8.5x11”, portrait orientation, max size = 3MB .pdf of notes you would like to have during the test.<br><br>Be sure to inspect the produced sample test pdf to make sure that your notes are successfully attached to the back and that they will be legible when printed.",
@@ -28,16 +28,15 @@
 		{
                     "actual_file": "student_file.pdf",
                     "deduction": 1.0,
-                    "description": "uploaded file",
+                    "description": "Student's uploaded .pdf file",
                     "method": "fileExists",
                     "show_actual": "always",
                     "show_message": "on_failure",
-					"failure_message": "Either could not find a .pdf file or found multiple .pdf files. Please submit exactly one PDF file."
-        },
-        { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
-        { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
-        { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
-
+		    "failure_message": "Looks like you either did not submit a .pdf file or you submitted multiple .pdf files. Please submit exactly one PDF file."
+                },
+                { "actual_file": "STDOUT.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDERR.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
 	    ]
 	},
         {
@@ -51,6 +50,8 @@
 		}
 	    ],
 	    "command" : [
+                // Just in case the student named a submission file 'test_template.pdf'
+                "mv test_template.pdf student_test_template.pdf",
                 // BUILD the simple blank page latex file
                 "pdflatex blank_page.tex",
                 // SEPARATE the pages of the students submitted .pdf
@@ -68,11 +69,11 @@
                 {
                     "actual_file": "test_template.pdf",
                     "deduction": 1.0,
-                    "description": "Test with your notes attached at the back",
+                    "description": "Test template with student notes attached at the back",
                     "method": "fileExists",
                     "show_actual": "always",
                     "show_message": "on_failure",
-					"failure_message": "Failed to attach submission to sample test. This could be because the .pdf file submitted was not a valid PDF. This could happen if you renamed another file type (such as .txt, .odt, .docx, .jpg) to .pdf instead of saving/exporting a file in PDF format."
+		    "failure_message": "We failed to attach your .pdf submission to the sample test. This could be because the .pdf file you submitted was not a valid PDF.  This could happen if you renamed another file type (such as .txt, .odt, .docx, .jpg) to .pdf instead of saving/exporting a file in PDF format."
                 },
                 { "actual_file": "STDOUT_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_0.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
@@ -80,7 +81,10 @@
                 { "actual_file": "STDERR_1.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDOUT_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "STDERR_2.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDOUT_3.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
+                { "actual_file": "STDERR_3.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" },
                 { "actual_file": "execute_logfile.txt", "method": "fileExists", "show_actual": "never", "show_message": "never" }
+
 	    ]
 	}
     ] 

--- a/more_autograding_examples/test_notes_upload_3page/config/test_input/separate_pages.py
+++ b/more_autograding_examples/test_notes_upload_3page/config/test_input/separate_pages.py
@@ -4,7 +4,7 @@ import sys
 from PyPDF2 import PdfFileWriter, PdfFileReader
 from shutil import copyfile
 
-inputpdf = PdfFileReader(open("student_file.pdf", "rb"))
+inputpdf = PdfFileReader(open("student_file.pdf", "rb"), strict=False)
 
 # separate the pages of the student input file
 for i in range(inputpdf.numPages):

--- a/sbin/shipper_utils/systemctl_wrapper.py
+++ b/sbin/shipper_utils/systemctl_wrapper.py
@@ -54,7 +54,7 @@ def print_status_message(status_code, mode, daemon, machine):
 
 # A wrapper for perform_systemctl_command_on_worker that iterates over all workers.
 def perform_systemctl_command_on_all_workers(daemon, mode):
-  # Right now, this script returns the greatesr (worst) status it receives from a worker.
+  # Right now, this script returns the greatest (worst) status it receives from a worker.
   greatest_status = 0
 
   for target in WORKERS.keys():

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
       local_directory = submitty_repository
       remote_host = '{0}@{1}'.format(user, host)
       foreign_directory = submitty_repository
-
+      print()
 
       # rsync the file
       print("performing rsync to {0}...".format(worker))

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -83,18 +83,18 @@ if __name__ == "__main__":
 
       exit_code = run_systemctl_command(worker, 'status')
       if exit_code == 1:
-        print("ERROR: {0}'s worker daemon was active when before rsynching began. Attempting to turn off.".format(worker))
+        print("ERROR: {0}'s worker daemon was active when before rsyncing began. Attempting to turn off.".format(worker))
         exit_code = run_systemctl_command(worker, 'stop')
         if exit_code != 0:
-          print("Could not turn off {0}'s daemon. Please allow rsynching to continue and then attempt another install.".format(worker))
+          print("Could not turn off {0}'s daemon. Please allow rsyncing to continue and then attempt another install.".format(worker))
 
       local_directory = submitty_repository
       remote_host = '{0}@{1}'.format(user, host)
       foreign_directory = submitty_repository
 
 
-      # rsynch the file
-      print("performing rsynch to {0}...".format(worker))
+      # rsync the file
+      print("performing rsync to {0}...".format(worker))
       # If this becomes too slow, we can exculde directories using --exclude.
       # e.g. --exclude=.git --exclude=.setup/data --exclude=site
       command = "rsync -a --no-perms --no-o --omit-dir-times --no-g {0}/ {1}:{2}".format(local_directory, remote_host, foreign_directory)
@@ -104,7 +104,7 @@ if __name__ == "__main__":
       success = install_worker(user, host)
       if success == True:
         print("Installed Submitty on {0}".format(worker))
-        print("Rebooting {0}...".format(worker))
+        print("Restart workers {0}...".format(worker))
         exit_code = run_systemctl_command(worker, 'start')
       else:
         print("Failed to update {0}. This likely indicates an error when installing submitty on the worker. Please attempt an install locally on the worker and inspect for errors.".format(worker))

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -91,7 +91,6 @@ if __name__ == "__main__":
       local_directory = submitty_repository
       remote_host = '{0}@{1}'.format(user, host)
       foreign_directory = submitty_repository
-      print()
 
       # rsync the file
       print("performing rsync to {0}...".format(worker))


### PR DESCRIPTION
Don't use strict checking to allow more test notes pages to be accepted by the reader (such as duplicate dictionary entries at a byte). Not sure if this will allow some bad things through, documentation wasn't very specific.

Tested and it seems like [make_all.py](https://github.com/Submitty/InstructorTools/blob/master/QR_TestMaker/make_all.py) doesn't need the option. Might still add it since it will leave the input a little more flexible if the tool is adapted for sources other than through the script introduced in #3254 