### PR TITLE
Added loading message to testcases

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -50,9 +50,17 @@
 
                 {# Details button #}
                 {% if testcase.has_extra_results and can_view_details %}
-                    <div style="float:right; color: #0000EE; text-decoration: underline">
-                        Details
-                    </div>
+                    <span class="loading-tools" style="float:right">
+                        <span class="loading-tools-hide" style="color: #0000EE; text-decoration: underline;" hidden>
+                            Hide Details
+                        </span>
+                        <span class="loading-tools-show" style="color: #0000EE; text-decoration: underline;">
+                            Show Details
+                        </span>
+                        <span class="loading-tools-in-progress" hidden>
+                            <i class="fas fa-circle-notch fa-spin save-button" aria-hidden="true"></i>Loading...
+                        </span>
+                    </span>
                 {% endif %}
                 {# /Details button #}
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -107,19 +107,25 @@ function changeDiffView(div_name, gradeable_id, who_id, version, index, autochec
 }
 
 function loadTestcaseOutput(div_name, gradeable_id, who_id, index, version = ''){
-    orig_div_name = div_name
+    let orig_div_name = div_name;
     div_name = "#" + div_name;
-    var isVisible = $( div_name ).is( " :visible" );
 
-    if(isVisible){
-        toggleDiv(orig_div_name);
+    let loadingTools = $("#tc_" + index).find(".loading-tools");
+
+    if($(div_name).is(":visible")){
         $("#show_char_"+index).toggle();
         $(div_name).empty();
+        toggleDiv(orig_div_name);
+
+        loadingTools.find("span").hide();
+        loadingTools.find(".loading-tools-show").show();
     }else{
         $("#show_char_"+index).toggle();
         var url = buildUrl({'component': 'grading', 'page': 'electronic', 'action': 'load_student_file',
             'gradeable_id': gradeable_id, 'who_id' : who_id, 'index' : index, 'version' : version});
 
+        loadingTools.find("span").hide();
+        loadingTools.find(".loading-tools-in-progress").show();
         $.getJSON({
             url: url,
             success: function(response) {
@@ -130,6 +136,9 @@ function loadTestcaseOutput(div_name, gradeable_id, who_id, index, version = '')
                 $(div_name).empty();
                 $(div_name).html(response.data);
                 toggleDiv(orig_div_name);
+
+                loadingTools.find("span").hide();
+                loadingTools.find(".loading-tools-hide").show();
             },
             error: function(e) {
                 alert("Could not load diff, please refresh the page and try again.");


### PR DESCRIPTION
Added loading message to testcase output since it loads the entire image at once.  This makes the design more responsive, especially for large output files.  Loading messages are similar to the TA grading loading messages.  I just made the text the same style as the old `Details` text, but it would be easy enough to make them look like buttons if we want.

![image](https://user-images.githubusercontent.com/3719964/54479621-f8023f80-47f4-11e9-8656-e2a7f21d7765.png)
![image](https://user-images.githubusercontent.com/3719964/54479640-2d0e9200-47f5-11e9-885c-697231616d4e.png)
![image](https://user-images.githubusercontent.com/3719964/54479651-48799d00-47f5-11e9-9c7d-9da31b597701.png)
