### PR TITLE
[Refactor] Remove references to setcsvfields.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -53,7 +53,6 @@ exclude=
     sbin/killall.py,
     sbin/run_lichen_plagiarism.py,
     sbin/sendEmail.py,
-    sbin/setcsvfields.py,
     sbin/submitty_autograding_shipper.py,
     sbin/submitty_autograding_worker.py,
     sbin/untrusted_canary.py,

--- a/.gitattributes
+++ b/.gitattributes
@@ -27,7 +27,6 @@
 *.xml eol=lf
 *.yaml eol=lf
 Vagrantfile eol=lf
-setcsvfields eol=lf
 
 # Files marked 'binary' are not modified.
 # NOTE: *.odt, *.ods, *.odp are open file formats used by

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -734,15 +734,6 @@ if [ ${WORKER} == 0 ]; then
         else
             python3 ${SUBMITTY_REPOSITORY}/.setup/bin/setup_sample_courses.py --submission_url ${SUBMISSION_URL}
         fi
-        #################################################################
-        # SET CSV FIELDS (for classlist upload data)
-        #################
-        # Vagrant auto-settings are based on Rensselaer Polytechnic Institute School
-        # of Science 2015-2016.
-
-        # Other Universities will need to rerun /bin/setcsvfields to match their
-        # classlist csv data.  See wiki for details.
-        ${SUBMITTY_INSTALL_DIR}/sbin/setcsvfields.py 13 12 15 7
     fi
 fi
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
`vagrant up` fails on fresh build as `install_system.sh` still refers to the deleted setcsvfields.py

### What is the new behavior?
Allows `vagrant up` to work as expected.