### PR TITLE
[Bugfix:Installation] skip worker installation when enabled=false

### DIFF
--- a/sbin/shipper_utils/systemctl_wrapper.py
+++ b/sbin/shipper_utils/systemctl_wrapper.py
@@ -73,6 +73,10 @@ def perform_systemctl_command_on_worker(daemon, mode, target):
     print("There is no machine with the key {0}".format(target))
     sys.exit(EXIT_CODES['bad_arguments'])
 
+  if WORKERS[target]['enabled'] == False:
+    print("Skipping {0} of {1} because worker machine {2} is disabled".format(mode, daemon, target))
+    return EXIT_CODES['inactive']
+
   user = WORKERS[target]['username']
   host = WORKERS[target]['address']
 

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -77,8 +77,13 @@ if __name__ == "__main__":
   for worker, stats in autograding_workers.items():
       user = stats['username']
       host = stats['address']
+      enabled = stats['enabled']
 
       if worker == 'primary' or host == 'localhost':
+          continue
+
+      if enabled == False:
+          print("Skipping rsync to {0} because it is disabled.".format(worker))
           continue
 
       exit_code = run_systemctl_command(worker, 'status')


### PR DESCRIPTION
When a machine has enabled=false, skip attempt to restart worker & rsync new Submitty code