### PR TITLE
[Refactor] Do not mutate args Namespace within migrator

### DIFF
--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -1,6 +1,7 @@
 """Basic migration script to handle the database."""
 
 from collections import OrderedDict
+from copy import deepcopy
 from datetime import datetime
 import os
 from pathlib import Path
@@ -62,12 +63,12 @@ def status(args):
     :param args: arguments for status
     :type args: argparse.Namespace
     """
-    args.config.database['dbname'] = 'submitty'
-
     for environment in get_environments(args.environments):
         if environment in ['master', 'system']:
+            loop_args = deepcopy(args)
+            loop_args.config.database['dbname'] = 'submitty'
             try:
-                database = db.Database(args.config.database, environment)
+                database = db.Database(loop_args.config.database, environment)
                 exists = database.engine.dialect.has_table(
                     database.engine,
                     database.migration_table.__tablename__
@@ -76,7 +77,7 @@ def status(args):
                     print('Could not find migration table for {}'.format(environment))
                     database.close()
                     continue
-                print_status(database, environment, args)
+                print_status(database, environment, loop_args)
                 database.close()
             except OperationalError:
                 print(
@@ -89,18 +90,19 @@ def status(args):
                 continue
             for semester in os.listdir(str(course_dir)):
                 for course in os.listdir(os.path.join(str(course_dir), semester)):
-                    cond1 = args.choose_course is not None
-                    cond2 = [semester, course] != args.choose_course
+                    loop_args = deepcopy(args)
+                    cond1 = loop_args.choose_course is not None
+                    cond2 = [semester, course] != loop_args.choose_course
                     if cond1 and cond2:
                         continue
-                    args.semester = semester
-                    args.course = course
-                    args.config.database['dbname'] = 'submitty_{}_{}'.format(
+                    loop_args.semester = semester
+                    loop_args.course = course
+                    loop_args.config.database['dbname'] = 'submitty_{}_{}'.format(
                         semester,
                         course
                     )
                     try:
-                        database = db.Database(args.config.database, environment)
+                        database = db.Database(loop_args.config.database, environment)
                         exists = database.engine.dialect.has_table(
                             database.engine,
                             database.migration_table.__tablename__
@@ -114,7 +116,7 @@ def status(args):
                             )
                             database.close()
                             continue
-                        print_status(database, environment, args)
+                        print_status(database, environment, loop_args)
                         database.close()
                     except OperationalError:
                         print('Could not get the status for the migrations '
@@ -195,12 +197,10 @@ def handle_migration(args):
     :param args: arguments parsed from argparse
     :type args: argparse.Namespace
     """
-    args.config.database['dbname'] = 'submitty'
-
     for environment in get_environments(args.environments):
-        args.course = None
-        args.semester = None
         if environment in ['master', 'system']:
+            loop_args = deepcopy(args)
+            loop_args.config.database['dbname'] = 'submitty'
             try:
                 database = db.Database(args.config.database, environment)
             except OperationalError:
@@ -216,19 +216,20 @@ def handle_migration(args):
                 continue
             for semester in os.listdir(str(course_dir)):
                 for course in os.listdir(os.path.join(str(course_dir), semester)):
-                    cond1 = args.choose_course is not None
-                    cond2 = [semester, course] != args.choose_course
+                    loop_args = deepcopy(args)
+                    cond1 = loop_args.choose_course is not None
+                    cond2 = [semester, course] != loop_args.choose_course
                     if cond1 and cond2:
                         continue
-                    args.semester = semester
-                    args.course = course
-                    args.config.database['dbname'] = 'submitty_{}_{}'.format(
+                    loop_args.semester = semester
+                    loop_args.course = course
+                    loop_args.config.database['dbname'] = 'submitty_{}_{}'.format(
                         semester,
                         course
                     )
                     try:
-                        database = db.Database(args.config.database, environment)
-                        migrate_environment(database, environment, args)
+                        database = db.Database(loop_args.config.database, environment)
+                        migrate_environment(database, environment, loop_args)
                         database.close()
                     except OperationalError:
                         print("Submitty Database Migration Warning:  "

--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -203,7 +203,7 @@ def handle_migration(args):
             loop_args = deepcopy(args)
             loop_args.config.database['dbname'] = 'submitty'
             try:
-                database = db.Database(args.config.database, environment)
+                database = db.Database(loop_args.config.database, environment)
             except OperationalError:
                 print('Database does not exist for {}'.format(environment))
                 continue

--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -88,8 +88,9 @@ def status(args):
             if not course_dir.exists():
                 print("Could not find courses directory: {}".format(course_dir))
                 continue
-            for semester in os.listdir(str(course_dir)):
-                for course in os.listdir(os.path.join(str(course_dir), semester)):
+            for semester in sorted(os.listdir(str(course_dir))):
+                courses = sorted(os.listdir(os.path.join(str(course_dir), semester)))
+                for course in courses:
                     loop_args = deepcopy(args)
                     cond1 = loop_args.choose_course is not None
                     cond2 = [semester, course] != loop_args.choose_course
@@ -214,8 +215,9 @@ def handle_migration(args):
             if not course_dir.exists():
                 print("Could not find courses directory: {}".format(course_dir))
                 continue
-            for semester in os.listdir(str(course_dir)):
-                for course in os.listdir(os.path.join(str(course_dir), semester)):
+            for semester in sorted(os.listdir(str(course_dir))):
+                courses = sorted(os.listdir(os.path.join(str(course_dir), semester)))
+                for course in courses:
                     loop_args = deepcopy(args)
                     cond1 = loop_args.choose_course is not None
                     cond2 = [semester, course] != loop_args.choose_course

--- a/migration/test/test_handle_migration.py
+++ b/migration/test/test_handle_migration.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from copy import deepcopy
 from io import StringIO
 from pathlib import Path
 import shutil
@@ -17,11 +18,9 @@ class TestHandleMigration(unittest.TestCase):
     def setUp(self):
         self.stdout = sys.stdout
         sys.stdout = StringIO()
-        self.args = Namespace()
         self.dir = tempfile.mkdtemp()
         self.old_migrations_path = migrator.MIGRATIONS_PATH
         migrator.MIGRATIONS_PATH = Path(self.dir)
-        self.databases = dict()
 
     def tearDown(self):
         sys.stdout = self.stdout
@@ -31,19 +30,22 @@ class TestHandleMigration(unittest.TestCase):
     def setup_test(self, environment, create=True):
         Path(self.dir, environment).mkdir()
         self.stdout = sys.stdout
+
+    def create_database(environment, create=True):
         database = migrator.db.Database({'database_driver': 'sqlite'}, environment)
         if create:
             database.DynamicBase.metadata.create_all(database.engine)
-        self.databases[environment] = database
-    
+        return database
+
     def test_no_course_dir(self):
-        self.args.environments = ['course']
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
-        self.args.config.submitty = {
+        args = Namespace()
+        args.environments = ['course']
+        args.config = SimpleNamespace()
+        args.config.database = dict()
+        args.config.submitty = {
             'submitty_data_dir': self.dir
         }
-        main.handle_migration(self.args)
+        main.handle_migration(args)
         self.assertEqual(
             "Could not find courses directory: {}\n".format(
                 str(Path(self.dir, 'courses'))
@@ -51,61 +53,65 @@ class TestHandleMigration(unittest.TestCase):
             sys.stdout.getvalue()
         )
 
-    def test_status_no_db_master(self):
-        self.args.environments = ['master']
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
+    def test_migration_no_db_master(self):
+        args = Namespace()
+        args.environments = ['master']
+        args.config = SimpleNamespace()
+        args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
-            main.handle_migration(self.args)
+            main.handle_migration(args)
         self.assertEqual(
             "Database does not exist for master\n",
             sys.stdout.getvalue()
         )
 
-    def test_status_no_db_system(self):
-        self.args.environments = ['system']
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
+    def test_migration_no_db_system(self):
+        args = Namespace()
+        args.environments = ['system']
+        args.config = SimpleNamespace()
+        args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
-            main.handle_migration(self.args)
+            main.handle_migration(args)
         self.assertEqual(
             "Database does not exist for system\n",
             sys.stdout.getvalue()
         )
 
-    def test_status_no_db_course(self):
-        self.args.environments = ['course']
-        self.args.choose_course = None
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
-        self.args.config.submitty = dict()
-        self.args.config.submitty['submitty_data_dir'] = Path(self.dir)
+    def test_migration_no_db_course(self):
+        args = Namespace()
+        args.environments = ['course']
+        args.choose_course = None
+        args.config = SimpleNamespace()
+        args.config.database = dict()
+        args.config.submitty = dict()
+        args.config.submitty['submitty_data_dir'] = Path(self.dir)
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
         with patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
-            main.handle_migration(self.args)
+            main.handle_migration(args)
         self.assertEqual(
             "Submitty Database Migration Warning:  Database does not exist for semester=f19 course=csci1100\n",
             sys.stdout.getvalue()
         )
 
-    def test_status_no_db_all(self):
-        self.args.environments = ['course', 'master', 'system']
-        self.args.choose_course = None
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
-        self.args.config.submitty = dict()
-        self.args.config.submitty['submitty_data_dir'] = Path(self.dir)
+    def test_migration_no_db_all(self):
+        args = Namespace()
+        args.environments = ['course', 'master', 'system']
+        args.choose_course = None
+        args.config = SimpleNamespace()
+        args.config.database = dict()
+        args.config.submitty = dict()
+        args.config.submitty['submitty_data_dir'] = Path(self.dir)
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
         with patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
-            main.handle_migration(self.args)
+            main.handle_migration(args)
         expected = """Database does not exist for master
 Database does not exist for system
 Submitty Database Migration Warning:  Database does not exist for semester=f19 course=csci1100
@@ -113,58 +119,125 @@ Submitty Database Migration Warning:  Database does not exist for semester=f19 c
         self.assertEqual(expected, sys.stdout.getvalue())
 
     @patch('migrator.main.migrate_environment')
-    def test_status_master(self, mock_method):
+    def test_migration_master(self, mock_method):
+        args = Namespace()
         self.setup_test('master')
-        self.args.environments = ['master']
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
+        database = self.create_database('master')
+        args.environments = ['master']
+        args.config = SimpleNamespace()
+        args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['master']]
-            main.handle_migration(self.args)
+            mock_class.side_effect = [database]
+            main.handle_migration(args)
         self.assertTrue(mock_class.called)
         self.assertTrue(mock_method.called)
-        self.assertEqual(self.databases['master'], mock_method.call_args[0][0])
+        self.assertEqual(1, mock_method.call_count)
+        self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('master', mock_method.call_args[0][1])
-        self.assertEqual(self.args, mock_method.call_args[0][2])
-        self.assertFalse(self.databases['master'].open)
+        self.assertEqual(args, mock_method.call_args[0][2])
+        self.assertFalse(database.open)
 
     @patch('migrator.main.migrate_environment')
-    def test_status_system(self, mock_method):
+    def test_migration_system(self, mock_method):
+        args = Namespace()
         self.setup_test('system')
-        self.args.environments = ['system']
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
+        database = self.create_database('system')
+        args.environments = ['system']
+        args.config = SimpleNamespace()
+        args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['system']]
-            main.handle_migration(self.args)
+            mock_class.side_effect = [database]
+            main.handle_migration(args)
         self.assertTrue(mock_class.called)
         self.assertTrue(mock_method.called)
-        self.assertEqual(self.databases['system'], mock_method.call_args[0][0])
+        self.assertEqual(1, mock_method.call_count)
+        self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('system', mock_method.call_args[0][1])
-        self.assertEqual(self.args, mock_method.call_args[0][2])
-        self.assertFalse(self.databases['system'].open)
+        self.assertEqual(args, mock_method.call_args[0][2])
+        self.assertFalse(database.open)
 
     @patch('migrator.main.migrate_environment')
-    def test_status_course(self, mock_method):
+    def test_migration_course(self, mock_method):
+        args = Namespace()
         self.setup_test('course')
-        self.args.environments = ['course']
-        self.args.choose_course = None
-        self.args.config = SimpleNamespace()
-        self.args.config.database = dict()
-        self.args.config.submitty = dict()
-        self.args.config.submitty['submitty_data_dir'] = Path(self.dir)
+        database = self.create_database('course')
+        args.environments = ['course']
+        args.choose_course = None
+        args.config = SimpleNamespace()
+        args.config.database = dict()
+        args.config.submitty = dict()
+        args.config.submitty['submitty_data_dir'] = Path(self.dir)
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['course']]
-            main.handle_migration(self.args)
+            mock_class.side_effect = [database]
+            main.handle_migration(args)
         self.assertTrue(mock_class.called)
         self.assertTrue(mock_method.called)
-        self.assertEqual(self.databases['course'], mock_method.call_args[0][0])
+        self.assertEqual(1, mock_method.call_count)
+        self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('course', mock_method.call_args[0][1])
-        self.assertEqual(self.args, mock_method.call_args[0][2])
-        self.assertEqual(self.args.semester, 'f19')
-        self.assertEqual(self.args.course, 'csci1100')
-        self.assertFalse(self.databases['course'].open)
+        # Test that mutation did not happen
+        self.assertEqual(args.config.database, dict())
+        self.assertNotIn('semester', args)
+        self.assertNotIn('course', args)
+        args.config.database = {'dbname': 'submitty_f19_csci1100'}
+        args.semester = 'f19'
+        args.course = 'csci1100'
+        self.assertEqual(args, mock_method.call_args[0][2])
+        self.assertEqual(args.semester, 'f19')
+        self.assertEqual(args.course, 'csci1100')
+        self.assertFalse(database.open)
+
+    @patch('migrator.main.migrate_environment')
+    def test_migration_multiple_courses(self, mock_method):
+        args = Namespace()
+        self.setup_test('course')
+        database_1 = self.create_database('course')
+        database_2 = self.create_database('course')
+        args.environments = ['course']
+        args.choose_course = None
+        args.config = SimpleNamespace()
+        args.config.database = dict()
+        args.config.submitty = dict()
+        args.config.submitty['submitty_data_dir'] = Path(self.dir)
+        Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
+        Path(self.dir, 'courses', 'f19', 'csci1200').mkdir(parents=True)
+        with patch.object(migrator.db, 'Database') as mock_class:
+            mock_class.side_effect = [database_1, database_2]
+            main.handle_migration(args)
+        self.assertTrue(mock_class.called)
+        self.assertTrue(mock_method.called)
+        self.assertEqual(2, mock_method.call_count)
+
+        mock_args = mock_method.call_args_list[0][0]
+        expected_args = deepcopy(args)
+        self.assertEqual(database_1, mock_args[0])
+        self.assertEqual('course', mock_args[1])
+        self.assertEqual(args.config.database, dict())
+        self.assertNotIn('semester', expected_args)
+        self.assertNotIn('course', expected_args)
+        expected_args.config.database = {'dbname': 'submitty_f19_csci1200'}
+        expected_args.semester = 'f19'
+        expected_args.course = 'csci1200'
+        self.assertEqual(expected_args, mock_args[2])
+        self.assertEqual(expected_args.semester, 'f19')
+        self.assertEqual(expected_args.course, 'csci1200')
+        self.assertFalse(database_1.open)
+
+        mock_args = mock_method.call_args_list[1][0]
+        expected_args = deepcopy(args)
+        self.assertEqual(database_2, mock_args[0])
+        self.assertEqual('course', mock_args[1])
+        self.assertEqual(expected_args.config.database, dict())
+        self.assertNotIn('semester', expected_args)
+        self.assertNotIn('course', expected_args)
+        expected_args.config.database = {'dbname': 'submitty_f19_csci1100'}
+        expected_args.semester = 'f19'
+        expected_args.course = 'csci1100'
+        self.assertEqual(expected_args, mock_args[2])
+        self.assertEqual(expected_args.semester, 'f19')
+        self.assertEqual(expected_args.course, 'csci1100')
+        self.assertFalse(database_2.open)

--- a/migration/test/test_handle_migration.py
+++ b/migration/test/test_handle_migration.py
@@ -130,6 +130,8 @@ Submitty Database Migration Warning:  Database does not exist for semester=f19 c
             mock_class.side_effect = [database]
             main.handle_migration(args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(1, mock_class.call_count)
+        self.assertTrue(({'dbname': 'submitty'}, 'master'), mock_class.call_args[0])
         self.assertTrue(mock_method.called)
         self.assertEqual(1, mock_method.call_count)
         self.assertEqual(database, mock_method.call_args[0][0])
@@ -150,6 +152,8 @@ Submitty Database Migration Warning:  Database does not exist for semester=f19 c
             mock_class.side_effect = [database]
             main.handle_migration(args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(1, mock_class.call_count)
+        self.assertTrue(({'dbname': 'submitty'}, 'system'), mock_class.call_args[0])
         self.assertTrue(mock_method.called)
         self.assertEqual(1, mock_method.call_count)
         self.assertEqual(database, mock_method.call_args[0][0])
@@ -174,6 +178,11 @@ Submitty Database Migration Warning:  Database does not exist for semester=f19 c
             mock_class.side_effect = [database]
             main.handle_migration(args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(1, mock_class.call_count)
+        self.assertTrue(
+            ({'dbname': 'submitty_f19_csci1100'}, 'course'),
+            mock_class.call_args[0]
+        )
         self.assertTrue(mock_method.called)
         self.assertEqual(1, mock_method.call_count)
         self.assertEqual(database, mock_method.call_args[0][0])
@@ -210,6 +219,19 @@ Submitty Database Migration Warning:  Database does not exist for semester=f19 c
             mock_class.side_effect = [database_1, database_2, database_3]
             main.handle_migration(args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(3, mock_class.call_count)
+        self.assertTrue(
+            ({'dbname': 'submitty_f18_csci1100'}, 'course'),
+            mock_class.call_args_list[0][0]
+        )
+        self.assertTrue(
+            ({'dbname': 'submitty_f19_csci1100'}, 'course'),
+            mock_class.call_args_list[1][0]
+        )
+        self.assertTrue(
+            ({'dbname': 'submitty_f19_csci1200'}, 'course'),
+            mock_class.call_args_list[2][0]
+        )
         self.assertTrue(mock_method.called)
         self.assertEqual(3, mock_method.call_count)
 

--- a/migration/test/test_status.py
+++ b/migration/test/test_status.py
@@ -15,7 +15,7 @@ import migrator
 from migrator import main
 
 
-class TestPrintStatus(unittest.TestCase):
+class TestStatus(unittest.TestCase):
     def setUp(self):
         self.stdout = sys.stdout
         sys.stdout = StringIO()
@@ -207,6 +207,9 @@ Could not find migration table for f19.csci1100
         self.assertTrue(mock_method.called)
         self.assertEqual(self.databases['master'], mock_method.call_args[0][0])
         self.assertEqual('master', mock_method.call_args[0][1])
+        # Test that mutation did not happen
+        self.assertEqual(self.args.config.database, dict())
+        self.args.config.database = {'dbname': 'submitty'}
         self.assertEqual(self.args, mock_method.call_args[0][2])
         self.assertFalse(self.databases['master'].open)
 
@@ -224,6 +227,9 @@ Could not find migration table for f19.csci1100
         self.assertTrue(mock_method.called)
         self.assertEqual(self.databases['system'], mock_method.call_args[0][0])
         self.assertEqual('system', mock_method.call_args[0][1])
+        # Test that mutation did not happen
+        self.assertEqual(self.args.config.database, dict())
+        self.args.config.database = {'dbname': 'submitty'}
         self.assertEqual(self.args, mock_method.call_args[0][2])
         self.assertFalse(self.databases['system'].open)
 
@@ -245,6 +251,13 @@ Could not find migration table for f19.csci1100
         self.assertTrue(mock_method.called)
         self.assertEqual(self.databases['course'], mock_method.call_args[0][0])
         self.assertEqual('course', mock_method.call_args[0][1])
+        # Test that mutation did not happen
+        self.assertEqual(self.args.config.database, dict())
+        self.assertNotIn('semester', self.args)
+        self.assertNotIn('course', self.args)
+        self.args.config.database = {'dbname': 'submitty_f19_csci1100'}
+        self.args.semester = 'f19'
+        self.args.course = 'csci1100'
         self.assertEqual(self.args, mock_method.call_args[0][2])
         self.assertEqual(self.args.semester, 'f19')
         self.assertEqual(self.args.course, 'csci1100')

--- a/migration/test/test_status.py
+++ b/migration/test/test_status.py
@@ -233,6 +233,8 @@ Could not find migration table for f19.csci1100
             mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(1, mock_class.call_count)
+        self.assertTrue(({'dbname': 'submitty'}, 'system'), mock_class.call_args[0])
         self.assertTrue(mock_method.called)
         self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('system', mock_method.call_args[0][1])
@@ -258,6 +260,11 @@ Could not find migration table for f19.csci1100
             mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(1, mock_class.call_count)
+        self.assertTrue(
+            ({'dbname': 'submitty_f19_csci1100'}, 'course'),
+            mock_class.call_args[0]
+        )
         self.assertTrue(mock_method.called)
         self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('course', mock_method.call_args[0][1])
@@ -297,6 +304,19 @@ Could not find migration table for f19.csci1100
             ]
             main.status(self.args)
         self.assertTrue(mock_class.called)
+        self.assertEqual(3, mock_class.call_count)
+        self.assertTrue(
+            ({'dbname': 'submitty_f18_csci1100'}, 'course'),
+            mock_class.call_args_list[0][0]
+        )
+        self.assertTrue(
+            ({'dbname': 'submitty_f19_csci1100'}, 'course'),
+            mock_class.call_args_list[1][0]
+        )
+        self.assertTrue(
+            ({'dbname': 'submitty_f19_csci1200'}, 'course'),
+            mock_class.call_args_list[2][0]
+        )
         self.assertTrue(mock_method.called)
         self.assertEqual(3, mock_method.call_count)
 

--- a/migration/test/test_status.py
+++ b/migration/test/test_status.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from copy import deepcopy
 from io import StringIO
 from pathlib import Path
 import shutil
@@ -23,20 +24,20 @@ class TestStatus(unittest.TestCase):
         self.dir = tempfile.mkdtemp()
         self.old_migrations_path = migrator.MIGRATIONS_PATH
         migrator.MIGRATIONS_PATH = Path(self.dir)
-        self.databases = dict()
 
     def tearDown(self):
         sys.stdout = self.stdout
         shutil.rmtree(self.dir)
         migrator.MIGRATIONS_PATH = self.old_migrations_path
 
-    def setup_test(self, environment, create=True):
+    def setup_test(self, environment):
         Path(self.dir, environment).mkdir()
-        self.stdout = sys.stdout
+
+    def create_database(self, environment, create=True):
         database = migrator.db.Database({'database_driver': 'sqlite'}, environment)
-        if create:
+        if create is True:
             database.DynamicBase.metadata.create_all(database.engine)
-        self.databases[environment] = database
+        return database
 
     def test_no_course_dir(self):
         self.args.environments = ['course']
@@ -115,38 +116,41 @@ Could not get the status for the migrations for f19.csci1100
         self.assertEqual(expected, sys.stdout.getvalue())
 
     def test_status_no_table_master(self):
-        self.setup_test('master', False)
+        self.setup_test('master')
+        database = self.create_database('master', False)
         self.args.environments = ['master']
         self.args.config = SimpleNamespace()
         self.args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['master']]
+            mock_class.side_effect = [database]
             main.status(self.args)
         self.assertEqual(
             "Could not find migration table for master\n",
             sys.stdout.getvalue()
         )
-        self.assertFalse(self.databases['master'].open)
+        self.assertFalse(database.open)
 
     def test_status_no_table_system(self):
-        self.setup_test('system', False)
+        self.setup_test('system')
+        database = self.create_database('system', False)
         self.args.environments = ['system']
         self.args.config = SimpleNamespace()
         self.args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['system']]
+            mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
         self.assertEqual(
             "Could not find migration table for system\n",
             sys.stdout.getvalue()
         )
-        self.assertFalse(self.databases['system'].open)
+        self.assertFalse(database.open)
 
     def test_status_no_table_course(self):
-        self.setup_test('course', False)
+        self.setup_test('course')
+        database = self.create_database('course', False)
         self.args.environments = ['course']
         self.args.choose_course = None
         self.args.config = SimpleNamespace()
@@ -156,19 +160,22 @@ Could not get the status for the migrations for f19.csci1100
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['course']]
+            mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
         self.assertEqual(
             "Could not find migration table for f19.csci1100\n",
             sys.stdout.getvalue()
         )
-        self.assertFalse(self.databases['course'].open)
+        self.assertFalse(database.open)
 
     def test_status_no_table_all(self):
-        self.setup_test('master', False)
-        self.setup_test('system', False)
-        self.setup_test('course', False)
+        self.setup_test('master')
+        database_1 = self.create_database('master', False)
+        self.setup_test('system')
+        database_2 = self.create_database('system', False)
+        self.setup_test('course')
+        database_3 = self.create_database('course', False)
         self.args.environments = ['system', 'course', 'master']
         self.args.choose_course = None
         self.args.config = SimpleNamespace()
@@ -179,9 +186,9 @@ Could not get the status for the migrations for f19.csci1100
 
         with patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = [
-                self.databases['master'],
-                self.databases['system'],
-                self.databases['course']
+                database_1,
+                database_2,
+                database_3
             ]
             main.status(self.args)
         expected = """Could not find migration table for master
@@ -189,53 +196,56 @@ Could not find migration table for system
 Could not find migration table for f19.csci1100
 """
         self.assertEqual(expected, sys.stdout.getvalue())
-        self.assertFalse(self.databases['master'].open)
-        self.assertFalse(self.databases['system'].open)
-        self.assertFalse(self.databases['course'].open)
+        self.assertFalse(database_1.open)
+        self.assertFalse(database_2.open)
+        self.assertFalse(database_3.open)
 
     @patch('migrator.main.print_status')
     def test_status_master(self, mock_method):
         self.setup_test('master')
+        database = self.create_database('master')
         self.args.environments = ['master']
         self.args.config = SimpleNamespace()
         self.args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['master']]
+            mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
         self.assertTrue(mock_method.called)
-        self.assertEqual(self.databases['master'], mock_method.call_args[0][0])
+        self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('master', mock_method.call_args[0][1])
         # Test that mutation did not happen
         self.assertEqual(self.args.config.database, dict())
         self.args.config.database = {'dbname': 'submitty'}
         self.assertEqual(self.args, mock_method.call_args[0][2])
-        self.assertFalse(self.databases['master'].open)
+        self.assertFalse(database.open)
 
     @patch('migrator.main.print_status')
     def test_status_system(self, mock_method):
         self.setup_test('system')
+        database = self.create_database('system')
         self.args.environments = ['system']
         self.args.config = SimpleNamespace()
         self.args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['system']]
+            mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
         self.assertTrue(mock_method.called)
-        self.assertEqual(self.databases['system'], mock_method.call_args[0][0])
+        self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('system', mock_method.call_args[0][1])
         # Test that mutation did not happen
         self.assertEqual(self.args.config.database, dict())
         self.args.config.database = {'dbname': 'submitty'}
         self.assertEqual(self.args, mock_method.call_args[0][2])
-        self.assertFalse(self.databases['system'].open)
+        self.assertFalse(database.open)
 
     @patch('migrator.main.print_status')
     def test_status_course(self, mock_method):
         self.setup_test('course')
+        database = self.create_database('course')
         self.args.environments = ['course']
         self.args.choose_course = None
         self.args.config = SimpleNamespace()
@@ -245,11 +255,11 @@ Could not find migration table for f19.csci1100
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = [self.databases['course']]
+            mock_class.side_effect = [database]
             main.status(self.args)
         self.assertTrue(mock_class.called)
         self.assertTrue(mock_method.called)
-        self.assertEqual(self.databases['course'], mock_method.call_args[0][0])
+        self.assertEqual(database, mock_method.call_args[0][0])
         self.assertEqual('course', mock_method.call_args[0][1])
         # Test that mutation did not happen
         self.assertEqual(self.args.config.database, dict())
@@ -261,4 +271,79 @@ Could not find migration table for f19.csci1100
         self.assertEqual(self.args, mock_method.call_args[0][2])
         self.assertEqual(self.args.semester, 'f19')
         self.assertEqual(self.args.course, 'csci1100')
-        self.assertFalse(self.databases['course'].open)
+        self.assertFalse(database.open)
+
+    @patch('migrator.main.print_status')
+    def test_status_multiple_course(self, mock_method):
+        self.setup_test('course')
+        database_1 = self.create_database('course')
+        database_2 = self.create_database('coures')
+        database_3 = self.create_database('course')
+        self.args.environments = ['course']
+        self.args.choose_course = None
+        self.args.config = SimpleNamespace()
+        self.args.config.database = dict()
+        self.args.config.submitty = dict()
+        self.args.config.submitty['submitty_data_dir'] = Path(self.dir)
+        Path(self.dir, 'courses', 'f18', 'csci1100').mkdir(parents=True)
+        Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
+        Path(self.dir, 'courses', 'f19', 'csci1200').mkdir(parents=True)
+
+        with patch.object(migrator.db, 'Database') as mock_class:
+            mock_class.side_effect = [
+                database_1,
+                database_2,
+                database_3
+            ]
+            main.status(self.args)
+        self.assertTrue(mock_class.called)
+        self.assertTrue(mock_method.called)
+        self.assertEqual(3, mock_method.call_count)
+
+        mock_args = mock_method.call_args_list[0][0]
+        expected_args = deepcopy(self.args)
+        self.assertEqual(database_1, mock_args[0])
+        self.assertEqual('course', mock_args[1])
+        # Test that mutation did not happen
+        self.assertEqual(expected_args.config.database, dict())
+        self.assertNotIn('semester', expected_args)
+        self.assertNotIn('course', expected_args)
+        expected_args.config.database = {'dbname': 'submitty_f18_csci1100'}
+        expected_args.semester = 'f18'
+        expected_args.course = 'csci1100'
+        self.assertEqual(expected_args, mock_args[2])
+        self.assertEqual(expected_args.semester, 'f18')
+        self.assertEqual(expected_args.course, 'csci1100')
+        self.assertFalse(database_1.open)
+
+        mock_args = mock_method.call_args_list[1][0]
+        expected_args = deepcopy(self.args)
+        self.assertEqual(database_2, mock_args[0])
+        self.assertEqual('course', mock_args[1])
+        # Test that mutation did not happen
+        self.assertEqual(expected_args.config.database, dict())
+        self.assertNotIn('semester', expected_args)
+        self.assertNotIn('course', expected_args)
+        expected_args.config.database = {'dbname': 'submitty_f19_csci1100'}
+        expected_args.semester = 'f19'
+        expected_args.course = 'csci1100'
+        self.assertEqual(expected_args, mock_args[2])
+        self.assertEqual(expected_args.semester, 'f19')
+        self.assertEqual(expected_args.course, 'csci1100')
+        self.assertFalse(database_2.open)
+
+        mock_args = mock_method.call_args_list[2][0]
+        expected_args = deepcopy(self.args)
+        self.assertEqual(database_3, mock_args[0])
+        self.assertEqual('course', mock_args[1])
+        # Test that mutation did not happen
+        self.assertEqual(expected_args.config.database, dict())
+        self.assertNotIn('semester', expected_args)
+        self.assertNotIn('course', expected_args)
+        expected_args.config.database = {'dbname': 'submitty_f19_csci1200'}
+        expected_args.semester = 'f19'
+        expected_args.course = 'csci1200'
+        self.assertEqual(expected_args, mock_args[2])
+        self.assertEqual(expected_args.semester, 'f19')
+        self.assertEqual(expected_args.course, 'csci1200')
+        self.assertFalse(database_3.open)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #3525. The args Namespace used to be mutated throughout the run of Migrator. This made it hard to check that function calls of the Migrator had the right arguments as we could only ever check it for the last argument call.

### What is the new behavior?
Creates a deepcopy on any loop that uses the base args Namespace object. This makes it possible to test that we are properly calling functions with the right arguments, allowing for testing of multiple courses.
