### PR TITLE
[Bugfix] Removing warning on undefined individual_viewed_percent

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -232,7 +232,7 @@ class ElectronicGraderView extends AbstractView {
             "component_overall_percentage" => $component_overall_percentage,
             "individual_viewed_grade" => $individual_viewed_grade,
             "total_students_submitted" => $total_students_submitted,
-            "individual_viewed_percent" => $individual_viewed_percent,
+            "individual_viewed_percent" => $individual_viewed_percent ?? 0,
             "regrade_requests" => $regrade_requests
         ]);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
![Screenshot from 2019-07-19 14-14-07](https://user-images.githubusercontent.com/20266703/61513388-7daa2c00-aa2f-11e9-8511-b7f1d1eb2927.png)


### What is the new behavior?
The warning is removed.