### PR TITLE
[Bugfix:InstructorUI] remove bulk upload forensics from non is_scanned submissions

### DIFF
--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -148,7 +148,7 @@
                     Download Zip of All Students
                 </a>
             {% endif %}
-            {% if core.getUser().accessFullGrading() %}
+            {% if core.getUser().accessFullGrading() and is_scanned_exam %}
                 <a class="btn btn-primary"
                    href="{{ core.buildUrl({'component': 'submission', 'action': 'stat_page', 'gradeable_id': gradeable_id}) }}">
                     Bulk Upload Forensics

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -196,6 +196,7 @@ class ElectronicGraderView extends AbstractView {
             "gradeable_title" => $gradeable->getTitle(),
             "team_assignment" => $gradeable->isTeamAssignment(),
             "ta_grades_released" => $gradeable->isTaGradeReleased(),
+            "is_scanned_exam" => $gradeable->isScannedExam(),
             "rotating_sections_error" => (!$gradeable->isGradeByRegistration()) and $no_rotating_sections
                 and $this->core->getUser()->getGroup() == User::GROUP_INSTRUCTOR,
             "autograding_non_extra_credit" => $gradeable->getAutogradingConfig()->getTotalNonExtraCredit(),


### PR DESCRIPTION
Signed-off-by: fenn-cs <fenn25.fn@gmail.com>

### What is the current behavior?
When we click on the "Grade" or "Regrade" button for an assignment that is uploaded by students, and then click on "Bulk Upload Forensics", multiple errors described in #3889 are gotten.

This is because forensics is only available for bulk uploads (i.e gradeables of type `scanned_exam`), so the functionality fails to work on other gradeables which is not of the mentioned type.

Fixes: #3889 

### What is the new behavior?
Hide "Bulk upload forensics" button if the gradeable does not support bulk uploads.

**_Working gradeable page for gradeable with bulk upload support._**

![Screenshot from 2019-07-07 02-21-54](https://user-images.githubusercontent.com/14317775/60762702-1ae38880-a05e-11e9-8e2c-0f36adfc2454.png)

![Screenshot from 2019-07-07 02-07-52](https://user-images.githubusercontent.com/14317775/60762664-837e3580-a05d-11e9-9756-707993283f9c.png)

**_Otherwise_**

![Screenshot from 2019-07-07 02-19-41](https://user-images.githubusercontent.com/14317775/60762713-32227600-a05e-11e9-9fcf-e7ed95a11590.png)


### Other information?
