### PR TITLE
[Bugfix] Display categories when editing forum threads

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -318,6 +318,7 @@ class ForumThreadView extends AbstractView {
         }
 
         $return = $this->core->getOutput()->renderTwigTemplate("forum/ShowForumThreads.twig", [
+            "categories" => $categories,
             "filterFormData" => $filterFormData,
             "button_params" => $button_params,
             "thread_exists" => $threadExists,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Categories do not show up in the thread editing form.
![Screenshot from 2019-06-22 15-59-00](https://user-images.githubusercontent.com/20266703/59961171-b3c6bf80-9506-11e9-8700-5386eb4e4b6c.png)

### What is the new behavior?
Now categories are displayed correctly like before
![Screenshot from 2019-06-22 16-00-24](https://user-images.githubusercontent.com/20266703/59961179-dd7fe680-9506-11e9-9c81-c20424df5ccf.png)
.
