### PR TITLE
Clarify PR template on good syntax for issue referencing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,10 @@
 * [ ] Documentation has been updated/added if relevant
 
 ### What is the current behavior?
-<!-- List issue if it fixes/implements one using the "Fixes #<number>" syntax -->
+<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
 
 ### What is the new behavior?
 
 ### Other information?
 <!-- Is this a breaking change? -->
-<!-- How did you test >
+<!-- How did you test -->


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
The current PR template uses the phrase 'using the "Fixes #<number>" syntax' which makes it seem to contributors like we only want that syntax (see https://github.com/Submitty/Submitty/pull/3578#issuecomment-483859959) while the Closes #<number> syntax is equally fine (and accomplishes the same thing).

### What is the new behavior?
Clarifies that you can use either one to hopefully avoid this type of bikeshedding going forward.
