### PR TITLE
[Bugfix] Display bulk uploaded pdf pages in order

### DIFF
--- a/site/cgi-bin/pdf_check.cgi
+++ b/site/cgi-bin/pdf_check.cgi
@@ -108,13 +108,15 @@ try:
         total_pages = pdfReader.numPages
 
         div = total_pages // num
+        div_length = len(str(div))
         
         i = 0
         while i < total_pages:
             cover_writer = PdfFileWriter()
-            cover_writer.addPage(pdfReader.getPage(i)) 
-            cover_filename = '{}_{}_cover.pdf'.format(filename[:-4], i)
-            output_filename = '{}_{}.pdf'.format(filename[:-4], i)
+            cover_writer.addPage(pdfReader.getPage(i))
+            prepended_index = str(i).zfill(div_length)
+            cover_filename = '{}_{}_cover.pdf'.format(filename[:-4], prepended_index)
+            output_filename = '{}_{}.pdf'.format(filename[:-4], prepended_index)
             pdf_writer = PdfFileWriter()
             start = i
             for j in range(start, start+num):

--- a/site/cgi-bin/pdf_check.cgi
+++ b/site/cgi-bin/pdf_check.cgi
@@ -108,13 +108,13 @@ try:
         total_pages = pdfReader.numPages
 
         div = total_pages // num
-        div_length = len(str(div-1))
+        max_length = len(str(total_pages - num))
         
         i = 0
         while i < total_pages:
             cover_writer = PdfFileWriter()
             cover_writer.addPage(pdfReader.getPage(i))
-            prepended_index = str(i).zfill(div_length)
+            prepended_index = str(i).zfill(max_length)
             cover_filename = '{}_{}_cover.pdf'.format(filename[:-4], prepended_index)
             output_filename = '{}_{}.pdf'.format(filename[:-4], prepended_index)
             pdf_writer = PdfFileWriter()

--- a/site/cgi-bin/pdf_check.cgi
+++ b/site/cgi-bin/pdf_check.cgi
@@ -108,7 +108,7 @@ try:
         total_pages = pdfReader.numPages
 
         div = total_pages // num
-        div_length = len(str(div))
+        div_length = len(str(div-1))
         
         i = 0
         while i < total_pages:


### PR DESCRIPTION
Closes #2417 

This change makes bulk uploaded pdf page numbers displayed in order.

Before:
<pdf_name>_0.pdf
<pdf_name>_100.pdf
<pdf_name>_101.pdf

After:
<pdf_name>_000.pdf
<pdf_name>_001.pdf
<pdf_name>_002.pdf