### PR TITLE
[Feature:InstructorUI] Course autograding config repo changes

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -210,6 +210,7 @@ class AdminGradeableController extends AbstractController {
         if ($config_repo_name !== '') {
             $repository_config_dir = $config_repo_name;
             $repository_error_message = $this->getValidPathsToConfigDirectories($repository_config_dir,$all_repository_config_paths);
+            usort($all_repository_config_paths, function($a,$b) { return $a[0] > $b[0]; } );
         }
 
         // Load output from build of config file

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -64,7 +64,10 @@
             <div class="option-desc col-md-8">
                 <label for="private_repository">
                     <div class="option-title">Course Autograding Config Directory</div>
-                    <div class="option-alt">Use your own directory for storing gradeable configs. Will appear in the create/edit gradeable page.<br>Leave blank if you do not have a private repository for gradeable configurations.</div>
+                    <div class="option-alt">Use your own directories for storing gradeable configs. Will appear in the create/edit gradeable page.<br>
+					To enter multiple directories, type the full paths separated by a comma. <br>
+					Leave blank if you do not have a private repository for gradeable configurations.
+					</div>
                 </label>
             </div>
             <div class="option-input col-md-4">

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -5,9 +5,9 @@
                     from the Course Settings Page. </p>
                 <p> Manually type the full path to a configuration file, or select from the list below. </p>
 		<p> The dropdown list has all existing configurations that contain the current text. Hit the red X to clear current text.</p>
-		{% if repository_error_message != '' %}
-			<div name="config_search_error">({{repository_error_message}})</div>
-		{% endif %}
+		{% for error_message in repository_error_messages %}
+			<div name="config_search_error">({{error_message}})</div>
+		{% endfor %}
 		{% if not currently_valid_repository %}
 			<div name="config_search_error"> The current path is not valid, selecting Rebuild Gradeable without changing it will fail.</div>
 		{% endif %}

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -6,7 +6,10 @@
                 <p> Manually type the full path to a configuration file, or select from the list below. </p>
 		<p> The dropdown list has all existing configurations that contain the current text. Hit the red X to clear current text.</p>
 		{% if repository_error_message != '' %}
-			<div id="repository_error">({{repository_error_message}})</div>
+			<div name="config_search_error">({{repository_error_message}})</div>
+		{% endif %}
+		{% if not currently_valid_repository %}
+			<div name="config_search_error"> The current path is not valid, selecting Rebuild Gradeable without changing it will fail.</div>
 		{% endif %}
 
     <fieldset>

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -114,7 +114,7 @@ table#grader-history th, table#grader-history td {
     margin-top: 20px;
 }
 
-#repository_error {
+[name = 'config_search_error'] {
     font-weight:normal;
     /* color is danger-red from colors.css can be changed when available */
     color:#e84848;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the new behavior?

- Repository configs are now sorted alphabetically on the dropdown menu.
- There is now a warning if the current path is invalid (when a path is manually typed, or a file selected from the dropdown is renamed/moved).
- Multiple repositories can be entered in "course settings" separated by commas.  Warnings will be displayed if any are parsed incorrectly.  Repositories are labeled (123...) in the dropdown and in warnings.
- The way the repositories are parsed for config.json files was changed.  Now uses a breadth first search so that it does not check files in folders deeper than the config.json, and folders searched are counted instead of files encountered.  

![aaaPr](https://user-images.githubusercontent.com/34327811/60924292-d5e27080-a26e-11e9-930a-01e2b2f69771.png)
