### PR TITLE
Updated account information in distro setup script

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -88,15 +88,17 @@ if [ ${VAGRANT} == 1 ]; then
 ############################################################
 ${DISTRO_LINE}
 ##                                                        ##
-##  All user accounts have same password unless otherwise ##
-##  noted below. The following user accounts exist:       ##
-##    vagrant/vagrant, root/vagrant, submitty_dbuser,     ##
-##    submitty_php, submitty_cgi, submitty_daemon, ta,    ##
-##    instructor, developer, postgres                     ##
+##  All user accounts have same password as name.         ##
 ##                                                        ##
-##  The following accounts have database accounts         ##
-##  with same password as above:                          ##
-##    submitty_dbuser, postgres, root, vagrant            ##
+##  The following accounts are system users:              ##
+##    vagrant, root, submitty_php, submitty_cgi,          ##
+##    submitty_daemon, ta, instructor, postgres           ##
+##                                                        ##
+##  The following accounts are database accounts:         ##
+##    submitty_dbuser, root, vagrant                      ##
+##                                                        ##
+##  The following users can log into the website:         ##
+##    instructor, ta, ta2, ta3, student                   ##
 ##                                                        ##
 ##  The VM can be accessed with the following urls:       ##
 ${SUBMISSION_LINE}

--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -95,7 +95,7 @@ ${DISTRO_LINE}
 ##    submitty_daemon, ta, instructor, postgres           ##
 ##                                                        ##
 ##  The following accounts are database accounts:         ##
-##    submitty_dbuser, root, vagrant                      ##
+##    submitty_dbuser, postgres, vagrant                  ##
 ##                                                        ##
 ##  The following users can log into the website:         ##
 ##    instructor, ta, ta2, ta3, student                   ##


### PR DESCRIPTION
### What is the current behavior?
Addresses an inconsistency in the "setup_distro.sh" script, which has information on various accounts and their purposes in the VM environment. (https://submitty.org/developer/vm_install_using_vagrant, step 11)

Some of the listed accounts either did not exist or were categorized incorrectly.

### What is the new behavior?
The script now has information that matches the table in step 11 on the aforementioned page. Clarifies the role and existence of each account.

### Other information?
NOTE: The system user "root" does not have the password "vagrant". Tested by logging in as another user, then back into root. Likewise, the system user "postgres" does not have the password "postgres", tested the same way (can access from root without password, but not from any other account)
NOTE: There is no database user "postgres" despite various documentation of the user (https://submitty.org/sysadmin/database_overview)

Tested using Vagrant; first attempted to access all user accounts listed; then attempted to log into the database with `psql` using each user listed; then logged into the Submitty website using available accounts from  (https://submitty.org/developer/vm_install_using_vagrant, step 11). Updated information as necessary.
