### PR TITLE
Made file submission box VPAT compliant

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -225,7 +225,7 @@
                             {% endif %}
                         </div>
                         {% set num_inputs = num_inputs + 1 %}
-                    {% endfor %}_
+                    {% endfor %}
                 </div>
             {% endfor %}
     

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -208,7 +208,7 @@
                                 <fieldset>
                                     {% for choice in i.choices %}
                                         {% if i.allow_multiple == true %}
-                                            <input type="checkbox" name="input_{{ num_inputs }}" id="input_{{ num_inputs }}" value="{{ choice }}" onclick="handle_input_keypress();"" />
+                                            <input type="checkbox" name="input_{{ num_inputs }}" id="input_{{ num_inputs }}" value="{{ choice }}" onclick="handle_input_keypress();" />
                                             <label for="{{ choice }}">
                                                 {{ choice }}
                                             </label>
@@ -231,7 +231,12 @@
     
             {# Submit boxes #}
             {% for part in part_names %}
-                <div tabindex="0" id="upload{{ loop.index }}" onkeypress="clicked_on_box(event)" style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 150px;">
+                <div tabindex="0"
+                     id="upload{{ loop.index }}"
+                     onkeypress="clicked_on_box(event)"
+                     role="text"
+                     aria-label="Press enter to select your {{ part }} file"
+                     style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 150px;">
                     <h3 class="label" id="label{{ loop.index }}">
                         {% if part_names|length > 1 %}
                             Drag your {{ part }} here or click to open file browser

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -225,13 +225,13 @@
                             {% endif %}
                         </div>
                         {% set num_inputs = num_inputs + 1 %}
-                    {% endfor %}
+                    {% endfor %}_
                 </div>
             {% endfor %}
     
             {# Submit boxes #}
             {% for part in part_names %}
-                <div id="upload{{ loop.index }}" style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 150px;">
+                <div tabindex="0" id="upload{{ loop.index }}" onkeypress="clicked_on_box(event)" style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 150px;">
                     <h3 class="label" id="label{{ loop.index }}">
                         {% if part_names|length > 1 %}
                             Drag your {{ part }} here or click to open file browser

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -235,7 +235,7 @@
                      id="upload{{ loop.index }}"
                      onkeypress="clicked_on_box(event)"
                      role="text"
-                     aria-label="Press enter to select your {{ part }} file"
+                     aria-label="Press enter to upload your {{ part }} file"
                      style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 150px;">
                     <h3 class="label" id="label{{ loop.index }}">
                         {% if part_names|length > 1 %}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2081,3 +2081,7 @@ end of styles used in the admin gradeable page
 #upload-boxes > div:focus {
     outline: 2px solid cornflowerblue;
 }
+
+.fa-trash:focus {
+    outline: 2px solid cornflowerblue;
+}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2076,3 +2076,7 @@ end of styles used in the admin gradeable page
     caption-side: top;
     border: 0;
 }
+
+#upload-boxes > div:focus {
+    outline: 2px solid cornflowerblue;
+}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2077,6 +2077,7 @@ end of styles used in the admin gradeable page
     border: 0;
 }
 
+/* Give file submission boxes a blue outline when they have focus (for VPAT compliance) */
 #upload-boxes > div:focus {
     outline: 2px solid cornflowerblue;
 }

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -292,6 +292,14 @@ function addLabel(filename, filesize, part, previous){
         this.parentNode.parentNode.removeChild(this.parentNode);
         deleteSingleFile(filename, part, previous);
     };
+
+    // FOR VPAT if trash can has focus and key is pressed it will delete item
+    tmp.children[0].onkeypress = function(e){
+        e.stopPropagation();
+        this.parentNode.parentNode.removeChild(this.parentNode);
+        deleteSingleFile(filename, part, previous);
+    };
+
     // add to parent div
     var dropzone = document.getElementById("upload" + part);
     // Uncomment if want buttons for emptying single bucket

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -276,7 +276,8 @@ function addLabel(filename, filesize, part, previous){
     var tmp = document.createElement('label');
     tmp.setAttribute("class", "mylabel");
     tmp.setAttribute("fname", filename);
-    tmp.innerHTML =  filename + " " + filesize + "kb <i tabindex='0' class='fas fa-trash'></i><br />";
+    tmp.innerHTML =  filename + " " + filesize + "kb <i role='text' aria-label='Press enter to remove file " + filename + "' tabindex='0' class='fas fa-trash'></i><br />";
+
     // styling
     tmp.children[0].onmouseover = function(e){
         e.stopPropagation();

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -276,7 +276,7 @@ function addLabel(filename, filesize, part, previous){
     var tmp = document.createElement('label');
     tmp.setAttribute("class", "mylabel");
     tmp.setAttribute("fname", filename);
-    tmp.innerHTML =  filename + " " + filesize + "kb <i class='fas fa-trash'></i><br />";
+    tmp.innerHTML =  filename + " " + filesize + "kb <i tabindex='0' class='fas fa-trash'></i><br />";
     // styling
     tmp.children[0].onmouseover = function(e){
         e.stopPropagation();


### PR DESCRIPTION
Closes #3155

### What is the current behavior?
Previously when using the tab key to navigate through items on the page file submission boxes were passed over, making it impossible for keyboard only users to submit files.

### What is the new behavior?
File submission boxes can now receive focus when using the tab key.  When a file submission box has focus and the enter key is pressed the file selector appears.

### Other information?
Mostly tested with Development -> Choice Of Language and also with other development grades that utilize a single file submission box.
