### PR TITLE
Show server time and update dynamically

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -96,12 +96,21 @@ class SubmissionController extends AbstractController {
             case 'stat_page':
                 return $this->showStats();
                 break;
+            case 'fetch_time':
+                return $this->fetchTime();
+                break;
             case 'display':
             default:
                 return $this->showHomeworkPage();
                 break;
         }
     }
+
+    private function fetchTime(){
+        $this->core->getOutput()->renderJsonSuccess(Array("time" => time(), "offset"=>date("Z")));
+        return;
+    }
+
     private function requestRegrade() {
         $content = $_POST['replyTextArea'] ?? '';
         $gradeable_id = $_REQUEST['gradeable_id'] ?? '';

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -18,6 +18,7 @@
         {% endif %}
     </div>
 
+    {%  if due_in_a_day %}
     <script>
         $(function(){
 
@@ -33,7 +34,6 @@
             var fetchTimeUrl = window.location.href + "&action=fetch_time";
 
             setTimeout(function(){
-                console.log("Ran");
                 $.ajax({
                     url: fetchTimeUrl,
                     dataType: "json",
@@ -59,6 +59,7 @@
             }
         });
     </script>
+    {% endif %}
 
     {% if show_no_late_submission_warning %}
         <div>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -10,9 +10,55 @@
     <div class="upperinfo">
         <h1 class="upperinfo-left">New submission for: {{ gradeable_name }}</h1>
         {% if has_due_date %}
-            <h3 class="upperinfo-right">Due: {{ formatted_due_date }}</h3>
+            <h3 class="upperinfo-right">Due: {{ formatted_due_date }} <br>
+                {%  if due_in_a_day %}
+                    <span>Now: <span id="current-server-time">{{ formatted_current_time }}</span></span>
+                {% endif %}
+            </h3>
         {% endif %}
     </div>
+
+    <script>
+        $(function(){
+
+            // Get browser's time, timezone offset and unix timestamp (all in milliseconds)
+            var localDate = new Date();
+            var localTimestamp = localDate.getTime();
+            var localOffset = localDate.getTimezoneOffset() * 60000;
+
+            // Calculate shift to UTC in milliseconds
+            var UTCTime = localTimestamp + localOffset;
+            var serverTimeShift;
+
+            var fetchTimeUrl = window.location.href + "&action=fetch_time";
+
+            setTimeout(function(){
+                console.log("Ran");
+                $.ajax({
+                    url: fetchTimeUrl,
+                    dataType: "json",
+                    success: function(result){
+                        // timezone offset returned in seconds from server
+                        var serverOffset = result.data.offset * 1000;
+
+                        // server time shift is shift from UTC and the seconds before the ajax call was made is added to it.
+                        serverTimeShift = UTCTime + serverOffset + ((60 - localDate.getSeconds())*1000);
+
+                        setTime(); // Since setInterval runs after the interval and we need an update right now, run the function once
+                        setInterval(function(){setTime()}, 60 * 1000);
+                    }
+                });
+            }, (60 - localDate.getSeconds())*1000); // setting ajax call to server time fetch only when seconds on clock is 00
+
+            function setTime(){
+                var serverDate = new Date(serverTimeShift); //
+                var datestring = ("0" + serverDate.getDate()).slice(-2) + "-" + ("0"+(serverDate.getMonth()+1)).slice(-2) + "-" +
+                    serverDate.getFullYear() + " @ " + ("0" + serverDate.getHours()).slice(-2) + ":" + ("0" + serverDate.getMinutes()).slice(-2);
+                $('#current-server-time').empty().append(datestring);
+                serverTimeShift += 60*1000; // update time, in milliseconds
+            }
+        });
+    </script>
 
     {% if show_no_late_submission_warning %}
         <div>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -360,6 +360,8 @@ class HomeworkView extends AbstractView {
             'gradeable_id' => $gradeable->getId(),
             'gradeable_name' => $gradeable->getTitle(),
             'formatted_due_date' => $gradeable->getSubmissionDueDate()->format($DATE_FORMAT),
+            'formatted_current_time' => date($DATE_FORMAT, time()),
+            'due_in_a_day' => ($gradeable->getSubmissionDueDate()->format("U") - time()) <= (24*60*60),
             'part_names' => $gradeable->getAutogradingConfig()->getPartNames(),
             'is_vcs' => $gradeable->isVcs(),
             'vcs_subdirectory' => $gradeable->getVcsSubdirectory(),

--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -37,6 +37,10 @@
     margin-bottom: 0px !important;
 }
 
+.upperinfo-right span{
+    color: #777;
+}
+
 .highlight-hover {
     background-color: #ddf !important;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Fixes #1865 

### What is the new behavior?
The Current server time is displayed only when 1 day or less is remaining from the due date. It keeps updating every minute and the maximum error for the time is 1 minute. 

### Other information?
Is this a breaking change? - No
How did you test - 
[1] Test Case 1: Laptop in ON state, tab active 
Let the page stay for a while in tab active state, the time kept updating correctly. 

[2] Test Case 2: Laptop in ON state, tab inactive
Let the page stay while on another tab. Returned to find the correct time, and updates too came in correctly.

[3] Test Case 3: Laptop put on sleep
Opened page, checked one correct update. 
Put laptop to sleep for 10 minutes.
Returned to find correct time displayed
Next update at correct time.

(I used [ClockTab](http://www.clocktab.com) to check if updates where happening at 0 seconds on the clock). 