### PR TITLE
Add optional folder argument to addInternalJs

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -395,9 +395,9 @@ class Output {
         $this->css[] = $url.(($timestamp !== 0) ? "?v={$timestamp}" : '');
     }
 
-    public function addInternalJs($file) {
-        $timestamp = filemtime(FileUtils::joinPaths(__DIR__, '..', '..', 'public', 'js', $file));
-        $this->addJs($this->core->getConfig()->getBaseUrl()."js/".$file, $timestamp);
+    public function addInternalJs($file, $folder='js') {
+        $timestamp = filemtime(FileUtils::joinPaths(__DIR__, '..', '..', 'public', $folder, $file));
+        $this->addJs($this->core->getConfig()->getBaseUrl().$folder."/".$file, $timestamp);
     }
 
     public function addJs($url, $timestamp=0) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Currently all JS files must live under `site/public/js/`, even if it's third-party code that should live elsewhere for better/cleaner organization of what's stuff we develop and stuff that is coming from elsewhere.

### What is the new behavior?
This makes it match how addInternalCss works and allows for referencing scripts under other places (like `site/public/vendor`).

### Other information?
* Not a breaking change.
* Tested by navigating around the site to see if any JS was broken.