### PR TITLE
[Bugfix:Autograding] Image Diff Fails Gracefully on Different Sized Images

### DIFF
--- a/grading/dispatch.cpp
+++ b/grading/dispatch.cpp
@@ -1139,6 +1139,17 @@ TestResults* dispatch::ImageDiff_doit(const TestCase &tc, const nlohmann::json& 
     return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "Image comparison failed; expected file does not exist.")});
   }
 
+  // Before we compare, make certain that the images are the same size.
+  std::string size_command_actual = "identify -ping -format '%w %h' " + actual_file;
+  std::string size_command_expected = "identify -ping -format '%w %h' " + expected_file;
+
+  std::string actual_size_output = output_of_system_command(size_command_actual.c_str());
+  std::string expected_size_output = output_of_system_command(size_command_expected.c_str());
+
+  if(actual_size_output != expected_size_output){
+    return new TestResults(0.0, {std::make_pair(MESSAGE_FAILURE, "Image comparison failed; Images are not of the same size.")});
+  }
+
   std::string command = "compare -metric RMSE " + actual_file + " " + expected_file + " NULL: 2>&1";
   std::string output = output_of_system_command(command.c_str()); //get the string
   std::cout << "captured the following:\n" << output << "\n" <<std::endl;

--- a/more_autograding_examples/image_diff_mirror/config/config.json
+++ b/more_autograding_examples/image_diff_mirror/config/config.json
@@ -7,7 +7,6 @@
     "testcases" : [    
         {
             "title" : "Mirror",
-            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -22,7 +21,6 @@
         },
         {
             "title" : "Student 1 Professor 1",
-            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -41,7 +39,6 @@
         },
         {
             "title" : "Student 2 Professor 2",
-            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -60,7 +57,6 @@
         },
         {
             "title" : "Student 1 Professor 2",
-            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -79,7 +75,6 @@
         },
         {
             "title" : "Student 2 Professor 1",
-            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [

--- a/more_autograding_examples/image_diff_mirror/config/config.json
+++ b/more_autograding_examples/image_diff_mirror/config/config.json
@@ -1,23 +1,13 @@
 {
     "autograding" : {
         "submission_to_runner" : [ "*.txt", "*.png" ],
-	"work_to_details" : ["*.png"]
+	       "work_to_details" : ["**/*.png"]
     },
     "max_submission_size" : 2000000,
     "testcases" : [    
-        // *************** COMPILATION *****************
-        {
-            "type" : "Compilation",
-            "title" : "Compilation",
-            //Note the multistep compilation which first 
-            //calls cmake and then make. 
-            "command" : ["g++ *.cpp"],
-            "executable_name" : "a.out",
-            "points" : 4
-        },    
         {
             "title" : "Mirror",
-            "command" : "./a.out",
+            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -32,7 +22,7 @@
         },
         {
             "title" : "Student 1 Professor 1",
-            "command" : "./a.out",
+            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -51,7 +41,7 @@
         },
         {
             "title" : "Student 2 Professor 2",
-            "command" : "./a.out",
+            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -70,7 +60,7 @@
         },
         {
             "title" : "Student 1 Professor 2",
-            "command" : "./a.out",
+            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [
@@ -89,7 +79,7 @@
         },
         {
             "title" : "Student 2 Professor 1",
-            "command" : "./a.out",
+            "command" : "sleep .001",
             "points" : 1,
             "validation" :
             [

--- a/more_autograding_examples/image_diff_mirror/submissions/main.cpp
+++ b/more_autograding_examples/image_diff_mirror/submissions/main.cpp
@@ -1,8 +1,0 @@
-#include <iostream>
-
-int main()
-{
-	int a = 1;
-	int b = 2;
-	int c = a+b;
-}


### PR DESCRIPTION
Closes #3438

### This PR:
1. Updates the image diff validation type so that it fails gracefully if images are of a different size. 
2. Updates the ```image diff mirror``` gradable in development to fix bugs and make it simpler.

#### Before
![before_image_updates](https://user-images.githubusercontent.com/11758882/60905641-791d9080-a243-11e9-8c7c-84ed2fb0d488.png)

#### After
![not_of_same_size](https://user-images.githubusercontent.com/11758882/60905656-80dd3500-a243-11e9-904b-c515598fa726.png)

