### PR TITLE
VPAT — fix for "empty link" errors.

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -62,7 +62,7 @@
                         {% endfor %}
                     </div>
                 </div>
-                <a class="col-12 col-sm-auto" id="logo-box" href="http://submitty.org" target=_blank>
+                <a class="col-12 col-sm-auto" id="logo-box" href="http://submitty.org" target="_blank" aria-label="Visit submitty dot org">
                     <img id="logo-submitty" src="../img/submitty_logo.png" alt="Submitty Logo">
                 </a>
             </div>

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -57,7 +57,7 @@
                                 {{ b.getTitle() }}
                             {% endif %}
                             {% if b.getExternalUrl() is not empty %}
-                                <a class="external" href="{{ b.getExternalUrl() }}" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+                                <a class="external" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -49,12 +49,12 @@
                         <td>
                             {{ g_info.name }}
                             {% if g_info.url|trim != "" %}
-                                <a class="external" href="{{ g_info.url }}" target="_blank">
+                                <a class="external" href="{{ g_info.url }}" target="_blank" aria-label="Go to instructions for {{ g_info.name }}">
                                     <i style="margin-left: 10px;" class="fas fa-external-link-alt"></i>
                                 </a>
                             {% endif %}
                             {% if g_info.can_delete %}
-                                <i class="fas fa-trash fa-fw" style="cursor:pointer;" aria-hidden="true" title="Delete Gradeable" onclick='newDeleteGradeableForm("{{ core.buildUrl({'component': 'admin', 'page': 'admin_gradeable', 'action': 'delete_gradeable', 'id': g_info.id}) }}","{{ g_info.name }}");'></i>
+                                <i class="fas fa-trash fa-fw" style="cursor:pointer;" aria-label="Delete {{ g_info.name }}" title="Delete Gradeable" onclick='newDeleteGradeableForm("{{ core.buildUrl({'component': 'admin', 'page': 'admin_gradeable', 'action': 'delete_gradeable', 'id': g_info.id}) }}","{{ g_info.name }}");'></i>
                             {% endif %}
                         </td>
                         {% for button in g_info.buttons %}

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -641,7 +641,7 @@ class NavigationView extends AbstractView {
             "href" => $this->core->buildUrl(array('component' => 'admin', 'page' => 'admin_gradeable', 'action' => 'edit_gradeable_page', 'id' => $gradeable->getId())),
             "class" => "fas fa-pencil-alt",
             "title_on_hover" => true,
-            "aria_label" => "edit gradeable {$gradeable->getId()}"
+            "aria_label" => "edit gradeable {$gradeable->getTitle()}"
         ]);
         return $button;
     }


### PR DESCRIPTION
Fix for areas specifically reported in issue #2311 (possibly closes)

This PR adds/adjusts `aria-label` properties so that 

1. WAVE does not report an "empty link" accessibility error over those hrefs wrapped around a font awesome icon without additional text.
2. Makes the purpose of a couple links better understood.  Note that my screen reader actually _spelled out_ letter per letter, "submitty.org".  Therefore I use "submitty dot org" to have it properly spoken as words.

