### PR TITLE
VCS subdirectory will rebuild gradeable

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -822,7 +822,7 @@ class AdminGradeableController extends AbstractController {
         }
 
         // Trigger a rebuild if the config changes
-        $trigger_rebuild_props = ['autograding_config_path'];
+        $trigger_rebuild_props = ['autograding_config_path', 'vcs_subdirectory'];
         $trigger_rebuild = count(array_intersect($trigger_rebuild_props, array_keys($details))) > 0;
 
         $boolean_properties = [


### PR DESCRIPTION
Changing the VCS subdirectory for a gradeable will put the gradeable in the build queue (and update the form .json file) similar to how changing the autograding config will.  @bmcutler  is this what you were looking for?