### PR TITLE
Prevent students from accessing course materials prior to release

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -166,8 +166,16 @@ class MiscController extends AbstractController {
                 return false;
             }
         } else {
+
             if (!$this->core->getAccess()->canI("path.read", ["dir" => $dir, "path" => $path])) {
                 $this->core->getOutput()->showError("You do not have access to this file");
+                return false;
+            }
+
+            // If the user attempting to access the file is not an instructor then ensure the file has been released
+            if(!$this->core->getUser()->accessAdmin() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+            {
+                $this->core->getOutput()->showError("You may not access this file until it is released.");
                 return false;
             }
         }

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -6,6 +6,7 @@ namespace app\controllers;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 use app\libraries\Core;
+use app\models\CourseMaterial;
 
 class MiscController extends AbstractController {
     public function run() {
@@ -87,10 +88,20 @@ class MiscController extends AbstractController {
                 return false;
             }
         } else {
+
+            // Check access through Access library
             if (!$this->core->getAccess()->canI("path.read", ["dir" => $dir, "path" => $path])) {
                 $this->core->getOutput()->showError("You do not have access to this file");
                 return false;
             }
+
+            // If the user attempting to access the file is not an instructor then ensure the file has been released
+            if(!$this->core->getUser()->accessAdmin() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+            {
+                $this->core->getOutput()->showError("You may not access this file until it is released.");
+                return false;
+            }
+
         }
         $file_name = basename(rawurldecode(htmlspecialchars_decode($path)));
         $corrected_name = pathinfo($path, PATHINFO_DIRNAME) . "/" .  $file_name;

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -1,0 +1,53 @@
+<?php
+
+
+namespace app\models;
+
+
+use app\exceptions\FileNotFoundException;
+use app\libraries\Core;
+
+class CourseMaterial extends AbstractModel
+{
+    /**
+     * Determine if a course materials file has been released
+     *
+     * @param Core $core Application core
+     * @param string $path_to_file Full path to the file that we would like to check is released or not
+     * @return bool Indicates if the file has been released or not
+     * @throws FileNotFoundException The course_materials_file_data.json was not found
+     */
+    public static function isMaterialReleased(Core $core, string $path_to_file)
+    {
+        // Before students are allowed to view or download a course materials file we must ensure
+        // it has been released.  To return true the file metadata must be found in course_materials_file_data.json
+        // and the current time must be greater than the release_datetime
+
+        // Get path to the meta data json
+        $meta_data_json = $core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
+
+        if(!is_file($meta_data_json))
+        {
+            throw new FileNotFoundException('Unable to locate the course_materials_file_data.json file');
+        }
+
+        $meta_data = json_decode(file_get_contents($meta_data_json));
+
+        // If file path does not exist as key in $meta_data then it has not been released
+        if(!property_exists($meta_data, $path_to_file))
+        {
+            return false;
+        }
+        // Else key does exist
+        else
+        {
+            $current_time = new \DateTime('now');
+            $release_time = \DateTime::createFromFormat('Y-m-d H:i:s', $meta_data->$path_to_file->release_datetime);
+
+            // If current time is greater than release time return true, else return false
+            $current_time > $release_time ? $retVal = true : $retVal = false;
+
+            return $retVal;
+        }
+    }
+}


### PR DESCRIPTION
Closes #1921

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Students could access course materials even if the materials had not yet been released, provided the student knew the URL to the resource.

### What is the new behavior?
Only instructors may view or download unreleased course materials.  Even if a student knows the url to a resource, they may no longer view or download it until it has been released.

### Other information?
Tested manually by uploaded files and attempting to view/download course material files logged in as a student in a separate browser.