### PR TITLE
[Bugfix] Stop fading of error messages

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1392,7 +1392,7 @@ $(function() {
     }
 
     setTimeout(function() {
-        $('.inner-message').fadeOut();
+        $('.alert-success').fadeOut();
     }, 5000);
 });
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3515 . Presently both error message(Message shown in red) and success message(Message shown in green) fade in just 5 seconds.
### What is the new behavior?
As discussed with @bmcutler and @emaicus success message for 5 seconds is good but for alert message it should be for time upto which they are not able to solve the error
![Screenshot from 2019-06-25 01-56-54](https://user-images.githubusercontent.com/42701709/60049755-99e6d180-96ec-11e9-997d-0e2e3c141f72.png)
It will remain till instructor(student) want to remove it.  
Videos:-
#### Error Messages
![ezgif com-video-to-gif(20)](https://user-images.githubusercontent.com/42701709/60050554-89cff180-96ee-11e9-8cfa-1bf7b56fc3c6.gif)
#### Success Messages
![ezgif com-video-to-gif(21)](https://user-images.githubusercontent.com/42701709/60050556-8a688800-96ee-11e9-9e6c-4d7d4fffec78.gif)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
