### PR TITLE
Fix tab / enter navigation on bulk upload labeling

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -54,13 +54,25 @@
                                     value =""
                                 {% endif %}
 
-                                onkeydown="uploadOnEnter( {{ loop.index }} );"
+                                {# we should only submit on enter for normal bulk uploads or on the last team upload box #}
+                                {% if not team_assignment %} 
+                                    onkeydown="uploadOnEnter( {{ loop.index }} );"
+                                {% else %}
+                                    onkeydown="focusNextOnEnter({{ loop.index }}, 0)"
+                                {% endif %}
                             />
                             {% if team_assignment %}
                                 {# (size - 1) because twig loops are range inclusive #}
                                 {% set outer_loop = loop %}
                                 {% for i in 1..(max_team_size - 1) %}
-                                    <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value ="" onkeydown="uploadOnEnter( {{ outer_loop.index }} );" />
+                                    <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value ="" 
+                                        {# if this is the last input box submit on enter, otherwise move to next box#}
+                                        {% if i == (max_team_size - 1) %}
+                                            onkeydown="uploadOnEnter({{ outer_loop.index }});" 
+                                        {% else %}
+                                            onkeydown="focusNextOnEnter({{ outer_loop.index}}, {{ i }} )" 
+                                        {% endif %}
+                                    />
                                 {% endfor %}
                             {% endif %}
                         </div>
@@ -137,20 +149,32 @@
         }
     }
 
-    function focusNextSubmission(index){
+    function moveToNextSubmission(index){
         if( (index + 1) <= num_submissions){
             document.getElementById("bulk_user_id_" + String(index + 1)).focus();
         }
         document.getElementById('row-' + String(index)).remove();
         num_submissions -= 1;
+        
     }
 
     //if the user presses 'enter' try and make a submission as if hitting the submit button
     function uploadOnEnter(index){
         var key = window.event.keyCode;
-        if(key === 13){
+        if(key === 13)
             uploadSplit(index);
-        }
+    }
+
+    //on enter move focus on the next submission box in a given row
+    function focusNextOnEnter(table_row, input_index ){
+        var key = window.event.keyCode;
+        if(key !== 13)
+            return;
+        var input_box  = document.getElementById("bulk_user_id_" + String(table_row) + "[" + String(input_index + 1) + "]" ); 
+        if(!input_box)
+            return;
+        
+        input_box.focus();
     }
 
     function uploadSplit(index){
@@ -191,9 +215,14 @@
                     //user closes do nothing
                     if(option === -1){
                         toggleButtons(index, false);
+                        //if the user does nothing focus back on the first box or the last team box
+                        if(is_team_assignment){
+                            document.getElementById("bulk_user_id_" + String(index) + "[" + String(max_team_size-1) + "]").focus();
+                        }else{
+                            user_id_textarea.focus();
+                        }
                         return;
                     }
-
 
                     var merge_previous = false;
                     var clobber = false;
@@ -221,7 +250,7 @@
         submitSplitItem(CSRF, g_id, user_id, path, merge_previous, clobber)
         .then(function(submit_response){
             displaySubmissionMessage(submit_response,index);
-            focusNextSubmission(index);
+            moveToNextSubmission(index);
         })
         .catch(function(submit_response){
             displaySubmissionMessage({'success' : false, 'message' : submit_response}, index);
@@ -245,7 +274,7 @@
             deleteSplitItem(CSRF,g_id,path)
             .then(function(submit_response){
                 displaySubmissionMessage(submit_response, index);
-                focusNextSubmission(index);
+                moveToNextSubmission(index);
             })
             .catch(function(submit_response){
                 console.error(submit_response);

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -42,7 +42,9 @@
                         </div>
                     </td>
                     <td>
-                        <a onclick="openFile('{{ file.url_full }}')"><i class="fas fa-window-restore" aria-hidden="true" title="Pop out the full PDF in a new window"></i></a>
+                        <a href="javascript:openFile('{{ file.url_full }}');" aria-label="View full PDF in a new window">
+			    <i class="fas fa-window-restore" aria-hidden="true"></i>
+			</a>
                     </td>
                     <td id="input_area">
                         <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}"/>

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -38,7 +38,7 @@
                         {{ file.filename_full }}
                         <br>
                         <div class="scrollable-image" >
-                            <img src="{{ file.cover_image.url }}" width="100%"/>
+                            <img src="{{ file.cover_image.url }}" width="100%" alt = "{{ file.filename_full }} preview"/>
                         </div>
                     </td>
                     <td>
@@ -47,7 +47,7 @@
                     <td id="input_area">
                         <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}"/>
                         <div id="users_{{ loop.index }}">
-                            <input type="text" id="bulk_user_id_{{ loop.index }}" 
+                            <input type="text" id="bulk_user_id_{{ loop.index }}" aria-label = "Enter User ID to assign" 
                                 {% if use_qr_codes %}
                                     value ="{{ file["id"] }}"
                                 {% else %}

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -43,8 +43,8 @@
                     </td>
                     <td>
                         <a href="javascript:openFile('{{ file.url_full }}');" aria-label="View full PDF in a new window">
-			    <i class="fas fa-window-restore" aria-hidden="true"></i>
-			</a>
+                            <i class="fas fa-window-restore" aria-hidden="true"></i>
+			            </a>
                     </td>
                     <td id="input_area">
                         <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}"/>
@@ -58,7 +58,7 @@
 
                                 {# we should only submit on enter for normal bulk uploads or on the last team upload box #}
                                 {% if not team_assignment %} 
-                                    onkeydown="uploadOnEnter( {{ loop.index }} );"
+                                    onkeydown="uploadOnEnter( {{ loop.index }}, event );"
                                 {% else %}
                                     onkeydown="focusNextOnEnter({{ loop.index }}, 0)"
                                 {% endif %}
@@ -70,7 +70,7 @@
                                     <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value ="" 
                                         {# if this is the last input box submit on enter, otherwise move to next box#}
                                         {% if i == (max_team_size - 1) %}
-                                            onkeydown="uploadOnEnter({{ outer_loop.index }});" 
+                                            onkeydown="uploadOnEnter({{ outer_loop.index }}, event);" 
                                         {% else %}
                                             onkeydown="focusNextOnEnter({{ outer_loop.index}}, {{ i }} )" 
                                         {% endif %}
@@ -161,15 +161,15 @@
     }
 
     //if the user presses 'enter' try and make a submission as if hitting the submit button
-    function uploadOnEnter(index){
-        var key = window.event.keyCode;
+    function uploadOnEnter(index, e = null){
+        key = window.event ? window.event.keyCode : e.keyCode;
         if(key === 13)
             uploadSplit(index);
     }
 
     //on enter move focus on the next submission box in a given row
-    function focusNextOnEnter(table_row, input_index ){
-        var key = window.event.keyCode;
+    function focusNextOnEnter(table_row, input_index, e = null ){
+        var key = window.event ? window.event.keyCode : e.keyCode;
         if(key !== 13)
             return;
         var input_box  = document.getElementById("bulk_user_id_" + String(table_row) + "[" + String(input_index + 1) + "]" ); 

--- a/site/app/templates/submission/homework/BulkUploadProgressBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadProgressBox.twig
@@ -1,10 +1,10 @@
 <div class="content" id="bulk_progress_box">
-	<h3>Bulk upload processing progress 
+	<h2>Bulk upload processing progress 
 		<button onClick="window.location.reload()" id="refresh_btn" style="margin:15px;" class="btn btn-default" disabled>Refresh</button>
-	</h3>
+	</h2>
 	<div>
-		<h4 style="float:left;">Processing</h4>
-		<h4 style="float:right;">Files ready to assign <span class="green-message">Note: please refresh too see newly added files</span></h4>
+		<h3 style="float:left;">Processing</h3>
+		<h3 style="float:right;">Files ready to assign <span class="green-message">Note: please refresh too see newly added files</span></h3>
 	</div>
 	<br>
 	<div class="box col-md-6" id = "processing_box">

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -17,7 +17,7 @@
     <div class="upperinfo">
         <h1 class="upperinfo-left">New submission for: {{ gradeable_name }}</h1>
         {% if has_due_date %}
-            <h3 class="upperinfo-right">Due: {{ formatted_due_date }}</h3>
+            <h2 class="upperinfo-right">Due: {{ formatted_due_date }}</h2>
         {% endif %}
     </div>
 
@@ -49,26 +49,27 @@
                 </div>
                 <div class="sub">
                     <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
-                    user_id: <input type="text" id= "user_id" value ="" placeholder="{{ user_id }}"/>
+                    <label for="user_id"> user_id: </label>
+		    <input type="text" id= "user_id" value ="" placeholder="{{ user_id }}"/>
                 </div>
             </div>
             <br />
             <div class = "sub" id="pdf_submit_button" style="display: none">
                 <div class="sub">
-                    Split by QR code?
+                    <label for="use_qr">Split by QR code?</label>
                     <input type="checkbox" id="use_qr">
                     <br />
-                    <span id="pages_prompt"># of page(s) per PDF:</span>
+                    <label id="pages_prompt" for="num_pages"># of page(s) per PDF:</label>
                     <span id="prefix_prompt">QR code prefix/suffix:
-                    <a style="text-decoration:none;" href = "https://submitty.org/instructor/exams#bulk-upload-and-split-with-qr-codes" target="_none">
-                        <i title="Bulk Upload QR Help" class="far fa-question-circle helpicon"></i>
+                    <a style="text-decoration:none;" aria-label="Help with QR bulk uploads" href = "https://submitty.org/instructor/exams#bulk-upload-and-split-with-qr-codes" target="_none">
+	                    <i aria-hidden="true" title="Bulk Upload QR Help" class="far fa-question-circle helpicon"></i>
                     </a>
                     </span>
                     <input type="number" id= "num_pages" placeholder="required"/>
-                    <input type="text" id="qr_prefix" placeholder="Prefix (optional)" />
-                    <input type="text" id="qr_suffix" placeholder="Suffix (optional)" />
+                    <input type="text" id="qr_prefix" placeholder="Prefix (optional)" aria-label="QR Prefix (Optional)" />
+                    <input type="text" id="qr_suffix" placeholder="Suffix (optional)" aria-label="QR Suffix (Optional)" />
                     <div id="expected_num_box">
-                    Expected Number of pages per PDF:
+                    <label for= "expected_pages_input"> Expected Number of pages per PDF: </label>
                     <input type="number" id= "expected_pages_input" placeholder="optional" onchange="highlightPageCount()" />
                     </div>
                 </div>
@@ -370,14 +371,14 @@
                      role="text"
                      aria-label="Press enter to upload your {{ part }} file"
                      style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 150px;">
-                    <h3 class="label" id="label{{ loop.index }}">
+                    <h2 class="label" id="label{{ loop.index }}">
                         {% if part_names|length > 1 %}
                             Drag your {{ part }} here or click to open file browser
                         {% else %}
                             Drag your file(s) here or click to open file browser
                         {% endif %}
-                    </h3>
-                    <input type="file" name="files" id="input_file{{ loop.index }}" style="display: none" onchange="addFilesFromInput({{ loop.index }})" multiple />
+                    </h2>
+                    <input type="file" name="files" id="input_file{{ loop.index }}" style="display: none" onchange="addFilesFromInput({{ loop.index }})" multiple aria-label="Select Files to upload" />
                 </div>
             {% endfor %}
 

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -30,6 +30,8 @@
     {# Admin submission type selector #}
     {% if core.getUser().accessFullGrading() %}
         <form id="submissionForm" method="post" style="width: 100%; ">
+	    <fieldset>
+            <legend> Select either normal, upload for a student or bulk upload </legend>	
             <div style="clear:both;">
                 <input type='radio' id="radio_normal" name="submission_type" checked="true">
                 <label for="radio_normal">Normal Submission</label>
@@ -75,6 +77,7 @@
                 </div>
                 <br />
             </div>
+            </fieldset>
         </form>
 
         <script type="text/javascript">

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -473,15 +473,15 @@ function displayPreviousSubmissionOptions(callback){
     $("#instructor-submit-option-new").attr('tabindex', '0');
     $("#instructor-submit-option-merge-1").attr('tabindex', '0');
     $("#instructor-submit-option-merge-2").attr('tabindex', '0');
-    form.find('input:radio')[radio_idx].focus();
-    var current_btn = radio_idx;
+    submit_btn.focus();
+    var current_btn = 4;
     if(form.css('display') !== 'none'){
-        $(document).keydown(function(e){
+        document.addEventListener("keydown", e => {
             if(e.keyCode == 9){
                 //on tab update the focus, cycle through the radio buttons and then
                 //the close/submit buttons and then back to the radio buttons
                 $('input[name=instructor-submit]').css({"outline": "none"});
-                event.preventDefault();
+                e.preventDefault();
                 if(current_btn === 0){
                     $("#instructor-submit-option-merge-1").focus();
                     $("#instructor-submit-option-merge-1").css({"outline" : "2px solid #C1E0FF"});
@@ -515,6 +515,8 @@ function displayPreviousSubmissionOptions(callback){
                 }else if(current_btn === 3){
                     //close the modal if the close button is selected
                     closer_btn.click();
+                }else if(current_btn === 4){
+                    submit_btn.click();
                 }
             }
         });

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -442,6 +442,8 @@ function displayPreviousSubmissionOptions(callback){
     var closer_btn = form.find(".close-button");
 
     var option;
+    submit_btn.tabindex = -1;
+    closer_btn.tabindex = -1;
     // on click, make submission based on which radio input was checked
     submit_btn.on('click', function() { 
         if($("#instructor-submit-option-new").is(":checked")) {
@@ -482,6 +484,35 @@ function displayPreviousSubmissionOptions(callback){
         radio_idx = parseInt(localStorage.getItem("instructor-submit-option"));
     }
     form.find('input:radio')[radio_idx].checked = true;
+    //since the modal object isn't rendered on the page manually set what the tab button does
+    form.find('input:radio')[radio_idx].focus();
+    var current_btn = radio_idx;
+    if(form.css('display') !== 'none'){
+        $(document).keydown(function(e){
+            if(e.keyCode == 9){
+                event.preventDefault();
+                if(current_btn === 0){
+                    $("#instructor-submit-option-merge-1").focus();
+                }else if(current_btn === 1){
+                    $("#instructor-submit-option-merge-2").focus();
+                }else if(current_btn === 2){
+                    closer_btn.focus();
+                }else if(current_btn === 3){
+                    submit_btn.focus();
+                }else if(current_btn === 4){
+                    $("#instructor-submit-option-new").focus();
+                }
+                current_btn = (current_btn == 4) ? 0 : current_btn + 1;
+            }
+            if(e.keyCode == 13 &&  closer_btn.is(":focus")){
+                closer_btn.click();
+                console.log("!!!");
+            }
+            if(e.keyCode == 27){
+                closer_btn.click();
+            }
+        });
+    }
 }
 
 /**

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -442,8 +442,8 @@ function displayPreviousSubmissionOptions(callback){
     var closer_btn = form.find(".close-button");
 
     var option;
-    submit_btn.tabindex = -1;
-    closer_btn.tabindex = -1;
+    submit_btn.attr('tabindex', '0');
+    closer_btn.attr('tabindex', '0');
     // on click, make submission based on which radio input was checked
     submit_btn.on('click', function() { 
         if($("#instructor-submit-option-new").is(":checked")) {
@@ -485,31 +485,52 @@ function displayPreviousSubmissionOptions(callback){
     }
     form.find('input:radio')[radio_idx].checked = true;
     //since the modal object isn't rendered on the page manually set what the tab button does
+    $("#instructor-submit-option-new").attr('tabindex', '0');
+    $("#instructor-submit-option-merge-1").attr('tabindex', '0');
+    $("#instructor-submit-option-merge-2").attr('tabindex', '0');
     form.find('input:radio')[radio_idx].focus();
     var current_btn = radio_idx;
     if(form.css('display') !== 'none'){
         $(document).keydown(function(e){
             if(e.keyCode == 9){
+                //on tab update the focus, cycle through the radio buttons and then
+                //the close/submit buttons and then back to the radio buttons
+                $('input[name=instructor-submit]').css({"outline": "none"});
                 event.preventDefault();
                 if(current_btn === 0){
                     $("#instructor-submit-option-merge-1").focus();
+                    $("#instructor-submit-option-merge-1").css({"outline" : "2px solid #C1E0FF"});
                 }else if(current_btn === 1){
                     $("#instructor-submit-option-merge-2").focus();
+                    $("#instructor-submit-option-merge-2").css({"outline" : "2px solid #C1E0FF"});
                 }else if(current_btn === 2){
                     closer_btn.focus();
                 }else if(current_btn === 3){
                     submit_btn.focus();
                 }else if(current_btn === 4){
                     $("#instructor-submit-option-new").focus();
+                    $("#instructor-submit-option-new").css({"outline" : "2px solid #C1E0FF"});
                 }
                 current_btn = (current_btn == 4) ? 0 : current_btn + 1;
-            }
-            if(e.keyCode == 13 &&  closer_btn.is(":focus")){
+            }else if(e.keyCode === 27){
+                //close the modal box on escape
                 closer_btn.click();
-                console.log("!!!");
-            }
-            if(e.keyCode == 27){
-                closer_btn.click();
+            }else if(e.keyCode === 13){
+                //on enter update whatever the user is focussing on
+                //uncheck everything and then recheck the desired button to make sure it actually updates
+                if(current_btn === 1){
+                    $('input[name=instructor-submit]').prop('checked', false);
+                    $("#instructor-submit-option-merge-1").prop('checked', true);
+                }else if(current_btn === 2){
+                    $('input[name=instructor-submit]').prop('checked', false);
+                    $("#instructor-submit-option-merge-2").prop('checked', true);
+                }else if(current_btn === 0){
+                    $('input[name=instructor-submit]').prop('checked', false);
+                    $("#instructor-submit-option-new").prop('checked', true);
+                }else if(current_btn === 3){
+                    //close the modal if the close button is selected
+                    closer_btn.click();
+                }
             }
         });
     }


### PR DESCRIPTION
When the dialog box for previous submissions appears the focus would still be behind the modal object.

Now the modal object radio boxes are focused on. The user can use tab to focus on the next radio buttons, then the close/submit buttons. Escaping the box will return focus to the next submission to assign. Pressing escape will now exit the modal container.

Pressing enter on a team submission will bring it to the next box unless its the very last in the row, then it'll attempt to submit the team gradeable.

fixes #3791