### PR TITLE
Custom Messages / RainbowGrades Compatibility

### DIFF
--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -2,7 +2,15 @@
 
 {% if display_custom_message %}
     <div class="content">
-        {{ message_file_contents|raw }}
+        <table border=1 cellpadding=5 cellspacing=0 style=\"background-color:#ddffdd; width:auto;\">
+        <tr><td>
+        <table border=0 cellpadding=5 cellspacing=0>
+        <h3>{{message_file_details.title}}</h3>
+        <tr><td><a href="{{message_file_details.filename}}" download="provided_files.zip">{{message_file_details.description}}</a></td></tr>
+        </table>
+        </tr></td>
+        </table>
+        {#{{ message_file_details|raw }}#}
     </div>
 {% endif %}
 

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -2,15 +2,14 @@
 
 {% if display_custom_message %}
     <div class="content">
-        <table border=1 cellpadding=5 cellspacing=0 style=\"background-color:#ddffdd; width:auto;\">
+        <table border=1 cellpadding=5 cellspacing=0 style="background-color:#ddffdd; width:auto;">
         <tr><td>
         <table border=0 cellpadding=5 cellspacing=0>
-        <h3>{{message_file_details.title}}</h3>
-        <tr><td><a href="{{message_file_details.filename}}" download="provided_files.zip">{{message_file_details.description}}</a></td></tr>
+        <h3>{{ message_file_details.title }}</h3>
+        <tr><td><a href="{{ message_file_details.filename }}" download="provided_files.zip">{{ message_file_details.description }}</a></td></tr>
         </table>
         </tr></td>
         </table>
-        {#{{ message_file_details|raw }}#}
     </div>
 {% endif %}
 

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -84,14 +84,27 @@ class NavigationView extends AbstractView {
         // ======================================================================================
         // DISPLAY CUSTOM BANNER (previously used to display room seating assignments)
         // note: placement of this information this may eventually be re-designed
+        // note: in the future this could be extended to take other options, but right now it's
+        //       for displaying a link to provided materials
         // ======================================================================================
         $display_custom_message = $this->core->getConfig()->displayCustomMessage();
-        $message_file_contents = "";
+        $message_file_details = null;
+		//Course settings have enabled displaying custom (banner) message
         if($display_custom_message) {
-            $message_file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "reports", "summary_html", $this->core->getUser()->getId() . "_message.html");
+            $message_file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "reports", "summary_html", $this->core->getUser()->getId() . ".json");
             $display_custom_message = is_file($message_file_path);
-            if ($display_custom_message) {
-                $message_file_contents = file_get_contents($message_file_path);
+			//If statement seems redundant, but will help in case we ever decouple the is_file check from $display_custom_message
+            if ($display_custom_message && is_file($message_file_path)) {
+				$message_json = json_decode(file_get_contents($message_file_path));
+				if(property_exists($message_json, 'special_message')){
+					$message_file_details = $message_json->special_message;
+
+					//If any fields are missing, treat this as though we just didn't have a message for this user.
+					if(!property_exists($message_file_details,'title') || !property_exists($message_file_details,'description') || !property_exists($message_file_details,'filename') ){
+						$display_custom_message = false;
+						$messsage_file_details = null;
+					}
+				}
             }
         }
 
@@ -176,7 +189,7 @@ class NavigationView extends AbstractView {
             "course_name" => $this->core->getConfig()->getCourseName(),
             "course_id" => $this->core->getConfig()->getCourse(),
             "sections" => $render_sections,
-            "message_file_contents" => $message_file_contents,
+            "message_file_contents" => $message_file_details,
             "display_custom_message" => $display_custom_message,
             "user_seating_details" => $user_seating_details,
             "display_room_seating" => $display_room_seating,

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -189,7 +189,7 @@ class NavigationView extends AbstractView {
             "course_name" => $this->core->getConfig()->getCourseName(),
             "course_id" => $this->core->getConfig()->getCourse(),
             "sections" => $render_sections,
-            "message_file_contents" => $message_file_details,
+            "message_file_details" => $message_file_details,
             "display_custom_message" => $display_custom_message,
             "user_seating_details" => $user_seating_details,
             "display_room_seating" => $display_room_seating,


### PR DESCRIPTION
Navigation view updates to work with userid.json files which are generated by Rainbow Grades as of Submitty/RainbowGrades#3 when the "Display Custom Message" option is selected for a course in Course Settings.

The table-in-a-table code looks kind of ugly, but it's what was being posted as raw HTML from Rainbow Grades before so I just copied it verbatim. Open to styling changes. We might want to discuss if this should serve a more generic purpose, like allowing per-student messages to uploaded in the JSON through a new field? I'm not sure how much use we expect this feature to see, for now I just focused on migrating the existing behavior (formerly done through userid_message.html files).