### PR TITLE
Assign split items on enter (for non-team bulk uploads)

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -45,7 +45,7 @@
                         <a onclick="openFile('{{ file.url_full }}')"><i class="fas fa-window-restore" aria-hidden="true" title="Pop out the full PDF in a new window"></i></a>
                     </td>
                     <td id="input_area">
-                        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+                        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}"/>
                         <div id="users_{{ loop.index }}">
                             <input type="text" id="bulk_user_id_{{ loop.index }}" 
                                 {% if use_qr_codes %}
@@ -54,9 +54,7 @@
                                     value =""
                                 {% endif %}
 
-                                {% if team_assignment %}
-                                    onkeydown="uploadOnEnter( {{ loop.index }} );"
-                                {% endif %}
+                                onkeydown="uploadOnEnter( {{ loop.index }} );"
                             />
                             {% if team_assignment %}
                                 {# (size - 1) because twig loops are range inclusive #}
@@ -150,7 +148,7 @@
     //if the user presses 'enter' try and make a submission as if hitting the submit button
     function uploadOnEnter(index){
         var key = window.event.keyCode;
-        if(key === 13 && is_team_assignment){
+        if(key === 13){
             uploadSplit(index);
         }
     }


### PR DESCRIPTION
### What is the current behavior?
Before you had to press the submit button to assign a split pdf to a student 

### What is the new behavior?
The behavior now matches team bulk uploads in that hitting enter will attempt to assign 
the split pdf to the student and move to the next file to assign.

I didn't realize this was how bulk uploads behaved before the refactor but it should be good
this fixes the request by Konstantin in the submitty developer email list