### PR TITLE
[Travis] Only run integrate tests against single gcc target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,17 +254,17 @@ jobs:
             - libpcre3-dev
             - unzip
             - libboost-all-dev
-      env: CLANG_VER="5.0.1"
+      env: gcc="5"
       before_install: source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
       install:
-        - export LLVM_ARCHIVE_PATH=${HOME}/clang+llvm.tar.xz
-        - wget http://releases.llvm.org/${CLANG_VER}/clang+llvm-${CLANG_VER}-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O ${LLVM_ARCHIVE_PATH}
-        - mkdir ${HOME}/clang+llvm
-        - tar xf ${LLVM_ARCHIVE_PATH} -C ${HOME}/clang+llvm --strip-components 1
-        - export PATH=${HOME}/clang+llvm/bin:${PATH}
+        # - export LLVM_ARCHIVE_PATH=${HOME}/clang+llvm.tar.xz
+        # - wget http://releases.llvm.org/${CLANG_VER}/clang+llvm-${CLANG_VER}-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O ${LLVM_ARCHIVE_PATH}
+        # - mkdir ${HOME}/clang+llvm
+        # - tar xf ${LLVM_ARCHIVE_PATH} -C ${HOME}/clang+llvm --strip-components 1
+        # - export PATH=${HOME}/clang+llvm/bin:${PATH}
         # Create symlink so that it's in expected location for whitelist
-        - sudo ln -s $(which clang) /usr/bin/clang
-        - sudo ln -s $(which clang++) /usr/bin/clang++
+        # - sudo ln -s $(which clang) /usr/bin/clang
+        # - sudo ln -s $(which clang++) /usr/bin/clang++
         - pip3 install -U pip
         - pip3 install PyYAML
         - pip3 install python-dateutil
@@ -281,9 +281,9 @@ jobs:
         - sudo bash .setup/travis/setup_test_suite.sh
       script:
         - sudo python3 /usr/local/submitty/test_suite/integrationTests/run.py
-    - <<: *04-integration
-      env: CLANG_VER="6.0.0"
-      if: branch = master OR type = pull_request
+    # - <<: *04-integration
+    #   env: CLANG_VER="6.0.0"
+    #   if: branch = master OR type = pull_request
 
 notifications:
   email: false


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
We run two different integration tests supposedly against two different clang targets. However, this is not actually true, and that we're only testing against the default gcc version installed on Ubuntu xenial.

### What is the new behavior?
Comment out the unused expansion and getting clang and make it more clear what's being tested here.

Filed #3932 to investigate expanding this matrix for more versions of gcc and clang.
