### PR TITLE
[WIP] Test Enhancement for Symfony Router

### DIFF
--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -36,13 +36,15 @@ class NavigationController extends AbstractController {
         }
     }
 
-    private function noAccess() {
+    /**
+     * @Route("/{_semester}/{_course}/no_access")
+     */
+    public function noAccess() {
         $this->core->getOutput()->renderOutput('Navigation', 'noAccessCourse');
     }
 
     /**
      * @Route("/{_semester}/{_course}")
-     * @Route("/{_semester}/{_course}/navigation")
      */
     public function navigationPage() {
         $gradeables_list = new GradeableList($this->core);

--- a/site/app/libraries/routers/ApiRouter.php
+++ b/site/app/libraries/routers/ApiRouter.php
@@ -15,10 +15,15 @@ use app\libraries\Core;
 
 
 class ApiRouter {
+    /** @var Core  */
     protected $core;
 
-    public function __construct(Core $core) {
+    /** @var Request  */
+    protected $request;
+
+    public function __construct(Request $request, Core $core) {
         $this->core = $core;
+        $this->request = $request;
     }
 
     public function run() {
@@ -37,7 +42,7 @@ class ApiRouter {
         $matcher = new UrlMatcher($collection, new RequestContext());
 
         try {
-            $parameters = $matcher->matchRequest(Request::createFromGlobals());
+            $parameters = $matcher->matchRequest($this->request);
 
             $controllerName = $parameters['_controller'];
             $methodName = $parameters['_method'];

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -29,12 +29,13 @@ class WebRouter {
     /** @var UrlMatcher  */
     protected $matcher;
 
-    public function __construct(Core $core, $logged_in) {
+    public function __construct(Request $request, Core $core, $logged_in) {
         $this->core = $core;
-        $this->request = Request::createFromGlobals();
+        $this->request = $request;
         $this->logged_in = $logged_in;
 
         $fileLocator = new FileLocator();
+        /** @noinspection PhpUnhandledExceptionInspection */
         $annotationLoader = new AnnotatedRouteLoader(new AnnotationReader());
         $loader = new AnnotationDirectoryLoader($fileLocator, $annotationLoader);
         $collection = $loader->load(realpath(__DIR__ . "/../../controllers"));
@@ -53,6 +54,7 @@ class WebRouter {
         if (in_array('semester', $this->parameters) && in_array('course', $this->parameters)) {
             $semester = $this->parameters['semester'];
             $course = $this->parameters['course'];
+            /** @noinspection PhpUnhandledExceptionInspection */
             $this->core->loadConfig($semester, $course);
         }
 

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -304,7 +304,6 @@ else {
         $router->run();
     }
     catch (Exception $e) {
-//        die($e->getMessage());
         $caught = true;
     }
 }

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -10,6 +10,7 @@ use app\libraries\TokenManager;
 use app\libraries\routers\ClassicRouter;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Symfony\Component\HttpFoundation\Request;
 
 /*
  * The user's umask is ignored for the user running php, so we need
@@ -29,6 +30,8 @@ ini_set('display_errors', 1);
 
 $loader = require_once(__DIR__.'/../vendor/autoload.php');
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+
+$request = Request::createFromGlobals();
 
 $core = new Core();
 $core->setRouter(new ClassicRouter($_GET['url'] ?? ''));
@@ -292,12 +295,12 @@ if (empty($_REQUEST['component']) && $core->getUser() !== null) {
 $caught = false;
 
 if ($is_api) {
-    $router = new app\libraries\routers\ApiRouter($core);
+    $router = new app\libraries\routers\ApiRouter($request, $core);
     $router->run();
 }
 else {
     try {
-        $router = new app\libraries\routers\WebRouter($core, $logged_in);
+        $router = new app\libraries\routers\WebRouter($request, $core, $logged_in);
         $router->run();
     }
     catch (Exception $e) {

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -304,6 +304,7 @@ else {
         $router->run();
     }
     catch (Exception $e) {
+//        die($e->getMessage());
         $caught = true;
     }
 }

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -9,8 +9,19 @@ use app\libraries\Utils;
 use app\models\Config;
 use app\models\User;
 use ReflectionException;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
 
 class BaseUnitTest extends \PHPUnit\Framework\TestCase {
+
+    /**
+     * Loads annotations for routers.
+     */
+    public static function setUpBeforeClass(): void {
+        $loader = require(__DIR__.'/../vendor/autoload.php');
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    }
+
     /** @noinspection PhpDocSignatureInspection */
     /**
      * Creates a mocked the Core object predefining things with known values so that we don't have to do this

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -84,29 +84,28 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
         }
         $core->method('getQueries')->willReturn($mock_queries);
 
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $user = $this->createMockModel(User::class);
-        $user->method('getId')->willReturn("testUser");
-        if (isset($user_config['access_grading'])) {
-            $user->method('accessGrading')->willReturn($user_config['access_grading'] == true);
-        }
-        else {
-            $user->method('accessGrading')->willReturn(false);
-        }
-        if (isset($user_config['access_full_grading'])) {
-            $user->method('accessFullGrading')->willReturn($user_config['access_full_grading'] == true);
-        }
-        else {
-            $user->method('accessFullGrading')->willReturn(false);
-        }
-        if (isset($user_config['access_admin'])) {
-            $user->method('accessAdmin')->willReturn($user_config['access_admin'] == true);
-        }
-        else {
-            $user->method('accessAdmin')->willReturn(false);
-        }
+        if (!isset($user_config['no_user'])) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $user = $this->createMockModel(User::class);
+            $user->method('getId')->willReturn("testUser");
+            if (isset($user_config['access_grading'])) {
+                $user->method('accessGrading')->willReturn($user_config['access_grading'] == true);
+            } else {
+                $user->method('accessGrading')->willReturn(false);
+            }
+            if (isset($user_config['access_full_grading'])) {
+                $user->method('accessFullGrading')->willReturn($user_config['access_full_grading'] == true);
+            } else {
+                $user->method('accessFullGrading')->willReturn(false);
+            }
+            if (isset($user_config['access_admin'])) {
+                $user->method('accessAdmin')->willReturn($user_config['access_admin'] == true);
+            } else {
+                $user->method('accessAdmin')->willReturn(false);
+            }
 
-        $core->method('getUser')->willReturn($user);
+            $core->method('getUser')->willReturn($user);
+        }
 
         /** @noinspection PhpParamsInspection */
         $output = new Output($core);

--- a/site/tests/app/libraries/routers/ClassicRouterTester.php
+++ b/site/tests/app/libraries/routers/ClassicRouterTester.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\app\libraries;
+namespace tests\app\libraries\routers;
 
 use app\libraries\routers\ClassicRouter;
 

--- a/site/tests/app/libraries/routers/ClassicRouterTester.php
+++ b/site/tests/app/libraries/routers/ClassicRouterTester.php
@@ -2,9 +2,9 @@
 
 namespace tests\app\libraries;
 
-use app\libraries\ClassicRouter;
+use app\libraries\routers\ClassicRouter;
 
-class RouterTester {
+class ClassicRouterTester extends \PHPUnit\Framework\TestCase {
     public function testRouter() {
         $router = new ClassicRouter('part/part2/part3');
         $expected = ['part', 'part2', 'part3'];
@@ -19,7 +19,7 @@ class RouterTester {
     }
 
     public function testEmptyRouter() {
-        $router = new ClassicRouter();
+        $router = new ClassicRouter('');
         $this->assertFalse($router->hasNext());
         $this->assertNull($router->getNext());
     }

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace tests\app\libraries\routers;
+
+use app\libraries\routers\WebRouter;
+use tests\BaseUnitTest;
+use Symfony\Component\HttpFoundation\Request;
+
+class WebRouterTester extends BaseUnitTest {
+    public function testLogin() {
+        $core = $this->createMockCore();
+        $request = Request::create(
+            "/authentication/login"
+        );
+        $router = new WebRouter($request, $core, false);
+        $this->assertEquals($router->parameters['_controller'], "app\controllers\AuthenticationController");
+        $this->assertEquals($router->parameters['_method'], "loginForm");
+    }
+}

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -38,25 +38,28 @@ class WebRouterTester extends BaseUnitTest {
         $this->assertEquals("loginForm", $router->parameters['_method']);
     }
 
-    public function testRedirectToLoginFromEverywhere() {
-        $core = $this->createMockCore();
-        $request = Request::create(
-            "/everywhere"
-        );
-        $router = new WebRouter($request, $core, false);
-        $this->assertEquals("app\controllers\AuthenticationController", $router->parameters['_controller']);
-        $this->assertEquals("loginForm", $router->parameters['_method']);
-    }
+    /* REMOVE THE COMMENTS ONCE THE ROUTER IS READY */
+    /*
+        public function testRedirectToLoginFromEverywhere() {
+            $core = $this->createMockCore();
+            $request = Request::create(
+                "/everywhere"
+            );
+            $router = new WebRouter($request, $core, false);
+            $this->assertEquals("app\controllers\AuthenticationController", $router->parameters['_controller']);
+            $this->assertEquals("loginForm", $router->parameters['_method']);
+        }
 
-    public function testRedirectToHomeFromEverywhere() {
-        $core = $this->createMockCore();
-        $request = Request::create(
-            "/everywhere"
-        );
-        $router = new WebRouter($request, $core, true);
-        $this->assertEquals("app\controllers\HomePageController", $router->parameters['_controller']);
-        $this->assertEquals("showHomepage", $router->parameters['_method']);
-    }
+        public function testRedirectToHomeFromEverywhere() {
+            $core = $this->createMockCore();
+            $request = Request::create(
+                "/everywhere"
+            );
+            $router = new WebRouter($request, $core, true);
+            $this->assertEquals("app\controllers\HomePageController", $router->parameters['_controller']);
+            $this->assertEquals("showHomepage", $router->parameters['_method']);
+        }
+    */
 
     public function testNoUser() {
         $core = $this->createMockCore(['semester' => 's19', 'course' => 'sample'], ['no_user' => true]);

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -7,13 +7,65 @@ use tests\BaseUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 
 class WebRouterTester extends BaseUnitTest {
+
     public function testLogin() {
         $core = $this->createMockCore();
         $request = Request::create(
             "/authentication/login"
         );
         $router = new WebRouter($request, $core, false);
-        $this->assertEquals($router->parameters['_controller'], "app\controllers\AuthenticationController");
-        $this->assertEquals($router->parameters['_method'], "loginForm");
+        $this->assertEquals("app\controllers\AuthenticationController", $router->parameters['_controller']);
+        $this->assertEquals("loginForm", $router->parameters['_method']);
     }
+
+    public function testLogout() {
+        $core = $this->createMockCore();
+        $request = Request::create(
+            "/authentication/logout"
+        );
+        $router = new WebRouter($request, $core, true);
+        $this->assertEquals("app\controllers\AuthenticationController", $router->parameters['_controller']);
+        $this->assertEquals("logout", $router->parameters['_method']);
+    }
+
+    public function testRedirectToLoginFromCourse() {
+        $core = $this->createMockCore(['semester' => 's19', 'course' => 'sample']);
+        $request = Request::create(
+            "/s19/sample"
+        );
+        $router = new WebRouter($request, $core, false);
+        $this->assertEquals("app\controllers\AuthenticationController", $router->parameters['_controller']);
+        $this->assertEquals("loginForm", $router->parameters['_method']);
+    }
+
+    public function testRedirectToLoginFromEverywhere() {
+        $core = $this->createMockCore();
+        $request = Request::create(
+            "/everywhere"
+        );
+        $router = new WebRouter($request, $core, false);
+        $this->assertEquals("app\controllers\AuthenticationController", $router->parameters['_controller']);
+        $this->assertEquals("loginForm", $router->parameters['_method']);
+    }
+
+    public function testRedirectToHomeFromEverywhere() {
+        $core = $this->createMockCore();
+        $request = Request::create(
+            "/everywhere"
+        );
+        $router = new WebRouter($request, $core, true);
+        $this->assertEquals("app\controllers\HomePageController", $router->parameters['_controller']);
+        $this->assertEquals("showHomepage", $router->parameters['_method']);
+    }
+
+    public function testNoUser() {
+        $core = $this->createMockCore(['semester' => 's19', 'course' => 'sample'], ['no_user' => true]);
+        $request = Request::create(
+            "/s19/sample"
+        );
+        $router = new WebRouter($request, $core, true);
+        $this->assertEquals("app\controllers\NavigationController", $router->parameters['_controller']);
+        $this->assertEquals("noAccess", $router->parameters['_method']);
+    }
+
 }


### PR DESCRIPTION
This branch is based on branch `symfony_router`. Will do a rebase once #3743 is merged.

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Partially addresses #3740.

### What is the new behavior?
- [x] Broken ClassicRouterTester is fixed.
- [x] Routers, to facilitate testing and to be of a better pattern, get requests from index.php instead of getting from global variables.
- [ ] Tests for existing new routes concerning authentication are added.

Correct me if I am wrong:

This PR will be mainly testing `$this->loginCheck();` - to ensure that the router is working and correctly directs users to go to the login page, no_access page, etc. I don't think we need to test all routes because (1) the testing file would be crazily big, (2) routes are automatically generated from annotations, there is no need to worry about the correctness of that.

Next PR would be about removing the authentication part of the classic router, modifying `buildUrl` related to authentication & adding e2e tests to make sure everything is working as expected.