### PR TITLE
[Refactor] Fix assert that commands array should be empty for server

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -217,7 +217,7 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
       }
 
       if(this_testcase["containers"][container_num]["server"] == true){
-        assert(!this_testcase["containers"][container_num]["commands"].size() > 0);
+        assert(this_testcase["containers"][container_num]["commands"].size() == 0);
       }else{
         found_non_server = true;
       }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The assert is evaluated such that it applies the `!` operator then does the `>` comparison which might give unintended consequence.

### What is the new behavior?
Fixes the assert to be clearer in what its testing, mainly that the "commands" array should be empty.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This should not be a breaking change and the previous behavior is maintained. An example of what's currently being evaluated can be seen [here](https://repl.it/repls/PurpleParallelPlane).
