### PR TITLE
[SampleData] Replace <br> in assignment messages with markdown newlines

### DIFF
--- a/more_autograding_examples/cpp_simple_lab/config/config.json
+++ b/more_autograding_examples/cpp_simple_lab/config/config.json
@@ -4,7 +4,7 @@
         "EXTRA_CREDIT_POINTS" : 2
     },
 
-    "assignment_message" : "The homework submission area & autograding points for Lab 1 are just practice.<br>The only grades for Lab 1 are the 3 checkpoints recorded by your TA & mentors.",
+    "assignment_message" : "The homework submission area & autograding points for Lab 1 are just practice.  \nThe only grades for Lab 1 are the 3 checkpoints recorded by your TA & mentors.",
 
     "part_names" : [ "README", "CODE" ],
 

--- a/more_autograding_examples/iclicker_upload/config/config.json
+++ b/more_autograding_examples/iclicker_upload/config/config.json
@@ -1,6 +1,6 @@
 {
 
-    "assignment_message" : "Locate the 8 digit iClicker Remote ID near the battery access panel on the back of your iClicker.<br>Note: This number does not begin with 'T24', that's the model number.<br>If you lost your original remote and purchased a replacement, enter BOTH remote IDs in the box below, separated by a comma.",
+    "assignment_message" : "Locate the 8 digit iClicker Remote ID near the battery access panel on the back of your iClicker.  \nNote: This number does not begin with 'T24', that's the model number.  \nIf you lost your original remote and purchased a replacement, enter BOTH remote IDs in the box below, separated by a comma.",
 
     "textboxes" : [
         {

--- a/more_autograding_examples/left_right_exam_seating/config/config.json
+++ b/more_autograding_examples/left_right_exam_seating/config/config.json
@@ -1,5 +1,5 @@
 {
-    "assignment_message" : "To better accomodate students for the upcoming exam, please let us know if you are left-handed or right-handed.<br>We will use this information to make the seating assignments.",
+    "assignment_message" : "To better accomodate students for the upcoming exam, please let us know if you are left-handed or right-handed.  \nWe will use this information to make the seating assignments.",
     "autograding": {
         "submission_to_validation" : [ "left_right.txt" ],
         "work_to_details" : [ "left_right.txt" ]

--- a/more_autograding_examples/pdf_exam/config/config.json
+++ b/more_autograding_examples/pdf_exam/config/config.json
@@ -4,6 +4,6 @@
     
     // 100 mb maximum submission size
     "max_submission_size" : 100000000,
-    "assignment_message" : "100 mb maximum total file upload.<br>No automatic grading for this assignment.",
+    "assignment_message" : "100 mb maximum total file upload.  \nNo automatic grading for this assignment.",
     "testcases" : [ ] 
 }

--- a/more_autograding_examples/test_notes_upload/config/config.json
+++ b/more_autograding_examples/test_notes_upload/config/config.json
@@ -16,7 +16,7 @@
             "test01/student_file.pdf", "test02/test_template.pdf" ]
     },
 
-    "assignment_message" : "Prepare a 2 page, black & white, 8.5x11”, portrait orientation, max size = 2MB .pdf of notes you would like to have during the test.<br><br>Be sure to inspect the produced sample test pdf to make sure that your notes are successfully attached to the back and that they will be legible when printed.",
+    "assignment_message" : "Prepare a 2 page, black & white, 8.5x11”, portrait orientation, max size = 2MB .pdf of notes you would like to have during the test.\n\nBe sure to inspect the produced sample test pdf to make sure that your notes are successfully attached to the back and that they will be legible when printed.",
 
     "testcases" : [
 	{

--- a/more_autograding_examples/test_notes_upload_3page/config/config.json
+++ b/more_autograding_examples/test_notes_upload_3page/config/config.json
@@ -16,7 +16,7 @@
             "test01/student_file.pdf", "test02/test_template.pdf" ]
     },
 
-    "assignment_message" : "Prepare a 3 page, black & white, 8.5x11”, portrait orientation, max size = 3MB .pdf of notes you would like to have during the test.<br><br>Be sure to inspect the produced sample test pdf to make sure that your notes are successfully attached to the back and that they will be legible when printed.",
+    "assignment_message" : "Prepare a 3 page, black & white, 8.5x11”, portrait orientation, max size = 3MB .pdf of notes you would like to have during the test.\n\nBe sure to inspect the produced sample test pdf to make sure that your notes are successfully attached to the back and that they will be legible when printed.",
 
     "testcases" : [
 	{

--- a/more_autograding_examples/upload_only/config/config.json
+++ b/more_autograding_examples/upload_only/config/config.json
@@ -1,6 +1,6 @@
 {
     // 1 mb maximum submission size
     "max_submission_size" : 1000000,
-    "assignment_message" : "1 mb maximum total file upload.<br>No automatic grading for this assignment.",
+    "assignment_message" : "1 mb maximum total file upload.  \nNo automatic grading for this assignment.",
     "testcases" : [ ] 
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #4086. 

Some number of sample gradeables had html newlines (`<br>` or `<br/>`) which were no longer working as we've switched to markdown with no HTML allowed for the messages.

### What is the new behavior?
This updates the sample gradeables to use the appropriate markdown construct to get the newlines.