### PR TITLE
[Bugfix] Fix upload for student images and efficiency improvements

### DIFF
--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -46,7 +46,6 @@ class ImagesController extends AbstractController {
         }
         $instructor_permission = ($user_group === USER::GROUP_INSTRUCTOR);
         $students = $this->core->getQueries()->getAllUsers();
-        $this->core->getOutput()->disableBuffer();
         $this->core->getOutput()->renderOutput(array('grading', 'Images'), 'listStudentImages', $students, $grader_sections, $instructor_permission);
     }
 }

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -18,7 +18,7 @@
                         <tr id="user-{{ student.getId() }}">
                     {% endif %}
                     {% if imageData[student.getId()] is defined %}
-                        <td><img src="data:image/{{ imageData[student.getId()].subtype }};base64,{{ imageData[student.getId()].image }}" width="150" height="200/>
+                        <td>{{ base64_image(imageData[student.getId()].path, student.getId()) }}
                         <div class="name"><br /><br />{{student.getDisplayedFirstName()}} {{student.getDisplayedLastName()}}
                         <br />{{student.getId()}}</div>
                         </td>
@@ -27,7 +27,7 @@
                             <td><i><font color="gray"><img alt="No Image Available" /></font></i>
                             <div class="name"><br />
                         {% else %}
-                            <td><img src="data:image/{{ errorImageData.subtype }};base64,{{ errorImageData.image }}" width="150" height="200/>
+                            <td>{{ base64_image(errorImageData.path, 'No Image Available') }}
                             <div class="name"><br /><br />
                         {% endif %}
                         {{student.getDisplayedFirstName()}} {{student.getDisplayedLastName()}}

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -15,6 +15,8 @@ class ImagesView extends AbstractView {
      */
     public function listStudentImages($students, $grader_sections, $instructor_permission) {
         $this->core->getOutput()->addBreadcrumb("Student Photos");
+        $this->core->getOutput()->addInternalJs("drag-and-drop.js");
+
         //Assemble students into sections if they are in grader_sections based on the registration section.
         $sections = [];
         foreach ($students as $student) {
@@ -39,28 +41,24 @@ class ImagesView extends AbstractView {
                 $expected_image = $fileinfo->getPathname();
                 list($mime_type, $mime_subtype) = explode('/', FileUtils::getMimeType($expected_image), 2);
                 if ($mime_type === "image" && in_array($mime_subtype, $valid_image_subtypes)) {
-                    // Read image path, convert to base64 encoding
-                    $expected_img_data = base64_encode(file_get_contents($expected_image));
-
                     $img_name = $fileinfo->getBasename('.' . $fileinfo->getExtension());
                     if ($img_name === "error_image") {
                         $error_image_data = [
                             'subtype' => $mime_subtype,
-                            'image' => $expected_img_data
+                            'path' => $expected_image
                         ];
                     }
                     else {
                         $image_data[$img_name] = [
                             'subtype' => $mime_subtype,
-                            'image' => $expected_img_data
+                            'path' => $expected_image
                         ];
                     }
                 }
             }
         }
 
-        $this->core->getOutput()->addInternalJs("drag-and-drop.js");
-
+        $this->core->getOutput()->disableBuffer();
         return $this->core->getOutput()->renderTwigTemplate("grading/Images.twig", [
             "sections" => $sections,
             "imageData" => $image_data,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
From #3712, the change to not buffer things meant that drag-and-drop.js was not being properly loaded for the page, which caused the upload to break.

### What is the new behavior?
drag-and-drop.js is properly imported. I've also added a new Twig function to allow us to in-place base64_encode image paths so that we don't have to construct a potentially huge array in the View before going to Twig to display the images. Lowers the amount of memory PHP should use per process slightly, though does not appear to fix the underlying problem of potentially to show huge images.