### PR TITLE
Fix grading team gradeables

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1053,7 +1053,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             'u.rotating_section',
         ],
         'team_id' => [
-            'user_id'
+            'u.user_id'
         ]
     ];
     const graded_gradeable_key_map_team = [
@@ -1066,6 +1066,9 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             'team.rotating_section'
         ],
         'team_id' => [
+            'team.team_id'
+        ],
+        'user_id' => [
             'team.team_id'
         ]
     ];

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1052,9 +1052,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         'rotating_section' => [
             'u.rotating_section',
         ],
-        'team_id' => [
-            'u.user_id'
-        ]
+        'team_id' => []
     ];
     const graded_gradeable_key_map_team = [
         'registration_section' => [
@@ -1068,9 +1066,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         'team_id' => [
             'team.team_id'
         ],
-        'user_id' => [
-            'team.team_id'
-        ]
+        'user_id' => []
     ];
 
     /**
@@ -1092,16 +1088,19 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             if (empty($key_map)) {
                 return 'ORDER BY ' . implode(',', $sort_keys);
             }
-            return 'ORDER BY ' . implode(',', array_map(function ($key_ext) use ($key_map) {
+            return 'ORDER BY ' . implode(',', array_filter(array_map(function ($key_ext) use ($key_map) {
                     $split_key = explode(' ', $key_ext);
                     $key = $split_key[0];
                     $order = '';
                     if (count($split_key) > 1) {
                         $order = $split_key[1];
                     }
+                    if (isset($key_map[$key]) && count($key_map[$key]) === 0) {
+                        return '';
+                    }
                     // Map any keys with special requirements to the proper statements and preserve specified order
                     return implode(" $order,", $key_map[$key] ?? [$key]) . " $order";
-                }, $sort_keys));
+                }, $sort_keys), function($a) { return $a !== ''; }));
         }
         return '';
     }


### PR DESCRIPTION
There is an issue with sorting by user or team id.  Since a gradeable will only be one or the other, we define 'team_id' to have no order affect on users and 'user_id' have no affect on teams.

This fixes a database exception being thrown when trying to grade team gradeables.