### PR TITLE
Fixed "Publish" setting on new marks

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1798,6 +1798,7 @@ class ElectronicGraderController extends GradingController {
         $component_id = $_POST['component_id'] ?? '';
         $points = $_POST['points'] ?? '';
         $title = $_POST['title'] ?? null;
+        $publish = ($_POST['publish'] ?? 'false') === 'true';
 
         // Validate required parameters
         if ($title === null) {
@@ -1833,7 +1834,7 @@ class ElectronicGraderController extends GradingController {
 
         try {
             // Once we've parsed the inputs and checked permissions, perform the operation
-            $mark = $this->addNewMark($component, $title, $points);
+            $mark = $this->addNewMark($component, $title, $points, $publish);
             $this->core->getOutput()->renderJsonSuccess(['mark_id' => $mark->getId()]);
         } catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
@@ -1842,8 +1843,8 @@ class ElectronicGraderController extends GradingController {
         }
     }
 
-    public function addNewMark(Component $component, string $title, float $points) {
-        $mark = $component->addMark($title, $points, false);
+    public function addNewMark(Component $component, string $title, float $points, bool $publish) {
+        $mark = $component->addMark($title, $points, $publish);
         $this->core->getQueries()->saveComponent($component);
         return $mark;
     }

--- a/site/public/js/ta-grading-rubric-conflict.js
+++ b/site/public/js/ta-grading-rubric-conflict.js
@@ -132,12 +132,11 @@ function openMarkConflictPopup(component_id, conflictMarks) {
                                     });
                             } else {
                                 // If the mark was deleted from the server, but we want to keep our changes,
-                                //  we need to re-add the mark, then save it to preserve the 'publish' setting
+                                //  we need to re-add the mark
                                 if (isMarkServerDeleted(id)) {
-                                    return ajaxAddNewMark(gradeable_id, component_id, mark.title, mark.points)
+                                    return ajaxAddNewMark(gradeable_id, component_id, mark.title, mark.points, mark.publish)
                                         .then(function (data) {
                                             mark.id = data.mark_id;
-                                            return ajaxSaveMark(gradeable_id, component_id, data.mark_id, mark.title, mark.points, mark.publish);
                                         });
                                 } else {
                                     return ajaxSaveMark(gradeable_id, component_id, id, mark.title, mark.points, mark.publish);

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -410,9 +410,10 @@ function ajaxSaveOverallComment(gradeable_id, anon_id, overall_comment) {
  * @param {int} component_id
  * @param {string} title
  * @param {number} points
+ * @param {boolean} publish
  * @return {Promise} Rejects except when the response returns status 'success'
  */
-function ajaxAddNewMark(gradeable_id, component_id, title, points) {
+function ajaxAddNewMark(gradeable_id, component_id, title, points, publish) {
     return new Promise(function (resolve, reject) {
         $.getJSON({
             type: "POST",
@@ -427,7 +428,8 @@ function ajaxAddNewMark(gradeable_id, component_id, title, points) {
                 'gradeable_id': gradeable_id,
                 'component_id': component_id,
                 'title': title,
-                'points': points
+                'points': points,
+                'publish': publish
             },
             success: function (response) {
                 if (response.status !== 'success') {
@@ -2887,7 +2889,7 @@ function tryResolveMarkSave(gradeable_id, component_id, domMark, serverMark, old
             return Promise.resolve(true);
         } else {
             // The mark never existed and isn't deleted, so its new
-            return ajaxAddNewMark(gradeable_id, component_id, domMark.title, domMark.points)
+            return ajaxAddNewMark(gradeable_id, component_id, domMark.title, domMark.points, domMark.publish)
                 .then(function (data) {
                     // Success, then resolve true
                     domMark.id = data.mark_id;
@@ -2976,7 +2978,7 @@ function saveGradedComponent(component_id) {
             missingMarks.forEach(function (mark) {
                 sequence = sequence
                     .then(function () {
-                        return ajaxAddNewMark(gradeable_id, component_id, mark.title, mark.points);
+                        return ajaxAddNewMark(gradeable_id, component_id, mark.title, mark.points, mark.publish);
                     })
                     .then(function (data) {
                         // Make sure to add it to the grade.  We don't bother removing the deleted mark ids


### PR DESCRIPTION
Closes #3411

Previously, the `publish` setting on a mark was only being set at save-time and not at add-time.  Now, when a mark is added the publish setting will be saved.