### PR TITLE
[Bugfix:Forum] Fix managing forum categories

### DIFF
--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -63,7 +63,7 @@
             items : '.category-sortable',
             handle: ".handle",
             update: function (event, ui) {
-                reorderCategories();
+                reorderCategories('{{ csrf_token }}');
             }
         });
         $("#ui-category-list").find(".fa-trash").click(function() {

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -966,6 +966,7 @@ class ForumThreadView extends AbstractView {
         $this->core->getOutput()->addBreadcrumb("Manage Categories", $this->core->buildUrl(array('component' => 'forum', 'page' => 'show_categories')));
 
         $this->core->getOutput()->addInternalJs('drag-and-drop.js');
+        $this->core->getOutput()->addInternalJs('forum.js');
         $this->core->getOutput()->addVendorJs('flatpickr/flatpickr.js');
         $this->core->getOutput()->addVendorJs('jquery.are-you-sure/jquery.are-you-sure.js');
 

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -816,8 +816,9 @@ function refreshCategories() {
     $(".cat-buttons").trigger("eventChangeCatClass");
 }
 
-function reorderCategories(){
+function reorderCategories(csrf_token) {
     var data = $('#ui-category-list').sortable('serialize');
+    data += "&csrf_token=" + csrf_token;
     var url = buildUrl({'component': 'forum', 'page': 'reorder_categories'});
     $.ajax({
         url: url,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4094. The manage categories page was attempting to call functions that were not defined on the page. Result of #3905.

### What is the new behavior?
Loads forum.js for this page, adding the necessary JS functions to the global scope. Fixes an additional bug in that it was impossible to re-order categories as the csrf_token wasn't being passed in the POST request.

### Other Information
I was able to:
1. Create a category
2. Reorder categories
3. Delete an empty category
4. See error message when attempting to delete in-use category (as expected)