### PR TITLE
Fixing Errors Caused by Special Characters in Emails 

### DIFF
--- a/sbin/send_email.py
+++ b/sbin/send_email.py
@@ -114,7 +114,7 @@ def send_email():
     for email_data in queued_emails:
         email = construct_mail_string(
             email_data["send_to"], email_data["subject"], email_data["body"])
-        mail_client.sendmail(EMAIL_SENDER, email_data["send_to"], email)
+        mail_client.sendmail(EMAIL_SENDER, email_data["send_to"], email.encode('utf8'))
         mark_sent(email_data["id"], db)
 
     LOG_FILE.write("[{}] Sucessfully Emailed {} Users\n".format(

--- a/sbin/send_email.py
+++ b/sbin/send_email.py
@@ -98,8 +98,19 @@ def mark_sent(email_id, db):
 
 def construct_mail_string(send_to, subject, body):
     """Format an email string."""
-    return "Content-Type: text/plain; charset=utf-8\nTO:%s\nFrom: %s\nSubject:  %s \n\n\n %s \n\n" % (
-        send_to, EMAIL_SENDER, subject, body)
+    headers = [
+        ('Content-Type', 'text/plain; charset=utf-8'),
+        ('TO', send_to),
+        ('From', EMAIL_SENDER),
+        ('Subject', subject)
+    ]
+
+    msg = ''
+    for header in headers:
+        msg += "{}: {}\n".format(*header)
+
+    msg += "\n\n{}\n\n".format(body)
+    return msg
 
 
 def send_email():

--- a/sbin/send_email.py
+++ b/sbin/send_email.py
@@ -98,7 +98,7 @@ def mark_sent(email_id, db):
 
 def construct_mail_string(send_to, subject, body):
     """Format an email string."""
-    return "TO:%s\nFrom: %s\nSubject:  %s \n\n\n %s \n\n" % (
+    return "Content-Type: text/plain; charset=utf-8\nTO:%s\nFrom: %s\nSubject:  %s \n\n\n %s \n\n" % (
         send_to, EMAIL_SENDER, subject, body)
 
 


### PR DESCRIPTION
fixes #3581 

Tested by recreating error and then encoding the email string and making sure emails containing special characters were sent. 