### PR TITLE
Gradeable report contains team members

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -305,6 +305,12 @@ class ReportController extends AbstractController {
             'grade_released_date' => $g->getGradeReleasedDate()->format('Y-m-d H:i:s O'),
         ];
 
+        // Add team members to output
+        if ($g->isTeamAssignment()) {
+            $entry['team_members'] = $gg->getSubmitter()->isTeam() ? $gg->getSubmitter()->getTeam()->getMemberUserIds()
+                : $gg->getSubmitter()->getId(); // If the user isn't on a team, the only member is themselves
+        }
+
         $entry['score'] = $gg->getTotalScore();
 
         // Add information special to electronic file submissions


### PR DESCRIPTION
Closes #3274

If the gradeable is a team assignment, the `team_members` field in the gradeable output will contain the members of the user's team.  If the user was not on a team for that gradeable, then they are the only member on the team.

Note: The `team_members` list contains all members of the team (including the `this` user)