### PR TITLE
Radio Button Grouping

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -40,53 +40,56 @@
         {{ action == 'edit' ? 'readonly' : 'required' }} />
 
 <br />
+<fieldset>
+    <legend>
+        {% if action == 'new' or action == 'template' %}
+            <!-- Gradeable Type radio buttons (readonly in edit mode) -->
+            What is the <a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#types-of-gradeables">type of the gradeable</a>?:
 
-{% if action == 'new' or action == 'template' %}
-    <!-- Gradeable Type radio buttons (readonly in edit mode) -->
-    What is the <a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#types-of-gradeables">type of the gradeable</a>?:
+            <span id="required_type" >(Required)</span>
+        {% else %}
+            Gradeable type: <span id="gradeable-type-string">{{ type_string }}</span>
+            <br />
+        {% endif %}
+    </legend>
+    <div>
+        <div id="gradeable_type_container" {{ action == 'edit' ? 'hidden' : '' }}>
+            <div>
+                <input type='radio' id="radio_checkpoints" name="type" value="Checkpoints"
+                    {{ action != 'new' and gradeable.getType() == 1 ? 'checked' : '' }}> {{ gradeable_type_strings['checkpoint'] }}
+            </div>
 
-    <span id="required_type" >(Required)</span>
-{% else %}
-    Gradeable type: <span id="gradeable-type-string">{{ type_string }}</span>
-    <br />
-{% endif %}
-<div>
-    <div id="gradeable_type_container" {{ action == 'edit' ? 'hidden' : '' }}>
-        <div>
-            <input type='radio' id="radio_checkpoints" name="type" value="Checkpoints"
-                {{ action != 'new' and gradeable.getType() == 1 ? 'checked' : '' }}> {{ gradeable_type_strings['checkpoint'] }}
-        </div>
+            <div>
+                <input type='radio' id="radio_numeric" name="type" value="Numeric"
+                    {{ action != 'new' and gradeable.getType() == 2 ? 'checked' : '' }}> {{ gradeable_type_strings['numeric'] }}
+            </div>
 
-        <div>
-            <input type='radio' id="radio_numeric" name="type" value="Numeric"
-                {{ action != 'new' and gradeable.getType() == 2 ? 'checked' : '' }}> {{ gradeable_type_strings['numeric'] }}
-        </div>
+            <div hidden>
+                <input type='radio' id="radio_electronic_file" name="type" value="Electronic File"
+                        {{ action != 'new' and gradeable.getType() == 0 ? 'checked' : '' }}> Electronic File (multiple types)
+            </div>
 
-        <div hidden>
-            <input type='radio' id="radio_electronic_file" name="type" value="Electronic File"
-                    {{ action != 'new' and gradeable.getType() == 0 ? 'checked' : '' }}> Electronic File (multiple types)
-        </div>
+            {# Real input fields to back the exposed configurations options #}
+            <input name="scanned_exam" value="{{ action != 'new' and gradeable.isScannedExam() ? 'true' : 'false' }}" hidden>
+            <input name="vcs" value="{{ action != 'new' and gradeable.isVcs() ? 'true' : 'false' }}" hidden>
 
-        {# Real input fields to back the exposed configurations options #}
-        <input name="scanned_exam" value="{{ action != 'new' and gradeable.isScannedExam() ? 'true' : 'false' }}" hidden>
-        <input name="vcs" value="{{ action != 'new' and gradeable.isVcs() ? 'true' : 'false' }}" hidden>
+            <div>
+                <input class="ignore" type="radio" id="radio_ef_student_upload" name="electronic_gradeable_presets" value="normal"
+                        {{ action != 'new' and not gradeable.isScannedExam() and not gradeable.isVcs() ? 'checked' : ''}}> {{ gradeable_type_strings['electronic_hw'] }}
+            </div>
 
-        <div>
-            <input class="ignore" type="radio" id="radio_ef_student_upload" name="electronic_gradeable_presets" value="normal"
-                    {{ action != 'new' and not gradeable.isScannedExam() and not gradeable.isVcs() ? 'checked' : ''}}> {{ gradeable_type_strings['electronic_hw'] }}
-        </div>
+            <div>
+                <input class="ignore" type="radio" id="radio_ef_vcs_upload" name="electronic_gradeable_presets" value="vcs"
+                        {{ action != 'new' and not gradeable.isScannedExam() and gradeable.isVcs() ? 'checked' : ''}}> {{ gradeable_type_strings['electronic_hw_vcs'] }}
+            </div>
 
-        <div>
-            <input class="ignore" type="radio" id="radio_ef_vcs_upload" name="electronic_gradeable_presets" value="vcs"
-                    {{ action != 'new' and not gradeable.isScannedExam() and gradeable.isVcs() ? 'checked' : ''}}> {{ gradeable_type_strings['electronic_hw_vcs'] }}
-        </div>
-
-        <div>
-            <input class="ignore" type="radio" id="radio_ef_scanned_exam" name="electronic_gradeable_presets" value="scanned_exam"
-                    {{ action != 'new' and gradeable.isScannedExam() ? 'checked' : '' }}> {{ gradeable_type_strings['electronic_exam'] }}
+            <div>
+                <input class="ignore" type="radio" id="radio_ef_scanned_exam" name="electronic_gradeable_presets" value="scanned_exam"
+                        {{ action != 'new' and gradeable.isScannedExam() ? 'checked' : '' }}> {{ gradeable_type_strings['electronic_exam'] }}
+            </div>
         </div>
     </div>
-</div>
+</fieldset>
 
 <!-- This is only relevant to Electronic Files -->
 <fieldset class="gradeable_type_options electronic_file" id="electronic_file">

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -89,108 +89,107 @@
             </div>
         </div>
     </div>
-</fieldset>
 
-<!-- This is only relevant to Electronic Files -->
-<fieldset class="gradeable_type_options electronic_file" id="electronic_file">
-    <div><legend>Will any or all of this assignment be manually graded (e.g., by the TAs or the instructor)?</legend></div>
-    <div>
-        <input type="radio" id="yes_ta_grade" name="ta_grading" value="true" class="bool_val auto_save date-related"
-                {{ action != 'new' and gradeable.getTaGrading() ? 'checked' : '' }} /> <label for="yes_ta_grade">Yes</label>
-        <input type="radio" id="no_ta_grade" name="ta_grading" value="false" class="bool_val auto_save date-related"
-                {{ not (action != 'new' and gradeable.getTaGrading()) ? 'checked' : '' }} /> <label for="no_ta_grade">No</label>
-    </div>
-    {% if regrade_enabled %}
-        <div id="regrade_request_enable_container">
-            Will grade inquiries be enabled for this assignment?
+    <!-- This is only relevant to Electronic Files -->
+    <fieldset class="gradeable_type_options electronic_file" id="electronic_file">
+        <div><legend>Will any or all of this assignment be manually graded (e.g., by the TAs or the instructor)?</legend></div>
+        <div>
+            <input type="radio" id="yes_ta_grade" name="ta_grading" value="true" class="bool_val auto_save date-related"
+                    {{ action != 'new' and gradeable.getTaGrading() ? 'checked' : '' }} /> <label for="yes_ta_grade">Yes</label>
+            <input type="radio" id="no_ta_grade" name="ta_grading" value="false" class="bool_val auto_save date-related"
+                    {{ not (action != 'new' and gradeable.getTaGrading()) ? 'checked' : '' }} /> <label for="no_ta_grade">No</label>
+        </div>
+        {% if regrade_enabled %}
+            <div id="regrade_request_enable_container">
+                Will grade inquiries be enabled for this assignment?
+                <br />
+                <input type="radio" id="yes_regrade_allowed" name="regrade_allowed" value="true" class="bool_val auto_save date-related"
+                        {{ action != 'new' and gradeable.isRegradeAllowed() ? 'checked' : '' }} /> Yes
+                <input type="radio" id="no_regrade_allowed" name="regrade_allowed" value="false" class="bool_val auto_save date-related"
+                        {{ not (action != 'new' and gradeable.isRegradeAllowed()) ? 'checked' : '' }} /> No
+            </div>
+        {% endif %}
+
+        <div id="team-settings-container">
+            {% if action == 'new' or action == 'template' %}
+                Is this a team assignment?
+            {% else %}
+                Team Settings:
+                {{ gradeable.isTeamAssignment() ? '' : ' This is an individual assignment' }}
+            {% endif %}
+            <div style="{{ action == 'edit' ? 'display:none' : '' }}">
+                <input type="radio" id = "team_yes_radio" name="team_assignment" value="true"
+                        {{ action != 'new' and gradeable.isTeamAssignment() ? 'checked' : '' }}> <label for="team_yes_radio">Yes</label>
+
+                <input type="radio" id = "team_no_radio" name="team_assignment" value ="false"
+                        {{ not (action != 'new' and gradeable.isTeamAssignment()) ? 'checked' :  '' }}> <label for="team_no_radio">No</label>
+            </div>
+        </div>
+
+        <!-- Team settings (read only in edit mode) -->
+        <div class="team_assignment team_yes" id="team_yes">
+
+            <label for="team_size_max">What is the maximum team size?</label>
+                <input style="width: 50px" name="team_size_max" id="team_size_max" class="int_val auto_save" type="text"
+                       value="{{ action != 'new' ? gradeable.getTeamSizeMax() : '3' }}"/>
+
+            {#Use teams from a previous gradeable:
+            <!-- Inherit teams from another gradeable? -->
             <br />
-            <input type="radio" id="yes_regrade_allowed" name="regrade_allowed" value="true" class="bool_val auto_save date-related"
-                    {{ action != 'new' and gradeable.isRegradeAllowed() ? 'checked' : '' }} /> Yes
-            <input type="radio" id="no_regrade_allowed" name="regrade_allowed" value="false" class="bool_val auto_save date-related"
-                    {{ not (action != 'new' and gradeable.isRegradeAllowed()) ? 'checked' : '' }} /> No
+
+                <!--Use a combo box if we can edit the value, otherwise show a text box (readonly)-->
+
+            {% if action == 'new' %}
+                <select id='gradeable_teams' name="eg_inherit_teams_from" style='width: 170px;'
+                    value='{{ admin_gradeable.getEgInheritTeamsFrom() }}'>
+                    <option value=''>--None--</option>
+
+                    {% for parent in inherit_teams_list %}
+                        <option {{ admin_gradeable.getEgInheritTeamsFrom() == parent.g_id ? 'selected' : '' }}
+                            value="{{ parent.g_id }}">{{ parent.g_title }}</option>
+                    {% endfor %}
+                </select>
+            {% else %}
+                <input id='gradeable_teams_read' name='gradeable_teams_read' style='width=170px'
+                    value='{{ admin_gradeable.getEgInheritTeamsFrom() }}' readonly/>
+            {% endif %}
+            #}
         </div>
-    {% endif %}
 
-    <div id="team-settings-container">
-        {% if action == 'new' or action == 'template' %}
-            Is this a team assignment?
-        {% else %}
-            Team Settings:
-            {{ gradeable.isTeamAssignment() ? '' : ' This is an individual assignment' }}
-        {% endif %}
-        <div style="{{ action == 'edit' ? 'display:none' : '' }}">
-            <input type="radio" id = "team_yes_radio" name="team_assignment" value="true"
-                    {{ action != 'new' and gradeable.isTeamAssignment() ? 'checked' : '' }}> <label for="team_yes_radio">Yes</label>
+        <div id="repository">
+            <h3>Path for the Version Control System (VCS) repository:</h3>
 
-            <input type="radio" id = "team_no_radio" name="team_assignment" value ="false"
-                    {{ not (action != 'new' and gradeable.isTeamAssignment()) ? 'checked' :  '' }}> <label for="team_no_radio">No</label>
+            VCS base URL (from Course Settings): <kbd>{{ vcs_base_url }}</kbd><br /><br />
+
+            <b>Specify the remainder of the VCS URL</b>, for example one of the following:<br />
+            <kbd>&#123;&#36;gradeable_id&#125;/&#123;&#36;user_id&#125;</kbd><br />
+            <kbd>&#123;&#36;gradeable_id&#125;/&#123;&#36;team_id&#125;</kbd><br />
+            <kbd>final_project/&#123;&#36;user_id&#125;</kbd><br />
+            <br />
+
+            <b>Or specify the complete url/path</b>, for example:<br />
+            <kbd>https://github.com/test-course/&#123;&#36;gradeable_id&#125;/&#123;&#36;repo_id&#125;</kbd>
+            <br /><br />
+
+            <b>Or if the entire URL will be provided by the student</b>, then leave this input blank.
+            <br /><br />
+
+            <em>Note: The following string variables will be replaced:</em><br />
+            <ul style="list-style-position: inside;">
+               <li><kbd>&#123;&#36;vcs_type&#125;</kbd></li>
+               <li><kbd>&#123;&#36;gradeable_id&#125;</kbd></li>
+               <li><kbd>&#123;&#36;user_id&#125;</kbd> OR <kbd>&#123;&#36;team_id&#125;</kbd> OR <kbd>&#123;&#36;repo_id&#125;</kbd> (use only one)</li>
+            </ul>
+            <br />
+
+            <input style='width: 83%' type='text' id="subdirectory" name='vcs_subdirectory' class="auto_save"
+                   value="{{ action != 'new' ? gradeable.getVcsSubdirectory() : '' }}" placeholder="(Optional)"/><br />
+            <br />
+
+            FULL VCS URL: <kbd id="vcs_url"></kbd>
         </div>
-    </div>
-
-    <!-- Team settings (read only in edit mode) -->
-    <div class="team_assignment team_yes" id="team_yes">
-
-        <label for="team_size_max">What is the maximum team size?</label>
-            <input style="width: 50px" name="team_size_max" id="team_size_max" class="int_val auto_save" type="text"
-                   value="{{ action != 'new' ? gradeable.getTeamSizeMax() : '3' }}"/>
-
-        {#Use teams from a previous gradeable:
-        <!-- Inherit teams from another gradeable? -->
-        <br />
-
-            <!--Use a combo box if we can edit the value, otherwise show a text box (readonly)-->
-
-        {% if action == 'new' %}
-            <select id='gradeable_teams' name="eg_inherit_teams_from" style='width: 170px;'
-                value='{{ admin_gradeable.getEgInheritTeamsFrom() }}'>
-                <option value=''>--None--</option>
-
-                {% for parent in inherit_teams_list %}
-                    <option {{ admin_gradeable.getEgInheritTeamsFrom() == parent.g_id ? 'selected' : '' }}
-                        value="{{ parent.g_id }}">{{ parent.g_title }}</option>
-                {% endfor %}
-            </select>
-        {% else %}
-            <input id='gradeable_teams_read' name='gradeable_teams_read' style='width=170px'
-                value='{{ admin_gradeable.getEgInheritTeamsFrom() }}' readonly/>
-        {% endif %}
-        #}
-    </div>
-
-    <div id="repository">
-        <h3>Path for the Version Control System (VCS) repository:</h3>
-
-        VCS base URL (from Course Settings): <kbd>{{ vcs_base_url }}</kbd><br /><br />
-
-        <b>Specify the remainder of the VCS URL</b>, for example one of the following:<br />
-        <kbd>&#123;&#36;gradeable_id&#125;/&#123;&#36;user_id&#125;</kbd><br />
-        <kbd>&#123;&#36;gradeable_id&#125;/&#123;&#36;team_id&#125;</kbd><br />
-        <kbd>final_project/&#123;&#36;user_id&#125;</kbd><br />
-        <br />
-
-        <b>Or specify the complete url/path</b>, for example:<br />
-        <kbd>https://github.com/test-course/&#123;&#36;gradeable_id&#125;/&#123;&#36;repo_id&#125;</kbd>
-        <br /><br />
-
-        <b>Or if the entire URL will be provided by the student</b>, then leave this input blank.
-        <br /><br />
-
-        <em>Note: The following string variables will be replaced:</em><br />
-        <ul style="list-style-position: inside;">
-           <li><kbd>&#123;&#36;vcs_type&#125;</kbd></li>
-           <li><kbd>&#123;&#36;gradeable_id&#125;</kbd></li>
-           <li><kbd>&#123;&#36;user_id&#125;</kbd> OR <kbd>&#123;&#36;team_id&#125;</kbd> OR <kbd>&#123;&#36;repo_id&#125;</kbd> (use only one)</li>
-        </ul>
-        <br />
-
-        <input style='width: 83%' type='text' id="subdirectory" name='vcs_subdirectory' class="auto_save"
-               value="{{ action != 'new' ? gradeable.getVcsSubdirectory() : '' }}" placeholder="(Optional)"/><br />
-        <br />
-
-        FULL VCS URL: <kbd id="vcs_url"></kbd>
-    </div>
+    </fieldset>
 </fieldset>
-
 <!-- Gradeable bucket (read/write in all modes) -->
 <label for="syllabus_bucket">What <a target=_blank href="http://submitty.org/instructor/rainbow_grades">syllabus category</a> does this item belong to?:</label>
 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -40,9 +40,12 @@ What is the <a target=_blank href="http://submitty.org/instructor/create_edit_gr
     {% endfor %}
 </select>
 <br />
-<a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section">How should graders be assigned</a> to grade this item?:
-<br />
+
 <fieldset>
+    <legend>
+        <a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section">How should graders be assigned</a> to grade this item?:
+        <br />
+    </legend>
     <input type="radio" name="grade_by_registration" value="true" id="registration_section"
         {{ (gradeable.isGradeByRegistration() == true or action == "new") ? 'checked' : '' }}> Registration Section
 


### PR DESCRIPTION
Partially addresses  #2896 -- will leave this issue open.

Before :-
![screenshot from 2019-02-28 01-37-31](https://user-images.githubusercontent.com/42701709/53519892-568fa400-3afa-11e9-88cb-45bdab436524.png)
![screenshot from 2019-02-28 01-43-43](https://user-images.githubusercontent.com/42701709/53519893-57283a80-3afa-11e9-90fa-a62308b567b9.png)

After :-
![screenshot from 2019-02-28 01-13-01](https://user-images.githubusercontent.com/42701709/53518702-999c4800-3af7-11e9-9295-5e5bb2bbebe4.png)

`Fieldset` is given to `radio` button which answer `"what is the type of gradeable "`. With legend as `"what is the type of gradeable "` .This changes are done in `AdminGradeableCreate.twig`  

![screenshot from 2019-02-28 01-23-40](https://user-images.githubusercontent.com/42701709/53518703-999c4800-3af7-11e9-8c31-8a3f929c0209.png)
Legend `"How should graders be assigned to grade this item?"`  is given to fieldset in `AdminGradeableGraders.twig`   