### PR TITLE
[Bugfix] More bulk assign fixes

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -245,6 +245,14 @@ class BulkUpload(CourseJob):
             if not os.path.isfile(os.path.join(split_path, filename)):
                 shutil.copyfile(os.path.join(bulk_path, filename), os.path.join(split_path, filename))
 
+            # reset permissions just in case, group needs read/write
+            # access so submitty_php can view & delete pdfs when they are
+            # assigned to a student and/or deleted
+            self.add_permissions_recursive(split_path,
+                                       stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |   stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |   stat.S_ISGID,
+                                       stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |   stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |   stat.S_ISGID,
+                                       stat.S_IRUSR | stat.S_IWUSR |                  stat.S_IRGRP | stat.S_IWGRP                                  )
+
             # move to copy folder
             os.chdir(split_path)
         except Exception:
@@ -274,11 +282,3 @@ class BulkUpload(CourseJob):
             pass
 
         os.chdir(current_path)
-
-        # reset permissions just in case, group needs read/write
-        # access so submitty_php can view & delete pdfs when they are
-        # assigned to a student and/or deleted
-        self.add_permissions_recursive(split_path,
-                                       stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |   stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |   stat.S_ISGID,
-                                       stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |   stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |   stat.S_ISGID,
-                                       stat.S_IRUSR | stat.S_IWUSR |                  stat.S_IRGRP | stat.S_IWGRP                                  )

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -791,7 +791,7 @@ class SubmissionController extends AbstractController {
         $timestamp_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
             $gradeable->getId(), $timestamp);
         $files = FileUtils::getAllFiles($timestamp_path);
-        if (count($files) == 0 || (count($files) == 1 && array_key_exists('decoded.json', $files)  )) {
+        if (count($files) == 0) {
             if (!FileUtils::recursiveRmdir($timestamp_path)) {
                 return $this->uploadResult("Failed to remove the empty timestamp directory {$timestamp} from the split_pdf directory.", false);
             }
@@ -924,17 +924,7 @@ class SubmissionController extends AbstractController {
         $timestamp_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
             $gradeable->getId(), $timestamp);
         $files = FileUtils::getAllFiles($timestamp_path);
-
-        //check if there are any pdfs left to assign to students, otherwise delete the folder
-        $any_pdfs_left = false;
-        foreach ($files as $file){
-            if(strpos($file['name'], ".pdf") !== false){
-                $any_pdfs_left = true;
-                break;
-            }
-        }
-
-        if (count($files) == 0 || !$any_pdfs_left   ) {
+        if(count($files) === 0){
             if (!FileUtils::recursiveRmdir($timestamp_path)) {
                 return $this->uploadResult("Failed to remove the empty timestamp directory {$timestamp} from the split_pdf directory.", false);
             }

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -282,7 +282,7 @@
     }
 
     function submitAll(index){
-        if(index > Object.keys(path_list).length || index > num_submissions)
+        if(index > Object.keys(path_list).length)
             return;
 
         var text_area = document.getElementById("bulk_user_id_" + String(index));
@@ -318,7 +318,7 @@
                 var delete_btn = document.getElementById("bulk_delete_" + String(index));
                 var user_id_textarea = document.getElementById("bulk_user_id_" + String(index));
 
-                toggleButtons(index, true);
+                moveToNextSubmission(index);
                 uploadSplitHelper(user_id,path,index);
                 return submitAll(index + 1);
             }else{
@@ -335,13 +335,11 @@
     function confirmDeleteAll(){
         if(confirm("Are you sure you want to delete " + String(num_submissions) + " submissions?")){
             deleteAll(1);
-            //all done, refresh the page
-            window.location.reload();
         }
     }
 
     function deleteAll(index){
-        if(index > Object.keys(path_list).length || index > num_submissions){
+        if(index > Object.keys(path_list).length){
             return;
         }
 
@@ -354,15 +352,12 @@
         }else if(submit_btn.disabled === true){
             return deleteAll(index + 1);
         }
-
-        toggleButtons(index, true);
-
         var path = decodeURIComponent(path_list[index]);
 
         deleteSplitItem(CSRF,g_id,path)
         .then(function(submit_response){
             displaySubmissionMessage(submit_response);
-            num_submissions -= 1;
+            moveToNextSubmission(index);
             return deleteAll(index + 1);
         })
         .catch(function(submit_response){

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -313,7 +313,7 @@
 
         validateUserId(CSRF,g_id,user_id)
         .then(function(response){
-            if(response['previous_submission'] === false){
+            if(response['data']['previous_submission'] === false){
                 var submit_btn = document.getElementById("bulk_submit_" + String(index));
                 var delete_btn = document.getElementById("bulk_delete_" + String(index));
                 var user_id_textarea = document.getElementById("bulk_user_id_" + String(index));
@@ -335,13 +335,15 @@
     function confirmDeleteAll(){
         if(confirm("Are you sure you want to delete " + String(num_submissions) + " submissions?")){
             deleteAll(1);
+            //all done, refresh the page
+            window.location.reload();
         }
     }
 
     function deleteAll(index){
-
-        if(index > path_list.length || index > num_submissions)
+        if(index > Object.keys(path_list).length || index > num_submissions){
             return;
+        }
 
         var submit_btn = document.getElementById("bulk_submit_" + String(index));
         var delete_btn = document.getElementById("bulk_delete_" + String(index));
@@ -360,6 +362,7 @@
         deleteSplitItem(CSRF,g_id,path)
         .then(function(submit_response){
             displaySubmissionMessage(submit_response);
+            num_submissions -= 1;
             return deleteAll(index + 1);
         })
         .catch(function(submit_response){
@@ -367,7 +370,6 @@
             displaySubmissionMessage(submit_response);
 
             toggleButtons(index, false);
-
             return deleteAll(index + 1);
         });
     }

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -479,9 +479,9 @@ class HomeworkView extends AbstractView {
         }
 
         for ($i = 0; $i < count($files); $i++) {
-            if($bulk_upload_data['is_qr'] && !array_key_exists($files[$i]['filename_full'], $bulk_upload_data)){
+            if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr'] && !array_key_exists($files[$i]['filename_full'], $bulk_upload_data)){
                 continue;
-            }else if($bulk_upload_data['is_qr']){
+            }else if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']){
                 $data = $bulk_upload_data[ $files[$i]['filename_full'] ];
             }
 
@@ -489,14 +489,25 @@ class HomeworkView extends AbstractView {
             $is_valid = true;
             $id = '';
 
-            if($bulk_upload_data['is_qr']){
-                $id = $data['id'];
-                $is_valid = $this->core->getQueries()->getUserById($id);
-                $page_count = $data['page_count'];
+            //decoded.json may be read before the assoicated data is written, check if key exists first
+            if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']){
+                if(array_key_exists('id', $data)){
+                    $id = $data['id'];
+                    $is_valid = $this->core->getQueries()->getUserById($id);
+                }else{
+                    //set the blank id as invalid for now, after a page refresh it will recorrect
+                    $id = '';
+                    $is_valid = false;
+                }
+                if(array_key_exists('page_count', $data)){
+                    $page_count = $data['page_count'];
+                }
             }else{
                 $is_valid = true;
                 $id = '';
-                $page_count = $bulk_upload_data['page_count'];
+                if(array_key_exists('page_count', $bulk_upload_data)){
+                    $page_count = $bulk_upload_data['page_count'];
+                }
             }
 
             $files[$i] += ['page_count' => $page_count, 

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -604,9 +604,9 @@ function deleteSplitItem(csrf_token, gradeable_id, path) {
                     reject(response);
                 }
             },
-            error: function(err) {
+            error: function(jqXHR, err_msg, exception) {
                 console.error("Failed while deleting split item");
-                reject({'status' : 'failed', 'message' : err});
+                reject({'status' : 'failed', 'message' : err_msg});
             }
         });
     });

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -404,7 +404,7 @@ function validateUserId(csrf_token, gradeable_id, user_id){
             },
             error : function(err){
                 console.log("Error while trying to validate user id" + user_id);
-                reject(new Error(err));
+                reject({'status' : 'failed', 'message' : err});
             }
         });
     });
@@ -572,7 +572,7 @@ function submitSplitItem(csrf_token, gradeable_id, user_id, path, merge_previous
             },
             error: function(err) {
                 console.log("Failed while submiting split item");
-                reject(new Error(err));
+                reject({'status' : 'failed', 'message' : err});
             }
         });
     });
@@ -605,8 +605,8 @@ function deleteSplitItem(csrf_token, gradeable_id, path) {
                 }
             },
             error: function(err) {
-                console.log("Failed while deleting split item");
-                reject(new Error(err));
+                console.error("Failed while deleting split item");
+                reject({'status' : 'failed', 'message' : err});
             }
         });
     });


### PR DESCRIPTION
The bulkupload job in jobs.py corrects the file permissions of split paths after the entire job is done. If an instructor tries to submit or delete a split pdf before the permissions are corrected it'll throw an error. 

If a file processed 1 split pdf and an instructor submitted or deleted it right away, the controller would check if there were anymore pdfs since the job only processed 1 there would be none and Submitty would wrongly think this is the last pdf being assigned and delete the entire split folder which would cause the job to error and die. I removed this check for now but a better method to delete the split folder when everything is done is still needed.

Since the JSON file containing all the decoded information could be read before a job writes to it we need to check if the php key exists first, this didn't cause any issues but would throw php errors. 

EDIT: Since delete all is asynchronous, the pasge refresh at the end would kill some ajax calls which fail to delete certain split pdfs, now the page removes split pdfs from the user interface without a page reload.