### PR TITLE
Fix Badge title and confetti on Autograding only gradeables

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -16,7 +16,7 @@
     </script>
 {% endif %}
 
-{% if not is_ta_grade_released %}
+{% if not is_ta_grading %}
     <canvas id="confetti_canvas"></canvas>
 {% endif %}
 
@@ -31,7 +31,7 @@
             {% endif %}
          >
             {{ Badge.render(nonhidden_earned, nonhidden_max, false) }}
-            <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }} {% if show_hidden_breakdown %} <i>(Without Hidden Points)</i>{% endif %}</h4>
+            <h4>{{ is_ta_grading ? "Autograding Subtotal" : "Total" }} {% if show_hidden_breakdown %} <i>(Without Hidden Points)</i>{% endif %}</h4>
         </div>
     </div>
     {% if show_hidden_breakdown %}
@@ -43,7 +43,7 @@
         >
             <div class="box-title">
                 {{ Badge.render(hidden_earned, hidden_max, false) }}
-                <h4>{{ is_ta_grade_released ? "Autograding Subtotal" : "Total" }} <i>(With Hidden Points)</i></h4>
+                <h4>{{ is_ta_grading ? "Autograding Subtotal" : "Total" }} <i>(With Hidden Points)</i></h4>
             </div>
         </div>
     {% endif %}

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -16,9 +16,12 @@
     </script>
 {% endif %}
 
-{% if not is_ta_grading %}
+{% if show_hidden_breakdown and hidden_earned >= hidden_max %}
+    <canvas id="confetti_canvas"></canvas>
+{% elseif nonhidden_earned >= nonhidden_max %}
     <canvas id="confetti_canvas"></canvas>
 {% endif %}
+
 
 {% if num_visible_testcases > 1 %}
     {# check if instructor grades exist and change title, display hidden points when TA grades are released (if hidden tests exist) #}

--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -42,9 +42,16 @@
         {% endif %}
         {# /Overview #}
 
+        {% if (graded_score >= graded_max) or (total_score >= total_max) %}
+            <canvas id="confetti_canvas"></canvas>
+        {% endif %}
+
         {# Manual total #}
         <div class="box">
-            <div class="box-title">
+            <div class="box-title" 
+                {% if graded_score >= graded_max %}
+                        onclick="addConfetti();" style="cursor:pointer;"
+                {% endif %}>
                 {{ Badge.render(graded_score, graded_max, false) }}
                 <h4>{{ has_autograding ? "TA / Instructor Grading Subtotal" : "Total" }}</h4>
             </div>
@@ -121,7 +128,6 @@
                     <h4>Total</h4>
                 </div>
             </div>
-            <canvas id="confetti_canvas"></canvas>
         {% endif %}
         {# /Total auto + manual #}
     </div>

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -106,7 +106,8 @@ class AutoGradingView extends AbstractView {
             "has_badges" => $has_badges,
             'testcases' => $testcase_array,
             'is_ta_grade_released' => $gradeable->isTaGradeReleased(),
-            'display_version' => $version_instance->getVersion()
+            'display_version' => $version_instance->getVersion(),
+            'is_ta_grading' => $gradeable->isTaGrading()
         ]);
     }
 


### PR DESCRIPTION
Minor bugfix, the method to check if a gradeable was autograding only was broken previouslly 
as a result confetti would not display :(

Fixed logic : now autograding, ta grading, and total all can launch confetti if any are perfect or higher

Also fixed the bug where if a gradeable is autograding only the top level badge would display as "Autograding subtotal" instead of just "Total" 