### PR TITLE
Fixed position of edit name button

### DIFF
--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -1,7 +1,7 @@
 <div class="content">
     <div class="row">
         <div class="box col-md-6">
-            <h1>About You</h1>
+            <h1>About You <a onclick="userNameChange()" class="edit-name-button"><i class="fas fa-pencil-alt" aria-hidden="true"></i></a> </h1>
             <table>
                 <tbody>
                 <tr>
@@ -9,7 +9,6 @@
                 </tr>
                 <tr>
                     <td><b>First Name:</b> {{ user.getDisplayedFirstName() }} </td>
-                    <td><a onclick="userNameChange()"><i class="fas fa-pencil-alt" aria-hidden="true"></i></a></td>
                 </tr>
                 <tr>
                     <td><b>Last Name:</b> {{ user.getDisplayedLastName() }} </td>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1229,6 +1229,13 @@ table .instructor .two-options{
     padding-bottom: 10px;
 }
 
+.edit-name-button {
+    margin-left: 10px;
+    font-size: 16px;
+    vertical-align: middle;
+    color: #333;
+}
+
 .td-open {
     width: 10%;
 }


### PR DESCRIPTION
The button to edit the name in the homepage is positioned such that it indicates only that the First name can be edited.
![Screenshot_2019-03-10 Submitty](https://user-images.githubusercontent.com/25076171/54087199-9d8d5d00-4376-11e9-9687-6c0887161839.png)

This PR fixes this visual problem by moving the edit button beside the *About You* heading. Indicating that the edit will affect subsequent entries.

![Screenshot_2019-03-10 Submitty(2)](https://user-images.githubusercontent.com/25076171/54087242-d9c0bd80-4376-11e9-9dba-59a3d01e61e6.png)
