### PR TITLE
[Bugfix] Fix Broken Vagrant Up

### DIFF
--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -16,6 +16,7 @@ fi
 #################
 
 apt-get -qqy update
+yes | apt-get -qq dist-upgrade
 
 apt-get install -qqy apt-transport-https ca-certificates curl software-properties-common
 apt-get install -qqy python python-dev python3 python3-dev libpython3.6

--- a/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/xenial/setup_distro.sh
@@ -37,6 +37,7 @@ fi
 #################
 
 apt-get update -qqy
+yes | apt-get -qq dist-upgrade
 
 ############################
 # NTP: Network Time Protocol


### PR DESCRIPTION
A dependency issue is currently causing vagrant up to fail. This PR addresses the issue by adding a ```dist-upgrade``` to the ```setup_distro.sh``` scripts.