### PR TITLE
[Bugfix:Forum] Minor forum bugs

### DIFF
--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -32,12 +32,15 @@
                                 {% endif %}
                             </td>
                             <td colspan="4">
-                                 {% set link_action = has_link ? "open_notification" : "mark_as_seen"%}
-                                <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": link_action, "nid": notification.getId(), "seen": notification.isSeen() }) }}">
+                                {% if hasLink %}
+                                    <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": "open_notification", "nid": notification.getId(), "seen": notification.isSeen() }) }}">
+                                {% endif %}
                                     <div style="height: 100%; width: 100%;">
                                         {{ notification.getNotifyContent() }}
                                     </div>
-                                </a>
+                                {% if hasLink %}
+                                    </a>
+                                {% endif %}
                             </td>
                             <td colspan="2">
                                 {{ notification.getNotifyTime() }}

--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -32,15 +32,12 @@
                                 {% endif %}
                             </td>
                             <td colspan="4">
-                                {% if hasLink %}
-                                    <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": "open_notification", "nid": notification.getId(), "seen": notification.isSeen() }) }}">
-                                {% endif %}
+                                 {% set link_action = has_link ? "open_notification" : "mark_as_seen"%}
+                                <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": link_action, "nid": notification.getId(), "seen": notification.isSeen() }) }}">
                                     <div style="height: 100%; width: 100%;">
                                         {{ notification.getNotifyContent() }}
                                     </div>
-                                {% if hasLink %}
-                                    </a>
-                                {% endif %}
+                                </a>
                             </td>
                             <td colspan="2">
                                 {{ notification.getNotifyTime() }}

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -102,11 +102,11 @@
 	          	{% endif %}
 	        {% endfor %}
 	          <li class="dropdown-divider"></li>
-	              <li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item'><a tabindex="-1" onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a></li>
-	              <li title="Sort posts by ascending chronological order" id="time" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a></li>
-				  <li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological  <i class="fas fa-angle-down"></i> </a></li>
+	              <li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item'><a tabindex="-1" onclick="changeDisplayOptions('tree')" href="#">Hierarchical</a></li>
+	              <li title="Sort posts by ascending chronological order" id="time" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('time')">Chronological  <i class="fas fa-angle-up"></i> </a></li>
+				  <li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('reverse-time')">Chronological  <i class="fas fa-angle-down"></i> </a></li>
 	              {% if user_group <= core.getUser().accessGrading() %}
-	              	<li title="Sort posts by author's last name" id="alpha" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('alpha', {{ current_thread }})">Alphabetical</a></li>
+	              	<li title="Sort posts by author's last name" id="alpha" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('alpha')">Alphabetical</a></li>
 	              {% endif %}
 	        </ul>
 	    </div>

--- a/site/app/templates/forum/GeneratePostList.twig
+++ b/site/app/templates/forum/GeneratePostList.twig
@@ -1,3 +1,4 @@
+<data id="current-thread" value="{{ post_data[0].thread_id }}"></data>
 {% for post_d in  post_data %}
 
     {% include "forum/CreatePost.twig" with {
@@ -66,3 +67,4 @@
         "possibleMerges" : merge_thread_content.possibleMerges
     } %}
 {% endif %}
+

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -293,7 +293,8 @@ function editPost(post_id, thread_id, shouldEditThread, csrf_token) {
 }
 
 
-function changeDisplayOptions(option, thread_id){
+function changeDisplayOptions(option){
+    thread_id = $('#current-thread').val();
     document.cookie = "forum_display_option=" + option + ";";
     window.location.replace(buildUrl({'component': 'forum', 'page': 'view_thread', 'option': option, 'thread_id': thread_id}));
 }


### PR DESCRIPTION
### What is the current behavior?
- When post display options are clicked, ie. hierarchical, alphabetical, on reload the top most thread would be loaded because on an ajax call as changing the thread only the post list would change and the 'more' buttons would not be updated of the current thread.

### What is the new behavior?
- When a post display list item is clicked the changeDisplayOption function looks for a data element to get the current thread. 

A deleted thread/post notification should be 'deleted' by clicking the mark as seen check mark on the right hand side.

closes #3218 