### PR TITLE
Customizable theme using layout tables

### DIFF
--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -42,20 +42,26 @@
 </html>
 
 {% macro query_list(queries) %}
+    {# This is a data table #}
     <table>
-        <tr>
-            <td class="query-list"></td>
-            <td></td>
-        </tr>
-        {% for query in queries %}
+        <caption />
+        <thead>
             <tr>
-                <td class="index">
-                    {{ loop.index }}&nbsp;&nbsp;
-                </td>
-                <td>
-                    <pre>{{ query }}</pre>
-                </td>
+                <th class="query-list">Index</th>
+                <th>Queries</th>
             </tr>
-        {% endfor %}
+        </thead>
+        <tbody>
+            {% for query in queries %}
+                <tr>
+                    <td class="index">
+                        {{ loop.index }}&nbsp;&nbsp;
+                    </td>
+                    <td>
+                        <pre>{{ query }}</pre>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
     </table>
 {% endmacro %}

--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -2,6 +2,7 @@
     <div class="row">
         <div class="box col-md-6">
             <h1>About You</h1>
+            {# This is layout table #}
             <table>
                 <tbody>
                 <tr>
@@ -27,6 +28,7 @@
             {% for ranks in statuses %}
                 {% if loop.index == 1 or ranks|length > 0 %}
                     <h2>Your {{ loop.index == 1 ? "" : "Archived " }}Courses</h2>
+                    {# This is also a layout table #}
                     <table class="courses-table">
                         <tbody>
                         {% for rank in ranks %}

--- a/site/app/templates/LateDaysTablePlugin.twig
+++ b/site/app/templates/LateDaysTablePlugin.twig
@@ -17,18 +17,20 @@
 <p>Total late days remaining for future assignments: {{ late_days.getLateDaysRemaining() }}</p>
 <br>
 <br>
+{# This table is a data table #}
 <table>
+    <caption />
     <thead>
-    <tr>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle;" align="left">Assignment name</th>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle">Due date</th>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle">Maximum number of late days allowed for this
-            assignment</th>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle">Assignment submitted # of days after deadline</th>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle">Student granted # of days extension for this assignment</th>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle">Status</th>
-        <th style="padding:5px; border:thin solid black; vertical-align:middle">Late days charged for this assignment</th>
-    </tr>
+        <tr>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle;" align="left">Assignment name</th>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle">Due date</th>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle">Maximum number of late days allowed for this
+                assignment</th>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle">Assignment submitted # of days after deadline</th>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle">Student granted # of days extension for this assignment</th>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle">Status</th>
+            <th style="padding:5px; border:thin solid black; vertical-align:middle">Late days charged for this assignment</th>
+        </tr>
     </thead>
     <tbody id="late_day_table">
     {% for late_day_info in late_days.getLateDayInfo() %}

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -2,27 +2,27 @@
     <h1>Grade Reports</h1>
     <table>
         <tbody>
-        <tr>
-            <td width="50%">
-                <p> Pushing this button will update the grade summary data used to generate the rainbow grades reports, for all students in the class.
-                </p>
-            </td>
-            <td width="5%"> </td>
-            <td width="45%" style="position:relative">
-                <button onclick="location.href='{{ core.buildUrl({'component': 'admin', 'page': 'reports', 'action': 'summary' }) }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
-            </td>
-        </tr>
-        <tr class="bar"></tr>
-        <tr class="bar"></tr>
-        <tr>
-            <td width="50%">
-                <p>Pushing this button will generate a CSV file, with all grades for all gradeables. </p>
-            </td>
-            <td width="5%"> </td>
-            <td width="45%" style="position:relative">
-                <button onclick="location.href='{{ core.buildUrl({'component': 'admin', 'page': 'reports', 'action': 'csv' }) }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
-            </td>
-        </tr>
-        <tbody>
+            <tr>
+                <td width="50%">
+                    <p> Pushing this button will update the grade summary data used to generate the rainbow grades reports, for all students in the class.
+                    </p>
+                </td>
+                <td width="5%"> </td>
+                <td width="45%" style="position:relative">
+                    <button onclick="location.href='{{ core.buildUrl({'component': 'admin', 'page': 'reports', 'action': 'summary' }) }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
+                </td>
+            </tr>
+            <tr class="bar"></tr>
+            <tr class="bar"></tr>
+            <tr>
+                <td width="50%">
+                    <p>Pushing this button will generate a CSV file, with all grades for all gradeables. </p>
+                </td>
+                <td width="5%"> </td>
+                <td width="45%" style="position:relative">
+                    <button onclick="location.href='{{ core.buildUrl({'component': 'admin', 'page': 'reports', 'action': 'csv' }) }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
+                </td>
+            </tr>
+            <tbody>
     </table>
 </div>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1758,3 +1758,9 @@ end of styles used in the admin gradeable page
     width: 100%;
     max-height: 300px;
 }
+/*Layout of tables*/
+
+th,td{
+    text-align: left;
+    padding: 10px;
+}


### PR DESCRIPTION
addresses a portion of #2936 
According to  this issue there are mainly two types of `Tables` :
   1) `Layout tables`
   2) `Data tables`
According to me data tables are present in following code :
   1) `site/app/templates/GlobalFooter.twig`
   2) `site/app/templates/LateDaysTablePlugin.twig`
And `Layout Tables` are as follows :- 
   1) `site/app/templates/HomePage.twig`
   2) `site/app/templates/admin/Report.twig`
Thead and caption is given to `site/app/templates/GlobalFooter.twig`.
