### PR TITLE
Better Multi-Line Support for TA Grading

### DIFF
--- a/site/app/templates/autograding/TAResultsNew.twig
+++ b/site/app/templates/autograding/TAResultsNew.twig
@@ -22,7 +22,7 @@
                 {% if overall_comment|length != 0 %}
             <hr>
             Overall note from Grader:
-            <span class='gradeable_comment'>{{ overall_comment|escape }}</span>
+            <span class='gradeable_comment'>{{ overall_comment|nl2br }}</span>
             {% endif %}
             </p>
         </div>
@@ -80,7 +80,7 @@
                                         {{ mark.points|number_format(num_decimals) }}
                                     </td>
                                     <td>
-                                        {{ mark.title|escape }}
+                                        {{ mark.title|nl2br }}
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -93,7 +93,7 @@
                                         {{ component.custom_mark_score|number_format(num_decimals) }}
                                     </td>
                                     <td>
-                                        {{ component.comment|escape }}
+                                        {{ component.comment|nl2br }}
                                     </td>
                                 </tr>
                             {% endif %}

--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -615,7 +615,7 @@ tr.is_publish {
 
 .gradeable .mark-container span.mark-title textarea {
     width: 100%;
-    resize: vertical;
+    resize: none;
     min-height: 20px;
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -2615,3 +2615,20 @@ $(document).ready(function() {
     });
     checkSidebarCollapse();
 });
+
+// Credit to https://stackoverflow.com/a/24676492/2972004
+//      Solution to autoexpand the height of a textarea
+function auto_grow(element) {
+    element.style.height = "5px";
+    element.style.height = (element.scrollHeight + 5)+"px";
+}
+
+/**
+ * Sets the 'noscroll' textareas to have the correct height
+ */
+function resizeNoScrollTextareas() {
+    // Make sure textareas resize correctly
+    $('textarea.noscroll').each(function() {
+        auto_grow(this);
+    })
+}

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1253,7 +1253,7 @@ function getMarkFromDOM(mark_id) {
         return {
             id: parseInt(domElement.attr('data-mark_id')),
             points: parseFloat(domElement.find('input[type=number]').val()),
-            title: domElement.find('input[type=text]').val(),
+            title: domElement.find('textarea').val(),
             deleted: domElement.hasClass('mark-deleted'),
             publish: domElement.find('.mark-publish-container input[type=checkbox]').is(':checked')
         };
@@ -2531,7 +2531,8 @@ function scrollToPage(page_num){
 function openComponent(component_id) {
     setComponentInProgress(component_id);
     // Achieve polymorphism in the interface using this `isInstructorEditEnabled` flag
-    return isInstructorEditEnabled() ? openComponentInstructorEdit(component_id) : openComponentGrading(component_id);
+    return (isInstructorEditEnabled() ? openComponentInstructorEdit(component_id) : openComponentGrading(component_id))
+        .then(resizeNoScrollTextareas);
 }
 
 /**

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1149,7 +1149,7 @@ function getCountDirection(component_id) {
  * @param {string} title
  */
 function setMarkTitle(mark_id, title) {
-    getMarkJQuery(mark_id).find('.mark-title input').val(title);
+    getMarkJQuery(mark_id).find('.mark-title textarea').val(title);
 }
 
 /**

--- a/site/public/templates/grading/EditComponent.twig
+++ b/site/public/templates/grading/EditComponent.twig
@@ -41,7 +41,7 @@
                 <span>Note to TAs</span>
             </div>
             <div class="col tight-right">
-                <textarea class="ta-comment" placeholder="Note to TAs">{{ component.ta_comment|escape }}</textarea>
+                <textarea class="ta-comment noscroll" onkeyup="auto_grow(this)" placeholder="Note to TAs">{{ component.ta_comment|escape }}</textarea>
             </div>
         </div>
 
@@ -51,7 +51,7 @@
                 <span>Note to Students</span>
             </div>
             <div class="col tight-right">
-                <textarea class="student-comment" placeholder="Note to Students">{{ component.student_comment|escape }}</textarea>
+                <textarea class="student-comment noscroll" onkeyup="auto_grow(this)" placeholder="Note to Students">{{ component.student_comment|escape }}</textarea>
             </div>
         </div>
 

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -71,9 +71,10 @@ Required inputs:
             <span class="col-sm mark-title">
                 Custom:
                 <textarea onchange="onCustomMarkChange(this)"
+                          onkeyup="auto_grow(this)"
                           rows="1"
                           placeholder="Custom message for student..."
-                          class="mark-note-custom"
+                          class="mark-note-custom noscroll"
                 >{{ graded_component.comment|escape }}</textarea>
             </span>
         </div>
@@ -104,7 +105,7 @@ Required inputs:
                             <span>{{ mark.points }}</span>
                         </div>
                         <div class="col">
-                            <span>{{ mark.title|escape }}</span>
+                            <span>{{ mark.title|nl2br }}</span>
                         </div>
                     </div>
                 {% endif %}
@@ -119,7 +120,7 @@ Required inputs:
                         <span>{{ graded_component.score }}</span>
                     </div>
                     <div class="col">
-                        <span>{{ graded_component.comment|escape }}</span>
+                        <span>{{ graded_component.comment|nl2br }}</span>
                     </div>
                 </div>
             {% endif %}

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -43,11 +43,10 @@ Required Input:
     <span class="col-sm mark-title"
           data-title="{{ mark.title|escape }}">
         {% if edit_marks_enabled %}
-            <input type="text"
-                   value="{{ mark.title|escape }}"
-                   {{ first_mark ? 'disabled' : '' }}/>
+            <textarea onkeyup="auto_grow(this)" class="noscroll"
+                    {{ first_mark ? 'disabled' : '' }}>{{ mark.title|escape }}</textarea>
         {% else %}
-            {{ mark.title|escape }}
+            {{ mark.title|nl2br }}
         {% endif %}
     </span>
     {% if show_publish %}

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -24,12 +24,13 @@ Required Parameters:
         {% if editable %}
             <textarea id="overall-comment"
                       rows="5"
-                      class="general-comment-entry"
+                      class="general-comment-entry noscroll"
                       onclick="event.stopPropagation()"
+                      onkeyup="auto_grow(this)"
                       placeholder="Overall message for student about the gradeable..."
             >{{ overall_comment|escape }}</textarea>
         {% else %}
-            <span id="overall-comment-collapsed">{{ overall_comment|escape }}</span>
+            <span id="overall-comment-collapsed">{{ overall_comment|nl2br }}</span>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
Fixed issues in original PR causing the no credit / full credit mark to not change when the count up / count down buttons are pressed.  This was due forgetting to change a `input` to a `textarea` tag in one of the JS functions.  I have combed through similar kinds of statements and found no other occurrences of that error.