### PR TITLE
[Bugfix] Fix awkward rendering of CodeMirror on the discussion forum

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1911,7 +1911,9 @@ function generateCodeMirrorBlocks(container_element) {
     if (lineCount == 1) {
         editor0.setSize("100%", (editor0.defaultTextHeight() * 2) + "px");
     } else {
-        editor0.setSize("100%", "max-content");
+        //Default height for CodeMirror is 300px... 500px looks good
+        var h = (editor0.defaultTextHeight()) * lineCount + 15;
+        editor0.setSize("100%", (h > 500 ? 500 : h) + "px");
     }
 
     editor0.setOption("theme", "eclipse");


### PR DESCRIPTION
Firefox:
![firefoxCodeMirror](https://user-images.githubusercontent.com/16356240/55366920-cbb71600-54b8-11e9-926d-af1f6ac97889.gif)

Chrome:
![chromeCodeMirror](https://user-images.githubusercontent.com/16356240/55366924-cd80d980-54b8-11e9-8849-1de4545afffc.gif)
