### PR TITLE
Added a 'save' button to the component

### DIFF
--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -523,16 +523,6 @@ tr.is_publish {
 .gradeable .component .content-block {
 }
 
-/* Save tools */
-
-.save-tools-cancel:hover {
-    background-color: #FCC;
-}
-
-.save-tools-save:hover {
-    background-color: #CFC;
-}
-
 .gradeable .ta-rubric-table,
 .gradeable .received-marks-list {
     padding: 8px 0px;

--- a/site/public/templates/grading/Gradeable.twig
+++ b/site/public/templates/grading/Gradeable.twig
@@ -23,15 +23,24 @@
     //    https://stackoverflow.com/questions/4945932/window-onbeforeunload-ajax-request-in-chrome
     //
     var __unloadRequestSent = false;
+    var __unloadRequestComplete = false;
     function unloadSave() {
         if (!__unloadRequestSent) {
-            __unloadRequestSent = true;
-            AJAX_USE_ASYNC = false;
-            closeAllComponents(true)
-                .catch(function () {
-                    // Unable to save so try saving at a different time
-                    __unloadRequestSent = false;
-                });
+            if (getOpenComponentIds().length > 0) {
+                __unloadRequestSent = true;
+                __unloadRequestComplete = false;
+                AJAX_USE_ASYNC = false;
+                closeAllComponents(true)
+                    .then(function() {
+                        __unloadRequestComplete = true;
+                    })
+                    .catch(function () {})
+                    .then(function () {
+                        // Unable to save so try saving at a different time
+                        __unloadRequestSent = false;
+                    });
+                return __unloadRequestComplete ? null : "Your changes may not be saved.  Close all open Components";
+            }
         }
     }
     // Will work for Chrome

--- a/site/public/templates/grading/Gradeable.twig
+++ b/site/public/templates/grading/Gradeable.twig
@@ -23,24 +23,15 @@
     //    https://stackoverflow.com/questions/4945932/window-onbeforeunload-ajax-request-in-chrome
     //
     var __unloadRequestSent = false;
-    var __unloadRequestComplete = false;
     function unloadSave() {
         if (!__unloadRequestSent) {
-            if (getOpenComponentIds().length > 0) {
-                __unloadRequestSent = true;
-                __unloadRequestComplete = false;
-                AJAX_USE_ASYNC = false;
-                closeAllComponents(true)
-                    .then(function() {
-                        __unloadRequestComplete = true;
-                    })
-                    .catch(function () {})
-                    .then(function () {
-                        // Unable to save so try saving at a different time
-                        __unloadRequestSent = false;
-                    });
-                return __unloadRequestComplete ? null : "Your changes may not be saved.  Close all open Components";
-            }
+            __unloadRequestSent = true;
+            AJAX_USE_ASYNC = false;
+            closeAllComponents(true)
+                .catch(function () {
+                    // Unable to save so try saving at a different time
+                    __unloadRequestSent = false;
+                });
         }
     }
     // Will work for Chrome

--- a/site/public/templates/grading/SavingTools.twig
+++ b/site/public/templates/grading/SavingTools.twig
@@ -8,8 +8,11 @@ Required Parameters:
 #}
 <span class="save-tools">
     {% if show_save_tools %}
-        <span class="save-tools-cancel" onclick="{{ cancel_on_click }} ;event.stopPropagation()">
-            <i class="fas fa-times cancel-button" aria-hidden="true">Cancel</i>
+        <span class="btn btn-default save-tools-cancel" onclick="{{ cancel_on_click }} ;event.stopPropagation()">
+            Cancel
+        </span>
+        <span class="btn btn-primary save-tools-save">
+            Save
         </span>
     {% endif %}
     <span class="save-tools-in-progress" hidden>


### PR DESCRIPTION
Closes #3308 

I'm able to reproduce the saving problem on FireFox, but only when closing the page (it saves fine when clicking another link on the page).  I added a "save" button  that just closes the component.  This appears in both edit and grade mode because the saving problem appears in both modes (in FF at least).  I restyled the 'save' and 'cancel' buttons to have the same style as all of the other buttons on the site to stay consistent.  It looks something like this:

![image](https://user-images.githubusercontent.com/3719964/53900551-c5915f00-400a-11e9-8dc5-d68187a120f8.png)

It looks like it is possible to stall the page exit long enough for the request to complete on all browsers by popping up the 'unsaved changes' alert, but this popup is very annoying when you don't need it and it isn't trivial to figure out if it is necessary.  It should be looked into, however.