### PR TITLE
Test Notes Upload Config Syntax

### DIFF
--- a/more_autograding_examples/test_notes_upload/config/config.json
+++ b/more_autograding_examples/test_notes_upload/config/config.json
@@ -8,7 +8,7 @@
 
     "autograding" : {
 	"submission_to_compilation" : [ ],
-	"submission_to_runner" : [ *.pdf ],
+	"submission_to_runner" : [ "*.pdf" ],
 	"submission_to_validation" : [ ],
 	"work_to_details" : [
             "test01/student_file.pdf", "test02/test_template.pdf" ],


### PR DESCRIPTION
There was a syntax error in `test_notes_upload/config/config.json` due to a string missing delimiters. I've made a separate copy of the config and tested on live, and it seems to work as expected with this quick fix done.