### PR TITLE
[Router] Let Router Catch MethodNotAllowedException

### DIFF
--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -121,7 +121,7 @@ class WebRouter {
                 );
             }
         }
-        catch (ResourceNotFoundException $e) {
+        catch (ResourceNotFoundException | MethodNotAllowedException $e) {
             // redirect to login page or home page
             if (!$logged_in) {
                 return Response::RedirectOnlyResponse(

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -129,7 +129,8 @@ class WebRouterTester extends BaseUnitTest {
             ["/index.php?semester=s19&course=sample"],
             ["/s19/sample/random/invalid/endpoint"],
             ["/aaa?_controller=otherController&_method=otherMethod"],
-            ["/authentication/check_login"]
+            ["/authentication/check_login"],
+            ["/s19/sample/course_materials/upload"]
         ];
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Currently, if we go to some POST only places using browser which sends GET requests, a `MethodNotAllowedException` will be thrown. Although it is very rare a case if users do not come up with URLs by themselves, it is better if we could handle it gracefully.

### What is the new behavior?
It is now  redirected to login/home page like the case where the route is not found.