### PR TITLE
[Bugfix] Chmod site/public *.map files to 444 instead of 440

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -121,7 +121,7 @@ chmod -R 440 ${SUBMITTY_INSTALL_DIR}/site
 find ${SUBMITTY_INSTALL_DIR}/site -type d -exec chmod ogu+x {} \;
 
 # "other" can read all of these files
-array=( css otf jpg png ico txt twig )
+array=( css otf jpg png ico txt twig map )
 for i in "${array[@]}"; do
     find ${SUBMITTY_INSTALL_DIR}/site/public -type f -name \*.${i} -exec chmod o+r {} \;
 done


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The map files are not accessible for the minified vendor files due to permission error.

### What is the new behavior?
Can access the map files