### PR TITLE
Fix sidebar hover on discussion forum

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -198,6 +198,10 @@ HTML;
 			    enableTabsInTextArea('.post_content_reply');
 				saveScrollLocationOnRefresh('posts_list');
 				addCollapsable();
+				var b = $('#nav-buttons li a');
+				$.each(b, function(e) {
+					$(b[e]).tooltip('disable').attr('title', $(b[e]).attr('data-original-title'));
+				});
 				$('#{$display_option}').attr('checked', 'checked'); //Saves the radiobutton state when refreshing the page
 				$(".post_reply_from").submit(publishPost);
 				$("form").areYouSure();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
As a result of the most recent PR, the tooltips changed on the discussion forum when viewing full navbars.

![badHover](https://user-images.githubusercontent.com/16356240/56709038-2bd25e00-66ed-11e9-81d9-7b9927dac00e.gif)


### What is the new behavior?
Defaults to normal html tooltips rather than the bootstrap dependency. Fix for the meantime till refactor.

![hoverGood](https://user-images.githubusercontent.com/16356240/56709041-31c83f00-66ed-11e9-95bc-ea2d6f123f56.gif)
