### PR TITLE
[Refactor] Remove unnecessary alias from database query

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -263,7 +263,7 @@ class DatabaseQueries {
         if($blockNumber <= -1) {
             // Find the last block
             $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, false, false);
-            $query = "SELECT count(*) FROM (SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where}) AS SUBQUERY";
+            $query = "SELECT count(*) FROM (SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where})";
             $this->course_db->query($query, $query_parameters);
             $results = $this->course_db->rows();
             $row_count = $results[0]['count'];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Query has a useless ALIAS attached to the form clause in it which was causing the syntax highlighting in the file to break for me when using VSCode + an extension (which I've also now stopped using) as I no longer need it. Bug had already been filed for it as well on this particular behavior.

### What is the new behavior?
Removes the pointless alias, no change in overall behavior.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Does not actually change anything about how the code works.