### PR TITLE
[Bugfix] Automatically determine and get appropriate chromedriver version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,7 +184,9 @@ jobs:
         - pip3 install pause
         - pip3 install paramiko
         - pip3 install psutil
-        - wget https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
+        - CHROME_VERSION=$(google-chrome --version | egrep -o -e '[0-9]+\.[0-9]+\.[0-9]+')
+        - CHROME_DRIVER_VERSION=$(curl -L https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION})
+        - wget https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip
         - unzip chromedriver_linux64.zip
         - sudo chmod u+x chromedriver
         - sudo mv chromedriver /usr/bin/


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Fixes #3563
Right now, we have a static version of chromedriver that we need to manually update every time a new version is released and google-chrome on Travis is updated.

### What is the new behavior?
This makes it so that the appropriate version of the ChromeDriver is gotten automatically for our version of google chrome (based on algorithm given at https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection?pli=1) so that we should never have to update the .travis.yml file to increment this again.

### Other information?
Tested by letting Travis run and passing all e2e tests which require chromedriver to be working
