### PR TITLE
[Feature] Add dedicated submitty crontab file to repo

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -575,6 +575,12 @@ installed_commit=$(jq '.installed_commit' /usr/local/submitty/config/version.jso
 most_recent_git_tag=$(jq '.most_recent_git_tag' /usr/local/submitty/config/version.json)
 echo -e "Completed installation of the Submitty version ${most_recent_git_tag//\"/}, commit ${installed_commit//\"/}\n"
 
+################################################################################################################
+################################################################################################################
+# INSTALL SUBMITTY CRONTAB
+#############################################################
+
+cat "${SUBMITTY_REPOSITORY}/.setup/submitty_crontab" | envsubst | cat - > "/etc/cron.d/submitty"
 
 ################################################################################################################
 ################################################################################################################

--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -126,13 +126,6 @@ for i in "${array[@]}"; do
     find ${SUBMITTY_INSTALL_DIR}/site/public -type f -name \*.${i} -exec chmod o+r {} \;
 done
 
-#Setup Email Cron Job
-crontab -u submitty_daemon -l > /tmp/cron_jobs
-grep "python3 ${SUBMITTY_INSTALL_DIR}/sbin/send_email.py" /tmp/cron_jobs || echo "* * * * * python3 ${SUBMITTY_INSTALL_DIR}/sbin/send_email.py" >> /tmp/cron_jobs
-crontab -u submitty_daemon -r
-crontab -u submitty_daemon /tmp/cron_jobs
-rm -f /tmp/cron_jobs
-
 # Set permissions of files
 # set special user $PHP_USER as owner & group of all website files
 find ${SUBMITTY_INSTALL_DIR}/site -exec chown ${PHP_USER}:${PHP_GROUP} {} \;

--- a/.setup/submitty_crontab
+++ b/.setup/submitty_crontab
@@ -1,0 +1,13 @@
+
+# /etc/cron.d/submitty: crontab for Submitty
+#
+# THIS FILE IS AUTO-GENERATED AS PART OF SUBMITTY INSTALLATION!
+# YOU MUST EDIT .setup/submitty_crontab IN YOUR GIT REPOSITORY
+# AND THEN RE-INSTALL SUBMITTY.
+#
+# As part of the installation process, any variable defined in
+# INSTALL_SUBMITTY_HELPER_SITE.sh is processed and expanded
+# automatically.
+#
+# Run the send_email.py script every minute
+* * * * * submitty_daemon   python3 ${SUBMITTY_INSTALL_DIR}/sbin/send_email.py

--- a/migration/migrator/migrations/system/20190617114139_crontab.py
+++ b/migration/migrator/migrations/system/20190617114139_crontab.py
@@ -1,0 +1,29 @@
+"""Migration for deleting old crontab usage."""
+
+from pathlib import Path
+
+
+def up(config):
+    """
+    Deletes the old crontab file we used to use if it exists.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    cron_file = Path("/var", "spool", "cron", "crontabs", "submitty_daemon")
+    if cron_file.exists():
+        cron_file.unlink()
+
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    Delete the new style crontab
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    cron_file = Path("/etc", "cron.d", "submitty")
+    if cron_file.exists():
+        cron_file.unlink()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
We install the one crontab to a user's crontab. This does throw several errors on the initial installation as the crontab does not yet exist (shown in the failing of Travis for #3863). The user crontab file is also not ideal to be used for automation.

### What is the new behavior?
Uses the `/etc/cron.d` interface to add a crontab which is the more standardized way to add crontabs through an installer/automation, at least across several major Linux distros (I checked Ubuntu, Debian, CentOS, and Fedora).

This is a proper solution to issue #3256 (fixing the problems with #3650) in that it's easy to see the user who runs a given cron job (as it's part of the line), their schedule, etc. and it's all in one place in-case we also ever want to add some root specific tasks (like DB backing up or something) to the core system.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I tested that the crontab was being run by monitoring `/var/log/syslog` to see the relevant entries being added when running the file. Migrator tested by doing a migrate and rollback to check that both files were deleted. Ran the `SUBMITTY_INSTALLER_HELPER.sh` to make sure the new crontab installed in the appropriate place with the appropriate environment variables filled in.
