### PR TITLE
Fix minor bugs in Late Days' page and Extensions' page

### DIFF
--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -6,7 +6,7 @@
         <input type="hidden" name="option" value="-1" />
         <div class="option">
             <p> Use this form to grant an extension (e.g., for an excused absence) to a user on a specific assignment.<br><br><br></p>
-            <div class="option"><label for="g_id">Select Rubric:</label><br>
+            <div class="option"><label for="g_id">Select Gradeable:</label><br>
                 <select name="g_id" id="g_id" onchange="loadHomeworkExtensions($(this).val());" style="margin-top: 10px; width: 50%">
                     <option disabled selected value> -- select an option -- </option>
                     {% for index, value in gradeable_ids %}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -2407,7 +2407,7 @@ function refreshOnResponseLateDays(json) {
         $('#late_day_table').append('<tr><td colspan="6">No late days are currently entered.</td></tr>');
     }
     json['users'].forEach(function(elem){
-        elem_delete = "<a onclick=\"deleteLateDays('"+elem['user_id']+"', '"+elem['datestamp']+"');\"><i class='fas fa-close'></i></a>";
+        elem_delete = "<a onclick=\"deleteLateDays('"+elem['user_id']+"', '"+elem['datestamp']+"');\"><i class='fas fa-trash'></i></a>";
         var bits = ['<tr><td>' + elem['user_id'], elem['user_firstname'], elem['user_lastname'], elem['late_days'], elem['datestamp'], elem_delete + '</td></tr>'];
         $('#late_day_table').append(bits.join('</td><td>'));
     });


### PR DESCRIPTION
1. In late days' page, if you add one entry, the trash bin icon will not be displayed before refreshing.

Before fix (the trash bin icon doesn't show up):
![before](https://user-images.githubusercontent.com/20266703/54418707-e6b91600-46c2-11e9-9bc7-3e0e80f7b1d6.png)

After (the trash bin immediately shows as soon as the entry is entered):
![after](https://user-images.githubusercontent.com/20266703/54418709-e91b7000-46c2-11e9-8797-92dec7c27295.png)

2. In extensions' page, I think there is a typo. Because the list below consists of gradeables instead of rubrics. It is changed to "Select Gradeable" in the pr.

![rubric](https://user-images.githubusercontent.com/20266703/54418745-09e3c580-46c3-11e9-8d9b-a3b6c05449e9.png)
