### PR TITLE
[BugFix] Fix bulk upload assignment for first submission

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -196,7 +196,7 @@
         //verify user id is valid, then assign
         validateUserId(CSRF, g_id, user_id)
         .then(function(response){
-            if(response['previous_submission'] === false){
+            if(response['data']['previous_submission'] === false){
                 //no previous submission, submit split item normally
                 uploadSplitHelper(user_id,path, index);
             }else{


### PR DESCRIPTION
Fixed error that caused the assignment submission to think students always had more than
1 submission and then attempt to handle a second submission even though it should have been first which prevented anyone from assigning students.