### PR TITLE
Add the api_key column to users table

### DIFF
--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -126,7 +126,7 @@ CREATE TABLE users (
     user_updated BOOLEAN NOT NULL DEFAULT FALSE,
     instructor_updated BOOLEAN NOT NULL DEFAULT FALSE,
     last_updated timestamp(6) with time zone,
-    api_key character varying(255) NOT NULL default encode(gen_random_bytes(16), 'hex')
+    api_key character varying(255) NOT NULL UNIQUE DEFAULT encode(gen_random_bytes(16), 'hex')
 );
 
 CREATE TABLE courses_registration_sections (

--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -21,7 +21,7 @@ SET row_security = off;
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 --
 -- TOC entry 2161 (class 0 OID 0)
@@ -125,7 +125,8 @@ CREATE TABLE users (
     user_email character varying NOT NULL,
     user_updated BOOLEAN NOT NULL DEFAULT FALSE,
     instructor_updated BOOLEAN NOT NULL DEFAULT FALSE,
-    last_updated timestamp(6) with time zone
+    last_updated timestamp(6) with time zone,
+    api_key character varying(255) NOT NULL default encode(gen_random_bytes(16), 'hex')
 );
 
 CREATE TABLE courses_registration_sections (
@@ -336,6 +337,15 @@ EXCEPTION WHEN integrity_constraint_violation THEN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION generate_api_key() RETURNS TRIGGER AS $generate_api_key$
+-- TRIGGER function to generate api_key on INSERT or UPDATE of user_password in
+-- table users.
+BEGIN
+    NEW.api_key := encode(gen_random_bytes(16), 'hex');
+    RETURN NEW;
+END;
+$generate_api_key$ LANGUAGE plpgsql;
+
 -- Foreign Key Constraint *REQUIRES* insert trigger to be assigned to course_users.
 -- Updates can happen in either users and/or courses_users.
 CREATE TRIGGER user_sync_courses_users AFTER INSERT OR UPDATE ON courses_users FOR EACH ROW EXECUTE PROCEDURE sync_courses_user();
@@ -344,3 +354,6 @@ CREATE TRIGGER user_sync_users AFTER UPDATE ON users FOR EACH ROW EXECUTE PROCED
 -- INSERT and DELETE triggers for syncing registration sections happen on different instances of TG_WHEN (after vs before).
 CREATE TRIGGER insert_sync_registration_id AFTER INSERT OR UPDATE ON courses_registration_sections FOR EACH ROW EXECUTE PROCEDURE sync_insert_registration_section();
 CREATE TRIGGER delete_sync_registration_id BEFORE DELETE ON courses_registration_sections FOR EACH ROW EXECUTE PROCEDURE sync_delete_registration_section();
+
+-- Generate API key when a user is created or its password is changed.
+CREATE TRIGGER generate_api_key BEFORE INSERT OR UPDATE OF user_password ON users FOR EACH ROW EXECUTE PROCEDURE generate_api_key();

--- a/migration/migrator/migrations/master/20190526013255_add_api_key.py
+++ b/migration/migrator/migrations/master/20190526013255_add_api_key.py
@@ -1,0 +1,52 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    if not database.table_has_column("users", "api_key"):
+    
+        database.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;")
+
+        database.execute("ALTER TABLE users ADD COLUMN api_key character varying(255) NOT NULL default encode(gen_random_bytes(16), 'hex');")
+
+        database.execute("""
+CREATE OR REPLACE FUNCTION generate_api_key() 
+RETURNS TRIGGER AS $generate_api_key$
+-- TRIGGER function to generate api_key on INSERT or UPDATE of user_password in
+-- table users.
+BEGIN
+  NEW.api_key := encode(gen_random_bytes(16), 'hex');
+  RETURN NEW;
+END;
+$generate_api_key$ LANGUAGE plpgsql;
+""")
+
+        database.execute("""
+DROP TRIGGER IF EXISTS generate_api_key ON users;
+""")
+
+        database.execute("""
+CREATE TRIGGER generate_api_key 
+BEFORE INSERT OR UPDATE OF user_password ON users
+FOR EACH ROW
+EXECUTE PROCEDURE generate_api_key();
+""")
+
+
+def down(config, database):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    pass

--- a/migration/migrator/migrations/master/20190526013255_add_api_key.py
+++ b/migration/migrator/migrations/master/20190526013255_add_api_key.py
@@ -14,7 +14,7 @@ def up(config, database):
     
         database.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;")
 
-        database.execute("ALTER TABLE users ADD COLUMN api_key character varying(255) NOT NULL default encode(gen_random_bytes(16), 'hex');")
+        database.execute("ALTER TABLE users ADD COLUMN api_key character varying(255) NOT NULL UNIQUE DEFAULT encode(gen_random_bytes(16), 'hex');")
 
         database.execute("""
 CREATE OR REPLACE FUNCTION generate_api_key() 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Partially addresses #300. Currently, we do not have an API key for each user, which makes it hard to revoke a user's token from the server side. In this case, if a malicious user steals other people's tokens, he/she can impersonate other users at his/her will before the tokens expire, which is not the desired behavior.

### What is the new behavior?
An API key is generated for each user, and it gets updated automatically when their password is changed. The key will be later used for authentication via JWT, where it is put inside the "payload" part and the server checks it against the database for every request that requires authentication.