### PR TITLE
[Bugfix:InstructorUI] Moved edit user css to its own page

### DIFF
--- a/site/app/templates/admin/users/UserForm.twig
+++ b/site/app/templates/admin/users/UserForm.twig
@@ -33,7 +33,13 @@
             Email:
             <input type="text" name="user_email" id="user_email" />
         </label>
-        <label for="registered_section">
+        {% if use_database %}
+            <label>
+                Password:
+                <input type="password" name="user_password" placeholder="New Password" />
+            </label>
+        {% endif %}
+        <label for="registered_section" class="full-width">
             Registration Section:
             <select name="registered_section" id="registered_section">
                 <option value="null">Not Registered</option>
@@ -42,19 +48,10 @@
                 {% endfor %}
             </select>
         </label>
-        <p id="user-form-student-error-message" class="red-message">
+        <p id="user-form-student-error-message" class="red-message full-width">
             Warning: Students with no registration section cannot login to the course
         </p>
-        <label for="user_group">
-            Group:
-            <select name="user_group" id="user_group">
-                <option value="1">Instructor</option>
-                <option value="2">Full Access Grader (Grad TA)</option>
-                <option value="3">Limited Access Grader (Mentor)</option>
-                <option value="4">Student</option>
-            </select>
-        </label>
-        <label for="rotating_section">
+        <label for="rotating_section" class="full-width">
             Rotating Section:
             <select name="rotating_section" id="rotating_section">
                 <option value="null">No Section</option>
@@ -63,11 +60,20 @@
                 {% endfor %}
             </select>
         </label>
-        <label for="manual_registration">
+        <label for="manual_registration" class="full-width">
             <input type="checkbox" id="manual_registration" name="manual_registration">
             Manually Registered User (no automatic updates)
         </label>
-        <div id="user-form-assigned-sections" hidden>
+        <label for="user_group" class="full-width">
+            Group:
+            <select name="user_group" id="user_group">
+                <option value="1">Instructor</option>
+                <option value="2">Full Access Grader (Grad TA)</option>
+                <option value="3">Limited Access Grader (Mentor)</option>
+                <option value="4">Student</option>
+            </select>
+        </label>
+        <div id="user-form-assigned-sections" class="full-width" hidden>
             <h3>Assigned Registration Sections for Grading</h3>
             {% for section in reg_sections %}
                 <label for="grs_{{ section.sections_registration_id }}">
@@ -76,12 +82,6 @@
                 </label>
             {% endfor %}
         </div>
-        {% if use_database %}
-            <label>
-                Password:
-                <input type="password" name="user_password" placeholder="New Password" />
-            </label>
-        {% endif %}
     </div>
 {% endblock %}
 {% block form %}

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -22,6 +22,7 @@ class UsersView extends AbstractView {
         }
 
         $this->core->getOutput()->addInternalCss('studentlist.css');
+        $this->core->getOutput()->addInternalCss('userform.css');
         $this->core->getOutput()->addInternalCss('table.css');
         $this->core->getOutput()->addInternalJs('userform.js');
 
@@ -42,6 +43,7 @@ class UsersView extends AbstractView {
      * @return string
      */
     public function listGraders($graders, $reg_sections, $rot_sections, $use_database=false) {
+        $this->core->getOutput()->addInternalCss('userform.css');
         $this->core->getOutput()->addInternalJs('userform.js');
 
         return $this->core->getOutput()->renderTwigTemplate("admin/users/GraderList.twig", [

--- a/site/public/css/studentlist.css
+++ b/site/public/css/studentlist.css
@@ -29,30 +29,6 @@ caption {
     background: var(--standard-focus-cornflowe-blue) !important;
 }
 
-#edit-user-form {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-#edit-user-form > label {
-    flex: 1 0 34%;
-    margin: 6px;
-    min-width: 200px;
-}
-
-#edit-user-form label input[type="text"], 
-#edit-user-form label input[type="password"], 
-#edit-user-form label select {
-    display: flex;
-    width: 100%;
-}
-
-#user-form-assigned-sections {
-    display: flex;
-    flex-direction: column;
-    margin: 6px 0;
-}
-
 @media (max-width: 800px) {
     #student-table {
         border: none;

--- a/site/public/css/userform.css
+++ b/site/public/css/userform.css
@@ -1,0 +1,23 @@
+#edit-user-form {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+#edit-user-form > label {
+    flex: 1 0 34%;
+    margin: 6px;
+    min-width: 200px;
+}
+
+#edit-user-form label input[type="text"], 
+#edit-user-form label input[type="password"], 
+#edit-user-form label select {
+    display: flex;
+    width: 100%;
+}
+
+#user-form-assigned-sections {
+    display: flex;
+    flex-direction: column;
+    margin: 6px 0;
+}

--- a/site/public/css/userform.css
+++ b/site/public/css/userform.css
@@ -9,6 +9,10 @@
     min-width: 200px;
 }
 
+#edit-user-form > label.full-width {
+    flex: 1 0 70%;
+}
+
 #edit-user-form label input[type="text"], 
 #edit-user-form label input[type="password"], 
 #edit-user-form label select {


### PR DESCRIPTION
Closes #4143 

Used to look like this
![image](https://user-images.githubusercontent.com/32647488/61538022-88040000-aa06-11e9-9ad8-d10f017aa5b1.png)

Now looks like this
![image](https://user-images.githubusercontent.com/32647488/61538059-9ce09380-aa06-11e9-948d-61560d8e399d.png)

The CSS was previously bound to studentlist, now it's modular so we can use it on both pages