### PR TITLE
Fix course material extensions

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -34,7 +34,7 @@
         <div class="file-viewer">
             <k class="fas fa-file" style='vertical-align:text-bottom;'></k>
             {{ dir }}&nbsp;
-            {% set dirExtension = dir|split('.')|last %}
+            {% set dirExtension = dir|split('.')|last|lower %}
             {% if '.' ~ dirExtension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs'] %}
                  <a onclick='openFileCourseMaterial("{{ dir }}", "{{ path | url_encode }}")'><i class="fas fa-window-restore" aria-hidden="true" title="Pop up the file in a new window"></i></a>
             {% endif %}


### PR DESCRIPTION
Closes #3193 

The `file-viewer` class is now case insensitive so that files with `PDF` extension is treated the same as `pdf`.

Before:
![bug_before](https://user-images.githubusercontent.com/20266703/52173130-6d78eb80-2732-11e9-9b98-347033d03eab.png)

After:
![bug_after](https://user-images.githubusercontent.com/20266703/52173129-66ea7400-2732-11e9-9747-1ef9b1461817.png)
