### PR TITLE
Perform VCS checkout at submission time (not grading time)

### DIFF
--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -111,33 +111,6 @@ def unzip_queue_file(zipfilename):
     return queue_obj
 
 
-def valid_github_user_id(userid):
-    # Github username may only contain alphanumeric characters or
-    # hyphens. Github username cannot have multiple consecutive
-    # hyphens. Github username cannot begin or end with a hyphen.
-    # Maximum is 39 characters.
-    if (userid==''):
-        # GitHub userid cannot be empty
-        return False
-    checklegal = lambda char: char.isalnum() or char == '-'
-    filtered_userid = ''.join(list(filter(checklegal,userid)))
-    if not userid == filtered_userid:
-        return False
-    return True
-
-
-def valid_github_repo_id(repoid):
-    # Only characters, numbers, dots, minus and underscore are allowed.
-    if (repoid==''):
-        # GitHub repoid cannot be empty
-        return False
-    checklegal = lambda char: char.isalnum() or char == '.' or char == '-' or char == '_'
-    filtered_repoid = ''.join(list(filter(checklegal,repoid)))
-    if not repoid == filtered_repoid:
-        return False
-    return True
-
-
 # ==================================================================================
 # ==================================================================================
 def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_directory,next_to_grade):
@@ -226,100 +199,18 @@ def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_di
     # 'touch' a file in the logs folder
     open(os.path.join(tmp_logs,"overall.txt"), 'a')
 
-    # grab the submission time
-    with open (os.path.join(submission_path,".submit.timestamp")) as submission_time_file:
-        submission_string = submission_time_file.read().rstrip()
-    submission_datetime = dateutils.read_submitty_date(submission_string)
-
     # --------------------------------------------------------------------
-    # CHECKOUT THE STUDENT's REPO
+    # CONFIRM WE HAVE A CHECKOUT OF THE STUDENT'S REPO
     if is_vcs:
+        # there should be a checkout log file in the results directory
+        # move that file to the tmp logs directory..
+        vcs_checkout_logfile = os.path.join(results_path,"logs","vcs_checkout.txt")
+        exists = os.path.isfile(vcs_checkout_logfile)
+        if exists:
+            shutil.move(vcs_checkout_logfile,tmp_logs)
+        else:
+            grade_items_logging.log_message(JOB_ID, message=str(my_name)+" ERROR: missing vcs_checkout.txt logfile "+str(vcs_checkout_logfile))
 
-        # cleanup the previous checkout (if it exists)
-        shutil.rmtree(checkout_path,ignore_errors=True)
-        os.makedirs(checkout_path, exist_ok=True)
-
-        try:
-            # If we are public or private github, we will have an empty vcs_subdirectory
-            if vcs_subdirectory == '':
-                with open (os.path.join(submission_path,".submit.VCS_CHECKOUT")) as submission_vcs_file:
-                    VCS_JSON = json.load(submission_vcs_file)
-                    git_user_id = VCS_JSON["git_user_id"]
-                    git_repo_id = VCS_JSON["git_repo_id"]
-                    if not valid_github_user_id(git_user_id):
-                        raise Exception ("Invalid GitHub user/organization name: '"+git_user_id+"'")
-                    if not valid_github_repo_id(git_repo_id):
-                        raise Exception ("Invalid GitHub repository name: '"+git_repo_id+"'")
-                    # construct path for GitHub
-                    vcs_path="https://www.github.com/"+git_user_id+"/"+git_repo_id
-
-            # is vcs_subdirectory standalone or should it be combined with base_url?
-            elif vcs_subdirectory[0] == '/' or '://' in vcs_subdirectory:
-                vcs_path = vcs_subdirectory
-            else:
-                if '://' in vcs_base_url:
-                    vcs_path = urllib.parse.urljoin(vcs_base_url, vcs_subdirectory)
-                else:
-                    vcs_path = os.path.join(vcs_base_url, vcs_subdirectory)
-
-            with open(os.path.join(tmp_logs, "overall.txt"), 'a') as f:
-                print("====================================\nVCS CHECKOUT", file=f)
-                print('vcs_base_url', vcs_base_url, file=f)
-                print('vcs_subdirectory', vcs_subdirectory, file=f)
-                print('vcs_path', vcs_path, file=f)
-                print(['/usr/bin/git', 'clone', vcs_path, checkout_path], file=f)
-
-            # git clone may fail -- because repository does not exist,
-            # or because we don't have appropriate access credentials
-            try:
-                subprocess.check_call(['/usr/bin/git', 'clone', vcs_path, checkout_path])
-                os.chdir(checkout_path)
-
-                # determine which version we need to checkout
-                # if the repo is empty or the master branch does not exist, this command will fail
-                try:
-                    what_version = subprocess.check_output(['git', 'rev-list', '-n', '1', '--before="'+submission_string+'"', 'master'])
-                    what_version = str(what_version.decode('utf-8')).rstrip()
-                    if what_version == "":
-                        # oops, pressed the grade button before a valid commit
-                        shutil.rmtree(checkout_path, ignore_errors=True)
-                    else:
-                        # and check out the right version
-                        subprocess.call(['git', 'checkout', '-b', 'grade', what_version])
-                    os.chdir(tmp)
-                    subprocess.call(['ls', '-lR', checkout_path], stdout=open(tmp_logs + "/overall.txt", 'a'))
-                    obj['revision'] = what_version
-
-                # exception on git rev-list
-                except subprocess.CalledProcessError as error:
-                    grade_items_logging.log_message(job_id,message="ERROR: failed to determine version on master branch " + str(error))
-                    os.chdir(checkout_path)
-                    with open(os.path.join(checkout_path,"failed_to_determine_version_on_master_branch.txt"),'w') as f:
-                        print(str(error),file=f)
-                        print("\n",file=f)
-                        print("Check to be sure the repository is not empty.\n",file=f)
-                        print("Check to be sure the repository has a master branch.\n",file=f)
-                        print("And check to be sure the timestamps on the master branch are reasonable.\n",file=f)
-
-            # exception on git clone
-            except subprocess.CalledProcessError as error:
-                grade_items_logging.log_message(job_id,message="ERROR: failed to clone repository " + str(error))
-                os.chdir(checkout_path)
-                with open(os.path.join(checkout_path,"failed_to_clone_repository.txt"),'w') as f:
-                    print(str(error),file=f)
-                    print("\n",file=f)
-                    print("Check to be sure the repository exists.\n",file=f)
-                    print("And check to be sure the submitty_daemon user has appropriate access credentials.\n",file=f)
-
-        # exception in constructing full git repository url/path
-        except Exception as error:
-            grade_items_logging.log_message(job_id,message="ERROR: failed to construct valid repository url/path" + str(error))
-            os.chdir(checkout_path)
-            with open(os.path.join(checkout_path,"failed_to_construct_valid_repository_url.txt"),'w') as f:
-                print(str(error),file=f)
-                print("\n",file=f)
-                print("Check to be sure the repository exists.\n",file=f)
-                print("And check to be sure the submitty_daemon user has appropriate access credentials.\n",file=f)
 
     copytree_if_exists(submission_path,os.path.join(tmp_submission,"submission"))
     copytree_if_exists(checkout_path,os.path.join(tmp_submission,"checkout"))

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -205,8 +205,7 @@ def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_di
         # there should be a checkout log file in the results directory
         # move that file to the tmp logs directory..
         vcs_checkout_logfile = os.path.join(results_path,"logs","vcs_checkout.txt")
-        exists = os.path.isfile(vcs_checkout_logfile)
-        if exists:
+        if os.path.isfile(vcs_checkout_logfile):
             shutil.move(vcs_checkout_logfile,tmp_logs)
         else:
             grade_items_logging.log_message(JOB_ID, message=str(my_name)+" ERROR: missing vcs_checkout.txt logfile "+str(vcs_checkout_logfile))

--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -102,7 +102,7 @@ def replay(starttime,endtime):
             pause.until(pause_time)
             queue_time = dateutils.write_submitty_date()
             print(datetime.datetime.now(),"      REPLAY: ",original_time," ",my_job)
-            # FIXME : This will need to be adjust for team assigments
+            # FIXME : This will need to be adjust for team assignments
             # and assignments with special required capabilities!
             item = {"semester": what[0],
                     "course": what[1],
@@ -217,6 +217,9 @@ def main():
                     my_team = my_who
                     my_is_team = True
 
+                # FIXME: Set this value appropriately
+                is_vcs_checkout = False
+
                 grade_queue.append({"semester": my_semester,
                                     "course": my_course,
                                     "gradeable": my_gradeable,
@@ -225,6 +228,7 @@ def main():
                                     "who": my_who,
                                     "is_team": my_is_team,
                                     "version": my_version,
+                                    "vcs_checkout": is_vcs_checkout,
                                     "required_capabilities" : required_capabilities,
                                     "queue_time":queue_time,
                                     "regrade":True,

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -486,7 +486,7 @@ def checkout_vcs_repo(my_file):
 
         # OPTION: A shallow clone, with just the most recent commit.
         #
-        #  NOTE: If the server is busy, it might take seconds of
+        #  NOTE: If the server is busy, it might take seconds or
         #     minutes for an available shipper to process the git
         #     clone, and thethe timestamp might be slightly late)
         #

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -395,6 +395,8 @@ def valid_github_user_id(userid):
     # hyphens. Github username cannot have multiple consecutive
     # hyphens. Github username cannot begin or end with a hyphen.
     # Maximum is 39 characters.
+    #
+    # NOTE: We only scrub the input for allowed characters.
     if (userid==''):
         # GitHub userid cannot be empty
         return False
@@ -424,9 +426,10 @@ def checkout_vcs_repo(my_file):
         obj = json.load(infile)
 
     partial_path = os.path.join(obj["gradeable"],obj["who"],str(obj["version"]))
-    submission_path = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"submissions",partial_path)
-    checkout_path = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"checkout",partial_path)
-    results_path = os.path.join(SUBMITTY_DATA_DIR,"courses",obj["semester"],obj["course"],"results",partial_path)
+    course_dir = os.path.join(SUBMITTY_DATA_DIR, "courses", obj["semester"], obj["course"])
+    submission_path = os.path.join(course_dir, "submissions", partial_path)
+    checkout_path = os.path.join(course_dir, "checkout", partial_path)
+    results_path = os.path.join(course_dir, "results", partial_path)
 
     is_vcs,vcs_type,vcs_base_url,vcs_subdirectory = packer_unpacker.get_vcs_info(SUBMITTY_DATA_DIR,obj["semester"],obj["course"],obj["gradeable"],obj["who"],obj["team"])
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1411,10 +1411,11 @@ class SubmissionController extends AbstractController {
           if (@file_put_contents($vcs_queue_file, FileUtils::encodeJson($queue_data), LOCK_EX) === false) {
             return $this->uploadResult("Failed to create vcs file for grading queue.", false);
           }
-        }
-        // Then create the file that will trigger autograding
-        if (@file_put_contents($queue_file, FileUtils::encodeJson($queue_data), LOCK_EX) === false) {
+        } else {
+          // Then create the file that will trigger autograding
+          if (@file_put_contents($queue_file, FileUtils::encodeJson($queue_data), LOCK_EX) === false) {
             return $this->uploadResult("Failed to create file for grading queue.", false);
+          }
         }
 
         if($gradeable->isTeamAssignment()) {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -833,6 +833,8 @@ class SubmissionController extends AbstractController {
         $queue_file = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "to_be_graded_queue",
             implode("__", $queue_file));
 
+        $vcs_checkout = isset($_REQUEST['vcs_checkout']) ? $_REQUEST['vcs_checkout'] === "true" : false;
+
         // create json file...
         $queue_data = array("semester" => $this->core->getConfig()->getSemester(),
             "course" => $this->core->getConfig()->getCourse(),
@@ -844,7 +846,8 @@ class SubmissionController extends AbstractController {
             "team" => $team_id,
             "who" => $who_id,
             "is_team" => $gradeable->isTeamAssignment(),
-            "version" => $new_version);
+            "version" => $new_version,
+            "vcs_checkout" => $vcs_checkout);
 
         if (@file_put_contents($queue_file, FileUtils::encodeJson($queue_data), LOCK_EX) === false) {
             return $this->uploadResult("Failed to create file for grading queue.", false);
@@ -1372,15 +1375,22 @@ class SubmissionController extends AbstractController {
             return $this->uploadResult("Failed to save timestamp file for this submission.", false);
         }
 
-        $queue_file = array($this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse(),
-            $gradeable->getId(), $who_id, $new_version);
+        $queue_file_helper = array($this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse(),
+                                   $gradeable->getId(), $who_id, $new_version);
+        $queue_file_helper = implode("__", $queue_file_helper);
         $queue_file = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "to_be_graded_queue",
-            implode("__", $queue_file));
+                                           $queue_file_helper);
+        // SPECIAL NAME FOR QUEUE FILE OF VCS GRADEABLES
+        $vcs_queue_file = "";
+        if ($vcs_checkout === true) {
+          $vcs_queue_file = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "to_be_graded_queue",
+                                                 "VCS__".$queue_file_helper);
+        }
 
         // create json file...
         $queue_data = array("semester" => $this->core->getConfig()->getSemester(),
             "course" => $this->core->getConfig()->getCourse(),
-            "gradeable" =>  $gradeable->getId(),
+            "gradeable" => $gradeable->getId(),
             "required_capabilities" => $gradeable->getAutogradingConfig()->getRequiredCapabilities(),
             "max_possible_grading_time" => $gradeable->getAutogradingConfig()->getMaxPossibleGradingTime(),
             "queue_time" => $current_time,
@@ -1388,13 +1398,21 @@ class SubmissionController extends AbstractController {
             "team" => $team_id,
             "who" => $who_id,
             "is_team" => $gradeable->isTeamAssignment(),
-            "version" => $new_version);
+            "version" => $new_version,
+            "vcs_checkout" => $vcs_checkout);
 
         if ($gradeable->isTeamAssignment()) {
             $queue_data['team_members'] = $team->getMemberUserIds();
         }
 
-
+        // Create the vcs file first!  (avoid race condition, we must
+        // check out the files before trying to grade them)
+        if ($vcs_queue_file !== "") {
+          if (@file_put_contents($vcs_queue_file, FileUtils::encodeJson($queue_data), LOCK_EX) === false) {
+            return $this->uploadResult("Failed to create vcs file for grading queue.", false);
+          }
+        }
+        // Then create the file that will trigger autograding
         if (@file_put_contents($queue_file, FileUtils::encodeJson($queue_data), LOCK_EX) === false) {
             return $this->uploadResult("Failed to create file for grading queue.", false);
         }

--- a/site/app/libraries/GradingQueue.php
+++ b/site/app/libraries/GradingQueue.php
@@ -24,6 +24,7 @@ class GradingQueue {
     private $grading_files = [];
 
     const GRADING_FILE_PREFIX = 'GRADING_';
+    const VCS_FILE_PREFIX = 'VCS__';
     const QUEUE_FILE_SEPARATOR = '__';
 
     const NOT_QUEUED = -1;
@@ -93,6 +94,7 @@ class GradingQueue {
             $auto_graded_version->getVersion()
         ]);
         $grading_queue_file = self::GRADING_FILE_PREFIX . $queue_file;
+        $vcs_queue_file = self::VCS_FILE_PREFIX . $queue_file;
 
         //FIXME: it would be nice to show the student which queue their assignment is in
         //FIXME:    but this could be a pretty expensive operation
@@ -105,13 +107,18 @@ class GradingQueue {
 
         // Then, check its position in the queue
         $queue_status = array_search($queue_file, $this->queue_files, true);
-        if($queue_status === false) {
-            // This means the file didn't exist when we loaded the queue state
-            return self::NOT_QUEUED;
-        } else {
+        if($queue_status == false) {
+          // Also check for the vcs queue file, which will soon be converted into a regular queue file
+          $queue_status = array_search($vcs_queue_file, $this->queue_files, true);
+        }
+
+        if($queue_status !== false) {
             // Convert from 0-indexed array since 0 is self::GRADING
             return $queue_status + 1;
         }
+
+        // Otherwise...  the file didn't exist when we loaded the queue state (likely something went wrong)
+        return self::NOT_QUEUED;
     }
 
     /**

--- a/site/app/libraries/GradingQueue.php
+++ b/site/app/libraries/GradingQueue.php
@@ -107,7 +107,7 @@ class GradingQueue {
 
         // Then, check its position in the queue
         $queue_status = array_search($queue_file, $this->queue_files, true);
-        if($queue_status == false) {
+        if($queue_status === false) {
           // Also check for the vcs queue file, which will soon be converted into a regular queue file
           $queue_status = array_search($vcs_queue_file, $this->queue_files, true);
         }

--- a/site/tests/app/controllers/submission/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/submission/SubmissionControllerTester.php
@@ -764,7 +764,7 @@ class SubmissionControllerTester extends BaseUnitTest {
         sort($files);
         $this->assertEquals(array('.submit.VCS_CHECKOUT', '.submit.timestamp'), $files);
         $touch_file = implode("__", array($this->config['semester'], $this->config['course'], "test", "testUser", "1"));
-        $this->assertFileExists(FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_queue", $touch_file));
+        $this->assertFileExists(FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_queue", "VCS__".$touch_file));
     }
 
     public function testEmptyPost() {


### PR DESCRIPTION
Creates a new type of autograding queue file, prefixed with "VCS__".  These files should be handled ASAP (by the next available shipper), to perform the checkout of files.  Then the task becomes a normal queue file (it only cuts in line to do the checkout, then it goes to the back of the line for autograding).  

Benefits:  The file checkout will only occur once.  And this eliminates the potential git commit timestamp + batch regrade 'exploit' to sneak additional work into an earlier submission.

Closes #3690 


Also...  only does a shallow / depth=1 clone of the repo (less filespace wasted on potentially lengthy edit history).   This closes #1886.  Note:  now that we're doing the checkout more promptly (and only once) the timestamp is less important.  Github repos seem to have an error when the --shallow-since flag is used.  

While leaving off the date has a potential exploit of a short delay before the checkout occurs, leaving off the date has an advantage if the students local time is inaccurate.  For example:  If a student's machine is a few minutes in the future, and they quickly commit, then push & request grading, the server will not grab the most recent commit -- because it's in the future.  This has confused students in the past!  So leaving off the date is probably the best all around solution.