### PR TITLE
[Bugfix] Show Late Submit button in default colour for gradeables with no autograding points

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -424,8 +424,12 @@ class NavigationView extends AbstractView {
                 }
             }
 
+            // Due date passed with at least 50 percent points in autograding or gradable with no autograding points
             if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
-                $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() != 0 && $points_percent >= 0.5 &&
+                (
+                    !$gradeable->getAutogradingConfig()->anyPoints() ||
+                    $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() != 0 && $points_percent >= 0.5
+                ) &&
                 $list_section == GradeableList::CLOSED) {
                 $class = "btn-default";
             }


### PR DESCRIPTION
Closes #3530 

### Requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
* The submit button was shown in red(danger) colour after submission due date even if the gradable has no autograding points and the student had already made submission.

### What is the new behavior?
* The submit button will be shown in default colour if the gradable has no autograding points after the due date is over and a submission is made.

### Other information?
* I manually tested by changing the deadlines of tasks using instructor account.
* The cases include,
   * Checking colour change for Late Submit button for gradables with no autograding points.
   * Case where a student makes submission after the due date, and the colour of the submit button will become default after at least one submission is made for the question.