### PR TITLE
Remove |raw in course setting page

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -18,7 +18,7 @@
                     <div class="option-alt">Input the course name that should appear in the header of the site (your course code is {{ core.getConfig().getCourse() }})</div>
                 </label>
             </div>
-            <div class="option-input col-md-4"><input type="text" name="course_name" id="course_name" value="{{ fields['course_name']|raw }}" /></div>
+            <div class="option-input col-md-4"><input type="text" name="course_name" id="course_name" value="{{ fields['course_name'] }}" /></div>
         </div>
 
         <div class="option row">
@@ -57,7 +57,7 @@
                         on the submission page.</div>
                 </label>
             </div>
-            <div class="option-input col-md-4"><textarea style="height: 50px" name="upload_message" id="upload_message">{{ fields['upload_message']|raw }}</textarea></div>
+            <div class="option-input col-md-4"><textarea style="height: 50px" name="upload_message" id="upload_message">{{ fields['upload_message'] }}</textarea></div>
         </div>
 
         <div class="option row">
@@ -155,7 +155,7 @@
                     <div class="option-alt">Input the message shown on grades returned to students.  Include instructions for grade inquiries and the course staff mailing list.</div>
                 </label>
             </div>
-            <div class="option-input col-md-4"><textarea style="height: 50px" name="course_email" id="course_email"  />{{ fields['course_email']|raw  }}</textarea></div>
+            <div class="option-input col-md-4"><textarea style="height: 50px" name="course_email" id="course_email"  />{{ fields['course_email']  }}</textarea></div>
         </div>
 
         <div class="option row">
@@ -176,7 +176,7 @@
                     <div class="option-alt">Input the warning message show to students while submitting a grade inquiry.</div>
                 </label>
             </div>
-            <div class="option-input col-md-4"><textarea style="height: 50px" name="regrade_message" id="regrade_message" rows="4"/>{{ fields['regrade_message']|raw}}</textarea></div>
+            <div class="option-input col-md-4"><textarea style="height: 50px" name="regrade_message" id="regrade_message" rows="4"/>{{ fields['regrade_message'] }}</textarea></div>
         </div>
 
         {# TODO: Not sure what this is


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #3801 .
Previously any javascript content in course full name will run because of `|raw` 
![ezgif com-video-to-gif(22)](https://user-images.githubusercontent.com/42701709/60453098-cc914c80-9c4d-11e9-96c8-4a5a0ccf14f6.gif)

### What is the new behavior?
Removing `|raw` will stop javascript running
![ezgif com-video-to-gif(23)](https://user-images.githubusercontent.com/42701709/60453108-d5821e00-9c4d-11e9-8f52-e72eb9531435.gif)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
