### PR TITLE
Solved the buggy information of "has viewed" for grading detail

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1118,11 +1118,6 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         $this->course_db->query("
 SELECT COUNT(*) as cnt
 FROM gradeable_data
-INNER JOIN (
-    SELECT user_id FROM users AS u
-    WHERE {$section_key} IS NOT NULL
-) AS u
-ON u.user_id=gd_user_id
 WHERE g_id = ? AND gd_user_viewed_date IS NOT NULL
 
         ", array($g_id));


### PR DESCRIPTION
close #3131.
Solved the buggy information of "has viewed" for grading detail. It is because in the database of gradeable_data, the team assignment doesn't have a user_id, just a team_id. Therefore, the "has viewed" is buggy for team assignment. 