### PR TITLE
Use Authentication::authenticate directly for VCS Login

### DIFF
--- a/sbin/authentication.py
+++ b/sbin/authentication.py
@@ -77,13 +77,13 @@ if __name__ == "__main__":
     True
     """
     #
-    print(check_password({'REQUEST_URI': '/git/f17/sample/open_homework/instructor'}, 'instructor', 'instructor'))
-    print(check_password({'REQUEST_URI': '/git/f17/sample/open_homework/instructor'}, 'ta', 'ta'))
-    print(check_password({'REQUEST_URI': '/git/f17/sample/open_homework/instructor'}, 'student', 'student'))
-    print(check_password({'REQUEST_URI': '/git/f17/sample/open_homework/student'}, 'student', 'student'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/open_homework/instructor'}, 'instructor', 'instructor'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/open_homework/instructor'}, 'ta', 'ta'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/open_homework/instructor'}, 'student', 'student'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/open_homework/student'}, 'student', 'student'))
 
-    print(check_password({'REQUEST_URI': '/git/f17/sample/instructor'}, 'instructor', 'instructor'))
-    print(check_password({'REQUEST_URI': '/git/f17/sample/instructor'}, 'ta', 'ta'))
-    print(check_password({'REQUEST_URI': '/git/f17/sample/instructor'}, 'student', 'student'))
-    print(check_password({'REQUEST_URI': '/git/f17/sample/student'}, 'student', 'student'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/instructor'}, 'instructor', 'instructor'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/instructor'}, 'ta', 'ta'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/instructor'}, 'student', 'student'))
+    print(check_password({'REQUEST_URI': '/git/s19/sample/student'}, 'student', 'student'))
 

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -164,7 +164,7 @@ class AuthenticationController extends AbstractController {
         }
         $this->core->getAuthentication()->setUserId($_POST['user_id']);
         $this->core->getAuthentication()->setPassword($_POST['password']);
-        if ($this->core->authenticate(false) !== true) {
+        if ($this->core->getAuthentication()->authenticate() !== true) {
             $msg = "Could not login using that user id or password";
             return $this->core->getOutput()->renderJsonFail($msg);
         }

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -337,7 +337,7 @@ class Core {
                     $this->getConfig()->getSecretSession(),
                     $persistent_cookie
                 );
-                return Utils::setCookie('submitty_session', (string) $token, $cookie_data['expire_time']);
+                return Utils::setCookie('submitty_session', (string) $token, $token->getClaim('expire_time'));
             }
         }
         catch (\Exception $e) {

--- a/site/tests/app/controllers/AuthenticationControllerTester.php
+++ b/site/tests/app/controllers/AuthenticationControllerTester.php
@@ -16,7 +16,7 @@ class AuthenticationControllerTester extends BaseUnitTest {
         $auth = $this->createMock(AbstractAuthentication::class);
         $auth->method('setUserId')->willReturn(null);
         $auth->method('setPassword')->willReturn(null);
-        $core->method('authenticate')->willReturn($authenticate);
+        $auth->method('authenticate')->willReturn($authenticate);
         $core->method('getAuthentication')->willReturn($auth);
         return $core;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The VCS Login method used for Git used core->authenticate() which checks the authentication as well as creating a session and a cookie. Given that we never use the session or cookie again, this is a useless step.

### What is the new behavior?
Uses the AuthenticationMethod::authenticate() directly which just does the validation, and does not create a new session or cookie.
