### PR TITLE
Add gif Graphics Action

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -1172,7 +1172,6 @@ int execute(const std::string &cmd,
       std::string windowName; 
       int rss_memory = 0;
       int actions_taken = 0;   
-      int number_of_screenshots = 0;
       do {
           //dispatcher actions
           if(!input_queue.empty()){
@@ -1264,13 +1263,13 @@ int execute(const std::string &cmd,
             if (!time_kill && !memory_kill){
               //if we expect a window, and the window exists, and we still have actions to take
               if(window_mode && windowName != "" && windowExists(windowName) && actions_taken < actions.size()){ 
-                takeAction(actions, actions_taken, number_of_screenshots, windowName, 
+                takeAction(actions, actions_taken, windowName, 
                   childPID, elapsed, next_checkpoint, seconds_to_run, rss_memory, allowed_rss_memory, 
                   memory_kill, time_kill, logfile); //Takes each action on the window. Requires delay parameters to do delays.
               }
               //If we do not expect a window and we still have actions to take
               else if(!window_mode && actions_taken < actions.size()){ 
-                takeAction(actions, actions_taken, number_of_screenshots, windowName, 
+                takeAction(actions, actions_taken, windowName, 
                   childPID, elapsed, next_checkpoint, seconds_to_run, rss_memory, allowed_rss_memory, 
                   memory_kill, time_kill, logfile); //Takes each action on the window. Requires delay parameters to do delays.
               }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -294,18 +294,36 @@ void FormatDispatcherActions(nlohmann::json &whole_config) {
   }
 }
 
+
+/*
+* Given an action, makes sure that the mouse button in the action is valid (left, right, middle).
+* If there is no mouse button specified, "left" is added.
+*/
 void validate_mouse_button(nlohmann::json& action){
   if(action["mouse_button"].is_null()){
     action["mouse_button"] = "left";
   }else{
     assert(action["mouse_button"].is_string());
-    assert(action["mouse_button"] == "left" || action["mouse_button"] == "middle" || action["mouse_button"] == "right")
+    assert(action["mouse_button"] == "left" || action["mouse_button"] == "middle" || action["mouse_button"] == "right");
   }
 }
 
-void validate_integer(nlohmann::json& action, std::string& field, bool populate_default, int min_val, int default_value){
+/*
+* Given an action and a field, makes certain that the value in the field is an integer greater than min_val.
+* if the field doesn't exist and populate_default is true, the field is set to default_value.
+*/
+void validate_integer(nlohmann::json& action, std::string field, bool populate_default, int min_val, int default_value){
   if(!action[field].is_null()){
+    std::string action_name = action["action"];
+
+    if(!action[field].is_number_integer()){
+      std::cout << "ERROR: For the " << action_name << " action, " << field << " must be an integer." << std::endl;
+    }
     assert(action[field].is_number_integer());
+
+    if(action[field] < min_val){
+      std::cout << "ERROR: For the " << action_name << " action, " << field << " must be greater than " << min_val << "." << std::endl;
+    }
     assert(action[field] >= min_val);
   } else{
     if(populate_default){
@@ -320,7 +338,7 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
   assert (tc != whole_config.end());
 
   int testcase_num = 0;
-  int number_of_screenshots = 1;
+  int number_of_screenshots = 0;
   for (typename nlohmann::json::iterator itr = tc->begin(); itr != tc->end(); itr++,testcase_num++){
 
     nlohmann::json this_testcase = whole_config["testcases"][testcase_num];
@@ -341,47 +359,107 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
       std::string action_name = action.value("action","");
       assert(action != "");
 
+      //Origin and center have no additional fields.
       if(action_name == "origin" || action_name == "center"){
         continue;
-      }else if(action_name == "delay"){
+      }
+      // Delay requires a float number of seconds, which must be greater than 0
+      // and defaults to 1.
+      else if(action_name == "delay"){
 
+        if(action["seconds"].is_null()){
+          std::cout << "ERROR: all delay actions must have a number of seconds specified." << std::endl;
+        }
         assert(!action["seconds"].is_null());
-        assert(action["seconds"].is_number_float());
+
+        if(!action["seconds"].is_number()){
+          std::cout << "ERROR: all delay actions must have a number of seconds specified." << std::endl;
+        }
+        assert(action["seconds"].is_number());
 
         float delay_time_in_seconds = float(action.value("seconds",1.0));
 
         assert(delay_time_in_seconds > 0);
         action["seconds"] = delay_time_in_seconds;
-
-      }else if(action_name == "screenshot"){
-        
+      }
+      //screenshot can contain an optional name. Otherwise, it is labeled in numerical order.
+      else if(action_name == "screenshot"){
+        number_of_screenshots++;
         if(action["name"].is_null()){
-          action["name"] = "screenshot" + number_of_screenshots + ".png";
-          number_of_screenshots++;
+          action["name"] = "screenshot" + std::to_string(number_of_screenshots) + ".png";
         }else{
+          if(!action["name"].is_string()){
+            std::cout << "ERROR: if a screenshot name is specified, it must be a string." << std::endl;
+          }
           assert(action["name"].is_string());
           assert(action["name"] != "");
+          std::string screenshot_name = action["name"];
+
+          if(screenshot_name.find(".") != std::string::npos){
+            std::cout << "ERROR: screenshot names should not contain file extensions. File extensions will be added automatically." << std::endl;
+          }
+          if(screenshot_name.find(" ") != std::string::npos){
+            std::cout << "ERROR: screenshot names should not contain spaces." << std::endl;
+          }
+          if(screenshot_name.find("/") != std::string::npos||
+             screenshot_name.find("$") != std::string::npos||
+             screenshot_name.find("'") != std::string::npos||
+             screenshot_name.find("\"") != std::string::npos||
+             screenshot_name.find("\\") != std::string::npos){
+            std::cout << "ERROR: screenshot names should not contain special characters." << std::endl;
+          }
+          assert(screenshot_name.find(" ") == std::string::npos);
+          assert(screenshot_name.find(".") == std::string::npos);
+          assert(screenshot_name.find("/") == std::string::npos);
+          assert(screenshot_name.find("$") == std::string::npos);
+          assert(screenshot_name.find("'") == std::string::npos);
+          assert(screenshot_name.find("\"") == std::string::npos);
+          assert(screenshot_name.find("\\") == std::string::npos);
+          assert(screenshot_name.find("*") == std::string::npos);
+          action["name"] = screenshot_name + ".png";
         }
-      }else if(action_name == "type"){
-        float delay_time_in_seconds = float(action.value("delay_in_seconds",1.0));
+      }
+      //Type requires a string to type and can have an optional "delay_in_seconds" and "presses"
+      else if(action_name == "type"){
+        float delay_time_in_seconds = float(action.value("delay_in_seconds",.1));
+        if(delay_time_in_seconds <= 0){
+          std::cout << "ERROR: In the type command, delay must be greater than zero." << std::endl;
+        }
+        assert(delay_time_in_seconds > 0);
         action["delay_in_seconds"] = delay_time_in_seconds;
 
         validate_integer(action, "presses", true, 1, 1);
 
+        if(action["string"].is_null()){
+          std::cout << "ERROR: an output string must be specified in the type command." << std::endl;
+        }
         assert(!action["string"].is_null());
         assert( action["string"].is_string());
         assert( action["string"] != "");
 
-      }else if(action_name == "key"){
-        float delay_time_in_seconds = float(action.value("delay_in_seconds",1.0));
+      }
+      //Type requires a key_combination to press and can have an optional "delay_in_seconds" and "presses"
+      else if(action_name == "key"){
+        float delay_time_in_seconds = float(action.value("delay_in_seconds",.1));
+        
+        if(delay_time_in_seconds <= 0){
+          std::cout << "ERROR: In the key command, delay must be greater than zero." << std::endl;
+        }
+        assert(delay_time_in_seconds > 0);
         action["delay_in_seconds"] = delay_time_in_seconds;
 
         validate_integer(action, "presses", true, 1, 1);
-
+        
+        if(action["key_combination"].is_null()){
+          std::cout << "ERROR: key combination to be pressed must be specified in the key command." << std::endl;
+        }
         assert(!action["key_combination"].is_null());
         assert( action["key_combination"].is_string());
         assert( action["key_combination"] != "");
-      }else if(action_name == "click and drag"){
+      }
+      //Click and drag can have an optional start_x and start_y, and must have an end_x and end_y
+      // which are greater than 0.
+      else if(action_name == "click and drag"){
         
         validate_mouse_button(action);
 
@@ -390,26 +468,44 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
         validate_integer(action, "end_x",   true,  0, 0);
         validate_integer(action, "end_y",   true,  0, 0);
 
+        if(action["end_x"] == 0 && action["end_y"] == 0){
+          std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
+        }
         assert(action["end_x"] != 0 || action["end_y"] != 0);
 
-      }else if(action_name == "click and drag delta"){
+      }
+      //Click and drag delta can have an optional mouse button, and must have and end_x and end_y.
+      else if(action_name == "click and drag delta"){
        
         validate_mouse_button(action);
 
         validate_integer(action, "end_x",   true,  0, 0);
         validate_integer(action, "end_y",   true,  0, 0);
 
+        if(action["end_x"] == 0 && action["end_y"] == 0){
+          std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
+        }
+
         assert(action["end_x"] != 0 || action["end_y"] != 0);
 
-      }else if(action_name == "click"){
+      }
+      //Click has an optional mouse button.
+      else if(action_name == "click"){
         validate_mouse_button(action);
-        validate_integer(action, "repetitions", true, 1, 1);        
-      }else if(action_name == "mouse move"){
+      }
+      //Mouse move has an optional end_x and end_y.
+      else if(action_name == "mouse move"){
         validate_integer(action, "end_x", true, 0, 0);
         validate_integer(action, "end_y", true, 0, 0);
       }
+      //Fail if the action is not valid.
       else{
         bool valid_action_type = false;
+        if(action_name == ""){
+          std::cout << "ERROR: no 'action' feild defined." << std::endl;
+        }else{
+          std::cout << "ERROR: Could not recognize action " << action_name << std::endl;
+        }
         assert(valid_action_type == true);
       }
     }
@@ -659,6 +755,7 @@ nlohmann::json LoadAndProcessConfigJSON(const std::string &rcsid) {
   AddDockerConfiguration(answer);
   FormatDispatcherActions(answer);
   formatPreActions(answer);
+  FormatGraphicsActions(answer);
   AddSubmissionLimitTestCase(answer);
   AddAutogradingConfiguration(answer);
 

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -751,6 +751,7 @@ void InflateTestcase(nlohmann::json &single_testcase, nlohmann::json &whole_conf
     assert (itr->is_array());
     VerifyGraderDeductions(*itr);
     std::vector<nlohmann::json> containers = mapOrArrayOfMaps(single_testcase, "containers");
+    AddDefaultGraphicsChecks(*itr,single_testcase);
     AddDefaultGraders(containers,*itr,whole_config);
 
      for (int i = 0; i < (*itr).size(); i++) {
@@ -825,7 +826,36 @@ nlohmann::json LoadAndProcessConfigJSON(const std::string &rcsid) {
   return answer;
 }
 
+/**
+* Add automatic GIF filechecks.
+*/
+void AddDefaultGraphicsChecks(nlohmann::json &json_graders, const nlohmann::json &testcase){
+  if(testcase.find("actions") == testcase.end()){
+    return;
+  }
+  
+  std::vector<nlohmann::json> actions = mapOrArrayOfMaps(testcase, "actions");
 
+  for (int action_num = 0; action_num < actions.size(); action_num++){
+    nlohmann::json action = actions[action_num];
+    std::string action_name = action.value("action","");
+    if(action_name != "gif"){
+      continue;
+    }
+    //We found a gif! Add a filecheck for it.
+    nlohmann::json j;
+    std::string gif_name = action["name"];
+    std::string full_gif_name = gif_name + ".gif";
+
+    j["actual_file"] = full_gif_name;
+    j["deduction"]   = 0;
+    j["description"] = "Student GIF: " + gif_name;
+    j["method"]      = "warnIfEmpty";
+    j["show_actual"] = "always";
+    j["show_message"]= "never";
+    json_graders.push_back(j);
+  }
+}
 
 /*
 * Start

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -520,7 +520,6 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
         assert(action["seconds"].is_number());
 
         float gif_duration = float(action.value("seconds",1.0));
-
         assert(gif_duration > 0);
         action["seconds"] = gif_duration;
         
@@ -536,6 +535,20 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
           std::string gif_name = action["name"];
           validate_gif_or_screenshot_name(gif_name);
         }
+
+        if(action["preserve_individual_frames"].is_null()){
+          action["preserve_individual_frames"] = false;
+        }else{
+          assert(action["preserve_individual_frames"].is_boolean());
+        }
+        //minimum frames_per_second is 1, default is 10.
+        validate_integer(action, "frames_per_second", true, 1, 10);
+
+        if(action["frames_per_second"] > 30){
+          std::cout << "ERROR: Submitty does not allow gifs with an fps greater than 30." << std::endl;
+          assert(action["frames_per_second"] <= 30);
+        }
+
         number_of_gifs++;
       }
       //Fail if the action is not valid.
@@ -814,22 +827,8 @@ nlohmann::json LoadAndProcessConfigJSON(const std::string &rcsid) {
 
 
 
-
-
 /*
 * Start
-
-
-
-
-
-
-
-
-
-
-
-
 */
 
 // Every command sends standard output and standard error to two

--- a/grading/load_config_json.h
+++ b/grading/load_config_json.h
@@ -49,4 +49,8 @@ void VerifyGraderDeductions(nlohmann::json &json_graders);
 
 bool validShowValue(const nlohmann::json& v);
 
+void validate_mouse_button(nlohmann::json& action);
+
+void validate_integer(nlohmann::json& action, std::string field, bool populate_default, int min_val, int default_value);
+
 #endif

--- a/grading/load_config_json.h
+++ b/grading/load_config_json.h
@@ -19,6 +19,8 @@ void InflateTestcase(nlohmann::json &single_testcase, nlohmann::json &whole_conf
 
 nlohmann::json LoadAndProcessConfigJSON(const std::string &rcsid);
 
+void AddDefaultGraphicsChecks(nlohmann::json &json_graders, const nlohmann::json &testcase);
+
 void AddDefaultGrader(const std::string &command,
                       const std::set<std::string> &files_covered,
                       nlohmann::json& json_graders,

--- a/grading/load_config_json.h
+++ b/grading/load_config_json.h
@@ -53,4 +53,6 @@ void validate_mouse_button(nlohmann::json& action);
 
 void validate_integer(nlohmann::json& action, std::string field, bool populate_default, int min_val, int default_value);
 
+void validate_gif_or_screenshot_name(std::string filename);
+
 #endif

--- a/grading/myersDiff.cpp
+++ b/grading/myersDiff.cpp
@@ -198,7 +198,7 @@ TestResults* ImageDiff_doit(const TestCase &tc, const nlohmann::json& j, int aut
 
   if (access(expected_file.c_str(), F_OK|R_OK ) == -1)
   {
-        return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "ERROR: The instructor's image was not found. Please notify your instructor")});
+    return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "ERROR: The instructor's image was not found. Please notify your instructor")});
   }
 
   float acceptable_threshold = stringToFloat(acceptable_threshold_str,6); //window_utils function.

--- a/grading/myersDiff.cpp
+++ b/grading/myersDiff.cpp
@@ -207,6 +207,17 @@ TestResults* ImageDiff_doit(const TestCase &tc, const nlohmann::json& j, int aut
   actual_file = tc.getPrefix() + actual_file;
   std::cout << "About to compare " << actual_file << " and " << expected_file << std::endl;
 
+  //Check existence. File is closed by destructor.
+  std::ifstream img_file_actual(actual_file);
+  if(!img_file_actual.good()){
+    return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "Image comparison failed; student file does not exist.")});
+  }
+
+  //Check existence. File is closed by destructor.
+  std::ifstream img_file_expected(expected_file);
+  if(!img_file_expected.good()){
+    return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "Image comparison failed; expected file does not exist.")});
+  }
 
   std::string command = "compare -metric RMSE " + actual_file + " " + expected_file + " NULL: 2>&1";
   std::string output = output_of_system_command(command.c_str()); //get the string

--- a/grading/window_utils.h
+++ b/grading/window_utils.h
@@ -72,7 +72,7 @@ bool windowExists(std::string window_name);
 * uses number_of_screenshots to title the image (submitty prepends it with the test #)
 * updates the number of screenshots taken. 
 */
-bool screenshot(std::string window_name, int& number_of_screenshots);
+bool screenshot(std::string window_name, std::string screenshot_name);
 
 /**
 * This function uses xdotool to put the mouse button associated with int button into the 'down' state
@@ -165,7 +165,7 @@ bool isWindowedAction(const nlohmann::json action);
 * NOTE TO DEVLOPERS: If you want to add a new action, also modify the preprocessing script for config.json to 
 * include your new action as valid.
 */
-void takeAction(const std::vector<nlohmann::json>& actions, int& actions_taken, int& number_of_screenshots, 
+void takeAction(const std::vector<nlohmann::json>& actions, int& actions_taken, 
                 std::string window_name, int childPID, float &elapsed, float& next_checkpoint, 
                 float seconds_to_run, int& rss_memory, int allowed_rss_memory, int& memory_kill, int& time_kill, 
                 std::ostream &logfile);

--- a/grading/window_utils.h
+++ b/grading/window_utils.h
@@ -74,7 +74,12 @@ bool windowExists(std::string window_name);
 */
 bool screenshot(std::string window_name, std::string screenshot_name);
 
-bool make_gif(std::string window_name, std::string gif_name, float duration_in_seconds,
+/**
+* A quick helper function which pads an integer with leading zeroes.
+*/
+std::string pad_integer(int number, int padding);
+
+bool make_gif(std::string window_name, std::string gif_name, float duration_in_seconds, int fps, bool save_pngs,
   int childPID, float &elapsed, float& next_checkpoint, float seconds_to_run, 
   int& rss_memory, int allowed_rss_memory, int& memory_kill, int& time_kill,
   std::ostream &logfile);

--- a/grading/window_utils.h
+++ b/grading/window_utils.h
@@ -74,6 +74,11 @@ bool windowExists(std::string window_name);
 */
 bool screenshot(std::string window_name, std::string screenshot_name);
 
+bool make_gif(std::string window_name, std::string gif_name, float duration_in_seconds,
+  int childPID, float &elapsed, float& next_checkpoint, float seconds_to_run, 
+  int& rss_memory, int allowed_rss_memory, int& memory_kill, int& time_kill,
+  std::ostream &logfile);
+
 /**
 * This function uses xdotool to put the mouse button associated with int button into the 'down' state
 * Checks to see if the window exists so that we don't click on anything that doesn't belong to us.

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -168,7 +168,8 @@ class Utils {
     public static function isImage($filename) {
         return (substr($filename,strlen($filename)-4,4) == ".png") ||
             (substr($filename,strlen($filename)-4,4) == ".jpg") ||
-            (substr($filename,strlen($filename)-4,4) == ".jpeg");
+            (substr($filename,strlen($filename)-4,4) == ".jpeg")||
+            (substr($filename,strlen($filename)-4,4) == ".gif");
     }
 
     public static function checkUploadedImageFile($id){


### PR DESCRIPTION
Closes #1096
Requires and contains PR #3295

* Adds the ```gif``` graphics action, which creates a GIF of the running student application.
* Allows users to configure gifs using the following arguments:
    * ```seconds```: __required__. The duration of the gif in seconds.
    * ```name```: a custom output name for the gif. By default it is gif_#, where # is the gif's order in the testcase.
    * ```frames_per_second```: The number of images per second displayed in the gif. Defaults to 10. Maximum value is 30. Gif display rate on Submitty roughly synchronizes to the fps chosen.
    * ```preserve_individual_frames```: If true, saves the images used to create the gif. Defaults to false.

An example gif specification is as follows:

```
{
    "action" : "gif",
    "seconds" : 5,
    "name" : "custom_gif_name",
    "frames_per_second" : 15,
    "preserve_individual_frames" : false
}
```

The action specified creates a 5 second long gif which refreshes at a rate of 15 frames per second, and is saved as ```custom_gif_name.gif```. The individual images used to preserve the gif are destroyed after gif creation, per the ```preserve_individual_frames``` argument.

Updates to the docs will follow.