### PR TITLE
VPAT fix missing label error in configuration.twig

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -234,7 +234,7 @@
                     {% endfor %}
                 </select>
                 <br>
-                <p style = "display: inline;" class="option-alt">Visible only to Instructors? </p>
+                <p style = "display: inline;" class="option-alt"><label for="seating_only_for_instructor">Visible only to Instructors?</label></p>
                 <input type="checkbox" name="seating_only_for_instructor" id="seating_only_for_instructor" value="true"{{ fields['seating_only_for_instructor'] ? 'checked' : '' }} />
             </div>
 


### PR DESCRIPTION
Fixed missing `<label>` error in configuration view.
