### PR TITLE
Move from submitty_utils.glob to Path.glob

### DIFF
--- a/bin/grading_done.py
+++ b/bin/grading_done.py
@@ -12,11 +12,11 @@ USAGE:
 
 import argparse
 import os
+from pathlib import Path
 import subprocess
 import time
 import psutil
 import json
-from submitty_utils import glob
 
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'config')
 with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
@@ -87,15 +87,13 @@ def main():
 
         if os.access(GRADING_QUEUE, os.R_OK):
             # most instructors do not have read access to the interactive queue
-
-            files = glob.glob(os.path.join(GRADING_QUEUE, "*"))
             interactive_count = 0
             interactive_grading_count = 0
             regrade_count = 0
             regrade_grading_count = 0
 
-            for full_path_file in files:
-                json_file = full_path_file
+            for full_path_file in Path(GRADING_QUEUE).glob("*"):
+                json_file = str(full_path_file)
 
                 # get the file name (without the path)
                 just_file = full_path_file[len(GRADING_QUEUE)+1:]

--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -14,10 +14,12 @@ USAGE:
 import argparse
 import json
 import os
-from submitty_utils import glob, dateutils
+from pathlib import Path
 import time
 import datetime
 import pause
+
+from submitty_utils import dateutils
 
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'config')
 with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
@@ -173,12 +175,13 @@ def main():
             pattern_version=dirs[len(data_dirs)+5]
 
         # full pattern may include wildcards!
-        pattern = os.path.join(data_dir,pattern_semester,pattern_course,"submissions",pattern_gradeable,pattern_who,pattern_version)
+        pattern = os.path.join(pattern_semester,pattern_course,"submissions",pattern_gradeable,pattern_who,pattern_version)
 
         print("pattern: ",pattern)
 
         # Find all matching submissions
-        for d in glob.glob(pattern):
+        for d in Path(data_dir).glob(pattern):
+            d = str(d)
             if os.path.isdir(d):
                 my_dirs = d.split(os.sep)
                 if len(my_dirs) != len(data_dirs)+6:

--- a/sbin/autograder/grade_item.py
+++ b/sbin/autograder/grade_item.py
@@ -17,7 +17,7 @@ import sys
 import traceback
 from pwd import getpwnam
 
-from submitty_utils import dateutils, glob
+from submitty_utils import dateutils
 from . import grade_items_logging, grade_item_main_runner, write_grade_history, CONFIG_PATH
 
 with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:

--- a/sbin/autograder/grade_item_main_runner.py
+++ b/sbin/autograder/grade_item_main_runner.py
@@ -18,7 +18,7 @@ import csv
 import json
 from pwd import getpwnam
 
-from submitty_utils import dateutils, glob
+from submitty_utils import dateutils
 from . import grade_item, grade_items_logging, write_grade_history, CONFIG_PATH
 
 with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:

--- a/sbin/autograder/packer_unpacker.py
+++ b/sbin/autograder/packer_unpacker.py
@@ -13,7 +13,7 @@ import random
 import socket
 import zipfile
 
-from submitty_utils import dateutils, glob
+from submitty_utils import dateutils
 
 from . import grade_item, insert_database_version_data, grade_items_logging, write_grade_history, CONFIG_PATH
 

--- a/sbin/build_config_upload.py
+++ b/sbin/build_config_upload.py
@@ -6,12 +6,16 @@
 #
 
 import os
+from pathlib import Path
 import pwd
 import time
 import subprocess
-from submitty_utils import glob
 import json
 
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'config')
+with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
+    JSON = json.load(open_file)
+DATA_DIR = JSON['submitty_data_dir']
 
 # ------------------------------------------------------------------------
 def build_one(data):
@@ -19,8 +23,8 @@ def build_one(data):
     course = data["course"]
 
     # construct the paths for this course
-    build_script = "/var/local/submitty/courses/" + semester + "/" + course + "/BUILD_" + course + ".sh"
-    build_output = "/var/local/submitty/courses/" + semester + "/" + course + "/build_script_output.txt"
+    build_script = os.path.join(DATA_DIR, "courses", semester, course, "BUILD_" + course + ".sh")
+    build_output = os.path.join(DATA_DIR, "courses", semester, course, "build_script_output.txt")
 
     # construct the command line to build/rebuild/clean/delete the gradeable
     build_args = [build_script]
@@ -37,7 +41,7 @@ def build_one(data):
 
 # ------------------------------------------------------------------------
 def build_all():
-    for filename in glob.iglob("/var/local/submitty/to_be_built/*.json"):
+    for filename in Path(DATA_DIR, "to_be_built").glob("*.json"):
         with open(filename) as data_file:
             print("going to process: " + filename)
             data = json.load(data_file)
@@ -62,7 +66,7 @@ def main():
         raise SystemError("ERROR!  This script must be run by submitty_daemon")
 
     # ensure future pushd & popd commands don't complain
-    os.chdir("/var/local/submitty/to_be_built/")
+    os.chdir(os.path.join(DATA_DIR, "to_be_built"))
 
     start = time.time()
     count = 0

--- a/sbin/count_autograding_logs.py
+++ b/sbin/count_autograding_logs.py
@@ -8,7 +8,7 @@ python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/sbin/count_autograding_logs.py
 
 import sys
 import os
-from submitty_utils import dateutils, glob
+from submitty_utils import dateutils
 
 #import path
 

--- a/sbin/run_lichen_plagiarism.py
+++ b/sbin/run_lichen_plagiarism.py
@@ -10,7 +10,6 @@ import sys
 import pwd
 import time
 import subprocess
-from submitty_utils import glob
 import json
 
 

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -9,7 +9,8 @@ import shutil
 import contextlib
 import datetime
 import multiprocessing
-from submitty_utils import dateutils, glob
+from pathlib import Path
+from submitty_utils import dateutils
 import operator
 import paramiko
 import tempfile
@@ -387,9 +388,10 @@ def get_job(my_name,which_machine,my_capabilities,which_untrusted,overall_lock):
 
     # Grab all the files currently in the folder, sorted by creation
     # time, and put them in the queue to be graded
-    files = glob.glob(os.path.join(folder, "*"))
+    files = sorted(Path(folder).glob('*'))
     files_and_times = list()
     for f in files:
+        f = str(f)
         try:
             my_time = os.path.getctime(f)
         except:
@@ -501,14 +503,17 @@ def launch_shippers(worker_status_map):
 
     # Clean up old files from previous shipping/autograding (any
     # partially completed work will be re-done)
-    for file_path in glob.glob(os.path.join(INTERACTIVE_QUEUE, "GRADING_*")):
+    for file_path in Path(INTERACTIVE_QUEUE).glob("GRADING_*")):
+        file_path = str(file_path)
         grade_items_logging.log_message(JOB_ID, message="Remove old queue file: " + file_path)
         os.remove(file_path)
 
-    for file_path in glob.glob(os.path.join(SUBMITTY_DATA_DIR,"autograding_TODO","unstrusted*")):
+    for file_path in Path(SUBMITTY_DATA_DIR, "autograding_TODO").glob("untrusted*"):
+        file_path = str(file_path)
         grade_items_logging.log_message(JOB_ID, message="Remove autograding TODO file: " + file_path)
         os.remove(file_path)
-    for file_path in glob.glob(os.path.join(SUBMITTY_DATA_DIR,"autograding_DONE","*")):
+    for file_path in Path(SUBMITTY_DATA_DIR, "autograding_DONE").glob("*"):
+        file_path = str(file_path)
         grade_items_logging.log_message(JOB_ID, message="Remove autograding DONE file: " + file_path)
         os.remove(file_path)
 


### PR DESCRIPTION
Closes #2392.

The gist of it is that the [glob](https://docs.python.org/3/library/glob.html) adds some functionality to support the `**` notation only in 3.5+, while [pathlib](https://docs.python.org/3/library/pathlib.html) supports it in 3.4+, and so to overcome that, I made a glob module under submitty_utils. By switching, we can now drop the `submitty_utils.glob` module. The only difference between the two is that the pathlib glob always returns a generator (glob.glob returns a list, glob.iglob returns a generator) and that all of the returned paths from pathlib are `Path` objects (and so have to be converted to strings for our normal usage onward).

I've created issue #3277 to replace the remaining usages of the the actual [glob](https://docs.python.org/3/library/glob.html) module.