### PR TITLE
Fix 'now' and 'end of time' datepicker buttons from not saving on gradeable dates

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -136,15 +136,17 @@
                         label: "or",
                         onClick: (index, fp) => {
                             let date;
+                            let event = new Event("change");
                             switch (index) {
                                 case 0: 
                                     date = new Date();
                                     break;
                                 case 1: 
-                                    date = new Date("9999-01-01 00:00:00");
+                                    date = new Date("9998-01-01 00:00:00");
                                     break;
                             }
                             fp.setDate(date);
+                            $(".date_picker").each(function(i, obj){obj.dispatchEvent(event); });
                         }
                     }
                 )],


### PR DESCRIPTION
Forces the date textareas to update in order to validate and save the dates entered by pressing the buttons on the flatpicker calender in the gradeable edit pages.

(Also changed the end of time value  to be 1998 I think comparing dates with the actual end of time was causing JS math issues and would always say fail to save)
