### PR TITLE
Leave permissions on python package folder alone

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -553,14 +553,6 @@ pip3 install .
 chmod -R 555 /usr/local/lib/python*/*
 chmod 555 /usr/lib/python*/dist-packages
 
-#Set up pam if not in worker mode.
-if [ "${WORKER}" == 0 ]; then
-    sudo chmod 500   /usr/local/lib/python*/dist-packages/pam.py*
-    sudo chown ${CGI_USER} /usr/local/lib/python*/dist-packages/pam.py*
-fi
-sudo chmod o+r /usr/local/lib/python*/dist-packages/submitty_utils*.egg
-sudo chmod o+r /usr/local/lib/python*/dist-packages/easy-install.pth
-
 popd > /dev/null
 
 

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -549,10 +549,6 @@ echo -e "Install python_submitty_utils"
 pushd ${SUBMITTY_REPOSITORY}/python_submitty_utils
 pip3 install .
 
-# fix permissions
-chmod -R 555 /usr/local/lib/python*/*
-chmod 555 /usr/lib/python*/dist-packages
-
 popd > /dev/null
 
 

--- a/.setup/distro_setup/ubuntu/rpi.sh
+++ b/.setup/distro_setup/ubuntu/rpi.sh
@@ -174,13 +174,6 @@ pip3 install opencv-python
 pip3 install scipy
 
 ##################################################
-# Fixup the permissions
-chmod -R 555 /usr/local/lib/python*/*
-chmod 555 /usr/lib/python*/dist-packages
-sudo chmod 500   /usr/local/lib/python*/dist-packages/pam.py*
-sudo chown ${CGI_USER} /usr/local/lib/python*/dist-packages/pam.py*
-
-##################################################
 #install some pdflatex packages
 apt-get install -qqy texlive-latex-base texlive-extra-utils texlive-latex-recommended
 apt-get install -qqy texlive-generic-recommended

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -260,14 +260,6 @@ apt-get install libzbar0 --yes
 pip3 install pyzbar
 pip3 install pdf2image
 
-sudo chmod -R 555 /usr/local/lib/python*/*
-sudo chmod 555 /usr/lib/python*/dist-packages
-sudo chmod 500 /usr/local/lib/python*/dist-packages/pam.py*
-
-if [ ${WORKER} == 0 ]; then
-    sudo chown ${CGI_USER} /usr/local/lib/python*/dist-packages/pam.py*
-fi
-
 #################################################################
 # JAR SETUP
 #################

--- a/migration/migrations/system/20180619110916_lichen_package_installation.py
+++ b/migration/migrations/system/20180619110916_lichen_package_installation.py
@@ -15,13 +15,6 @@ def up(config):
     # python tokenzier
     os.system("sudo pip3 install parso")
 
-    # permissions on pip
-    os.system("sudo chmod -R 555 /usr/local/lib/python*/*")
-    os.system("sudo chmod 555 /usr/lib/python*/dist-packages")
-    os.system("sudo chmod 500 /usr/local/lib/python*/dist-packages/pam.py*")
-
-    pass
-
 
 def down(config):
     pass

--- a/migration/migrations/system/20181028021533_qr_codes.py
+++ b/migration/migrations/system/20181028021533_qr_codes.py
@@ -1,16 +1,12 @@
 import os
-import subprocess
 
 
 def up(config):
     os.system("apt-get install libzbar0 --yes")
-    
+
     os.system("pip3 install pyzbar")
     os.system("pip3 install pdf2image")
 
-    os.system("sudo chmod -R 555 /usr/local/lib/python*/*")
-    os.system("sudo chmod 555 /usr/lib/python*/dist-packages")
-    os.system("sudo chmod 500 /usr/local/lib/python*/dist-packages/pam.py*")
 
 def down(config):
     pass

--- a/migration/migrations/system/20190306102812_python_permissions.py
+++ b/migration/migrations/system/20190306102812_python_permissions.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import subprocess
+
+
+def up(config):
+    for path in Path('/usr/local/lib').glob('python*'):
+        subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'd', '-exec', 'chmod', '755', '{}', '+'])
+        subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'f', '-name', '*.py*', '-exec', 'chmod', '644', '{}', '+'])
+        subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'f', '-name', '*.so', '-exec', 'chmod', '755', '{}', '+'])
+        if Path(path, 'dist-packages', 'pam.py').exists():
+            subprocess.call(['chown', 'root:staff', Path(path, 'dist-packages', 'pam.py')])

--- a/migration/migrations/system/20190306102812_python_permissions.py
+++ b/migration/migrations/system/20190306102812_python_permissions.py
@@ -5,7 +5,7 @@ import subprocess
 def up(config):
     for path in Path('/usr/local/lib').glob('python*'):
         subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'd', '-exec', 'chmod', '755', '{}', '+'])
+        subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'f', '-exec', 'chmod', '755', '{}', '+'])
         subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'f', '-name', '*.py*', '-exec', 'chmod', '644', '{}', '+'])
-        subprocess.call(['find', Path(path, 'dist-packages'), '-type', 'f', '-name', '*.so', '-exec', 'chmod', '755', '{}', '+'])
         if Path(path, 'dist-packages', 'pam.py').exists():
             subprocess.call(['chown', 'root:staff', Path(path, 'dist-packages', 'pam.py')])


### PR DESCRIPTION
Submitty sets the permissions on the global Python module installation directory. While this might have been necessary at one point, it's no longer and we should leave the permissions set to the normal default.

This PR contains a migration to reset the permissions on the folder back to what they are on a normal system and then removes any trace of Submitty changing the permissions on those folders.