### PR TITLE
Bulk Upload autofill fix

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -243,13 +243,13 @@ class Utils {
     public static function getAutoFillData($students, $students_version = null){
         $students_full = array();
         $null_section = array();
-        $i = 0;
         foreach ($students as $student) {
             if($student->getRegistrationSection() != null){
                 $student_entry = array('value' => $student->getId(),
                 'label' => $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>');
-                if ($students_version != null && $students_version[$i][1] !== 0) {
-                    $student_entry['label'] .= ' (' . $students_version[$i][1] . ' Prev Submission)';
+                if ($students_version != null && $students_version[$student->getId()] !== 0) {
+                    $student_entry['label'] .= ' (' .
+                    $students_version[$student->getId()] . ' Prev Submission)';
                 }
                 $students_full[] = $student_entry;
             }else{
@@ -262,7 +262,6 @@ class Utils {
                 }
                 if(!$in_null_section) $null_section[] = $null_entry;
             }
-            $i++;
         }
         $students_full = array_unique(array_merge($students_full, $null_section), SORT_REGULAR);
         return json_encode($students_full);

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -260,7 +260,7 @@ class HomeworkView extends AbstractView {
             $students_version = array();
             foreach ($this->core->getQueries()->getGradedGradeables([$gradeable], $student_ids) as $gg) {
                 /** @var GradedGradeable $gg */
-                $students_version[] = array($gg->getSubmitter()->getId(), $gg->getAutoGradedGradeable()->getHighestVersion());
+                $students_version[$gg->getSubmitter()->getId()] = $gg->getAutoGradedGradeable()->getHighestVersion();
             }
             $students_full = json_decode(Utils::getAutoFillData($students, $students_version));
         }


### PR DESCRIPTION
Uses student id as a key instead of indexing through list of students, 
should fix the students having previous submissions when they didn't have any
and showing students who did have prev submissions not having any.

credit to @goldschmidt for coming up with the fix.

