### PR TITLE
Misleading fact on "vagrant ssh" 

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -100,7 +100,7 @@ ${DISTRO_LINE}
 ##    ${SUBMISSION_URL}/git (git)                     ##
 ##                                                        ##
 ##  The database can be accessed on the host machine at   ##
-##   localhost:15432                                      ##
+##   localhost:16432                                      ##
 ##                                                        ##
 ##  Happy developing!                                     ##
 ############################################################


### PR DESCRIPTION
Fixes #3366 

Changed `15432` to `16432` in `.setup/distro_setup/setup_distro.sh` in line no `103`

`15432` was misleading user that database is hosted on `15432` but actually it was hosted on `16432`
