### PR TITLE
[Feature] Enable Router to Pass _GET Params to Controllers

### DIFF
--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -6,6 +6,7 @@ use app\libraries\Core;
 use app\libraries\database\DatabaseQueries;
 use app\libraries\Output;
 use app\libraries\Utils;
+use app\libraries\Access;
 use app\models\Config;
 use app\models\User;
 use ReflectionException;
@@ -24,7 +25,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
      *
      * @return Core
      */
-    protected function createMockCore($config_values=array(), $user_config=array(), $queries=array()) {
+    protected function createMockCore($config_values=array(), $user_config=array(), $queries=array(), $access=array()) {
         $core = $this->createMock(Core::class);
 
         $config = $this->createMockModel(Config::class);
@@ -68,6 +69,12 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
         else {
             $core->method('isTesting')->willReturn(true);
         }
+
+        $mock_access = $this->createMock(Access::class);
+        foreach ($access as $method => $value) {
+            $mock_access->method($method)->willReturn($value);
+        }
+        $core->method('getAccess')->willReturn($mock_access);
 
         $mock_queries = $this->createMock(DatabaseQueries::class);
         foreach ($queries as $method => $value) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Controllers rely on `$_GET` to get query parameters.

### What is the new behavior?
Let the router pass `$_GET` parameters to controllers.

### Other information?
New tests are added to ensure that the user does not have control over the router by through weird queries.
