### PR TITLE
Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve Submitty
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+2. 
+3. 
+4. See error
+
+**Configuration**
+ - OS: [e.g. Windows, Linux, ...]
+ - Browser [e.g. chrome, safari]
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for implementation
+
+---
+
+**What problem are you trying to solve with Submitty**
+A clear and concise description of what the problem is.
+
+**Describe the way you'd like to solve this problem**
+A clear and concise description of what you want to happen.
+
+**Describe any potential alternatives you'd tried to solve the problem**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Please check if the PR fulfills these requirements:
 
-* [ ] The PR title and message follows our guidelines
+* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
 * [ ] Tests for the changes have been added/updated (if possible)
 * [ ] Documentation has been updated/added if relevant
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Please check if the PR fulfills these requirements:
+
+* [ ] The PR title and message follows our guidelines
+* [ ] Tests for the changes have been added/updated (if possible)
+* [ ] Documentation has been updated/added if relevant
+
+### What is the current behavior?
+<!-- List issue if it fixes/implements one using the "Fixes #<number>" syntax -->
+
+### What is the new behavior?
+
+### Other information?
+<!-- Is this a breaking change? -->
+<!-- How did you test >


### PR DESCRIPTION
This PR adds templates that are shown to users when opening new issues or PRs. When opening an issue, they are prompted to select if they are opening a bug report or a feature request and are then shown the appropriate template (or can select "other" and have a blank slate). All PRs are shown the single template. This should help to make sure our issues are standalone, easier for outsiders to pick up and work on (or if we come back a year later), and hopefully easier to parse/read.

See https://help.github.com/en/articles/about-issue-and-pull-request-templates#issue-templates for description of how this works.