### PR TITLE
[Bugfix] http for git push

### DIFF
--- a/bin/generate_repos.py
+++ b/bin/generate_repos.py
@@ -35,6 +35,7 @@ def create_folder(folder):
         os.makedirs(folder, mode=0o770)
         os.chdir(folder)
         os.system('git init --bare --shared')
+        os.system('git config --file config http.receivepack true')
         for root, dirs, files in os.walk(folder):
             for entry in files + dirs:
                 shutil.chown(os.path.join(root, entry), group=DAEMONCGI_GROUP)


### PR DESCRIPTION
Don't know how things were working before.
This allows users to write to a git repo over http.

To patch existing repos, go to /var/local/submitty/vcs/git/<SEMESTER>/ and run:

for i in */*/*; do echo $i; pushd $i; git config --file config http.receivepack true; popd; done