### PR TITLE
[Extensions] update absence drop down lists to show students only once

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -240,32 +240,42 @@ class Utils {
      * students_version is an array of user and their highest submitted version
      */
 
-    public static function getAutoFillData($students, $students_version = null){
+    public static function getAutoFillData($students, $students_version = null) {
         $students_full = array();
         $null_section = array();
         foreach ($students as $student) {
             $student_entry = array('value' => $student->getId(),
                     'label' => $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>');
-            $students_full[] = $student_entry;
-            if($students_version != null){
-                if($student->getRegistrationSection() != null && array_key_exists($student->getId(),$students_version)){
+            if($students_version != null) {
+                if($student->getRegistrationSection() != null && array_key_exists($student->getId(),$students_version)) {
                     if ($students_version[$student->getId()] !== 0) {
                         $student_entry['label'] .= ' (' .
                         $students_version[$student->getId()] . ' Prev Submission)';
                     }
                 }
-            }else{
+                $students_full[] = $student_entry;
+            } else {
                 $null_entry = array('value' => $student->getId(),
-                'label' => '[NULL section] ' . $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>'); 
+                'label' => '[NULL section]' . $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>'); 
 
                 $in_null_section = false;
                 foreach ($null_section as $null_student) {
                     if($null_student['value'] === $student->getId()) $in_null_section = true;
                 }
-                if(!$in_null_section) $null_section[] = $null_entry;
+                if(!$in_null_section) $null_section[] = $null_entry; 
+                //$students_full = self::removeStudentWithId($students_full, 'value', $student->getId());
             }
         }
         $students_full = array_unique(array_merge($students_full, $null_section), SORT_REGULAR);
         return json_encode($students_full);
     }
+
+    public static function removeStudentWithId($students, $key, $id) {
+        foreach($students as $subKey => $student) {
+             if($student[$key] === $id) {
+                  unset($students[$subKey]);
+             }
+        }
+        return $students;
+   }
 }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -246,6 +246,7 @@ class Utils {
         foreach ($students as $student) {
             $student_entry = array('value' => $student->getId(),
                     'label' => $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>');
+            $students_full[] = $student_entry;
             if($students_version != null) {
                 if($student->getRegistrationSection() != null && array_key_exists($student->getId(),$students_version)) {
                     if ($students_version[$student->getId()] !== 0) {
@@ -253,17 +254,18 @@ class Utils {
                         $students_version[$student->getId()] . ' Prev Submission)';
                     }
                 }
-                $students_full[] = $student_entry;
             } else {
                 $null_entry = array('value' => $student->getId(),
-                'label' => '[NULL section]' . $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>'); 
+                'label' => '[NULL section] ' . $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>'); 
 
                 $in_null_section = false;
                 foreach ($null_section as $null_student) {
                     if($null_student['value'] === $student->getId()) $in_null_section = true;
                 }
-                if(!$in_null_section) $null_section[] = $null_entry; 
-                //$students_full = self::removeStudentWithId($students_full, 'value', $student->getId());
+                if(!$in_null_section && $student->getRegistrationSection() == null) {
+                    $null_section[] = $null_entry; 
+                    $students_full = self::removeStudentWithId($students_full, 'value', $student->getId());
+                } 
             }
         }
         $students_full = array_unique(array_merge($students_full, $null_section), SORT_REGULAR);

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -271,6 +271,10 @@ class Utils {
         $students_full = array_unique(array_merge($students_full, $null_section), SORT_REGULAR);
         return json_encode($students_full);
     }
+    
+    /*
+     * Given a multidimensional array of students, key, and id, removeStudentWithId deletes matching student row(s).
+     */
 
     public static function removeStudentWithId($students, $key, $id) {
         foreach($students as $subKey => $student) {


### PR DESCRIPTION
Signed-off-by: fenn-cs <fenn25.fn@gmail.com>

### What is the current behavior?
As in #3765, All students (both regular & dropped) are listed twice -- as both a regular student and in the NULL section. 

Fixes: #3765
 
### What is the new behavior?
Show students exactly ones in the dropdown.

### Other information?

- I added a `removeStudentWithId()` function which I could use to achieve the same results but did not use it since it's not efficient to add null students in the array before removing them, so students are only added to their respective arrays no need for removal, however, I contemplating if the `removeStudentWithId()` can be useful in the Utils?

### Main change
_Moved  ` $students_full[] = $student_entry; ` into NOT NULL condition_
https://github.com/Submitty/Submitty/blob/263fcda4bc45e6076b9a15505ed83b759dae603d/site/app/libraries/Utils.php#L246-L256

_other changes are just formattting e.g `function(){}` => `function () {}`_