### PR TITLE
Allow PHP Assignments When Grading in a Docker Container

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -149,6 +149,7 @@ bool system_program(const std::string &program, std::string &full_path_executabl
 
   if(running_in_docker){
     allowed_system_programs.insert({"bash", "/bin/bash"});
+    allowed_system_programs.insert({"php",  "/usr/bin/php"});
   }
   // find full path name
   std::map<std::string,std::string>::const_iterator itr = allowed_system_programs.find(program);
@@ -225,7 +226,8 @@ std::string validate_program(const std::string &program, const nlohmann::json &w
     std::cerr << message << std::endl;
     exit(1);
   } else {
-    bool running_in_docker = whole_config.value("docker_enabled", false);
+    std::string mode = whole_config.value("autograding_method", "");
+    bool running_in_docker = (mode == "docker") ? true : false;
     if (system_program(program,full_path_executable,running_in_docker)) {
       return full_path_executable;
     }


### PR DESCRIPTION
1. Adds php to the list of allowed programs when grading within a docker container. 
2. Fixes a bug which caused ```execute.cpp``` to be unable to detect whether or not it was being run in a container. 