### PR TITLE
Validate Graphics Actions

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -1172,7 +1172,6 @@ int execute(const std::string &cmd,
       std::string windowName; 
       int rss_memory = 0;
       int actions_taken = 0;   
-      int number_of_screenshots = 0;
       do {
           //dispatcher actions
           if(!input_queue.empty()){
@@ -1264,13 +1263,13 @@ int execute(const std::string &cmd,
             if (!time_kill && !memory_kill){
               //if we expect a window, and the window exists, and we still have actions to take
               if(window_mode && windowName != "" && windowExists(windowName) && actions_taken < actions.size()){ 
-                takeAction(actions, actions_taken, number_of_screenshots, windowName, 
+                takeAction(actions, actions_taken, windowName, 
                   childPID, elapsed, next_checkpoint, seconds_to_run, rss_memory, allowed_rss_memory, 
                   memory_kill, time_kill, logfile); //Takes each action on the window. Requires delay parameters to do delays.
               }
               //If we do not expect a window and we still have actions to take
               else if(!window_mode && actions_taken < actions.size()){ 
-                takeAction(actions, actions_taken, number_of_screenshots, windowName, 
+                takeAction(actions, actions_taken, windowName, 
                   childPID, elapsed, next_checkpoint, seconds_to_run, rss_memory, allowed_rss_memory, 
                   memory_kill, time_kill, logfile); //Takes each action on the window. Requires delay parameters to do delays.
               }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -294,18 +294,36 @@ void FormatDispatcherActions(nlohmann::json &whole_config) {
   }
 }
 
+
+/*
+* Given an action, makes sure that the mouse button in the action is valid (left, right, middle).
+* If there is no mouse button specified, "left" is added.
+*/
 void validate_mouse_button(nlohmann::json& action){
   if(action["mouse_button"].is_null()){
     action["mouse_button"] = "left";
   }else{
     assert(action["mouse_button"].is_string());
-    assert(action["mouse_button"] == "left" || action["mouse_button"] == "middle" || action["mouse_button"] == "right")
+    assert(action["mouse_button"] == "left" || action["mouse_button"] == "middle" || action["mouse_button"] == "right");
   }
 }
 
-void validate_integer(nlohmann::json& action, std::string& field, bool populate_default, int min_val, int default_value){
+/*
+* Given an action and a field, makes certain that the value in the field is an integer greater than min_val.
+* if the field doesn't exist and populate_default is true, the field is set to default_value.
+*/
+void validate_integer(nlohmann::json& action, std::string field, bool populate_default, int min_val, int default_value){
   if(!action[field].is_null()){
+    std::string action_name = action["action"];
+
+    if(!action[field].is_number_integer()){
+      std::cout << "ERROR: For the " << action_name << " action, " << field << " must be an integer." << std::endl;
+    }
     assert(action[field].is_number_integer());
+
+    if(action[field] < min_val){
+      std::cout << "ERROR: For the " << action_name << " action, " << field << " must be greater than " << min_val << "." << std::endl;
+    }
     assert(action[field] >= min_val);
   } else{
     if(populate_default){
@@ -320,7 +338,7 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
   assert (tc != whole_config.end());
 
   int testcase_num = 0;
-  int number_of_screenshots = 1;
+  int number_of_screenshots = 0;
   for (typename nlohmann::json::iterator itr = tc->begin(); itr != tc->end(); itr++,testcase_num++){
 
     nlohmann::json this_testcase = whole_config["testcases"][testcase_num];
@@ -341,47 +359,107 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
       std::string action_name = action.value("action","");
       assert(action != "");
 
+      //Origin and center have no additional fields.
       if(action_name == "origin" || action_name == "center"){
         continue;
-      }else if(action_name == "delay"){
+      }
+      // Delay requires a float number of seconds, which must be greater than 0
+      // and defaults to 1.
+      else if(action_name == "delay"){
 
+        if(action["seconds"].is_null()){
+          std::cout << "ERROR: all delay actions must have a number of seconds specified." << std::endl;
+        }
         assert(!action["seconds"].is_null());
-        assert(action["seconds"].is_number_float());
+
+        if(!action["seconds"].is_number()){
+          std::cout << "ERROR: all delay actions must have a number of seconds specified." << std::endl;
+        }
+        assert(action["seconds"].is_number());
 
         float delay_time_in_seconds = float(action.value("seconds",1.0));
 
         assert(delay_time_in_seconds > 0);
         action["seconds"] = delay_time_in_seconds;
-
-      }else if(action_name == "screenshot"){
-        
+      }
+      //screenshot can contain an optional name. Otherwise, it is labeled in numerical order.
+      else if(action_name == "screenshot"){
+        number_of_screenshots++;
         if(action["name"].is_null()){
-          action["name"] = "screenshot" + number_of_screenshots + ".png";
-          number_of_screenshots++;
+          action["name"] = "screenshot" + std::to_string(number_of_screenshots) + ".png";
         }else{
+          if(!action["name"].is_string()){
+            std::cout << "ERROR: if a screenshot name is specified, it must be a string." << std::endl;
+          }
           assert(action["name"].is_string());
           assert(action["name"] != "");
+          std::string screenshot_name = action["name"];
+
+          if(screenshot_name.find(".") != std::string::npos){
+            std::cout << "ERROR: screenshot names should not contain file extensions. File extensions will be added automatically." << std::endl;
+          }
+          if(screenshot_name.find(" ") != std::string::npos){
+            std::cout << "ERROR: screenshot names should not contain spaces." << std::endl;
+          }
+          if(screenshot_name.find("/") != std::string::npos||
+             screenshot_name.find("$") != std::string::npos||
+             screenshot_name.find("'") != std::string::npos||
+             screenshot_name.find("\"") != std::string::npos||
+             screenshot_name.find("\\") != std::string::npos){
+            std::cout << "ERROR: screenshot names should not contain special characters." << std::endl;
+          }
+          assert(screenshot_name.find(" ") == std::string::npos);
+          assert(screenshot_name.find(".") == std::string::npos);
+          assert(screenshot_name.find("/") == std::string::npos);
+          assert(screenshot_name.find("$") == std::string::npos);
+          assert(screenshot_name.find("'") == std::string::npos);
+          assert(screenshot_name.find("\"") == std::string::npos);
+          assert(screenshot_name.find("\\") == std::string::npos);
+          assert(screenshot_name.find("*") == std::string::npos);
+          action["name"] = screenshot_name + ".png";
         }
-      }else if(action_name == "type"){
-        float delay_time_in_seconds = float(action.value("delay_in_seconds",1.0));
+      }
+      //Type requires a string to type and can have an optional "delay_in_seconds" and "presses"
+      else if(action_name == "type"){
+        float delay_time_in_seconds = float(action.value("delay_in_seconds",.1));
+        if(delay_time_in_seconds <= 0){
+          std::cout << "ERROR: In the type command, delay must be greater than zero." << std::endl;
+        }
+        assert(delay_time_in_seconds > 0);
         action["delay_in_seconds"] = delay_time_in_seconds;
 
         validate_integer(action, "presses", true, 1, 1);
 
+        if(action["string"].is_null()){
+          std::cout << "ERROR: an output string must be specified in the type command." << std::endl;
+        }
         assert(!action["string"].is_null());
         assert( action["string"].is_string());
         assert( action["string"] != "");
 
-      }else if(action_name == "key"){
-        float delay_time_in_seconds = float(action.value("delay_in_seconds",1.0));
+      }
+      //Type requires a key_combination to press and can have an optional "delay_in_seconds" and "presses"
+      else if(action_name == "key"){
+        float delay_time_in_seconds = float(action.value("delay_in_seconds",.1));
+        
+        if(delay_time_in_seconds <= 0){
+          std::cout << "ERROR: In the key command, delay must be greater than zero." << std::endl;
+        }
+        assert(delay_time_in_seconds > 0);
         action["delay_in_seconds"] = delay_time_in_seconds;
 
         validate_integer(action, "presses", true, 1, 1);
-
+        
+        if(action["key_combination"].is_null()){
+          std::cout << "ERROR: key combination to be pressed must be specified in the key command." << std::endl;
+        }
         assert(!action["key_combination"].is_null());
         assert( action["key_combination"].is_string());
         assert( action["key_combination"] != "");
-      }else if(action_name == "click and drag"){
+      }
+      //Click and drag can have an optional start_x and start_y, and must have an end_x and end_y
+      // which are greater than 0.
+      else if(action_name == "click and drag"){
         
         validate_mouse_button(action);
 
@@ -390,26 +468,44 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
         validate_integer(action, "end_x",   true,  0, 0);
         validate_integer(action, "end_y",   true,  0, 0);
 
+        if(action["end_x"] == 0 && action["end_y"] == 0){
+          std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
+        }
         assert(action["end_x"] != 0 || action["end_y"] != 0);
 
-      }else if(action_name == "click and drag delta"){
+      }
+      //Click and drag delta can have an optional mouse button, and must have and end_x and end_y.
+      else if(action_name == "click and drag delta"){
        
         validate_mouse_button(action);
 
         validate_integer(action, "end_x",   true,  0, 0);
         validate_integer(action, "end_y",   true,  0, 0);
 
+        if(action["end_x"] == 0 && action["end_y"] == 0){
+          std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
+        }
+
         assert(action["end_x"] != 0 || action["end_y"] != 0);
 
-      }else if(action_name == "click"){
+      }
+      //Click has an optional mouse button.
+      else if(action_name == "click"){
         validate_mouse_button(action);
-        validate_integer(action, "repetitions", true, 1, 1);        
-      }else if(action_name == "mouse move"){
+      }
+      //Mouse move has an optional end_x and end_y.
+      else if(action_name == "mouse move"){
         validate_integer(action, "end_x", true, 0, 0);
         validate_integer(action, "end_y", true, 0, 0);
       }
+      //Fail if the action is not valid.
       else{
         bool valid_action_type = false;
+        if(action_name == ""){
+          std::cout << "ERROR: no 'action' feild defined." << std::endl;
+        }else{
+          std::cout << "ERROR: Could not recognize action " << action_name << std::endl;
+        }
         assert(valid_action_type == true);
       }
     }
@@ -659,6 +755,7 @@ nlohmann::json LoadAndProcessConfigJSON(const std::string &rcsid) {
   AddDockerConfiguration(answer);
   FormatDispatcherActions(answer);
   formatPreActions(answer);
+  FormatGraphicsActions(answer);
   AddSubmissionLimitTestCase(answer);
   AddAutogradingConfiguration(answer);
 

--- a/grading/load_config_json.h
+++ b/grading/load_config_json.h
@@ -49,4 +49,8 @@ void VerifyGraderDeductions(nlohmann::json &json_graders);
 
 bool validShowValue(const nlohmann::json& v);
 
+void validate_mouse_button(nlohmann::json& action);
+
+void validate_integer(nlohmann::json& action, std::string field, bool populate_default, int min_val, int default_value);
+
 #endif

--- a/grading/myersDiff.cpp
+++ b/grading/myersDiff.cpp
@@ -207,6 +207,17 @@ TestResults* ImageDiff_doit(const TestCase &tc, const nlohmann::json& j, int aut
   actual_file = tc.getPrefix() + actual_file;
   std::cout << "About to compare " << actual_file << " and " << expected_file << std::endl;
 
+  //Check existence. File is closed by destructor.
+  std::ifstream img_file_actual(actual_file);
+  if(!img_file_actual.good()){
+    return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "Image comparison failed; student file does not exist.")});
+  }
+
+  //Check existence. File is closed by destructor.
+  std::ifstream img_file_expected(expected_file);
+  if(!img_file_expected.good()){
+    return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "Image comparison failed; expected file does not exist.")});
+  }
 
   std::string command = "compare -metric RMSE " + actual_file + " " + expected_file + " NULL: 2>&1";
   std::string output = output_of_system_command(command.c_str()); //get the string

--- a/grading/window_utils.h
+++ b/grading/window_utils.h
@@ -72,7 +72,7 @@ bool windowExists(std::string window_name);
 * uses number_of_screenshots to title the image (submitty prepends it with the test #)
 * updates the number of screenshots taken. 
 */
-bool screenshot(std::string window_name, int& number_of_screenshots);
+bool screenshot(std::string window_name, std::string screenshot_name);
 
 /**
 * This function uses xdotool to put the mouse button associated with int button into the 'down' state
@@ -165,7 +165,7 @@ bool isWindowedAction(const nlohmann::json action);
 * NOTE TO DEVLOPERS: If you want to add a new action, also modify the preprocessing script for config.json to 
 * include your new action as valid.
 */
-void takeAction(const std::vector<nlohmann::json>& actions, int& actions_taken, int& number_of_screenshots, 
+void takeAction(const std::vector<nlohmann::json>& actions, int& actions_taken, 
                 std::string window_name, int childPID, float &elapsed, float& next_checkpoint, 
                 float seconds_to_run, int& rss_memory, int allowed_rss_memory, int& memory_kill, int& time_kill, 
                 std::ostream &logfile);


### PR DESCRIPTION
Closes #3248 


* Adds validation of graphics action syntax to ```load_config_json.cpp```
* **Changes the default screenshot name from #.png to screenshot_#.png**
* Moves some amount of error checking out of ```window_utils.cpp``` and into ```load_config_json.cpp```
* Allows users to name screenshot files using the ```name``` field.
* Fixes a bug which caused the imagediff to crash when either the expected or actual file didn't exist.
* Sets the stage for GIF capture.