### PR TITLE
Student Photos Supports More Extensions

### DIFF
--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -46,6 +46,7 @@ class ImagesController extends AbstractController {
         }
         $instructor_permission = ($user_group === USER::GROUP_INSTRUCTOR);
         $students = $this->core->getQueries()->getAllUsers();
+        $this->core->getOutput()->disableBuffer();
         $this->core->getOutput()->renderOutput(array('grading', 'Images'), 'listStudentImages', $students, $grader_sections, $instructor_permission);
     }
 }

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -39,6 +39,7 @@
                     {% endif %}
                 {% endfor %}
                 </tbody>
+                {% flush %}
             {% endfor %}
         {% else %}
             <tr>

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -17,23 +17,17 @@
                     {% if loop.index % 5 == 1 %}
                         <tr id="user-{{ student.getId() }}">
                     {% endif %}
-                    {% set image_found = false %}
-                    {% for imageData in imageDataArray if not image_found %}
-                        {% set imgName = imageNameArray[loop.index-1] %}
-                        {% if student.getId() == imgName %}
-                            <td><img src="data:imgName/png;base64,{{ imageData }}" width="150" height="200/>
-                            <div class="name"><br /><br />{{student.getDisplayedFirstName()}} {{student.getDisplayedLastName()}}
-                            <br />{{student.getId()}}</div>
-                            </td>
-                            {% set image_found = true %}
-                        {% endif %}
-                    {% endfor %}
-                    {% if not image_found %}
+                    {% if imageData[student.getId()] is defined %}
+                        <td><img src="data:image/{{ imageData[student.getId()].subtype }};base64,{{ imageData[student.getId()].image }}" width="150" height="200/>
+                        <div class="name"><br /><br />{{student.getDisplayedFirstName()}} {{student.getDisplayedLastName()}}
+                        <br />{{student.getId()}}</div>
+                        </td>
+                    {% else %}
                         {% if errorImageData == '_NONE_' %}
                             <td><i><font color="gray"><img alt="No Image Available" /></font></i>
                             <div class="name"><br />
                         {% else %}
-                            <td><img src="data:imgName/png;base64,{{ errorImageData }}" width="150" height="200/>
+                            <td><img src="data:image/{{ errorImageData.subtype }};base64,{{ errorImageData.image }}" width="150" height="200/>
                             <div class="name"><br /><br />
                         {% endif %}
                         {{student.getDisplayedFirstName()}} {{student.getDisplayedLastName()}}
@@ -41,7 +35,6 @@
                         </td>
                     {% endif %}
                     {% if loop.index % 5 == 0 %}
-
                         </tr>
                     {% endif %}
                 {% endfor %}

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -37,9 +37,9 @@
                     {% if loop.index % 5 == 0 %}
                         </tr>
                     {% endif %}
+                    {% flush %}
                 {% endfor %}
                 </tbody>
-                {% flush %}
             {% endfor %}
         {% else %}
             <tr>

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -46,7 +46,7 @@ class ImagesView extends AbstractView {
                     // Read image path, convert to base64 encoding
                     $expected_img_data = base64_encode(file_get_contents($expected_image));
 
-                    $img_name = $fileinfo->getBasename('.png');
+                    $img_name = pathinfo($fileinfo->getBasename(), PATHINFO_FILENAME);
                     if ($img_name === "error_image") {
                         $error_image_data = $expected_img_data;
                     }

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -25,10 +25,7 @@ class ImagesView extends AbstractView {
         }
 
 
-        //$images_data_array to contain base64_encoded image urls
-        $images_data_array = array();
-        //$images_names_array to contain the names of the images (rcs ids)
-        $images_names_array = array();
+        $image_data = array();
         $error_image_data = '_NONE_';
 
         //Get the expected images path and png files to loop through
@@ -36,23 +33,27 @@ class ImagesView extends AbstractView {
 
         $dir = new \DirectoryIterator($expected_images_path);
         //Extensions array can be extended if we want to support more types
-        $valid_image_extensions = array("png", "jpg", "jpeg");
+        $valid_image_subtypes = array('png', 'jpg', 'jpeg', 'gif');
         foreach ($dir as $fileinfo) {
-            if (!$fileinfo->isDot() && in_array($fileinfo->getExtension(), $valid_image_extensions)) {
-
+            if (!$fileinfo->isDot() && !$fileinfo->isDir()) {
                 $expected_image = $fileinfo->getPathname();
-                $content_type = FileUtils::getContentType($expected_image);
-                if (substr($content_type, 0, 5) === "image") {
+                list($mime_type, $mime_subtype) = explode('/', FileUtils::getMimeType($expected_image), 2);
+                if ($mime_type === "image" && in_array($mime_subtype, $valid_image_subtypes)) {
                     // Read image path, convert to base64 encoding
                     $expected_img_data = base64_encode(file_get_contents($expected_image));
 
-                    $img_name = pathinfo($fileinfo->getBasename(), PATHINFO_FILENAME);
+                    $img_name = $fileinfo->getBasename('.' . $fileinfo->getExtension());
                     if ($img_name === "error_image") {
-                        $error_image_data = $expected_img_data;
+                        $error_image_data = [
+                            'subtype' => $mime_subtype,
+                            'image' => $expected_img_data
+                        ];
                     }
                     else {
-                        array_push($images_data_array, $expected_img_data);
-                        array_push($images_names_array, $img_name);
+                        $image_data[$img_name] = [
+                            'subtype' => $mime_subtype,
+                            'image' => $expected_img_data
+                        ];
                     }
                 }
             }
@@ -62,8 +63,7 @@ class ImagesView extends AbstractView {
 
         return $this->core->getOutput()->renderTwigTemplate("grading/Images.twig", [
             "sections" => $sections,
-            "imageNameArray" => $images_names_array,
-            "imageDataArray" => $images_data_array,
+            "imageData" => $image_data,
             "errorImageData" => $error_image_data,
             "hasInstructorPermission" => $instructor_permission
         ]);

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -35,8 +35,11 @@ class ImagesView extends AbstractView {
         $expected_images_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "student_images");
 
         $dir = new \DirectoryIterator($expected_images_path);
+        //Extensions array can be extended if we want to support more types
+        $valid_image_extensions = array("png", "jpg", "jpeg");
         foreach ($dir as $fileinfo) {
-            if (!$fileinfo->isDot() && $fileinfo->getExtension() === "png") {
+            $extension = $fileinfo->getExtension();
+            if (!$fileinfo->isDot() && in_array($fileinfo->getExtension(), $valid_image_extensions)) {
 
                 $expected_image = $fileinfo->getPathname();
                 $content_type = FileUtils::getContentType($expected_image);

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -38,7 +38,6 @@ class ImagesView extends AbstractView {
         //Extensions array can be extended if we want to support more types
         $valid_image_extensions = array("png", "jpg", "jpeg");
         foreach ($dir as $fileinfo) {
-            $extension = $fileinfo->getExtension();
             if (!$fileinfo->isDot() && in_array($fileinfo->getExtension(), $valid_image_extensions)) {
 
                 $expected_image = $fileinfo->getPathname();

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -25,7 +25,7 @@ class ImagesView extends AbstractView {
         }
 
 
-        $image_data = array();
+        $image_data = [];
         $error_image_data = '_NONE_';
 
         //Get the expected images path and png files to loop through
@@ -33,7 +33,7 @@ class ImagesView extends AbstractView {
 
         $dir = new \DirectoryIterator($expected_images_path);
         //Extensions array can be extended if we want to support more types
-        $valid_image_subtypes = array('png', 'jpg', 'jpeg', 'gif');
+        $valid_image_subtypes = ['png', 'jpg', 'jpeg', 'gif'];
         foreach ($dir as $fileinfo) {
             if (!$fileinfo->isDot() && !$fileinfo->isDir()) {
                 $expected_image = $fileinfo->getPathname();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [N/A] Tests for the changes have been added/updated (if possible)
* [N/A] Documentation has been updated/added if relevant

### What is the current behavior?
Closes #3704 .

### What is the new behavior?
Supports png/jpg/jpeg.

### Other information?
Tested using student.png, student.jpeg, instructor.png, and instructor.jpg - started with just the pngs, then with everything uploaded, then deleted the pngs. Behavior was as expected - when there's only one image for a given user it's used, but if there's multiple images, it's whatever order the filesystem chooses to iterate in.

As a side note, since this seemed to be geared towards specifically .png previously, I kept the extensions limited, but I think file extension checking might be pointless since we also extract the content type and look for `image/...` types. I could change that in this PR if we want.
