### PR TITLE
Prevents limited access graders from accessing stats page

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -307,7 +307,7 @@ HTML;
 							"onclick" => array(true, $show_deleted_action)
 						),
 						array(
-							"required_rank" => 3,
+							"required_rank" => 2,
 							"display_text" => 'Stats',
 							"style" => 'position:relative;top:3px;display:inline-block;',
 							"link" => array(true, $this->core->buildUrl(array('component' => 'forum', 'page' => 'show_stats'))),
@@ -998,7 +998,7 @@ HTML;
 
 	if($thread_exists) {
 		$buttons = array_merge($buttons, array(
-			"required_rank" => 3,
+			"required_rank" => 2,
 			"display_text" => 'Stats',
 			"style" => 'position:relative;top:3px;display:inline-block;',
 			"link" => array(true, $this->core->buildUrl(array('component' => 'forum', 'page' => 'show_stats'))),
@@ -1047,8 +1047,13 @@ HTML;
 
 	public function statPage($users) {
 
-		if(!$this->forumAccess() || $this->core->getUser()->getGroup() > 3){
+		if(!$this->forumAccess()){
 			$this->core->redirect($this->core->buildUrl(array('component' => 'navigation')));
+			return;
+		}
+
+		if(!$this->core->getUser()->accessFullGrading()){
+			$this->core->redirect($this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread')));
 			return;
 		}
 


### PR DESCRIPTION
### What is the current behavior?
Fixes #3552
Currently limited access graders can view the stats page

### What is the new behavior?
Button to the stats page is not rendered if the user is not a full access grader or instructor.
If the a limited access grader/student tries to access the stats page via url then they are redirected to the forum.

