### PR TITLE
Exclude scanned exams from extension menu

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1881,8 +1881,8 @@ WHERE gcm_id=?", $params);
         $this->course_db->query(
           "SELECT g_id, g_title " .
           "FROM gradeable INNER JOIN electronic_gradeable USING (g_id) " .
-          "WHERE eg_scanned_exam=FALSE " .
-          "ORDER BY g_grade_released_date DESC"
+          "WHERE eg_scanned_exam=FALSE and eg_has_due_date=TRUE " .
+          "ORDER BY eg_submission_due_date ASC"
         );
         return $this->course_db->rows();
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1875,7 +1875,12 @@ WHERE gcm_id=?", $params);
      * gets ids of all electronic gradeables
      */
     public function getAllElectronicGradeablesIds() {
-        $this->course_db->query("SELECT g_id, g_title FROM gradeable WHERE g_gradeable_type=0 ORDER BY g_grade_released_date DESC");
+        $this->course_db->query(
+          "SELECT g_id, g_title " .
+          "FROM gradeable INNER JOIN electronic_gradeable USING (g_id) " .
+          "WHERE eg_scanned_exam=FALSE " .
+          "ORDER BY g_grade_released_date DESC"
+        );
         return $this->course_db->rows();
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1879,10 +1879,10 @@ WHERE gcm_id=?", $params);
      */
     public function getAllElectronicGradeablesIds() {
         $this->course_db->query(
-          "SELECT g_id, g_title " .
-          "FROM gradeable INNER JOIN electronic_gradeable USING (g_id) " .
-          "WHERE eg_scanned_exam=FALSE and eg_has_due_date=TRUE " .
-          "ORDER BY eg_submission_due_date ASC"
+          "SELECT g_id, g_title 
+          FROM gradeable INNER JOIN electronic_gradeable USING (g_id)
+          WHERE eg_scanned_exam=FALSE and eg_has_due_date=TRUE
+          ORDER BY eg_submission_due_date ASC"
         );
         return $this->course_db->rows();
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1878,12 +1878,12 @@ WHERE gcm_id=?", $params);
      * @return array
      */
     public function getAllElectronicGradeablesIds() {
-        $this->course_db->query(
-          "SELECT g_id, g_title 
+        $this->course_db->query("
+          SELECT g_id, g_title 
           FROM gradeable INNER JOIN electronic_gradeable USING (g_id)
           WHERE eg_scanned_exam=FALSE and eg_has_due_date=TRUE
-          ORDER BY eg_submission_due_date ASC"
-        );
+          ORDER BY eg_submission_due_date ASC
+        ");
         return $this->course_db->rows();
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1872,7 +1872,10 @@ WHERE gcm_id=?", $params);
     }
 
     /**
-     * gets ids of all electronic gradeables
+     * gets ids of all electronic gradeables excluding assignments that will be bulk
+     * uploaded by TA or instructor.
+     *
+     * @return array
      */
     public function getAllElectronicGradeablesIds() {
         $this->course_db->query(


### PR DESCRIPTION
Closes #3418 

These changes are made so that only electronic gradeables with `eg_scanned_exam=FALSE` will be selected. 

In the new sql command, `g_gradeable_type=0` is removed from `where` because only electronic gradeables remain after `JOIN` operation.