### PR TITLE
Default case for electronic grader controller won't throw exception

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -103,12 +103,8 @@ class ElectronicGraderController extends GradingController {
             case 'remove_empty':
                 $this->ajaxRemoveEmpty();
                 break;
-            case '':
-                $this->showStatus();
-                break;
             default:
-                // TODO: this is for testing
-                throw new \InvalidArgumentException('AHHH');
+                $this->showStatus();
                 break;
         }
     }


### PR DESCRIPTION
For debugging purposes in the past, the default case for the` ElectronicGraderController` would throw an exception.  That should not be the case, so the default case will show the status page.