### PR TITLE
[Bugfix:UI] Fix html for display seating guide email button

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -221,7 +221,7 @@
                     {% if not email_enabled %}
                         <p class="yellow-message">Emails are disabled: contact your System Admin to enable emails</p>
                     {% else %}
-                        <button class ="option-alt"> <a href="{{ email_room_seating_url }}" class="btn btn-primary" id="email_seating_assignment">Email Seating Assignments</a> </button>
+                        <a href="{{ email_room_seating_url }}" class="btn btn-primary" id="email_seating_assignment">Email Seating Assignments</a>
                     {% endif %}
                 </label>
             </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4087 where display for email seating configuration button did not look right.
 
No gradeable selected:  
![Screen Shot 2019-07-14 at 9 29 15 PM](https://user-images.githubusercontent.com/1845314/61191988-a2448380-a67e-11e9-85d3-d43404610c46.png)

---
Gradeable selected:
![Screen Shot 2019-07-14 at 9 29 28 PM](https://user-images.githubusercontent.com/1845314/61191991-a53f7400-a67e-11e9-80a9-f455fe521807.png)

### What is the new behavior?
No gradeable selected:  
![Screen Shot 2019-07-14 at 9 30 12 PM](https://user-images.githubusercontent.com/1845314/61191992-a83a6480-a67e-11e9-9b76-5d2abcaffc38.png)

---
Gradeable selected:
![Screen Shot 2019-07-14 at 9 30 26 PM](https://user-images.githubusercontent.com/1845314/61191993-a83a6480-a67e-11e9-9e9d-ba69732422a8.png)
