### PR TITLE
Fix team actions causing 'invalid csrf token error'

### DIFF
--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -38,6 +38,7 @@
                 {% else %}
                     <form action="{{ cancel_invitation_url }}" method="post">
                         <input type="hidden" name="cancel_id" value={{ invited }} />
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                         &emsp;{{ invited }}: <input type="submit" value = "Cancel" class="btn btn-danger" />
                     </form>
                     <br />
@@ -76,6 +77,7 @@
         <br />
         <form action="{{ send_invitation_url }}" method="post">
             <input type="text" name="invite_id" id="invite_id" placeholder="User ID" />
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <input type="submit" value = "Invite" class="btn btn-primary" />
         </form>
         <br />
@@ -91,6 +93,7 @@
             {% for invite in invites_received %}
                 <form action="{{ accept_invitation_url }}" method="post">
                     <input type="hidden" name="team_id" value={{ invite.getId() }} />
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                     &emsp;{{  invite.getMemberList() }}: <input type="submit" value = "Accept" class="btn btn-success" />
                 </form>
                 <br />

--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -59,6 +59,7 @@ class TeamView extends AbstractView {
             "send_invitation_url" => $this->core->buildNewCourseUrl([$gradeable_id, 'team', 'invitation', 'new']),
             "accept_invitation_url" => $this->core->buildNewCourseUrl([$gradeable_id, 'team', 'invitation', 'accept']),
             "cancel_invitation_url" => $this->core->buildNewCourseUrl([$gradeable_id, 'team', 'invitation', 'cancel']),
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }


### PR DESCRIPTION
For some reason whenever I try and action with a team it throws me back to the course list page and gives an error saying invalid CSRF token.
Tried with send invite, cancel invite, and accept invite which are all html forms, I'm assuming the access controller is validating CSRF tokens in between or the router has changed somewhere and the expected tokens are not being sent with the requst.

This adds them to each form and seems to fix, @zjxiaohan  can you double check this isn't happening anywhere else, my guess is that this is caused by the changes the teamController using the new router. Let me know if theres a better fix for this if you have seen this issue before. 