### PR TITLE
[Refactor] Fix PHPUnit warnings for test suite

### DIFF
--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -96,7 +96,7 @@ class ExceptionHandler {
         }
 
         $message = "{$exception_name} (Code: {$exception->getCode()}) thrown in {$file} (Line {$exception_line}) by:\n";
-        $message .= "{$line_code}\n\nMessage:\n{$exception->getMessage()}\n\nStrack Trace:\n";
+        $message .= "{$line_code}\n\nMessage:\n{$exception->getMessage()}\n\nStack Trace:\n";
         $message .= "{$trace_string}\n";
 
         if ($is_base_exception) {

--- a/site/tests/app/authentication/PamAuthenticationTester.php
+++ b/site/tests/app/authentication/PamAuthenticationTester.php
@@ -100,10 +100,6 @@ class PamAuthenticationTester extends BaseUnitTest {
         $this->assertFalse($pam->authenticate());
     }
 
-    /**
-     * @expectedException \app\exceptions\AuthenticationException
-     * @expectedExceptionMessage Error attempting to authenticate against PAM: Invalid HTTP Code 0.
-     */
     public function testCurlThrow() {
         $config = $this->createMockModel(Config::class);
         $queries = $this->createMock(DatabaseQueries::class);
@@ -117,13 +113,11 @@ class PamAuthenticationTester extends BaseUnitTest {
         $pam = new PamAuthentication($core);
         $pam->setUserId('test');
         $pam->setPassword('test');
+        $this->expectException(\app\exceptions\AuthenticationException::class);
+        $this->expectExceptionMessage('Error attempting to authenticate against PAM: Invalid HTTP Code 0.');
         $pam->authenticate();
     }
 
-    /**
-     * @expectedException \app\exceptions\AuthenticationException
-     * @expectedExceptionMessage Error JSON response for PAM: Syntax error
-     */
     public function testInvalidJsonResponse() {
         $core = $this->getMockCore('{invalid_json: true}');
 
@@ -131,13 +125,11 @@ class PamAuthenticationTester extends BaseUnitTest {
         $pam = new PamAuthentication($core);
         $pam->setUserId('test');
         $pam->setPassword('test');
+        $this->expectException(\app\exceptions\AuthenticationException::class);
+        $this->expectExceptionMessage('Error JSON response for PAM: Syntax error');
         $pam->authenticate();
     }
 
-    /**
-     * @expectedException \app\exceptions\AuthenticationException
-     * @expectedExceptionMessage Missing response in JSON for PAM
-     */
     public function testNoAuthenticatedKey() {
         $core = $this->getMockCore('{"key": true}');
 
@@ -145,6 +137,8 @@ class PamAuthenticationTester extends BaseUnitTest {
         $pam = new PamAuthentication($core);
         $pam->setUserId('test');
         $pam->setPassword('test');
+        $this->expectException(\app\exceptions\AuthenticationException::class);
+        $this->expectExceptionMessage('Missing response in JSON for PAM');
         $pam->authenticate();
     }
 }

--- a/site/tests/app/libraries/CoreTester.php
+++ b/site/tests/app/libraries/CoreTester.php
@@ -15,11 +15,9 @@ class CoreTester extends \PHPUnit\Framework\TestCase {
         $this->assertFalse($core->isTesting());
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testErrorDatabaseBeforeConfig() {
         $core = new Core();
+        $this->expectException(\Exception::class);
         $core->loadDatabases();
     }
 }

--- a/site/tests/app/libraries/DiffViewerTester.php
+++ b/site/tests/app/libraries/DiffViewerTester.php
@@ -43,30 +43,24 @@ class DiffViewerTester extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($diff->existsDifference());
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testActualException() {
         $diff = new DiffViewer("file_that_doesnt_exist", "", "", "");
+        $this->expectException(\Exception::class);
         $diff->buildViewer();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testExpectedException() {
         $diff = new DiffViewer(__TEST_DATA__."/diffs/diff_test_01/input_actual.txt",
                                "file_that_doesnt_exist", "", "");
+        $this->expectException(\Exception::class);
         $diff->buildViewer();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testDifferencesException() {
         $diff = new DiffViewer(__TEST_DATA__."/diffs/diff_test_01/input_actual.txt",
                                __TEST_DATA__."/diffs/diff_test_01/input_expected.txt",
                                "file_that_doesnt_exist", "");
+        $this->expectException(\Exception::class);
         $diff->buildViewer();
     }
 }

--- a/site/tests/app/libraries/ExceptionHandlerTester.php
+++ b/site/tests/app/libraries/ExceptionHandlerTester.php
@@ -24,13 +24,12 @@ class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {
 
     public function testThrowServerException() {
         $message = ExceptionHandler::handleException(new \RuntimeException("test"));
-        $this->assertContains("An exception was thrown. Please contact an administrator about what you were doing that caused this exception.", $message);
-        $this->assertNotContains("test", $message);
+        $this->assertEquals("An exception was thrown. Please contact an administrator about what you were doing that caused this exception.\n", $message);
     }
 
     public function testThrowRuntimeException() {
         ExceptionHandler::setDisplayExceptions(true);
-        $this->assertContains("test", ExceptionHandler::handleException(new \RuntimeException("test")));
+        $this->assertRegExp("/Message:\ntest\n\n/", ExceptionHandler::handleException(new \RuntimeException("test")));
         ExceptionHandler::setDisplayExceptions(false);
     }
 
@@ -66,7 +65,7 @@ class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {
         catch(AuthenticationException $e) {
             ExceptionHandler::setDisplayExceptions(true);
             $message = ExceptionHandler::handleException($e);
-            $this->assertContains("tests\\app\\libraries\\ExceptionHandlerTester->authenticate()", $message);
+            $this->assertRegExp("/Stack Trace:\n#0 (.*)\/site\/tests\/app\/libraries\/ExceptionHandlerTester\.php\(62\): tests\\\app\\\libraries\\\ExceptionHandlerTester\-\>authenticate\(\)\n/", $message);
         }
     }
 
@@ -75,7 +74,7 @@ class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {
         $exception = new BaseException("exception message");
         $exception->setDisplayMessage(true);
         $message = ExceptionHandler::handleException($exception);
-        $this->assertContains("exception message", $message);
-        $this->assertNotContains("Stack Trace", $message);
+        $this->assertStringContainsString("exception message", $message);
+        $this->assertStringNotContainsString("Stack Trace", $message);
     }
 }

--- a/site/tests/app/libraries/IniParserTester.php
+++ b/site/tests/app/libraries/IniParserTester.php
@@ -5,11 +5,9 @@ namespace tests\app\libraries;
 use app\libraries\IniParser;
 
 class IniParserTester extends \PHPUnit\Framework\TestCase {
-    /**
-     * @expectedException \app\exceptions\FileNotFoundException
-     * @expectedExceptionMessage Could not find ini file to parse: invalid_file
-     */
     public function testNonExistFile() {
+        $this->expectException(\app\exceptions\FileNotFoundException::class);
+        $this->expectExceptionMessage('Could not find ini file to parse: invalid_file');
         IniParser::readFile("invalid_file");
     }
 

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -211,13 +211,11 @@ SELECT * FROM test ORDER BY pid");
         $database->disconnect();
     }
 
-    /**
-     * @expectedException \app\exceptions\DatabaseException
-     * @expectedExceptionMessage SQLSTATE[HY000]: General error: 1 no such table: test
-     */
     public function testIteratorDatabaseException() {
         $database = new SqliteDatabase(array('memory' => true));
         $database->connect();
+        $this->expectException(\app\exceptions\DatabaseException::class);
+        $this->expectExceptionMessage('SQLSTATE[HY000]: General error: 1 no such table: test');
         $database->queryIterator('SELECT * FROM test ORDER BY pid');
         $this->fail("DatabaseException should have been thrown");
     }
@@ -303,20 +301,16 @@ SELECT * FROM test ORDER BY pid");
         $this->assertSame(array('pid' => 1, 'tcol' => 'a', 'bcol' => true), $result);
     }
 
-    /**
-     * @expectedException \app\exceptions\DatabaseException
-     */
     public function testInvalidDSN() {
         $database = new PostgresqlDatabase(array('dbname' => 'invalid_db'));
+        $this->expectException(\app\exceptions\DatabaseException::class);
         $database->connect();
     }
 
-    /**
-     * @expectedException \app\exceptions\DatabaseException
-     */
     public function testBadQuery() {
         $database = new SqliteDatabase(array('memory' => true));
         $database->connect();
+        $this->expectException(\app\exceptions\DatabaseException::class);
         $database->query("SELECT * FROM invalid_table");
     }
 

--- a/site/tests/app/libraries/database/DatabaseFactoryTester.php
+++ b/site/tests/app/libraries/database/DatabaseFactoryTester.php
@@ -36,12 +36,10 @@ class DatabaseFactoryTester extends BaseUnitTest {
         $this->assertInstanceOf(DatabaseQueries::class, $factory->getQueries($this->createMockCore()));
     }
 
-    /**
-     * @expectedException \app\exceptions\NotImplementedException
-     * @expectedExceptionMessage Database not implemented for driver: invalid
-     */
     public function testDatabaseFactoryInvalid() {
          $factory = new DatabaseFactory('invalid');
+         $this->expectException(\app\exceptions\NotImplementedException::class);
+         $this->expectExceptionMessage('Database not implemented for driver: invalid');
          $factory->getDatabase(array());
     }
 }

--- a/site/tests/app/libraries/database/SqliteDatabaseTester.php
+++ b/site/tests/app/libraries/database/SqliteDatabaseTester.php
@@ -15,19 +15,15 @@ class SqliteDatabaseTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals("sqlite:/tmp/test.sq3", $database->getDSN());
     }
 
-    /**
-     * @expectedException \app\exceptions\NotImplementedException
-     */
     public function testFromDatabaseToPHPArray() {
         $database = new SqliteDatabase();
+        $this->expectException(\app\exceptions\NotImplementedException::class);
         $database->fromDatabaseToPHPArray("");
     }
 
-    /**
-     * @expectedException \app\exceptions\NotImplementedException
-     */
     public function testFromPHPToDatabaseArray() {
         $database = new SqliteDatabase();
+        $this->expectException(\app\exceptions\NotImplementedException::class);
         $database->fromPHPToDatabaseArray(array());
     }
 }

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -329,64 +329,52 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($config->displayRoomSeating());
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessage Could not find config directory: /invalid/path
-     */
     public function testInvalidMasterConfigPath() {
         $config = new Config($this->core, "s17", "csci1000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Could not find config directory: /invalid/path');
         $config->loadMasterConfigs('/invalid/path');
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessageRegExp /Could not find config directory: .*\/config\/database.json/
-     */
     public function testConfigPathFile() {
         $this->createConfigFile();
         $config = new Config($this->core, "s17", "csci1000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessageRegExp('/Could not find config directory: .*\/config\/database.json/');
         $config->loadMasterConfigs(FileUtils::joinPaths($this->temp_dir, 'config', 'database.json'));
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessageRegExp /Could not find database config: .*\/config\/database.json/
-     */
     public function testMissingDatabaseJson() {
         $this->createConfigFile();
         unlink(FileUtils::joinPaths($this->temp_dir, 'config', 'database.json'));
         $config = new Config($this->core, "s17", "csci1000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessageRegExp('/Could not find database config: .*\/config\/database.json/');
         $config->loadMasterConfigs($this->config_path);
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessageRegExp /Could not find submitty config: .*\/config\/submitty.json/
-     */
     public function testMissingSubmittyJson() {
         $this->createConfigFile();
         unlink(FileUtils::joinPaths($this->temp_dir, 'config', 'submitty.json'));
         $config = new Config($this->core, "s17", "csci1000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessageRegExp('/Could not find submitty config: .*\/config\/submitty.json/');
         $config->loadMasterConfigs($this->config_path);
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessage Could not find course config file: /invalid/path
-     */
     public function testInvalidCourseConfigPath() {
         $config = new Config($this->core, "s17", "csci1000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Could not find course config file: /invalid/path');
         $config->loadCourseJson("/invalid/path");
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessageRegExp /Error parsing the config file: Syntax error/
-     */
     public function testInvalidCourseConfigJson() {
         $this->createConfigFile();
         $config = new Config($this->core, "s17", "csci1000");
         file_put_contents(FileUtils::joinPaths($this->temp_dir, "test.txt"), "afds{}fasdf");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Error parsing the config file: Syntax error');
         $config->loadCourseJson(FileUtils::joinPaths($this->temp_dir, "test.txt"));
     }
 
@@ -458,39 +446,33 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
 
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessage Invalid Timezone identifier: invalid
-     */
     public function testInvalidTimezone() {
         $extra = ['timezone' => "invalid"];
         $this->createConfigFile($extra);
 
         $config = new Config($this->core, "s17", "csci0000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Invalid Timezone identifier: invalid');
         $config->loadMasterConfigs($this->config_path);
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessage Invalid path for setting submitty_path: /invalid
-     */
     public function testInvalidSubmittyPath() {
         $extra = ['submitty_data_dir' => '/invalid'];
         $this->createConfigFile($extra);
 
         $config = new Config($this->core, "s17", "csci0000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Invalid path for setting submitty_path: /invalid');
         $config->loadMasterConfigs($this->config_path);
     }
 
-    /**
-     * @expectedException \app\exceptions\ConfigException
-     * @expectedExceptionMessage Invalid path for setting submitty_log_path: /invalid
-     */
     public function testInvalidLogPath() {
         $extra = ['site_log_path' => '/invalid'];
         $this->createConfigFile($extra);
 
         $config = new Config($this->core, "s17", "csci0000");
+        $this->expectException(\app\exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Invalid path for setting submitty_log_path: /invalid');
         $config->loadMasterConfigs($this->config_path);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3670

### What is the new behavior?
Uses the non-deprecated syntax for testing exceptions in PHPUnit

