### PR TITLE
[Bugfix] Ignore migration files not starting with numbers and ending with py

### DIFF
--- a/migration/migrator/loader.py
+++ b/migration/migrator/loader.py
@@ -1,6 +1,7 @@
 """Module to handle loading of migrations and modules."""
 from collections import OrderedDict
 from importlib.machinery import SourceFileLoader
+import re
 
 
 def load_module(name, path):
@@ -27,8 +28,9 @@ def load_migrations(path):
     :type path: pathlib.Path or str
     """
     migrations = OrderedDict()
+    r = re.compile(r'^[0-9]+\_.+\.py$')
     filtered = filter(
-        lambda x: x.endswith('.py'),
+        lambda x: r.search(x) is not None,
         [x.name for x in path.iterdir()]
     )
     for migration in sorted(filtered):

--- a/migration/test/test_loader.py
+++ b/migration/test/test_loader.py
@@ -42,3 +42,22 @@ def foo():
             'table': None
         }
         self.assertDictEqual(expected, migrations['1_test'])
+
+    def test_load_migrations_bad_filename(self):
+        self.create_migration('1_test.py')
+        self.create_migration('.2_test.py')
+        self.create_migration('#3_test.py')
+        self.create_migration('.#4_test.py')
+        self.create_migration('5_test.pyc')
+        self.create_migration('6_test.py.bak')
+        migrations = loader.load_migrations(Path(self.dir))
+        self.assertEqual(1, len(migrations.keys()))
+        self.assertListEqual(['1_test'], list(migrations.keys()))
+        expected = {
+            'id': '1_test',
+            'commit_time': None,
+            'status': 0,
+            'module': loader.load_module('1_test', Path(self.dir, '1_test.py')),
+            'table': None
+        }
+        self.assertDictEqual(expected, migrations['1_test'])


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3661

We ignore files that don't start with a number or end with `.py` as we (safely) assume that these files are not ones which house valid python migration files, and are most likely ones created by an editor (such as emacs).

### What is the new behavior?
Only load files in the migrations folders that start with a number and end with `.py` and that have an underscore between the starting numbers and some more text before the `.py`.