### PR TITLE
Set default timezone for displaying dates in Twig

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -67,6 +67,8 @@ class Output {
             'cache' => $this->core->getConfig()->isDebug() ? false : $cache_path,
             'debug' => $this->core->getConfig()->isDebug()
         ]);
+        $this->twig->getExtension(\Twig\Extension\CoreExtension::class)
+            ->setTimezone($this->core->getConfig()->getTimezone());
         $this->twig->addGlobal("core", $this->core);
         $this->twig->addFunction(new \Twig_Function("render_template", function(... $args) {
             return call_user_func_array('self::renderTemplate', $args);


### PR DESCRIPTION
This sets a default timezone to use within Twig when trying to display any \DateTime objects. This isn't really added to fix any bugs, but is still probably best practice to just ensure the timezone that Twig might use is the same as the rest of the Submitty php code, which does not use the value in php.ini, but rather one we set ourselves.

See https://twig.symfony.com/doc/2.x/filters/date.html#timezone for documentation on this
