### PR TITLE
[UI] Switch to AM/PM on assignment deadlines

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -72,6 +72,7 @@ class NavigationView extends AbstractView {
     ];
 
     const DATE_FORMAT = "m/d/Y @ H:i";
+    const AMPM_FORMAT = "m/d/Y @ h:i A";
 
     public function showGradeables($sections_to_list, $graded_gradeables, array $submit_everyone) {
         // ======================================================================================
@@ -301,7 +302,7 @@ class NavigationView extends AbstractView {
         $past_lock_date = $date < $gradeable->getTeamLockDate();
 
         if ($past_lock_date) {
-            $team_display_date = "(teams lock {$gradeable->getTeamLockDate()->format(self::DATE_FORMAT)})";
+            $team_display_date = "(teams lock {$gradeable->getTeamLockDate()->format(self::AMPM_FORMAT)})";
         } else {
             $team_display_date = '';
         }
@@ -352,8 +353,8 @@ class NavigationView extends AbstractView {
         $class = self::gradeableSections[$list_section]["button_type_submission"];
         $title = self::gradeableSections[$list_section]["prefix"];
         $display_date = ($list_section == GradeableList::FUTURE || $list_section == GradeableList::BETA) ?
-            "(opens " . $gradeable->getSubmissionOpenDate()->format(self::DATE_FORMAT) . ")" :
-            "(due " . $gradeable->getSubmissionDueDate()->format(self::DATE_FORMAT) . ")";
+            "(opens " . $gradeable->getSubmissionOpenDate()->format(self::AMPM_FORMAT) . ")" :
+            "(due " . $gradeable->getSubmissionDueDate()->format(self::AMPM_FORMAT) . ")";
         $points_percent = NAN;
 
         $href = $this->core->buildNewCourseUrl(['student', $gradeable->getId()]);

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -71,8 +71,7 @@ class NavigationView extends AbstractView {
         ]
     ];
 
-    const DATE_FORMAT = "m/d/Y @ H:i";
-    const AMPM_FORMAT = "m/d/Y @ h:i A";
+    const DATE_FORMAT = "m/d/Y @ h:i A";
 
     public function showGradeables($sections_to_list, $graded_gradeables, array $submit_everyone) {
         // ======================================================================================
@@ -302,7 +301,7 @@ class NavigationView extends AbstractView {
         $past_lock_date = $date < $gradeable->getTeamLockDate();
 
         if ($past_lock_date) {
-            $team_display_date = "(teams lock {$gradeable->getTeamLockDate()->format(self::AMPM_FORMAT)})";
+            $team_display_date = "(teams lock {$gradeable->getTeamLockDate()->format(self::DATE_FORMAT)})";
         } else {
             $team_display_date = '';
         }
@@ -353,8 +352,8 @@ class NavigationView extends AbstractView {
         $class = self::gradeableSections[$list_section]["button_type_submission"];
         $title = self::gradeableSections[$list_section]["prefix"];
         $display_date = ($list_section == GradeableList::FUTURE || $list_section == GradeableList::BETA) ?
-            "(opens " . $gradeable->getSubmissionOpenDate()->format(self::AMPM_FORMAT) . ")" :
-            "(due " . $gradeable->getSubmissionDueDate()->format(self::AMPM_FORMAT) . ")";
+            "(opens " . $gradeable->getSubmissionOpenDate()->format(self::DATE_FORMAT) . ")" :
+            "(due " . $gradeable->getSubmissionDueDate()->format(self::DATE_FORMAT) . ")";
         $points_percent = NAN;
 
         $href = $this->core->buildNewCourseUrl(['student', $gradeable->getId()]);

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -350,7 +350,7 @@ class HomeworkView extends AbstractView {
         // Import custom js for notebook items
         $this->core->getOutput()->addInternalJs('gradeable-notebook.js');
 
-        $DATE_FORMAT = "m/d/Y @ H:i";
+        $DATE_FORMAT = "m/d/Y @ h:i A";
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
             'base_url' => $this->core->getConfig()->getBaseUrl(),
             'gradeable_id' => $gradeable->getId(),


### PR DESCRIPTION
Changes assignment deadlines to use AM/PM for student facing assignments
This changes the dates on the buttons on the navigation page to use AM/PM
and also the submission page for gradeables.

![b](https://user-images.githubusercontent.com/12129065/60497370-b6ea4a00-9c82-11e9-83a3-996c3fbcd9dd.png)
![1](https://user-images.githubusercontent.com/12129065/60497372-b6ea4a00-9c82-11e9-853a-1cb3b5e931e6.png)


Fixes #3313