### PR TITLE
Fix const text of "Show Deleted Threads" button

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -254,13 +254,16 @@ HTML;
 HTML;
 	$show_deleted_class = '';
 	$show_deleted_action = '';
+	$show_deleted_title = '';
 	if($this->core->getUser()->getGroup() <= 2){
 		if($show_deleted) {
 			$show_deleted_class = "active";
 			$show_deleted_action = "alterShowDeletedStatus(0);";
+            $show_deleted_title = "Hide Deleted Threads";
 		} else {
 			$show_deleted_class = "";
 			$show_deleted_action = "alterShowDeletedStatus(1);";
+            $show_deleted_title = "Show Deleted Threads";
 		}
 	}
 	$categories = $this->core->getQueries()->getCategories();
@@ -324,11 +327,11 @@ HTML;
 						),
 						array(
 							"required_rank" => 2,
-							"display_text" => 'Show Deleted Threads',
+							"display_text" => $show_deleted_title,
 							"style" => 'position:relative;top:3px;display:inline-block;',
 							"link" => array(false),
 							"optional_class" => $show_deleted_class,
-							"title" => 'Show Deleted Threads',
+							"title" => $show_deleted_title,
 							"onclick" => array(true, $show_deleted_action)
 						),
 						array(


### PR DESCRIPTION
This PR fixes the problem that, after clicking "Show Deleted Threads", the text of the button remains unchanged.

The expected text of the button should be "Hide Deleted Threads" like the "Hide Merged Threads" button next to it.

Before:
![before](https://user-images.githubusercontent.com/20266703/54864370-97529580-4d13-11e9-8a8b-b615aaa2e728.png)

After:
![after](https://user-images.githubusercontent.com/20266703/54864371-991c5900-4d13-11e9-921a-686f5d7dba16.png)
