### PR TITLE
Team Rotating Sections bug fix

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -537,13 +537,10 @@ class ElectronicGraderController extends GradingController {
         }
 
         $graded_gradeables = [];
-        $user_ids = []; // Collect user ids so we know who isn't on a team
+        $user_ids = $this->core->getQueries()->getUsersOnTeamsForGradeable($gradeable); // Collect user ids so we know who isn't on a team
         /** @var GradedGradeable $g */
         foreach ($order->getSortedGradedGradeables() as $g) {
             $graded_gradeables[] = $g;
-            if($gradeable->isTeamAssignment()) {
-                $user_ids = array_merge($user_ids, $g->getSubmitter()->getTeam()->getMemberUserIds());
-            }
         }
         $teamless_users = [];
         if ($gradeable->isTeamAssignment()) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1427,6 +1427,24 @@ ORDER BY user_id ASC");
     }
 
     /**
+     * Gets all user_ids that are on a team for a given gradeable
+     *
+     * @param $gradeable
+     * @returns string[]
+     */
+    public function getUsersOnTeamsForGradeable($gradeable) {
+        $params = array($gradeable->getId());
+        $this->course_db->query("SELECT user_id FROM teams WHERE 
+                team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)",$params);
+
+        $users = [];
+        foreach ($this->course_db->rows() as $row){
+            $users[] = $row['user_id'];
+        }
+        return $users;
+    }
+
+    /**
      * This inserts an row in the electronic_gradeable_data table for a given gradeable/user/version combination.
      * The values for the row are set to defaults (0 for numerics and NOW() for the timestamp) with the actual values
      * to be later filled in by the submitty_autograding_shipper.py and insert_database_version_data.py scripts.


### PR DESCRIPTION
Closes #3846 
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Correct teams in section 1 and 4 (notice the highlighted student)
![pr5section1](https://user-images.githubusercontent.com/34327811/60038686-00cfa080-9683-11e9-93e9-e1f818f57190.png)
![pr5section4](https://user-images.githubusercontent.com/34327811/60038733-180e8e00-9683-11e9-9ecf-5133968f0dbe.png)

What displays for grader with access to rotating section 1 only:
![pr5bug2](https://user-images.githubusercontent.com/34327811/60039130-0083d500-9684-11e9-8f75-1f6c5f00f98f.png)

### What is the new behavior?
Teams are no longer deconstructed when a grader is not assigned to grade their section.

See issue closed for more detailed explanation.