### PR TITLE
added active head 0 (cancelled submission, to activelist of active heads

### DIFF
--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -840,7 +840,14 @@ class Course(object):
                                 os.system("chown -R submitty_php:{}_tas_www {}".format(self.code, gradeable_path))
                             if not os.path.exists(submission_path):
                                 os.makedirs(submission_path)
-                            active_version = random.choice(range(1, versions_to_submit+1))
+                            # Reduce the propability to get a canceled submission (active_version = 0)
+                            # This is done my making other possibilities three times more likely
+                            version_population = []
+                            for version in range(1, versions_to_submit+1):
+                                version_population.append((version, 3))
+                            version_population = [(0,1)] + version_population
+                            version_population = [ver for ver, freq in version_population for i in range(freq)]
+                            active_version = random.choice(version_population)
                             if team_id is not None:
                                 json_history = {"active_version": active_version, "history": [], "team_history": []}
                             else:


### PR DESCRIPTION
Signed-off-by: fenn-cs <fenn25.fn@gmail.com.

### What is the current behavior?
In the sample submissions generated by `.setup/bin/setup_sample_courses.py`, no submissions are marked as canceled. All students either have no submission or has an active submission.
Fixes: #2467

### What is the new behavior?
`setup_sample_courses.py` would now mark a few submissions as canceled.

### Other information?

The submissions marked as canceled are not defined in a fixed way, rather active_head 0 which represents a canceled_submission has been added to the list that is used to randomly determine the state of a submission.

I set the probability of a submission to be set as canceled, 3 times lower than the probability of other possibilities just so we don't have too many canceled submissions.

![myimage](https://user-images.githubusercontent.com/14317775/59462345-79309900-8e1b-11e9-9f9c-3f179972ba0e.gif)
