### PR TITLE
[Bugfix] Saving grading component after removing all grades

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1303,16 +1303,19 @@ class ElectronicGraderController extends GradingController {
             $ta_graded_gradeable->deleteGradedComponent($graded_component->getComponent(), $graded_component->getGrader());
             $graded_component = null;
         }
+        else{
+
+            //change the component to be unverified after changing a mark
+            if($graded_component->isMarksModified()){
+                $graded_component->setVerifier();
+                $graded_component->setVerifyTime(null);
+            }
+        }
 
         // TODO: is this desirable
         // Reset the user viewed date since we updated the grade
         $ta_graded_gradeable->resetUserViewedDate();
 
-        //change the component to be unverified after changing a mark
-        if($graded_component->isMarksModified()){
-            $graded_component->setVerifier();
-            $graded_component->setVerifyTime(null);
-        }
         // Finally, save the changes to the database
         $this->core->getQueries()->saveTaGradedGradeable($ta_graded_gradeable);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)


### What is the current behavior?
Closes #3579 

### What is the new behavior?

Able to save component after removing all grades, after grading has been done once. 

https://www.loom.com/share/bf3f00cb278f43bebdfebd25f799b2ce

The error was happening due to `$graded_component = null;` at Line 1304. Once the variable was set to null, it is no longer having the method  `$graded_component->isMarksModified()` on Line 1312 of ElectronicGradingController.php 

Moving the latter block of code inside an `else` block makes sure the unset Verified portion is not called for a blank grading. It is not needed in case the grading is completely removed since the graded component itself is being deleted and all its associated information alongwith.

### Other information?
Is this a breaking change? - No
How did you test - there is no specific e2e test for this, so the testing was manual. 

Steps to test - 
1. Grade a component
2. Save it
3. Open it again
4. Clear graded marks
5. Save it

You should not be greeted with an alert. 