### PR TITLE
[Documentation:Installation] Enhance error message for new course group

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -130,7 +130,10 @@ class Core {
                 $this->config->loadCourseJson($course_json_path);
             }
             else{
-                $message = "Unable to access configuration file " . $course_json_path . " for " . $semester . " " . $course . " please contact your system administrator.";
+                $message = "Unable to access configuration file " . $course_json_path . " for " .
+                  $semester . " " . $course . " please contact your system administrator.\n" .
+                  "If this is a new course, the error might be solved by restarting php-fpm:\n" .
+                  "sudo service php7.2-fpm restart";
                 $this->addErrorMessage($message);
             }
         }


### PR DESCRIPTION
If a new course with new group is added, but php-fpm is not restarted, 
the configuration file will be unaccessible.  Enhancing this error message 
will save time & frustration when this step is accidentally skipped.