### PR TITLE
Fix unable to post thread by student

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1485,7 +1485,8 @@ function publishFormWithAttachments(form, test_category, error_message) {
         return false;
     }
     if(test_category) {
-        if((!form.prop("ignore-cat")) && form.find('.cat-selected').length == 0) {
+
+        if((!form.prop("ignore-cat")) && form.find('.cat-selected').length == 0 && ($('.cat-buttons input').is(":checked") == false)) {
             alert("At least one category must be selected.");
             return false;
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
A temporary patch for #3839, but still needs more debugging to ensure visuals match between student & instructor/grader

### What is the new behavior?
An additional condition has been added, to see if any category checkboxes are checked in the create thread page.

### Other information?
Is this a breaking change? - None
How did you test: Checked by trying to create a thread for all types of users, with and without categories selected. 
