### PR TITLE
[Refactor:Router] Forced ordering of arguments

### DIFF
--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -148,7 +148,7 @@ class WebRouter {
         $method = new \ReflectionMethod($this->controller_name, $this->method_name);
         foreach ($method->getParameters() as $param) {
             $param_name = $param->getName();
-            $arguments[$param_name] = $this->parameters[$param_name];
+            $arguments[$param_name] = $this->parameters[$param_name] ?? null;
             if (!isset($arguments[$param_name])) {
                 $arguments[$param_name] = $this->request->query->get($param_name);
             }

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -143,18 +143,18 @@ class WebRouter {
         $this->method_name = $this->parameters['_method'];
         $controller = new $this->controller_name($this->core);
 
-        foreach ($this->parameters as $key => $value) {
-            if (Utils::startsWith($key, "_")) {
-                unset($this->parameters[$key]);
+        $arguments = array();
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $method = new \ReflectionMethod($this->controller_name, $this->method_name);
+        foreach ($method->getParameters() as $param) {
+            $param_name = $param->getName();
+            $arguments[$param_name] = $this->parameters[$param_name];
+            if (!isset($arguments[$param_name])) {
+                $arguments[$param_name] = $this->request->query->get($param_name);
             }
         }
 
-        // pass $_GET to controllers
-        // the user-specified $_GET should NOT override the controller name and method name matched
-        $this->request->query->remove('url');
-        $this->parameters = array_merge($this->parameters, $this->request->query->all());
-
-        return call_user_func_array([$controller, $this->method_name], $this->parameters);
+        return call_user_func_array([$controller, $this->method_name], $arguments);
     }
 
     private function loadCourses() {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1746,7 +1746,7 @@ function escapeHTML(str) {
 
 function changePermission(filename, checked) {
     // send to server to handle file permission change
-    let url = buildNewCourseUrl(['course_materials', 'modify_permission']) + '?filename=' + encodeURIComponent(filename) + '&checked=' + checked;
+    let url = buildNewCourseUrl(['course_materials', 'modify_permission']) + '?filenames=' + encodeURIComponent(filename) + '&checked=' + checked;
 
     $.ajax({
         type: "POST",
@@ -1761,7 +1761,7 @@ function changePermission(filename, checked) {
 
 function changeFolderPermission(filenames, checked,handleData) {
     // send to server to handle file permission change
-    let url = buildNewCourseUrl(['course_materials', 'modify_permission']) + '?filename=' + encodeURIComponent(filenames[0]) + '&checked=' + checked;
+    let url = buildNewCourseUrl(['course_materials', 'modify_permission']) + '?filenames=' + encodeURIComponent(filenames[0]) + '&checked=' + checked;
 
     $.ajax({
         type: "POST",
@@ -1780,7 +1780,7 @@ function changeFolderPermission(filenames, checked,handleData) {
 
 function changeNewDateTime(filename, newdatatime,handleData) {
     // send to server to handle file date/time change
-    let url = buildNewCourseUrl(['course_materials', 'modify_timestamp']) + '?filename=' + encodeURIComponent(filename) + '&newdatatime=' + newdatatime;
+    let url = buildNewCourseUrl(['course_materials', 'modify_timestamp']) + '?filenames=' + encodeURIComponent(filename) + '&newdatatime=' + newdatatime;
     var tbr;
     tbr=false;
     $.ajax({
@@ -1802,7 +1802,7 @@ function changeNewDateTime(filename, newdatatime,handleData) {
 
 function changeFolderNewDateTime(filenames, newdatatime,handleData) {
     // send to server to handle folder date/time change
-    let url = buildNewCourseUrl(['course_materials', 'modify_timestamp']) + '?filename=' + encodeURIComponent(filenames[0]) + '&newdatatime=' + newdatatime;
+    let url = buildNewCourseUrl(['course_materials', 'modify_timestamp']) + '?filenames=' + encodeURIComponent(filenames[0]) + '&newdatatime=' + newdatatime;
     var tbr;
     tbr=false;
     $.ajax({


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Our current router relies on the ordering of GET parameters regardless of their names, which may be problematic.

For example, `http://192.168.56.111/f19/sample/course_materials/modify_timestamp?newdatatime=456&filenames=123` will let `app\controllers\course\CourseMaterialsController->modifyCourseMaterialsFileTimeStamp('456', '123')` be called although `123` should be the first parameter (`filenames`) by definition.

### What is the new behavior?
The router now takes parameter names into consideration.

### Other information?
I did a check for all existing routes and it looks ok, but we need to pay more attention to get parameters in the future in case there are naming inconsistencies between function parameters & GET parameters.

Not sure how to write unit test for this.