### PR TITLE
Option for Clearing All Rotating Section Assignments

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -291,12 +291,18 @@ class UsersController extends AbstractController {
         }
 
         if (!isset($_REQUEST['sort_type'])) {
-            $this->core->addErrorMessage("Must select one of the three options for setting up rotating sections");
+            $this->core->addErrorMessage("Must select one of the four options for setting up rotating sections");
             $this->core->redirect($return_url);
         }
         else if ($_REQUEST['sort_type'] === "drop_null") {
             $this->core->getQueries()->setNonRegisteredUsersRotatingSectionNull();
             $this->core->addSuccessMessage("Non registered students removed from rotating sections");
+            $this->core->redirect($return_url);
+        }
+        else if ($_REQUEST['sort_type'] === "drop_all") {
+            $this->core->getQueries()->setAllUsersRotatingSectionNull();
+            $this->core->getQueries()->setAllTeamsRotatingSectionNull();
+            $this->core->addSuccessMessage("All students removed from rotating sections");
             $this->core->redirect($return_url);
         }
 

--- a/site/app/templates/admin/users/RotatingSectionsForm.twig
+++ b/site/app/templates/admin/users/RotatingSectionsForm.twig
@@ -16,7 +16,7 @@
                 $("[name='sections']").val({{ max_section }}).addClass('disabled').attr('readonly', 'readonly');
                 $("[name='rotating_type']").val("random").addClass('disabled').attr('disabled', 'true');
             }
-            else if (val == "drop_null") {
+            else if (val == "drop_null" || val == "drop_all") {
                 $("[name='sections']").addClass('disabled').attr('readonly', 'readonly');
                 $("[name='rotating_type']").addClass('disabled').attr('disabled', 'true');
             }
@@ -174,6 +174,9 @@
 					<label>
 						<input type="radio" style="margin-top: -2px" name="sort_type" value="fewest" /> Remove unregistered students (registration section=NULL) from rotating sections and put newly registered students into rotating section with fewest members
 					</label><br /><br />
+                    <label>
+                        <input type="radio" style="margin-top: -2px" name="sort_type" value="drop_all" /> Remove all students from rotating sections
+                    </label><br /><br />
 					<label>
 						<input type="radio" style="margin-top: -2px" name="sort_type" value="redo" /> Redo rotating sections completely
 					</label><br />


### PR DESCRIPTION
Closes #2366 

This pull request adds another option for clearing all rotating section assignments, in other words, this option makes all the assigned rotating sections of students/teams NULL.

![remove_all](https://user-images.githubusercontent.com/20266703/54070692-fc889000-4217-11e9-840b-4f4618fb64a6.png)
