### PR TITLE
[Feature] Download Zips in Course Material Page

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -517,7 +517,7 @@ class MiscController extends AbstractController {
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
 
-        if(!$this->core->getUser()->accessAdmin()) {
+        if(!$this->core->getUser()->accessGrading()) {
             // if the user is not the instructor
             // download all accessible files according to course_materials_file_data.json
             $file_data = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -4,6 +4,7 @@ namespace app\controllers;
 
 
 use app\libraries\FileUtils;
+use app\libraries\DateUtils;
 use app\libraries\Utils;
 use app\libraries\Core;
 
@@ -527,7 +528,8 @@ class MiscController extends AbstractController {
                 if (!Utils::startsWith(realpath($path), $root_path)) {
                     continue;
                 }
-                if ($file['release_datetime'] < $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")) {
+                if ($file['checked'] === '1' &&
+                    $file['release_datetime'] < $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")) {
                     $relative_path = substr($path, strlen($root_path) + 1);
                     $zip->addFile($path, $relative_path);
                 }

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -524,7 +524,8 @@ class MiscController extends AbstractController {
             $json = FileUtils::readJsonFile($file_data);
 
             foreach ($json as $path => $file) {
-                if (substr(realpath($path), 0, strlen($root_path)) != $root_path) {
+                // check if the file is in the requested folder
+                if (!Utils::startsWith(realpath($path), $root_path)) {
                     continue;
                 }
                 if ($file['release_datetime'] < $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")) {

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -4,7 +4,6 @@ namespace app\controllers;
 
 
 use app\libraries\FileUtils;
-use app\libraries\DateUtils;
 use app\libraries\Utils;
 use app\libraries\Core;
 

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -40,6 +40,9 @@ class MiscController extends AbstractController {
             case 'download_all_assigned':
                 $this->downloadAssignedZips();
                 break;
+            case 'download_course_material_zip':
+                $this->downloadCourseMaterialZip();
+                break;
             case 'base64_encode_pdf':
                 $this->encodePDF();
                 break;
@@ -495,6 +498,68 @@ class MiscController extends AbstractController {
         unlink($zip_name); //deletes the random zip file
     }
 
+    private function downloadCourseMaterialZip() {
+        $dir_name = $_REQUEST["dir_name"];
+        $root_path = realpath($_REQUEST["path"]);
+
+        // check if the user has access to course materials
+        if (!$this->core->getAccess()->canI("path.read", ["dir" => 'course_materials', "path" => $root_path])) {
+            $this->core->getOutput()->showError("You do not have access to this folder");
+            return false;
+        }
+
+        $temp_dir = "/tmp";
+        // makes a random zip file name on the server
+        $temp_name = uniqid($this->core->getUser()->getId(), true);
+        $zip_name = $temp_dir . "/" . $temp_name . ".zip";
+        $zip_file_name = $dir_name . ".zip";
+
+        $zip = new \ZipArchive();
+        $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+
+        if(!$this->core->getUser()->accessAdmin()) {
+            // if the user is not the instructor
+            // download all accessible files according to course_materials_file_data.json
+            $file_data = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
+            $json = FileUtils::readJsonFile($file_data);
+
+            foreach ($json as $path => $file) {
+                if (substr(realpath($path), 0, strlen($root_path)) != $root_path) {
+                    continue;
+                }
+                if ($file['release_datetime'] < $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")) {
+                    $relative_path = substr($path, strlen($root_path) + 1);
+                    $zip->addFile($path, $relative_path);
+                }
+            }
+        }
+        else {
+            // if the user is an instructor
+            // download all files
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root_path),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            );
+
+            foreach ($files as $name => $file) {
+                if (!$file->isDir()) {
+                    $file_path = $file->getRealPath();
+                    $relativePath = substr($file_path, strlen($root_path) + 1);
+
+                    $zip->addFile($file_path, $relativePath);
+                }
+            }
+        }
+
+        $zip->close();
+        header("Content-type: application/zip");
+        header("Content-Disposition: attachment; filename=$zip_file_name");
+        header("Content-length: " . filesize($zip_name));
+        header("Pragma: no-cache");
+        header("Expires: 0");
+        readfile("$zip_name");
+        unlink($zip_name); //deletes the random zip file
+    }
 
     public function modifyCourseMaterialsFilePermission() {
 

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -512,7 +512,7 @@ class MiscController extends AbstractController {
         // makes a random zip file name on the server
         $temp_name = uniqid($this->core->getUser()->getId(), true);
         $zip_name = $temp_dir . "/" . $temp_name . ".zip";
-        $zip_file_name = $dir_name . ".zip";
+        $zip_file_name = preg_replace('/\s+/', '_', $dir_name) . ".zip";
 
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
@@ -522,7 +522,6 @@ class MiscController extends AbstractController {
             // download all accessible files according to course_materials_file_data.json
             $file_data = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
             $json = FileUtils::readJsonFile($file_data);
-
             foreach ($json as $path => $file) {
                 // check if the file is in the requested folder
                 if (!Utils::startsWith(realpath($path), $root_path)) {

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -62,6 +62,7 @@
                 <span class="fas fa-folder open-all-folder" style='vertical-align:text-top;font-size:20px'></span>
                 {{ dir }}
             </a>
+            <a onclick='downloadCourseMaterialZip("{{ dir }}", "{{ folderPath | url_encode }}")'><i class="fas fa-download" aria-hidden="true" title="Download the folder"></i></a>
             {% if userGroup == 1 %}
                 <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'misc', 'page': 'delete_course_material_folder', 'dir': 'course_materials', 'file': dir, 'path': folderPath }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
             {% endif %}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1205,6 +1205,10 @@ function downloadFileWithAnyRole(file_name, path) {
     window.location = buildUrl({'component': 'misc', 'page': 'download_file_with_any_role', 'dir': 'course_materials', 'file': file, 'path': path});
 }
 
+function downloadCourseMaterialZip(dir_name, path) {
+    window.location = buildUrl({'component': 'misc', 'page': 'download_course_material_zip', 'dir_name': dir_name, 'path': path});
+}
+
 function checkColorActivated() {
     var pos = 0;
     var seq = "&&((%'%'BA\r";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Documentation has been updated/added if relevant (**Will do if the changes are approved**)

### What is the current behavior?
Closes #3746 .

### What is the new behavior?
In the course material page, instructors and students are able to download zips made of files in a directory.

### Other information?

Instructor downloading the `bin` folder:
![Screenshot from 2019-06-03 20-44-10](https://user-images.githubusercontent.com/20266703/58803689-ad010700-8642-11e9-8104-8c385a372b99.png)

Student downloading the `bin` folder:
![Screenshot from 2019-06-03 20-51-12](https://user-images.githubusercontent.com/20266703/58803701-b12d2480-8642-11e9-8f7f-2278262654a7.png)

