### PR TITLE
Install netplan.io=0.40.1~18.04.4 in setup_distro.sh

### DIFF
--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -98,7 +98,7 @@ if [ ${VAGRANT} == 1 ]; then
     if [ "$NPIO_MAJOR" -eq 0 -a "$NPIO_MINOR" -lt 40 ]; then
         # Update netplan.io
         echo "Detected old version of netplan.io (${NETPLANIO_VERSION})... updating it automatically"
-        apt install -y netplan.io=0.40.1~18.04.3
+        apt install -y netplan.io=0.40.1~18.04.4
     fi
 fi
 

--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -98,7 +98,7 @@ if [ ${VAGRANT} == 1 ]; then
     if [ "$NPIO_MAJOR" -eq 0 -a "$NPIO_MINOR" -lt 40 ]; then
         # Update netplan.io
         echo "Detected old version of netplan.io (${NETPLANIO_VERSION})... updating it automatically"
-        apt install -y netplan.io=0.40.1~18.04.4
+        apt-get install -y netplan.io=0.40.1~18.04.4
     fi
 fi
 


### PR DESCRIPTION
Previously, the install script installed netplan.io=0.40.1~18.04.3
However, this version has been removed from the Ubuntu repositories, as
the latest version is now 0.40.1~18.04.4
(see https://packages.ubuntu.com/bionic/netplan.io)

This allows setup_distro.sh to succeed when provisioning a new VM