### PR TITLE
Display error on window resize

### DIFF
--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -38,6 +38,20 @@
         Course Queries: <br /> {{ self.query_list(course_queries) }}
     </div>
 {% endif %}
+
+<script>
+    $(window).bind('resize', function(e)
+    {
+        if (window.RT) clearTimeout(window.RT);
+        window.RT = setTimeout(function()
+        {
+            if(confirm("Window resized. Reload page?")) {
+                this.location.reload(false);
+            }
+        }, 100);
+    });
+</script>
+
 </body>
 </html>
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #2164 - On resizing the window the Submitty topbar is left out of the screen. Also, the left navigation does not automatically collapse to adjust from larger to smaller screen size and vice versa. 

### What is the new behavior?
The page should display a warning and ask for reload. This would make the necessary changes to the page on fresh load. Preferably reload using cache.

https://www.useloom.com/share/331a6e2a6644492ca200dee4a7295327

### Other information?
Is this a breaking change? - No.
How did you test - Resizing checked on Linux (Elementary OS 5) using Chrome and Firefox. 
