### PR TITLE
[Bugfix] Load compressed cmaps for PDF.js viewer

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -103,6 +103,8 @@ cp ${NODE_FOLDER}/pdfjs-dist/build/pdf.min.js ${VENDOR_FOLDER}/pdfjs
 cp ${NODE_FOLDER}/pdfjs-dist/build/pdf.worker.min.js ${VENDOR_FOLDER}/pdfjs
 cp ${NODE_FOLDER}/pdfjs-dist/web/pdf_viewer.css ${VENDOR_FOLDER}/pdfjs/pdf_viewer.css
 cp ${NODE_FOLDER}/pdfjs-dist/web/pdf_viewer.js ${VENDOR_FOLDER}/pdfjs/pdf_viewer.js
+cp -R ${NODE_FOLDER}/pdfjs-dist/cmaps ${VENDOR_FOLDER}/pdfjs
+
 # pdf-annotate.js
 cp -R "${NODE_FOLDER}/@submitty/pdf-annotate.js/dist" ${VENDOR_FOLDER}/pdf-annotate.js
 # twig.js
@@ -138,6 +140,7 @@ rm -f /tmp/cron_jobs
 find ${SUBMITTY_INSTALL_DIR}/site -exec chown ${PHP_USER}:${PHP_GROUP} {} \;
 find ${SUBMITTY_INSTALL_DIR}/site/cgi-bin -exec chown ${CGI_USER}:${CGI_GROUP} {} \;
 # "other" can read & execute these files
+find ${SUBMITTY_INSTALL_DIR}/site/public -type f -name \*.bcmap -exec chmod o+rx {} \;
 find ${SUBMITTY_INSTALL_DIR}/site/public -type f -name \*.ttf -exec chmod o+rx {} \;
 find ${SUBMITTY_INSTALL_DIR}/site/public -type f -name \*.eot -exec chmod o+rx {} \;
 find ${SUBMITTY_INSTALL_DIR}/site/public -type f -name \*.svg -exec chmod o+rx {} \;

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -63,7 +63,11 @@ function render(gradeable_id, user_id, grader_id, file_name, page_num, url = "")
             } catch (err){
                 alert("Something went wrong, please try again later.");
             }
-            pdfjsLib.getDocument({data: pdfData}).then((pdf) => {
+            pdfjsLib.getDocument({
+                data: pdfData,
+                cMapUrl: '../../vendor/pdfjs/cmaps/',
+                cMapPacked: true
+            }).then((pdf) => {
                 window.RENDER_OPTIONS.pdfDocument = pdf;
                 let viewer = document.getElementById('viewer');
                 $(viewer).on('touchstart touchmove', function(e){


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #3857. PDFs generated with cmaps currently do not load properly.

### What is the new behavior?
PDFs will load properly and should be completely readable.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Uploaded a PDF generated with cmaps for grading, opened the pdf-annotation window before applying this fix (got a `Warning: Error during font loading: CMap baseUrl must be specified, see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked")` message. Enabled this patch, warning went away as well as the PDF loading fine.