### PR TITLE
[BugFix] Make QR split upload handle special chars in prefix

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import json
 import stat
-import urllib.parse
+from urllib.parse import unquote
 
 from . import INSTALL_DIR, DATA_DIR
 
@@ -182,8 +182,8 @@ class BulkQRSplit(CourseJob):
         gradeable_id = self.job_details['g_id']
         filename = self.job_details['filename']
 
-        qr_prefix = urllib.parse.unquote(self.job_details['qr_prefix'])
-        qr_suffix = urllib.parse.unquote(self.job_details['qr_suffix'])
+        qr_prefix = unquote(unquote(self.job_details['qr_prefix']))
+        qr_suffix = unquote(unquote(self.job_details['qr_suffix']))
 
         qr_script = Path(INSTALL_DIR, 'sbin', 'bulk_qr_split.py')
         #create paths


### PR DESCRIPTION
Reserved URL chars in prefix/suffix of a qr code do not get cut off
fixes #3564

After moving from a web request to the submitty job system, reserved  URL chars were not getting decoded completely, this fixes that, allowing URLs to be used like before.