### PR TITLE
[BUGFIX] Fix mising link in notifications when post is deleted

### DIFF
--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -210,7 +210,7 @@ class Notification extends AbstractModel {
     }
 
     private function actAsForumDeletedNotification($thread_id, $post_content, $target){
-        $this->setNotifyMetadata(json_encode(array()));
+        $this->setNotifyMetadata(json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id))));
         $this->setNotifyContent("Deleted: A thread/post '".$this->textShortner($post_content)."' was deleted by ".Utils::getDisplayNameForum(false, $this->core->getQueries()->getDisplayUserInfoFromUserId($this->getCurrentUser())));
         $this->setNotifySource($this->getCurrentUser());
         $this->setNotifyTarget($target);

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -481,6 +481,10 @@ registerKeyHandler({name: "Toggle Grade Inquiry Panel", code: "KeyX"}, function(
     toggleRegrade();
     updateCookies();
 });
+registerKeyHandler({name: "Toggle Discussion Panel", code: "KeyD"}, function() {
+    toggleDiscussion();
+    updateCookies();
+});
 //-----------------------------------------------------------------------------
 // Show/hide components
 


### PR DESCRIPTION
Fixes #3218 
![ezgif com-video-to-gif(7)](https://user-images.githubusercontent.com/42701709/55009144-1b549800-5008-11e9-9a52-2add6fa2751e.gif)
