### PR TITLE
[Refactor] Gather Course Material Functions

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -28,29 +28,14 @@ class MiscController extends AbstractController {
             case 'download_file_with_any_role':
                 $this->downloadFile(true);
                 break;
-            case 'delete_course_material_file':
-                $this->deleteCourseMaterialFile();
-                break;
-            case 'delete_course_material_folder':
-                $this->deleteCourseMaterialFolder();
-                break;
             case 'download_zip':
                 $this->downloadZip();
                 break;
             case 'download_all_assigned':
                 $this->downloadAssignedZips();
                 break;
-            case 'download_course_material_zip':
-                $this->downloadCourseMaterialZip();
-                break;
             case 'base64_encode_pdf':
                 $this->encodePDF();
-                break;
-            case 'modify_course_materials_file_permission':
-                $this->modifyCourseMaterialsFilePermission();
-                break;
-            case 'modify_course_materials_file_time_stamp':
-                $this->modifyCourseMaterialsFileTimeStamp();
                 break;
             case 'check_bulk_progress':
                 $this->checkBulkProgress();
@@ -128,90 +113,6 @@ class MiscController extends AbstractController {
                 $this->core->getOutput()->renderOutput('Misc', 'displayFile', $contents);
             }
         }
-    }
-
-    private function deleteCourseMaterialFile() {
-        $dir = "course_materials";
-        $path = $this->core->getAccess()->resolveDirPath($dir, $_REQUEST["path"]);
-
-        if (!$this->core->getAccess()->canI("path.write", ["path" => $path, "dir" => $dir])) {
-            $message = "You do not have access to that page. ";
-            $this->core->addErrorMessage($message);
-            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
-                'page' => 'course_materials',
-                'action' => 'view_course_materials_page')));
-        }
-
-        // delete the file from upload/course_materials
-        // $filename = (pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . basename(rawurldecode(htmlspecialchars_decode($_REQUEST['path']))));
-
-        if ( unlink($path) )
-        {
-            $this->core->addSuccessMessage(basename($path) . " has been successfully removed.");
-        }
-        else{
-            $this->core->addErrorMessage("Failed to remove " . basename($path));
-        }
-
-        // remove entry from json file
-        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-
-        $json = FileUtils::readJsonFile($fp);
-        if ($json != false)
-        {
-            unset($json[$path]);
-
-            if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
-                return "Failed to write to file {$fp}";
-            }
-        }
-
-        //refresh course materials page
-        $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
-            'page' => 'course_materials',
-            'action' => 'view_course_materials_page')));
-    }
-
-    private function deleteCourseMaterialFolder() {
-        // security check
-        $dir = "course_materials";
-        $path = $this->core->getAccess()->resolveDirPath($dir, $_REQUEST["path"]);
-
-        if (!$this->core->getAccess()->canI("path.write", ["path" => $path, "dir" => $dir])) {
-            $message = "You do not have access to that page.";
-            $this->core->addErrorMessage($message);
-            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
-                'page' => 'course_materials',
-                'action' => 'view_course_materials_page')));
-        }
-
-        // remove entry from json file
-        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-        $json = FileUtils::readJsonFile($fp);
-
-        if ($json != false)
-        {
-            $all_files = FileUtils::getAllFiles($path);
-            foreach($all_files as $file){
-                $filename = $file['path'];
-                unset($json[$filename]);
-            }
-
-            file_put_contents($fp, FileUtils::encodeJson($json));
-        }
-
-        if ( FileUtils::recursiveRmdir($path) )
-        {
-            $this->core->addSuccessMessage(basename($path) . " has been successfully removed.");
-        }
-        else{
-            $this->core->addErrorMessage("Failed to remove " . basename($path));
-        }
-
-        //refresh course materials page
-        $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
-            'page' => 'course_materials',
-            'action' => 'view_course_materials_page')));
     }
 
     private function readFile() {
@@ -496,144 +397,6 @@ class MiscController extends AbstractController {
         header("Expires: 0");
         readfile("$zip_name");
         unlink($zip_name); //deletes the random zip file
-    }
-
-    private function downloadCourseMaterialZip() {
-        $dir_name = $_REQUEST["dir_name"];
-        $root_path = realpath($_REQUEST["path"]);
-
-        // check if the user has access to course materials
-        if (!$this->core->getAccess()->canI("path.read", ["dir" => 'course_materials', "path" => $root_path])) {
-            $this->core->getOutput()->showError("You do not have access to this folder");
-            return false;
-        }
-
-        $temp_dir = "/tmp";
-        // makes a random zip file name on the server
-        $temp_name = uniqid($this->core->getUser()->getId(), true);
-        $zip_name = $temp_dir . "/" . $temp_name . ".zip";
-        $zip_file_name = preg_replace('/\s+/', '_', $dir_name) . ".zip";
-
-        $zip = new \ZipArchive();
-        $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-
-        if(!$this->core->getUser()->accessGrading()) {
-            // if the user is not the instructor
-            // download all accessible files according to course_materials_file_data.json
-            $file_data = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-            $json = FileUtils::readJsonFile($file_data);
-            foreach ($json as $path => $file) {
-                // check if the file is in the requested folder
-                if (!Utils::startsWith(realpath($path), $root_path)) {
-                    continue;
-                }
-                if ($file['checked'] === '1' &&
-                    $file['release_datetime'] < $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")) {
-                    $relative_path = substr($path, strlen($root_path) + 1);
-                    $zip->addFile($path, $relative_path);
-                }
-            }
-        }
-        else {
-            // if the user is an instructor
-            // download all files
-            $files = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($root_path),
-                \RecursiveIteratorIterator::LEAVES_ONLY
-            );
-
-            foreach ($files as $name => $file) {
-                if (!$file->isDir()) {
-                    $file_path = $file->getRealPath();
-                    $relativePath = substr($file_path, strlen($root_path) + 1);
-
-                    $zip->addFile($file_path, $relativePath);
-                }
-            }
-        }
-
-        $zip->close();
-        header("Content-type: application/zip");
-        header("Content-Disposition: attachment; filename=$zip_file_name");
-        header("Content-length: " . filesize($zip_name));
-        header("Pragma: no-cache");
-        header("Expires: 0");
-        readfile("$zip_name");
-        unlink($zip_name); //deletes the random zip file
-    }
-
-    public function modifyCourseMaterialsFilePermission() {
-
-        // security check
-        if(!$this->core->getUser()->accessAdmin()) {
-            $message = "You do not have access to that page. ";
-            $this->core->addErrorMessage($message);
-            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
-                'page' => 'course_materials',
-                'action' => 'view_course_materials_page')));
-            return;
-        }
-
-        if (!isset($_REQUEST['filename']) ||
-            !isset($_REQUEST['checked'])) {
-            return;
-        }
-
-        $file_name = htmlspecialchars($_REQUEST['filename']);
-        $checked =  $_REQUEST['checked'];
-
-        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-
-        $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
-        $json = FileUtils::readJsonFile($fp);
-        if ($json != false) {
-            $release_datetime  = $json[$file_name]['release_datetime'];
-        }
-
-        if (!isset($release_datetime))
-        {
-            $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
-        }
-
-        $json[$file_name] = array('checked' => $checked, 'release_datetime' => $release_datetime);
-
-        if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
-            return "Failed to write to file {$fp}";
-        }
-    }
-
-    public function modifyCourseMaterialsFileTimeStamp() {
-
-        if(!$this->core->getUser()->accessAdmin()) {
-            $message = "You do not have access to that page. ";
-            $this->core->addErrorMessage($message);
-            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
-                'page' => 'course_materials',
-                'action' => 'view_course_materials_page')));
-            return;
-        }
-
-        if (!isset($_REQUEST['filename']) ||
-            !isset($_REQUEST['newdatatime'])) {
-            return;
-        }
-
-        $file_name = htmlspecialchars($_REQUEST['filename']);
-        $new_data_time = htmlspecialchars($_REQUEST['newdatatime']);
-
-        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-
-        $checked = '0';
-        $json = FileUtils::readJsonFile($fp);
-        if ($json != false) {
-            $checked  = $json[$file_name]['checked'];
-        }
-
-        $json[$file_name] = array('checked' => $checked, 'release_datetime' => $new_data_time);
-
-        if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
-            return "Failed to write to file {$fp}";
-        }
     }
 
     public function checkBulkProgress(){

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -7,12 +7,30 @@ use app\libraries\FileUtils;
 
 class CourseMaterialsController extends AbstractController {
     public function run() {
+        foreach (array('path', 'file') as $key) {
+            if (isset($_REQUEST[$key])) {
+                $_REQUEST[$key] = htmlspecialchars_decode(urldecode($_REQUEST[$key]));
+            }
+        }
+
         switch ($_REQUEST['action']) {
             case 'view_course_materials_page':
-            		$this->viewCourseMaterialsPage();
+                $this->viewCourseMaterialsPage();
                 break;
-            case 'delete_course_materials_file':
-                $this->deleteCourseMaterialsFile();
+            case 'delete_course_material_file':
+                $this->deleteCourseMaterialFile();
+                break;
+            case 'delete_course_material_folder':
+                $this->deleteCourseMaterialFolder();
+                break;
+            case 'download_course_material_zip':
+                $this->downloadCourseMaterialZip();
+                break;
+            case 'modify_course_materials_file_permission':
+                $this->modifyCourseMaterialsFilePermission();
+                break;
+            case 'modify_course_materials_file_time_stamp':
+                $this->modifyCourseMaterialsFileTimeStamp();
                 break;
             default:
                 $this->viewCourseMaterialsPage();
@@ -21,30 +39,229 @@ class CourseMaterialsController extends AbstractController {
     }
 
     public function viewCourseMaterialsPage() {
-        $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'flatpickr.min.js'));
-        $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
-        $user_group = $this->core->getUser()->getGroup();
-        $this->core->getOutput()->renderOutput(array('course', 'CourseMaterials'), 'listCourseMaterials', $user_group);
+        $this->core->getOutput()->renderOutput(
+            ['course', 'CourseMaterials'],
+            'listCourseMaterials',
+            $user_group = $this->core->getUser()->getGroup()
+        );
     }
 
-    public function deleteCourseMaterialsFile() {
+    public function deleteCourseMaterialFile() {
+        $dir = "course_materials";
+        $path = $this->core->getAccess()->resolveDirPath($dir, $_REQUEST["path"]);
+
+        if (!$this->core->getAccess()->canI("path.write", ["path" => $path, "dir" => $dir])) {
+            $message = "You do not have access to that page. ";
+            $this->core->addErrorMessage($message);
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+                'page' => 'course_materials',
+                'action' => 'view_course_materials_page')));
+        }
+
+        if ( unlink($path) )
+        {
+            $this->core->addSuccessMessage(basename($path) . " has been successfully removed.");
+        }
+        else{
+            $this->core->addErrorMessage("Failed to remove " . basename($path));
+        }
+
+        // remove entry from json file
+        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
+
+        $json = FileUtils::readJsonFile($fp);
+        if ($json != false)
+        {
+            unset($json[$path]);
+
+            if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
+                return "Failed to write to file {$fp}";
+            }
+        }
+
+        //refresh course materials page
+        $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+            'page' => 'course_materials',
+            'action' => 'view_course_materials_page')));
+    }
+
+    private function deleteCourseMaterialFolder() {
+        // security check
+        $dir = "course_materials";
+        $path = $this->core->getAccess()->resolveDirPath($dir, $_REQUEST["path"]);
+
+        if (!$this->core->getAccess()->canI("path.write", ["path" => $path, "dir" => $dir])) {
+            $message = "You do not have access to that page.";
+            $this->core->addErrorMessage($message);
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+                'page' => 'course_materials',
+                'action' => 'view_course_materials_page')));
+        }
+
+        // remove entry from json file
+        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
+        $json = FileUtils::readJsonFile($fp);
+
+        if ($json != false)
+        {
+            $all_files = FileUtils::getAllFiles($path);
+            foreach($all_files as $file){
+                $filename = $file['path'];
+                unset($json[$filename]);
+            }
+
+            file_put_contents($fp, FileUtils::encodeJson($json));
+        }
+
+        if ( FileUtils::recursiveRmdir($path) )
+        {
+            $this->core->addSuccessMessage(basename($path) . " has been successfully removed.");
+        }
+        else{
+            $this->core->addErrorMessage("Failed to remove " . basename($path));
+        }
+
+        //refresh course materials page
+        $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+            'page' => 'course_materials',
+            'action' => 'view_course_materials_page')));
+    }
+
+    private function downloadCourseMaterialZip() {
+        $dir_name = $_REQUEST["dir_name"];
+        $root_path = realpath($_REQUEST["path"]);
+
+        // check if the user has access to course materials
+        if (!$this->core->getAccess()->canI("path.read", ["dir" => 'course_materials', "path" => $root_path])) {
+            $this->core->getOutput()->showError("You do not have access to this folder");
+            return false;
+        }
+
+        $temp_dir = "/tmp";
+        // makes a random zip file name on the server
+        $temp_name = uniqid($this->core->getUser()->getId(), true);
+        $zip_name = $temp_dir . "/" . $temp_name . ".zip";
+        $zip_file_name = preg_replace('/\s+/', '_', $dir_name) . ".zip";
+
+        $zip = new \ZipArchive();
+        $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+
+        if(!$this->core->getUser()->accessGrading()) {
+            // if the user is not the instructor
+            // download all accessible files according to course_materials_file_data.json
+            $file_data = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
+            $json = FileUtils::readJsonFile($file_data);
+            foreach ($json as $path => $file) {
+                // check if the file is in the requested folder
+                if (!Utils::startsWith(realpath($path), $root_path)) {
+                    continue;
+                }
+                if ($file['checked'] === '1' &&
+                    $file['release_datetime'] < $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")) {
+                    $relative_path = substr($path, strlen($root_path) + 1);
+                    $zip->addFile($path, $relative_path);
+                }
+            }
+        }
+        else {
+            // if the user is an instructor
+            // download all files
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root_path),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            );
+
+            foreach ($files as $name => $file) {
+                if (!$file->isDir()) {
+                    $file_path = $file->getRealPath();
+                    $relativePath = substr($file_path, strlen($root_path) + 1);
+
+                    $zip->addFile($file_path, $relativePath);
+                }
+            }
+        }
+
+        $zip->close();
+        header("Content-type: application/zip");
+        header("Content-Disposition: attachment; filename=$zip_file_name");
+        header("Content-length: " . filesize($zip_name));
+        header("Pragma: no-cache");
+        header("Expires: 0");
+        readfile("$zip_name");
+        unlink($zip_name); //deletes the random zip file
+    }
+
+    public function modifyCourseMaterialsFilePermission() {
+
+        // security check
         if(!$this->core->getUser()->accessAdmin()) {
-           return $this->uploadResult("You have no permission to delete this file", false);
+            $message = "You do not have access to that page. ";
+            $this->core->addErrorMessage($message);
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+                'page' => 'course_materials',
+                'action' => 'view_course_materials_page')));
+            return;
         }
 
-        if (!isset($_POST['filename'])) {
-            return $this->uploadResult("Empty file.", false);
+        if (!isset($_REQUEST['filename']) ||
+            !isset($_REQUEST['checked'])) {
+            return;
         }
 
-        $file_name = $_POST['filename'];
+        $file_name = htmlspecialchars($_REQUEST['filename']);
+        $checked =  $_REQUEST['checked'];
 
-        $course_materials_file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "course_materials", $filename);
+        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
 
-        if (!@unlink($course_materials_file_path)) {
-            return $this->uploadResult("Failed to delete the file {$filename} from the server.", false);
+        $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
+        $json = FileUtils::readJsonFile($fp);
+        if ($json != false) {
+            $release_datetime  = $json[$file_name]['release_datetime'];
         }
 
+        if (!isset($release_datetime))
+        {
+            $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
+        }
 
-        return $this->uploadResult("Successfully deleted!", true);
-      }
+        $json[$file_name] = array('checked' => $checked, 'release_datetime' => $release_datetime);
+
+        if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
+            return "Failed to write to file {$fp}";
+        }
+    }
+
+    public function modifyCourseMaterialsFileTimeStamp() {
+
+        if(!$this->core->getUser()->accessAdmin()) {
+            $message = "You do not have access to that page. ";
+            $this->core->addErrorMessage($message);
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+                'page' => 'course_materials',
+                'action' => 'view_course_materials_page')));
+            return;
+        }
+
+        if (!isset($_REQUEST['filename']) ||
+            !isset($_REQUEST['newdatatime'])) {
+            return;
+        }
+
+        $file_name = htmlspecialchars($_REQUEST['filename']);
+        $new_data_time = htmlspecialchars($_REQUEST['newdatatime']);
+
+        $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
+
+        $checked = '0';
+        $json = FileUtils::readJsonFile($fp);
+        if ($json != false) {
+            $checked  = $json[$file_name]['checked'];
+        }
+
+        $json[$file_name] = array('checked' => $checked, 'release_datetime' => $new_data_time);
+
+        if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
+            return "Failed to write to file {$fp}";
+        }
+    }
 }

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -4,6 +4,7 @@ namespace app\controllers\course;
 
 use app\controllers\AbstractController;
 use app\libraries\FileUtils;
+use app\libraries\Utils;
 
 class CourseMaterialsController extends AbstractController {
     public function run() {
@@ -58,11 +59,10 @@ class CourseMaterialsController extends AbstractController {
                 'action' => 'view_course_materials_page')));
         }
 
-        if ( unlink($path) )
-        {
+        if (unlink($path)) {
             $this->core->addSuccessMessage(basename($path) . " has been successfully removed.");
         }
-        else{
+        else {
             $this->core->addErrorMessage("Failed to remove " . basename($path));
         }
 
@@ -102,10 +102,9 @@ class CourseMaterialsController extends AbstractController {
         $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
         $json = FileUtils::readJsonFile($fp);
 
-        if ($json != false)
-        {
+        if ($json != false) {
             $all_files = FileUtils::getAllFiles($path);
-            foreach($all_files as $file){
+            foreach($all_files as $file) {
                 $filename = $file['path'];
                 unset($json[$filename]);
             }
@@ -113,11 +112,10 @@ class CourseMaterialsController extends AbstractController {
             file_put_contents($fp, FileUtils::encodeJson($json));
         }
 
-        if ( FileUtils::recursiveRmdir($path) )
-        {
+        if (FileUtils::recursiveRmdir($path)) {
             $this->core->addSuccessMessage(basename($path) . " has been successfully removed.");
         }
-        else{
+        else {
             $this->core->addErrorMessage("Failed to remove " . basename($path));
         }
 
@@ -219,8 +217,7 @@ class CourseMaterialsController extends AbstractController {
             $release_datetime  = $json[$file_name]['release_datetime'];
         }
 
-        if (!isset($release_datetime))
-        {
+        if (!isset($release_datetime)) {
             $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
         }
 

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -89,7 +89,7 @@ class CourseMaterialsController extends AbstractController {
             'action' => 'view_course_materials_page')));
     }
 
-    private function deleteCourseMaterialFolder() {
+    public function deleteCourseMaterialFolder() {
         // security check
         $dir = "course_materials";
         $path = $this->core->getAccess()->resolveDirPath($dir, $_REQUEST["path"]);
@@ -129,7 +129,7 @@ class CourseMaterialsController extends AbstractController {
             'action' => 'view_course_materials_page')));
     }
 
-    private function downloadCourseMaterialZip() {
+    public function downloadCourseMaterialZip() {
         $dir_name = $_REQUEST["dir_name"];
         $root_path = realpath($_REQUEST["path"]);
 
@@ -202,12 +202,13 @@ class CourseMaterialsController extends AbstractController {
             $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
                 'page' => 'course_materials',
                 'action' => 'view_course_materials_page')));
-            return;
         }
 
         if (!isset($_REQUEST['filename']) ||
             !isset($_REQUEST['checked'])) {
-            return;
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+                'page' => 'course_materials',
+                'action' => 'view_course_materials_page')));
         }
 
         $file_name = htmlspecialchars($_REQUEST['filename']);
@@ -240,12 +241,13 @@ class CourseMaterialsController extends AbstractController {
             $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
                 'page' => 'course_materials',
                 'action' => 'view_course_materials_page')));
-            return;
         }
 
         if (!isset($_REQUEST['filename']) ||
             !isset($_REQUEST['newdatatime'])) {
-            return;
+            $this->core->redirect($this->core->buildUrl(array('component' => 'grading',
+                'page' => 'course_materials',
+                'action' => 'view_course_materials_page')));
         }
 
         $file_name = htmlspecialchars($_REQUEST['filename']);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -78,9 +78,6 @@ class SubmissionController extends AbstractController {
             case 'upload_images_files':
                 return $this->ajaxUploadImagesFiles();
                 break;
-            case 'upload_course_materials_files':
-                return $this->ajaxUploadCourseMaterialsFiles();
-                break;
             case 'delete_split':
                 return $this->ajaxDeleteSplitItem();
                 break;
@@ -1501,26 +1498,8 @@ class SubmissionController extends AbstractController {
                 }
             }
         }
-        return $this->uploadResultMessage($message, $success);
+        return $this->core->getOutput()->renderResultMessage($message, $success);
     }
-
-    private function uploadResultMessage($message, $success = true, $show_msg = true) {
-        if ($show_msg == true) {
-            if ($success) {
-                $this->core->addSuccessMessage($message);
-            }
-            else {
-                $this->core->addErrorMessage($message);
-            }
-        }
-
-        if ($success == true) {
-            return $this->core->getOutput()->renderJsonSuccess($message);
-        } else {
-            return $this->core->getOutput()->renderJsonFail($message);
-        }
-    }
-
 
     private function updateSubmissionVersion() {
         $ta = $_REQUEST['ta'] ?? false;
@@ -1646,16 +1625,16 @@ class SubmissionController extends AbstractController {
 
     private function ajaxUploadImagesFiles() {
         if(!$this->core->getUser()->accessAdmin()) {
-            return $this->uploadResultMessage("You have no permission to access this page", false);
+            return $this->core->getOutput()->renderResultMessage("You have no permission to access this page", false);
         }
 
         if (empty($_POST)) {
            $max_size = ini_get('post_max_size');
-           return $this->uploadResultMessage("Empty POST request. This may mean that the sum size of your files are greater than {$max_size}.", false, false);
+           return $this->core->getOutput()->renderResultMessage("Empty POST request. This may mean that the sum size of your files are greater than {$max_size}.", false, false);
         }
 
         if (!isset($_POST['csrf_token']) || !$this->core->checkCsrfToken($_POST['csrf_token'])) {
-            return $this->uploadResultMessage("Invalid CSRF token.", false, false);
+            return $this->core->getOutput()->renderResultMessage("Invalid CSRF token.", false, false);
         }
 
         $uploaded_files = array();
@@ -1679,11 +1658,11 @@ class SubmissionController extends AbstractController {
 
         if (count($errors) > 0) {
             $error_text = implode("\n", $errors);
-            return $this->uploadResultMessage("Upload Failed: ".$error_text, false);
+            return $this->core->getOutput()->renderResultMessage("Upload Failed: ".$error_text, false);
         }
 
         if (empty($uploaded_files)) {
-            return $this->uploadResultMessage("No files to be submitted.", false);
+            return $this->core->getOutput()->renderResultMessage("No files to be submitted.", false);
         }
 
         $file_size = 0;
@@ -1692,14 +1671,14 @@ class SubmissionController extends AbstractController {
             for ($j = 0; $j < $count_item; $j++) {
                 if (FileUtils::getMimeType($uploaded_files[1]["tmp_name"][$j]) == "application/zip") {
                     if(FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
-                        return $this->uploadResultMessage("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside ".$uploaded_files[1]["name"][$j].".", false);
+                        return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside ".$uploaded_files[1]["name"][$j].".", false);
                     }
                     $uploaded_files[1]["is_zip"][$j] = true;
                     $file_size += FileUtils::getZipSize($uploaded_files[1]["tmp_name"][$j]);
                 }
                 else {
                     if(FileUtils::isValidFileName($uploaded_files[1]["name"][$j]) === false) {
-                        return $this->uploadResultMessage("Error: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_files[1]["name"][$j].".", false);
+                        return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_files[1]["name"][$j].".", false);
                     }
                     $uploaded_files[1]["is_zip"][$j] = false;
                     $file_size += $uploaded_files[1]["size"][$j];
@@ -1709,14 +1688,14 @@ class SubmissionController extends AbstractController {
 
         $max_size = 10485760;
         if ($file_size > $max_size) {
-            return $this->uploadResultMessage("File(s) uploaded too large.  Maximum size is ".($max_size/1024)." kb. Uploaded file(s) was ".($file_size/1024)." kb.", false);
+            return $this->core->getOutput()->renderResultMessage("File(s) uploaded too large.  Maximum size is ".($max_size/1024)." kb. Uploaded file(s) was ".($file_size/1024)." kb.", false);
         }
 
         // creating uploads/student_images directory
 
         $upload_img_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "student_images");
         if (!FileUtils::createDir($upload_img_path)) {
-            return $this->uploadResultMessage("Failed to make image path.", false);
+            return $this->core->getOutput()->renderResultMessage("Failed to make image path.", false);
         }
 
         if (isset($uploaded_files[1])) {
@@ -1741,23 +1720,23 @@ class SubmissionController extends AbstractController {
                         // so we have that string hardcoded, otherwise we can just get the status string as
                         // normal.
                         $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
-                        return $this->uploadResultMessage("Could not properly unpack zip file. Error message: ".$error_message.".", false);
+                        return $this->core->getOutput()->renderResultMessage("Could not properly unpack zip file. Error message: ".$error_message.".", false);
                     }
                 }
                 else {
                     if ($this->core->isTesting() || is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {
                         $dst = FileUtils::joinPaths($upload_img_path, $uploaded_files[1]["name"][$j]);
                         if (!@copy($uploaded_files[1]["tmp_name"][$j], $dst)) {
-                            return $this->uploadResultMessage("Failed to copy uploaded file {$uploaded_files[1]["name"][$j]} to current location.", false);
+                            return $this->core->getOutput()->renderResultMessage("Failed to copy uploaded file {$uploaded_files[1]["name"][$j]} to current location.", false);
                         }
                     }
                     else {
-                        return $this->uploadResultMessage("The tmp file '{$uploaded_files[1]['name'][$j]}' was not properly uploaded.", false);
+                        return $this->core->getOutput()->renderResultMessage("The tmp file '{$uploaded_files[1]['name'][$j]}' was not properly uploaded.", false);
                     }
                 }
                 // Is this really an error we should fail on?
                 if (!@unlink($uploaded_files[1]["tmp_name"][$j])) {
-                    return $this->uploadResultMessage("Failed to delete the uploaded file {$uploaded_files[1]["name"][$j]} from temporary storage.", false);
+                    return $this->core->getOutput()->renderResultMessage("Failed to delete the uploaded file {$uploaded_files[1]["name"][$j]} from temporary storage.", false);
                 }
             }
         }
@@ -1773,139 +1752,7 @@ class SubmissionController extends AbstractController {
         else {
             $message = 'Successfully uploaded!';
         }
-        return $this->uploadResultMessage($message, true);
-    }
-
-    private function ajaxUploadCourseMaterialsFiles() {
-      if(!$this->core->getUser()->accessAdmin()) {
-         return $this->uploadResultMessage("You have no permission to access this page", false);
-      }
-
-      if (empty($_POST)) {
-         $max_size = ini_get('post_max_size');
-         return $this->uploadResultMessage("Empty POST request. This may mean that the sum size of your files are greater than {$max_size}.", false, false);
-      }
-
-      if (!isset($_POST['csrf_token']) || !$this->core->checkCsrfToken($_POST['csrf_token'])) {
-          return $this->uploadResultMessage("Invalid CSRF token.", false, false);
-      }
-
-      $expand_zip = "";
-      if (isset($_POST['expand_zip'])) {
-          $expand_zip = $_POST['expand_zip'];
-      }
-
-      $requested_path = "";
-      if (isset($_POST['requested_path'])) {
-          $requested_path = $_POST['requested_path'];
-      }
-
-      $n = strpos($requested_path, '..');
-      if ($n !== false) {
-          return $this->uploadResultMessage(".. is not supported in the path.", false, false);
-      }
-
-      $uploaded_files = array();
-      if (isset($_FILES["files1"])) {
-          $uploaded_files[1] = $_FILES["files1"];
-      }
-      $errors = array();
-      if (isset($uploaded_files[1])) {
-          $count_item = count($uploaded_files[1]["name"]);
-          for ($j = 0; $j < $count_item[1]; $j++) {
-              if (!isset($uploaded_files[1]["tmp_name"][$j]) || $uploaded_files[1]["tmp_name"][$j] === "") {
-                  $error_message = $uploaded_files[1]["name"][$j]." failed to upload. ";
-                  if (isset($uploaded_files[1]["error"][$j])) {
-                      $error_message .= "Error message: ". ErrorMessages::uploadErrors($uploaded_files[1]["error"][$j]). ".";
-                  }
-                  $errors[] = $error_message;
-              }
-          }
-      }
-
-      if (count($errors) > 0) {
-          $error_text = implode("\n", $errors);
-          return $this->uploadResultMessage("Upload Failed: ".$error_text, false);
-      }
-
-      if (empty($uploaded_files)) {
-          return $this->uploadResultMessage("No files to be submitted.", false);
-      }
-
-      $file_size = 0;
-      if (isset($uploaded_files[1])) {
-          for ($j = 0; $j < $count_item; $j++) {
-              if(FileUtils::isValidFileName($uploaded_files[1]["name"][$j]) === false) {
-                  return $this->uploadResultMessage("Error: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_files[1]["name"][$j].".", false);
-              }
-              $file_size += $uploaded_files[1]["size"][$j];
-          }
-      }
-
-      $max_size = 10485760;
-      if ($file_size > $max_size) {
-          return $this->uploadResultMessage("File(s) uploaded too large.  Maximum size is ".($max_size/1024)." kb. Uploaded file(s) was ".($file_size/1024)." kb.", false);
-      }
-
-      // creating uploads/course_materials directory
-      $upload_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "course_materials");
-      if (!FileUtils::createDir($upload_path)) {
-          return $this->uploadResultMessage("Failed to make image path.", false);
-      }
-
-      // create nested path
-      if (!empty($requested_path)) {
-          $upload_nested_path = FileUtils::joinPaths($upload_path, $requested_path);
-          if (!FileUtils::createDir($upload_nested_path, null, true)) {
-             return $this->uploadResultMessage("Failed to make image path.", false);
-          }
-          $upload_path = $upload_nested_path;
-      }
-
-      if (isset($uploaded_files[1])) {
-          for ($j = 0; $j < $count_item; $j++) {
-                if ($this->core->isTesting() || is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {
-                    $dst = FileUtils::joinPaths($upload_path, $uploaded_files[1]["name"][$j]);
-                    //
-                    $is_zip_file = false;
-
-                    if (FileUtils::getMimeType($uploaded_files[1]["tmp_name"][$j]) == "application/zip") {
-                        if(FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
-                            return $this->uploadResultMessage("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside ".$uploaded_files[$i]["name"][$j].".", false);
-                        }
-                        $is_zip_file = true;
-                    }
-                    //cannot check if there are duplicates inside zip file, will overwrite
-                    //it is convenient for bulk uploads
-                    if ($expand_zip == 'on' && $is_zip_file === true) {
-                        $zip = new \ZipArchive();
-                        $res = $zip->open($uploaded_files[1]["tmp_name"][$j]);
-                        if ($res === true) {
-                            $zip->extractTo($upload_path);
-                            $zip->close();
-                        }
-                    }
-                    else
-                    {
-                        if (!@copy($uploaded_files[1]["tmp_name"][$j], $dst)) {
-                           return $this->uploadResultMessage("Failed to copy uploaded file {$uploaded_files[1]["name"][$j]} to current location.", false);
-                      }
-                    }
-                    //
-                }
-                else {
-                    return $this->uploadResultMessage("The tmp file '{$uploaded_files[1]['name'][$j]}' was not properly uploaded.", false);
-                }
-            // Is this really an error we should fail on?
-              if (!@unlink($uploaded_files[1]["tmp_name"][$j])) {
-                  return $this->uploadResultMessage("Failed to delete the uploaded file {$uploaded_files[1]["name"][$j]} from temporary storage.", false);
-              }
-          }
-      }
-
-
-      return $this->uploadResultMessage("Successfully uploaded!", true);
-
+        return $this->core->getOutput()->renderResultMessage($message, true);
     }
 
     /**

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -246,6 +246,30 @@ HTML;
         // Because sometimes the controllers want to return the response array
         return $response;
     }
+
+    /**
+     * Renders success/error messages and/or JSON responses.
+     * @param $message
+     * @param bool $success
+     * @param bool $show_msg
+     * @return array
+     */
+    public function renderResultMessage($message, $success = true, $show_msg = true) {
+        if ($show_msg == true) {
+            if ($success) {
+                $this->core->addSuccessMessage($message);
+            }
+            else {
+                $this->core->addErrorMessage($message);
+            }
+        }
+
+        if ($success == true) {
+            return $this->core->getOutput()->renderJsonSuccess($message);
+        } else {
+            return $this->core->getOutput()->renderJsonFail($message);
+        }
+    }
     
     public function renderString($string) {
         $this->output_buffer .= $string;

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -39,7 +39,7 @@
             {% endif %}
             <a onclick='downloadFileWithAnyRole("{{ dir }}", "{{ path | url_encode }}")'><i class="fas fa-download" aria-hidden="true" title="Download the file"></i></a>
             {% if userGroup == 1 %}
-                <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'view_course_materials_page', 'dir': 'course_materials', 'file': dir, 'path': path }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+                <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'delete_course_material_file', 'dir': 'course_materials', 'file': dir, 'path': path }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
                 <input id="share_checkbox_{{ id }}" type="checkbox"
                 {% if ( (fileShares[path] == "1") )%}
                    checked="true"

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -39,7 +39,7 @@
             {% endif %}
             <a onclick='downloadFileWithAnyRole("{{ dir }}", "{{ path | url_encode }}")'><i class="fas fa-download" aria-hidden="true" title="Download the file"></i></a>
             {% if userGroup == 1 %}
-                <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'misc', 'page': 'delete_course_material_file', 'dir': 'course_materials', 'file': dir, 'path': path }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+                <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'view_course_materials_page', 'dir': 'course_materials', 'file': dir, 'path': path }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
                 <input id="share_checkbox_{{ id }}" type="checkbox"
                 {% if ( (fileShares[path] == "1") )%}
                    checked="true"
@@ -64,7 +64,7 @@
             </a>
             <a onclick='downloadCourseMaterialZip("{{ dir }}", "{{ folderPath | url_encode }}")'><i class="fas fa-download" aria-hidden="true" title="Download the folder"></i></a>
             {% if userGroup == 1 %}
-                <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'misc', 'page': 'delete_course_material_folder', 'dir': 'course_materials', 'file': dir, 'path': folderPath }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+                <a onclick='newDeleteCourseMaterialForm("{{ core.buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'delete_course_material_folder', 'dir': 'course_materials', 'file': dir, 'path': folderPath }) }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
             {% endif %}
         </div>
         <div id='div_viewer_{{ id }}' style='margin-left:15px; display: none' data-file_name="{{ dir }}">

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -7,7 +7,6 @@ use app\libraries\DateUtils;
 use app\models\User;
 use app\views\AbstractView;
 use app\libraries\FileUtils;
-use app\libraries\Utils;
 
 
 class CourseMaterialsView extends AbstractView {
@@ -19,12 +18,7 @@ class CourseMaterialsView extends AbstractView {
         $this->core->getOutput()->addBreadcrumb("Course Materials");
         function add_files(Core $core, &$files, &$file_datas, &$file_release_dates, $expected_path, $json, $course_materials_array, $start_dir_name, $user_group) {
             $files[$start_dir_name] = array();
-            $working_dirRoot = &$files[$start_dir_name];
-
             $student_access = ($user_group === 4);
-
-            $arrlength = count($course_materials_array);
-
             $now_date_time = $core->getDateTimeNow();
 
             foreach($course_materials_array as $file) {
@@ -76,8 +70,6 @@ class CourseMaterialsView extends AbstractView {
         $submissions = array();
         $file_shares = array();
         $file_release_dates = array();
-
-        $course_materials_array = array();
 
         //Get the expected course materials path and files
         $upload_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads");

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -15,6 +15,8 @@ class CourseMaterialsView extends AbstractView {
      * @return string
      */
     public function listCourseMaterials($user_group) {
+        $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'flatpickr.min.js'));
+        $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
         $this->core->getOutput()->addBreadcrumb("Course Materials");
         function add_files(Core $core, &$files, &$file_datas, &$file_release_dates, $expected_path, $json, $course_materials_array, $start_dir_name, $user_group) {
             $files[$start_dir_name] = array();

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -940,7 +940,7 @@ function handleDownloadImages(csrf_token) {
  */
 
 function handleUploadCourseMaterials(csrf_token, expand_zip, cmPath, requested_path) {
-    var submit_url = buildUrl({'component': 'student', 'page': 'submission', 'action': 'upload_course_materials_files'});
+    var submit_url = buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'upload_course_materials_files'});
     var return_url = buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'view_course_materials_page'});
     var formData = new FormData();
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -2634,7 +2634,7 @@ function changePermission(filename, checked) {
 
 function changeNewDateTime(filename, newdatatime) {
     // send to server to handle file permission change
-    var url = buildUrl({'component': 'misc', 'page': 'course_materials', 'action': 'modify_course_materials_file_time_stamp', 'filename': encodeURIComponent(filename), 'newdatatime': encodeURIComponent(newdatatime)});
+    var url = buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'modify_course_materials_file_time_stamp', 'filename': encodeURIComponent(filename), 'newdatatime': encodeURIComponent(newdatatime)});
 
     $.ajax({
         url: url,

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1216,7 +1216,7 @@ function downloadFileWithAnyRole(file_name, path) {
 }
 
 function downloadCourseMaterialZip(dir_name, path) {
-    window.location = buildUrl({'component': 'misc', 'page': 'download_course_material_zip', 'dir_name': dir_name, 'path': path});
+    window.location = buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'download_course_material_zip', 'dir_name': dir_name, 'path': path});
 }
 
 function checkColorActivated() {
@@ -2621,7 +2621,7 @@ function escapeHTML(str) {
 
 function changePermission(filename, checked) {
     // send to server to handle file permission change
-    var url = buildUrl({'component': 'misc', 'page': 'modify_course_materials_file_permission', 'filename': encodeURIComponent(filename), 'checked': checked});
+    var url = buildUrl({'component': 'grading', 'page': 'course_materials', 'action': 'modify_course_materials_file_permission', 'filename': encodeURIComponent(filename), 'checked': checked});
 
     $.ajax({
         url: url,
@@ -2634,7 +2634,7 @@ function changePermission(filename, checked) {
 
 function changeNewDateTime(filename, newdatatime) {
     // send to server to handle file permission change
-    var url = buildUrl({'component': 'misc', 'page': 'modify_course_materials_file_time_stamp', 'filename': encodeURIComponent(filename), 'newdatatime': encodeURIComponent(newdatatime)});
+    var url = buildUrl({'component': 'misc', 'page': 'course_materials', 'action': 'modify_course_materials_file_time_stamp', 'filename': encodeURIComponent(filename), 'newdatatime': encodeURIComponent(newdatatime)});
 
     $.ajax({
         url: url,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Some course material related functions are scattered in MiscController and SubmissionController. This makes it hard to add routes to the course material part and make other controllers filled with too many functions.

### What is the new behavior?
- Gathers all functions concerned to CourseMaterialsController.
- Removes unused method (the deletion function in the original CourseMaterialsController) and unused variables.
- Modifies all links concerned.

### Other information?
Tested by manually going through all "actions".

`uploadResultMessage` is shared by `SubmissionController` and `CourseMaterialsController`, so I put it in `Output.php`. It looks like what we would like the API to be, but in the future, we will move to a more implicit way in `index.php` (or the main router).