### PR TITLE
Contrast Error in Global footer view

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -479,7 +479,7 @@ table tr.table-header {
 }
 
 #footer a:hover {
-    color: #4078c0;
+    color: #405E90;
 }
 
 #footer #copyright {
@@ -491,7 +491,7 @@ table tr.table-header {
 }
 
 #copyright > a {
-    color: #4078c0;
+    color: #405E90;
 }
 
 #copyright > a:hover {


### PR DESCRIPTION
Fixes #2312 
Color of link is changed `#4078C0` to `#405E90`

This changes color contrast ratio from 4.1 to 5.93

Before:-
![screenshot from 2019-02-26 15-30-10](https://user-images.githubusercontent.com/42701709/53407281-ceb67680-39e1-11e9-880f-8738cc7400e6.png)
 
After:-
![screenshot from 2019-02-26 15-36-38](https://user-images.githubusercontent.com/42701709/53407296-dfff8300-39e1-11e9-9756-eacd88944ea9.png)
