### PR TITLE
[Refactor] Refactor Simple Grader Controller JSON Responses

### DIFF
--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -198,9 +198,7 @@ class SimpleGraderController extends GradingController  {
 
     public function save($action) {
         if (!isset($_REQUEST['g_id']) || !isset($_REQUEST['user_id'])) {
-            $response = array('status' => 'fail', 'message' => 'Did not pass in g_id or user_id');
-            $this->core->getOutput()->renderJson($response);
-            return $response;
+            return $this->core->getOutput()->renderJsonFail('Did not pass in g_id or user_id');
         }
         $g_id = $_REQUEST['g_id'];
         $user_id = $_REQUEST['user_id'];
@@ -210,21 +208,13 @@ class SimpleGraderController extends GradingController  {
 
         $user = $this->core->getQueries()->getUserById($user_id);
         if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $this->core->getCsrfToken()) {
-            $response = array('status' => 'fail', 'message' => 'Invalid CSRF token');
-            $this->core->getOutput()->renderJson($response);
-            return $response;
+            return $this->core->getOutput()->renderJsonFail('Invalid CSRF token');
         } else if ($gradeable === null) {
-            $response = array('status' => 'fail', 'message' => 'Invalid gradeable ID');
-            $this->core->getOutput()->renderJson($response);
-            return $response;
+            return $this->core->getOutput()->renderJsonFail('Invalid gradeable ID');
         } else if ($user === null) {
-            $response = array('status' => 'fail', 'message' => 'Invalid user ID');
-            $this->core->getOutput()->renderJson($response);
-            return $response;
+            return $this->core->getOutput()->renderJsonFail('Invalid user ID');
         } else if (!isset($_POST['scores']) || empty($_POST['scores'])) {
-            $response = array('status' => 'fail', 'message' => "Didn't submit any scores");
-            $this->core->getOutput()->renderJson($response);
-            return $response;
+            return $this->core->getOutput()->renderJsonFail("Didn't submit any scores");
         }
 
         $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $user_id, null);
@@ -249,15 +239,11 @@ class SimpleGraderController extends GradingController  {
                 } else {
                     if ($component->getUpperClamp() < $data ||
                         !is_numeric($data)) {
-                        $response = array('status' => 'fail', 'message' => "Save error: score must be a number less than the upper clamp");
-                        $this->core->getOutput()->renderJson($response);
-                        return $response;
+                        return $this->core->getOutput()->renderJsonFail("Save error: score must be a number less than the upper clamp");
                     }
                     $db_data = $component_grade->getTotalScore();
                     if ($original_data != $db_data) {
-                        $response = array('status' => 'fail', 'message' => "Save error: displayed stale data (" . $original_data . ") does not match database (" . $db_data . ")");
-                        $this->core->getOutput()->renderJson($response);
-                        return $response;
+                        return $this->core->getOutput()->renderJsonFail("Save error: displayed stale data (" . $original_data . ") does not match database (" . $db_data . ")");
                     }
                     $component_grade->setScore($data);
                 }
@@ -268,9 +254,7 @@ class SimpleGraderController extends GradingController  {
         $ta_graded_gradeable->setOverallComment('');
         $this->core->getQueries()->saveTaGradedGradeable($ta_graded_gradeable);
 
-        $response = array('status' => 'success', 'data' => null);
-        $this->core->getOutput()->renderJson($response);
-        return $response;
+        return $this->core->getOutput()->renderJsonSuccess();
     }
 
     public function UploadCSV($action) {
@@ -365,9 +349,7 @@ class SimpleGraderController extends GradingController  {
             }
         }
 
-        $response = array('status' => 'success', 'data' => $return_data);
-        $this->core->getOutput()->renderJson($response);
-        return $response;
+        return $this->core->getOutput()->renderJsonSuccess($return_data);
     }
 
 

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -19,19 +19,19 @@ class SimpleGraderController extends GradingController  {
         }
         switch ($_REQUEST['action']) {
             case 'lab':
-                $this->grade('lab');
+                $this->grade();
                 break;
             case 'save_lab':
-                $this->save('lab');
+                $this->save();
                 break;
             case 'numeric':
-                $this->grade('numeric');
+                $this->grade();
                 break;
             case 'save_numeric':
-                $this->save('numeric');
+                $this->save();
                 break;
             case 'upload_csv_numeric':
-                $this->UploadCSV('numeric');
+                $this->UploadCSV();
                 break;
             case 'print_lab':
                 $this->printLab();
@@ -117,7 +117,7 @@ class SimpleGraderController extends GradingController  {
         $this->core->getOutput()->renderOutput(array('grading', 'SimpleGrader'), 'displayPrintLab', $gradeable, $section, $students);
     }
 
-    public function grade($action) {
+    public function grade() {
         if (!isset($_REQUEST['g_id'])) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable');
         }
@@ -196,7 +196,7 @@ class SimpleGraderController extends GradingController  {
         $this->core->getOutput()->renderOutput(array('grading', 'SimpleGrader'), 'simpleDisplay', $gradeable, $rows, $student_full, $graders, $section_key, $show_all_sections_button, $sort);
     }
 
-    public function save($action) {
+    public function save() {
         if (!isset($_REQUEST['g_id']) || !isset($_REQUEST['user_id'])) {
             return $this->core->getOutput()->renderJsonFail('Did not pass in g_id or user_id');
         }
@@ -257,7 +257,7 @@ class SimpleGraderController extends GradingController  {
         return $this->core->getOutput()->renderJsonSuccess();
     }
 
-    public function UploadCSV($action) {
+    public function UploadCSV() {
 
         $users = $_POST['users'];
         $g_id = $_POST['g_id'];

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -207,7 +207,7 @@ class SimpleGraderController extends GradingController  {
         $gradeable = $this->core->getQueries()->getGradeableConfig($g_id);
 
         $user = $this->core->getQueries()->getUserById($user_id);
-        if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $this->core->getCsrfToken()) {
+        if (!$this->core->checkCsrfToken()) {
             return $this->core->getOutput()->renderJsonFail('Invalid CSRF token');
         } else if ($gradeable === null) {
             return $this->core->getOutput()->renderJsonFail('Invalid gradeable ID');

--- a/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
+++ b/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
@@ -112,7 +112,7 @@ class SimpleGraderControllerTester extends BaseUnitTest {
         $_POST['scores'] = "123";
         $user = $this->createMockModel(User::class);
         $gradeable = $this->createMockModel(Gradeable::class);
-        $core = $this->createMockCore(['csrf_token' => true], [], ['getGradeableConfig' => $gradeable, 'getUserById' => $user]);
+        $core = $this->createMockCore(['csrf_token' => true], [], ['getGradeableConfig' => $gradeable, 'getUserById' => $user], ['canI' => false]);
         $controller = new SimpleGraderController($core);
         $response = $controller->save();
         $this->assertEquals(

--- a/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
+++ b/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace tests\app\controllers\grading;
+
+use app\controllers\grading\SimpleGraderController;
+use app\models\User;
+use app\models\gradeable\Gradeable;
+use tests\BaseUnitTest;
+
+class SimpleGraderControllerTester extends BaseUnitTest {
+
+    public function testSaveMissingGradeableId() {
+        $_REQUEST['g_id'] = null;
+        $core = $this->createMockCore();
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'Did not pass in g_id or user_id'
+            ],
+            $response
+        );
+    }
+
+    public function testSaveMissingUserId() {
+        $_REQUEST['user_id'] = null;
+        $core = $this->createMockCore();
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'Did not pass in g_id or user_id'
+            ],
+            $response
+        );
+    }
+
+    public function testSaveWrongCsrfToken() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $core = $this->createMockCore(['csrf_token' => false]);
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'Invalid CSRF token'
+            ],
+            $response
+        );
+    }
+
+    public function testSaveInvalidGradeable() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $core = $this->createMockCore(['csrf_token' => true], ['no_user' => true], ['getGradeableConfig' => null]);
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'Invalid gradeable ID'
+            ],
+            $response
+        );
+    }
+
+    public function testSaveInvalidUser() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $gradeable = $this->createMockModel(Gradeable::class);
+        $core = $this->createMockCore(['csrf_token' => true], ['no_user' => $gradeable], ['getGradeableConfig' => true]);
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => 'Invalid user ID'
+            ],
+            $response
+        );
+    }
+
+    public function testSaveMissingScores() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $_POST['scores'] = '';
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockModel(Gradeable::class);
+        $core = $this->createMockCore(['csrf_token' => true], [], ['getGradeableConfig' => $gradeable, 'getUserById' => $user]);
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => "Didn't submit any scores"
+            ],
+            $response
+        );
+    }
+
+    public function testSaveNoAccess() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $_POST['scores'] = "123";
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockModel(Gradeable::class);
+        $core = $this->createMockCore(['csrf_token' => true], [], ['getGradeableConfig' => $gradeable, 'getUserById' => $user]);
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => "You do not have permission to do this."
+            ],
+            $response
+        );
+    }
+}

--- a/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
+++ b/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
@@ -5,9 +5,52 @@ namespace tests\app\controllers\grading;
 use app\controllers\grading\SimpleGraderController;
 use app\models\User;
 use app\models\gradeable\Gradeable;
+use app\models\gradeable\GradedGradeable;
+use app\models\gradeable\TaGradedGradeable;
+use app\models\gradeable\Component;
+use app\models\gradeable\GradedComponent;
 use tests\BaseUnitTest;
 
 class SimpleGraderControllerTester extends BaseUnitTest {
+
+    /**
+     * Helper method to generate a gradeable.
+     *
+     * @param $upper_clamp
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createMockGradeable($upper_clamp) {
+        $gradeable = $this->createMockModel(Gradeable::class);
+        $component = $this->createMockModel(Component::class);
+
+        $gradeable->method('getComponents')->willReturn([$component]);
+        $component->method('getId')->willReturn(0);
+        $component->method('getUpperClamp')->willReturn($upper_clamp);
+
+        return $gradeable;
+    }
+
+    /**
+     * Helper method to generate a graded gradeable.
+     *
+     * @param $total_score
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createMockGradedGradeable($total_score) {
+        $graded_gradeable = $this->createMockModel(GradedGradeable::class);
+        $ta_graded_gradeable = $this->createMockModel(TaGradedGradeable::class);
+        $graded_component = $this->createMockModel(GradedComponent::class);
+
+        $graded_component->method('getTotalScore')->willReturn($total_score);
+        $graded_component->method('setGrader')->willReturn(true);
+        $graded_component->method('setScore')->willReturn(true);
+        $graded_component->method('setGradeTime')->willReturn(true);
+        $graded_gradeable->method('getOrCreateTaGradedGradeable')->willReturn($ta_graded_gradeable);
+        $ta_graded_gradeable->method('getOrCreateGradedComponent')->willReturn($graded_component);
+        $ta_graded_gradeable->method('setOverallComment')->willReturn(true);
+
+        return $graded_gradeable;
+    }
 
     public function testSaveMissingGradeableId() {
         $_REQUEST['g_id'] = null;
@@ -119,6 +162,84 @@ class SimpleGraderControllerTester extends BaseUnitTest {
             [
                 'status' => 'fail',
                 'message' => "You do not have permission to do this."
+            ],
+            $response
+        );
+    }
+
+    public function testExceedUpperClamp() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $_POST['scores'] = [5];
+        $_POST['old_scores'] = [1];
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockGradeable(4);
+        $graded_gradeable = $this->createMockGradedGradeable(1);
+        $core = $this->createMockCore(
+            ['csrf_token' => true],
+            [],
+            ['getGradeableConfig' => $gradeable, 'getUserById' => $user, 'getGradedGradeable' => $graded_gradeable],
+            ['canI' => true]
+        );
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => "Save error: score must be a number less than the upper clamp"
+            ],
+            $response
+        );
+    }
+
+    public function testStaleData() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $_POST['scores'] = [5];
+        $_POST['old_scores'] = [1];
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockGradeable(6);
+        $graded_gradeable = $this->createMockGradedGradeable(2);
+        $core = $this->createMockCore(
+            ['csrf_token' => true],
+            [],
+            ['getGradeableConfig' => $gradeable, 'getUserById' => $user, 'getGradedGradeable' => $graded_gradeable],
+            ['canI' => true]
+        );
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'fail',
+                'message' => "Save error: displayed stale data (1) does not match database (2)"
+            ],
+            $response
+        );
+    }
+
+    public function testSuccess() {
+        $_REQUEST['g_id'] = 'test';
+        $_REQUEST['user_id'] = 'test';
+        $_REQUEST['csrf_token'] = 'test';
+        $_POST['scores'] = [5];
+        $_POST['old_scores'] = [2];
+        $user = $this->createMockModel(User::class);
+        $gradeable = $this->createMockGradeable(6);
+        $graded_gradeable = $this->createMockGradedGradeable(2);
+        $core = $this->createMockCore(
+            ['csrf_token' => true],
+            [],
+            ['getGradeableConfig' => $gradeable, 'getUserById' => $user, 'getGradedGradeable' => $graded_gradeable],
+            ['canI' => true]
+        );
+        $controller = new SimpleGraderController($core);
+        $response = $controller->save();
+        $this->assertEquals(
+            [
+                'status' => 'success',
+                'data' => null
             ],
             $response
         );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Partially addresses #2362 .

### What is the new behavior?
Simple Grader Controller now uses our JSend format functions. The controller itself has been returning JSend format JSON all the time. This PR just switches to using `renderJsonFail` and `renderJsonSuccess` for easier future maintenance.

`$action` is removed because it is not used in the code.