### PR TITLE
Implement course materials 'Pop up' button with pure HTML

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -36,7 +36,7 @@
             {{ dir }}&nbsp;
             {% set dirExtension = dir|split('.')|last %}
             {% if '.' ~ dirExtension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs'] %}
-                 <a onclick='openFileCourseMaterial("{{ dir }}", "{{ path | url_encode }}")'><i class="fas fa-window-restore" aria-hidden="true" title="Pop up the file in a new window"></i></a>
+                 <a target="_blank" href="{{ core.getConfig().getSiteUrl() }}&component=misc&page=display_file&dir=course_materials&file={{ dir }}&path={{ path | url_encode }}"><i class="fas fa-window-restore" aria-hidden="true" title="Pop up the file in a new window"></i></a>
             {% endif %}
             <a onclick='downloadFileWithAnyRole("{{ dir }}", "{{ path | url_encode }}")'><i class="fas fa-download" aria-hidden="true" title="Download the file"></i></a>
             {% if userGroup == 1 %}
@@ -119,12 +119,6 @@
             }
         });
         }
-    }
-
-    function openFileCourseMaterial(html_file, url_file) {
-        var win = window.open("{{ core.getConfig().getSiteUrl()|escape("js")}}&component=misc&page=display_file&dir=course_materials&file=" + html_file + "&path=" + url_file,'_blank');
-        win.focus();
-        return false;
     }
 
     function shareToOther(id, path) {


### PR DESCRIPTION
This commit removes the 'onclick' handler from the 'Pop up the file in a
new window' button on the Course Materials page. By using the
'target=_blank' attribute, the link will be opened in a new tab, just as
the event handler currently does.

By directly specifying an 'href', rather than opening the link from
JavaScript, the browser is able to provide the usual link context menu
options (copy link, open in new window, etc)