### PR TITLE
Add Global Container Defaults to Assignment Configuration

### DIFF
--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -8,7 +8,7 @@
 export AnalysisTools_Version=v.18.06.00
 export Lichen_Version=v.18.12.00
 export RainbowGrades_Version=v.18.07.00
-export Tutorial_Version=v.18.09.00
+export Tutorial_Version=v.19.02.00
 export Pdf_Annotate_Js_Version=v.18.10.00
 
 # JAVA

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -99,7 +99,14 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
     whole_config["docker_enabled"] = false;
   }
 
+  if(!whole_config["default_container_image"].is_string()){
+    whole_config["default_container_image"] = "ubuntu:custom";
+  }
+
+  std::string default_container_image = whole_config["default_container_image"];
   bool docker_enabled = whole_config["docker_enabled"];
+
+
 
   if (!whole_config["use_router"].is_boolean()){
     whole_config["use_router"] = false;
@@ -198,7 +205,7 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
 
       if(this_testcase["containers"][container_num]["container_image"].is_null()){
         //TODO: store the default system image somewhere and fill it in here.
-        this_testcase["containers"][container_num]["container_image"] = "ubuntu:custom";
+        this_testcase["containers"][container_num]["container_image"] = default_container_image;
       }    
     }
 
@@ -209,7 +216,7 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
       insert_router["commands"].push_back("python3 submitty_router.py");
       insert_router["container_name"] = "router";
       insert_router["import_default_router"] = true;
-      insert_router["container_image"] = "ubuntu:custom";
+      insert_router["container_image"] = default_container_image;
       this_testcase["containers"].push_back(insert_router);
     }
 

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -110,10 +110,10 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
 
   //check if docker is globally enabled.
   if (!whole_config["autograding_method"].is_string()) {
-    whole_config["autograding_method"] = "jailed sandbox";
+    whole_config["autograding_method"] = "jailed_sandbox";
   }else{
     assert(whole_config["autograding_method"] == "docker"
-        || whole_config["autograding_method"]  == "jailed sandbox");
+        || whole_config["autograding_method"]  == "jailed_sandbox");
   }
 
   //check if there are global container defaults present. If not, add an empty object.

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -281,7 +281,7 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
         complete_config_obj = json.load(infile)
 
     # intentionally fragile to avoid redundancy
-    USE_DOCKER = complete_config_obj['docker_enabled']
+    USE_DOCKER = True if complete_config_obj["autograding_method"] == "docker" else False
 
     # --------------------------------------------------------------------
     # COMPILE THE SUBMITTED CODE

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -280,8 +280,9 @@ def grade_from_zip(my_autograding_zip_file,my_submission_zip_file,which_untruste
     with open(complete_config, 'r') as infile:
         complete_config_obj = json.load(infile)
 
-    # intentionally fragile to avoid redundancy
-    USE_DOCKER = True if complete_config_obj["autograding_method"] == "docker" else False
+    # Save ourselves if autograding_method is None.
+    autograding_method = complete_config_obj.get("autograding_method", "")
+    USE_DOCKER = True if autograding_method == "docker" else False
 
     # --------------------------------------------------------------------
     # COMPILE THE SUBMITTED CODE


### PR DESCRIPTION
Closes #3255

Added global ```container_options``` object to the autograding configuration json. Within, default values for ```container_image```, ```use_router```, and ```single_port_per_container``` may be specified.  

Changed the global flag ```docker_enabled``` to be a new string ```autograding_method```, which can currently be specified as ```docker``` or ```jailed sandbox```. If ```autograding_method``` is not set, ```jailed sandbox``` is used by default. If an assignment built before this pull request is graded, ```jailed sandbox``` is assumed.