### PR TITLE
[Bugfix] Remove duplicate rows from viewed_responses before adding primary key

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -608,7 +608,7 @@ CREATE TABLE "viewed_responses" (
 	"thread_id" int NOT NULL,
 	"user_id" character varying NOT NULL,
 	"timestamp" timestamp with time zone NOT NULL,
-    CONSTRAINT viewed_responses_pk PRIMARY KEY ("thread_id", "user_id")
+    CONSTRAINT viewed_responses_pkey PRIMARY KEY ("thread_id", "user_id")
 );
 
 

--- a/migration/migrator/migrations/course/20190402220151_viewed_responses_update.py
+++ b/migration/migrator/migrations/course/20190402220151_viewed_responses_update.py
@@ -1,4 +1,5 @@
 def up(config, database, semester, course):
+    database.execute("DELETE FROM viewed_responses AS a USING viewed_responses AS b WHERE a.timestamp < b.timestamp AND a.thread_id = b.thread_id AND a.user_id = b.user_id")
     database.execute("ALTER TABLE viewed_responses DROP CONSTRAINT IF EXISTS viewed_responses_pkey")
     database.execute("ALTER TABLE viewed_responses ADD PRIMARY KEY(thread_id, user_id)")
     pass


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
The current DB before running #3268 to add a primary key could have duplicate rows in this table. 

### What is the new behavior?
This ensures we first de-duplicate the table before we add the new primary key (or else this migration will fail).
