### PR TITLE
[Bugfix:UI] Use getBaseUrl instead of getHomepageUrl

### DIFF
--- a/site/app/views/ErrorView.php
+++ b/site/app/views/ErrorView.php
@@ -26,7 +26,7 @@ class ErrorView extends AbstractView {
         return $this->core->getOutput()->renderTwigTemplate("error/NoAccessCourse.twig", [
             "course_name" => $this->core->getDisplayedCourseName(),
             "semester" => $this->core->getFullSemester(),
-            "main_url" => $this->core->getConfig()->getHomepageUrl()
+            "main_url" => $this->core->getConfig()->getBaseUrl()
         ]);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #4020. The page was using a method that was removed in #3945 

### What is the new behavior?
Uses `getBaseUrl()` which returns the URL we want (due to the router work).