### PR TITLE
Add Worker Machine Boolean to Submitty Configuration JSON

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -454,7 +454,6 @@ config['submitty_install_dir'] = SUBMITTY_INSTALL_DIR
 config['submitty_repository'] = SUBMITTY_REPOSITORY
 config['submitty_data_dir'] = SUBMITTY_DATA_DIR
 config['autograding_log_path'] = AUTOGRADING_LOG_PATH
-config['timezone'] = TIMEZONE
 
 if not args.worker:
     config['site_log_path'] = TAGRADING_LOG_PATH
@@ -464,6 +463,9 @@ if not args.worker:
     config['institution_name'] = INSTITUTION_NAME
     config['username_change_text'] = USERNAME_TEXT
     config['institution_homepage'] = INSTITUTION_HOMEPAGE
+    config['timezone'] = TIMEZONE
+
+config['worker'] = True if args.worker == 1 else False
 
 with open(SUBMITTY_JSON, 'w') as json_file:
     json.dump(config, json_file, indent=2)
@@ -512,19 +514,20 @@ if not args.worker:
 ##############################################################################
 # Write email json
 
-config = OrderedDict()
-config['email_enabled'] = EMAIL_ENABLED
-config['email_user'] = EMAIL_USER
-config['email_password'] = EMAIL_PASSWORD
-config['email_sender'] = EMAIL_SENDER
-config['email_reply_to'] = EMAIL_REPLY_TO
-config['email_server_hostname'] = EMAIL_SERVER_HOSTNAME
-config['email_server_port'] = EMAIL_SERVER_PORT
+if not args.worker:
+    config = OrderedDict()
+    config['email_enabled'] = EMAIL_ENABLED
+    config['email_user'] = EMAIL_USER
+    config['email_password'] = EMAIL_PASSWORD
+    config['email_sender'] = EMAIL_SENDER
+    config['email_reply_to'] = EMAIL_REPLY_TO
+    config['email_server_hostname'] = EMAIL_SERVER_HOSTNAME
+    config['email_server_port'] = EMAIL_SERVER_PORT
 
-with open(EMAIL_JSON, 'w') as json_file:
-    json.dump(config, json_file, indent=2)
-shutil.chown(EMAIL_JSON, 'root', DAEMONPHP_GROUP)
-os.chmod(EMAIL_JSON, 0o440)
+    with open(EMAIL_JSON, 'w') as json_file:
+        json.dump(config, json_file, indent=2)
+    shutil.chown(EMAIL_JSON, 'root', DAEMONPHP_GROUP)
+    os.chmod(EMAIL_JSON, 0o440)
 
 
 

--- a/migration/migrator/migrations/system/20190708100715_add_worker_to_submitty_config.py
+++ b/migration/migrator/migrations/system/20190708100715_add_worker_to_submitty_config.py
@@ -1,0 +1,28 @@
+"""
+Migration for the Submitty system.
+Adds bool to specify if the machine is a worker to Submitty.config
+"""
+from pathlib import Path
+import json
+import os
+
+
+def up(config):
+    submitty_json = str(Path(config.submitty['submitty_install_dir'], 'config', 'submitty.json'))
+    submitty_conf = str(Path(config.submitty['submitty_install_dir'], '.setup', 'submitty_conf.json'))
+
+    with open(submitty_conf, 'r') as infile:
+        conf_data = json.load(infile)
+        is_worker = conf_data['worker']
+
+    with open(submitty_json, 'r') as infile:
+        data = json.load(infile)
+
+    data['worker'] = True if is_worker == 1 else False
+
+    with open(submitty_json, 'w') as outfile:
+        json.dump(data, outfile, indent=4)
+
+# no need for down as email_enabled is not used in previous builds
+def down(config):
+    pass


### PR DESCRIPTION
Closes #3671

### This PR:
1. Adds a boolean to ```submitty.json``` which specifies whether or not the machine is primary or a worker.
2. Adds a migration to add the boolean in existing installs. In new installs, the boolean is added by ```CONFIGURE_SUBMITTY.py```.
3. Fixes a bug which was making it impossible to install new worker machines.