### PR TITLE
[Refactor:Router] New URL for NotificationController

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -67,7 +67,7 @@ class GlobalController extends AbstractController {
 
             if ($unread_notifications_count !== null) {
                 $sidebar_buttons[] = new Button($this->core, [
-                    "href" => $this->core->buildUrl(array('component' => 'notification', 'page' => 'notifications')),
+                    "href" => $this->core->buildNewCourseUrl(['notifications']),
                     "title" => "Notifications",
                     "badge" => $unread_notifications_count,
                     "class" => "nav-row",

--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -4,7 +4,8 @@
     }
 </style>
 <div class="content">
-    <form method="post" action="{{ core.buildUrl({'component': 'notification', 'page': 'alter_notification_settings'}) }}" id="form_notification_settings">
+    <form method="post" action="{{ update_settings_url }}" id="form_notification_settings">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div id="config">
             {% if email_enabled %}
                 {% set header = "Notification/Email Settings" %}

--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -2,13 +2,13 @@
 
 <div class="content">
     <div style="float: right; margin-bottom: 20px;">
-         <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": "mark_all_as_seen"}) }}" class="btn btn-primary">Mark all as seen</a>
+         <a href="{{ mark_all_as_seen_url }}" class="btn btn-primary">Mark all as seen</a>
         {% if show_all %}
-            <a href="{{ core.buildUrl({"component": "notification", "page": "notifications"}) }}" class="btn btn-primary">Show unread only</a>
+            <a href="{{ notifications_url }}" class="btn btn-primary">Show unread only</a>
         {% else %}
-            <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "show_all": "1"}) }}" class="btn btn-primary">Show All</a>
+            <a href="{{ notifications_url }}?show_all=true" class="btn btn-primary">Show All</a>
         {% endif %}
-        <a href="{{ core.buildUrl({"component": "notification", "page": "notification_settings" }) }}" class="btn btn-primary">Settings</a>
+        <a href="{{ notification_settings_url }}" class="btn btn-primary">Settings</a>
     </div>
     <h1>Notifications</h1>
     {# This is a layout table #}
@@ -33,7 +33,7 @@
                             </td>
                             <td colspan="4">
                                 {% if hasLink %}
-                                    <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": "open_notification", "nid": notification.getId(), "seen": notification.isSeen() }) }}">
+                                    <a href="{{ notifications_url }}/{{ notification.getId() }}?seen={{ notification.isSeen() }}">
                                 {% endif %}
                                     <div style="height: 100%; width: 100%;">
                                         {{ notification.getNotifyContent() }}
@@ -47,7 +47,7 @@
                             </td>
                             <td colspan="1">
                                 {% if not notification.isSeen() %}
-                                    <a href="{{ core.buildUrl({"component": "notification", "page": "notifications", "action": "mark_as_seen", "nid": notification.getId() }) }}" title="Mark as seen">
+                                    <a href="{{ notifications_url }}/{{ notification.getId() }}/seen" title="Mark as seen">
                                         <i class="fas fa-check" aria-hidden="true"></i>
                                     </a>
                                 {% endif %}

--- a/site/app/views/NotificationView.php
+++ b/site/app/views/NotificationView.php
@@ -9,16 +9,21 @@ class NotificationView extends AbstractView {
             'course' => $current_course,
             'show_all' => $show_all,
             'notifications' => $notifications,
-            'notification_saves' => $notification_saves
+            'notification_saves' => $notification_saves,
+            'notifications_url' => $this->core->buildNewCourseUrl(['notifications']),
+            'mark_all_as_seen_url' => $this->core->buildNewCourseUrl(['notifications', 'seen']),
+            'notification_settings_url' => $this->core->buildNewCourseUrl(['notifications', 'settings'])
         ]);
     }
 
     public function showNotificationSettings($notification_saves) {
-        $this->core->getOutput()->addBreadcrumb("Notifications", $this->core->buildUrl(['component' => 'notification', 'page' => 'notifications']));
+        $this->core->getOutput()->addBreadcrumb("Notifications", $this->core->buildNewCourseUrl(['notifications']));
         $this->core->getOutput()->addBreadcrumb("Notification Settings");
         $this->core->getOutput()->renderTwigOutput("NotificationSettings.twig", [
             'notification_saves' => $notification_saves,
-            'email_enabled' => $this->core->getConfig()->isEmailEnabled()
+            'email_enabled' => $this->core->getConfig()->isEmailEnabled(),
+            'csrf_token' => $this->core->getCsrfToken(),
+            'update_settings_url' => $this->core->buildNewCourseUrl(['notifications', 'settings'])
         ]);
     }
 }


### PR DESCRIPTION
### URL Changes

- GET `/f19/sample/notifications` Notification Page
- GET `/f19/sample/notifications?show_all=true` All Notifications Page
- GET `/f19/sample/notifications/1` View Notification nid=1 and Mark as Seen
- GET `/f19/sample/notifications/1?seen=1` View Notification nid=1
- GET `/f19/sample/notifications/1/seen` Mark Notification nid=1 as seen
- GET `/f19/sample/notifications/seen` Mark All as Seen
- GET `/f19/sample/notifications/settings` Notification Settings Page
- POST `/f19/sample/notifications/settings` Notification Settings Update

### Testing
Manually tested all the routes above, including view unseen notifications, view all notifications, mark all as seen, mark single one as seen, view single notification, see settings page and update settings.