### PR TITLE
[Travis] Update versions of clang to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -266,7 +266,9 @@ jobs:
         - sudo ln -s $(which clang) /usr/bin/clang
         - sudo ln -s $(which clang++) /usr/bin/clang++
         - export CC=/usr/bin/clang
+        - export CC_FOR_BUILD=/usr/bin/clang
         - export CXX=/usr/bin/clang++
+        - export CXX_FOR_BUILD=/usr/bin/clang++
         - pip3 install -U pip
         - pip3 install PyYAML
         - pip3 install python-dateutil

--- a/.travis.yml
+++ b/.travis.yml
@@ -231,6 +231,7 @@ jobs:
     - &04-integration
       stage: Integration test
       language: cpp
+      env: CLANG_VER="6.0.0"
       addons:
         postgresql: "9.5"
         apt:
@@ -254,7 +255,6 @@ jobs:
             - libpcre3-dev
             - unzip
             - libboost-all-dev
-      env: CLANG_VER="5.0.1"
       before_install: source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
       install:
         - export LLVM_ARCHIVE_PATH=${HOME}/clang+llvm.tar.xz
@@ -282,7 +282,10 @@ jobs:
       script:
         - sudo python3 /usr/local/submitty/test_suite/integrationTests/run.py
     - <<: *04-integration
-      env: CLANG_VER="6.0.0"
+      env: CLANG_VER="7.1.0"
+      if: branch = master OR type = pull_request
+    - <<: *04-integration
+      env: CLANG_VER="8.0.0"
       if: branch = master OR type = pull_request
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -265,6 +265,8 @@ jobs:
         # Create symlink so that it's in expected location for whitelist
         - sudo ln -s $(which clang) /usr/bin/clang
         - sudo ln -s $(which clang++) /usr/bin/clang++
+        - export CC=/usr/bin/clang
+        - export CXX=/usr/bin/clang++
         - pip3 install -U pip
         - pip3 install PyYAML
         - pip3 install python-dateutil

--- a/grading/dispatch.cpp
+++ b/grading/dispatch.cpp
@@ -937,7 +937,7 @@ TestResults* dispatch::warnIfNotEmpty_doit (const TestCase &tc, const nlohmann::
     return new TestResults(1.0,messages);
   }
   if (student_file_contents != "") {
-    if (j.find("jvm_memory") != j.end() && j["jvm_memory"] == true &&
+    if (j.find("jvm_memory") != j.end() && j["jvm_memory"].get<bool>() == true &&
         JavaToolOptionsCheck(student_file_contents)) {
       return new TestResults(1.0);
     }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -216,7 +216,7 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
         this_testcase["containers"][container_num]["server"] = false;
       }
 
-      if(this_testcase["containers"][container_num]["server"] == true){
+      if(this_testcase["containers"][container_num]["server"].get<bool>() == true){
         assert(!this_testcase["containers"][container_num]["commands"].size() > 0);
       }else{
         found_non_server = true;
@@ -342,10 +342,10 @@ void validate_integer(nlohmann::json& action, std::string field, bool populate_d
     }
     assert(action[field].is_number_integer());
 
-    if(action[field] < min_val){
+    if(action[field].get<int>() < min_val){
       std::cout << "ERROR: For the " << action_name << " action, " << field << " must be greater than " << min_val << "." << std::endl;
     }
-    assert(action[field] >= min_val);
+    assert(action[field].get<int>() >= min_val);
   } else{
     if(populate_default){
       action[field] = default_value;
@@ -491,10 +491,10 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
         validate_integer(action, "end_x",   true,  0, 0);
         validate_integer(action, "end_y",   true,  0, 0);
 
-        if(action["end_x"] == 0 && action["end_y"] == 0){
+        if(action["end_x"].get<int>() == 0 && action["end_y"].get<int>() == 0){
           std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
         }
-        assert(action["end_x"] != 0 || action["end_y"] != 0);
+        assert(action["end_x"].get<int>() != 0 || action["end_y"].get<int>() != 0);
 
       }
       //Click and drag delta can have an optional mouse button, and must have and end_x and end_y.
@@ -505,11 +505,11 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
         validate_integer(action, "end_x",   true,  0, 0);
         validate_integer(action, "end_y",   true,  0, 0);
 
-        if(action["end_x"] == 0 && action["end_y"] == 0){
+        if(action["end_x"].get<int>() == 0 && action["end_y"].get<int>() == 0){
           std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
         }
 
-        assert(action["end_x"] != 0 || action["end_y"] != 0);
+        assert(action["end_x"].get<int>() != 0 || action["end_y"].get<int>() != 0);
 
       }
       //Click has an optional mouse button.
@@ -560,9 +560,9 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
         //minimum frames_per_second is 1, default is 10.
         validate_integer(action, "frames_per_second", true, 1, 10);
 
-        if(action["frames_per_second"] > 30){
+        if(action["frames_per_second"].get<int>() > 30){
           std::cout << "ERROR: Submitty does not allow gifs with an fps greater than 30." << std::endl;
-          assert(action["frames_per_second"] <= 30);
+          assert(action["frames_per_second"].get<int>() <= 30);
         }
 
         number_of_gifs++;
@@ -906,7 +906,7 @@ void AddDefaultGraders(const std::vector<nlohmann::json> &containers,
   //For every container, for every command, we want to add default graders for the appropriate files.
   for (int i = 0; i < containers.size(); i++) {
 
-    if(containers[i]["server"] == true){
+    if(containers[i]["server"].get<bool>() == true){
       continue;
     }
 
@@ -1036,7 +1036,7 @@ void FileCheck_Helper(nlohmann::json &single_testcase) {
       single_testcase["penalty"] = -0.1;
     } else {
       assert (itr->is_number());
-      assert ((*itr) <= 0);
+      assert ((*itr).get<int>() <= 0);
     }
     itr = single_testcase.find("title");
     if (itr == single_testcase.end()) {

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -217,7 +217,7 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
       }
 
       if(this_testcase["containers"][container_num]["server"].get<bool>() == true){
-        assert(!this_testcase["containers"][container_num]["commands"].size() > 0);
+        assert(this_testcase["containers"][container_num]["commands"].size() == 0);
       }else{
         found_non_server = true;
       }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Test suite currently tests against Clang 5 and 6. Minimal version of clang on Ubuntu 18.04 is 6.

### What is the new behavior?
Drops testing of clang 5 (unsupported), promoting 6 to the main version to test against. 7.1 and 8 are added for tests for PRs to test for any potential future breakage.
