### PR TITLE
Notebook multiple choice selection fix

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -318,22 +318,22 @@
                                 {% if cell.allow_multiple == true %}
                                     <input type="checkbox"
                                            name="multiple_choice_{{ num_multiple_choice }}"
-                                           id="multiple_choice_{{ num_multiple_choice }}"
+                                           id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                            value="{{ choice.value }}"
                                            onclick="handle_input_keypress();" />
 
-                                    <label for="multiple_choice_{{ num_multiple_choice }}">
+                                    <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
                                         {{ choice.description | markdown }}
                                     </label>
 
                                 {% else %}
                                     <input type="radio"
                                            name="multiple_choice_{{ num_multiple_choice }}"
-                                           id="multiple_choice_{{ num_multiple_choice }}"
+                                           id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                            value="{{ choice.value }}"
                                            onclick="handle_input_keypress();" />
 
-                                    <label for="multiple_choice_{{ num_multiple_choice }}">
+                                    <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
                                         {{ choice.description | markdown }}
                                     </label>
 


### PR DESCRIPTION
Closes #4095 

### What is the current behavior?
Clicking a multiple choice input label inside a notebook page would incorrectly select the first input in the fieldset instead of the corresponding input.

### What is the new behavior?
Clicking the label now correctly clicks the corresponding input.

### Other information?
Tested manually
