### PR TITLE
Change Background color of deleted posts and threads

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -731,12 +731,12 @@ table tr.table-header {
 
 /* TODO: MAKE THIS CASCADE */
 .deleted {
-    background-color: #A9A9A9;
+    background-color: #DDDDDD;
     color: #4a4a4a;
 }
 
 .deleted.active {
-    background-color: #505050;
+    background-color: #C0C0C0;
 }
 
 .new_post {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3628
1. Color contrast for below configuration is 3.77:1 and ideally it should be greater than 4.5:1 
![Screenshot from 2019-05-13 10-34-02](https://user-images.githubusercontent.com/42701709/57597041-36a14580-756b-11e9-8bab-f49527093e12.png)
2. Color contrast for below configuration is 1.09:1 which is very less comparable to 4.5:1
![Screenshot from 2019-05-13 10-15-34](https://user-images.githubusercontent.com/42701709/57597042-3739dc00-756b-11e9-9c7a-680099f7d045.png)
 

### What is the new behavior?
1. Background color is changed from `#A9A9A9` to `#DDDDDD` this changed color contrast ratio from `3.77:1` to `6.52:1`
![Screenshot from 2019-05-13 10-08-28](https://user-images.githubusercontent.com/42701709/57597150-d232b600-756b-11e9-848d-ef8b4d81fae6.png)
2. Background color is changed from `#505050` to `#C0C0C0` this changed color contrast ratio from `1.09:1` to `4.87:1`
![Screenshot from 2019-05-13 10-08-05](https://user-images.githubusercontent.com/42701709/57597153-d2cb4c80-756b-11e9-8e2e-47d83fa25660.png)
