### PR TITLE
Add option to re-assign team rotating sections

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -226,6 +226,24 @@ class UsersController extends AbstractController {
         $students = $this->core->getQueries()->getAllUsers();
         $reg_sections = $this->core->getQueries()->getRegistrationSections();
         $non_null_counts = $this->core->getQueries()->getCountUsersRotatingSections();
+
+
+        //Adds "invisible" sections: rotating sections that exist but have no students assigned to them
+        $sections_with_students = array();
+        foreach ($non_null_counts as $rows) {
+            array_push($sections_with_students,$rows['rotating_section']);
+        }
+        for ($i = 1; $i <= $this->core->getQueries()->getMaxRotatingSection(); $i++) {
+            if ( !in_array($i,$sections_with_students) ) {
+                array_push($non_null_counts,[
+                    "rotating_section" => $i,
+                    "count" => 0
+                ]);
+            }
+        }
+
+
+
         $null_counts = $this->core->getQueries()->getCountNullUsersRotatingSections();
         $max_section = $this->core->getQueries()->getMaxRotatingSection();
         $this->core->getOutput()->renderOutput(array('admin', 'Users'), 'rotatingSectionsForm', $students, $reg_sections,

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -37,6 +37,8 @@ class ElectronicGraderController extends GradingController {
             case 'import_teams':
                 $this->importTeams();
                 break;
+            case 'randomize_team_rotating_sections':
+                $this->randomizeTeamRotatingSections();
             case 'grade':
                 $this->showGrading();
                 break;
@@ -106,8 +108,9 @@ class ElectronicGraderController extends GradingController {
             default:
                 $this->showStatus();
                 break;
+            }
         }
-    }
+
 
     /**
      * Checks that a given diff viewer option is valid using DiffViewer::isValidSpecialCharsOption
@@ -559,13 +562,14 @@ class ElectronicGraderController extends GradingController {
         $show_edit_teams = $this->core->getAccess()->canI("grading.electronic.show_edit_teams") && $gradeable->isTeamAssignment();
         $show_import_teams_button = $show_edit_teams && (count($all_teams) > count($empty_teams));
         $show_export_teams_button = $show_edit_teams && (count($all_teams) == count($empty_teams));
+        $past_grade_start_date = $gradeable->getDates()['grade_start_date'] < $this->core->getDateTimeNow();
 
-        $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $view_all);
+        $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all);
 
         if ($show_edit_teams) {
             $all_reg_sections = $this->core->getQueries()->getRegistrationSections();
             $key = 'sections_registration_id';
-            foreach ($all_reg_sections as $i => $section) {
+                foreach ($all_reg_sections as $i => $section) {
                 $all_reg_sections[$i] = $section[$key];
             }
 
@@ -577,6 +581,8 @@ class ElectronicGraderController extends GradingController {
             }
             $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'adminTeamForm', $gradeable, $all_reg_sections, $all_rot_sections);
             $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'importTeamForm', $gradeable);
+
+            $this->core->getOutput()->renderOutput(array('grading','ElectronicGrader'), 'randomizeButtonWarning', $gradeable);
         }
     }
 
@@ -715,6 +721,42 @@ class ElectronicGraderController extends GradingController {
         $filename = $this->core->getConfig()->getCourse() . "_" . $gradeable_id . "_teams.csv";
         $this->core->getOutput()->renderFile($csvdata, $filename);
     }
+
+    /**
+     * Randomly redistributes teams with members into Rotating Grading Sections
+     * Evenly distributes them between all sections, giving extra teams to Sections numerically if necessary
+     *      Ex: 13 teams in 3 sections will always give Section 1: 5 teams; Section 2: 4 teams;  Section 3: 4 teams
+     */
+    public function randomizeTeamRotatingSections() {
+        $gradeable_id = $_REQUEST['gradeable_id'];
+        $section_count = $this->core->getQueries()->getMaxRotatingSection();
+        $return_url = $this->core->buildUrl((
+            array('component' => 'grading', 'page' => 'electronic', 'action' => 'details', 'gradeable_id' => $gradeable_id, 'view' => 'all')));
+        $teams = $this->core->getQueries()->getTeamsWithMembersFromGradeableID($gradeable_id);
+
+        //Does nothing if there are no sections or no teams
+        if ($section_count <= 0 or empty($teams)) {
+            $this->core->redirect($return_url);
+            return;
+        }
+
+        shuffle($teams);
+
+        $cur_group = 1;
+        foreach ($teams as $team_id) {
+            $this->core->getQueries()->updateTeamRotatingSection($team_id,$cur_group);
+            $cur_group++;
+            if ($cur_group > $section_count) {
+                $cur_group = 1;
+            }
+        }
+
+        $this->core->redirect($return_url);
+        return;
+    }
+
+
+
 
     /**
      * Handle requests to create individual teams via the AdminTeamForm

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -108,8 +108,8 @@ class ElectronicGraderController extends GradingController {
             default:
                 $this->showStatus();
                 break;
-            }
         }
+    }
 
 
     /**
@@ -569,7 +569,7 @@ class ElectronicGraderController extends GradingController {
         if ($show_edit_teams) {
             $all_reg_sections = $this->core->getQueries()->getRegistrationSections();
             $key = 'sections_registration_id';
-                foreach ($all_reg_sections as $i => $section) {
+            foreach ($all_reg_sections as $i => $section) {
                 $all_reg_sections[$i] = $section[$key];
             }
 

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -39,6 +39,7 @@ class ElectronicGraderController extends GradingController {
                 break;
             case 'randomize_team_rotating_sections':
                 $this->randomizeTeamRotatingSections();
+                break;
             case 'grade':
                 $this->showGrading();
                 break;

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1817,6 +1817,31 @@ WHERE gcm_id=?", $params);
         throw new NotImplementedException();
     }
 
+
+    /**
+     * Return an array of team_ids for a gradeable that have at least one user in the team
+     * @param string $g_id
+     * @return [ team ids ]
+     */
+    public function getTeamsWithMembersFromGradeableID($g_id) {
+        $team_map = $this->core->getQueries()->getTeamIdsAllGradeables();
+
+        if (!array_key_exists( $g_id ,$team_map)) {
+            return array();
+        }
+
+        $teams = $team_map[$g_id];
+
+        $this->course_db->query("SELECT team_id FROM teams");
+        $teams_with_members = array();
+        foreach ($this->course_db->rows() as $row) {
+            $teams_with_members[] = $row['team_id'];
+        }
+
+        return array_intersect($teams,$teams_with_members);
+    }
+
+
     /**
      * Add ($g_id,$user_id) pair to table seeking_team
      * @param string $g_id

--- a/site/app/templates/admin/users/RotatingSectionsForm.twig
+++ b/site/app/templates/admin/users/RotatingSectionsForm.twig
@@ -1,32 +1,4 @@
-<script type="text/javascript">
-    $(function() {
-        $("[name='rotating_type']").change(function() {
-            if ($(this).val() == "alphabetically") {
-                $("[name='fewest']").prop('checked', false).attr('onclick', 'return false').addClass("disabled");
 
-            }
-            else {
-                $("[name='fewest']").attr('onclick', '').removeClass('disabled');
-            }
-        });
-
-        $("[name='sort_type']").change(function() {
-            var val = $(this).val();
-            if (val == "fewest") {
-                $("[name='sections']").val({{ max_section }}).addClass('disabled').attr('readonly', 'readonly');
-                $("[name='rotating_type']").val("random").addClass('disabled').attr('disabled', 'true');
-            }
-            else if (val == "drop_null" || val == "drop_all") {
-                $("[name='sections']").addClass('disabled').attr('readonly', 'readonly');
-                $("[name='rotating_type']").addClass('disabled').attr('disabled', 'true');
-            }
-            else {
-                $("[name='sections']").removeClass('disabled').prop('readonly', false);
-                $("[name='rotating_type']").removeClass('disabled').prop('disabled', false);
-            }
-        });
-    });
-</script>
 <div class="content">
     <h1>Manage Registration Sections</h1>
     <p>

--- a/site/app/templates/admin/users/RotatingSectionsForm.twig
+++ b/site/app/templates/admin/users/RotatingSectionsForm.twig
@@ -1,4 +1,32 @@
-
+<script type="text/javascript">
+    $(function() {
+        $("[name='rotating_type']").change(function() {
+            if ($(this).val() == "alphabetically") {
+                $("[name='fewest']").prop('checked', false).attr('onclick', 'return false').addClass("disabled");
+				
+            }
+            else {
+                $("[name='fewest']").attr('onclick', '').removeClass('disabled');
+            }
+        });
+		
+        $("[name='sort_type']").change(function() {
+            var val = $(this).val();
+            if (val == "fewest") {
+                $("[name='sections']").val({{ max_section }}).addClass('disabled').attr('readonly', 'readonly');
+                $("[name='rotating_type']").val("random").addClass('disabled').attr('disabled', 'true');
+            }
+            else if (val == "drop_null" || val == "drop_all") {
+                $("[name='sections']").addClass('disabled').attr('readonly', 'readonly');
+                $("[name='rotating_type']").addClass('disabled').attr('disabled', 'true');
+            }
+            else {
+                $("[name='sections']").removeClass('disabled').prop('readonly', false);
+                $("[name='rotating_type']").removeClass('disabled').prop('disabled', false);
+            }
+        });
+    });
+</script>
 <div class="content">
     <h1>Manage Registration Sections</h1>
     <p>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -49,6 +49,17 @@
         <button style="float: right;" class="btn btn-primary" onclick="importTeamForm();">Import Teams Members</button>
     {% endif %}
     {# /Import+Export teams buttons #}
+		
+	{# Randomize team button #}
+	{% if (not gradeable.isGradeByRegistration()) and (show_export_teams_button or show_import_teams_button) %}
+		{% if past_grade_start_date %}
+			<Button style="float: left;" class="btn btn-default" onclick="randomizeRotatingGroupsButton()"> Randomly Re-Assign Teams to Rotating Sections</Button>
+		{% else %}
+			<a style="float: left;" class="btn btn-default" href="{{ core.buildUrl({'component': 'grading', 'page': 
+				'electronic', 'action': 'randomize_team_rotating_sections', 'gradeable_id': gradeable.getId()}) }}"> Randomly Re-Assign Teams to Rotating Sections</a>
+		{% endif %}
+	{% endif %}
+	
     <br />
     <br />
     {# This is a data table #}

--- a/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
+++ b/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
@@ -1,0 +1,14 @@
+{% extends 'generic/Popup.twig' %}
+{% block popup_id %}randomize-button-warning{% endblock %}
+{% block title %}WARNING: Grading may be in progress!{% endblock %}
+{% block body %}
+    <p> Updating the sections for this gradeable will change the submissions assigned to each grader.<br />
+        If grading has begun, this may interupt or redistribute grade submissions.<br /><br /><br />
+        Are you sure you want to continue? <br /><br />
+    </p><br />
+{% endblock %}
+{% block buttons %}
+    <a style="float: left;" onclick="$('#{{ block('popup_id') }}').css('display', 'none'); event.stopPropagation();" class="btn btn-default close-button"> Cancel </a>
+    <a style="float: right;" class="btn btn-primary" href="{{ core.buildUrl({'component': 'grading', 'page': 
+				'electronic', 'action': 'randomize_team_rotating_sections', 'gradeable_id': gradeable_id}) }}"> Randomly Re-Assign Teams to Rotating Sections </a>
+{% endblock %}

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -1,3 +1,13 @@
+
+{% if rotating_sections_error %}
+<div class='content' style="background-color:#e84848">
+	<p> WARNING: This page may be inaccurate.  <br />
+		This gradeable is set to assign grades by Rotating Section, but Rotating Sections are not set up properly. <br />
+		To fix Rotating Sections, go to the Manage Sections page. <br />
+	</p>
+</div>
+{% endif %}
+
 <div class="content">
     <h1>Status of {{ gradeable_title }}</h1>
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1055,6 +1055,14 @@ function importTeamForm() {
     $('[name="upload_team"]', form).val(null);
 }
 
+
+function randomizeRotatingGroupsButton() {
+    $('.popup-form').css('display', 'none');
+    var form = $("#randomize-button-warning");
+    form.css("display", "block");
+}
+
+
 /**
  * Toggles the page details box of the page, showing or not showing various information
  * such as number of queries run, length of time for script execution, and other details


### PR DESCRIPTION
Closes #2367 

Pull request includes a new button that randomly re-assigns teams to rotating sections.  (For more information see issue closed).  It does not affect student rotating section for the course, and does not affect students that are not on a team yet.  The button will only appear for instructors and only on gradeables that are team assignments graded by rotating section.  If the gradable is open to grading, a popup will warn instructors and require additional confirmation.
Warning Popup:
![popup_warning](https://user-images.githubusercontent.com/34327811/59132764-12efd600-8944-11e9-8e33-d54bcac59dd3.png)

Fixed a divide by zero exception caused by the "remove all students from rotating sections" option of Manage sections.  However, this option still causes information on the status page for gradeables that are set to be graded by rotating section to be incorrect/nonsense, so a warning banner was added.

Modified the rotating sections form to display the correct number of rotating sections, even if no students are assigned to them.
Before: 
![before](https://user-images.githubusercontent.com/34327811/59133532-5b0ff800-8946-11e9-8b0a-095e7b3c412c.png)
After: 

![after](https://user-images.githubusercontent.com/34327811/59133538-606d4280-8946-11e9-8e6f-e115984d6b97.png)

Also fixed a small bug that caused rotating sections to be displayed out of order for team assignments, if no teams were created yet.  
Before:
![beforechanges](https://user-images.githubusercontent.com/34327811/59133104-f7d19600-8944-11e9-929e-6ebfcce82c93.png)

After:
![afterchanges](https://user-images.githubusercontent.com/34327811/59133113-fd2ee080-8944-11e9-8f44-f35fb09db678.png)
