### PR TITLE
[API] Endpoint for rainbow grade generation

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -54,6 +54,7 @@ class ReportController extends AbstractController {
      * Generates grade summary files for every user
      *
      * @Route("/{_semester}/{_course}/reports/summaries")
+     * @Route("/api/{_semester}/{_course}/reports/summaries", methods={"POST"})
      */
     public function generateGradeSummaries() {
         if (!$this->core->getUser()->accessAdmin()) {
@@ -76,7 +77,8 @@ class ReportController extends AbstractController {
             return null;
         });
         $this->core->addSuccessMessage("Successfully Generated Grade Summaries");
-        $this->core->getOutput()->renderOutput(array('admin', 'Report'), 'showReportUpdates');
+        $this->core->redirect($this->core->buildNewCourseUrl(['reports']));
+        return $this->core->getOutput()->renderJsonSuccess();
     }
 
     /**

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -77,6 +77,8 @@ if ($core->getRouter()->hasNext()) {
     $first = $core->getRouter()->getNext();
     if ($first === 'api') {
         $is_api = True;
+        $semester = $core->getRouter()->getNext() ?? '';
+        $course = $core->getRouter()->getNext() ?? '';
     }
     elseif (in_array($first, ['authentication', 'home'])) {
         $_REQUEST['component'] = $first;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Partially addresses #3711 

### What is the new behavior?
We can now POST to `/api/{_semester}/{_course}/reports/summaries` to generate rainbow grades.

### Other information?

#### Why two extra lines are added in `index.php`?

The extra two lines is a workaround to make api work in pages that require course info.

Reason: I found that `core->loadUser` relies on `isCourseLoaded` to be true to load course users instead of submitty users. Therefore, if we do not load user before the authentication part (which is currently in `index.php` for backward compatibility and it may be in the router in the future), the user that we are to load is a submitty user without course access info.

#### How will API help #3711 ?

So my plan is:
- After #3929 is merged, create API endpoint to get courses.
- Write a script that looks like this:
```
# rainbow_grade_gen.py

courses = post_with_jwt("/api/courses")
for course in courses:
    post_with_jwt("api/semester/course/reports/summaries")
```
- So the sysadmin can write a cron job by repeatedly running `rainbow_grade_gen.py --token=jwt_of_submitty_admin`.

The reason why I would prefer using jwt is that it makes authentication more controllable. It expires as time comes or we change the api_key. I feel it is safer than storing plaintext somewhere. Also, it would take unnecessary efforts to log in and get new token each time to gen rainbow grades.

Suggestions needed.