### PR TITLE
Show posts in ascending order in statistics page

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -324,7 +324,7 @@ class DatabaseQueries {
 	}
 
     public function getPosts(){
-        $this->course_db->query("SELECT * FROM posts where deleted = false");
+        $this->course_db->query("SELECT * FROM posts where deleted = false ORDER BY timestamp ASC");
         return $this->course_db->rows();
     }
 


### PR DESCRIPTION
This makes the list of posts in forum stat page clearer.

Before:
![beforeasc](https://user-images.githubusercontent.com/20266703/54486283-4d653d80-4843-11e9-960b-a5e0ec63a893.png)

After:
![afterasc](https://user-images.githubusercontent.com/20266703/54486284-4f2f0100-4843-11e9-9613-82d6fceff893.png)
