### PR TITLE
[Bugfix] Only catch exceptions for JWT parsing for cookie session

### DIFF
--- a/site/app/libraries/TokenManager.php
+++ b/site/app/libraries/TokenManager.php
@@ -2,7 +2,6 @@
 
 namespace app\libraries;
 
-use app\exceptions\AuthenticationException;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Token;
@@ -41,7 +40,7 @@ class TokenManager {
     public static function parseSessionToken(string $token, string $issuer, string $secret): Token {
         $token = (new Parser())->parse($token);
         if (!$token->verify(new Sha256(), $secret)) {
-            throw new AuthenticationException("Invalid signature for token");
+            throw new \InvalidArgumentException("Invalid signature for token");
         }
         
         $headers = [
@@ -50,19 +49,19 @@ class TokenManager {
         ];
         foreach ($headers as $key => $value) {
             if ($token->getHeader($key) !== $value) {
-                throw new AuthenticationException("Invalid value for ${key}: ${value}");
+                throw new \InvalidArgumentException("Invalid value for ${key}: ${value}");
             }
         }
 
         $data = new ValidationData();
         $data->setIssuer($issuer);
         if (!$token->validate($data)) {
-            throw new AuthenticationException('Invalid claims in token');
+            throw new \InvalidArgumentException('Invalid claims in token');
         }
 
         $claims = $token->getClaims();
         if (!$token->hasClaim('session_id') || !$token->hasClaim('expire_time') || !$token->hasClaim('sub')) {
-            throw new AuthenticationException('Missing claims in session token');
+            throw new \InvalidArgumentException('Missing claims in session token');
         }
         return $token;
     }

--- a/site/app/libraries/TokenManager.php
+++ b/site/app/libraries/TokenManager.php
@@ -2,6 +2,7 @@
 
 namespace app\libraries;
 
+use app\exceptions\AuthenticationException;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Token;
@@ -40,7 +41,7 @@ class TokenManager {
     public static function parseSessionToken(string $token, string $issuer, string $secret): Token {
         $token = (new Parser())->parse($token);
         if (!$token->verify(new Sha256(), $secret)) {
-            throw new \RuntimeException("Invalid signature for token");
+            throw new AuthenticationException("Invalid signature for token");
         }
         
         $headers = [
@@ -49,19 +50,19 @@ class TokenManager {
         ];
         foreach ($headers as $key => $value) {
             if ($token->getHeader($key) !== $value) {
-                throw new \RuntimeException("Invalid value for ${key}: ${value}");
+                throw new AuthenticationException("Invalid value for ${key}: ${value}");
             }
         }
 
         $data = new ValidationData();
         $data->setIssuer($issuer);
         if (!$token->validate($data)) {
-            throw new \RuntimeException('Invalid claims in token');
+            throw new AuthenticationException('Invalid claims in token');
         }
 
         $claims = $token->getClaims();
         if (!$token->hasClaim('session_id') || !$token->hasClaim('expire_time') || !$token->hasClaim('sub')) {
-            throw new \RuntimeException('Missing claims in session token');
+            throw new AuthenticationException('Missing claims in session token');
         }
         return $token;
     }

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -1,7 +1,6 @@
 <?php
 
 use app\exceptions\BaseException;
-use app\exceptions\AuthenticationException;
 use app\libraries\Core;
 use app\libraries\ExceptionHandler;
 use app\libraries\Logger;
@@ -181,7 +180,7 @@ if (isset($_COOKIE[$cookie_key])) {
             }
         }
     }
-    catch (AuthenticationException $exc) {
+    catch (\InvalidArgumentException $exc) {
         // Invalid cookie data, delete it
         Utils::setCookie($cookie_key, "", time() - 3600);
     }

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use app\exceptions\BaseException;
+use app\exceptions\AuthenticationException;
 use app\libraries\Core;
 use app\libraries\ExceptionHandler;
 use app\libraries\Logger;
@@ -180,7 +181,7 @@ if (isset($_COOKIE[$cookie_key])) {
             }
         }
     }
-    catch (Exception $exc) {
+    catch (AuthenticationException $exc) {
         // Invalid cookie data, delete it
         Utils::setCookie($cookie_key, "", time() - 3600);
     }

--- a/site/tests/app/libraries/TokenManagerTester.php
+++ b/site/tests/app/libraries/TokenManagerTester.php
@@ -3,6 +3,7 @@
 namespace tests\app\libraries;
 
 use app\libraries\TokenManager;
+use app\exceptions\AuthenticationException;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 
 class TokenManagerTester extends \PHPUnit\Framework\TestCase {
@@ -37,7 +38,7 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
             'secret'
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Invalid signature for token');
         TokenManager::parseSessionToken((string) $token, 'https://submitty.org', '');
     }
@@ -50,7 +51,7 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
             'secret'
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Invalid claims in token');
         TokenManager::parseSessionToken((string) $token, 'https://wrong.org', 'secret');        
     }
@@ -58,14 +59,14 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
     public function testWrongType() {
         // Generated at https://jwt.io/ with typ JWT
         $token = 'eyJ0eXAiOiJBQUEiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N1Ym1pdHR5Lm9yZyIsInN1YiI6InVzZXJfaWQiLCJzZXNzaW9uX2lkIjoic2Vzc2lvbl9pZCJ9.H10IvoXjP-Gf2Z6fgT-e8V5TgHkohi48Xlq6lD4rHwg';
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Invalid value for typ: JWT');
         TokenManager::parseSessionToken($token, 'https://submitty.org', 'secret');
     }
 
     public function testMissingSessionId() {
         $token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiaXNzIjoiaHR0cHM6Ly9zdWJtaXR0eS5vcmciLCJleHBpcmVfdGltZSI6MH0.SDjPG61GUYWf5agRWJVZAd_iuiHHlQceuKeGgCsc1dY';
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Missing claims in session token');
         TokenManager::parseSessionToken($token, 'https://submitty.org', '');
     }

--- a/site/tests/app/libraries/TokenManagerTester.php
+++ b/site/tests/app/libraries/TokenManagerTester.php
@@ -103,7 +103,7 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
             'secret'
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid signature for token');
         TokenManager::parseApiToken((string) $token, 'https://submitty.org', '');
     }
@@ -115,14 +115,14 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
             'secret'
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid claims in token');
         TokenManager::parseApiToken((string) $token, 'https://wrong.org', 'secret');
     }
 
     public function testMissingApiKey() {
         $token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3N1Ym1pdHR5Lm9yZyJ9.J9gYCSxsWhDg2SQ0ZU1-8vSBagRqfujj1zh3CJ7JGgM';
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing claims in api token');
         TokenManager::parseApiToken($token, 'https://submitty.org', 'secret');
     }

--- a/site/tests/app/libraries/TokenManagerTester.php
+++ b/site/tests/app/libraries/TokenManagerTester.php
@@ -3,7 +3,6 @@
 namespace tests\app\libraries;
 
 use app\libraries\TokenManager;
-use app\exceptions\AuthenticationException;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 
 class TokenManagerTester extends \PHPUnit\Framework\TestCase {
@@ -38,7 +37,7 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
             'secret'
         );
 
-        $this->expectException(AuthenticationException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid signature for token');
         TokenManager::parseSessionToken((string) $token, 'https://submitty.org', '');
     }
@@ -51,7 +50,7 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
             'secret'
         );
 
-        $this->expectException(AuthenticationException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid claims in token');
         TokenManager::parseSessionToken((string) $token, 'https://wrong.org', 'secret');        
     }
@@ -59,14 +58,14 @@ class TokenManagerTester extends \PHPUnit\Framework\TestCase {
     public function testWrongType() {
         // Generated at https://jwt.io/ with typ JWT
         $token = 'eyJ0eXAiOiJBQUEiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N1Ym1pdHR5Lm9yZyIsInN1YiI6InVzZXJfaWQiLCJzZXNzaW9uX2lkIjoic2Vzc2lvbl9pZCJ9.H10IvoXjP-Gf2Z6fgT-e8V5TgHkohi48Xlq6lD4rHwg';
-        $this->expectException(AuthenticationException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value for typ: JWT');
         TokenManager::parseSessionToken($token, 'https://submitty.org', 'secret');
     }
 
     public function testMissingSessionId() {
         $token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiaXNzIjoiaHR0cHM6Ly9zdWJtaXR0eS5vcmciLCJleHBpcmVfdGltZSI6MH0.SDjPG61GUYWf5agRWJVZAd_iuiHHlQceuKeGgCsc1dY';
-        $this->expectException(AuthenticationException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing claims in session token');
         TokenManager::parseSessionToken($token, 'https://submitty.org', '');
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Fixes #3713 .

### What is the new behavior?
1. Let the TokenManager throw AuthenticationException, which is more informative than the original RuntimeException.
2. Let `index.php` only catches AuthenticationException. If the AuthenticationException is caught, which means the token is invalid, clear the cookie. If there are other exceptions, display the default exception page.
