### PR TITLE
[Feature] Add script to automate hitting generate grade summaries button

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
@@ -71,7 +71,7 @@ chmod 550 ${SUBMITTY_INSTALL_DIR}/sbin/authentication.py
 chmod 555 ${SUBMITTY_INSTALL_DIR}/sbin/killall.py
 
 # DAEMON_USER only things
-array=( build_config_upload.py run_lichen_plagiarism.py send_email.py submitty_autograding_shipper.py submitty_autograding_worker.py submitty_daemon_jobs autograder)
+array=( build_config_upload.py run_lichen_plagiarism.py send_email.py generate_grade_summaries.py submitty_autograding_shipper.py submitty_autograding_worker.py submitty_daemon_jobs autograder)
 for i in "${array[@]}"; do
     chown -R root:"${DAEMON_GROUP}" ${SUBMITTY_INSTALL_DIR}/sbin/${i}
     chmod -R 750 ${SUBMITTY_INSTALL_DIR}/sbin/${i}

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -187,6 +187,7 @@ pip3 install paramiko
 pip3 install tzlocal
 pip3 install PyPDF2
 pip3 install distro
+pip3 install requests-html
 
 # for Lichen / Plagiarism Detection
 pip3 install parso

--- a/migration/migrator/migrations/system/20190619222417_generate_grade_summaries_script.py
+++ b/migration/migrator/migrations/system/20190619222417_generate_grade_summaries_script.py
@@ -11,13 +11,3 @@ def up(config):
     :type config: migrator.config.Config
     """
     os.system("pip3 install requests-html")
-
-
-def down(config):
-    """
-    Run down migration (rollback).
-
-    :param config: Object holding configuration details about Submitty
-    :type config: migrator.config.Config
-    """
-    pass

--- a/migration/migrator/migrations/system/20190619222417_generate_grade_summaries_script.py
+++ b/migration/migrator/migrations/system/20190619222417_generate_grade_summaries_script.py
@@ -1,0 +1,23 @@
+"""Migration for the Submitty system."""
+
+import os
+
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    os.system("pip3 install requests-html")
+
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    pass

--- a/sbin/generate_grade_summaries.py
+++ b/sbin/generate_grade_summaries.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Script to trigger the generate grade summaries.
+
+Usage:
+./generate_grade_summaries.py <user_id> <password> <base_url>
+./generate_grade_summaries.py instructor instructor "http://192.168.56.111/"
+"""
+
+import argparse
+import re
+from requests_html import HTMLSession
+
+
+def main():
+    """Run the generate function."""
+    parser = argparse.ArgumentParser(
+        description='Automatically click the Generate Grade Summaries button'
+    )
+    parser.add_argument('user_id')
+    parser.add_argument('password')
+    parser.add_argument('base_url')
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip('/')
+    session = HTMLSession()
+
+    data = {
+        "user_id": args.user_id,
+        "password": args.password
+    }
+    res = session.post('{}/authentication/check_login'.format(base_url), data)
+    res = session.get('{}'.format(base_url))
+    pattern = re.compile(r'.*\/(.*)\/(.*)$')
+
+    for child in res.html.find('.courses-table')[0].find('td'):
+        links = child.absolute_links
+        if len(links) == 0:
+            continue
+        match = pattern.match(list(links)[0])
+        # print("Running grade summaries for {}.{}".format(match[1], match[2]))
+        base = "semester={}&course={}".format(match[1], match[2])
+        action = "component=admin&page=reports&action=summary"
+        session.get('{}/index.php?{}&{}'.format(base_url, base, action))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3711, as currently there was no way to automate "pressing" the grade summaries button.

### What is the new behavior?
A script (that can be hooked up to cron or manually run) that will click the button when passed the appropriate credentials. Script is runnable by the submitty_daemon user.

Runnable by doing:
`/usr/local/submitty/sbin/generate_grade_summaries.py <user_id> <password> <url>`
e.g.:
`/usr/local/submitty/sbin/generate_grade_summaries.py instructor instructor http://192.168.56.111`

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
A future revision of this is probably to save the user credential information into a config file. Additionally, the base_url should also probably be read from a config file at the same time (I had originally written this as a script in SysadminTools, and moved it here as is).

This will probably be modified somewhat once the API is in place, but the gist of it will be very similar/same.