### PR TITLE
[Bugfix] Changed fa-times-circle to a fa-check-circle in success messages

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -35,7 +35,12 @@
                 {% for message in messages %}
                     <div id='{{ message.type }}-{{ message.key }}' class="inner-message alert alert-{{ message.type }}">
                         <a class="fas fa-times message-close" onClick="removeMessagePopup('{{ message.type }}-{{ message.key }}');"></a>
-                        <i class="fas fa-times-circle"></i> {{ message.error }}
+                        {% if message.type == "error" %}
+                        <i class="fas fa-times-circle"></i> 
+                        {% else %}
+                        <i class="fas fa-check-circle"></i> 
+                        {% endif %}
+                        {{ message.error }}
                     </div>
                 {% endfor %}
             </div>

--- a/site/app/templates/NotificationsSettings.twig
+++ b/site/app/templates/NotificationsSettings.twig
@@ -17,7 +17,7 @@
                         if(json['error']) {
                             var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['error'] + '</div>';
                         } else {
-                            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['success'] + '</div>';
+                            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>' + json['success'] + '</div>';
                         }
                     } catch(err) {
                         var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -509,7 +509,7 @@ function submitSplitItem(csrf_token, gradeable_id, user_id, path, count, merge_p
                     $("#bulk_submit_" + count).prop("disabled", true);
                     $("#bulk_delete_" + count).prop("disabled", true);
                     $("#users_" + count + " :input").prop("disabled", true);
-                    var message ='<div id="submit_' + count +  '" class="inner-message alert alert-success"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'submit_' + count +'\');"></a><i class="fas fa-times-circle"></i>' + data['message'] + '</div>';
+                    var message ='<div id="submit_' + count +  '" class="inner-message alert alert-success"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'submit_' + count +'\');"></a><i class="fas fa-check-circle"></i>' + data['message'] + '</div>';
                     $('#messages').append(message);
                     setTimeout(function() {
                         $('#submit_' + count).fadeOut();
@@ -571,7 +571,7 @@ function deleteSplitItem(csrf_token, gradeable_id, path, count) {
                     $("#bulk_delete_" + count).prop("disabled", true);
                     $("#bulk_user_id_" + count).val("");
                     $("#bulk_user_id_" + count).prop("disabled", true);
-                    var message ='<div id="delete_' + count + '" class="inner-message alert alert-success"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'delete_' + count + '\');"></a><i class="fas fa-times-circle"></i>' + data['message'] + '</div>';
+                    var message ='<div id="delete_' + count + '" class="inner-message alert alert-success"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'delete_' + count + '\');"></a><i class="fas fa-check-circle"></i>' + data['message'] + '</div>';
                     $('#messages').append(message);
                     setTimeout(function() {
                         $('#delete_' + count).fadeOut();

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1522,7 +1522,7 @@ function changeThreadStatus(thread_id) {
 					return;
 				}
 				window.location.reload();
-				var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Thread marked as resolved.</div>';
+				var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Thread marked as resolved.</div>';
 					$('#messages').append(message);
 			},
 			error: function() {
@@ -1959,7 +1959,7 @@ function addNewCategory(){
                     $('#messages').append(message);
                     return;
                 }
-                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Successfully created category "'+ escapeSpecialChars(newCategory) +'".</div>';
+                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully created category "'+ escapeSpecialChars(newCategory) +'".</div>';
                 $('#messages').append(message);
                 $('#new_category_text').val("");
                 // Create new item in #ui-category-list using dummy category
@@ -2006,7 +2006,7 @@ function deleteCategory(category_id, category_desc){
                     $('#messages').append(message);
                     return;
                 }
-                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Successfully deleted category "'+ escapeSpecialChars(category_desc) +'"</div>';
+                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully deleted category "'+ escapeSpecialChars(category_desc) +'"</div>';
                 $('#messages').append(message);
                 $('#categorylistitem-'+category_id).remove();
                 refreshCategories();
@@ -2046,7 +2046,7 @@ function editCategory(category_id, category_desc, category_color) {
                     $('#messages').append(message);
                     return;
                 }
-                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Successfully updated!</div>';
+                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully updated!</div>';
                 $('#messages').append(message);
                 setTimeout(function() {removeMessagePopup('theid');}, 1000);
                 if(category_color !== null) {
@@ -2163,7 +2163,7 @@ function reorderCategories(){
                     $('#messages').append(message);
                     return;
                 }
-                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Successfully reordered categories.';
+                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully reordered categories.';
                 $('#messages').append(message);
                 setTimeout(function() {removeMessagePopup('theid');}, 1000);
                 refreshCategories();
@@ -2355,7 +2355,7 @@ function updateHomeworkExtensions(data) {
             $('#user_id').val(this.defaultValue);
             $('#late_days').val(this.defaultValue);
             $('#csv_upload').val(this.defaultValue);
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Updated exceptions for ' + json['gradeable_id'] + '.</div>';
+            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Updated exceptions for ' + json['gradeable_id'] + '.</div>';
             $('#messages').append(message);
         },
         error: function() {
@@ -2439,7 +2439,7 @@ function updateLateDays(data) {
             $('#csv_upload').val(this.defaultValue);
             $('#csv_option_overwrite_all').prop('checked',true);
             //Display confirmation message
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Late days have been updated.</div>';
+            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Late days have been updated.</div>';
             $('#messages').append(message);
         },
         error: function() {
@@ -2471,7 +2471,7 @@ function deleteLateDays(user_id, datestamp) {
                     return;
                 }
                 refreshOnResponseLateDays(json);
-                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Late days entry removed.</div>';
+                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Late days entry removed.</div>';
                 $('#messages').append(message);
             },
             error: function() {


### PR DESCRIPTION
There are several places where the `fa-times-circle` is used incorrectly for success messages.
This PR replaces the incorrectly used `fa-times-circle` to `fa-check-circle`

For example:
The following is the incorrect version of the message:
![Screenshot_2019-03-18 DEVELOPMENT](https://user-images.githubusercontent.com/25076171/54548972-0a37d580-49cf-11e9-92c2-4583d5ba75fa.png)

Which after correction results in:
![Screenshot_2019-03-18 DEVELOPMENT(1)](https://user-images.githubusercontent.com/25076171/54549016-2471b380-49cf-11e9-8f76-4be5d4e7a98f.png)

Currently due to hard coded `fa-times-circle` in `GlobalHeader.twig` the messages for success do not show `fa-check-circle` for example: successful login.
I am working on adding an if condition based on `message.type` for the same
