### PR TITLE
[Bugfix] Adding 'Send Seating Assignment Email' button

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -214,6 +214,7 @@
                     <div class="option-title">Display Room Seating Guide</div>
                     <div class="option-alt">Pick a gradeable for which seating will be shown to students. Select --None-- to hide seating guide.</div>
                      <div class="option-alt" style="margin-top: 15px" id="email_seating_assignment_label">Customize an email to send to each students.</div>
+                     <div class ="option-alt"> <a href="{{ email_room_seating_url }}" class="btn btn-primary" id="email_seating_assignment" style="margin-top: 25px">Email Seating Assignments</a> </div>
                 </label>
             </div>
             <div class="option-input col-md-4">


### PR DESCRIPTION
### What is the current behavior?
The course settings page is missing the button for sending seating assignment emails. For some reason this was lost during merge when we reverted the original branch. 

### What is the new behavior?
The button now appears when a seating assignment is selected. 
