### PR TITLE
Log Autograding Exceptions

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -224,6 +224,7 @@ fi
 
 mkdir -p ${SUBMITTY_DATA_DIR}/logs
 mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding
+mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding/stack_traces
 
 #Make site logging directories if not in worker mode.
 if [ "${WORKER}" == 0 ]; then

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -77,6 +77,7 @@ def copy_contents_into(job_id,source,target,tmp_logs):
                 try:
                     shutil.copy(os.path.join(source,item),target)
                 except:
+                    grade_items_logging.log_stack_trace(job_id=job_id,trace=traceback.format_exc())
                     raise RuntimeError("ERROR COPYING FILE: " +  os.path.join(source,item) + " -> " + os.path.join(target,item))
 
 
@@ -217,8 +218,11 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
     # unzip autograding and submission folders
     tmp_autograding = os.path.join(tmp,"TMP_AUTOGRADING")
     tmp_submission = os.path.join(tmp,"TMP_SUBMISSION")
-    unzip_this_file(my_autograding_zip_file,tmp_autograding)
-    unzip_this_file(my_submission_zip_file,tmp_submission)
+    try:
+        unzip_this_file(my_autograding_zip_file,tmp_autograding)
+        unzip_this_file(my_submission_zip_file,tmp_submission)
+    except:
+        raise
     os.remove(my_autograding_zip_file)
     os.remove(my_submission_zip_file)
 
@@ -401,7 +405,7 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
                                                    cwd=testcase_folder)
                 except Exception as e:
                     print('An error occurred when compiling with docker.')
-                    traceback.print_exc()
+                    grade_items_logging.log_stack_trace(job_id,is_batch_job,which_untrusted,item_name,trace=traceback.format_exc())
                 finally:
                     if compilation_container != None:
                         subprocess.call(['docker', 'rm', '-f', compilation_container])
@@ -616,6 +620,7 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
         with open(os.path.join(tmp_logs,"overall.txt"),'a') as f:
             print ("\n\nERROR: Grading incomplete -- Could not open ",os.path.join(tmp_work,"grade.txt"))
             grade_items_logging.log_message(job_id,is_batch_job,which_untrusted,item_name,message="ERROR: grade.txt does not exist")
+            grade_items_logging.log_stack_trace(job_id,is_batch_job,which_untrusted,item_name,trace=traceback.format_exc())
 
     # --------------------------------------------------------------------
     # MAKE RESULTS DIRECTORY & COPY ALL THE FILES THERE
@@ -663,6 +668,7 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
         with open(os.path.join(tmp_logs,"overall.txt"),'a') as f:
             print ("\n\nERROR: Grading incomplete -- Could not copy ",os.path.join(tmp_work,"grade.txt"))
         grade_items_logging.log_message(job_id,is_batch_job,which_untrusted,item_name,message="ERROR: grade.txt does not exist")
+        grade_items_logging.log_stack_trace(job_id,is_batch_job,which_untrusted,item_name,trace=traceback.format_exc())
 
     # -------------------------------------------------------------
     # create/append to the results history
@@ -703,6 +709,7 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
         with open(os.path.join(tmp_logs,"overall.txt"),'a') as f:
             print ("\n\nERROR: Grading incomplete -- Could not open/write ",os.path.join(tmp_work,"results.json"))
             grade_items_logging.log_message(job_id,is_batch_job,which_untrusted,item_name,message="ERROR: results.json read/write error")
+            grade_items_logging.log_stack_trace(job_id,is_batch_job,which_untrusted,item_name,trace=traceback.format_exc())
 
     write_grade_history.just_write_grade_history(history_file,
                                                  gradeable_deadline_longstring,

--- a/sbin/autograder/grade_item_main_runner.py
+++ b/sbin/autograder/grade_item_main_runner.py
@@ -151,8 +151,10 @@ def executeTestcases(complete_config_obj, tmp_logs, tmp_work, queue_obj, submiss
                         first_testcase = False
 
                 except Exception as e:
-                    grade_items_logging.log_message(job_id, message="ERROR while grading by docker:\n {0}".format(traceback.format_exc()))
+                    grade_items_logging.log_message(job_id, message="ERROR while grading by docker. See traces entry for more details")
                     traceback.print_exc()
+                    grade_items_logging.log_stack_trace(job_id,trace=traceback.format_exc())
+
                 finally:
                     clean_up_containers(container_info,job_id,is_batch_job,which_untrusted,item_name,grading_began,use_router)
                     print("CLEANED UP CONTAINERS")
@@ -171,8 +173,9 @@ def executeTestcases(complete_config_obj, tmp_logs, tmp_work, queue_obj, submiss
                                                       str(testcase_num)],
                                                       stdout=logfile)
                 except Exception as e:
+                    grade_items_logging.log_message(job_id, message="ERROR thrown by main runner. See traces entry for more details.")
                     print ("ERROR caught runner.out exception={0}".format(str(e.args[0])).encode("utf-8"),file=logfile)
-                    traceback.print_exc()
+                    grade_items_logging.log_stack_trace(job_id,trace=traceback.format_exc())
             logfile.flush()
             os.chdir(tmp_work)
 
@@ -245,16 +248,19 @@ def setup_folder_for_grading(target_folder, tmp_work, job_id, tmp_logs, testcase
           try:
             shutil.copy(os.path.join(tmp_work,source),os.path.join(target_folder,destination))
           except Exception as e:
-            print("encountered a copy error")
             traceback.print_exc()
+            grade_items_logging.log_message(job_id, message="Encountered an error while processing pre-command. See traces entry for more details.")
+            grade_items_logging.log_stack_trace(job_id,trace=traceback.format_exc())
+
             #TODO: can we pass something useful to students?
             pass
         else:
           try:
             grade_item.copy_contents_into(job_id,os.path.join(tmp_work,source),os.path.join(target_folder,destination),tmp_logs)
           except Exception as e:
-            print("encountered a copy error")
             traceback.print_exc()
+            grade_items_logging.log_message(job_id, message="Encountered an error while processing pre-command. See traces entry for more details.")
+            grade_items_logging.log_stack_trace(job_id,trace=traceback.format_exc())
             #TODO: can we pass something useful to students?
             pass
       else:

--- a/sbin/autograder/grade_item_main_runner.py
+++ b/sbin/autograder/grade_item_main_runner.py
@@ -74,7 +74,6 @@ def executeTestcases(complete_config_obj, tmp_logs, tmp_work, queue_obj, submiss
                     # Networks containers together if there are more than one of them. Modifies container_info to store 'network'
                     #   The name of the docker network it is connected to.
                     network_containers(container_info,os.path.join(tmp_work, "test_input"),which_untrusted,use_router,single_port_per_container)
-                    print('NETWORKED CONTAINERS')
                     #The containers are now ready to execute.
 
                     processes = dict()
@@ -157,7 +156,6 @@ def executeTestcases(complete_config_obj, tmp_logs, tmp_work, queue_obj, submiss
 
                 finally:
                     clean_up_containers(container_info,job_id,is_batch_job,which_untrusted,item_name,grading_began,use_router)
-                    print("CLEANED UP CONTAINERS")
             else:
                 try:
                     # Move the files necessary for grading (runner, inputs, etc.) into the testcase folder.
@@ -206,7 +204,6 @@ def at_least_one_alive(processes):
 
 #targets must hold names/keys for the processes dictionary
 def send_message_to_processes(message, processes, targets):
-    print("sending {0} to {1}".format(message, targets))
     for target in targets:
         p = processes[target]
         # poll returns None if the process is still running.
@@ -421,7 +418,6 @@ def network_containers_routerless(container_info,which_untrusted):
   for name, info in sorted(container_info.items()):
       my_full_name = "{0}_{1}".format(which_untrusted, name)
       #container_info[name]['network'] = network_name
-      print('adding {0} to network {1}'.format(name,network_name))
       subprocess.check_output(['docker', 'network', 'connect', '--alias', name, network_name, my_full_name]).decode('utf8').strip()
 
 #Connect dockers in a network, updates the container_info with network names, and creates knownhosts.csv
@@ -439,7 +435,6 @@ def network_containers_with_router(container_info,which_untrusted):
 
       container_info[name]['network'] = network_name
       actual_name  = '{0}_Actual'.format(name)
-      print('adding {0} to network {1} with actual name {2}'.format(name,network_name, actual_name))
       subprocess.check_output(['docker', 'network', 'create', '--internal', '--driver', 'bridge', network_name]).decode('utf8').strip()
       subprocess.check_output(['docker', 'network', 'connect', '--alias', actual_name, network_name, my_name]).decode('utf8').strip()
 
@@ -469,7 +464,6 @@ def network_containers_with_router(container_info,which_untrusted):
           aliases.append('--alias')
           aliases.append(endpoint)
 
-      print('adding router to {0} with aliases {1}'.format(network_name, aliases))
       subprocess.check_output(['docker', 'network', 'connect'] + aliases + [network_name, router_name]).decode('utf8').strip()
 
 

--- a/sbin/autograder/grade_items_logging.py
+++ b/sbin/autograder/grade_items_logging.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import os
 from submitty_utils import dateutils
 import fcntl
+import traceback
 
 from . import CONFIG_PATH
 
@@ -10,6 +11,7 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
     OPEN_JSON = json.load(open_file)
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['autograding_log_path'], 'stack_traces')
 
 
 def log_message(job_id="UNKNOWN", is_batch=False, which_untrusted="", jobname="", timelabel="", elapsed_time=-1,
@@ -28,5 +30,23 @@ def log_message(job_id="UNKNOWN", is_batch=False, which_untrusted="", jobname=""
         print("%s | %6s | %5s | %11s | %-75s | %-6s %9s %3s | %s"
               % (easy_to_read_date, job_id, batch_string, which_untrusted,
                  jobname, timelabel, elapsed_time_string, time_unit, message),
+              file=myfile)
+        fcntl.flock(myfile, fcntl.LOCK_UN)
+
+def log_stack_trace(job_id="UNKNOWN", is_batch=False, which_untrusted="", jobname="", timelabel="", elapsed_time=-1, trace=""):
+    now = dateutils.get_current_time()
+    datefile = "stack_traces_{0}.txt".format(datetime.strftime(now, "%Y%m%d"))
+    autograding_log_file = os.path.join(AUTOGRADING_STACKTRACE_PATH, datefile)
+    easy_to_read_date = dateutils.write_submitty_date(now, True)
+    batch_string = "BATCH" if is_batch else ""
+    if elapsed_time == "":
+        elapsed_time = -1
+    elapsed_time_string = "" if elapsed_time < 0 else '{:9.3f}'.format(elapsed_time)
+    time_unit = "" if elapsed_time < 0 else "sec"
+    with open(autograding_log_file, 'a') as myfile:
+        fcntl.flock(myfile,fcntl.LOCK_EX | fcntl.LOCK_NB)
+        print("%s | %6s | %5s | %11s | %-75s | %-6s %9s %3s |\n%s"
+              % (easy_to_read_date, job_id, batch_string, which_untrusted,
+                 jobname, timelabel, elapsed_time_string, time_unit, trace),
               file=myfile)
         fcntl.flock(myfile, fcntl.LOCK_UN)

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -59,6 +59,7 @@ def add_fields_to_autograding_worker_json(autograding_worker_json, entry):
             installed_commit = submitty_details['installed_commit']
             most_recent_tag  = submitty_details['most_recent_git_tag']
     except FileNotFoundError as e:
+        grade_items_logging.log_stack_trace(trace=traceback.format_exc())
         raise SystemExit("ERROR, could not locate the submitty.json:", e)
 
     autograding_worker_json[entry]['server_name']     = socket.getfqdn()
@@ -74,6 +75,7 @@ def update_all_foreign_autograding_workers():
         with open(all_workers_json, 'r') as infile:
             autograding_workers = json.load(infile)
     except FileNotFoundError as e:
+        grade_items_logging.log_stack_trace(trace=traceback.format_exc())
         raise SystemExit("ERROR, could not locate autograding_workers_json :", e)
 
     for key, value in autograding_workers.items():
@@ -97,7 +99,8 @@ def update_worker_json(name, entry):
         host = autograding_worker_to_ship[name]['address']
     except Exception as e:
         print("ERROR: autograding_workers.json entry for {0} is malformatted. {1}".format(e, name))
-        grade_items_logging.log_message(JOB_ID, message="ERROR: autograding_workers.json entry for {0} is malformatted. {1}".format(e, name))
+        grade_items_logging.log_message(JOB_ID, message="ERROR: autograding_workers.json entry for {0} is malformed. {1}".format(e, name))
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
         return False
 
     #create a new temporary json with only the entry for the current machine.
@@ -111,6 +114,7 @@ def update_worker_json(name, entry):
             grade_items_logging.log_message(JOB_ID, message="Successfully updated local autograding_TODO/autograding_worker.json")
             return True
         except Exception as e:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             grade_items_logging.log_message(JOB_ID, message="ERROR: could not mv to local autograding_TODO/autograding_worker.json due to the following error: "+str(e))
             print("ERROR: could not mv to local autograding_worker.json due to the following error: {0}".format(e))
             return False
@@ -125,6 +129,7 @@ def update_worker_json(name, entry):
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             ssh.connect(hostname = host, username = user)
         except Exception as e:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             grade_items_logging.log_message(JOB_ID, message="ERROR: could not ssh to {0}@{1} due to following error: {2}".format(user, host,str(e)))
             print("ERROR: could not ssh to {0}@{1} due to following error: {2}".format(user, host,str(e)))
             return False
@@ -139,6 +144,7 @@ def update_worker_json(name, entry):
             grade_items_logging.log_message(JOB_ID, message="Successfully forwarded autograding_worker.json to {0}".format(name))
             success = True
         except Exception as e:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             grade_items_logging.log_message(JOB_ID, message="ERROR: could not sftp to foreign autograding_TODO/autograding_worker.json due to the following error: "+str(e))
             print("ERROR: could sftp to foreign autograding_TODO/autograding_worker.json due to the following error: {0}".format(e))
             success = False
@@ -176,6 +182,7 @@ def prepare_job(my_name,which_machine,which_untrusted,next_directory,next_to_gra
             queue_obj["which_machine"] = which_machine
             queue_obj["ship_time"] = dateutils.write_submitty_date(microseconds=True)
     except Exception as e:
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
         grade_items_logging.log_message(JOB_ID, message="ERROR: failed preparing submission zip or accessing next to grade "+str(e))
         print("ERROR: failed preparing submission zip or accessing next to grade ", e)
         return False
@@ -187,6 +194,7 @@ def prepare_job(my_name,which_machine,which_untrusted,next_directory,next_to_gra
             with open(todo_queue_file, 'w') as outfile:
                 json.dump(queue_obj, outfile, sort_keys=True, indent=4)
         except Exception as e:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             grade_items_logging.log_message(JOB_ID, message="ERROR: could not move files due to the following error: "+str(e))
             print("ERROR: could not move files due to the following error: {0}".format(e))
             return False
@@ -209,6 +217,7 @@ def prepare_job(my_name,which_machine,which_untrusted,next_directory,next_to_gra
             print("Successfully forwarded files to {0}".format(my_name))
             success = True
         except Exception as e:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             grade_items_logging.log_message(JOB_ID, message="ERROR: could not move files due to the following error: "+str(e))
             print("Could not move files due to the following error: {0}".format(e))
             success = False
@@ -281,12 +290,14 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
             success = True
         #This is the normal case (still grading on the other end) so we don't need to print anything.
         except FileNotFoundError:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             os.remove(local_results_zip)
             os.remove(local_done_queue_file)
             success = False
         #In this more general case, we do want to print what the error was.
         #TODO catch other types of exception as we identify them.
         except Exception as e:
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             grade_items_logging.log_message(JOB_ID, message="ERROR: Could not retrieve the file from the foreign machine "+str(e))
             print("ERROR: Could not retrieve the file from the foreign machine.\nERROR: {0}".format(e))
             os.remove(local_results_zip)
@@ -303,7 +314,8 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
     try:
         success = packer_unpacker.unpack_grading_results_zip(which_machine,which_untrusted,local_results_zip)
     except:
-        grade_items_logging.log_message(JOB_ID,jobname=item_name,message="ERROR: Exception when unpacking zip")
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
+        grade_items_logging.log_message(JOB_ID,jobname=item_name,message="ERROR: Exception when unpacking zip. For more details, see traces entry.")
         with contextlib.suppress(FileNotFoundError):
             os.remove(local_results_zip)
         success = False
@@ -355,6 +367,7 @@ def grade_queue_file(my_name, which_machine,which_untrusted,queue_file):
                     shipper_counter=0
 
     except Exception as e:
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
         print (my_name, " ERROR attempting to grade item: ", queue_file, " exception=",str(e))
         grade_items_logging.log_message(JOB_ID, message=str(my_name)+" ERROR attempting to grade item: " + queue_file + " exception " + repr(e))
 
@@ -363,11 +376,13 @@ def grade_queue_file(my_name, which_machine,which_untrusted,queue_file):
     try:
         os.remove(queue_file)
     except Exception as e:
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
         print (my_name, " ERROR attempting to remove queue file: ", queue_file, " exception=",str(e))
         grade_items_logging.log_message(JOB_ID, message=str(my_name)+" ERROR attempting to remove queue file: " + queue_file + " exception=" + str(e))
     try:
         os.remove(grading_file)
     except Exception as e:
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
         print (my_name, " ERROR attempting to remove grading file: ", grading_file, " exception=",str(e))
         grade_items_logging.log_message(JOB_ID, message=str(my_name)+" ERROR attempting to remove grading file: " + grading_file + " exception=" + str(e))
 
@@ -484,7 +499,8 @@ def shipper_process(my_name,my_data,full_address,which_untrusted,overall_lock):
                 time.sleep(1)
 
         except Exception as e:
-            my_message = "ERROR in get_job " + which_machine + " " + which_untrusted + " " + str(e)
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
+            my_message = "ERROR in get_job {0} {1} {2}. For more details, see traces entry".format(which_machine,which_untrusted,str(e))
             print (my_message)
             grade_items_logging.log_message(JOB_ID, message=my_message)
             time.sleep(1)
@@ -523,6 +539,7 @@ def launch_shippers(worker_status_map):
         with open(autograding_workers_path, 'r') as infile:
             autograding_workers = json.load(infile)
     except Exception as e:
+        grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
         raise SystemExit("ERROR: could not locate the autograding workers json: {0}".format(e))
 
     # There must always be a primary machine, it may or may not have
@@ -569,8 +586,9 @@ def launch_shippers(worker_status_map):
             single_machine_data = {name : machine}
             single_machine_data = add_fields_to_autograding_worker_json(single_machine_data, name)
         except Exception as e:
-            print("ERROR: autograding_workers.json entry for {0} contains an error: {1}".format(name, e))
-            grade_items_logging.log_message(JOB_ID, message="ERROR: autograding_workers.json entry for {0} contains an error: {1}".format(name,e))
+            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
+            print("ERROR: autograding_workers.json entry for {0} contains an error: {1}. For more details, see trace entry.".format(name, e))
+            grade_items_logging.log_message(JOB_ID, message="ERROR: autograding_workers.json entry for {0} contains an error: {1} For more details, see trace entry.".format(name,e))
             continue
         # launch the shipper threads
         for i in range(0,num_workers_on_machine):

--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -67,8 +67,8 @@ def worker_process(which_machine,address,which_untrusted,my_server):
                 with open(done_queue_file, 'w') as outfile:
                     json.dump(queue_obj, outfile, sort_keys=True, indent=4)        
             except Exception as e:
-                traceback.print_exc()
-                grade_items_logging.log_message(JOB_ID, message="ERROR attempting to unzip graded item: " + which_machine + " " + which_untrusted + " exception: " + traceback.format_exc())
+                grade_items_logging.log_message(JOB_ID, message="ERROR attempting to unzip graded item: " + which_machine + " " + which_untrusted + ". for more details, see traces entry.")
+                grade_items_logging.log_stack_trace(JOB_ID,trace=traceback.format_exc())
                 with contextlib.suppress(FileNotFoundError):
                     os.remove(autograding_zip)
                 with contextlib.suppress(FileNotFoundError):
@@ -179,6 +179,7 @@ def read_autograding_worker_json():
             name = list(name_and_stats.keys())[0]
             stats = name_and_stats[name]
     except Exception as e:
+        grade_items_logging.log_stack_trace(trace=traceback.format_exc())
         raise SystemExit("ERROR loading autograding_worker.json file: {0}".format(e))
     return name, stats
 # ==================================================================================


### PR DESCRIPTION
Adds logging for various stack traces created by errors caught during autograding.

Should be reviewed, as it was difficult to force good code coverage while testing.

Will likely require tuning as we decide which errors do and do not need to be logged by the system.