### PR TITLE
[Docs] Fix size of logo in README to be more reasonable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="http://submitty.org/images/submitty_logo.png" alt="Submitty Logo" style="width: 500px;"/>
+<p align="center">
+  <img src="http://submitty.org/images/submitty_logo.png" alt="Submitty Logo" width="500px"/>
+</p>
 
 [![Build Status](https://travis-ci.com/Submitty/Submitty.svg?branch=master)](https://travis-ci.com/Submitty/Submitty)
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
The width attribute for the logo was not being respected by GH and it was sizing it at max-size, which was a bit much as it would take up most of a screen.

### What is the new behavior?
Fixes the width to be what we had set it to be way back when we originally added it to the README, and so that you can now see some amount of content underneath it with it still on the screen.
