### PR TITLE
Remove redundant link in sidebar

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -128,6 +128,8 @@
                 </span>
             {% else %}
                 <a href="{{ button.getHref() }}"
+                    data-toggle="tooltip"
+                    title="{{ button.getTitle() }}"
                     {% if button.getClass() != "" %}
                         class="{{ button.getClass() }}"
                     {% endif %}
@@ -144,6 +146,7 @@
                         <span class="notification_badge">{{  button.getBadge() }} </span>
                     {% endif %}
                 </a>
+
             {% endif %}
         </li>
     {% endif %}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -108,22 +108,6 @@
         <li class="short-line"></li>
     {% else %}
         <li>
-            {% if button.getIcon() != null %}
-                <a
-                    class="collapse-icon {{ button.getClass() }}"
-                    href="{{ button.getHref() }}"
-                    data-toggle="tooltip"
-                    title="{{ button.getTitle() }}"
-                    {% if button.getId() != "" %}
-                        id="{{ button.getId() }}"
-                    {% endif %}
-                >
-                    <i class="fa {{ button.getIcon() }}"></i>
-                    {% if button.getBadge() > 0 %}
-                        <span class="notification_badge">{{  button.getBadge() }} </span>
-                    {% endif %}
-                </a>
-            {% endif %}
             {% if button.getHref() == null %}
                 <span
                     {% if button.getClass() != "" %}
@@ -155,7 +139,7 @@
                         <i class="fa {{ button.getIcon() }}"></i>
                     {% endif %}
 
-                    {{ button.getTitle() }}
+                    <span class="iconTitle"> {{ button.getTitle() }} </span>
                     {% if button.getBadge() > 0 %}
                         <span class="notification_badge">{{  button.getBadge() }} </span>
                     {% endif %}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1082,8 +1082,7 @@ table .instructor .two-options{
 }
 
 #sidebar.collapsed #nav-buttons ul li .nav-row .fa{
-    padding: 0.5px 15px;
-    font-size: 20px;
+    padding: 0.5px 17.5px;
 }
 
 
@@ -1203,6 +1202,7 @@ table .instructor .two-options{
 
 #sidebar.collapsed #nav-buttons ul li.short-line {
     margin-left: -30px;
+    width: 100px
 }
 
 #nav-buttons ul li.heading {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1082,7 +1082,7 @@ table .instructor .two-options{
 }
 
 #sidebar.collapsed #nav-buttons ul li .nav-row .fa{
-    padding: 0.5px 17.5px;
+    padding: 2px 17.5px;
 }
 
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1034,7 +1034,7 @@ table .instructor .two-options{
 }
 
 #sidebar.collapsed #nav-buttons {
-    width: 240px;
+    width: 30px;
 }
 
 #sidebar.collapsed #nav-buttons-visible {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1050,7 +1050,7 @@ table .instructor .two-options{
 }
 
 #sidebar.animate {
-    transition: 0.25s ease-out;
+    transition: 0.3s ease-out;
 }
 
 #sidebar.collapsed {
@@ -1077,13 +1077,15 @@ table .instructor .two-options{
     display: block;
 }
 
-#sidebar.collapsed #nav-buttons ul li .nav-row {
+#sidebar.collapsed #nav-buttons ul li .nav-row .iconTitle{
     display: none;
 }
 
-#nav-buttons ul li .collapse-icon {
-    display: none;
+#sidebar.collapsed #nav-buttons ul li .nav-row .fa{
+    padding: 0.5px 15px;
+    font-size: 20px;
 }
+
 
 #sidebar.collapsed #nav-buttons ul li .collapse-icon {
     display: inline-block;

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -2580,9 +2580,17 @@ function toggleSidebar() {
 }
 
 $(document).ready(function() {
-    //Collapsed sidebar tooltips
+    //Collapsed sidebar tooltips with content depending on state of sidebar
     $('[data-toggle="tooltip"]').tooltip({
-        position: { my: "right+0 bottom+0" }
+        position: { my: "right+0 bottom+0" },
+        content: function () {
+            if($("#sidebar").hasClass("collapsed")) {
+                return $(this).attr("title")
+            }
+            else {
+                return ""
+            }
+        }
     });
     $("#nav-sidebar-collapse.collapse-icon").attr("title", "Expand Sidebar");
 


### PR DESCRIPTION
Fixes #2729 
Remove rebundant link in side bar.the <a> showing icon is removed and `button.getTitle()`  is wrapped in span tag which is made  `Display : none`  on pressing sidebar when side bar is opened.

Icon are made large  when side bar is closed. This will increase accessibility of the button