### PR TITLE
[Bugfix] Explicitly set the Vagrant MotD file permissions

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -112,5 +112,5 @@ ${DATABASE_LINE}
 ##  Happy developing!                                     ##
 ############################################################
 " > /etc/motd
-    chmod +rx /etc/motd
+    chmod 644 /etc/motd
 fi


### PR DESCRIPTION
In case you re-run `setup_distro.sh` after the umask default is updated, this could make the `chmod +rx` line to fail with it complaining:
`/etc/update-motd.d/00-header: new permissions are rw-r--r-x, not rw-r--r--`