### PR TITLE
Better grading order: New model / Order fixes

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -512,8 +512,6 @@ class ElectronicGraderController extends GradingController {
             $student_ids = array_merge($student_ids, array_map(function(Submitter $submitter) { return $submitter->getId(); }, $section));
         }
 
-        //TODO: Clean this up
-
         $show_empty_teams = $this->core->getAccess()->canI("grading.electronic.details.show_empty_teams");
         $empty_teams = array();
         if ($gradeable->isTeamAssignment()) {

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -541,9 +541,17 @@ class ElectronicGraderController extends GradingController {
             }
         }
         $teamless_users = [];
-        if ($show_all && $gradeable->isTeamAssignment()) {
+        if ($gradeable->isTeamAssignment()) {
             //Find teamless users
-            $students = $this->core->getQueries()->getAllUsers();
+            if ($show_all) {
+                $students = $this->core->getQueries()->getAllUsers();
+            } else {
+                if ($gradeable->isGradeByRegistration()) {
+                    $students = $this->core->getQueries()->getUsersByRegistrationSections($order->getSectionNames());
+                } else {
+                    $students = $this->core->getQueries()->getUsersByRotatingSections($order->getSectionNames());
+                }
+            }
             foreach ($students as $user) {
                 if (!in_array($user->getId(), $user_ids)) {
                     $teamless_users[] = $user;

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -553,14 +553,6 @@ class ElectronicGraderController extends GradingController {
             }
         }
 
-        if ($peer) {
-            $grading_count = $gradeable->getPeerGradeSet();
-        } else if ($gradeable->isGradeByRegistration()) {
-            $grading_count = count($this->core->getUser()->getGradingRegistrationSections());
-        } else {
-            $grading_count = count($this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable->getId(), $this->core->getUser()->getId()));
-        }
-
         $show_all_sections_button = $can_show_all;
         $show_edit_teams = $this->core->getAccess()->canI("grading.electronic.show_edit_teams") && $gradeable->isTeamAssignment();
         $show_import_teams_button = $show_edit_teams && (count($all_teams) > count($empty_teams));

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -953,7 +953,7 @@ class ElectronicGraderController extends GradingController {
                 //order teams first by rotating section, then by leader id.
                 usort($teams_to_grade, function(Team $a, Team $b) {
                     if($a->getRotatingSection() == $b->getRotatingSection())
-                        return $a->getMembers()[0] < $b->getMembers()[0] ? -1 : 1;
+                        return $a->getLeaderId() < $b->getLeaderId() ? -1 : 1;
                     return $a->getRotatingSection() < $b->getRotatingSection() ? -1 : 1;
                 });
                 //$total = array_sum($this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, 'rotating_section'));

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -541,11 +541,9 @@ class ElectronicGraderController extends GradingController {
             }
         }
         $teamless_users = [];
-        if ($gradeable->isTeamAssignment()) {
-            // Get al users and separate by section (registration or rotating)
-            $get_user_section = function (User $user) use ($gradeable) {
-                return $gradeable->isGradeByRegistration() ? $user->getRegistrationSection() ?? 'NULL' : $user->getRotatingSection();
-            };
+        if ($show_all && $gradeable->isTeamAssignment()) {
+            //Find teamless users
+            $students = $this->core->getQueries()->getAllUsers();
             foreach ($students as $user) {
                 if (!in_array($user->getId(), $user_ids)) {
                     $teamless_users[] = $user;

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -532,7 +532,7 @@ class ElectronicGraderController extends GradingController {
         $graded_gradeables = [];
         $user_ids = []; // Collect user ids so we know who isn't on a team
         /** @var GradedGradeable $g */
-        foreach ($this->core->getQueries()->getGradedGradeables([$gradeable], $student_ids, null, [$section_key, 'user_id', 'team_id']) as $g) {
+        foreach ($order->getSortedGradedGradeables() as $g) {
             $graded_gradeables[] = $g;
             if($gradeable->isTeamAssignment()) {
                 $user_ids = array_merge($user_ids, $g->getSubmitter()->getTeam()->getMemberUserIds());

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3773,6 +3773,17 @@ AND gc_id IN (
     }
 
     /**
+     * Get the active version for all given submitter ids. If they do not have an active version,
+     * their version will be zero.
+     * @param \app\models\gradeable\Gradeable $gradeable
+     * @param string[] $submitter_ids
+     * @return bool[] Map of id=>version
+     */
+    public function getActiveVersions(gradeable\Gradeable $gradeable, array $submitter_ids) {
+        throw new NotImplementedException();
+    }
+
+    /**
      * Gets a list of emails for all active particpants in a course  
      */
     public function getClassEmailList(){

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1855,5 +1855,37 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             $ids,
             $gradeable_constructor);
     }
+
+    public function getActiveVersions(Gradeable\Gradeable $gradeable, array $submitter_ids) {
+        // (?), (?), (?)
+        $id_placeholders = implode(',', array_fill(0, count($submitter_ids), '(?)'));
+
+        $query = "
+            SELECT ids.id, (CASE WHEN m IS NULL THEN 0 ELSE m END) AS max
+            FROM (VALUES $id_placeholders) ids(id)
+            LEFT JOIN (
+              (SELECT user_id AS id, active_version as m
+              FROM electronic_gradeable_version
+              WHERE g_id = ? AND user_id IS NOT NULL)
+            
+              UNION
+            
+              (SELECT team_id AS id, active_version as m
+              FROM electronic_gradeable_version
+              WHERE g_id = ? AND team_id IS NOT NULL)
+            ) AS versions
+            ON versions.id = ids.id
+        ";
+
+        $params = array_merge($submitter_ids, [$gradeable->getId(), $gradeable->getId()]);
+
+        $this->course_db->query($query, $params);
+        $versions = [];
+        foreach ($this->course_db->rows() as $row) {
+            $versions[$row["id"]] = $row["max"];
+        }
+        return $versions;
+    }
+
 }
 

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1857,6 +1857,10 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     }
 
     public function getActiveVersions(Gradeable\Gradeable $gradeable, array $submitter_ids) {
+        if (count($submitter_ids) === 0) {
+            return [];
+        }
+
         // (?), (?), (?)
         $id_placeholders = implode(',', array_fill(0, count($submitter_ids), '(?)'));
 

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -111,6 +111,33 @@ class GradingOrder extends AbstractModel {
      * @return Submitter Previous submitter to grade
      */
     public function getPrevSubmitter(Submitter $submitter) {
+        return $this->getPrevSubmitterMatching($submitter, function(Submitter $sub) {
+            return $this->getHasSubmission($sub);
+        });
+    }
+
+    /**
+     * Given the current submitter, get the next submitter to grade.
+     * Will skip students that do not need to be graded (eg no submission)
+     * @param Submitter $submitter Current grading submitter
+     * @return Submitter Next submitter to grade
+     */
+    public function getNextSubmitter(Submitter $submitter) {
+        return $this->getNextSubmitterMatching($submitter, function(Submitter $sub) {
+            return $this->getHasSubmission($sub);
+        });
+
+    }
+
+
+    /**
+     * Given the current submitter, get the previous submitter to grade.
+     * Will only include students that cause $fn to return true
+     * @param Submitter $submitter Current grading submitter
+     * @param callable $fn Args: (Submitter) Returns: bool, true if the submitter should be included
+     * @return Submitter Previous submitter to grade
+     */
+    public function getPrevSubmitterMatching(Submitter $submitter, callable $fn) {
         $index = $this->getSubmitterIndex($submitter);
         if ($index === false) {
             return null;
@@ -122,19 +149,20 @@ class GradingOrder extends AbstractModel {
             if ($sub === false) {
                 return null;
             }
-            //Repeat until we find one that exists
-        } while (!$this->getHasSubmission($sub));
+            //Repeat until we find one that works
+        } while (!$fn($sub));
 
         return $sub;
     }
 
     /**
      * Given the current submitter, get the next submitter to grade.
-     * Will skip students that do not need to be graded (eg no submission)
+     * Will only include students that cause $fn to return true
      * @param Submitter $submitter Current grading submitter
+     * @param callable $fn Args: (Submitter) Returns: bool, true if the submitter should be included
      * @return Submitter Next submitter to grade
      */
-    public function getNextSubmitter(Submitter $submitter) {
+    public function getNextSubmitterMatching(Submitter $submitter, callable $fn) {
         $index = $this->getSubmitterIndex($submitter);
         if ($index === false) {
             return null;
@@ -146,8 +174,8 @@ class GradingOrder extends AbstractModel {
             if ($sub === false) {
                 return null;
             }
-            //Repeat until we find one that exists
-        } while (!$this->getHasSubmission($sub));
+            //Repeat until we find one that works
+        } while (!$fn($sub));
 
         return $sub;
     }

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -100,7 +100,8 @@ class GradingOrder extends AbstractModel {
     }
 
     /**
-     * Given the current submitter, get the previous submitter to grade
+     * Given the current submitter, get the previous submitter to grade.
+     * Will skip students that do not need to be graded (eg no submission)
      * @param Submitter $submitter Current grading submitter
      * @return Submitter Previous submitter to grade
      */
@@ -123,7 +124,8 @@ class GradingOrder extends AbstractModel {
     }
 
     /**
-     * Given the current submitter, get the next submitter to grade
+     * Given the current submitter, get the next submitter to grade.
+     * Will skip students that do not need to be graded (eg no submission)
      * @param Submitter $submitter Current grading submitter
      * @return Submitter Next submitter to grade
      */

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace app\models;
+
+use app\libraries\Core;
+use app\models\gradeable\Submitter;
+use app\models\gradeable\Gradeable;
+
+class GradingOrder extends AbstractModel {
+
+    /**
+     * @var Submitter[][] $section_submitters
+     */
+    protected $section_submitters;
+
+    /**
+     * @var GradingSection[] $sections
+     */
+    protected $sections;
+
+    /**
+     * GradingOrder constructor.
+     * @param Core $core
+     * @param Gradeable $gradeable
+     * @param User $user
+     */
+    public function __construct(Core $core, Gradeable $gradeable, User $user) {
+        parent::__construct($core);
+
+        //Get that user's grading sections
+
+        $this->section_submitters = [];
+        $this->sections = $gradeable->getGradingSectionsForUser($user);
+        foreach ($this->sections as $section) {
+            $this->section_submitters[] = $section->getSubmitters();
+        }
+
+        $this->sort();
+    }
+
+    public function sort() {
+        foreach ($this->section_submitters as &$section) {
+            usort($section, function(Submitter $a, Submitter $b) {
+                return ($a->getId() < $b->getId()) ? -1 : 1;
+            });
+        }
+        unset($section);
+    }
+
+    /**
+     * Given the current submitter, get the previous submitter to grade
+     * @param Submitter $submitter Current grading submitter
+     * @return Submitter Previous submitter to grade
+     */
+    public function getPrevSubmitter(Submitter $submitter) {
+        $index = $this->getSubmitterIndex($submitter);
+        if ($index === false) {
+            return null;
+        }
+        $sub = $this->getSubmitterByIndex($index - 1);
+        if ($sub === false) {
+            return null;
+        }
+        return $sub;
+    }
+
+    /**
+     * Given the current submitter, get the next submitter to grade
+     * @param Submitter $submitter Current grading submitter
+     * @return Submitter Next submitter to grade
+     */
+    public function getNextSubmitter(Submitter $submitter) {
+        $index = $this->getSubmitterIndex($submitter);
+        if ($index === false) {
+            return null;
+        }
+        $sub = $this->getSubmitterByIndex($index + 1);
+        if ($sub === false) {
+            return null;
+        }
+        return $sub;
+    }
+
+    /**
+     * Get the index of a Submitter in the order
+     * @param Submitter $submitter Submitter to find
+     * @return int|bool Index or false if not found
+     */
+    protected function getSubmitterIndex(Submitter $submitter) {
+        $count = 0;
+
+        //Iterate through all sections and their submitters to find this one
+        for ($i = 0; $i < count($this->section_submitters); $i ++) {
+            $section = $this->section_submitters[$i];
+
+            for ($j = 0; $j < count($section); $j ++) {
+                $testSub = $section[$j];
+
+                //Found them
+                if ($testSub->getId() === $submitter->getId()) {
+                    return $count;
+                }
+
+                $count ++;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Given a Submitter's index, find them
+     * @param int $index Index of Submitter in grading order
+     * @return Submitter|bool Submitter if found, false otherwise
+     */
+    protected function getSubmitterByIndex(int $index) {
+        //Sanity
+        if ($index < 0) {
+            return false;
+        }
+
+        //Iterate through all sections and their submitters to find this one
+        for ($i = 0; $i < count($this->section_submitters); $i ++) {
+            $section = $this->section_submitters[$i];
+
+            //Easy skip
+            if (count($section) <= $index) {
+                $index -= count($section);
+                continue;
+            }
+
+            //Found them
+            return $section[$index];
+        }
+        return false;
+    }
+
+    /**
+     * Check if we have the given submitter in one of our grading sections
+     * @param Submitter $submitter Id of submitter to check
+     * @return boolean True if we have them
+     */
+    public function containsSubmitter(Submitter $submitter) {
+        foreach ($this->section_submitters as $section) {
+            foreach ($section as $section_sub) {
+                if ($submitter->getId() === $section_sub->getId()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get a list of all submitters, split into sections
+     * @return Submitter[][]
+     */
+    public function getSectionSubmitters() {
+        return $this->section_submitters;
+    }
+}
+

--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -83,14 +83,17 @@ class GradingSection extends AbstractModel {
      * @return Submitter[] All Submitters
      */
     public function getSubmitters() {
-        if ($this->teams === null) {
+        if ($this->users !== null) {
             return array_map(function(User $user) {
                 return new Submitter($this->core, $user);
             }, $this->users);
-        } else {
+        } else if ($this->teams !== null) {
             return array_map(function(Team $team) {
                 return new Submitter($this->core, $team);
             }, $this->teams);
+        } else {
+            //No users, no teams, this section is empty!
+            return [];
         }
     }
 }

--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -3,6 +3,7 @@
 namespace app\models;
 
 use app\libraries\Core;
+use app\models\gradeable\Submitter;
 
 /**
  * Represents a single section of students or teams, and their graders
@@ -75,5 +76,21 @@ class GradingSection extends AbstractModel {
             }
         }
         return false;
+    }
+
+    /**
+     * Get an array of all Submitters for this section
+     * @return Submitter[] All Submitters
+     */
+    public function getSubmitters() {
+        if ($this->teams === null) {
+            return array_map(function(User $user) {
+                return new Submitter($this->core, $user);
+            }, $this->users);
+        } else {
+            return array_map(function(Team $team) {
+                return new Submitter($this->core, $team);
+            }, $this->teams);
+        }
     }
 }


### PR DESCRIPTION
Part 1 of improved grade order, this includes the GradingOrder model and should have no interface changes (I'm splitting those into a later PR so they can happen over time). 

New things:
- Grading now skips "no submission" students (closes #3192)
- Order on details page should match order of grading (closes #3245)