### PR TITLE
[Bugfix] Fix deleted posts not having gray background

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -712,6 +712,11 @@ table tr.table-header {
     /*    color: #4a4a4a;*/
     border: 4px solid #276394;
 }
+
+.viewed_post{
+    background-color: white;
+}
+
 /* TODO: MAKE THIS CASCADE */
 .deleted {
     background-color: #A9A9A9;
@@ -721,12 +726,10 @@ table tr.table-header {
 .deleted.active {
     background-color: #505050;
 }
+
 .new_post {
     background-color: var(--viewed_content);
     /*background-color: #d4e1f2;*/
-}
-.viewed_post{
-    background-color: white;
 }
 
 .important {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3604
Deleted post shows normal background of white color.This was happening because `viewed_post` was overriding CSS of `deleted` 
![Screenshot from 2019-04-26 07-33-14](https://user-images.githubusercontent.com/42701709/56778774-aededb80-67f5-11e9-80b7-12889724b70f.png)

### What is the new behavior?
`viewed_post` now will not override CSS for `deleted`
![Screenshot from 2019-04-26 07-37-20](https://user-images.githubusercontent.com/42701709/56778896-39bfd600-67f6-11e9-9d41-fde38b289f5a.png)

