### PR TITLE
[Bugfix] Fix broken redirect on exception on create gradeable

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -660,7 +660,7 @@ class AdminGradeableController extends AbstractController {
             $this->redirectToEdit($gradeable_id);
         } catch (\Exception $e) {
             $this->core->addErrorMessage($e);
-            $this->core->redirect($this->core->buildUrl());
+            $this->core->redirect($this->core->buildNewCourseUrl());
         }
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes issue that @jmcknight98 commented about in #3872. Any exception caused in the Create Gradeable flow would attempt to be redirected to `index.php?semester={_semester}&course={_course}` instead of `{_semester}/{_course}`.

### What is the new behavior?
Redirect now goes to the new (and working) `{_semester}/{_course}` endpoint.