### PR TITLE
[Feature:Installation] latest github release/tag & commit in footer

### DIFF
--- a/.setup/bin/track_git_version.py
+++ b/.setup/bin/track_git_version.py
@@ -25,6 +25,8 @@ if __name__ == "__main__":
     #run the command 'git rev-parse HEAD' from the submitty repository directory
     current_commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repository_dir)
     current_commit_hash = current_commit_hash.decode('ascii').strip()
+    current_short_commit_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], cwd=repository_dir)
+    current_short_commit_hash = current_short_commit_hash.decode('ascii').strip()
     print("Commit {0} is currently installed on this system.".format(current_commit_hash))
   except:
     print("ERROR: could not determine commit hash.")
@@ -43,6 +45,7 @@ if __name__ == "__main__":
   #remove newline at the end of the hash and tag and convert them from bytes to ascii.
 
   output_dict["installed_commit"] = current_commit_hash
+  output_dict["short_installed_commit"] = current_short_commit_hash
   output_dict["most_recent_git_tag"] = current_git_tag
 
   try:

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -108,6 +108,30 @@ class Core {
     }
 
     /**
+     * Load the Submitty software version configuration.
+     * @throws \Exception
+     */
+    public function loadSubmittyVersionConfig() {
+        $this->latest_tag = "xx";
+        $this->latest_commit = "yy";
+        $version_path = FileUtils::joinPaths('/', 'usr','local','submitty','config','version.json');
+        if (file_exists($version_path)) {
+          $contents = json_decode(file_get_contents($version_path),true);
+          if ($contents === null ||
+              !isset($contents['most_recent_git_tag']) ||
+              !isset($contents['short_installed_commit'])) {
+            throw new Exception("Error parsing version.json file");
+          }
+          $this->latest_tag = $contents['most_recent_git_tag'];
+          $this->latest_commit = $contents['short_installed_commit'];
+        }
+        else{
+          $message = "Unable to access version configuration file " . $version_path;
+          $this->addErrorMessage($message);
+        }
+    }
+
+    /**
      * Load the config details for the application. This takes in a file from the ../../../config as well as
      * then a config.json contained in {$SUBMITTY_DATA_DIR}/courses/{$SEMESTER}/{$COURSE}/config directory. These
      * files contain details about how the database, location of files, late days settings, etc.
@@ -171,6 +195,7 @@ class Core {
             $this->course_db->connect();
         }
         $this->database_queries = $database_factory->getQueries($this);
+        $this->loadSubmittyVersionConfig();
     }
 
     public function loadForum() {
@@ -246,6 +271,20 @@ class Core {
      */
     public function getSubmittyDB() {
         return $this->submitty_db;
+    }
+
+    /**
+     * @return AbstractDatabase
+     */
+    public function getLatestCommit() {
+      return $this->latest_commit;
+    }
+
+    /**
+     * @return AbstractDatabase
+     */
+    public function getLatestTag() {
+      return $this->latest_tag;
     }
 
     /**

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -112,8 +112,6 @@ class Core {
      * @throws \Exception
      */
     public function loadSubmittyVersionConfig() {
-        $this->latest_tag = "xx";
-        $this->latest_commit = "yy";
         $version_path = FileUtils::joinPaths('/', 'usr','local','submitty','config','version.json');
         if (file_exists($version_path)) {
           $contents = json_decode(file_get_contents($version_path),true);

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -108,28 +108,6 @@ class Core {
     }
 
     /**
-     * Load the Submitty software version configuration.
-     * @throws \Exception
-     */
-    public function loadSubmittyVersionConfig() {
-        $version_path = FileUtils::joinPaths('/', 'usr','local','submitty','config','version.json');
-        if (file_exists($version_path)) {
-          $contents = json_decode(file_get_contents($version_path),true);
-          if ($contents === null ||
-              !isset($contents['most_recent_git_tag']) ||
-              !isset($contents['short_installed_commit'])) {
-            throw new Exception("Error parsing version.json file");
-          }
-          $this->latest_tag = $contents['most_recent_git_tag'];
-          $this->latest_commit = $contents['short_installed_commit'];
-        }
-        else{
-          $message = "Unable to access version configuration file " . $version_path;
-          $this->addErrorMessage($message);
-        }
-    }
-
-    /**
      * Load the config details for the application. This takes in a file from the ../../../config as well as
      * then a config.json contained in {$SUBMITTY_DATA_DIR}/courses/{$SEMESTER}/{$COURSE}/config directory. These
      * files contain details about how the database, location of files, late days settings, etc.
@@ -193,7 +171,6 @@ class Core {
             $this->course_db->connect();
         }
         $this->database_queries = $database_factory->getQueries($this);
-        $this->loadSubmittyVersionConfig();
     }
 
     public function loadForum() {
@@ -269,20 +246,6 @@ class Core {
      */
     public function getSubmittyDB() {
         return $this->submitty_db;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLatestCommit() {
-      return $this->latest_commit;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLatestTag() {
-      return $this->latest_tag;
     }
 
     /**

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -272,14 +272,14 @@ class Core {
     }
 
     /**
-     * @return AbstractDatabase
+     * @return string
      */
     public function getLatestCommit() {
       return $this->latest_commit;
     }
 
     /**
-     * @return AbstractDatabase
+     * @return string
      */
     public function getLatestTag() {
       return $this->latest_tag;

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -153,6 +153,11 @@ class Config extends AbstractModel {
     protected $email_enabled;
 
     /** @property @var string */
+    protected $latest_tag;
+    /** @property @var string */
+    protected $latest_commit;
+
+    /** @property @var string */
     protected $course_name;
     /** @property @var string */
     protected $course_home_url;
@@ -331,6 +336,18 @@ class Config extends AbstractModel {
             throw new ConfigException("Could not find email config: {$this->config_path}/email.json");
         }
         $this->email_enabled = $email_json['email_enabled'];
+
+
+        $version_json = FileUtils::readJsonFile(FileUtils::joinPaths($this->config_path, 'version.json'));
+        if (!$version_json) {
+            throw new ConfigException("Could not find version file: {$this->config_path}/version.json");
+        }
+        if (!isset($version_json['most_recent_git_tag']) ||
+            !isset($version_json['short_installed_commit'])) {
+            throw new ConfigException("Error parsing version information: {$this->config_path}/version.json");
+        }
+        $this->latest_tag = $version_json['most_recent_git_tag'];
+        $this->latest_commit = $version_json['short_installed_commit'];
     }
 
     public function loadCourseJson($course_json_path) {

--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -5,7 +5,7 @@
             <footer>
                 &copy; {{ "now"|date("Y") }}
                 <a href="https://submitty.org" target="_blank" class="black-btn">Submitty</a>
-                (<a href="https://github.com/Submitty/Submitty/releases/tag/{{ latest_tag }}" target="_blank" class="black-btn">{{ latest_tag }}</a> {{ latest_commit }})
+                <a href="https://github.com/Submitty/Submitty/releases/tag/{{ latest_tag }}" target="_blank" title = "{{ latest_tag }} {{ latest_commit }}" class="black-btn">{{ latest_tag }}</a>
                 <span class="footer-separator">|</span> <a href="https://github.com/Submitty/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub" class="black-btn"><i class="fab fa-github fa-lg"></i></a>
                 <span class="footer-separator">|</span> <a href="https://rcos.io" target="_blank" class="black-btn">An RCOS project</a>
 

--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -3,7 +3,9 @@
             </div>
             </main>
             <footer>
-                &copy; {{ "now"|date("Y") }} <a href="https://submitty.org" target="_blank" class="black-btn">Submitty</a>
+                &copy; {{ "now"|date("Y") }}
+                <a href="https://submitty.org" target="_blank" class="black-btn">Submitty</a>
+                (<a href="https://github.com/Submitty/Submitty/releases/tag/{{ latest_tag }}" target="_blank" class="black-btn">{{ latest_tag }}</a> {{ latest_commit }})
                 <span class="footer-separator">|</span> <a href="https://github.com/Submitty/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub" class="black-btn"><i class="fab fa-github fa-lg"></i></a>
                 <span class="footer-separator">|</span> <a href="https://rcos.io" target="_blank" class="black-btn">An RCOS project</a>
 

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -53,8 +53,8 @@ class GlobalView extends AbstractView {
             "submitty_queries" => $this->core->getConfig()->isDebug() && $this->core->getSubmittyDB() ? $this->core->getSubmittyDB()->getPrintQueries() : [],
             "course_queries" => $this->core->getConfig()->isDebug() && $this->core->getCourseDB() ? $this->core->getCourseDB()->getPrintQueries() : [],
             "wrapper_urls" => $wrapper_urls,
-            "latest_tag" => $this->core->getLatestTag(),
-            "latest_commit" => $this->core->getLatestCommit(),
+            "latest_tag" => $this->core->getConfig()->getLatestTag(),
+            "latest_commit" => $this->core->getConfig()->getLatestCommit(),
             "footer_links" => $footer_links
         ]);
     }

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -53,6 +53,8 @@ class GlobalView extends AbstractView {
             "submitty_queries" => $this->core->getConfig()->isDebug() && $this->core->getSubmittyDB() ? $this->core->getSubmittyDB()->getPrintQueries() : [],
             "course_queries" => $this->core->getConfig()->isDebug() && $this->core->getCourseDB() ? $this->core->getCourseDB()->getPrintQueries() : [],
             "wrapper_urls" => $wrapper_urls,
+            "latest_tag" => $this->core->getLatestTag(),
+            "latest_commit" => $this->core->getLatestCommit(),
             "footer_links" => $footer_links
         ]);
     }


### PR DESCRIPTION
At installation, we store the latest git tag & short commit in config/version.json

Then this information can be displayed in the footer.  The commit hash is displayed when the user hovers over the tag.

We assume all tags are valid releases on the master branch of Submitty (this may not be true and then this will result in a broken link).

Note also that the commit may not match the tagged commit (there may be additional commits).  And further, it may not be a publicly available commit. 

<img width="846" alt="tag" src="https://user-images.githubusercontent.com/5871417/61565540-53fcff00-aa47-11e9-9c26-91ba1fdc46fc.png">

