### PR TITLE
Error Handling on Login Page

### DIFF
--- a/site/app/authentication/PamAuthentication.php
+++ b/site/app/authentication/PamAuthentication.php
@@ -18,7 +18,7 @@ use app\libraries\FileUtils;
  */
 class PamAuthentication extends AbstractAuthentication {
     public function authenticate() {
-        if ($this->user_id === null || $this->password === null ||
+        if ( strlen($this->user_id) === 0 || strlen($this->password) === 0 ||
             $this->core->getQueries()->getSubmittyUser($this->user_id) === null) {
             return false;
         }

--- a/site/app/authentication/PamAuthentication.php
+++ b/site/app/authentication/PamAuthentication.php
@@ -18,7 +18,8 @@ use app\libraries\FileUtils;
  */
 class PamAuthentication extends AbstractAuthentication {
     public function authenticate() {
-        if ( strlen($this->user_id) === 0 || strlen($this->password) === 0 ||
+        // Check for $this->user_id and $this->>password to be non empty
+        if ( empty($this->user_id)  || empty($this->password) ||
             $this->core->getQueries()->getSubmittyUser($this->user_id) === null) {
             return false;
         }

--- a/site/app/templates/Authentication.twig
+++ b/site/app/templates/Authentication.twig
@@ -11,8 +11,8 @@
             {% for key, value in old %}
                 <input type='hidden' name='old_{{ key }}' value='{{ value }}' />
             {% endfor %}
-            <input type="text" name="user_id" placeholder="User ID" autofocus/><br />
-            <input type="password" name="password" placeholder="Password" /><br />
+            <input type="text" name="user_id" placeholder="User ID" required autofocus/><br />
+            <input type="password" name="password" placeholder="Password" required /><br />
             <label for="stay_logged_in">Stay Logged In</label> <input type="checkbox" name="stay_logged_in" id="stay_logged_in" checked /><br />
             <input type="submit" name="login" value="Login" class="btn btn-primary" />
         </form>

--- a/site/cgi-bin/pam_check.cgi
+++ b/site/cgi-bin/pam_check.cgi
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 
 """
-Given a filaname, try to open that file, which should contain a JSON object
-containing a username and password, then test that against PAM printing out
-a JSON object that is authenticated and is true or false
+This script is called via POST passing in a username and password which is
+then checked against the system PAM. Depending on how PAM is configured,
+you will need to give submitty_cgi user any additional permissions it needs
+to access files (e.g. if using default setup, submitty_cgi needs to be in
+shadow group to access /etc/shadow). The script returns with a JSON object
+contained a singular key "authenticated" which is either True or False depending
+on if:
+- Username and Password were present in the POST payload
+- PAM returns true for the authentication request
 """
 import cgi
 # If things are not working, then this should be enabled for better troubleshooting
@@ -15,5 +21,8 @@ print("Content-type: text/html")
 print()
 
 arguments = cgi.FieldStorage(environ={'REQUEST_METHOD':'POST'})
-p = pam.pam()
-print(json.dumps({"authenticated": p.authenticate(arguments['username'].value, arguments['password'].value)}))
+authenticated = False
+if 'username' in arguments and 'password' in arguments:
+    p = pam.pam()
+    authenticated = p.authenticate(arguments['username'].value, arguments['password'].value)
+print(json.dumps({"authenticated": authenticated}))

--- a/site/tests/app/authentication/PamAuthenticationTester.php
+++ b/site/tests/app/authentication/PamAuthenticationTester.php
@@ -63,11 +63,28 @@ class PamAuthenticationTester extends BaseUnitTest {
         $this->assertFalse($pam->authenticate());
     }
 
+    public function testEmptyUserId() {
+        $core = $this->createMock(Core::class);
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('');
+        $this->assertFalse($pam->authenticate());
+    }
+
     public function testNoPassword() {
         $core = $this->createMock(Core::class);
         /** @noinspection PhpParamsInspection */
         $pam = new PamAuthentication($core);
         $pam->setUserId('test');
+        $this->assertFalse($pam->authenticate());
+    }
+
+    public function testEmptyPassword() {
+        $core = $this->createMock(Core::class);
+        /** @noinspection PhpParamsInspection */
+        $pam = new PamAuthentication($core);
+        $pam->setUserId('test');
+        $pam->setPassword('');
         $this->assertFalse($pam->authenticate());
     }
 


### PR DESCRIPTION
Fixes #3353 

Fatal error is given when password  is empty provided USER_ID is not empty and points at a real user id. This problem can be easily solved by providing required attribute to both of `Password` and `User_id` and ensuring that they're filled in and non-blank on the front-end as well as make sure backend handles the case where the fields could be blank, returning a failed authentication attempt instead of throwing an error.