### PR TITLE
[Fix] Remove duplicate HTML encoding for submission/upload message

### DIFF
--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -357,8 +357,6 @@ class Config extends AbstractModel {
             }
         }
 
-        $this->upload_message = Utils::prepareHtmlString($this->upload_message);
-
         foreach (array('default_hw_late_days', 'default_student_late_days') as $key) {
             $this->$key = intval($this->$key);
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
HTML entities are being encoded twice, for the "upload_message" field. 
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3513

### What is the new behavior?
HTML entities are being encoded once by twig.

### Other information?
Manuel testing indicates that this is not a breaking change. 
<!-- Is this a breaking change? -->
<!-- How did you test -->
