### PR TITLE
Tag people in post/reply

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3798,4 +3798,15 @@ AND gc_id IN (
               created)
             VALUES(?, ?, ?, NOW())", $parameters);
     }
+
+    /**
+     * Get userid by giving userfirsrname and usergroup
+     * @param number $user_group
+     * @param string $user_firstname
+     */
+    public function getUserIdByUsername($user_firstname,$user_group){
+        $this->course_db->query('SELECT user_id FROM users WHERE user_group <= ? AND user_firstname = ?',[$user_group,$user_firstname]);
+
+        return $this->course_db->rows();
+    }
 }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -196,6 +196,10 @@ HTML;
 		}
 
 			$( document ).ready(function() {
+			    $('.post_content').each(function(){
+                    var pdata = $(this);
+                    pdata.html( pdata.text().replace(/(@\w+)/g,'<strong>$1</strong>') );
+                });
 			    enableTabsInTextArea('.post_content_reply');
 				saveScrollLocationOnRefresh('posts_list');
 				addCollapsable();


### PR DESCRIPTION
Fixes #2322
### Feature 
Tag instructors, mentors and TAs in post\reply. Notification is sent when any of them is tagged.
![Screenshot from 2019-03-12 02-42-17](https://user-images.githubusercontent.com/42701709/54158974-d52cff80-4471-11e9-8ef2-b0dc10eb5167.png)
### Procedure
Simply write @name_of_people and tagged people are bolded on submit
![Screenshot from 2019-03-12 03-14-37](https://user-images.githubusercontent.com/42701709/54160243-0b1fb300-4475-11e9-9648-2b4d88e71554.png)
### Working
`taggedPeople` runs when the post is submitted to server and it convert text into array of `name_of_people` then this array is parsed when `publishPost` is excecuted .This array insert value into `notification` table with `to_user_id` equal to `name_of_people`
![Screenshot from 2019-03-12 03-20-41](https://user-images.githubusercontent.com/42701709/54160556-e37d1a80-4475-11e9-8993-9277c52783e3.png)
 
