### PR TITLE
[Travis] Add missing composer install line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ jobs:
       php: 7.2
       script:
         - pushd site
+        - travis_retry composer install --prefer-dist --no-interaction
         - vendor/bin/phpunit --version
         - vendor/bin/phpunit --configuration tests/phpunit.xml
         - popd
@@ -112,7 +113,6 @@ jobs:
         - pushd python_submitty_utils
         - python3 setup.py test
         - popd
-
         - pushd migration
         - python3 -m unittest discover
         - popd


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Travis does not actually install the composer dependencies as part of the build, relying on the existence of the composer cache from earlier steps.

### What is the new behavior?
Does an explicit composer install (which will pull in from the cache if it exists) to ensure the dependencies exist and are installed.
