### PR TITLE
Implement simple router for semester/course

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -430,7 +430,7 @@ if [ ${WORKER} == 0 ]; then
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
     rm -f /tmp/composer-setup.php
 
-    a2enmod include actions cgi suexec authnz_external headers ssl proxy_fcgi
+    a2enmod include actions cgi suexec authnz_external headers ssl proxy_fcgi rewrite
 
     # A real user will have to do these steps themselves for a non-vagrant setup as to do it in here would require
     # asking the user questions as well as searching the filesystem for certificates, etc.

--- a/.setup/travis/apache.conf
+++ b/.setup/travis/apache.conf
@@ -13,6 +13,16 @@
         Order deny,allow
         Allow from all
         Require all granted
+        
+        RewriteEngine On
+        # If the requested filename exists, simply serve it.
+        RewriteCond %{REQUEST_FILENAME} -f
+        RewriteRule ^ - [L]
+
+        # Else rewrite urls to be to some form of /index.php depending of if the
+        # url already contains index.php or not
+        RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+        RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
     </Directory>
 
     ErrorLog ${APACHE_LOG_DIR}/submitty-error.log

--- a/.setup/travis/apache.conf
+++ b/.setup/travis/apache.conf
@@ -10,17 +10,17 @@
         Options Indexes FollowSymLinks Includes ExecCGI
         AddHandler cgi-script .cgi
         AllowOverride All
-        Order deny,allow
-        Allow from all
         Require all granted
-        
+    </Directory>
+
+    <Directory /usr/local/submitty/site/public>
+        Require all granted
+
         RewriteEngine On
-        # If the requested filename exists, simply serve it.
+
         RewriteCond %{REQUEST_FILENAME} -f
         RewriteRule ^ - [L]
 
-        # Else rewrite urls to be to some form of /index.php depending of if the
-        # url already contains index.php or not
         RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
         RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
     </Directory>

--- a/.setup/vagrant/sites-available/submitty.conf
+++ b/.setup/vagrant/sites-available/submitty.conf
@@ -33,8 +33,12 @@
         RewriteCond %{REQUEST_FILENAME} -f
         RewriteRule ^ - [L]
 
-        # Else rewrite urls to be to some form of /index.php depending of if the
-        # url already contains index.php or not
+        # Else rewrite urls to use index.php, however we have to be aware of two
+        # possible conditions of whether index.php is in the URL already or not.
+        # To be backwards compatible, we want to ensure that having /index.php
+        # is valid and usable. In anycase, we rewrite everything up-to /index.php
+        # to be the "url" parameter of the query, and then append whatever else we
+        # had in the QUERY_STRING after it.
         RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
         RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
     </Directory>

--- a/.setup/vagrant/sites-available/submitty.conf
+++ b/.setup/vagrant/sites-available/submitty.conf
@@ -47,16 +47,18 @@
         Order allow,deny
         Allow from all
 
-        RewriteEngine On
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
 
-        # If the requested filename exists, simply serve it.
-        RewriteCond %{REQUEST_FILENAME} -f
-        RewriteRule ^ - [L]
+            # If the requested filename exists, simply serve it.
+            RewriteCond %{REQUEST_FILENAME} -f
+            RewriteRule ^ - [L]
 
-        # Else rewrite urls to be to some form of /index.php depending of if the
-        # url already contains index.php or not
-        RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
-        RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+            # Else rewrite urls to be to some form of /index.php depending of if the
+            # url already contains index.php or not
+            RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+            RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+        </IfModule>
     </Directory>
 
     <Directory "/usr/local/submitty/site/cgi-bin">

--- a/.setup/vagrant/sites-available/submitty.conf
+++ b/.setup/vagrant/sites-available/submitty.conf
@@ -47,18 +47,16 @@
         Order allow,deny
         Allow from all
 
-        <IfModule mod_rewrite.c>
-            RewriteEngine On
+        RewriteEngine On
 
-            # If the requested filename exists, simply serve it.
-            RewriteCond %{REQUEST_FILENAME} -f
-            RewriteRule ^ - [L]
+        # If the requested filename exists, simply serve it.
+        RewriteCond %{REQUEST_FILENAME} -f
+        RewriteRule ^ - [L]
 
-            # Else rewrite urls to be to some form of /index.php depending of if the
-            # url already contains index.php or not
-            RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
-            RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
-        </IfModule>
+        # Else rewrite urls to be to some form of /index.php depending of if the
+        # url already contains index.php or not
+        RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+        RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
     </Directory>
 
     <Directory "/usr/local/submitty/site/cgi-bin">

--- a/.setup/vagrant/sites-available/submitty.conf
+++ b/.setup/vagrant/sites-available/submitty.conf
@@ -46,6 +46,17 @@
         Require all granted
         Order allow,deny
         Allow from all
+
+        RewriteEngine On
+
+        # If the requested filename exists, simply serve it.
+        RewriteCond %{REQUEST_FILENAME} -f
+        RewriteRule ^ - [L]
+
+        # Else rewrite urls to be to some form of /index.php depending of if the
+        # url already contains index.php or not
+        RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+        RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
     </Directory>
 
     <Directory "/usr/local/submitty/site/cgi-bin">

--- a/migration/migrator/migrations/system/20190510232333_apache_rewrite.py
+++ b/migration/migrator/migrations/system/20190510232333_apache_rewrite.py
@@ -1,0 +1,32 @@
+"""Migration for the Submitty system."""
+import subprocess
+
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    subprocess.check_call(
+        ('a2enmod', 'rewrite'),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    subprocess.check_call(
+        ('systemctl', 'restart', 'apache2'),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    pass

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -53,6 +53,9 @@ class Core {
     /** @var Access $access */
     private $access = null;
 
+    /** @var Router */
+    private $router;
+
     /**
      * Core constructor.
      *
@@ -506,6 +509,14 @@ class Core {
         finally {
             curl_close($ch);
         }
+    }
+
+    public function setRouter(Router $router) {
+        $this->router = $router;
+    }
+
+    public function getRouter(): Router {
+        return $this->router;
     }
 
     /**

--- a/site/app/libraries/Router.php
+++ b/site/app/libraries/Router.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace app\libraries;
+
+class Router {
+    private $pieces = [];
+
+    public function __construct(string $url) {
+        if (!empty($url)) {
+            $this->pieces = explode('/', $url);
+        }
+    }
+
+    public function getNext(): ?string {
+        return array_shift($this->pieces);
+    }
+
+    public function hasNext(): bool {
+        return count($this->pieces) > 0;
+    }
+}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -63,7 +63,7 @@
                     </div>
                 </div>
                 <a class="col-12 col-sm-auto" id="logo-box" href="http://submitty.org" target="_blank" aria-label="Visit submitty dot org">
-                    <img id="logo-submitty" src="../img/submitty_logo.png" alt="Submitty Logo">
+                    <img id="logo-submitty" src="{{ base_url }}/img/submitty_logo.png" alt="Submitty Logo">
                 </a>
             </div>
             <noscript>

--- a/site/tests/app/libraries/RouterTester.php
+++ b/site/tests/app/libraries/RouterTester.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace tests\app\libraries;
+
+use app\libraries\Router;
+
+class RouterTester {
+    public function testRouter() {
+        $router = new Router('part/part2/part3');
+        $expected = ['part', 'part2', 'part3'];
+        $actual = [];
+        while ($router->hasNext()) {
+            $actual[] = $router->getNext();
+        }
+
+        $this->assertEquals($expected, $actual);
+        $this->assertNull($router->getNext());
+        $this->assertFalse($router->hasNext());
+    }
+
+    public function testEmptyRouter() {
+        $router = new Router();
+        $this->assertFalse($router->hasNext());
+        $this->assertNull($router->getNext());
+    }
+}

--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -6,7 +6,7 @@ class TestAccess(BaseTestCase):
         super().__init__(testname, log_in=False)
 
     def test_simple_router_course_page(self):
-        self.log_in('/index.php?semester=' + self.semester + '&course=sample')
+        self.log_in('/index.php?semester=' + self.semester + '&course=sample', title='SAMPLE')
         self.assertEqual('SAMPLE', self.driver.title)
         self.driver.get('/{}/sample/'.format(self.semester))
         self.assertEqual('SAMPLE', self.driver.title)

--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -8,7 +8,7 @@ class TestAccess(BaseTestCase):
     def test_simple_router_course_page(self):
         self.log_in('/index.php?semester=' + self.semester + '&course=sample', title='SAMPLE')
         self.assertEqual('SAMPLE', self.driver.title)
-        self.driver.get('/{}/sample/'.format(self.semester))
+        self.get('/{}/sample/'.format(self.semester))
         self.assertEqual('SAMPLE', self.driver.title)
 
     def test_no_course_in_url(self):

--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -5,6 +5,12 @@ class TestAccess(BaseTestCase):
     def __init__(self, testname):
         super().__init__(testname, log_in=False)
 
+    def test_simple_router_course_page(self):
+        self.log_in('/index.php?semester=' + self.semester + '&course=sample', user_id='student')
+        expected = self.driver.page_source
+        self.driver.get('/{}/sample/'.format(self.semester))
+        self.assertEqual(expected, self.driver.page_source)
+
     def test_no_course_in_url(self):
         self.log_in("/index.php?semester=null", "Submitty")
         self.assertEqual(self.test_url + "/index.php?&success_login=true", self.driver.current_url)

--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -7,9 +7,9 @@ class TestAccess(BaseTestCase):
 
     def test_simple_router_course_page(self):
         self.log_in('/index.php?semester=' + self.semester + '&course=sample')
-        expected = self.driver.page_source
+        self.assertEqual('SAMPLE', self.driver.title)
         self.driver.get('/{}/sample/'.format(self.semester))
-        self.assertEqual(expected, self.driver.page_source)
+        self.assertEqual('SAMPLE', self.driver.title)
 
     def test_no_course_in_url(self):
         self.log_in("/index.php?semester=null", "Submitty")

--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -6,7 +6,7 @@ class TestAccess(BaseTestCase):
         super().__init__(testname, log_in=False)
 
     def test_simple_router_course_page(self):
-        self.log_in('/index.php?semester=' + self.semester + '&course=sample', user_id='student')
+        self.log_in('/index.php?semester=' + self.semester + '&course=sample')
         expected = self.driver.page_source
         self.driver.get('/{}/sample/'.format(self.semester))
         self.assertEqual(expected, self.driver.page_source)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #933 

### What is the new behavior?
This adds in a basic router that can utilize mod_rewrite within apache to allow us to access pages using both `/index.php?semester={$semester}&course={$course}` or `/{$semester}/{$course}`. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is fully backwards compatible with the existing setup such that people can go to either the existing URL scheme, or use the new one. Looking forward, we can use the router to pop off pieces to get `$_REQUEST['component']`, `$_REQUEST['action']`, etc.

This is somewhat necessary before tackling a simple setup for some REST endpoints for #300.
