### PR TITLE
Fix param list for generatePostList for TA grading

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -684,7 +684,7 @@ HTML;
         foreach($threadIds as $threadId) {
             $posts = $this->core->getQueries()->getPostsForThread($this->core->getUser()->getId(), $threadId, false, 'time', $submitter_id);
             if(count($posts) > 0) {
-                $posts_view .= $this->core->getOutput()->renderTemplate('forum\ForumThread', 'generatePostList', $threadId, $posts, $currentCourse, false, true, $submitter_id);
+                $posts_view .= $this->core->getOutput()->renderTemplate('forum\ForumThread', 'generatePostList', $threadId, $posts, [], $currentCourse, false, true, $submitter_id);
             } else {
                 $posts_view .= <<<HTML
                     <h3 style="text-align: center;">No posts for thread id: {$threadId}</h3> <br/>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Reply box is currently being displayed. A new parameter was introduced in #3268.
![t2](https://user-images.githubusercontent.com/16356240/56781410-10c92200-67b1-11e9-89cf-613839b81158.png)

### What is the new behavior?
Reply box shouldn't be displayed here.
![t1](https://user-images.githubusercontent.com/16356240/56781408-0f97f500-67b1-11e9-9faf-14169d20e5de.png)


