### PR TITLE
Fix previous submissions not showing in autofill

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -246,15 +246,17 @@ class Utils {
         foreach ($students as $student) {
             $student_entry = array('value' => $student->getId(),
                     'label' => $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>');
-            $students_full[] = $student_entry;
-            if($students_version != null) {
+
+            if($students_version !== null) {
                 if($student->getRegistrationSection() != null && array_key_exists($student->getId(),$students_version)) {
                     if ($students_version[$student->getId()] !== 0) {
                         $student_entry['label'] .= ' (' .
                         $students_version[$student->getId()] . ' Prev Submission)';
                     }
                 }
-            } else {
+            } 
+            $students_full[] = $student_entry;
+            if($students_version === null){
                 $null_entry = array('value' => $student->getId(),
                 'label' => '[NULL section] ' . $student->getDisplayedFirstName() . ' ' . $student->getDisplayedLastName() . ' <' . $student->getId() . '>'); 
 


### PR DESCRIPTION
Small bugfix, when the autofill data was getting prepared it would be returned before the previous submissions were appended to it. 

![Screenshot (8)](https://user-images.githubusercontent.com/12129065/59134809-91e80d00-894a-11e9-93c2-1b05d2a0e35b.png)

Fixes #3797