### PR TITLE
Add Timeouts to Worker Machine Interactions

### DIFF
--- a/sbin/shipper_utils/systemctl_wrapper.py
+++ b/sbin/shipper_utils/systemctl_wrapper.py
@@ -86,12 +86,12 @@ def perform_systemctl_command_on_worker(daemon, mode, target):
       ssh = paramiko.SSHClient()
       ssh.get_host_keys()
       ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-      ssh.connect(hostname = host, username = user)
+      ssh.connect(hostname = host, username = user, timeout=10)
   except Exception as e:
       print("ERROR: could not ssh to {0}@{1} due to following error: {2}".format(user, host,str(e)))
       return EXIT_CODES['failure']
   try:
-      (stdin, stdout, stderr) = ssh.exec_command(command)
+      (stdin, stdout, stderr) = ssh.exec_command(command, timeout=5)
       status = int(stdout.channel.recv_exit_status())
   except Exception as e:
       print("ERROR: Command did not properly execute: ".format(host, str(e)))

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -33,13 +33,13 @@ def install_worker(user, host):
             ssh = paramiko.SSHClient()
             ssh.get_host_keys()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(hostname = host, username = user)
+            ssh.connect(hostname = host, username = user, timeout=5)
         except Exception as e:
             print("ERROR: could not ssh to {0}@{1} due to following error: {2}".format(user, host,str(e)))
             return False
         try:
             command = "sudo {0}".format(os.path.join(SUBMITTY_INSTALL_DIR, ".setup", "INSTALL_SUBMITTY.sh"))
-            (stdin, stdout, stderr) = ssh.exec_command(command)
+            (stdin, stdout, stderr) = ssh.exec_command(command, timeout=5)
             status = int(stdout.channel.recv_exit_status())
             if status == 0:
                 success = True

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -207,7 +207,7 @@ def prepare_job(my_name,which_machine,which_untrusted,next_directory,next_to_gra
             ssh.get_host_keys()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-            ssh.connect(hostname = host, username = user)
+            ssh.connect(hostname = host, username = user, timeout=5)
             sftp = ssh.open_sftp()
 
             sftp.put(autograding_zip_tmp,autograding_zip)
@@ -278,7 +278,7 @@ def unpack_job(which_machine,which_untrusted,next_directory,next_to_grade):
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         try:
-            ssh.connect(hostname = host, username = user)
+            ssh.connect(hostname = host, username = user, timeout=5)
 
             sftp = ssh.open_sftp()
             fd1, local_done_queue_file = tempfile.mkstemp()


### PR DESCRIPTION
Closes #3684 

Adds reasonable timeouts to all paramiko worker machine interactions made by Submitty.

Not tested locally.