### PR TITLE
Filter for unread threads/posts

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -39,6 +39,17 @@
 			</button>
 		</form>
 	{% endif %}
+		<label>Unread Only <input type="checkbox" id="unreadToggle" checked></label>
 
 </div>
+<script>
+	$('#unreadToggle').on('change',function () {
+		if($(this).prop("checked")==true){
+			$('.viewed').css({"display":"none"});
+		}
+		else{
+			$('.viewed').css({"display":"block"});
+		}
+	})
+</script>
 <hr/>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -721,6 +721,7 @@ table tr.table-header {
 
 .viewed {
     color: #888888;
+    display: none;
 }
 
 .box-title > h4 {


### PR DESCRIPTION
Fixes #3011 
### Before :- 
Read thread have a color code `#888888` and `visited` class 
![Screenshot from 2019-03-09 23-40-16](https://user-images.githubusercontent.com/42701709/54075388-c523ed00-42c4-11e9-95e8-046067cc9ff0.png)

### After:-
I used visited class  and created a checkbox which change css of visited class.
    1. When checkbox is checked `display :none` is given to visited class
    2. Else `display:block` is given to visited class
Checkbox is initially checked because as user when you enter discussion forum you should firstly check those thread which are new to the community.
![Screenshot from 2019-03-09 23-24-24](https://user-images.githubusercontent.com/42701709/54075276-7164d400-42c3-11e9-91f4-1595c0958e00.png)
![Screenshot from 2019-03-09 23-24-37](https://user-images.githubusercontent.com/42701709/54075277-7164d400-42c3-11e9-8d98-a1e0430b0194.png)
