### PR TITLE
[Refactor:Controller&Router] Separate GradeInquiryController from SubmissionController

### DIFF
--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -10,17 +10,17 @@ use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 
-class RegradeController extends AbstractController {
+class GradeInquiryController extends AbstractController {
     public function run() {
         return null;
     }
 
     /**
      * @param $gradeable_id
-     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/new", methods={"POST"})
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/new", methods={"POST"})
      * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function requestRegrade($gradeable_id) {
+    public function requestGradeInquiry($gradeable_id) {
         $content = $_POST['replyTextArea'] ?? '';
         $submitter_id = $_POST['submitter_id'] ?? '';
 
@@ -68,10 +68,10 @@ class RegradeController extends AbstractController {
 
     /**
      * @param $gradeable_id
-     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/post", methods={"POST"})
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/post", methods={"POST"})
      * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function makeRequestPost($gradeable_id) {
+    public function makeGradeInquiryPost($gradeable_id) {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
         $submitter_id = $_POST['submitter_id'] ?? '';
 
@@ -120,10 +120,10 @@ class RegradeController extends AbstractController {
 
     /**
      * @param $gradeable_id
-     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/toggle_status", methods={"POST"})
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/toggle_status", methods={"POST"})
      * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function changeRequestStatus($gradeable_id) {
+    public function changeGradeInquiryStatus($gradeable_id) {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
         $submitter_id = $_POST['submitter_id'] ?? '';
 

--- a/site/app/controllers/student/RegradeController.php
+++ b/site/app/controllers/student/RegradeController.php
@@ -31,7 +31,7 @@ class RegradeController extends AbstractController {
             return null;
         }
 
-        if(!$gradeable->isRegradeAllowed()) {
+        if(!$gradeable->isRegradeOpen()) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Grade inquiries are not enabled for this gradeable')
             );

--- a/site/app/controllers/student/RegradeController.php
+++ b/site/app/controllers/student/RegradeController.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace app\controllers\student;
+
+use app\controllers\AbstractController;
+use app\models\Notification;
+use app\models\Email;
+use app\libraries\response\Response;
+use app\libraries\response\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+
+class RegradeController extends AbstractController {
+    public function run() {
+        return null;
+    }
+
+    /**
+     * @param $gradeable_id
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/request", methods={"POST"})
+     * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
+     */
+    public function requestRegrade($gradeable_id) {
+        $content = $_POST['replyTextArea'] ?? '';
+        $submitter_id = $_POST['submitter_id'] ?? '';
+
+        $user = $this->core->getUser();
+
+        $gradeable = $this->tryGetGradeable($gradeable_id);
+        if ($gradeable === false) {
+            return null;
+        }
+
+        if(!$gradeable->isRegradeAllowed()) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Grade inquiries are not enabled for this gradeable')
+            );
+        }
+
+        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
+        if ($graded_gradeable === false) {
+            return null;
+        }
+
+        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]);
+        if (!$graded_gradeable->getSubmitter()->hasUser($user) && !$can_inquiry) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Insufficient permissions to request regrade')
+            );
+        }
+
+        try {
+            $this->core->getQueries()->insertNewRegradeRequest($graded_gradeable, $user, $content);
+            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, 'new');
+            return Response::JsonOnlyResponse(
+                JsonResponse::getSuccessResponse()
+            );
+        } catch (\InvalidArgumentException $e) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse($e->getMessage())
+            );
+        } catch (\Exception $e) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getErrorResponse($e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @param $gradeable_id
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/post", methods={"POST"})
+     * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
+     */
+    public function makeRequestPost($gradeable_id) {
+        $content = str_replace("\r", "", $_POST['replyTextArea']);
+        $submitter_id = $_POST['submitter_id'] ?? '';
+
+        $user = $this->core->getUser();
+
+        $gradeable = $this->tryGetGradeable($gradeable_id);
+        if ($gradeable === false) {
+            return null;
+        }
+
+        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
+        if ($graded_gradeable === false) {
+            return null;
+        }
+
+        if (!$graded_gradeable->hasRegradeRequest()) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Submitter has not made a grade inquiry')
+            );
+        }
+
+        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]);
+        if (!$graded_gradeable->getSubmitter()->hasUser($user) && !$can_inquiry) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Insufficient permissions to make grade inquiry post')
+            );
+        }
+
+        try {
+            $this->core->getQueries()->insertNewRegradePost($graded_gradeable->getRegradeRequest()->getId(), $user->getId(), $content);
+            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, 'reply');
+            $this->core->getQueries()->saveRegradeRequest($graded_gradeable->getRegradeRequest());
+            return Response::JsonOnlyResponse(
+                JsonResponse::getSuccessResponse()
+            );
+        } catch (\InvalidArgumentException $e) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse($e->getMessage())
+            );
+        } catch (\Exception $e) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getErrorResponse($e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @param $gradeable_id
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/toggle_status", methods={"POST"})
+     * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
+     */
+    public function changeRequestStatus($gradeable_id) {
+        $content = str_replace("\r", "", $_POST['replyTextArea']);
+        $submitter_id = $_POST['submitter_id'] ?? '';
+
+        $user = $this->core->getUser();
+
+        $gradeable = $this->tryGetGradeable($gradeable_id);
+        if ($gradeable === false) {
+            return null;
+        }
+
+        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
+        if ($graded_gradeable === false) {
+            return null;
+        }
+
+        if (!$graded_gradeable->hasRegradeRequest()) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Submitter has not made a grade inquiry')
+            );
+        }
+
+        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]);
+        if (!$graded_gradeable->getSubmitter()->hasUser($user) && !$can_inquiry) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Insufficient permissions to change grade inquiry status')
+            );
+        }
+
+        // toggle status
+        $status = $graded_gradeable->getRegradeRequest()->getStatus() === -1 ? 0 : -1;
+
+        try {
+            $graded_gradeable->getRegradeRequest()->setStatus($status);
+            $this->core->getQueries()->saveRegradeRequest($graded_gradeable->getRegradeRequest());
+            if ($content != "") {
+                $this->core->getQueries()->insertNewRegradePost($graded_gradeable->getRegradeRequest()->getId(), $user->getId(), $content);
+            }
+            return Response::JsonOnlyResponse(
+                JsonResponse::getSuccessResponse()
+            );
+        } catch (\InvalidArgumentException $e) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse($e->getMessage())
+            );
+        } catch (\Exception $e) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getErrorResponse($e->getMessage())
+            );
+        }
+    }
+
+    private function notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, $type){
+        //TODO: send notification to grader per component
+        if($graded_gradeable->hasTaGradingInfo()){
+            $course = $this->core->getConfig()->getCourse();
+            $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
+            $graders = $ta_graded_gradeable->getGraders();
+            $submitter = $graded_gradeable->getSubmitter();
+            $user_id = $this->core->getUser()->getId();
+
+            if ($type == 'new') {
+                // instructor/TA/Mentor submitted
+                if ($this->core->getUser()->accessGrading()) {
+                    $email_subject = "[Submitty $course] New Regrade Request";
+                    $email_body = "A Instructor/TA/Mentor submitted a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
+                    $n_content = "An Instructor/TA/Mentor has made a new Grade Inquiry for ".$gradeable_id;
+                }
+                // student submitted
+                else {
+                    $email_subject = "[Submitty $course] New Regrade Request";
+                    $email_body = "A student has submitted a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
+                    $n_content = "A student has submitted a new grade inquiry for ".$gradeable_id;
+                }
+            } else if ($type == 'reply') {
+                if ($this->core->getUser()->accessGrading()) {
+                    $email_subject = "[Submitty $course] New Regrade Request";
+                    $email_body = "A Instructor/TA/Mentor made a post in a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
+                    $n_content = "A instructor has replied to your Grade Inquiry for ".$gradeable_id;
+                }
+                // student submitted
+                else {
+                    $email_subject = "[Submitty $course] New Regrade Request";
+                    $email_body = "A student has made a post in a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
+                    $n_content = "New reply in Grade Inquiry for ".$gradeable_id;
+                }
+
+            }
+
+            // make graders' notifications and emails
+            $metadata = json_encode(array(array('component' => 'grading', 'page' => 'electronic', 'action' => 'grade', 'gradeable_id' => $gradeable_id, 'who_id' => $submitter->getId())));
+            foreach ($graders as $grader) {
+                if ($grader->accessFullGrading() && $grader->getId() != $user_id){
+                    $details = ['component' => 'grading', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $grader->getId()];
+                    $notifications[] = Notification::createNotification($this->core, $details);
+                    $emails[] = new Email($this->core,$details);
+                }
+            }
+
+            // make students' notifications and emails
+            $metadata = json_encode(array(array('component' => 'student', 'gradeable_id' => $gradeable_id)));
+            if($submitter->isTeam()){
+                $submitting_team = $submitter->getTeam()->getMemberUsers();
+                foreach($submitting_team as $submitting_user){
+                    if($submitting_user->getId() != $user_id) {
+                        $details = ['component' => 'student', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $submitting_user->getId()];
+                        $notifications[] = Notification::createNotification($this->core, $details);
+                        $emails[] = new Email($this->core,$details);
+                    }
+                }
+            } else {
+                if ($submitter->getUser()->getId() != $user_id) {
+                    $details = ['component' => 'student', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $submitter->getId()];
+                    $notifications[] = Notification::createNotification($this->core, $details);
+                    $emails[] = new Email($this->core,$details);
+                }
+            }
+            $this->core->getNotificationFactory()->sendNotifications($notifications);
+            if ($this->core->getConfig()->isEmailEnabled()) {
+                $this->core->getNotificationFactory()->sendEmails($emails);
+            }
+        }
+    }
+
+}

--- a/site/app/controllers/student/RegradeController.php
+++ b/site/app/controllers/student/RegradeController.php
@@ -17,7 +17,7 @@ class RegradeController extends AbstractController {
 
     /**
      * @param $gradeable_id
-     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/request", methods={"POST"})
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/new", methods={"POST"})
      * @return Response|null null is for tryGetGradeable and tryGetGradedGradeable
      */
     public function requestRegrade($gradeable_id) {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -3,20 +3,15 @@
 namespace app\controllers\student;
 
 use app\controllers\AbstractController;
-use app\libraries\DateUtils;
 use app\libraries\ErrorMessages;
 use app\libraries\FileUtils;
 use app\libraries\GradeableType;
 use app\libraries\Logger;
 use app\libraries\Utils;
 use app\models\gradeable\Gradeable;
-use app\models\Notification;
-use app\models\Email;
-use app\controllers\grading\ElectronicGraderController;
 use app\models\gradeable\SubmissionTextBox;
 use app\models\gradeable\SubmissionCodeBox;
 use app\models\gradeable\SubmissionMultipleChoice;
-use app\NotificationFactory;
 use Symfony\Component\Routing\Annotation\Route;
 
 
@@ -82,18 +77,6 @@ class SubmissionController extends AbstractController {
             case 'verify':
                 return $this->ajaxValidGradeable();
                 break;
-            case 'request_regrade':
-                return $this->requestRegrade();
-                break;
-            case 'make_request_post':
-                return $this->makeRequestPost();
-                break;
-            case 'delete_request':
-                return $this->deleteRequest();
-                break;
-            case 'change_request_status':
-                return $this->changeRequestStatus();
-                break;
             case 'stat_page':
                 return $this->showStats();
                 break;
@@ -107,176 +90,10 @@ class SubmissionController extends AbstractController {
                 break;
         }
     }
-    private function requestRegrade() {
-        $content = $_POST['replyTextArea'] ?? '';
-        $gradeable_id = $_REQUEST['gradeable_id'] ?? '';
-        $submitter_id = $_REQUEST['submitter_id'] ?? '';
-
-        $user = $this->core->getUser();
-
-        $gradeable = $this->tryGetGradeable($gradeable_id);
-        if ($gradeable === false) {
-            return;
-        }
-
-        if(!$gradeable->isRegradeAllowed()) {
-            $this->core->getOutput()->renderJsonFail('Grade inquiries are not enabled for this gradeable');
-            return;
-        }
-
-        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
-        if ($graded_gradeable === false) {
-            return;
-        }
-
-        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]);
-        if (!$graded_gradeable->getSubmitter()->hasUser($user) && !$can_inquiry) {
-            $this->core->getOutput()->renderJsonFail('Insufficient permissions to request regrade');
-            return;
-        }
-
-        try {
-            $this->core->getQueries()->insertNewRegradeRequest($graded_gradeable, $user, $content);
-            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, 'new');
-            $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
-            $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
-            $this->core->getOutput()->renderJsonError($e->getMessage());
-        }
-    }
-
-    private function makeRequestPost() {
-        $content = str_replace("\r", "", $_POST['replyTextArea']);
-        $gradeable_id = $_REQUEST['gradeable_id'] ?? '';
-        $submitter_id = $_REQUEST['submitter_id'] ?? '';
-
-        $user = $this->core->getUser();
-
-        $gradeable = $this->tryGetGradeable($gradeable_id);
-        if ($gradeable === false) {
-            return;
-        }
-
-        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
-        if ($graded_gradeable === false) {
-            return;
-        }
-
-        if (!$graded_gradeable->hasRegradeRequest()) {
-            $this->core->getOutput()->renderJsonFail('Submitter has not made a grade inquiry');
-            return;
-        }
-
-        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]);
-        if (!$graded_gradeable->getSubmitter()->hasUser($user) && !$can_inquiry) {
-            $this->core->getOutput()->renderJsonFail('Insufficient permissions to make grade inquiry post');
-            return;
-        }
-
-        try {
-            $this->core->getQueries()->insertNewRegradePost($graded_gradeable->getRegradeRequest()->getId(), $user->getId(), $content);
-            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, 'reply');
-            $this->core->getQueries()->saveRegradeRequest($graded_gradeable->getRegradeRequest());
-            $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
-            $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
-            $this->core->getOutput()->renderJsonError($e->getMessage());
-        }
-    }
-
-    private function deleteRequest() {
-        $gradeable_id = $_REQUEST['gradeable_id'] ?? '';
-        $submitter_id = $_REQUEST['submitter_id'] ?? '';
-
-        $user = $this->core->getUser();
-
-        $gradeable = $this->tryGetGradeable($gradeable_id);
-        if ($gradeable === false) {
-            return;
-        }
-
-        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
-        if ($graded_gradeable === false) {
-            return;
-        }
-
-        if (!$graded_gradeable->hasRegradeRequest()) {
-            $this->core->getOutput()->renderJsonFail('Submitter has not made a grade inquiry');
-            return;
-        }
-
-        // TODO: add to access control method
-        if (!$user->accessFullGrading()) {
-            $this->core->getOutput()->renderJsonFail('Insufficient permissions to delete grade inquiry');
-            return;
-        }
-
-        try {
-            $this->core->getQueries()->deleteRegradeRequest($graded_gradeable->getRegradeRequest());
-            $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
-            $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
-            $this->core->getOutput()->renderJsonError($e->getMessage());
-        }
-    }
-
-    private function changeRequestStatus() {
-        $content = str_replace("\r", "", $_POST['replyTextArea']);
-        $gradeable_id = $_REQUEST['gradeable_id'] ?? '';
-        $submitter_id = $_REQUEST['submitter_id'] ?? '';
-
-        $user = $this->core->getUser();
-
-        $gradeable = $this->tryGetGradeable($gradeable_id);
-        if ($gradeable === false) {
-            return;
-        }
-
-        $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $submitter_id);
-        if ($graded_gradeable === false) {
-            return;
-        }
-
-        if (!$graded_gradeable->hasRegradeRequest()) {
-            $this->core->getOutput()->renderJsonFail('Submitter has not made a grade inquiry');
-            return;
-        }
-
-        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]);
-        if (!$graded_gradeable->getSubmitter()->hasUser($user) && !$can_inquiry) {
-            $this->core->getOutput()->renderJsonFail('Insufficient permissions to change grade inquiry status');
-            return;
-        }
-
-        // toggle status
-        $status = $graded_gradeable->getRegradeRequest()->getStatus();
-        if ($status == -1) {
-            $status = 0;
-        }
-        else {
-            $status = -1;
-        }
-
-        try {
-            $graded_gradeable->getRegradeRequest()->setStatus($status);
-            $this->core->getQueries()->saveRegradeRequest($graded_gradeable->getRegradeRequest());
-            if ($content != "") {
-                $this->core->getQueries()->insertNewRegradePost($graded_gradeable->getRegradeRequest()->getId(), $user->getId(), $content);
-            }
-            $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
-            $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
-            $this->core->getOutput()->renderJsonError($e->getMessage());
-        }
-    }
 
     /**
-     * @Route("/{_semester}/{_course}/student/{gradeable_id}")
-     * @Route("/{_semester}/{_course}/student/{gradeable_id}/{gradeable_version}")
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}")
+     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/{gradeable_version}")
      * @return array
      */
     public function showHomeworkPage($gradeable_id, $gradeable_version = null) {
@@ -318,7 +135,7 @@ class SubmissionController extends AbstractController {
             return array('error' => true, 'message' => 'Must be on a team to access submission.');
         }
         else {
-            $url = $this->core->buildNewCourseUrl(['student', $gradeable->getId()]);
+            $url = $this->core->buildNewCourseUrl(['gradeable', $gradeable->getId()]);
             $this->core->getOutput()->addBreadcrumb($gradeable->getTitle(), $url);
             if (!$gradeable->hasAutogradingConfig()) {
                 $this->core->getOutput()->renderOutput('Error',
@@ -1527,7 +1344,7 @@ class SubmissionController extends AbstractController {
 
         $who = $_REQUEST['who'] ?? $this->core->getUser()->getId();
         $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $who, $who);
-        $url = $this->core->buildNewCourseUrl(['student', $gradeable->getId()]);
+        $url = $this->core->buildNewCourseUrl(['gradeable', $gradeable->getId()]);
         if (!isset($_POST['csrf_token']) || !$this->core->checkCsrfToken($_POST['csrf_token'])) {
             $msg = "Invalid CSRF token. Refresh the page and try again.";
             $this->core->addErrorMessage($msg);
@@ -1697,78 +1514,5 @@ class SubmissionController extends AbstractController {
         }
         $this->core->getOutput()->renderOutput('grading\ElectronicGrader', 'statPage', $users);
     }
-
-    private function notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, $type){
-      //TODO: send notification to grader per component
-      if($graded_gradeable->hasTaGradingInfo()){
-          $course = $this->core->getConfig()->getCourse();
-          $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
-          $graders = $ta_graded_gradeable->getGraders();
-          $submitter = $graded_gradeable->getSubmitter();
-          $user_id = $this->core->getUser()->getId();
-
-          if ($type == 'new') {
-              // instructor/TA/Mentor submitted
-              if ($this->core->getUser()->accessGrading()) {
-                  $email_subject = "[Submitty $course] New Regrade Request";
-                  $email_body = "A Instructor/TA/Mentor submitted a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
-                  $n_content = "An Instructor/TA/Mentor has made a new Grade Inquiry for ".$gradeable_id;
-              }
-              // student submitted
-              else {
-                  $email_subject = "[Submitty $course] New Regrade Request";
-                  $email_body = "A student has submitted a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
-                  $n_content = "A student has submitted a new grade inquiry for ".$gradeable_id;
-              }
-          } else if ($type == 'reply') {
-              if ($this->core->getUser()->accessGrading()) {
-                  $email_subject = "[Submitty $course] New Regrade Request";
-                  $email_body = "A Instructor/TA/Mentor made a post in a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
-                  $n_content = "A instructor has replied to your Grade Inquiry for ".$gradeable_id;
-              }
-              // student submitted
-              else {
-                  $email_subject = "[Submitty $course] New Regrade Request";
-                  $email_body = "A student has made a post in a grade inquiry for gradeable $gradeable_id.\n$user_id writes:\n$content\n\nPlease visit Submitty to follow up on this request";
-                  $n_content = "New reply in Grade Inquiry for ".$gradeable_id;
-              }
-
-          }
-
-          // make graders' notifications and emails
-          $metadata = json_encode(array(array('component' => 'grading', 'page' => 'electronic', 'action' => 'grade', 'gradeable_id' => $gradeable_id, 'who_id' => $submitter->getId())));
-          foreach ($graders as $grader) {
-              if ($grader->accessFullGrading() && $grader->getId() != $user_id){
-                  $details = ['component' => 'grading', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $grader->getId()];
-                  $notifications[] = Notification::createNotification($this->core, $details);
-                  $emails[] = new Email($this->core,$details);
-              }
-          }
-
-          // make students' notifications and emails
-          $metadata = json_encode(array(array('component' => 'student', 'gradeable_id' => $gradeable_id)));
-          if($submitter->isTeam()){
-              $submitting_team = $submitter->getTeam()->getMemberUsers();
-              foreach($submitting_team as $submitting_user){
-                  if($submitting_user->getId() != $user_id) {
-                      $details = ['component' => 'student', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $submitting_user->getId()];
-                      $notifications[] = Notification::createNotification($this->core, $details);
-                      $emails[] = new Email($this->core,$details);
-                  }
-              }
-          } else {
-              if ($submitter->getUser()->getId() != $user_id) {
-                  $details = ['component' => 'student', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $submitter->getId()];
-                  $notifications[] = Notification::createNotification($this->core, $details);
-                  $emails[] = new Email($this->core,$details);
-              }
-          }
-          $this->core->getNotificationFactory()->sendNotifications($notifications);
-          if ($this->core->getConfig()->isEmailEnabled()) {
-              $this->core->getNotificationFactory()->sendEmails($emails);
-          }
-      }
-    }
-
 
 }

--- a/site/app/libraries/response/JsonResponse.php
+++ b/site/app/libraries/response/JsonResponse.php
@@ -55,7 +55,7 @@ class JsonResponse extends AbstractResponse {
      * @param mixed|null $data
      * @return JsonResponse
      */
-    public static function getSuccessResponse($data) {
+    public static function getSuccessResponse($data = null) {
         return new self('success', $data);
     }
 

--- a/site/app/templates/submission/regrade/Discussion.twig
+++ b/site/app/templates/submission/regrade/Discussion.twig
@@ -76,8 +76,8 @@
     <div style="padding:20px;">
         {% if grade_inquiry_status != 'no_submission' %}
             <form method="POST" id="reply-text-form" >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}" >
                 <input type="hidden" id="thread_id" name="thread_id" value="{{ thread_id }}">
-                <input type="hidden" id="gradeable_id" name="gradeable_id" value="{{ gradeable_id }}">
                 <input type="hidden" id="submitter_id" name="submitter_id" value="{{ submitter_id }}">
                 {% if grade_inquiry_status == 'none' or grade_inquiry_status == 'resolved' %}
                     {% set text_area_label_text = 'Write an inquiry:' %}

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -356,7 +356,7 @@ class NavigationView extends AbstractView {
             "(due " . $gradeable->getSubmissionDueDate()->format(self::DATE_FORMAT) . ")";
         $points_percent = NAN;
 
-        $href = $this->core->buildNewCourseUrl(['student', $gradeable->getId()]);
+        $href = $this->core->buildNewCourseUrl(['gradeable', $gradeable->getId()]);
         $progress = null;
         $disabled = false;
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -742,19 +742,19 @@ class HomeworkView extends AbstractView {
         $request_regrade_url = $this->core->buildNewCourseUrl([
             'gradeable',
             $graded_gradeable->getGradeable()->getId(),
-            'regrade',
+            'grade_inquiry',
             'new'
         ]);
         $change_request_status_url = $this->core->buildNewCourseUrl([
             'gradeable',
             $graded_gradeable->getGradeable()->getId(),
-            'regrade',
+            'grade_inquiry',
             'toggle_status'
         ]);
         $make_regrade_post_url = $this->core->buildNewCourseUrl([
             'gradeable',
             $graded_gradeable->getGradeable()->getId(),
-            'regrade',
+            'grade_inquiry',
             'post'
         ]);
         if (!$graded_gradeable->hasSubmission()) {

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -743,7 +743,7 @@ class HomeworkView extends AbstractView {
             'gradeable',
             $graded_gradeable->getGradeable()->getId(),
             'regrade',
-            'request'
+            'new'
         ]);
         $change_request_status_url = $this->core->buildNewCourseUrl([
             'gradeable',

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -739,24 +739,24 @@ class HomeworkView extends AbstractView {
         $this->core->getOutput()->addInternalJs('forum.js');
 
         $regrade_message = $this->core->getConfig()->getRegradeMessage();
-        $request_regrade_url = $this->core->buildUrl(array(
-            'component' => 'student',
-            'gradeable_id' => $graded_gradeable->getGradeable()->getId(),
-            'submitter_id' => $graded_gradeable->getSubmitter()->getId(),
-            'action' => 'request_regrade'
-        ));
-        $change_request_status_url = $this->core->buildUrl(array(
-            'component' => 'student',
-            'gradeable_id' => $graded_gradeable->getGradeable()->getId(),
-            'submitter_id' => $graded_gradeable->getSubmitter()->getId(),
-            'action' => 'change_request_status'
-        ));
-        $make_regrade_post_url = $this->core->buildUrl(array(
-            'component' => 'student',
-            'gradeable_id' => $graded_gradeable->getGradeable()->getId(),
-            'submitter_id' => $graded_gradeable->getSubmitter()->getId(),
-            'action' => 'make_request_post'
-        ));
+        $request_regrade_url = $this->core->buildNewCourseUrl([
+            'gradeable',
+            $graded_gradeable->getGradeable()->getId(),
+            'regrade',
+            'request'
+        ]);
+        $change_request_status_url = $this->core->buildNewCourseUrl([
+            'gradeable',
+            $graded_gradeable->getGradeable()->getId(),
+            'regrade',
+            'toggle_status'
+        ]);
+        $make_regrade_post_url = $this->core->buildNewCourseUrl([
+            'gradeable',
+            $graded_gradeable->getGradeable()->getId(),
+            'regrade',
+            'post'
+        ]);
         if (!$graded_gradeable->hasSubmission()) {
             $grade_inquiry_status = "no_submission";
         }
@@ -809,7 +809,8 @@ class HomeworkView extends AbstractView {
             'thread_id' => $graded_gradeable->hasRegradeRequest() ? $graded_gradeable->getRegradeRequest()->getId() : 0,
             'submitter_id' => $graded_gradeable->getSubmitter()->getId(),
             'regrade_message' => $regrade_message,
-            'can_inquiry' => $can_inquiry
+            'can_inquiry' => $can_inquiry,
+            "csrf_token" => $this->core->getCsrfToken()
         ]);
     }
 }

--- a/tests/e2e/test_login.py
+++ b/tests/e2e/test_login.py
@@ -14,7 +14,7 @@ class TestLogin(BaseTestCase):
         you'll be taken to the login screen, and then once logged in,
         taken to that original page you had requested.
         """
-        url = "/" + self.semester + "/sample/student/open_homework"
+        url = "/" + self.semester + "/sample/gradeable/open_homework"
         self.log_in(url, title='Submitty')
         self.assertEqual(self.test_url + url, self.driver.current_url)
         cookies = list(filter(lambda x: x['name'] == 'submitty_token', self.driver.get_cookies()))


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
SubmissionController is such a monster that I feel very stressful editing it.

### What is the new behavior?
Separate code regarding regrading from SubmissionController, and add some routes.

### Other information?
New URLs:
- `/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/new` POST ONLY
- `/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/post` POST ONLY
- `/{_semester}/{_course}/gradeable/{gradeable_id}/regrade/toggle_status` POST ONLY

Also changed the URL for a single gradeable from `/{_semester}/{_course}/student/{gradeable_id}` to `/{_semester}/{_course}/gradeable/{gradeable_id}`.

Manually tested:
- Opening a grade inquiry
- Close it and reopen it from instructor's side and from student's side
- Make posts as a student and as an instructor