### PR TITLE
Use GET params for redirection

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -83,7 +83,7 @@ class AuthenticationController extends AbstractController {
      * @var string $old the url to redirect to after login
      */
     public function loginForm($old = null) {
-        $this->isLoggedIn(base64_decode($old));
+        $this->isLoggedIn(urldecode($old));
         $this->core->getOutput()->renderOutput('Authentication', 'loginForm', $old);
     }
     
@@ -99,7 +99,7 @@ class AuthenticationController extends AbstractController {
      */
     public function checkLogin($old = null) {
         if (isset($old)) {
-            $old = base64_decode($old);
+            $old = urldecode($old);
         }
         $this->isLoggedIn($old);
         $redirect = array();

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -79,7 +79,6 @@ class AuthenticationController extends AbstractController {
      * Display the login form to the user
      *
      * @Route("/authentication/login")
-     * @Route("/authentication/login/{old}")
      *
      * @var string $old the url to redirect to after login
      */
@@ -95,7 +94,6 @@ class AuthenticationController extends AbstractController {
      * to maintain that old request data passing it back into the login form.
      *
      * @Route("/authentication/check_login")
-     * @Route("/authentication/check_login/{old}")
      *
      * @var string $old the url to redirect to after login
      */

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -407,12 +407,17 @@ class Core {
 
     /**
      * @param array  $parts
+     * @param array  $query
      * @param string $hash
      *
      * @return string
      */
-    public function buildNewUrl($parts=array(), $hash = null) {
+    public function buildNewUrl($parts=array(), $query=array(), $hash = null) {
         $url = $this->getConfig()->getBaseUrl().implode("/", $parts);
+        $query_string = http_build_query($query);
+        if (!empty($query_string)) {
+            $url = $url . '?' . $query_string;
+        }
         return $url;
     }
 

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -407,17 +407,12 @@ class Core {
 
     /**
      * @param array  $parts
-     * @param array  $query
      * @param string $hash
      *
      * @return string
      */
-    public function buildNewUrl($parts=array(), $query=array(), $hash = null) {
+    public function buildNewUrl($parts=array(), $hash = null) {
         $url = $this->getConfig()->getBaseUrl().implode("/", $parts);
-        $query_string = http_build_query($query);
-        if (!empty($query_string)) {
-            $url = $url . '?' . $query_string;
-        }
         return $url;
     }
 

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -94,10 +94,10 @@ class WebRouter {
             $old_request_url = $this->request->getUriForPath($this->request->getPathInfo());
             $this->request = Request::create(
                 '/authentication/login',
-                'GET'
+                'GET',
+                ['old' => base64_encode($old_request_url)]
             );
             $this->parameters = $this->matcher->matchRequest($this->request);
-            $this->parameters['old'] = base64_encode($old_request_url);
         }
         elseif ($this->core->getUser() === null) {
             $this->core->loadSubmittyUser();

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -95,7 +95,7 @@ class WebRouter {
             $this->request = Request::create(
                 '/authentication/login',
                 'GET',
-                ['old' => base64_encode($old_request_url)]
+                ['old' => urlencode($old_request_url)]
             );
             $this->parameters = $this->matcher->matchRequest($this->request);
         }

--- a/site/app/views/AuthenticationView.php
+++ b/site/app/views/AuthenticationView.php
@@ -8,7 +8,7 @@ class AuthenticationView extends AbstractView {
             $old = urlencode($this->core->buildNewUrl(['home']));
         }
         return $this->core->getOutput()->renderTwigTemplate("Authentication.twig", [
-            "login_url" => $this->core->buildNewUrl(['authentication', 'check_login'], ['old' => $old])
+            "login_url" => $this->core->buildNewUrl(['authentication', 'check_login']) . '?' . http_build_query(['old' => $old])
         ]);
     }
 }

--- a/site/app/views/AuthenticationView.php
+++ b/site/app/views/AuthenticationView.php
@@ -5,7 +5,7 @@ namespace app\views;
 class AuthenticationView extends AbstractView {
     public function loginForm($old = null) {
         if (!isset($old)) {
-            $old = base64_encode($this->core->buildNewUrl(['home']));
+            $old = urlencode($this->core->buildNewUrl(['home']));
         }
         return $this->core->getOutput()->renderTwigTemplate("Authentication.twig", [
             "login_url" => $this->core->buildNewUrl(['authentication', 'check_login'], ['old' => $old])

--- a/site/app/views/AuthenticationView.php
+++ b/site/app/views/AuthenticationView.php
@@ -4,8 +4,11 @@ namespace app\views;
 
 class AuthenticationView extends AbstractView {
     public function loginForm($old = null) {
+        if (!isset($old)) {
+            $old = base64_encode($this->core->buildNewUrl(['home']));
+        }
         return $this->core->getOutput()->renderTwigTemplate("Authentication.twig", [
-            "login_url" => $this->core->buildNewUrl(['authentication', 'check_login', $old])
+            "login_url" => $this->core->buildNewUrl(['authentication', 'check_login'], ['old' => $old])
         ]);
     }
 }

--- a/tests/e2e/test_login.py
+++ b/tests/e2e/test_login.py
@@ -21,6 +21,14 @@ class TestLogin(BaseTestCase):
         self.assertEqual(1, len(cookies))
         self.assertRegex(cookies[0]['value'], r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
 
+    def test_login_from_login_page(self):
+        url = "/authentication/login"
+        self.log_in(url, title='Submitty')
+        self.assertEqual(self.test_url + "/home", self.driver.current_url)
+        cookies = list(filter(lambda x: x['name'] == 'submitty_token', self.driver.get_cookies()))
+        self.assertEqual(1, len(cookies))
+        self.assertRegex(cookies[0]['value'], r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+
     def test_bad_login_password(self):
         self.get("/" + self.semester + "/sample")
         self.driver.find_element_by_id("login-guest")


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Fixes #3843 . Our `ClassicRouter` has a feature that, after a successful login, redirects users to the page that they tried to visit but previously failed due to access control. This feature has been implemented in the `WebRouter`. However, a bug exists that you cannot be redirected if you go to `/authentication/login` directly and try to log in.

### What is the new behavior?
Instead of passing the URL to redirect to in the URL like `/authentication/login/{old}`, the old URL to redirect to is passed in GET parameters like `/authentication/login?old={old}`, which looks more natural. When `$old` is empty, go to the homepage as the default page, and the router will take care of it if the user did not successfully log in.