### PR TITLE
Update the new gradeable header as the ID changes

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -143,6 +143,7 @@
         // update the title bar when the gradeable name changes
         onTitleChange();
         $('#g_title').change(onTitleChange);
+        $('#g_id').change(onTitleChange);
 
 
         // TODO: below is selectively copied from previous ui.  It updates various


### PR DESCRIPTION
In "New Gradeable" page, if I enter the gradeable title first, and then enter the gradeable id, the title that appears on the top of the page does not change.

This is fixed by binding the function `onTitleChange` to the change event of `g_id` too so that the title on the top changes when `g_id` changes.

![g_id](https://user-images.githubusercontent.com/20266703/54561352-b18e1b80-4981-11e9-89fa-f59e883ddbdf.png)
