### PR TITLE
added identicon pngs for broken or missing student photos

### DIFF
--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -29,7 +29,8 @@
                     {% endfor %}
                     {% if not image_found %}
                         {% if errorImageData == '_NONE_' %}
-                            <td><i><font color="gray"><img alt="No Image Available" class="no-image-available"/></font></i>
+                            <td><i><font color="gray"><img alt="No Image Available" class="no-image-available" 
+                                data-student-name="{{student.getDisplayedFirstName()}}-{{student.getDisplayedLastName()}}"/></font></i>
                             <div class="name"><br />
                         {% else %}
                             <td><img src="data:imgName/png;base64,{{ errorImageData }}" width="150" height="200/>

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -29,7 +29,7 @@
                     {% endfor %}
                     {% if not image_found %}
                         {% if errorImageData == '_NONE_' %}
-                            <td><i><font color="gray"><img alt="No Image Available" /></font></i>
+                            <td><i><font color="gray"><img alt="No Image Available" class="no-image-available"/></font></i>
                             <div class="name"><br />
                         {% else %}
                             <td><img src="data:imgName/png;base64,{{ errorImageData }}" width="150" height="200/>

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -57,7 +57,10 @@ class ImagesView extends AbstractView {
         }
 
         $this->core->getOutput()->addInternalJs("drag-and-drop.js");
-
+        $this->core->getOutput()->addInternalJs("pnglib.js");
+        $this->core->getOutput()->addInternalJs("identicon.js");
+        $this->core->getOutput()->addInternalJs("images.js");
+        
         return $this->core->getOutput()->renderTwigTemplate("grading/Images.twig", [
             "sections" => $sections,
             "imageNameArray" => $images_names_array,

--- a/site/public/js/identicon.js
+++ b/site/public/js/identicon.js
@@ -1,0 +1,205 @@
+/**
+ * Identicon.js 2.3.3
+ * http://github.com/stewartlord/identicon.js
+ *
+ * PNGLib required for PNG output
+ * http://www.xarg.org/download/pnglib.js
+ *
+ * Copyright 2018, Stewart Lord
+ * Released under the BSD license
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+
+(function() {
+    var PNGlib;
+    if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+        PNGlib = require('./pnglib');
+    } else {
+        PNGlib = window.PNGlib;
+    }
+
+    var Identicon = function(hash, options){
+        if (typeof(hash) !== 'string' || hash.length < 15) {
+            throw 'A hash of at least 15 characters is required.';
+        }
+
+        this.defaults = {
+            background: [240, 240, 240, 255],
+            margin:     0.08,
+            size:       64,
+            saturation: 0.7,
+            brightness: 0.5,
+            format:     'png'
+        };
+
+        this.options = typeof(options) === 'object' ? options : this.defaults;
+
+        // backward compatibility with old constructor (hash, size, margin)
+        if (typeof(arguments[1]) === 'number') { this.options.size   = arguments[1]; }
+        if (arguments[2])                      { this.options.margin = arguments[2]; }
+
+        this.hash        = hash
+        this.background  = this.options.background || this.defaults.background;
+        this.size        = this.options.size       || this.defaults.size;
+        this.format      = this.options.format     || this.defaults.format;
+        this.margin      = this.options.margin !== undefined ? this.options.margin : this.defaults.margin;
+
+        // foreground defaults to last 7 chars as hue at 70% saturation, 50% brightness
+        var hue          = parseInt(this.hash.substr(-7), 16) / 0xfffffff;
+        var saturation   = this.options.saturation || this.defaults.saturation;
+        var brightness   = this.options.brightness || this.defaults.brightness;
+        this.foreground  = this.options.foreground || this.hsl2rgb(hue, saturation, brightness);
+    };
+
+    Identicon.prototype = {
+        background: null,
+        foreground: null,
+        hash:       null,
+        margin:     null,
+        size:       null,
+        format:     null,
+
+        image: function(){
+            return this.isSvg()
+                ? new Svg(this.size, this.foreground, this.background)
+                : new PNGlib(this.size, this.size, 256);
+        },
+
+        render: function(){
+            var image      = this.image(),
+                size       = this.size,
+                baseMargin = Math.floor(size * this.margin),
+                cell       = Math.floor((size - (baseMargin * 2)) / 5),
+                margin     = Math.floor((size - cell * 5) / 2),
+                bg         = image.color.apply(image, this.background),
+                fg         = image.color.apply(image, this.foreground);
+
+            // the first 15 characters of the hash control the pixels (even/odd)
+            // they are drawn down the middle first, then mirrored outwards
+            var i, color;
+            for (i = 0; i < 15; i++) {
+                color = parseInt(this.hash.charAt(i), 16) % 2 ? bg : fg;
+                if (i < 5) {
+                    this.rectangle(2 * cell + margin, i * cell + margin, cell, cell, color, image);
+                } else if (i < 10) {
+                    this.rectangle(1 * cell + margin, (i - 5) * cell + margin, cell, cell, color, image);
+                    this.rectangle(3 * cell + margin, (i - 5) * cell + margin, cell, cell, color, image);
+                } else if (i < 15) {
+                    this.rectangle(0 * cell + margin, (i - 10) * cell + margin, cell, cell, color, image);
+                    this.rectangle(4 * cell + margin, (i - 10) * cell + margin, cell, cell, color, image);
+                }
+            }
+
+            return image;
+        },
+
+        rectangle: function(x, y, w, h, color, image){
+            if (this.isSvg()) {
+                image.rectangles.push({x: x, y: y, w: w, h: h, color: color});
+            } else {
+                var i, j;
+                for (i = x; i < x + w; i++) {
+                    for (j = y; j < y + h; j++) {
+                        image.buffer[image.index(i, j)] = color;
+                    }
+                }
+            }
+        },
+
+        // adapted from: https://gist.github.com/aemkei/1325937
+        hsl2rgb: function(h, s, b){
+            h *= 6;
+            s = [
+                b += s *= b < .5 ? b : 1 - b,
+                b - h % 1 * s * 2,
+                b -= s *= 2,
+                b,
+                b + h % 1 * s,
+                b + s
+            ];
+
+            return[
+                s[ ~~h    % 6 ] * 255, // red
+                s[ (h|16) % 6 ] * 255, // green
+                s[ (h|8)  % 6 ] * 255  // blue
+            ];
+        },
+
+        toString: function(raw){
+            // backward compatibility with old toString, default to base64
+            if (raw) {
+                return this.render().getDump();
+            } else {
+                return this.render().getBase64();
+            }
+        },
+
+        isSvg: function(){
+            return this.format.match(/svg/i)
+        }
+    };
+
+    var Svg = function(size, foreground, background){
+        this.size       = size;
+        this.foreground = this.color.apply(this, foreground);
+        this.background = this.color.apply(this, background);
+        this.rectangles = [];
+    };
+
+    Svg.prototype = {
+        size:       null,
+        foreground: null,
+        background: null,
+        rectangles: null,
+
+        color: function(r, g, b, a){
+            var values = [r, g, b].map(Math.round);
+            values.push((a >= 0) && (a <= 255) ? a/255 : 1);
+            return 'rgba(' + values.join(',') + ')';
+        },
+
+        getDump: function(){
+          var i,
+                xml,
+                rect,
+                fg     = this.foreground,
+                bg     = this.background,
+                stroke = this.size * 0.005;
+
+            xml = "<svg xmlns='http://www.w3.org/2000/svg'"
+                + " width='" + this.size + "' height='" + this.size + "'"
+                + " style='background-color:" + bg + ";'>"
+                + "<g style='fill:" + fg + "; stroke:" + fg + "; stroke-width:" + stroke + ";'>";
+
+            for (i = 0; i < this.rectangles.length; i++) {
+                rect = this.rectangles[i];
+                if (rect.color == bg) continue;
+                xml += "<rect "
+                    + " x='"      + rect.x + "'"
+                    + " y='"      + rect.y + "'"
+                    + " width='"  + rect.w + "'"
+                    + " height='" + rect.h + "'"
+                    + "/>";
+            }
+            xml += "</g></svg>"
+
+            return xml;
+        },
+
+        getBase64: function(){
+            if ('function' === typeof btoa) {
+                return btoa(this.getDump());
+            } else if (Buffer) {
+                return new Buffer(this.getDump(), 'binary').toString('base64');
+            } else {
+                throw 'Cannot generate base64 output';
+            }
+        }
+    };
+
+    if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+        module.exports = Identicon;
+    } else {
+        window.Identicon = Identicon;
+    }
+})();

--- a/site/public/js/images.js
+++ b/site/public/js/images.js
@@ -2,18 +2,14 @@ $(document).ready(function(){
 
 $('.no-image-available').each(function(i, obj) {
 	var student_name = $(obj).data('student-name');
-	// Identicon requires a harsh of at least 15 chars
+	// Identicon requires a hash of at least 15 chars
 	// So to prevent short names from breaking it, the name is salted.
-	// This would ensure resulting harshes are longer than 15 chars.
+	// This would ensure resulting hashes are longer than 15 chars.
 	student_name = student_name+'0123456789_abcdefghijklmnopqrstuvwxyz';
     // create a base64 encoded PNG
-    var data = new Identicon(uniqueHarsh(student_name), 420).toString();
+    var data = new Identicon(btoa(student_name), 210).toString();
     // update no image tag.
     $(obj).replaceWith('<img width=210 height=210 src="data:image/png;base64,' + data + '">');
 });
-
-function uniqueHarsh(string) {
-    return btoa(string);
-}
 
 });

--- a/site/public/js/images.js
+++ b/site/public/js/images.js
@@ -1,0 +1,20 @@
+$(document).ready(function(){
+
+$('.no-image-available').each(function(i, obj) {
+    // create a base64 encoded PNG
+    var data = new Identicon(randomString(32), 420).toString();
+    // write to a data URI
+    $(obj).replaceWith('<img width=210 height=210 src="data:image/png;base64,' + data + '">');
+});
+
+function randomString(len, charSet) {
+    charSet = charSet || '0123456789abcdefghijklmn0123456789opqrstuvwxyz0123456789';
+    var randomString = '';
+    for (var i = 0; i < len; i++) {
+        var randomPoz = Math.floor(Math.random() * charSet.length);
+        randomString += charSet.substring(randomPoz,randomPoz+1);
+    }
+    return randomString;
+}
+
+});

--- a/site/public/js/images.js
+++ b/site/public/js/images.js
@@ -1,20 +1,19 @@
 $(document).ready(function(){
 
 $('.no-image-available').each(function(i, obj) {
+	var student_name = $(obj).data('student-name');
+	// Identicon requires a harsh of at least 15 chars
+	// So to prevent short names from breaking it, the name is salted.
+	// This would ensure resulting harshes are longer than 15 chars.
+	student_name = student_name+'0123456789_abcdefghijklmnopqrstuvwxyz';
     // create a base64 encoded PNG
-    var data = new Identicon(randomString(32), 420).toString();
-    // write to a data URI
+    var data = new Identicon(uniqueHarsh(student_name), 420).toString();
+    // update no image tag.
     $(obj).replaceWith('<img width=210 height=210 src="data:image/png;base64,' + data + '">');
 });
 
-function randomString(len, charSet) {
-    charSet = charSet || '0123456789abcdefghijklmn0123456789opqrstuvwxyz0123456789';
-    var randomString = '';
-    for (var i = 0; i < len; i++) {
-        var randomPoz = Math.floor(Math.random() * charSet.length);
-        randomString += charSet.substring(randomPoz,randomPoz+1);
-    }
-    return randomString;
+function uniqueHarsh(string) {
+    return btoa(string);
 }
 
 });

--- a/site/public/js/pnglib.js
+++ b/site/public/js/pnglib.js
@@ -1,0 +1,214 @@
+/**
+* A handy class to calculate color values.
+*
+* @version 1.0
+* @author Robert Eisele <robert@xarg.org>
+* @copyright Copyright (c) 2010, Robert Eisele
+* @link http://www.xarg.org/2010/03/generate-client-side-png-files-using-javascript/
+* @license http://www.opensource.org/licenses/bsd-license.php BSD License
+*
+*/
+
+(function() {
+
+	// helper functions for that ctx
+	function write(buffer, offs) {
+		for (var i = 2; i < arguments.length; i++) {
+			for (var j = 0; j < arguments[i].length; j++) {
+				buffer[offs++] = arguments[i].charAt(j);
+			}
+		}
+	}
+
+	function byte2(w) {
+		return String.fromCharCode((w >> 8) & 255, w & 255);
+	}
+
+	function byte4(w) {
+		return String.fromCharCode((w >> 24) & 255, (w >> 16) & 255, (w >> 8) & 255, w & 255);
+	}
+
+	function byte2lsb(w) {
+		return String.fromCharCode(w & 255, (w >> 8) & 255);
+	}
+
+	window.PNGlib = function(width,height,depth) {
+
+		this.width   = width;
+		this.height  = height;
+		this.depth   = depth;
+
+		// pixel data and row filter identifier size
+		this.pix_size = height * (width + 1);
+
+		// deflate header, pix_size, block headers, adler32 checksum
+		this.data_size = 2 + this.pix_size + 5 * Math.floor((0xfffe + this.pix_size) / 0xffff) + 4;
+
+		// offsets and sizes of Png chunks
+		this.ihdr_offs = 0;									// IHDR offset and size
+		this.ihdr_size = 4 + 4 + 13 + 4;
+		this.plte_offs = this.ihdr_offs + this.ihdr_size;	// PLTE offset and size
+		this.plte_size = 4 + 4 + 3 * depth + 4;
+		this.trns_offs = this.plte_offs + this.plte_size;	// tRNS offset and size
+		this.trns_size = 4 + 4 + depth + 4;
+		this.idat_offs = this.trns_offs + this.trns_size;	// IDAT offset and size
+		this.idat_size = 4 + 4 + this.data_size + 4;
+		this.iend_offs = this.idat_offs + this.idat_size;	// IEND offset and size
+		this.iend_size = 4 + 4 + 4;
+		this.buffer_size  = this.iend_offs + this.iend_size;	// total PNG size
+
+		this.buffer  = new Array();
+		this.palette = new Object();
+		this.pindex  = 0;
+
+		var _crc32 = new Array();
+
+		// initialize buffer with zero bytes
+		for (var i = 0; i < this.buffer_size; i++) {
+			this.buffer[i] = "\x00";
+		}
+
+		// initialize non-zero elements
+		write(this.buffer, this.ihdr_offs, byte4(this.ihdr_size - 12), 'IHDR', byte4(width), byte4(height), "\x08\x03");
+		write(this.buffer, this.plte_offs, byte4(this.plte_size - 12), 'PLTE');
+		write(this.buffer, this.trns_offs, byte4(this.trns_size - 12), 'tRNS');
+		write(this.buffer, this.idat_offs, byte4(this.idat_size - 12), 'IDAT');
+		write(this.buffer, this.iend_offs, byte4(this.iend_size - 12), 'IEND');
+
+		// initialize deflate header
+		var header = ((8 + (7 << 4)) << 8) | (3 << 6);
+		header+= 31 - (header % 31);
+
+		write(this.buffer, this.idat_offs + 8, byte2(header));
+
+		// initialize deflate block headers
+		for (var i = 0; (i << 16) - 1 < this.pix_size; i++) {
+			var size, bits;
+			if (i + 0xffff < this.pix_size) {
+				size = 0xffff;
+				bits = "\x00";
+			} else {
+				size = this.pix_size - (i << 16) - i;
+				bits = "\x01";
+			}
+			write(this.buffer, this.idat_offs + 8 + 2 + (i << 16) + (i << 2), bits, byte2lsb(size), byte2lsb(~size));
+		}
+
+		/* Create crc32 lookup table */
+		for (var i = 0; i < 256; i++) {
+			var c = i;
+			for (var j = 0; j < 8; j++) {
+				if (c & 1) {
+					c = -306674912 ^ ((c >> 1) & 0x7fffffff);
+				} else {
+					c = (c >> 1) & 0x7fffffff;
+				}
+			}
+			_crc32[i] = c;
+		}
+
+		// compute the index into a png for a given pixel
+		this.index = function(x,y) {
+			var i = y * (this.width + 1) + x + 1;
+			var j = this.idat_offs + 8 + 2 + 5 * Math.floor((i / 0xffff) + 1) + i;
+			return j;
+		}
+
+		// convert a color and build up the palette
+		this.color = function(red, green, blue, alpha) {
+
+			alpha = alpha >= 0 ? alpha : 255;
+			var color = (((((alpha << 8) | red) << 8) | green) << 8) | blue;
+
+			if (typeof this.palette[color] == "undefined") {
+				if (this.pindex == this.depth) return "\x00";
+
+				var ndx = this.plte_offs + 8 + 3 * this.pindex;
+
+				this.buffer[ndx + 0] = String.fromCharCode(red);
+				this.buffer[ndx + 1] = String.fromCharCode(green);
+				this.buffer[ndx + 2] = String.fromCharCode(blue);
+				this.buffer[this.trns_offs+8+this.pindex] = String.fromCharCode(alpha);
+
+				this.palette[color] = String.fromCharCode(this.pindex++);
+			}
+			return this.palette[color];
+		}
+
+		// output a PNG string, Base64 encoded
+		this.getBase64 = function() {
+
+			var s = this.getDump();
+
+			// If the current browser supports the Base64 encoding
+			// function, then offload the that to the browser as it
+			// will be done in native code.
+			if ((typeof window.btoa !== 'undefined') && (window.btoa !== null)) {
+				return window.btoa(s);
+			}
+
+			var ch = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+			var c1, c2, c3, e1, e2, e3, e4;
+			var l = s.length;
+			var i = 0;
+			var r = "";
+
+			do {
+				c1 = s.charCodeAt(i);
+				e1 = c1 >> 2;
+				c2 = s.charCodeAt(i+1);
+				e2 = ((c1 & 3) << 4) | (c2 >> 4);
+				c3 = s.charCodeAt(i+2);
+				if (l < i+2) { e3 = 64; } else { e3 = ((c2 & 0xf) << 2) | (c3 >> 6); }
+				if (l < i+3) { e4 = 64; } else { e4 = c3 & 0x3f; }
+				r+= ch.charAt(e1) + ch.charAt(e2) + ch.charAt(e3) + ch.charAt(e4);
+			} while ((i+= 3) < l);
+			return r;
+		}
+
+		// output a PNG string
+		this.getDump = function() {
+
+			// compute adler32 of output pixels + row filter bytes
+			var BASE = 65521; /* largest prime smaller than 65536 */
+			var NMAX = 5552;  /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
+			var s1 = 1;
+			var s2 = 0;
+			var n = NMAX;
+
+			for (var y = 0; y < this.height; y++) {
+				for (var x = -1; x < this.width; x++) {
+					s1+= this.buffer[this.index(x, y)].charCodeAt(0);
+					s2+= s1;
+					if ((n-= 1) == 0) {
+						s1%= BASE;
+						s2%= BASE;
+						n = NMAX;
+					}
+				}
+			}
+			s1%= BASE;
+			s2%= BASE;
+			write(this.buffer, this.idat_offs + this.idat_size - 8, byte4((s2 << 16) | s1));
+
+			// compute crc32 of the PNG chunks
+			function crc32(png, offs, size) {
+				var crc = -1;
+				for (var i = 4; i < size-4; i += 1) {
+					crc = _crc32[(crc ^ png[offs+i].charCodeAt(0)) & 0xff] ^ ((crc >> 8) & 0x00ffffff);
+				}
+				write(png, offs+size-4, byte4(crc ^ -1));
+			}
+
+			crc32(this.buffer, this.ihdr_offs, this.ihdr_size);
+			crc32(this.buffer, this.plte_offs, this.plte_size);
+			crc32(this.buffer, this.trns_offs, this.trns_size);
+			crc32(this.buffer, this.idat_offs, this.idat_size);
+			crc32(this.buffer, this.iend_offs, this.iend_size);
+
+			// convert PNG to string
+			return "\211PNG\r\n\032\n"+this.buffer.join('');
+		}
+	}
+
+})();


### PR DESCRIPTION
Signed-off-by: Fenn-CS <fenn25.fn@gmail.com>

### What is the current behavior?
On the student photos page, students with no image uploaded are displayed with broken `img` tags defined as Fixes #3503  

### What is the new behavior?
Now displays an identicon (using https://github.com/stewartlord/identicon.js) for such students.

![identicons](https://user-images.githubusercontent.com/14317775/56333142-d9dc8600-618a-11e9-865d-0fcbb1f8a9ec.png)

