### PR TITLE
[Bugfix] Update URL for sample courses

### DIFF
--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -172,7 +172,7 @@ def main():
     with open(list_of_courses_file, "w") as courses_file:
         courses_file.write("")
         for course_id in courses.keys():
-            courses_file.write('<a href="'+args.submission_url+'/index.php?semester='+get_current_semester()+'&course='+course_id+'">'+course_id+', '+semester+' '+str(today.year)+'</a>')
+            courses_file.write('<a href="'+args.submission_url+'/'+get_current_semester()+'/'+course_id+'">'+course_id+', '+semester+' '+str(today.year)+'</a>')
             courses_file.write('<br />')
 
     for course_id in sorted(courses.keys()):


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
The links to courses in the error page are using old-style URLs.
![Screenshot from 2019-06-22 19-03-23](https://user-images.githubusercontent.com/20266703/59963078-82f38400-9520-11e9-942b-877575ee7f9b.png)

### What is the new behavior?
Change to new-style URL.

### Other information?
Run `sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/recreate_sample_courses.sh` to make it update. The error page can be accessed by going to `http://192.168.56.111/index.php?semester=s19&course=development&component=admin` as a student.
