### PR TITLE
[Bugfix:InstructorUI] Fix autofill list showing behind modal on edit team form

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -993,6 +993,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
             $('[name="user_id_'+i+'"]', form).autocomplete({
                 source: student_full
             });
+            $('[name="user_id_'+i+'"]').autocomplete( "option", "appendTo", form );
         }
         var team_history_len=user_assignment_setting_json.team_history.length;
         team_history_title_div.append('Team History: ');


### PR DESCRIPTION
### What is the current behavior?
Editing a team on the grading details index page shows the autofill behind the modal

### What is the new behavior?
modal no longer appears on top of autofill list

fixes #3686
