### PR TITLE
[Vagrant] Set timezone of postgresql DB to UTC

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -539,7 +539,11 @@ if [ ${WORKER} == 0 ]; then
         su postgres -c "source ${SUBMITTY_REPOSITORY}/.setup/vagrant/db_users.sh";
         echo "Finished creating PostgreSQL users"
 
-        sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" "/etc/postgresql/${PG_VERSION}/main/postgresql.conf"
+        # Set timezone to UTC instead of using localtime (which is probably ET)
+        sed -i "s/timezone = 'localtime'/timezone = 'UTC'/" /etc/postgresql/${PG_VERSION}/main/postgresql.conf
+
+        # Set the listen address to be global so that we can access the guest DB from the host
+        sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/${PG_VERSION}/main/postgresql.conf
         service postgresql restart
     fi
 fi


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #3598 

### What is the new behavior?
Postgresql will use UTC any timestamp gotten via current_time instead of relying on the system time (which is ET).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested by doing `vagrant destroy` followed by `vagrant up` and then doing `SELECT current_time` in postgresql within Vagrant to see what the timezone it returned was.

Prior to change:
```
$ NO_SUBMISSIONS=1 vagrant up
$ vagrant ssh
root@vagrant:/usr/local/submitty# psql -U submitty_dbuser -d submitty_s19_sample
Password for user submitty_dbuser:
psql (10.7 (Ubuntu 10.7-0ubuntu0.18.04.1))
Type "help" for help.

submitty_s19_sample=# SELECT current_time;
    current_time
--------------------
 16:35:00.518627-04
(1 row)
```

And after the change:
```
$ NO_SUBMISSIONS=1 vagrant up
$ vagrant ssh
root@vagrant:/usr/local/submitty# psql -U submitty_dbuser -d submitty
Password for user submitty_dbuser:
psql: FATAL:  password authentication failed for user "submitty_dbuser"
root@vagrant:/usr/local/submitty# psql -U submitty_dbuser -d submitty
Password for user submitty_dbuser:
psql (10.7 (Ubuntu 10.7-0ubuntu0.18.04.1))
Type "help" for help.

submitty=# SELECT current_time;
    current_time
--------------------
 21:37:01.919571+00
(1 row)
```