### PR TITLE
[Bugfix] Fix status messages for bulk uploads

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -244,18 +244,18 @@
             //allow user to retry assigning on failure
             toggleButtons(index, false);
             console.error(response);
-            displaySubmissionMessage({'success' : false, 'message' : response});
+            displaySubmissionMessage(response);
         });
     }
 
     function uploadSplitHelper(user_id,path,index = 0,merge_previous = false,clobber = false){
         submitSplitItem(CSRF, g_id, user_id, path, merge_previous, clobber)
         .then(function(submit_response){
-            displaySubmissionMessage(submit_response,index);
+            displaySubmissionMessage(submit_response);
             moveToNextSubmission(index);
         })
         .catch(function(submit_response){
-            displaySubmissionMessage({'success' : false, 'message' : submit_response}, index);
+            displaySubmissionMessage(submit_response);
             console.error(submit_response);
             //allow user to retry assigning on failure
             toggleButtons(index, false);
@@ -275,12 +275,12 @@
         if(confirm("Are you sure you want to delete this submission?")){
             deleteSplitItem(CSRF,g_id,path)
             .then(function(submit_response){
-                displaySubmissionMessage(submit_response, index);
+                displaySubmissionMessage(submit_response);
                 moveToNextSubmission(index);
             })
             .catch(function(submit_response){
                 console.error(submit_response);
-                displaySubmissionMessage({'success' : false, 'message' : submit_response}, index);
+                displaySubmissionMessage(submit_response);
 
                 toggleButtons(index, false);
             });
@@ -335,7 +335,7 @@
             }
         })
         .catch(function(response){
-            displaySubmissionMessage({'success' : false, 'message' : response}, index);
+            displaySubmissionMessage(response);
             console.error(response);
             return submitAll(index + 1);
         });
@@ -368,12 +368,12 @@
 
         deleteSplitItem(CSRF,g_id,path)
         .then(function(submit_response){
-            displaySubmissionMessage(submit_response, index);
+            displaySubmissionMessage(submit_response);
             return deleteAll(index + 1);
         })
         .catch(function(submit_response){
             console.error(submit_response);
-            displaySubmissionMessage({'success' : false, 'message' : submit_response}, index);
+            displaySubmissionMessage(submit_response);
 
             toggleButtons(index, false);
 

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -397,9 +397,9 @@ function validateUserId(csrf_token, gradeable_id, user_id){
             success : function(response){ 
                 response = JSON.parse(response);
                 if(response['status'] === 'success'){
-                    resolve(response['data']);
+                    resolve(response);
                 }else{
-                    reject(response['message']);
+                    reject(response);
                 }
             },
             error : function(err){
@@ -413,17 +413,24 @@ function validateUserId(csrf_token, gradeable_id, user_id){
 //@param json a dictionary {success : true/false, message : string}
 //@param index used for id
 //function to display pop-up notification after bulk submission/delete
-function displaySubmissionMessage(json, index = 0){
-    var message ='<div id="bulk_message_' + String(index) + '" class="inner-message alert alert-' +
-                        (json['status'] === 'success' ? 'success' : 'error') + '">\
-                    <a class="fas fa-times message-close" onclick="removeMessagePopup(\'bulk_message_' + String(index) + '\');"></a>\
-                    <i class="' + (json['status'] === 'success' ? 'fas fa-check-circle' : 'fas fa-times-circle') +'"></i>' + json['status'] === 'success' ? json['data'] : json['message'] +
-                 '</div>';
+function displaySubmissionMessage(json){
+    //let the id be the date to prevent closing the wrong message
+    let d = new Date();
+    let t = String(d.getTime());
 
+    let class_str = 'class="inner-message alert ' + (json['status'] === 'success' ? 'alert-success' : 'alert-error') + '"' ; 
+    let close_btn = '<a class="fas fa-times message-close" onclick="removeMessagePopup(' + t + ');"></a>';
+    let fa_icon = '<i class="' + (json['status'] === 'success' ? 'fas fa-check-circle' : 'fas fa-times-circle') +'"></i>';
+    let response = (json['status'] === 'success' ? json['data'] : json['message'] )
+
+    let message = '<div id="' + t + '"' + class_str + '>' + fa_icon + response + close_btn + '</div>';
     $('#messages').append(message);
-    setTimeout(function() {
-        $("#bulk_message_" + String(index)).fadeOut().empty();
-    }, 5000);
+
+    if(json['status'] === 'success'){
+        setTimeout(function() {
+            removeMessagePopup(t);
+        }, 5000);
+    }
 }
 
 //@param callback to function when user selects an option


### PR DESCRIPTION
### What is the current behavior?
Fixes #3849

### What is the new behavior?
`displaySubmissionMessage` now accepts a JSON response,
the alert message for success and fail are built more clearly now

Success messages will delete themselfs after 5 seconds, errors will stay on screen until deleted. (for bulk upload messages only)