### PR TITLE
[Refactor:Router] Remove usage of "die" in WebRouter

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -42,7 +42,7 @@ class HomePageController extends AbstractController {
     }
 
     /**
-     * @Route("/home/change_password")
+     * @Route("/home/change_password", methods={"POST"})
      */
     public function changePassword(){
         $user = $this->core->getUser();
@@ -59,7 +59,7 @@ class HomePageController extends AbstractController {
     }
 
     /**
-     * @Route("/home/change_username")
+     * @Route("/home/change_username", methods={"POST"})
      */
     public function changeUserName(){
         $user = $this->core->getUser();

--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -34,7 +34,7 @@ class NavigationController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}", requirements={"_semester": "^((?!api).)*$"})
+     * @Route("/{_semester}/{_course}", requirements={"_semester": "^(?!api$)[^\/]+"})
      */
     public function navigationPage() {
         $gradeables_list = new GradeableList($this->core);

--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -34,7 +34,7 @@ class NavigationController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}", requirements={"_semester": "^(?!api$)[^\/]+"})
+     * @Route("/{_semester}/{_course}", requirements={"_semester": "^(?!api)[^\/]+", "_course": "[^\/]+"})
      */
     public function navigationPage() {
         $gradeables_list = new GradeableList($this->core);

--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -34,7 +34,7 @@ class NavigationController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}")
+     * @Route("/{_semester}/{_course}", requirements={"_semester": "^((?!api).)*$"})
      */
     public function navigationPage() {
         $gradeables_list = new GradeableList($this->core);

--- a/site/app/libraries/response/JsonResponse.php
+++ b/site/app/libraries/response/JsonResponse.php
@@ -13,7 +13,7 @@ use app\libraries\Core;
 class JsonResponse extends AbstractResponse {
 
     /** @var array json encoded array */
-    protected $json;
+    public $json;
 
     /**
      * JsonResponse constructor.

--- a/site/app/libraries/response/RedirectResponse.php
+++ b/site/app/libraries/response/RedirectResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace app\libraries\response;
+
+use app\libraries\Core;
+
+
+/**
+ * Class RedirectResponse
+ * @package app\libraries\response
+ */
+class RedirectResponse extends AbstractResponse {
+    /** @var string */
+    protected $url;
+
+    /**
+     * RedirectResponse constructor.
+     * @param $url
+     */
+    public function __construct($url) {
+        $this->url = $url;
+    }
+
+    /**
+     * Redirect to $this->url.
+     * @param Core $core
+     */
+    public function render(Core $core) {
+        $core->redirect($this->url);
+    }
+}

--- a/site/app/libraries/response/Response.php
+++ b/site/app/libraries/response/Response.php
@@ -12,13 +12,13 @@ use app\libraries\Core;
  */
 class Response extends AbstractResponse {
     /** @var null | WebResponse  */
-    protected $web_response = null;
+    public $web_response = null;
 
     /** @var null | JsonResponse  */
-    protected $json_response = null;
+    public $json_response = null;
 
     /** @var null | RedirectResponse */
-    protected $redirect_response = null;
+    public $redirect_response = null;
 
     /**
      * Response constructor.

--- a/site/app/libraries/response/Response.php
+++ b/site/app/libraries/response/Response.php
@@ -17,28 +17,47 @@ class Response extends AbstractResponse {
     /** @var null | JsonResponse  */
     protected $json_response = null;
 
+    /** @var null | RedirectResponse */
+    protected $redirect_response = null;
+
     /**
      * Response constructor.
      * @param JsonResponse|null $json_response
      * @param WebResponse|null $web_response
+     * @param RedirectResponse|null $redirect_response
      */
-    public function __construct(JsonResponse $json_response = null, WebResponse $web_response = null) {
+    public function __construct(
+        JsonResponse $json_response = null,
+        WebResponse $web_response = null,
+        RedirectResponse $redirect_response = null
+    ) {
         $this->json_response = $json_response;
         $this->web_response = $web_response;
+        $this->redirect_response = $redirect_response;
     }
 
     /**
      * @param WebResponse $web_response
+     * @return Response
      */
-    public function setWebResponse(WebResponse $web_response) {
-        $this->web_response = $web_response;
+    static public function WebOnlyResponse(WebResponse $web_response) {
+        return new self(null, $web_response, null);
     }
 
     /**
      * @param JsonResponse $json_response
+     * @return Response
      */
-    public function setJsonResponse(JsonResponse $json_response) {
-        $this->json_response = $json_response;
+    static public function JsonOnlyResponse(JsonResponse $json_response) {
+        return new self($json_response, null, null);
+    }
+
+    /**
+     * @param RedirectResponse $redirect_response
+     * @return Response
+     */
+    static public function RedirectOnlyResponse(RedirectResponse $redirect_response) {
+        return new self(null, null, $redirect_response);
     }
 
     /**
@@ -52,14 +71,15 @@ class Response extends AbstractResponse {
      * @param Core $core
      */
     public function render(Core $core) {
-        if ($this->web_response && is_null($this->json_response)) {
-            $this->web_response->render($core);
+        $web_response = $this->redirect_response ? $this->redirect_response : $this->web_response;
+        if ($web_response && is_null($this->json_response)) {
+            $web_response->render($core);
         }
-        elseif ($this->json_response && is_null($this->web_response)) {
+        elseif ($this->json_response && is_null($web_response)) {
             $this->json_response->render($core);
         }
         elseif ($core->getOutput()->getRender()) {
-            $this->web_response->render($core);
+            $web_response->render($core);
         }
         else {
             $this->json_response->render($core);

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -58,11 +58,11 @@
         </div>
     {% else %}
         <div class = "tab">
-            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Numerical Data'), this.blur()" id="defaultOpen">Numerical Data</button>
-            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Total Score Histogram'), this.blur()">Total Score Histogram</button>
-            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Autograding Score Histogram'), this.blur()">Autograding Score Histogram</button>
-            <button class="btn btn-primary" type="button" onclick="openStat(event, 'Component Averages'), this.blur()">Component Averages</button>
-            <div id = "Total Score Histogram" class = "tabcontent">
+            <button class="btn btn-primary" type="button" onclick="openStat(event, 'numerical-data'), this.blur()" id="defaultOpen">Numerical Data</button>
+            <button class="btn btn-primary" type="button" onclick="openStat(event, 'total-score-histogram'), this.blur()">Total Histogram</button>
+            <button class="btn btn-primary" type="button" onclick="openStat(event, 'autograding-score-histogram'), this.blur()">Autograding Histogram</button>
+            <button class="btn btn-primary" type="button" onclick="openStat(event, 'component-averages'), this.blur()">Component Averages</button>
+            <div id = "total-score-histogram" class = "tabcontent">
                 {% if overall_average == null or overall_average.getCount() == 0 %}
                     <br/>
                     No assignments have been completely graded yet.
@@ -233,13 +233,16 @@
                     Grade Inquiries: {{ GradeInq }}
                     {{ "\n"|nl2br }}
                     Incomplete Grading: {{ IncompGrading }}
+                    <br/>
+                    <br/>
+                    Double-click on the chart to zoom out
                 {% endif %}
 
 
             </div>
 
             {# Setup for Component Average Graphs#}
-            <div id="Component Averages" class="tabcontent">
+            <div id="component-averages" class="tabcontent">
 
                 {% if component_averages|length == 0 %}
                     <br/>
@@ -313,10 +316,13 @@
 
                         Plotly.newPlot('myDiv2', data, layout, {displayModeBar: false,displaylogo: false});
                     </script>
+                     <br/>
+                    <br/>
+                    Double-click on the chart to zoom out
                 {% endif %}
             </div>
             {# Graph Setup for Autograding #}
-            <div id="Autograding Score Histogram" class="tabcontent">
+            <div id="autograding-score-histogram" class="tabcontent">
                 {% if autograding_non_extra_credit != 0 %}
                     {# Only show autograder if we have autograding points #}
                 {% if autograded_average == null or autograded_average.getCount() == 0 %}
@@ -430,6 +436,9 @@
                     Grade Inquiries: {{ GradeInq }}
                     {{ "\n"|nl2br }}
                     Incomplete Grading: {{ IncompGrading }}
+                     <br/>
+                    <br/>
+                    Double-click on the chart to zoom out
                 {% endif %}
                 {% else %}
                 <br/>
@@ -437,7 +446,7 @@
                 {% endif %}
 
             </div>
-            <div id="Numerical Data" class="tabcontent">
+            <div id="numerical-data" class="tabcontent">
                 <div class = "row">
                     <div class = "box col-md-6">
                         {# LEFT CHUNK#}
@@ -451,24 +460,24 @@
                         {% endif %}
 
                         {% if team_assignment %}
-                            <br />
+                            <br/>
                             <b>Students on a team:</b> {{ team_total }}/{{ total_students }} ({{ team_percentage }}%)
-                            <br />
-                            <br />
+                            <br/>
+                            <br/>
                             <b>Number of teams:</b> {{ total_submissions }}
-                            <br />
-                            <br />
+                            <br/>
+                            <br/>
                             <b>Teams who have submitted:</b> {{ submitted_total }} / {{ total_submissions }} ({{ submitted_percentage }}%)
                         {% else %}
-                            <br />
+                            <br/>
                             <b>Students who have submitted:</b>  {{ submitted_total }} / {{ total_submissions }} ({{ submitted_percentage }}%)
-                            <br />
-                            <br />
+                            <br/>
+                            <br/>
                             <b>Current percentage of grading done:</b> {{ graded_total }} / {{ submitted_total }} ({{ graded_percentage }}%)
                         {% endif %}
 
-                        <br />
-                        <br />
+                        <br/>
+                        <br/>
                         {% if peer %}
                             <b>Current percentage of students grading done:</b> {{ peer_percentage }}% ({{ peer_graded }}/{{ peer_total }})
                         {% else %}
@@ -478,7 +487,7 @@
                                     Section {{ key }}: {{ section.graded }} / {{ section.total }} ({{ section.percentage }}%)<br />
                                 {% endfor %}
                             </div>
-                            <br />
+                            <br/>
                             <b>Graders:</b>
                             <div style="margin-left: 20px">
                                 {% for key, section in sections %}
@@ -488,24 +497,24 @@
                                     {% else %}
                                         {{ section.valid_graders | join(", ") }}
                                     {% endif %}
-                                    <br />
+                                    <br/>
                                 {% endfor %}
                             </div>
                         {% endif %}
 
                         {% if ta_grades_released %}
                             {% if team_assignment %}
-                                <br />
+                                <br/>
                                 <b>Number of teams who have viewed their grade:</b> {{ viewed_grade }} / {{ viewed_total }} ({{ viewed_percent }}%)
                             {% else %}
-                                <br />
+                                <br/>
                                 <b>Number of students who have viewed their grade:</b> {{ viewed_grade }} / {{ viewed_total }} ({{ viewed_percent }}%)
                             {% endif %}
                         {% endif %}
 
                         {% if core.getConfig().isRegradeEnabled() and not peer %}
-                            <br />
-                            <br />
+                            <br/>
+                            <br/>
                             <b>Number of students who have unresolved grade inquiries:</b> {{ regrade_requests }}
                         {% endif %}
                         {# LEFT CHUNK #}

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -8,6 +8,7 @@ use app\libraries\Utils;
 use app\libraries\Access;
 use app\libraries\TokenManager;
 use app\libraries\routers\ClassicRouter;
+use app\libraries\routers\WebRouter;
 use app\libraries\response\Response;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -295,11 +296,7 @@ if (empty($_REQUEST['component']) && $core->getUser() !== null) {
 $supported_by_new_router = in_array($_REQUEST['component'], ['authentication', 'home', 'navigation']);
 
 if ($is_api) {
-    $core->getOutput()->disableRender();
-    $core->disableRedirects();
-
-    $router = new app\libraries\routers\WebRouter($request, $core, $api_logged_in, true);
-    $response = $router->run();
+    $response = WebRouter::getApiResponse($request, $core, $api_logged_in);
 }
 elseif (!$supported_by_new_router) {
     switch($_REQUEST['component']) {

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -148,12 +148,11 @@ class WebRouterTester extends BaseUnitTest {
         $request = Request::create(
             "/api" . $url
         );
-        $this->expectException(ResourceNotFoundException::class);
-        $router = new WebRouter($request, $core, true, true);
+        $response = WebRouter::getApiResponse($request, $core, true);
         $this->assertEquals([
             'status' => "fail",
             'message' => "Endpoint not found."
-        ], $router->run()->render());
+        ], $response->json_response->json);
     }
 
     public function testApiWrongMethod() {
@@ -161,11 +160,10 @@ class WebRouterTester extends BaseUnitTest {
         $request = Request::create(
             "/api/token"
         );
-        $this->expectException(MethodNotAllowedException::class);
-        $router = new WebRouter($request, $core, true, true);
+        $response = WebRouter::getApiResponse($request, $core, true);
         $this->assertEquals([
             'status' => "fail",
             'message' => "Method not allowed."
-        ], $router->run()->render());
+        ], $response->json_response->json);
     }
 }

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -5,6 +5,8 @@ namespace tests\app\libraries\routers;
 use app\libraries\routers\WebRouter;
 use tests\BaseUnitTest;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 class WebRouterTester extends BaseUnitTest {
@@ -135,5 +137,35 @@ class WebRouterTester extends BaseUnitTest {
             ["/index.php?semester=s19&course=sample"],
             ["/s19/sample/random/invalid/endpoint"]
         ];
+    }
+
+    /**
+     * @param string $url a url to an nonexistent API endpoint
+     * @dataProvider randomUrlProvider
+     */
+    public function testApiNotFound($url) {
+        $core = $this->createMockCore(['semester' => 's19', 'course' => 'sample']);
+        $request = Request::create(
+            "/api" . $url
+        );
+        $this->expectException(ResourceNotFoundException::class);
+        $router = new WebRouter($request, $core, true, true);
+        $this->assertEquals([
+            'status' => "fail",
+            'message' => "Endpoint not found."
+        ], $router->run()->render());
+    }
+
+    public function testApiWrongMethod() {
+        $core = $this->createMockCore(['semester' => 's19', 'course' => 'sample']);
+        $request = Request::create(
+            "/api/token"
+        );
+        $this->expectException(MethodNotAllowedException::class);
+        $router = new WebRouter($request, $core, true, true);
+        $this->assertEquals([
+            'status' => "fail",
+            'message' => "Method not allowed."
+        ], $router->run()->render());
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
To display error messages, sometimes WebRouter has to `die` immediately.

### What is the new behavior?
Now API returns nice error JSON messages as `Response`.

Also added:
- `RedirectResponse`
- CSRF Token Check