### PR TITLE
Handle null in count() function

### DIFF
--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -326,8 +326,8 @@ HTML;
         $provided_code_filename="";
         $threshold="5";
         $sequence_length="10";
-        $prior_term_gradeables_number = count($saved_config['prev_term_gradeables'])+1;
-        $ignore_submission_number = count($saved_config['ignore_submissions'])+1;
+        $prior_term_gradeables_number = $saved_config['prev_term_gradeables'] ? count($saved_config['prev_term_gradeables'])+1 : 1;
+        $ignore_submission_number = $saved_config['ignore_submissions'] ? count($saved_config['ignore_submissions'])+1 : 1;
         $ignore="";
         $no_ignore="checked";
 


### PR DESCRIPTION
There are two warnings in the Plagiarism Detection mainpage.

They appear because [PHP 7.2 changes its behavior](https://wiki.php.net/rfc/counting_non_countables) when evaluating `count(null)`. Although this change is backward compatible, to avoid possible future bugs resulted from `count(null)`, I added a default value for null.

```

( ! ) Warning: count(): Parameter must be an array or an object that implements Countable in /usr/local/submitty/site/app/views/admin/PlagiarismView.php on line 329
--


1 | 0.0013 | 455432 | {main}( ) | .../index.php:0
2 | 0.1720 | 3342520 | app\controllers\AdminController->run( ) | .../index.php:238
3 | 0.1744 | 3683264 | app\controllers\admin\PlagiarismController->run( ) | .../AdminController.php:58
4 | 0.1745 | 3683680 | app\controllers\admin\PlagiarismController->configureNewGradeableForPlagiarismForm( ) | .../PlagiarismController.php:15
5 | 0.1765 | 3699760 | app\libraries\Output->renderOutput( ) | .../PlagiarismController.php:167
6 | 0.1765 | 3700136 | call_user_func_array:{/usr/local/submitty/site/app/libraries/Output.php:111} ( ) | .../Output.php:111
7 | 0.1765 | 3700232 | app\libraries\Output->renderTemplate( ) | .../Output.php:111
8 | 0.1773 | 3776048 | call_user_func_array:{/usr/local/submitty/site/app/libraries/Output.php:146} ( ) | .../Output.php:146
9 | 0.1773 | 3776112 | app\views\admin\PlagiarismView->configureGradeableForPlagiarismForm( ) | .../Output.php:146
10 | 0.1774 | 3776368 | count ( ) | .../PlagiarismView.php:329



( ! ) Warning: count(): Parameter must be an array or an object that implements Countable in /usr/local/submitty/site/app/views/admin/PlagiarismView.php on line 330
--


1 | 0.0013 | 455432 | {main}( ) | .../index.php:0
2 | 0.1720 | 3342520 | app\controllers\AdminController->run( ) | .../index.php:238
3 | 0.1744 | 3683264 | app\controllers\admin\PlagiarismController->run( ) | .../AdminController.php:58
4 | 0.1745 | 3683680 | app\controllers\admin\PlagiarismController->configureNewGradeableForPlagiarismForm( ) | .../PlagiarismController.php:15
5 | 0.1765 | 3699760 | app\libraries\Output->renderOutput( ) | .../PlagiarismController.php:167
6 | 0.1765 | 3700136 | call_user_func_array:{/usr/local/submitty/site/app/libraries/Output.php:111} ( ) | .../Output.php:111
7 | 0.1765 | 3700232 | app\libraries\Output->renderTemplate( ) | .../Output.php:111
8 | 0.1773 | 3776048 | call_user_func_array:{/usr/local/submitty/site/app/libraries/Output.php:146} ( ) | .../Output.php:146
9 | 0.1773 | 3776112 | app\views\admin\PlagiarismView->configureGradeableForPlagiarismForm( ) | .../Output.php:146
10 | 0.1775 | 3776480 | count ( ) | .../PlagiarismView.php:330
```