### PR TITLE
Fix file access for limited access graders and greater

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -95,11 +95,15 @@ class MiscController extends AbstractController {
                 return false;
             }
 
-            // If the user attempting to access the file is not at least a grader then ensure the file has been released
-            if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+            // If attempting to obtain course materials
+            if($dir == 'course_materials')
             {
-                $this->core->getOutput()->showError("You may not access this file until it is released.");
-                return false;
+                // If the user attempting to access the file is not at least a grader then ensure the file has been released
+                if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+                {
+                    $this->core->getOutput()->showError("You may not access this file until it is released.");
+                    return false;
+                }
             }
 
         }
@@ -172,11 +176,15 @@ class MiscController extends AbstractController {
                 return false;
             }
 
-            // If the user attempting to access the file is not at least a grader then ensure the file has been released
-            if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+            // If attempting to obtain course materials
+            if($dir == 'course_materials')
             {
-                $this->core->getOutput()->showError("You may not access this file until it is released.");
-                return false;
+                // If the user attempting to access the file is not at least a grader then ensure the file has been released
+                if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+                {
+                    $this->core->getOutput()->showError("You may not access this file until it is released.");
+                    return false;
+                }
             }
         }
 

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -95,8 +95,8 @@ class MiscController extends AbstractController {
                 return false;
             }
 
-            // If the user attempting to access the file is not an instructor then ensure the file has been released
-            if(!$this->core->getUser()->accessAdmin() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+            // If the user attempting to access the file is not at least a grader then ensure the file has been released
+            if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
             {
                 $this->core->getOutput()->showError("You may not access this file until it is released.");
                 return false;
@@ -172,8 +172,8 @@ class MiscController extends AbstractController {
                 return false;
             }
 
-            // If the user attempting to access the file is not an instructor then ensure the file has been released
-            if(!$this->core->getUser()->accessAdmin() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+            // If the user attempting to access the file is not at least a grader then ensure the file has been released
+            if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
             {
                 $this->core->getOutput()->showError("You may not access this file until it is released.");
                 return false;


### PR DESCRIPTION
Relates to #1921 and #4071

### What is the current behavior?
Only instructor/admin level users may view unreleased files.  This had unintended consequences as now limited access graders were unable to view files they needed to grade, or see unreleased course materials.

### What is the new behavior?
Anyone with limited access grader or greater permissions may view submission files, and also view unreleased course materials.

### Other information?
Tested by logging into as 'grader', 'student', and 'instructor' inside vagrant VM to test which users could access which files.
