### PR TITLE
[Refactor] Twig cleanup: Remove core.getCsrfToken() from twig files

### DIFF
--- a/site/app/templates/ChangePasswordForm.twig
+++ b/site/app/templates/ChangePasswordForm.twig
@@ -3,7 +3,7 @@
 {% block title %}Change Password{% endblock %}
 {% block body %}
     <p>&emsp;</p>
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <div>
         <label for="new_password">Password:</label> <input type="password" name="new_password" id="new_password" />
         <label for="confirm_new_password">Confirm:</label> <input type="password" name="confirm_new_password" id="confirm_new_password" />

--- a/site/app/templates/EditNameForm.twig
+++ b/site/app/templates/EditNameForm.twig
@@ -8,7 +8,7 @@
        a preferred name if it contains inappropriate or offensive language,
        or is being used for misrepresentation.</p>
     <p>&emsp;</p>
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <div>
     	<label for="user_firstname_change">Preferred First Name:&emsp;</label>
         <input type="text" name="user_firstname_change" value="{{ user_first }}" id="user_firstname_change" /><br /><br />

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -19,7 +19,7 @@
     {% endfor %}
 </head>
 <script>var onAjaxInit;</script>
-<body data-site-url="{{ site_url }}" data-csrf-token="{{ core.getCsrfToken() }}" onload="if (onAjaxInit) { onAjaxInit(); }">
+<body data-site-url="{{ site_url }}" data-csrf-token="{{ csrf_token }}" onload="if (onAjaxInit) { onAjaxInit(); }">
 <div id="container">
     {% if wrapper_urls['top_bar.html'] != null %}
         {# uploaded homepage redirect can go here? #}

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -4,7 +4,7 @@
         <a href="{{ theme_url }}" class="btn btn-default">Customize Website Theme</a>
     </span>
     <div id="config">
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
 
         <div class="heading">
             <h2>Course Info</h2>

--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -2,7 +2,7 @@
 <div class="content">
     <h1>Excused Absence Extensions</h1>
     <form id="excusedAbsenceForm" method="post" enctype="multipart/form-data" action="" onsubmit="return updateHomeworkExtensions($(this));">
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <input type="hidden" name="option" value="-1" />
         <div class="option">
             <p> Use this form to grant an extension (e.g., for an excused absence) to a user on a specific assignment.<br><br><br></p>
@@ -16,7 +16,7 @@
                 <p>Due Date: <span id ="due_date"></span></p>
             </div>
         </div>
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div class="option-title">Single Student Entry<br></div>
         <div class="option" style="width:25%; display:inline-block;"><label for="user_id">Student ID:</label><br>
             <input class="option-input" type="text" name="user_id" id="user_id" style="float:left">

--- a/site/app/templates/admin/LateDays.twig
+++ b/site/app/templates/admin/LateDays.twig
@@ -2,7 +2,7 @@
 <div class="content">
     <h1>Late Days Allowed</h1>
     <form id="lateDayForm" method="post" enctype="multipart/form-data" onsubmit="return updateLateDays($(this));">
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_tokeeen }}" />
         <p> Use this form to grant students additional late days (beyond the initial number specified in the course configuration).<br>
             Students may use these additional late days for any future homeworks (after the specificed date).<br><br><br>
         </p>

--- a/site/app/templates/admin/LateDays.twig
+++ b/site/app/templates/admin/LateDays.twig
@@ -2,7 +2,7 @@
 <div class="content">
     <h1>Late Days Allowed</h1>
     <form id="lateDayForm" method="post" enctype="multipart/form-data" onsubmit="return updateLateDays($(this));">
-        <input type="hidden" name="csrf_token" value="{{ csrf_tokeeen }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <p> Use this form to grant students additional late days (beyond the initial number specified in the course configuration).<br>
             Students may use these additional late days for any future homeworks (after the specificed date).<br><br><br>
         </p>

--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -22,7 +22,7 @@
     <br><br>
 
     <form action="{{ core.buildUrl({'component': 'admin', 'page': 'gradeable', 'action': 'process_upload_config'}) }}" method="POST" enctype="multipart/form-data">
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         Upload Config: <input type="file" name="config_upload" /><br />
         <input type="submit" value="Upload" />
     </form>

--- a/site/app/templates/admin/UploadWrapperForm.twig
+++ b/site/app/templates/admin/UploadWrapperForm.twig
@@ -46,7 +46,7 @@
         <td id="type_{{ aria_labelledby_id }}">{{ type }}</td>
         <td>
             <form action="{{ core.buildUrl({'component': 'admin', 'page': 'wrapper', 'action': 'process_upload_html'}) }}" method="POST" enctype="multipart/form-data">
-                <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                 <input type="hidden" name="location" value="{{ file }}">
                 <input type="file" name="wrapper_upload" aria-labelledby="name_{{ aria_labelledby_id }} type_{{ aria_labelledby_id }}">
                 <input type="submit" class="btn btn-default" value="Upload" />
@@ -56,7 +56,7 @@
             {% if wrapper_files[file] != null %}
                 <form action="{{ core.buildUrl({'component': 'admin', 'page': 'wrapper', 'action': 'delete_uploaded_html'}) }}" method="post">
                     <input type="hidden" name="location" value="{{ file }}">
-                    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="submit" class="btn btn-danger" value="Delete">&nbsp;
                     {{ wrapper_files[file] }}
                 </form>

--- a/site/app/templates/admin/users/ClassListForm.twig
+++ b/site/app/templates/admin/users/ClassListForm.twig
@@ -12,7 +12,7 @@
         Registration section can be null.<br>
         Do not use a header row.<br>
     </p>
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <label for="move_missing">Move students missing from the classlist to NULL section?</label><input type="checkbox" name="move_missing" id="move_missing" /><br>
     <br />
     <div>

--- a/site/app/templates/admin/users/GraderListForm.twig
+++ b/site/app/templates/admin/users/GraderListForm.twig
@@ -19,7 +19,7 @@
         Preferred first and last names are optional.<br>
         Do not use a header row.<br>
     </p>
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <div>
         <input type="file" name="upload" accept=".xlsx, .csv" aria-label="Choose File">
     </div>

--- a/site/app/templates/admin/users/RotatingSectionsForm.twig
+++ b/site/app/templates/admin/users/RotatingSectionsForm.twig
@@ -41,7 +41,7 @@
     </p>
     <br />
     <form action="{{ core.buildUrl({'component': 'admin', 'page': 'users', 'action': 'update_registration_sections'}) }}" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div class="row">
             <div class="box col-md-6">
                 <h2>Current Registration Section Counts</h2>
@@ -126,7 +126,7 @@
     <br />
 
     <form action="{{ core.buildUrl({'component': 'admin', 'page': 'users', 'action': 'update_rotating_sections'}) }}" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div class="row">
             <div class="box col-md-6" id="left_box">
                 <h2>Current Rotating Section Counts</h2>

--- a/site/app/templates/admin/users/UserForm.twig
+++ b/site/app/templates/admin/users/UserForm.twig
@@ -2,7 +2,7 @@
 {% block popup_id %}edit-user-form{% endblock %}
 {% block title %}Edit User{% endblock %}
 {% block body %}
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <input type="hidden" name="edit_user" value="false" />
     <div style="display: inline-block">
         <label for="user_id">User ID:</label><br />

--- a/site/app/templates/course/DeleteCourseMaterialForm.twig
+++ b/site/app/templates/course/DeleteCourseMaterialForm.twig
@@ -2,7 +2,7 @@
 {% block popup_id %}delete-course-material-form{% endblock %}
 {% block title %}Delete Course Materials{% endblock %}
 {% block body %}
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     Are you sure you want to delete
     <div name="delete-course-material-message">
     </div><br />

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -17,7 +17,7 @@
         <br><input id="expand_zip_checkbox" type="checkbox" value="off"/><label>Unzip zip files (Note: If checked, will replace all folders/files)</label>
     </fieldset>
     <br /> <br />
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <div id="upload-boxes" style="display:table; border-spacing: 5px; width:100%">
         <div id="upload1" style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 20px;">
             <h3 class="label" id="label">"Drag your file(s) here or click to open file browser"</h3>
@@ -26,7 +26,7 @@
     </div>
     <script type="text/javascript">
         function makeSubmission(expandZip,cmPath, requestedPath) {
-            handleUploadCourseMaterials("{{ core.getCsrfToken() }}", expandZip, cmPath, requestedPath);
+            handleUploadCourseMaterials("{{ csrf_token }}", expandZip, cmPath, requestedPath);
         }
         $(function() {
             $("#submit").click(function(e){ // Submit button

--- a/site/app/templates/forum/CategoriesForm.twig
+++ b/site/app/templates/forum/CategoriesForm.twig
@@ -2,10 +2,10 @@
 {% block popup_id %}category-list{% endblock %}
 {% block title %}Categories{% endblock %}
 {% block body %}
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <span  style="float: right;">
         <input id="new_category_text" placeholder="New Category" style="resize:none;" rows="1" type="text" name="new_category" id="new_category" maxlength="50" onkeyup="checkInputMaxLength($(this))" />
-        <button type="button" title="Add new category" onclick="addNewCategory('{{ core.getCsrfToken() }}');" style="margin-left:10px;" class="btn btn-primary btn-sm">
+        <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm">
             <i class="fas fa-plus-circle fa-1x"></i> Add category
         </button>
     </span>
@@ -56,7 +56,7 @@
                 var item = $(this).parent().parent().parent();
                 var category_id = parseInt(item.attr('id').split("-")[1]);
                 var category_desc = item.find(".categorylistitem-desc span").text().trim();
-                deleteCategory(category_id, category_desc, '{{ core.getCsrfToken() }}');
+                deleteCategory(category_id, category_desc, '{{ csrf_token }}');
             });
             $("#ui-category-list").find(".fa-edit").click(function() {
                 var item = $(this).parent().parent().parent();
@@ -78,7 +78,7 @@
                 var category_desc_original = item.find(".categorylistitem-desc span").text().trim();
                 var category_desc = item.find("input").val().trim();
                 if(category_desc != category_desc_original) {
-                    editCategory(category_id, category_desc, null, '{{ core.getCsrfToken() }}');
+                    editCategory(category_id, category_desc, null, '{{ csrf_token }}');
                 }
                 item.find(".categorylistitem-editdesc").hide();
                 item.find(".categorylistitem-desc").show();
@@ -89,7 +89,7 @@
             $(".category-color-picker").change(function(color) {
                 var category_id = parseInt($(this).parent().parent().attr('id').split("-")[1]);
                 var category_color = $(this).val();
-                editCategory(category_id, null, category_color, '{{ core.getCsrfToken() }}');
+                editCategory(category_id, null, category_color, '{{ csrf_token }}');
                 refresh_color_select($(this));
             });
             $(".category-color-picker").each(function(){

--- a/site/app/templates/forum/MergeThreadsForm.twig
+++ b/site/app/templates/forum/MergeThreadsForm.twig
@@ -4,7 +4,7 @@
 {% block body %}
         Merge current thread into
         <input type="hidden" id="merge_thread_child" name="merge_thread_child" value="{{ current_thread }}" data-ays-ignore="true">
-        <input type="hidden" id="csrf_token" name="csrf_token" value="{{ core.getCsrfToken() }}" data-ays-ignore="true"/>
+        <input type="hidden" id="csrf_token" name="csrf_token" value="{{ csrf_token }}" data-ays-ignore="true"/>
         <select class="chosen-select" id="merge_thread_parent" name="merge_thread_parent" style="width:200px;" data-ays-ignore="true">
             {% for threads in possibleMerges %}
                 <option value=({{ threads['id'] }})>({{ threads['id'] }}) {{ threads['title'] }}</option>

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -4,7 +4,7 @@
     {% endif %}
 >
 <div class="form-group row" style="position: relative;">
-    <input type="hidden" id="csrf_token" name="csrf_token" value="{{ core.getCsrfToken() }}" data-ays-ignore="true"/>
+    <input type="hidden" id="csrf_token" name="csrf_token" value="{{ csrf_token }}" data-ays-ignore="true"/>
     {% if show_title %}
     <span class="edit_thread">
         Title: <input type="text" size="45" placeholder="Title" name="title" id="title" required/>

--- a/site/app/templates/grading/AdminTeamForm.twig
+++ b/site/app/templates/grading/AdminTeamForm.twig
@@ -2,7 +2,7 @@
 {% block popup_id %}admin-team-form{% endblock %}
 {% block title_tag %}<h1 id="admin-team-title"></h1>{% endblock %}
 {% block body %}
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <input type="hidden" name="new_team" />
     <input type="hidden" name="new_team_user_id" />
     <input type="hidden" name="edit_team_team_id" />

--- a/site/app/templates/grading/ImportTeamForm.twig
+++ b/site/app/templates/grading/ImportTeamForm.twig
@@ -14,7 +14,7 @@
 {% block form %}
     <form method="post" action="{{ core.buildUrl({'component': 'grading', 'page': 'electronic', 'action': 'import_teams', 'gradeable_id': gradeable_id}) }}" enctype="multipart/form-data">
         {{ parent() }}
-        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     </form>
 {% endblock %}
 {% block buttons %}

--- a/site/app/templates/grading/UploadImagesForm.twig
+++ b/site/app/templates/grading/UploadImagesForm.twig
@@ -11,7 +11,7 @@
         Total files cannot exceed 10 mb or 10000 kb.<br><br>
     </p>
     <br/>
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <div id="upload-boxes" style="display:table; border-spacing: 5px; width:100%">
         <div id="upload1" style="cursor: pointer; text-align: center; border: dashed 2px lightgrey; display:table-cell; height: 20px;">
             <h3 class="label" id="label">"Drag your file(s) here or click to open file browser"</h3>
@@ -20,7 +20,7 @@
     </div>
     <script type="text/javascript">
         function makeSubmission() {
-            handleDownloadImages('{{ core.getCsrfToken() }}');
+            handleDownloadImages('{{ csrf_token }}');
         }
         $(function() {
             $("#submit").click(function(e){ // Submit button

--- a/site/app/templates/grading/electronic/StudentInformationPanel.twig
+++ b/site/app/templates/grading/electronic/StudentInformationPanel.twig
@@ -18,7 +18,7 @@
                                   'ta': true,
                                   'who': submitter_id
                               }) }}">
-                            <input type='hidden' name="csrf_token" value="{{ core.getCsrfToken() }}" />
+                            <input type='hidden' name="csrf_token" value="{{ csrf_token }}" />
                             {% if display_version == active_version %}
                                 <input type="submit" class="btn btn-default btn-xs" style="float:right; margin: 0 10px;" value="Cancel Student Submission">
                             {% else %}

--- a/site/app/templates/navigation/DeleteGradeableForm.twig
+++ b/site/app/templates/navigation/DeleteGradeableForm.twig
@@ -5,7 +5,7 @@
     <p>Note: A gradeable can only be deleted if it has no formed student teams and it has no student submission files and it has no TA grading data.
     </p>
     <br />
-    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     Are you sure you want to delete
     <div name="delete-gradeable-message">
     </div>

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -47,7 +47,7 @@
 			            </a>
                     </td>
                     <td id="input_area">
-                        <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}"/>
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                         <div id="users_{{ loop.index }}">
                             <input type="text" id="bulk_user_id_{{ loop.index }}" aria-label = "Enter User ID to assign" 
                                 {% if use_qr_codes %}
@@ -100,7 +100,7 @@
 <script type="text/javascript">
     var path_list = {{ count_array|json_encode|raw }};
     var num_submissions = {{ files|length }};
-    var CSRF = "{{ core.getCsrfToken() }}";
+    var CSRF = "{{ csrf_token }}";
     var g_id = "{{ gradeable_id }}";
     var max_team_size = {{ max_team_size }};
     //team_assignment may either be 1 or not given so convert to a string to handle either case

--- a/site/app/templates/submission/homework/CurrentVersionBox.twig
+++ b/site/app/templates/submission/homework/CurrentVersionBox.twig
@@ -13,14 +13,14 @@
         {% if display_version == active_version %}
             <form style="display: inline;" method="post"
                   action="{{ cancel_url }}">
-                <input type='hidden' name="csrf_token" value="{{ core.getCsrfToken() }}" />
+                <input type='hidden' name="csrf_token" value="{{ csrf_token }}" />
                 <input type="submit" id="do_not_grade" class="btn btn-default" style="float: right" value="Do Not Grade This Assignment">
             </form>
         {% else %}
             <form style="display: inline;" method="post"
                   onsubmit='return checkVersionChange({{ display_version_days_late }},{{ allowed_late_days }})'
                   action="{{ change_version_url }}">
-                <input type='hidden' name="csrf_token" value="{{ core.getCsrfToken() }}" />
+                <input type='hidden' name="csrf_token" value="{{ csrf_token }}" />
                 <input type="submit" id="version_change" class="btn btn-primary" value="Grade This Version">
             </form>
         {% endif %}

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -50,7 +50,7 @@
                     Note: This <i>permanently</i> affects the student's submissions, so please use with caution.
                 </div>
                 <div class="sub">
-                    <input type="hidden" name="csrf_token" value="{{ core.getCsrfToken() }}" />
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                     <label for="user_id"> user_id: </label>
 		    <input type="text" id= "user_id" value ="" placeholder="{{ user_id }}"/>
                 </div>
@@ -501,7 +501,7 @@
         // submit the selected pdf
         path = decodeURIComponent(path);
         if (is_pdf) {
-            submitSplitItem("{{ core.getCsrfToken() }}", "{{ gradeable_id }}", user_id, path, merge_previous, clobber);
+            submitSplitItem("{{ csrf_token }}", "{{ gradeable_id }}", user_id, path, merge_previous, clobber);
         }
 
         // otherwise, this is a regular submission of the uploaded files
@@ -510,7 +510,7 @@
                 {{ allowed_late_days }},
                 {{ highest_version }},
                 {{ max_submissions }},
-                "{{ core.getCsrfToken() }}",
+                "{{ csrf_token }}",
                 {{ is_vcs ? "true" : "false" }},
                 {{ num_inputs }},
                 "{{ gradeable_id }}",
@@ -528,7 +528,7 @@
                 {{ allowed_late_days }},
                 highest_version,
                 {{ max_submissions }},
-                "{{ core.getCsrfToken() }}",
+                "{{ csrf_token }}",
                 {{ is_vcs ? "true" : "false" }},
                 {{ num_inputs }},
                 "{{ gradeable_id }}",
@@ -578,7 +578,7 @@
             }
             // user id entered, need to validate first
             else {
-                validateUserId("{{ core.getCsrfToken() }}", "{{ gradeable_id }}", user_id)
+                validateUserId("{{ csrf_token }}", "{{ gradeable_id }}", user_id)
                 .then(function(response){
                     if(response['highest_version']){
                         var option = displayPreviousSubmissionOptions(getSubmissionOption);

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -32,7 +32,8 @@ class GlobalView extends AbstractView {
             "notifications_info" => $notifications_info,
             "wrapper_enabled" => $this->core->getConfig()->wrapperEnabled(),
             "wrapper_urls" => $wrapper_urls,
-            "system_message" => $this->core->getConfig()->getSystemMessage()
+            "system_message" => $this->core->getConfig()->getSystemMessage(),
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
      }
 

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -13,7 +13,7 @@ class HomePageView extends AbstractView {
     /*
     *@param List of courses the student is in.
     */
-    public function showHomePage($user, $unarchived_courses = array(), $archived_courses = array(), $changeNameText) {
+    public function showHomePage($user, $unarchived_courses = array(), $archived_courses = array(), $change_name_text) {
         $statuses = array();
         $course_types = [$unarchived_courses, $archived_courses];
         $rankTitles = [
@@ -60,8 +60,9 @@ class HomePageView extends AbstractView {
             "user_first" => $autofill_preferred_name[0],
             "user_last" => $autofill_preferred_name[1],
             "statuses" => $statuses,
-            "change_name_text" => $changeNameText,
-            "show_change_password" => $this->core->getAuthentication() instanceof DatabaseAuthentication
+            "change_name_text" => $change_name_text,
+            "show_change_password" => $this->core->getAuthentication() instanceof DatabaseAuthentication,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -725,6 +725,9 @@ class NavigationView extends AbstractView {
     }
 
     public function deleteGradeableForm() {
-        return $this->core->getOutput()->renderTwigTemplate("navigation/DeleteGradeableForm.twig");
+        return $this->core->getOutput()->renderTwigTemplate(
+            "navigation/DeleteGradeableForm.twig",
+            ['csrf_token' => $this->core->getCsrfToken()]
+        );
     }
 }

--- a/site/app/views/admin/ConfigurationView.php
+++ b/site/app/views/admin/ConfigurationView.php
@@ -11,7 +11,8 @@ class ConfigurationView extends AbstractView {
             "fields" => $fields,
             "gradeable_seating_options" => $gradeable_seating_options,
             "theme_url" => $theme_url,
-            "email_room_seating_url" => $email_room_seating_url
+            "email_room_seating_url" => $email_room_seating_url,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/admin/ExtensionsView.php
+++ b/site/app/views/admin/ExtensionsView.php
@@ -12,7 +12,8 @@ class ExtensionsView extends AbstractView {
 
         return $this->core->getOutput()->renderTwigTemplate("admin/Extensions.twig", [
             "gradeables" => $gradeables,
-            "student_full" => $student_full
+            "student_full" => $student_full,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/admin/GradeableView.php
+++ b/site/app/views/admin/GradeableView.php
@@ -15,7 +15,8 @@ class GradeableView extends AbstractView {
             "all_files" => $all_files,
             "target_dir" => $target_dir,
             "course" => $course,
-            "inuse_config" => $inuse_config
+            "inuse_config" => $inuse_config,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/admin/LateDayView.php
+++ b/site/app/views/admin/LateDayView.php
@@ -12,7 +12,8 @@ class LateDayView extends AbstractView {
 
         return $this->core->getOutput()->renderTwigTemplate("admin/LateDays.twig", [
             "users" => $users,
-            "student_full" => $student_full
+            "student_full" => $student_full,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -25,7 +25,8 @@ class UsersView extends AbstractView {
             "sections" => $sections,
             "reg_sections" => $reg_sections,
             "rot_sections" => $rot_sections,
-            "use_database" => $use_database
+            "use_database" => $use_database,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 
@@ -169,7 +170,8 @@ class UsersView extends AbstractView {
             "reg_sections_count" => $reg_sections_count,
             "not_null_counts" => $not_null_counts,
             "null_counts" => $null_counts,
-            "max_section" => $max_section
+            "max_section" => $max_section,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/admin/WrapperView.php
+++ b/site/app/views/admin/WrapperView.php
@@ -7,7 +7,8 @@ use app\views\AbstractView;
 class WrapperView extends AbstractView {
     public function displayPage($wrapper_files) {
         return $this->core->getOutput()->renderTwigTemplate("admin/UploadWrapperForm.twig", [
-            "wrapper_files" => $wrapper_files
+            "wrapper_files" => $wrapper_files,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -109,7 +109,8 @@ class CourseMaterialsView extends AbstractView {
             "submissions" => $submissions,
             "fileShares" => $file_shares,
             "fileReleaseDates" => $file_release_dates,
-            "userGroup" => $user_group
+            "userGroup" => $user_group,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -328,7 +328,8 @@ class ForumThreadView extends AbstractView {
             "currentThread" => $currentThread,
             "currentCourse" => $currentCourse,
             "generate_post_content" => $generatePostContent,
-            "display_option" => $display_option
+            "display_option" => $display_option,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
         return $return;
     }
@@ -900,6 +901,7 @@ class ForumThreadView extends AbstractView {
             "buttons" => $buttons,
             "thread_exists" => $thread_exists,
             "form_action" => $this->core->buildUrl(array('component' => 'forum', 'page' => 'publish_thread')),
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
 
         return $return;

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -578,12 +578,14 @@ HTML;
             "view" => isset($_REQUEST["view"]) ? $_REQUEST["view"] : null,
             "all_reg_sections" => $all_reg_sections,
             "all_rot_sections" => $all_rot_sections,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 
     public function importTeamForm(Gradeable $gradeable) {
         return $this->core->getOutput()->renderTwigTemplate("grading/ImportTeamForm.twig", [
-            "gradeable_id" => $gradeable->getId()
+            "gradeable_id" => $gradeable->getId(),
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 
@@ -838,6 +840,7 @@ HTML;
 
             "versions" => $version_data,
             'total_points' => $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit(),
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -63,7 +63,8 @@ class ImagesView extends AbstractView {
             "sections" => $sections,
             "imageData" => $image_data,
             "errorImageData" => $error_image_data,
-            "hasInstructorPermission" => $instructor_permission
+            "hasInstructorPermission" => $instructor_permission,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -391,7 +391,8 @@ class HomeworkView extends AbstractView {
             'testcase_messages' => $testcase_messages,
             'image_data' => $image_data,
             'component_names' => $component_names,
-            'upload_message' => $this->core->getConfig()->getUploadMessage()
+            'upload_message' => $this->core->getConfig()->getUploadMessage(),
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 
@@ -501,7 +502,8 @@ class HomeworkView extends AbstractView {
             'max_team_size' => $gradeable->getTeamSizeMax(),
             'count_array' => $count_array,
             'files' => $files,
-            'use_qr_codes' => $use_qr_codes
+            'use_qr_codes' => $use_qr_codes,
+            'csrf_token' => $this->core->getCsrfToken()
         ]);
     }
 
@@ -659,7 +661,8 @@ class HomeworkView extends AbstractView {
             'can_see_all_versions' => $this->core->getUser()->accessGrading() || $gradeable->isStudentSubmit(),
             'show_testcases' => $show_testcases,
             'active_same_as_graded' => $active_same_as_graded,
-            'show_incentive_message' => $show_incentive_message
+            'show_incentive_message' => $show_incentive_message,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
 
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/CurrentVersionBox.twig', $param);

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -515,7 +515,6 @@ class HomeworkView extends AbstractView {
             'max_team_size' => $gradeable->getTeamSizeMax(),
             'count_array' => $count_array,
             'files' => $files,
-            'use_qr_codes' => $use_qr_codes,
             'csrf_token' => $this->core->getCsrfToken()
         ]);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Partially addresses #2273. Currently, we use `core.getCsrfToken()` in twig files to obtain CSRF token.

### What is the new behavior?
Views pass CSRF token to twig files so that twig does not touch `core`. The whole point of using twig is not to have php mixed anyways.
