### PR TITLE
Add stoplight legends to grade details page

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -27,24 +27,28 @@
     {# /Import+Export teams buttons #}
 
     <br />
-    <div id="legend">
-        <div>
+    <ul id="details-legend" class="table-bordered">
+        <li>
             <i class="fas fa-circle grader-NULL"></i>
-            <p>ungraded component</p>
-        </div>
-        <div>
+            <p>Ungraded component</p>
+        </li>
+        <li>
             <i class="fas fa-circle grader-3"></i>
-            <p>component graded by a limited access grader</p>
-        </div>
-        <div>
+            <p>Component graded by a limited access grader</p>
+        </li>
+        <li>
             <i class="fas fa-circle grader-1"></i>
-            <p>component graded by a full access grader or instructor</p>
-        </div>
-        <div>
+            <p>Component graded by a full access grader or instructor</p>
+        </li>
+        <li>
+            <i class="fas fa-circle grader-4"></i>
+            <p>Component grade verified</p>
+        </li>
+        <li>
             <i class="fas fa-circle grader-double"></i>
-            <p>component grade verified or double-graded by a full access grader or instructor</p>
-        </div>
-    </div>
+            <p>Component double-graded by a full access grader or instructor</p>
+        </li>
+    </ul>
     <br />
     <br />
     <table class="table table-striped table-bordered persist-area">

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -27,6 +27,24 @@
     {# /Import+Export teams buttons #}
 
     <br />
+    <div id="legend">
+        <div>
+            <i class="fas fa-circle grader-NULL"></i>
+            <p>ungraded component</p>
+        </div>
+        <div>
+            <i class="fas fa-circle grader-3"></i>
+            <p>component graded by a limited access grader</p>
+        </div>
+        <div>
+            <i class="fas fa-circle grader-1"></i>
+            <p>component graded by a full access grader or instructor</p>
+        </div>
+        <div>
+            <i class="fas fa-circle grader-double"></i>
+            <p>component grade verified or double-graded by a full access grader or instructor</p>
+        </div>
+    </div>
     <br />
     <br />
     <table class="table table-striped table-bordered persist-area">

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -6,17 +6,41 @@
         Limited grader does not have "View All" option
         If nothing to grade, Instructor will see all sections
     #}
-    {% if show_all_sections_button %}
-        <div style="float: right; margin-bottom: 10px">
-            <a class="btn btn-default"
-               href="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action': 'details', 'gradeable_id': gradeable.getId(), 'view': view_all ? null : "all"}) }}">
-                {{ view_all ? "View Your Sections" : "View All" }}
-            </a>
-        </div>
-    {% endif %}
-    <div class="headings-details">
+    <div class="row" style="justify-content: space-between;margin-bottom: 5px">
     <h1>Grade Details for {{ gradeable.getTitle() }}</h1>
-
+        <div style="display: flex;flex-wrap: wrap;">
+            <ul style="justify-self: flex-end" id="details-legend" class="table-bordered">
+                <li>
+                    <i class="fas fa-circle grader-NULL"></i>
+                    Ungraded component
+                </li>
+                <li>
+                    <i class="fas fa-circle grader-3"></i>
+                    Component graded by a limited access grader
+                </li>
+                <li>
+                    <i class="fas fa-circle grader-1"></i>
+                    Component graded by a full access grader
+                </li>
+                <li>
+                    <i class="fas fa-circle grader-verified"></i>
+                    Limited access grader verified
+                </li>
+                <li>
+                    <i class="fas fa-circle grader-double"></i>
+                    Component double-graded by a full access grader or instructor
+                </li>
+            </ul>
+            {% if show_all_sections_button %}
+                <div style="justify-self: flex-end;flex-wrap: wrap;margin-left: 5px">
+                    <a class="btn btn-default"
+                       href="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action': 'details', 'gradeable_id': gradeable.getId(), 'view': view_all ? null : "all"}) }}">
+                        {{ view_all ? "View Your Sections" : "View All" }}
+                    </a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
     {# Import+Export teams buttons #}
     {% if show_import_teams_button %}
         <a style="float: right;" class="btn btn-primary" href="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action': 'export_teams', 'gradeable_id': gradeable.getId()}) }}">Export Teams Members</a>
@@ -25,29 +49,6 @@
         <button style="float: right;" class="btn btn-primary" onclick="importTeamForm();">Import Teams Members</button>
     {% endif %}
     {# /Import+Export teams buttons #}
-    <ul id="details-legend" class="table-bordered">
-        <li>
-            <i class="fas fa-circle grader-NULL"></i>
-            Ungraded component
-        </li>
-        <li>
-            <i class="fas fa-circle grader-3"></i>
-            Component graded by a limited access grader
-        </li>
-        <li>
-            <i class="fas fa-circle grader-1"></i>
-            Component graded by a full access grader
-        </li>
-        <li>
-            <i class="fas fa-circle grader-verified"></i>
-            Limited access grader verified
-        </li>
-        <li>
-            <i class="fas fa-circle grader-double"></i>
-            Component double-graded by a full access grader or instructor
-        </li>
-    </ul>
-    </div>
     <br />
     <br />
     <table class="table table-striped table-bordered persist-area">

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -30,23 +30,23 @@
     <ul id="details-legend" class="table-bordered">
         <li>
             <i class="fas fa-circle grader-NULL"></i>
-            <p>Ungraded component</p>
+            Ungraded component
         </li>
         <li>
             <i class="fas fa-circle grader-3"></i>
-            <p>Component graded by a limited access grader</p>
+            Component graded by a limited access grader
         </li>
         <li>
             <i class="fas fa-circle grader-1"></i>
-            <p>Component graded by a full access grader or instructor</p>
+            Component graded by a full access grader
         </li>
         <li>
             <i class="fas fa-circle grader-verified"></i>
-            <p>Component grade verified</p>
+            Limited access grader verified
         </li>
         <li>
             <i class="fas fa-circle grader-double"></i>
-            <p>Component double-graded by a full access grader or instructor</p>
+            Component double-graded by a full access grader or instructor
         </li>
     </ul>
     <br />

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -14,7 +14,7 @@
             </a>
         </div>
     {% endif %}
-
+    <div class="headings-details">
     <h1>Grade Details for {{ gradeable.getTitle() }}</h1>
 
     {# Import+Export teams buttons #}
@@ -25,8 +25,6 @@
         <button style="float: right;" class="btn btn-primary" onclick="importTeamForm();">Import Teams Members</button>
     {% endif %}
     {# /Import+Export teams buttons #}
-
-    <br />
     <ul id="details-legend" class="table-bordered">
         <li>
             <i class="fas fa-circle grader-NULL"></i>
@@ -49,6 +47,7 @@
             Component double-graded by a full access grader or instructor
         </li>
     </ul>
+    </div>
     <br />
     <br />
     <table class="table table-striped table-bordered persist-area">

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -41,7 +41,7 @@
             <p>Component graded by a full access grader or instructor</p>
         </li>
         <li>
-            <i class="fas fa-circle grader-4"></i>
+            <i class="fas fa-circle grader-verified"></i>
             <p>Component grade verified</p>
         </li>
         <li>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1758,17 +1758,7 @@ end of styles used in the admin gradeable page
     width: 100%;
     max-height: 300px;
 }
-
-#details-legend{
-    list-style: none;
-    width: 100%;
-    padding-left: 15px;
-
-}
 #details-legend > li{
-    align-items: center;
-    display: flex;
+    list-style: none;
+    padding-left: 15px;
 }
- #details-legend > li > .fas{
-     padding-right: 5px;
- }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1764,7 +1764,3 @@ end of styles used in the admin gradeable page
     font-size: 0.75em;
 }
 
-.headings-details{
-    display: flex;
-    justify-content: space-between;
-}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1762,14 +1762,13 @@ end of styles used in the admin gradeable page
 #details-legend{
     list-style: none;
     width: 100%;
-    padding-left: 10px;
+    padding-left: 15px;
 
 }
 #details-legend > li{
     align-items: center;
     display: flex;
-    margin:4px;
 }
- #details-legend > li > p{
-     padding-left: 5px;
+ #details-legend > li > .fas{
+     padding-right: 5px;
  }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1761,4 +1761,10 @@ end of styles used in the admin gradeable page
 #details-legend > li{
     list-style: none;
     padding-left: 15px;
+    font-size: 0.75em;
+}
+
+.headings-details{
+    display: flex;
+    justify-content: space-between;
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1759,19 +1759,17 @@ end of styles used in the admin gradeable page
     max-height: 300px;
 }
 
-#legend{
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
+#details-legend{
+    list-style: none;
     width: 100%;
-    border: 1px solid #AAAAAA;
-    border-radius: 4px;
+    padding-left: 10px;
+
 }
-#legend>div{
+#details-legend > li{
     align-items: center;
     display: flex;
-    margin:4px 4px 4px 10px;
+    margin:4px;
 }
-#legend>div>p{
-    padding-left: 5px;
-}
+ #details-legend > li > p{
+     padding-left: 5px;
+ }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1758,3 +1758,20 @@ end of styles used in the admin gradeable page
     width: 100%;
     max-height: 300px;
 }
+
+#legend{
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: 100%;
+    border: 1px solid #AAAAAA;
+    border-radius: 4px;
+}
+#legend>div{
+    align-items: center;
+    display: flex;
+    margin:4px 4px 4px 10px;
+}
+#legend>div>p{
+    padding-left: 5px;
+}


### PR DESCRIPTION
Fixes #2690 
![Screenshot from 2019-03-12 16-09-02](https://user-images.githubusercontent.com/42701709/54194034-540d5100-44e1-11e9-92df-d18577d18344.png)
Legend are added to `site/app/templates/grading/electronic/Details.twig`