### PR TITLE
Labels added to "Grade by Count Up" and "Grade by Count Down" icons

### DIFF
--- a/site/public/templates/grading/EditComponent.twig
+++ b/site/public/templates/grading/EditComponent.twig
@@ -99,14 +99,14 @@
                 <span class="radio-input">
                     <input type="radio" class="count-up-selector count-type-selector"
                            name="count-type-{{ component.id }}" {{ component.default == 0 ? 'checked' : '' }}
-                           onclick="onClickCountUp(this)">Grade by Count Up (from zero)
+                           onclick="onClickCountUp(this)" id="grade_by_count_up"> <label for="grade_by_count_up">Grade by Count Up (from zero)</label>
                 </span>
             </div>
             <div class="col">
                 <span class="radio-input">
                     <input type="radio" class="count-down-selector count-type-selector"
                            name="count-type-{{ component.id }}" {{ component.default != 0 ? 'checked' : '' }}
-                           onclick="onClickCountDown(this)">Grade by Count Down (from "Points")
+                           onclick="onClickCountDown(this)" id="grade_by_count_down"> <label for="grade_by_count_down">Grade by Count Down (from "Points")</label>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The system requires the user to click exactly on the checkbox to interact with it.

### What is the new behavior?
Now the user can check the checkbox by clicking the words next to the checkbox (including the checkbox itself).

### Other information?
This relates to issue #3592.

<!-- Is this a breaking change? -->
<!-- How did you test -->
