### PR TITLE
[Bugfix] nl2br for session messages

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -41,7 +41,7 @@
                         {% else %}
                         <i class="fas fa-check-circle"></i>
                         {% endif %}
-                        {{ message.error }}
+                        {{ message.error | nl2br }}
                     </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
There are some places that return multiple errors and they are separated by `\n`. When rendering them in the front end, we should use `<br />` instead.

https://github.com/Submitty/Submitty/blob/d43bb2643b3681b3095aa114aa707425f86a4bce/site/app/controllers/student/SubmissionController.php#L500-L503

### What is the new behavior?
Newlines are displayed correctly.

Thank @xprilion for pointing this out.