### PR TITLE
Fixed ignored timezone for json in CONFIGURE_SUBMITTY.py

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -415,7 +415,7 @@ config['submitty_install_dir'] = SUBMITTY_INSTALL_DIR
 config['submitty_repository'] = SUBMITTY_REPOSITORY
 config['submitty_data_dir'] = SUBMITTY_DATA_DIR
 config['autograding_log_path'] = AUTOGRADING_LOG_PATH
-config['timezone'] = tzlocal.get_localzone().zone
+config['timezone'] = TIMEZONE
 
 if not args.worker:
     config['site_log_path'] = TAGRADING_LOG_PATH


### PR DESCRIPTION
### What is the current behavior?

Fixes #3156 
Before, the CONFIGURE_SUBMITTY.py script would prompt the user for a timezone, but only write the given time zone to the INSTALL_SUBMITTY.sh script; it would use the default time zone for submitty_conf.json

### What is the new behavior?

Now, when running CONFIGURE_SUBMITTY.py, entering a custom time zone will correctly implement the time zone into both the INSTALL_SUBMITTY.sh script _and_ submitty_conf.json.

### Other information?

Tested using Vagrant; first ran CONFIGURE_SUBMITTY.py from GIT_CHECKOUT inside the VM, provided a custom time zone, and checked the two files after completion; submitty_conf.json had the incorrect time zone. Ran same tests again after making changes, and submitty_conf.json contained the correct time zone.
