### PR TITLE
[Bugfix] installation &  java_tools permissions

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -397,6 +397,12 @@ chmod 444 TestRunner.class
 
 popd > /dev/null
 
+
+# fix all java_tools permissions
+chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/java_tools
+chmod -R 755 ${SUBMITTY_INSTALL_DIR}/java_tools
+
+
 ########################################################################################################################
 ########################################################################################################################
 # COPY VARIOUS SCRIPTS USED BY INSTRUCTORS AND SYS ADMINS FOR COURSE ADMINISTRATION

--- a/.setup/distro_setup/ubuntu/rpi.sh
+++ b/.setup/distro_setup/ubuntu/rpi.sh
@@ -103,6 +103,7 @@ curl https://soot-build.cs.uni-paderborn.de/public/origin/develop/soot/soot-deve
 -o /dev/null > /dev/null 2>&1
 popd > /dev/null
 
+# fix all java_tools permissions
 chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/java_tools
 chmod -R 755 ${SUBMITTY_INSTALL_DIR}/java_tools
 

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -378,6 +378,9 @@ chmod o+r . *.jar
 popd > /dev/null
 
 
+# fix all java_tools permissions
+chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/java_tools
+chmod -R 755 ${SUBMITTY_INSTALL_DIR}/java_tools
 
 
 #################################################################


### PR DESCRIPTION
Some sequence of calling installation scripts & customization resulted in several java_tools .jar files missing the other read bit.  These (somewhat redundant) permissions changes should ensure this doesn't happen again.