### PR TITLE
[Feature:Developer] twig debug extension on developer environments

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -77,6 +77,11 @@ class Output {
             'cache' => $this->core->getConfig()->isDebug() ? false : $cache_path,
             'debug' => $this->core->getConfig()->isDebug()
         ]);
+
+        if($this->core->getConfig()->isDebug()){
+            $this->twig->addExtension(new \Twig\Extension\DebugExtension());
+        }
+        
         $this->twig->getExtension(\Twig\Extension\CoreExtension::class)
             ->setTimezone($this->core->getConfig()->getTimezone());
         $this->twig->addGlobal("core", $this->core);

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -79,7 +79,7 @@ class Output {
             'debug' => $debug
         ]);
 
-        if($this->core->getConfig()->isDebug()){
+        if($debug){
             $this->twig->addExtension(new \Twig\Extension\DebugExtension());
         }
         


### PR DESCRIPTION
Adds the the Twig DebugExtension if the debug environment is set to true, this will allow the dump function in twig files for development 