### PR TITLE
Global mobile header/footer, new login, menu and sidebar

### DIFF
--- a/sample_files/site_theme/override.css
+++ b/sample_files/site_theme/override.css
@@ -4,7 +4,7 @@ body {
 }
 
 /* Make the center site have a transparent white bg instead of the blue gradient */
-#site-body {
+main {
     background: rgba(240,240,240, 0.85) !important;
 }
 

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -106,6 +106,9 @@ HTML;
         $this->addVendorCss(FileUtils::joinPaths('jquery-ui', 'jquery-ui.min.css'));
         $this->addVendorCss(FileUtils::joinpaths('bootstrap', 'css', 'bootstrap-grid.min.css'));
         $this->addInternalCss('server.css');
+        $this->addInternalCss('global.css');
+        $this->addInternalCss('menu.css');
+        $this->addInternalCss('sidebar.css');
         $this->addInternalCss('bootstrap.css');
         $this->addInternalCss('diff-viewer.css');
         $this->addInternalCss('glyphicons-halflings.css');
@@ -114,6 +117,7 @@ HTML;
         $this->addVendorJs(FileUtils::joinPaths('jquery-ui', 'jquery-ui.min.js'));
         $this->addInternalJs('diff-viewer.js');
         $this->addInternalJs('server.js');
+        $this->addInternalJs('menu.js');
     }
 
     /**

--- a/site/app/templates/Authentication.twig
+++ b/site/app/templates/Authentication.twig
@@ -1,16 +1,14 @@
-<div class="row">
-    <div class="col-sm"></div>
-    <div class="content" id="login-box">
-        <h1 id="login-guest">Submitty Login</h1>
-        <!--
-        <em>Note: Registered students have not yet been uploaded to the Submitty course databases.  Please check back later.</em>
-        -->
-        <form action="{{ login_url }}" method="post" id="login">
-            <input type="text" name="user_id" onchange="$(this).val($(this).val().trim())" placeholder="User ID" required autofocus/><br />
-            <input type="password" name="password" placeholder="Password" required /><br />
-            <label for="stay_logged_in">Stay Logged In <input type="checkbox" name="stay_logged_in" id="stay_logged_in" checked /></label><br />
-            <input type="submit" name="login" value="Login" class="btn btn-primary" />
-        </form>
-    </div>
-    <div class="col-sm"></div>
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+<div class="content shadow" id="login-box">
+    <h1 id="login-guest">Login</h1>
+    <!--
+    <em>Note: Registered students have not yet been uploaded to the Submitty course databases.  Please check back later.</em>
+    -->
+    <form action="{{ login_url }}" method="post" id="login">
+        <input type="text" name="user_id" onchange="$(this).val($(this).val().trim())" placeholder="User ID" required autofocus/>
+        <input type="password" name="password" placeholder="Password" required />
+        <label for="stay_logged_in">Stay Logged In <input type="checkbox" name="stay_logged_in" id="stay_logged_in" checked /></label>
+        <input type="submit" name="login" value="Login" class="btn btn-primary" />
+    </form>
 </div>

--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -1,38 +1,34 @@
 {% import _self as self %}
 {# Looks mismatched because this is a continuation of GlobalHeader.twig #}
-                    </div> {# /#nav-positioner #}
-                </div> {# /.col-md#nav-body #}
-            </div> {# /.row #}
-            <div id="footer">
-                &copy; {{ "now"|date("Y") }} <a href="https://submitty.org" target="_blank">Submitty</a>
-                <span class="footer_seperator">|</span> <a href="https://github.com/Submitty/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub"><i class="fab fa-github fa-lg"></i></a>
-                <span class="footer_seperator">|</span> <a href="https://rcos.io" target="_blank">An RCOS project</a>
+                </main>
+            </div> {# /#wrapper #}
+            <footer>
+                &copy; {{ "now"|date("Y") }} <a href="https://submitty.org" target="_blank" class="black-btn">Submitty</a>
+                <span class="footer-separator">|</span> <a href="https://github.com/Submitty/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub" class="black-btn"><i class="fab fa-github fa-lg"></i></a>
+                <span class="footer-separator">|</span> <a href="https://rcos.io" target="_blank" class="black-btn">An RCOS project</a>
 
                 {% for link in footer_links %}
-                    <span class="footer_seperator">|</span>
+                    <span class="footer-separator">|</span>
                     {% if link['icon'] is defined %}
-                        <i class="footer_link_icon fa fa-lg {{ link['icon'] }}"></i>
+                        <i class="footer-link-icon fa fa-lg {{ link['icon'] }}"></i>
                     {% endif %}
-                    <a href="{{ link['url'] }}" target="_blank">{{ link['title'] }}</a>
+                    <a href="{{ link['url'] }}" target="_blank" class="black-btn">{{ link['title'] }}</a>
                 {% endfor %}
 
                 {% if is_debug %}
-                    <span class="footer_seperator">|</span>
-                    <a href="#" onClick="togglePageDetails();">Show Page Details</a>
+                    <span class="footer-separator">|</span>
+                    <a href="#" onClick="togglePageDetails();" class="black-btn">Show Page Details</a>
                 {% endif %}
-            </div>
-
-        </div> {# /#site-body #}
+            </footer>
+        </div> {# /#submitty-body #}
         {% if wrapper_urls['right_sidebar.html'] != null %}
             {# uploaded homepage redirect can go here? #}
             <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="right_sidebar" src="{{ wrapper_urls['right_sidebar.html'] }}" frameborder="0"></iframe>
         {% endif %}
-    </div> {# /#center-container #}
     {% if wrapper_urls['bottom_bar.html'] != null %}
         {# uploaded homepage redirect can go here? #}
         <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="bottom_bar" src="{{ wrapper_urls['bottom_bar.html'] }}" frameborder="0"></iframe>
     {% endif %}
-</div> {# /#container #}
 {% if is_debug %}
     <div id='page-info'>
         Runtime: {{ runtime }}<br /><br />

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -20,41 +20,42 @@
 </head>
 <script>var onAjaxInit;</script>
 <body data-site-url="{{ site_url }}" data-csrf-token="{{ core.getCsrfToken() }}" onload="if (onAjaxInit) { onAjaxInit(); }">
-<div id="container">
     {% if wrapper_urls['top_bar.html'] != null %}
         {# uploaded homepage redirect can go here? #}
         <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="top_bar" src="{{ wrapper_urls['top_bar.html'] }}" frameborder="0"></iframe>
     {% endif %}
-    <div id="center-container">
         {% if wrapper_urls['left_sidebar.html'] != null %}
             {# uploaded sidebar can go here? #}
             <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="left_sidebar" src="{{ wrapper_urls['left_sidebar.html'] }}" frameborder="0"></iframe>
         {% endif %}
-        <div id="site-body">
-            <div id='messages'>
-                {% for message in messages %}
-                    <div id='{{ message.type }}-{{ message.key }}' class="inner-message alert alert-{{ message.type }}">
-                        <a class="fas fa-times message-close" onClick="removeMessagePopup('{{ message.type }}-{{ message.key }}');"></a>
-                        {% if message.type == "error" %}
-                        <i class="fas fa-times-circle"></i>
-                        {% else %}
-                        <i class="fas fa-check-circle"></i>
+        {# separates our content from user custom bars #}
+        <div id="submitty-body" class="flex-col">
+            <div id="mobile-menu">
+                <div id="menu-header" class="flex-row">
+                    <h1>Menu</h1>
+                    <button id="menu-exit"><i class="fas fa-times"></i></button>
+                </div>
+                <ul>
+                    {% for button in sidebar_buttons %}
+                        {% if button.getTitle() != "Collapse Sidebar" %}
+                            {{ self.render_sidebar_button(button) }}
                         {% endif %}
-                        {{ message.error }}
-                    </div>
-                {% endfor %}
+                    {% endfor %}
+                </ul>
             </div>
-            <div id="header" class="row">
-                <div class="col-12 col-sm" id="header-text">
-                    <div>
+            <div id="menu-overlay"></div>
+            <nav class="flex-row shadow">
+                <div id="nav-links">
+                    <a id="home-button" class="black-btn" href="{{ core.getConfig().getHomepageUrl() }}" aria-label="Go to Submitty Home"><i class="fas fa-home"></i></a>
+                    <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}
-                                &gt;
+                                <span>&gt;</span> {# span required to give conditional rendering #}
                             {% endif %}
                             {% if b.getUrl() is not empty %}
                                 <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
                             {% else %}
-                                {{ b.getTitle() }}
+                                <span>{{ b.getTitle() }}</span>
                             {% endif %}
                             {% if b.getExternalUrl() is not empty %}
                                 <a class="external" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
@@ -62,79 +63,93 @@
                         {% endfor %}
                     </div>
                 </div>
-                <a class="col-12 col-sm-auto" id="logo-box" href="http://submitty.org" target="_blank" aria-label="Visit submitty dot org">
+                <a class="flex-col" id="logo-box" href="http://submitty.org" target="_blank" aria-label="Visit submitty dot org">
                     <img id="logo-submitty" src="{{ base_url }}/img/submitty_logo.png" alt="Submitty Logo">
                 </a>
-            </div>
-            <noscript>
-                <div class="row noscript">
-                    <span>You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.</span>
-                </div>
+                {# assuming that if sidebar_buttons only has len 2 it contains logout and collapse (on index page only) #}
+                {% if sidebar_buttons|length > 2 %}
+                    <button id="menu-button" class="black-btn">MENU</button>
+                {% elseif sidebar_buttons|length %}
+                    <a id="logout-button" class="black-btn" href="{{ core.buildNewUrl(['authentication', 'logout']) }}"><i class="fas fa-sign-out-alt"></i></a>
+                {% endif %}
+            </nav>
+            <noscript class="system-message danger">
+                You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.
             </noscript>
             {% if system_message is not null and system_message|length > 0 %}
-            <div class="row system_message">
-                <span>{{ system_message }}</span>
+            <div class="system-message warning">
+                {{ system_message }}
             </div>
             {% endif %}
-            <div class="row" id="push">
-                {% if sidebar_buttons|length > 0 %}
-                    <div class="col-md-auto" id="sidebar">
-                        <div id="nav-buttons-visible">
-                            <div id="nav-buttons">
-                                <ul>
-                                    {% for button in sidebar_buttons %}
-                                        {{ self.render_sidebar_button(button) }}
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        </div>
+            <div id='messages'>
+                {% for message in messages %}
+                    <div id='{{ message.type }}-{{ message.key }}' class="inner-message alert alert-{{ message.type }}">
+                        <span>
+                            {% if message.type == "error" %}
+                            <i class="fas fa-times-circle"></i>
+                            {% else %}
+                            <i class="fas fa-check-circle"></i>
+                            {% endif %}
+                            {{ message.error }}
+                        </span>
+                        <a class="fas fa-times" onClick="removeMessagePopup('{{ message.type }}-{{ message.key }}');"></a>
                     </div>
+                {% endfor %}
+            </div>
+            <div id="wrapper">
+                {% if sidebar_buttons|length > 0 %}
+                    <sidebar>
+                        <ul>
+                            {% for button in sidebar_buttons %}
+                                {{ self.render_sidebar_button(button) }}
+                            {% endfor %}
+                        </ul>
+                    </sidebar>
                 {% endif %}
-                <div class="col-md" id="nav-body">
-                    <div id="nav-positioner">
+                <main>
 {# Looks mismatched because this lines up with GlobalFooter.twig #}
 
 {% macro render_sidebar_button(button) %}
     {% if button.getTitle() == "" %}
-        <li class="short-line"></li>
+        <hr />
     {% else %}
         <li>
             {% if button.getHref() == null %}
                 <span
-                    {% if button.getClass() != "" %}
-                        class="{{ button.getClass() }}"
-                    {% endif %}
+                    class="flex-row {{ button.getClass() }}"
                     {% if button.getId() != "" %}
                         id="{{ button.getId() }}"
                     {% endif %}
                 >
-                    {% if button.getIcon() != null %}
-                        <i class="fa {{ button.getIcon() }}"></i>
-                    {% endif %}
+                    <span> {# col in flex-row #}
+                        {% if button.getIcon() != null %}
+                            <i class="fa {{ button.getIcon() }}"></i>
+                        {% endif %}
 
-                    {{ button.getTitle() }}
+                        {{ button.getTitle() }}
+                    </span>
                     {% if button.getBadge() > 0 %}
-                        <span class="notification_badge">{{  button.getBadge() }} </span>
+                        <span class="notification-badge">{{  button.getBadge() }} </span>
                     {% endif %}
                 </span>
             {% else %}
                 <a href="{{ button.getHref() }}"
                     data-toggle="tooltip"
                     title="{{ button.getTitle() }}"
-                    {% if button.getClass() != "" %}
-                        class="{{ button.getClass() }}"
-                    {% endif %}
+                    class="flex-row {{ button.getClass() }}"
                     {% if button.getId() != "" %}
                         id="{{ button.getId() }}"
                     {% endif %}
                 >
-                    {% if button.getIcon() != null %}
-                        <i class="fa {{ button.getIcon() }}"></i>
-                    {% endif %}
+                    <span> {# col in flex-row #}
+                        {% if button.getIcon() != null %}
+                            <i class="fa {{ button.getIcon() }}"></i>
+                        {% endif %}
 
-                    <span class="iconTitle"> {{ button.getTitle() }} </span>
+                        <span class="iconTitle"> {{ button.getTitle() }} </span>
+                    </span>
                     {% if button.getBadge() > 0 %}
-                        <span class="notification_badge">{{  button.getBadge() }} </span>
+                        <span class="notification-badge">{{  button.getBadge() }} </span>
                     {% endif %}
                 </a>
 

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -92,7 +92,7 @@
             {% endif %}
         >
             {% if button.getBadge() > 0 %}
-                <span class="notification_badge">{{  button.getBadge() }} </span>
+                <span class="notification-badge">{{  button.getBadge() }} </span>
             {% endif %}
 
             {% if not button.isTitleOnHover() and button.getTitle() != null %}

--- a/site/app/views/AuthenticationView.php
+++ b/site/app/views/AuthenticationView.php
@@ -7,6 +7,9 @@ class AuthenticationView extends AbstractView {
         if (!isset($old)) {
             $old = urlencode($this->core->buildNewUrl(['home']));
         }
+        $this->core->getOutput()->addInternalCss("input.css");
+        $this->core->getOutput()->addInternalCss("links.css");
+        $this->core->getOutput()->addInternalCss("authentication.css");
         return $this->core->getOutput()->renderTwigTemplate("Authentication.twig", [
             "login_url" => $this->core->buildNewUrl(['authentication', 'check_login']) . '?' . http_build_query(['old' => $old])
         ]);

--- a/site/public/css/authentication.css
+++ b/site/public/css/authentication.css
@@ -1,0 +1,45 @@
+#login-box h1 {
+    margin: 0 0 20px !important;
+}
+
+#login {
+    margin: 0;
+}
+
+#login > * {
+    margin-bottom: 1em;
+    width: 100%;
+    font-size: 1.1em;
+}
+
+#login label {
+    display: flex;
+    align-items: center;
+}
+
+#login input[type="text"],
+#login input[type="password"] {
+    padding: 1.1em;
+}
+
+#login input[type="submit"] {
+    padding: 0.5em 1em;
+}
+
+@media (min-width: 541px) {
+    
+}
+
+@media (min-width: 768px) {
+    #login-box {
+        margin: 30px auto;
+        min-width: 450px;
+        width: 30%;
+        height: fit-content;
+        height: -moz-fit-content;    
+    }
+
+    #login input[type="submit"] {
+        width: auto;
+    }
+}

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -1,0 +1,140 @@
+body {
+    font-family: 'Source Sans Pro', sans-serif;
+    margin: 0;
+    height: 100%;
+    width: 100%;
+    min-height: 100%;
+    min-width: 100%;
+    position: relative;
+    display: flex;
+    background: #f6fbfe;
+}
+
+#submitty-body {
+    flex: 1 1 auto;
+}
+
+nav {
+    background: #ffffff;
+    font-size: 1.5em;
+    font-weight: bold;
+}
+
+nav a,
+nav a:link,
+nav a:visited {
+    color: #000;
+    text-decoration: underline;
+}
+
+nav a:hover {
+    text-decoration: none;
+}
+
+nav a > i.fa, 
+nav a > i.fas, 
+nav a > i.f {
+    font-size: 20px;
+}
+
+#nav-links {
+    display: flex;
+    align-items: center;
+    padding: 15px;
+    flex-grow: 1;
+}
+
+#home-button {
+    margin-right: 15px;
+}
+
+#breadcrumbs {
+    display: flex;
+}
+
+#breadcrumbs > *:not(:last-child) {
+    padding-right: 7px;
+    display: none;
+}
+
+#logout-button {
+    margin: 15px;
+}
+
+#logo-submitty {
+    display: none;
+}
+
+.system-message {
+    width: 100%;
+    text-align: center;
+    margin: auto;
+    font-size: 1.5em;
+    font-weight: bold;
+}
+
+.inner-message {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 !important;
+    padding: 8px 14px !important;
+}
+
+#wrapper {
+    flex-grow: 1;
+    display: flex;
+}
+
+main {
+    display: flex;
+    height: 100%;
+    flex-grow: 1;
+    flex-direction: column;
+}
+
+footer {
+    position: relative;
+    clear: both;
+    margin-top: auto;
+    text-align: center;
+    padding: 10px;
+}
+
+footer a {
+    text-decoration: none !important;
+}
+
+footer .footer-separator {
+    padding: 0 8px;
+}
+
+@media (min-width: 541px) {
+    #home-button, #logout-button {
+        display: none;
+    }
+
+    #logo-submitty {
+        display: block;
+        height: 80px;
+    }
+
+    /* specificity less than no @media since :not stated (for speed) */
+    #breadcrumbs > * {
+        display: block !important;
+    }
+
+    #messages {
+        z-index: 999;
+        position: fixed;
+        top: 40px;
+        left: 50%;
+        width: 30%;
+        min-width: 450px;
+        transform: translateX(-50%);
+    }
+}
+
+@media (min-width: 768px) {
+    
+}

--- a/site/public/css/input.css
+++ b/site/public/css/input.css
@@ -1,0 +1,85 @@
+select,
+textarea,
+input[type="text"],
+input[type="password"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="date"],
+input[type="month"],
+input[type="time"],
+input[type="week"],
+input[type="number"],
+input[type="email"],
+input[type="url"],
+input[type="search"],
+input[type="tel"],
+input[type="color"] {
+    height: 30px;
+    padding: 4px 6px;
+    font-size: 14px;
+    line-height: 20px;
+    color: #555555;
+    vertical-align: middle;
+    border: 1px solid #ccc;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    width: auto;
+}
+
+input.readonly {
+    background-color: #f2f2f2;
+    cursor: not-allowed;
+}
+
+select {
+    padding: 5px 35px 5px 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    height: 34px;
+    background: #FFF;
+    background-size: 20px;
+}
+
+input[type="checkbox"]{
+    cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background: #FFF;
+    box-sizing: border-box;
+    width: 20px;
+    height: 20px;
+    border: 1px solid #000000;
+    transition: all .2s linear;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+}
+
+input[type="checkbox"]:checked{
+    background-color: #3093FC;
+}
+
+/* this requires loading the FontAwesome CSS from the CDN before loading the server.css */
+input[type="checkbox"]:checked:before {
+    font-family: 'Font Awesome\ 5 Free';
+    content: "\f00c";
+    color: #FFF;
+    font-size: 18px;
+    font-weight: 900
+}
+
+.helpicon::before {
+  font-family: 'Font Awesome 5 Free';
+  content: "\f059";
+  color: #1E90FF;
+  font-weight: 300;
+  display: inline-block;
+}
+
+select.disabled,
+textarea.disabled,
+input.disabled {
+    background-color: lightgrey;
+}

--- a/site/public/css/links.css
+++ b/site/public/css/links.css
@@ -1,0 +1,88 @@
+a, a:hover, a:link, a:visited {
+    cursor: pointer;
+}
+
+a,
+a:visited,
+a:link,
+a.fa:hover,
+a > i.fa:hover {
+    color: #2627ee;
+}
+a,
+a:visited,
+a:link,
+a.fas:hover,
+a > i.fas:hover {
+    color: #2627ee;
+}
+a,
+a:visited,
+a:link,
+a.far:hover,
+a > i.far:hover {
+    color: #2627ee;
+}
+
+a:hover {
+    color: #131399;
+}
+a:active {
+    color: #991313;
+}
+
+a.btn-success, a.btn-primary, a.btn-danger,
+a.fa.btn-success, a.btn-primary, a.btn-danger,
+a.btn-success > i.fa, a.btn-primary > i.fa, a.btn-danger > i.fa {
+    color: #fff;
+}
+a.btn-success, a.btn-primary, a.btn-danger,
+a.fas.btn-success, a.btn-primary, a.btn-danger,
+a.btn-success > i.fas, a.btn-primary > i.fas, a.btn-danger > i.fas {
+    color: #fff;
+}
+a.btn-success, a.btn-primary, a.btn-danger,
+a.far.btn-success, a.btn-primary, a.btn-danger,
+a.btn-success > i.far, a.btn-primary > i.far, a.btn-danger > i.far {
+    color: #fff;
+}
+
+a.btn-default,
+a.fa.btn-default,
+a.fa,
+a > i.fa {
+    color: #000;
+}
+
+a.btn-default,
+a.fas.btn-default,
+a.fas,
+a > i.fas {
+    color: #000;
+}
+
+a.btn-default,
+a.far.btn-default,
+a.far,
+a > i.far {
+    color: #000;
+}
+
+a.btn {
+    text-decoration: none;
+}
+
+.black-btn, .black-btn > i.fas {
+    color: #000 !important;
+    border-color: #000 !important;
+}
+
+.black-btn:hover, .black-btn > i.fas:hover {
+    color: #405E90 !important;
+    border-color: #405E90 !important;
+}
+
+.black-btn:active, .black-btn > i.fas:active {
+    color: #991313 !important;
+    border-color: #991313 !important;
+}

--- a/site/public/css/menu.css
+++ b/site/public/css/menu.css
@@ -1,0 +1,89 @@
+#menu-button {
+    border: 1px solid #000;
+    border-radius: 3px;
+    background: transparent;
+    margin: 15px;
+    padding: 6px 12px;
+}
+
+#mobile-menu {
+    display: none;
+    z-index: 2;
+    position: absolute;
+    height: 100%;
+    width: 90%;
+    background: #316498;
+    color: #FFF;
+    border-color: #FFF;
+    line-height: 31px;
+    list-style-type: none;
+    overflow-y: auto;
+    right: 0;
+    animation-duration: 0.5s;
+    animation-name: slideFromRight;
+}
+
+@keyframes slideFromRight {
+    from {
+        right: -100%;
+    }
+
+    to {
+        right: 0;
+    }
+}
+
+#mobile-menu a, #mobile-menu .fa {
+    text-decoration: none;
+    color: #FFF;
+    font-size: 20px;
+    width: 30px;
+    text-align: center;
+}
+
+#mobile-menu ul {
+    padding: 1em 0;
+    margin: 0;
+}
+
+#mobile-menu li {
+    padding: 10px;
+}
+
+#mobile-menu hr {
+    border-color: #FFF;
+}
+
+#menu-header {
+    border-bottom: 2px solid #FFF;
+}
+
+#menu-header h1 {
+    margin: 0;
+}
+
+#menu-header > * {
+    padding: 15px;
+}
+
+#menu-overlay {
+    display: none;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0,0,0,.55);
+    z-index: 1;
+}
+
+#menu-exit {
+    background: none;
+    border: none;
+    color: #FFF;
+    font-size: 31px;
+}
+
+@media (min-width: 541px) {
+    #menu-button {
+        display: none;
+    }
+}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1,34 +1,9 @@
 @import url("reset.css");
 @import url("google/inconsolata.css");
 
-html {
-    height: 100%;
-}
-
-body {
-    font-family: 'Source Sans Pro', sans-serif;
-    height: 100%;
-    width: 100%;
-    position: relative;
-}
 :root {
     --viewed_content: #e8f0f7;
 }
-#site-body {
-    /* OLD SEAFOAM GREEN COLOR */
-    /* background-color: #B6CECE; */
-
-    /* Submitty Logo blue */
-    background-color: #f6fbfe;
-
-    width: 100%;
-    /* A lighter shade of blue grey */
-    /* background: #b8d5e5; */
-    /* a gradient! */
-    /* background: linear-gradient(#0a6496, #b8d5e5); */
-    background-attachment: fixed;
-}
-
 a, a:hover, a:link, a:visited {
     cursor: pointer;
 }
@@ -36,9 +11,6 @@ a, a:hover, a:link, a:visited {
 a,
 a:visited,
 a:link,
-a.external,
-a.external:visited,
-a.external:link,
 a.fa:hover,
 a > i.fa:hover {
     color: #2627ee;
@@ -46,9 +18,6 @@ a > i.fa:hover {
 a,
 a:visited,
 a:link,
-a.external,
-a.external:visited,
-a.external:link,
 a.fas:hover,
 a > i.fas:hover {
     color: #2627ee;
@@ -56,62 +25,58 @@ a > i.fas:hover {
 a,
 a:visited,
 a:link,
-a.external,
-a.external:visited,
-a.external:link,
 a.far:hover,
 a > i.far:hover {
     color: #2627ee;
 }
 
-a:hover,
-a.external:hover {
+a:hover {
     color: #131399;
 }
-a:active,
-a.external:active {
+a:active {
     color: #991313;
 }
 
 a.btn-success, a.btn-primary, a.btn-danger,
 a.fa.btn-success, a.btn-primary, a.btn-danger,
 a.btn-success > i.fa, a.btn-primary > i.fa, a.btn-danger > i.fa {
-    color: #ffffff;
+    color: #fff;
 }
 a.btn-success, a.btn-primary, a.btn-danger,
 a.fas.btn-success, a.btn-primary, a.btn-danger,
 a.btn-success > i.fas, a.btn-primary > i.fas, a.btn-danger > i.fas {
-    color: #ffffff;
+    color: #fff;
 }
 a.btn-success, a.btn-primary, a.btn-danger,
 a.far.btn-success, a.btn-primary, a.btn-danger,
 a.btn-success > i.far, a.btn-primary > i.far, a.btn-danger > i.far {
-    color: #ffffff;
+    color: #fff;
 }
 
 a.btn-default,
 a.fa.btn-default,
 a.fa,
 a > i.fa {
-    color: #000000;
+    color: #000;
 }
+
 a.btn-default,
 a.fas.btn-default,
 a.fas,
 a > i.fas {
-    color: #000000;
+    color: #000;
 }
+
 a.btn-default,
 a.far.btn-default,
 a.far,
 a > i.far {
-    color: #000000;
+    color: #000;
 }
 
 a.btn {
     text-decoration: none;
 }
-
 
 /****************************
  * INPUT STYLES
@@ -206,9 +171,6 @@ input.disabled {
 /****************************
  * TABLE STYLES
  ***************************/
-table {
-}
-
 table a{
     text-decoration: none;
 }
@@ -221,10 +183,6 @@ table tr.table-header {
     width: 100%;
     text-align: center;
     border-collapse: collapse;
-}
-
-.table tr {
-
 }
 
 .table td {
@@ -302,152 +260,12 @@ table tr.table-header {
 
 /**********************************************************/
 
-#container {
-    min-height: 100%;
-    margin: 0 auto -60px;
-}
-
 .full_height {
     max-height: 100%;
 }
 
-#header.full_height {
-    min-height: fit-content;
-    min-height: -moz-fit-content;
-}
-
-#nav {
-    background-color: #000000;
-    color: #FFFFFF;
-    width: 100%;
-    left: 0;
-    top: 0;
-    z-index: 999;
-    font-size: 15px;
-    font-weight: 600;
-    margin-left:-1px;
-}
-
-#nav ul {
-  background-color: #000000;
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-  list-style-type: none;
-
-}
-
-#nav li {
-    float: left;
-}
-
-#nav li:hover, .dropdown:hover .dropbtn {
-    background-color: gray;
-    cursor: pointer;
-}
-
-#nav li a, .dropbtn {
-    color: #FFFFFF;
-    text-decoration: none;
-    /*display: inline-block;*/
-    display: block;
-    padding: 5px 10px;
-}
-
-#nav li a:hover {
-    text-decoration: none;
-}
-
-#nav li.dropdown {
-    display: inline-block;
-}
-
-#nav .dropdown-content {
-    display: none;
-    position: absolute;
-    background-color: #f9f9f9;
-    width: 160px;
-    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
-}
-
-#nav .dropdown-content a {
-    color: black;
-    padding: 12px 16px;
-    text-decoration: none;
-    text-align: left;
-}
-
-#nav .dropdown-content a:hover {
-    background-color: #d1d1d1;
-    width: 130px;
-}
-
-#nav .dropdown:hover .dropdown-content {
-    display: block;
-}
-
-#header {
-    background-color: #ffffff;
-    box-shadow: 0 2px 10px -5px #888888;
-    /* min-height: 125px; */
-    height: auto;
-    width: 100%;
-    overflow: hidden;
-}
-
-#header-text {font-weight: 300;display: flex;/* width: 100%; */align-items: center;}
-
-#header a,
-#header a:link,
-#header a:visited {
-    color: #000;
-    text-decoration: underline;
-}
-
-#header a:hover {
-    text-decoration: none;
-}
-
-#header a > i.fa {
-    font-size: 20px;
-}
-#header a > i.fas {
-    font-size: 20px;
-}
-#header a > i.far {
-    font-size: 20px;
-}
-
-#header-text>div {
-    display: block;
-    font-size: 1.5em;
-    font-weight: bold;
-}
-
 .text-center {
     text-align: center;
-}
-
-#logo-submitty {
-    height: 80px;
-}
-
-@media (min-width: 357px) {
-    #logo-submitty {
-        float: right;
-        margin-right: -15px;
-    }
-}
-@media (max-width: 356px) {
-    #logo-box {
-        margin: 0;
-        padding: 0;
-    }
-    #logo-submitty {
-        width: 100%;
-        height: auto;
-        background-size: contain;
-    }
 }
 
 .content {
@@ -494,40 +312,6 @@ table tr.table-header {
     font-size: smaller;
     word-wrap: unset;
     white-space: normal;
-}
-
-#footer {
-    margin-top: -10px;
-    z-index: 20;
-    width: 100%;
-    padding: 5px 0 10px 0;
-    text-align: center;
-    clear: both;
-}
-
-#push {
-    flex-grow: 1;
-}
-
-#footer a {
-    color: #000000;
-    text-decoration: none;
-}
-
-#footer a:hover {
-    color: #405E90;
-}
-
-#footer .footer_seperator {
-    padding-right: 8px;
-    padding-left: 8px;
-}
-
-#footer .footer_link_icon {
-    padding-right: 4px;
-}
-
-.sub {
 }
 
 .sub::after {
@@ -594,19 +378,6 @@ table tr.table-header {
     align-items: center;
 }
 
-#alerts {
-    z-index: 9999;
-}
-
-#messages {
-    z-index: 999;
-	position: fixed;
-    top: 40px;
-    left: 50%;
-    width: 40%;
-    margin-left: -20%;
-}
-
 .inner-message {
     margin: 0 auto 10px;
 }
@@ -628,9 +399,6 @@ table tr.table-header {
 
 .option-alt {
     font-style: italic;
-}
-
-.option-input {
 }
 
 .option-input > textarea,
@@ -657,20 +425,6 @@ table tr.table-header {
 .post-panel-btn {
     height: 20px;
     padding-right: 10px;
-}
-
-#login-box {
-    min-width: 300px;
-    flex-grow: 1;
-}
-
-#login {
-}
-
-#login input[type="text"],
-#login input[type="password"] {
-    width: 100%;
-    margin-bottom: 5px;
 }
 
 .label {
@@ -891,21 +645,6 @@ table tr.table-header {
     padding-bottom:10px;
     padding-right:10px;
     padding-left:10px;
-}
-
-.notification_badge{
-    background-color: red;
-    float: right;
-    padding-left: 5px;
-    padding-right: 5px;
-    margin-left: 5px;
-    border-radius: 2px;
-    color: white;
-    font-weight: bold;
-}
-
-#header #login a.btn-primary {
-    color: white;
 }
 
 #forum_wrapper{
@@ -1317,164 +1056,11 @@ table .instructor .two-options{
 	width: 15%;
 }
 
-#nav-body {
-    margin-top: 15px;
-    margin-left: 30px;
-    display: flex;
-    flex-direction: column;
-}
-
-#nav-positioner {
-    margin-left: -30px;
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-}
-
-#nav-buttons {
-    width: 230px;
-    display: flex;
-    flex-direction: column;
-    align-content: center;
-    justify-items: center;
-    padding: 20px;
-    margin-left: -5px;
-    padding-top: 30px;
-}
-
 div.full_height {
     position: -webkit-sticky; /* Safari */
     position: sticky;
     max-height: 95vh;
     top: 10px;
-}
-
-#sidebar.collapsed #nav-buttons {
-    width: 30px;
-}
-
-#sidebar.collapsed #nav-buttons-visible {
-    width: 60px;
-    overflow: hidden;
-    margin-left: -15px;
-    padding-left: 15px;
-}
-
-#sidebar {
-    width: 220px;
-    margin: 0;
-}
-
-#sidebar.animate {
-    transition: 0.3s ease-out;
-}
-
-#sidebar.collapsed {
-    width: 0;
-}
-
-#nav-buttons ul li {
-    list-style: none;
-    margin-bottom: -2px;
-    margin-left: -30px;
-    margin-right: -30px;
-}
-
-#nav-buttons ul li a.nav-row.selected {
-    background-color: #d9e1e2;
-    font-weight: bold;
-    color: #000000;
-}
-
-#nav-buttons ul li .nav-row {
-    padding: 6px;
-    padding-left: 48px;
-    width: 100%;
-    display: block;
-}
-
-#sidebar.collapsed #nav-buttons ul li .nav-row .iconTitle{
-    display: none;
-}
-
-#sidebar.collapsed #nav-buttons ul li .nav-row .fa{
-    padding: 2px 0px;
-}
-
-#sidebar.collapsed #nav-buttons ul li .nav-row .notification_badge {
-    font-size: 12px;
-    margin-top: -12px;
-    text-align: right;
-    position: relative; /* So it goes on top */
-}
-
-#nav-buttons ul li a.nav-row {
-    color: #006398;
-    text-decoration: none;
-}
-
-#nav-buttons ul li a.nav-row:hover {
-    color: #002334;
-}
-
-#nav-buttons ul li a.nav-row:active {
-    color: #790000;
-}
-
-#nav-buttons ul li a.nav-row i.fa {
-    color: #000000;
-}
-#nav-buttons ul li a.nav-row i.fas {
-    color: #000000;
-}
-#nav-buttons ul li a.nav-row i.far {
-    color: #000000;
-}
-
-#nav-buttons ul li .nav-row i.fa {
-    margin-left: -33px;
-    width: 30px;
-    text-align: center;
-}
-#nav-buttons ul li .nav-row i.fas {
-    margin-left: -33px;
-    width: 30px;
-    text-align: center;
-}
-#nav-buttons ul li .nav-row i.far {
-    margin-left: -33px;
-    width: 30px;
-    text-align: center;
-}
-
-#nav-buttons ul li.line {
-    border-bottom: 1px solid #bbb;
-    padding-bottom: 0;
-    margin-left: -20px;
-    margin-right: -20px;
-    margin-bottom: -10px;
-}
-
-#nav-buttons ul li.short-line {
-    border-bottom: 1px solid #aaaaaa;
-    margin-left: 6px;
-    margin-right: 10px;
-    padding-bottom: 0;
-    margin-top: 6px;
-    margin-bottom: 4px;
-    height: initial;
-}
-
-#sidebar.collapsed #nav-buttons ul li.short-line {
-    margin-left: -30px;
-    width: 100px
-}
-
-#nav-buttons ul li.heading {
-    margin-left: -15px;
-    font-weight: bold;
-    font-variant: all-small-caps;
-    font-size: 20px;
 }
 
 .spacer {
@@ -1778,8 +1364,6 @@ textarea.comment_display {
     background: #e1e1e1;
 }
 
-
-
 /*
 end of styles used in the admin gradeable page
 */
@@ -1902,37 +1486,6 @@ end of styles used in the admin gradeable page
     border-radius: 5px;
 }
 
-/* Site Wrapper */
-
-#container {
-    display: flex;
-    flex-direction: column;
-}
-
-#container #center-container {
-    display: flex;
-    flex-direction: row;
-    flex-grow: 1;
-}
-
-#site-body {
-    flex-grow: 2;
-    display: flex;
-    flex-direction: column;
-}
-
-#site-body > .row {
-    flex-wrap: nowrap;
-}
-
-#container iframe#top_bar, #container iframe#bottom_bar {
-    height: 60px;
-}
-
-#container iframe#left_sidebar, #container iframe#right_sidebar {
-    width: 200px;
-}
-
 /* Site Wrapper View */
 
 .wrapper-example {
@@ -1994,10 +1547,6 @@ end of styles used in the admin gradeable page
     text-align: right;
 }
 
-#header .fa-external-link {
-    margin-left: 10px;
-}
-
 .courses-table {
     width: 100%;
 }
@@ -2008,31 +1557,6 @@ end of styles used in the admin gradeable page
 
 .editor {
     width: 75%;
-}
-
-.noscript,
-.system_message {
-    width: 100%;
-    height: 2em;
-}
-
-.system_message {
-    background: #fff3cd;
-    color: #856404;
-    height: 2em;
-}
-
-.noscript {
-    background: #f2dede;
-    color: #b94a48;
-}
-
-.noscript span,
-.system_message span {
-    text-align: center;
-    margin: auto;
-    font-size: 1.5em;
-    font-weight: bold;
 }
 
 .scrollable-image{
@@ -2090,4 +1614,64 @@ end of styles used in the admin gradeable page
     background-color: #00000000;
     border: 0px;
     padding: 0px;
+}
+
+.warning {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.danger {
+    background: #f2dede;
+    color: #b94a48;
+}
+
+.black-btn, .black-btn > i.fas {
+    color: #000 !important;
+    border-color: #000 !important;
+}
+
+.black-btn:hover, .black-btn > i.fas:hover {
+    color: #405E90 !important;
+    border-color: #405E90 !important;
+}
+
+.black-btn:active, .black-btn > i.fas:active {
+    color: #991313 !important;
+    border-color: #991313 !important;
+}
+
+.flex-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.flex-row > * {
+    display: inherit;
+    align-items: inherit;
+}
+
+.flex-col {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+}
+
+.shadow {
+    box-shadow: 0 2px 15px -5px #888888;
+    border-radius: 3px;
+}
+
+.content {
+    margin: 10px;;
+    padding: 30px;
+    background-color: #ffffff;
+    flex-grow: 0 !important; /* last-child set to 1 in server.css */
+}
+
+@media (min-width: 541px) {
+    .content {
+        margin: 30px;
+    }
 }

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -1,0 +1,101 @@
+sidebar {
+    display: none;
+}
+
+@media (min-width: 541px) {
+    sidebar {
+        display: block;
+        margin: 0 -30px 0 0;
+        transition: width 0.3s ease-out;
+        padding-top: 30px;
+        margin-right: -30px;
+        width: 250px;
+    }
+
+    sidebar hr {
+        margin: 6px 15px;
+    }
+
+    sidebar i  {
+        color: #000;
+        width: 30px;
+        min-width: 30px;
+        text-align: center;
+        margin: 0 0 0 15px;
+    }
+
+    sidebar li {
+        list-style: none;
+    }
+        
+    sidebar li .nav-row {
+        padding: 6px 0;
+        width: 100%;
+        display: flex;
+    }
+
+    sidebar li.heading {
+        font-weight: bold;
+        font-variant: all-small-caps;
+        font-size: 20px;
+    }    
+
+    .iconTitle {
+        margin-right: 15px;
+        min-width: 100%;
+    }
+
+    .notification-badge {
+        background-color: red;
+        padding: 0 5px;
+        margin: 0 6px;
+        color: white;
+        font-weight: bold;
+        border-radius: 2px;
+    }
+
+    sidebar a {
+        text-decoration: none;
+    }
+        
+    sidebar a .iconTitle {
+        color: #006398;
+    }
+    
+    sidebar a .iconTitle:hover {
+        color: #002334;
+    }
+    
+    sidebar a .iconTitle:active {
+        color: #790000;
+    }
+
+    sidebar li .selected {
+        background-color: #d9e1e2;
+    }
+
+    sidebar a.selected .iconTitle {
+        color: #000;
+        font-weight: bold;
+    }
+
+    sidebar.collapsed {
+        width: 60px;
+    }
+
+    sidebar.collapsed .iconTitle {
+        display: none;
+    }
+    
+    sidebar.collapsed i {
+        padding: 2px 0px;
+        margin: 0 15px;
+    }
+    
+    /* put it on top of the icon */
+    sidebar.collapsed .notification-badge {
+        font-size: 12px;
+        position: absolute;
+        margin: 12px 0 0 32px;
+    }
+}

--- a/site/public/js/menu.js
+++ b/site/public/js/menu.js
@@ -1,0 +1,18 @@
+$(document).ready(function() {
+    function openMenu() {
+        $("body").css("overflow", "hidden");
+        window.scroll(0, 0);
+        $("#menu-overlay").css("display", "block");
+        $("#mobile-menu").css("display", "block");
+    }
+    
+    function closeMenu() {
+        $("body").css("overflow", "unset");
+        $("#menu-overlay").css("display", "none");
+        $("#mobile-menu").css("display", "none");
+    }
+
+    $("#menu-button").click(openMenu);
+    $("#menu-exit").click(closeMenu);
+    $("#menu-overlay").click(closeMenu);
+}); 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -2661,19 +2661,17 @@ $.fn.isInViewport = function() {                                        // jQuer
 function checkSidebarCollapse() {
     var size = $(document.body).width();
     if (size < 1000) {
-        $("#sidebar").toggleClass("collapsed", true);
+        $("sidebar").toggleClass("collapsed", true);
     }
     else{
-        $("#sidebar").toggleClass("collapsed", false);
+        $("sidebar").toggleClass("collapsed", false);
     }
 }
 
 //Called from the DOM collapse button, toggle collapsed and save to localStorage
 function toggleSidebar() {
-    var sidebar = $("#sidebar");
+    var sidebar = $("sidebar");
     var shown = sidebar.hasClass("collapsed");
-
-    sidebar.addClass("animate");
 
     localStorage.sidebar = !shown;
     sidebar.toggleClass("collapsed", !shown);
@@ -2684,7 +2682,7 @@ $(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip({
         position: { my: "right+0 bottom+0" },
         content: function () {
-            if($("#sidebar").hasClass("collapsed")) {
+            if($("sidebar").hasClass("collapsed")) {
                 if ($(this).attr("title") === "Collapse Sidebar") {
                     return "Expand Sidebar";
                 }
@@ -2699,7 +2697,7 @@ $(document).ready(function() {
     //Remember sidebar preference
     if (localStorage.sidebar !== "") {
         //Apparently !!"false" === true and if you don't cast this to bool then it will animate??
-        $("#sidebar").toggleClass("collapsed", localStorage.sidebar === "true");
+        $("sidebar").toggleClass("collapsed", localStorage.sidebar === "true");
     }
 
     //If they make their screen too small, collapse the sidebar to allow more horizontal space

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -460,8 +460,8 @@ function toggleDiscussion() {
 }
 
 function resetModules() {
-    var width = $("#nav-positioner").width();
-    var height = $("#nav-positioner").height();
+    var width = $("main").width();
+    var height = $("main").height();
 
     $('.grading_toolbar .fa-list').addClass('icon-selected');
     $("#autograding_results").attr("style", "z-index:30; left:0; top:60%; width:48%; height:40%; display:block;");

--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -147,7 +147,7 @@ class BaseTestCase(unittest.TestCase):
     # clicks the navigation header text to 'go back' pages
     # for homepage, selector can be gradeable list
     def click_header_link_text(self, text, loaded_selector):
-        self.driver.find_element_by_xpath("//div[@id='header-text']/div[1]/a[text()='{}']".format(text)).click()
+        self.driver.find_element_by_xpath("//div[@id='breadcrumbs']/div[1]/a[text()='{}']".format(text)).click()
         WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(EC.presence_of_element_located(loaded_selector))
 
 


### PR DESCRIPTION
- Reorganized global header and footing HTML structure for better semantics, more modular styling, and mobile compatibility
- Created new stylesheets for globalheader/globalfooter, the sidebar, the menu, and the authentication page
- Mobile header displays home button, only the latest breadcrumb, and a menu / logout button depending on the page
- Reworked the sidebar to work with the new mobile structure
- Mobile menu replaces sidebar on phones
- Cleaned css that does not meet our guidelines

To trigger mobile display on the authentication page, I added viewport control in the twig file so it uses mobile styling on phones. This is currently not used on any other page because I want to manually ensure their functionality is maintained. It is bad form to have a meta tag inside the body like this, but I don't want to make mobile truly active on every page until we're sure it works. If someone significantly scales down their browser, the changes will become noticeable - but it shouldn't affect anyone on their phones yet.