### PR TITLE
Fixed sidebar icon positions

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1072,7 +1072,7 @@ table .instructor .two-options{
 
 #nav-buttons ul li .nav-row {
     padding: 6px;
-    padding-left: 36px;
+    padding-left: 48px;
     width: 100%;
     display: block;
 }
@@ -1082,7 +1082,7 @@ table .instructor .two-options{
 }
 
 #sidebar.collapsed #nav-buttons ul li .nav-row .fa{
-    padding: 2px 17.5px;
+    padding: 2px 0px;
 }
 
 


### PR DESCRIPTION
The sidebar icons move to the side when the sidebar is opened. Ideally they should remain at the same place. This PR fixes this issue.

It has been tested on both latest versions of Firefox and Chrome.

Before:
![Peek 2019-03-12 21-47](https://user-images.githubusercontent.com/25076171/54216992-c6e1f080-4510-11e9-9146-f8aef5f18de6.gif)

After:
![Peek 2019-03-12 21-48](https://user-images.githubusercontent.com/25076171/54217008-cfd2c200-4510-11e9-9ab8-e3244dd5bbc9.gif)
