### PR TITLE
Fixed overflow of Overall Comment

### DIFF
--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -305,6 +305,11 @@ progress::-webkit-progress-value {
 
 #overall-comment-collapsed {
     padding: 0 0 0 20px;
+    max-height: 100px;
+    overflow-x: hidden;
+    overlfow-y: scroll;
+    width: 100%;
+    overflow-wrap: break-word;
 }
 
 .ta-rubric-table {


### PR DESCRIPTION
Closes #3501  

Very simple fix : set a maximum height to the comment span, break the long text on overflow and add a scrollbar on overflow to y axis.

https://www.useloom.com/share/bb46f4df0aac4c31a7c866bccd9d0b9a