### PR TITLE
Fix Excess Autograder Logging

### DIFF
--- a/sbin/autograder/grade_items_logging.py
+++ b/sbin/autograder/grade_items_logging.py
@@ -26,12 +26,15 @@ def log_message(job_id="UNKNOWN", is_batch=False, which_untrusted="", jobname=""
     elapsed_time_string = "" if elapsed_time < 0 else '{:9.3f}'.format(elapsed_time)
     time_unit = "" if elapsed_time < 0 else "sec"
     with open(autograding_log_file, 'a') as myfile:
-        fcntl.flock(myfile,fcntl.LOCK_EX | fcntl.LOCK_NB)
-        print("%s | %6s | %5s | %11s | %-75s | %-6s %9s %3s | %s"
-              % (easy_to_read_date, job_id, batch_string, which_untrusted,
-                 jobname, timelabel, elapsed_time_string, time_unit, message),
-              file=myfile)
-        fcntl.flock(myfile, fcntl.LOCK_UN)
+        try:
+            fcntl.flock(myfile,fcntl.LOCK_EX | fcntl.LOCK_NB)
+            print("%s | %6s | %5s | %11s | %-75s | %-6s %9s %3s | %s"
+                  % (easy_to_read_date, job_id, batch_string, which_untrusted,
+                     jobname, timelabel, elapsed_time_string, time_unit, message),
+                  file=myfile)
+            fcntl.flock(myfile, fcntl.LOCK_UN)
+        except:
+            print("Could not gain a lock on the log file.")
 
 def log_stack_trace(job_id="UNKNOWN", is_batch=False, which_untrusted="", jobname="", timelabel="", elapsed_time=-1, trace=""):
     now = dateutils.get_current_time()
@@ -44,9 +47,12 @@ def log_stack_trace(job_id="UNKNOWN", is_batch=False, which_untrusted="", jobnam
     elapsed_time_string = "" if elapsed_time < 0 else '{:9.3f}'.format(elapsed_time)
     time_unit = "" if elapsed_time < 0 else "sec"
     with open(autograding_log_file, 'a') as myfile:
-        fcntl.flock(myfile,fcntl.LOCK_EX | fcntl.LOCK_NB)
-        print("%s | %6s | %5s | %11s | %-75s | %-6s %9s %3s |\n%s"
-              % (easy_to_read_date, job_id, batch_string, which_untrusted,
-                 jobname, timelabel, elapsed_time_string, time_unit, trace),
-              file=myfile)
-        fcntl.flock(myfile, fcntl.LOCK_UN)
+        try:
+            fcntl.flock(myfile,fcntl.LOCK_EX | fcntl.LOCK_NB)
+            print("%s | %6s | %5s | %11s | %-75s | %-6s %9s %3s |\n%s"
+                  % (easy_to_read_date, job_id, batch_string, which_untrusted,
+                     jobname, timelabel, elapsed_time_string, time_unit, trace),
+                  file=myfile)
+            fcntl.flock(myfile, fcntl.LOCK_UN)
+        except:
+            print("Could not gain a lock on the log file.")

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -290,7 +290,6 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
             success = True
         #This is the normal case (still grading on the other end) so we don't need to print anything.
         except FileNotFoundError:
-            grade_items_logging.log_stack_trace(job_id=JOB_ID, trace=traceback.format_exc())
             os.remove(local_results_zip)
             os.remove(local_done_queue_file)
             success = False


### PR DESCRIPTION
*  Removes a line which was logging an expected file not found error.
*  Stops grading from throwing an exception when unable to gain a lock on the log file.
* We should briefly discuss how we want to handle cases where we can't gain a lock on the log file. We aren't blocking, so an exception is thrown when a lock is unavailable. We are not properly handling this exception throughout the system. This PR catches and ignores the exception.