### PR TITLE
[Refactor:Router] New URL for GradeableController

### DIFF
--- a/site/app/controllers/AdminController.php
+++ b/site/app/controllers/AdminController.php
@@ -3,7 +3,6 @@
 namespace app\controllers;
 
 use app\controllers\admin\ReportController;
-use app\controllers\admin\GradeableController;
 use app\controllers\admin\GradeablesController;
 use app\controllers\admin\AdminGradeableController;
 use app\controllers\admin\UsersController;
@@ -25,9 +24,6 @@ class AdminController extends AbstractController {
         switch ($_REQUEST['page']) {
             case 'users':
                 $controller = new UsersController($this->core);
-                break;
-            case 'gradeable':
-                $controller = new GradeableController($this->core);
                 break;
             case 'late':
                 $controller = new LateController($this->core);

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -312,11 +312,7 @@ class AdminGradeableController extends AbstractController {
             'is_in_rebuild_queue' => $is_in_rebuild_queue,
             'check_refresh_url' => $check_refresh_url,
 
-            'upload_config_url' => $this->core->buildUrl([
-                'component' => 'admin',
-                'page' => 'gradeable',
-                'action' => 'upload_config'
-            ])
+            'upload_config_url' => $this->core->buildNewCourseUrl(['gradeable_config'])
         ]);
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupStudents');
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupMarkConflicts');

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -312,7 +312,7 @@ class AdminGradeableController extends AbstractController {
             'is_in_rebuild_queue' => $is_in_rebuild_queue,
             'check_refresh_url' => $check_refresh_url,
 
-            'upload_config_url' => $this->core->buildNewCourseUrl(['gradeable_config'])
+            'upload_config_url' => $this->core->buildNewCourseUrl(['autograding_config'])
         ]);
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupStudents');
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupMarkConflicts');

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -13,11 +13,11 @@ use Symfony\Component\Routing\Annotation\Route;
 
 
 /**
- * Class GradeableConfigController
+ * Class AutogradingConfigController
  * @package app\controllers\admin
  * @AccessControl(role="INSTRUCTOR")
  */
-class GradeableConfigController extends AbstractController {
+class AutogradingConfigController extends AbstractController {
     /**
      * @deprecated
      */
@@ -26,7 +26,7 @@ class GradeableConfigController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}/gradeable_config", methods={"GET"})
+     * @Route("/{_semester}/{_course}/autograding_config", methods={"GET"})
      * @return Response
      */
     public function showConfig() {
@@ -56,14 +56,14 @@ class GradeableConfigController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}/gradeable_config/upload", methods={"POST"})
+     * @Route("/{_semester}/{_course}/autograding_config/upload", methods={"POST"})
      * @return Response
      */
     public function uploadConfig() {
         if (empty($_FILES) || !isset($_FILES['config_upload'])) {
             $this->core->addErrorMessage("Upload failed: No file to upload");
             return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+                new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
             );
         }
 
@@ -71,7 +71,7 @@ class GradeableConfigController extends AbstractController {
         if (!isset($upload['tmp_name']) || $upload['tmp_name'] === "") {
             $this->core->addErrorMessage("Upload failed: Empty tmp name for file");
             return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+                new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
             );
         }
 
@@ -97,7 +97,7 @@ class GradeableConfigController extends AbstractController {
                 $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
                 $this->core->addErrorMessage("Upload failed: {$error_message}");
                 return Response::RedirectOnlyResponse(
-                    new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+                    new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
                 );
             }
         }
@@ -106,18 +106,18 @@ class GradeableConfigController extends AbstractController {
                 FileUtils::recursiveRmdir($target_dir);
                 $this->core->addErrorMessage("Upload failed: Could not copy file");
                 return Response::RedirectOnlyResponse(
-                    new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+                    new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
                 );
             }
         }
         $this->core->addSuccessMessage("Gradeable config uploaded");
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+            new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
         );
     }
 
     /**
-     * @Route("/{_semester}/{_course}/gradeable_config/rename", methods={"POST"})
+     * @Route("/{_semester}/{_course}/autograding_config/rename", methods={"POST"})
      * @return Response
      */
     public function renameConfig(){
@@ -144,12 +144,12 @@ class GradeableConfigController extends AbstractController {
             }
         }
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+            new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
         );
     }
 
     /**
-     * @Route("/{_semester}/{_course}/gradeable_config/delete", methods={"POST"})
+     * @Route("/{_semester}/{_course}/autograding_config/delete", methods={"POST"})
      * @return Response
      */
     public function deleteConfig(){
@@ -175,13 +175,13 @@ class GradeableConfigController extends AbstractController {
             }
         }
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+            new RedirectResponse($this->core->buildNewCourseUrl(['autograding_config']))
         );
     }
 
     /**
      * @param $config_path
-     * @Route("/{_semester}/{_course}/gradeable_config/usage", methods={"GET"})
+     * @Route("/{_semester}/{_course}/autograding_config/usage", methods={"GET"})
      * @return Response
      */
     public function configUsedBy($config_path = null) {

--- a/site/app/controllers/admin/GradeableConfigController.php
+++ b/site/app/controllers/admin/GradeableConfigController.php
@@ -4,29 +4,32 @@ namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
 use app\libraries\FileUtils;
+use app\libraries\response\RedirectResponse;
+use app\libraries\routers\AccessControl;
+use app\libraries\response\Response;
+use app\libraries\response\WebResponse;
+use app\libraries\response\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
 
-class GradeableController extends AbstractController {
+
+/**
+ * Class GradeableConfigController
+ * @package app\controllers\admin
+ * @AccessControl(role="INSTRUCTOR")
+ */
+class GradeableConfigController extends AbstractController {
+    /**
+     * @deprecated
+     */
     public function run() {
-        switch ($_REQUEST['action']) {
-            case 'upload_config':
-                $this->upload_config();
-                break;
-            case 'process_upload_config':
-                $this->process_config_upload();
-                break;
-			case 'delete_config':
-			    $this->delete_config();
-				break;
-            case 'rename_config':
-                $this->rename_config();
-                break;
-            case 'check_being_used':
-                $this->configUsedBy();
-                break;
-        }
+        return null;
     }
 
-    public function upload_config() {
+    /**
+     * @Route("/{_semester}/{_course}/gradeable_config", methods={"GET"})
+     * @return Response
+     */
+    public function showConfig() {
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
         $all_files = FileUtils::getAllFiles($target_dir);
         $all_paths = array();
@@ -36,32 +39,40 @@ class GradeableController extends AbstractController {
         $inuse_config = array();
         foreach($this->core->getQueries()->getGradeableConfigs(null) as $gradeable){
             foreach($all_paths as $path){
-                if(strpos($gradeable->getAutogradingConfigPath(), $path) !== false){
+                if($gradeable->getAutogradingConfigPath() === $path){
                     $inuse_config[] = $path;
                 }
             }
         }
-        $this->core->getOutput()->renderOutput(array('admin', 'Gradeable'), 'uploadConfigForm', $target_dir, $all_files, $inuse_config);
+        return Response::WebOnlyResponse(
+            new WebResponse(
+                ['admin', 'Gradeable'],
+                'uploadConfigForm',
+                $target_dir,
+                $all_files,
+                $inuse_config
+            )
+        );
     }
 
-    public function process_config_upload() {
-        if (!isset($_POST['csrf_token']) || !$this->core->checkCsrfToken($_POST['csrf_token'])) {
-            $this->core->addErrorMessage("Upload failed: Invalid CSRF token");
-            $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-                'action' => 'upload_config')));
-        }
-
+    /**
+     * @Route("/{_semester}/{_course}/gradeable_config/upload", methods={"POST"})
+     * @return Response
+     */
+    public function uploadConfig() {
         if (empty($_FILES) || !isset($_FILES['config_upload'])) {
             $this->core->addErrorMessage("Upload failed: No file to upload");
-            $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-                'action' => 'upload_config')));
+            return Response::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+            );
         }
 
         $upload = $_FILES['config_upload'];
         if (!isset($upload['tmp_name']) || $upload['tmp_name'] === "") {
             $this->core->addErrorMessage("Upload failed: Empty tmp name for file");
-            $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-                'action' => 'upload_config')));
+            return Response::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+            );
         }
 
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
@@ -85,28 +96,34 @@ class GradeableController extends AbstractController {
                 FileUtils::recursiveRmdir($target_dir);
                 $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
                 $this->core->addErrorMessage("Upload failed: {$error_message}");
-                $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-                    'action' => 'upload_config')));
+                return Response::RedirectOnlyResponse(
+                    new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+                );
             }
         }
         else {
             if (!@copy($upload['tmp_name'], FileUtils::joinPaths($target_dir, $upload['name']))) {
                 FileUtils::recursiveRmdir($target_dir);
                 $this->core->addErrorMessage("Upload failed: Could not copy file");
-                $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-                    'action' => 'upload_config')));
+                return Response::RedirectOnlyResponse(
+                    new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+                );
             }
         }
         $this->core->addSuccessMessage("Gradeable config uploaded");
-        $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-            'action' => 'upload_config')));
+        return Response::RedirectOnlyResponse(
+            new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+        );
     }
 
-    public function rename_config(){
+    /**
+     * @Route("/{_semester}/{_course}/gradeable_config/rename", methods={"POST"})
+     * @return Response
+     */
+    public function renameConfig(){
         $config_file_path = $_POST['curr_config_name'] ?? null;
         if($config_file_path == null){
             $this->core->addErrorMessage("Unable to find file");
-
         } else if (strpos($config_file_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
             $this->core->addErrorMessage("This action can't be completed.");
         } else {
@@ -114,7 +131,7 @@ class GradeableController extends AbstractController {
             if ($new_name === "") {
                 $this->core->addErrorMessage("Could not rename upload because no name was entered.");
             }
-            else if (!ctype_alnum(str_replace(['_','-'], '', $new_name))) {
+            elseif (!ctype_alnum(str_replace(['_','-'], '', $new_name))) {
                 $this->core->addErrorMessage("Name can only contain alphanumeric characters, dashes, and underscores.");
             }
             else {
@@ -126,15 +143,20 @@ class GradeableController extends AbstractController {
                 }
             }
         }
-        $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-            'action' => 'upload_config')));
+        return Response::RedirectOnlyResponse(
+            new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+        );
     }
 
-    public function delete_config(){
-        $config_path = $_GET['config'] ?? null;
+    /**
+     * @Route("/{_semester}/{_course}/gradeable_config/delete", methods={"POST"})
+     * @return Response
+     */
+    public function deleteConfig(){
+        $config_path = $_POST['config_path'] ?? null;
         $in_use = false;
         foreach($this->core->getQueries()->getGradeableConfigs(null) as $gradeable){
-            if(strpos($gradeable->getAutogradingConfigPath(), $config_path) !== false){
+            if($gradeable->getAutogradingConfigPath() === $config_path){
                 $in_use = true;
                 break;
             }
@@ -146,50 +168,38 @@ class GradeableController extends AbstractController {
         } else if ($in_use){
             $this->core->addErrorMessage("This config is currently in use.");
         } else {
-            if($this->recursive_rmdir($config_path)){
+            if(FileUtils::recursiveRmdir($config_path)){
                 $this->core->addSuccessMessage("The config folder has been succesfully deleted");
             } else {
                 $this->core->addErrorMessage("Deleting config failed.");
             }
         }
-        $this->core->redirect($this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable',
-            'action' => 'upload_config')));
-    }
-
-    private function configUsedBy() {
-        // Returns a list of gradeables that are using this config
-        $config_path = $_GET['config'] ?? null;
-        if (!$config_path == null) {
-            $inuse_config = array();
-            foreach ($this->core->getQueries()->getGradeableConfigs(null) as $gradeable) {
-                if (strpos($gradeable->getAutogradingConfigPath(), $config_path) !== false) {
-                    $inuse_config[] = $gradeable->getId();
-                }
-            }
-            $this->core->getOutput()->renderJsonSuccess($inuse_config);
-        }
+        return Response::RedirectOnlyResponse(
+            new RedirectResponse($this->core->buildNewCourseUrl(['gradeable_config']))
+        );
     }
 
     /**
-     * @param $dir directory to remove
-     *
-     * This function is the same as rmdir, except it removes all the content inside as well.
-     *
-     * @return bool whether or not the dir is removed
+     * @param $config_path
+     * @Route("/{_semester}/{_course}/gradeable_config/usage", methods={"GET"})
+     * @return Response
      */
-    private function recursive_rmdir($dir) {
-        if (is_dir($dir)) {
-            $objects = scandir($dir);
-            foreach ($objects as $object) {
-                if ($object != "." && $object != "..") {
-                    if (is_dir($dir."/".$object))
-                        $this->recursive_rmdir($dir."/".$object);
-                    else
-                        unlink($dir."/".$object);
+    public function configUsedBy($config_path = null) {
+        $config_path = urldecode($config_path);
+        // Returns a list of gradeables that are using this config
+        if ($config_path) {
+            $inuse_config = array();
+            foreach ($this->core->getQueries()->getGradeableConfigs(null) as $gradeable) {
+                if ($gradeable->getAutogradingConfigPath() === $config_path) {
+                    $inuse_config[] = $gradeable->getId();
                 }
             }
-            if(!rmdir($dir)) return false;
+            return Response::JsonOnlyResponse(
+                JsonResponse::getSuccessResponse($inuse_config)
+            );
         }
-        return true;
+        return Response::JsonOnlyResponse(
+            JsonResponse::getFailResponse("Config path can't be empty.")
+        );
     }
 }

--- a/site/app/templates/admin/DeleteConfigPopup.twig
+++ b/site/app/templates/admin/DeleteConfigPopup.twig
@@ -1,0 +1,19 @@
+{% extends 'generic/Popup.twig' %}
+{% block popup_id %}delete_config_popup{% endblock %}
+{% block title %}Delete Gradeable Config{% endblock %}
+{% block body %}
+    <input type="hidden" name="config_path" id="config_path" value="">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+    Are you sure you want to delete
+    <div name="delete-config-message">
+    </div><br />
+{% endblock %}
+{% block form %}
+    <form name="delete-form" method="post" action="{{ delete_url }}">
+        {{ parent() }}
+    </form>
+{% endblock %}
+{% block buttons %}
+    {{ block('close_button') }}
+    <input class="btn btn-primary" type="submit" value="Submit" />
+{% endblock %}

--- a/site/app/templates/admin/RenameConfigPopup.twig
+++ b/site/app/templates/admin/RenameConfigPopup.twig
@@ -7,9 +7,10 @@
     </ol>
     <input name="new_config_name" id="new_config_name" value="" type="text">
     <input name="curr_config_name" type="hidden" value="" id="curr_config_name">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
 {% endblock %}
 {% block form %}
-    <form method="POST" enctype="multipart/form-data" action="{{ core.buildUrl({'component': 'admin', 'page': 'gradeable', 'action': 'rename_config'}) }}">
+    <form method="POST" enctype="multipart/form-data" action="{{ rename_url }}">
         {{ parent() }}
     </form>
 {% endblock %}

--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -1,7 +1,7 @@
 {% import _self as self %}
 
 <div class="content">
-    <h1>Upload Gradeable Config</h1>
+    <h1>Upload Autograding Config</h1>
     <br><br>
     <p>
         Following the assignment configuration specifications:<br>
@@ -14,7 +14,7 @@
 
     <br><br>
     <p>
-        Prepare your assignment configuration as a single <code>config.json</code> file.<br>
+        Prepare your autograding configuration as a single <code>config.json</code> file.<br>
         Or as a zip of the <code>config.json</code>, and the directories <code>provided_code</code>,
         <code>test_input</code>, <code>instructor_solution</code>, <code>test_output</code>, and/or <code>custom_validation_code</code>.
     </p>
@@ -36,7 +36,7 @@
     <br>&nbsp;<br>
     <script>
         function openRenamePopup(file_path){
-            let url = buildNewCourseUrl(['gradeable_config', 'usage']) + '?config_path=' + encodeURIComponent(file_path);
+            let url = buildNewCourseUrl(['autograding_config', 'usage']) + '?config_path=' + encodeURIComponent(file_path);
             $('#alert_in_use').html('');
             $('#gradeables_using_config').empty();
             $.ajax({

--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -21,7 +21,7 @@
 
     <br><br>
 
-    <form action="{{ core.buildUrl({'component': 'admin', 'page': 'gradeable', 'action': 'process_upload_config'}) }}" method="POST" enctype="multipart/form-data">
+    <form action="{{ upload_url }}" method="POST" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         Upload Config: <input type="file" name="config_upload" /><br />
         <input type="submit" value="Upload" />
@@ -36,7 +36,7 @@
     <br>&nbsp;<br>
     <script>
         function openRenamePopup(file_path){
-            var url = buildUrl({'component': 'admin', 'page': 'gradeable', 'action': 'check_being_used', 'config': file_path});
+            let url = buildNewCourseUrl(['gradeable_config', 'usage']) + '?config_path=' + encodeURIComponent(file_path);
             $('#alert_in_use').html('');
             $('#gradeables_using_config').empty();
             $.ajax({
@@ -50,9 +50,17 @@
                         }
                     }
                 }
-            })
+            });
             $('#rename_config_popup').css('display', 'block');
             $('#curr_config_name').val(file_path);
+        }
+
+        function openDeletePopup(file_path) {
+            let message = $('[name="delete-config-message"]');
+            message.html('');
+            message.append('<b>'+file_path+'</b>');
+            $('[name="config_path"]').val(file_path);
+            $('#delete_config_popup').css("display", "block");
         }
     </script>
     <ul>
@@ -71,7 +79,7 @@
                 {% if indent == 1 %}
                     <a class="fas fa-pencil-alt" onclick="openRenamePopup('{{ file.path }}')"></a>
                     {% if file.path not in inuse_config %}
-                        <a class="fas fa-trash" href="{{core.buildUrl({'component': 'admin', 'page': 'gradeable', 'action': 'delete_config', 'config': file.path})}}"></a>
+                        <a class="fas fa-trash" onclick="openDeletePopup('{{ file.path }}')"></a>
                     {% endif %}
                 {% endif %}
                 <span id='{{ id }}-span' class='fa icon-folder-closed'></span><a onclick='openDiv("{{ id }}");'>{{ seen_root ? name : file.path }}</a>
@@ -92,3 +100,4 @@
 {% endmacro %}
 
 {% include('admin/RenameConfigPopup.twig')%}
+{% include('admin/DeleteConfigPopup.twig')%}

--- a/site/app/views/admin/GradeableView.php
+++ b/site/app/views/admin/GradeableView.php
@@ -2,13 +2,11 @@
 
 namespace app\views\admin;
 
-use app\libraries\FileUtils;
 use app\views\AbstractView;
 
 class GradeableView extends AbstractView {
     public function uploadConfigForm($target_dir, $all_files, $inuse_config) {
-        $this->core->getOutput()->addBreadcrumb("upload config", $this->core->buildUrl(array('component' => 'admin', 'page' => 'gradeable', 'action' => 'upload_config')));
-        $semester = $this->core->getConfig()->getSemester();
+        $this->core->getOutput()->addBreadcrumb("upload config", $this->core->buildNewCourseUrl(['gradeable_config']));
         $course = $this->core->getConfig()->getCourse();
 
         return $this->core->getOutput()->renderTwigTemplate("admin/UploadConfigForm.twig", [
@@ -16,6 +14,9 @@ class GradeableView extends AbstractView {
             "target_dir" => $target_dir,
             "course" => $course,
             "inuse_config" => $inuse_config,
+            "upload_url" => $this->core->buildNewCourseUrl(['gradeable_config', 'upload']),
+            "rename_url" => $this->core->buildNewCourseUrl(['gradeable_config', 'rename']),
+            "delete_url" => $this->core->buildNewCourseUrl(['gradeable_config', 'delete']),
             "csrf_token" => $this->core->getCsrfToken()
         ]);
     }

--- a/site/app/views/admin/GradeableView.php
+++ b/site/app/views/admin/GradeableView.php
@@ -6,7 +6,7 @@ use app\views\AbstractView;
 
 class GradeableView extends AbstractView {
     public function uploadConfigForm($target_dir, $all_files, $inuse_config) {
-        $this->core->getOutput()->addBreadcrumb("upload config", $this->core->buildNewCourseUrl(['gradeable_config']));
+        $this->core->getOutput()->addBreadcrumb("upload config", $this->core->buildNewCourseUrl(['autograding_config']));
         $course = $this->core->getConfig()->getCourse();
 
         return $this->core->getOutput()->renderTwigTemplate("admin/UploadConfigForm.twig", [
@@ -14,9 +14,9 @@ class GradeableView extends AbstractView {
             "target_dir" => $target_dir,
             "course" => $course,
             "inuse_config" => $inuse_config,
-            "upload_url" => $this->core->buildNewCourseUrl(['gradeable_config', 'upload']),
-            "rename_url" => $this->core->buildNewCourseUrl(['gradeable_config', 'rename']),
-            "delete_url" => $this->core->buildNewCourseUrl(['gradeable_config', 'delete']),
+            "upload_url" => $this->core->buildNewCourseUrl(['autograding_config', 'upload']),
+            "rename_url" => $this->core->buildNewCourseUrl(['autograding_config', 'rename']),
+            "delete_url" => $this->core->buildNewCourseUrl(['autograding_config', 'delete']),
             "csrf_token" => $this->core->getCsrfToken()
         ]);
     }


### PR DESCRIPTION
### URL Changes

**Old:** 
- `/index.php?semester=f19&course=sample&component=admin&page=gradeable&action=upload_config`
- `/index.php?semester=f19&course=sample&component=admin&page=gradeable&action=process_upload_config`
- `/index.php?semester=f19&course=sample&component=admin&page=gradeable&action=delete_config&config=something`
- `/index.php?semester=f19&course=sample&component=admin&page=gradeable&action=rename_config`
- `/index.php?semester=f19&course=sample&component=admin&page=gradeable&action=check_being_used?config=something`

**New:** 
- `/f19/sample/gradeable_config` GET
- `/f19/sample/gradeable_config/upload` POST ONLY
- `/f19/sample/gradeable_config/delete` POST ONLY
- `/f19/sample/gradeable_config/rename` POST ONLY
- `/f19/sample/gradeable_config/usage?config_path=somepath` GET

### Tested Entrances
- Tried to access the URL directly as a student.
- As instructor, went to the page from the sidebar and did all the operations possible: upload, delete, rename used/unused)

### Other Info
- Changed the name from `GradeableController` to `GradeableConfigController` which I deem more proper.
- `strpos($gradeable->getAutogradingConfigPath(), $path) !== false` is used in several places to check if the config is used, which is problematic because the config starting with same names will be confused. e.g. config `345` is used by `open_homework` => config `3` is used by `open_homework`.
- Added a pop up for deletion because I want deletion to be POSTed.
- Renamed function names to be camelCase.
- Used `FileUtils::recursiveRmdir` instead of `recursive_rmdir`