### PR TITLE
This *should* fix the null error for the total score histogram and autograding score histogram

### DIFF
--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -59,10 +59,10 @@
     {% else %}
         <div class = "tab">
             <button class="btn btn-primary" type="button" onclick="openStat(event, 'Numerical Data'), this.blur()" id="defaultOpen">Numerical Data</button>
-            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Total Score Histogram'), this.blur()">Total Histogram</button>
-            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Autograding Score Histogram'), this.blur()">Autograding Histogram</button>
+            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Total Score Histogram'), this.blur()">Total Score Histogram</button>
+            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Autograding Score Histogram'), this.blur()">Autograding Score Histogram</button>
             <button class="btn btn-primary" type="button" onclick="openStat(event, 'Component Averages'), this.blur()">Component Averages</button>
-            <div id = "Total Histogram" class = "tabcontent">
+            <div id = "Total Score Histogram" class = "tabcontent">
                 {% if overall_average == null or overall_average.getCount() == 0 %}
                     <br/>
                     No assignments have been completely graded yet.
@@ -316,7 +316,7 @@
                 {% endif %}
             </div>
             {# Graph Setup for Autograding #}
-            <div id="Autograding Histogram" class="tabcontent">
+            <div id="Autograding Score Histogram" class="tabcontent">
                 {% if autograding_non_extra_credit != 0 %}
                     {# Only show autograder if we have autograding points #}
                 {% if autograded_average == null or autograded_average.getCount() == 0 %}


### PR DESCRIPTION
Closes #3688 
Now the  histograms should display properly!
![bugFix 2019-06-26 11-24](https://user-images.githubusercontent.com/36307579/60193037-f9d09b80-9804-11e9-9358-099768ea5027.gif)

