### PR TITLE
Fix Bulk Uploads

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -795,7 +795,8 @@ class SubmissionController extends AbstractController {
             "filepath" => $uploaded_file
         ];
 
-        if (FileUtils::writeJsonFile(FileUtils::joinPaths($version_path, "bulk_upload_data.json"), $bulk_upload_data)) {
+        #writeJsonFile returns false on failure.
+        if (FileUtils::writeJsonFile(FileUtils::joinPaths($version_path, "bulk_upload_data.json"), $bulk_upload_data) === false) {
             return $this->uploadResult("Failed to create bulk upload file for this submission.", false);
         }
         


### PR DESCRIPTION
Bulk upload was failing due to an improper check, which assumed that ```FileUtils::writeJsonFile``` returned true on failure.

This PR should fix the issue and re-enable bulk upload.