### PR TITLE
Add deprecation warnings to top of old distros

### DIFF
--- a/.setup/distro_setup/debian/jessie/setup_distro.sh
+++ b/.setup/distro_setup/debian/jessie/setup_distro.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+#####################################################################
+#            DEPRECATED
+#
+# Support for Debian 8 (jessie) is deprecated as of 05/01/2019.
+# This script has not been maintained since then and we will not
+# accept PRs fixing any drift that exists. Use at your own risk.
+#
+# To see the officially supported distros, please go to:
+#     https://submitty.org/sysadmin/server_os
+#
+#####################################################################
+
 # this script must be run by root or sudo
 if [[ "$UID" -ne "0" ]] ; then
     echo "ERROR: This script must be run by root or sudo"

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+#####################################################################
+#            DEPRECATED
+#
+# Support for Ubuntu 16.04 (xenial) is deprecated as of 05/01/2019.
+# This script has not been maintained since then and we will not
+# accept PRs fixing any drift that exists. Use at your own risk.
+#
+# To see the officially supported distros, please go to:
+#     https://submitty.org/sysadmin/server_os
+#
+#####################################################################
+
+
 # this script must be run by root or sudo
 if [[ "$UID" -ne "0" ]] ; then
     echo "ERROR: This script must be run by root or sudo"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,20 +53,6 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.network 'private_network', ip: '192.168.56.112'
   end
 
-  config.vm.define 'ubuntu-16.04', autostart: false do |ubuntu|
-    ubuntu.vm.box = 'bento/ubuntu-16.04'
-    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 15432
-    ubuntu.vm.network 'private_network', ip: '192.168.56.101'
-    ubuntu.vm.network 'private_network', ip: '192.168.56.102'
-  end
-
-  config.vm.define 'debian', autostart: false do |debian|
-    debian.vm.box = 'bento/debian-8'
-    debian.vm.network 'forwarded_port', guest: 5432, host: 25432
-    debian.vm.network 'private_network', ip: '192.168.56.201'
-    debian.vm.network 'private_network', ip: '192.168.56.202'
-  end
-
   config.vm.provider 'virtualbox' do |vb|
 
     vb.memory = 2048


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant (Submitty/submitty.github.io#79)

### Other information?
Officially drops support for Ubuntu 16.04 (xenial) and Debian 8 (jessie) from things that we claim we support (leaving only Ubuntu 18.04 currently). This would allow us to also look at using newer versions of the core languages of PHP and Python through the project as we no longer support these older distros.

This also removes these distros from the Vagrantfile as we will no longer test Submitty against them.