### PR TITLE
[Bugfix:InstructorUI] error on late days page

### DIFF
--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -25,12 +25,6 @@ class LateController extends AbstractController {
      * @return Response
      */
     public function viewLateDays() {
-        $user_table = $this->core->getQueries()->getUsersWithLateDays();
-        $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'flatpickr.min.js'));
-        $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
-        $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'shortcut-buttons-flatpickr.min.js'));
-        $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
-        $this->core->getOutput()->renderOutput(array('admin', 'LateDay'), 'displayLateDays', $user_table);
         return Response::WebOnlyResponse(
             new WebResponse(
                 ['admin', 'LateDay'],

--- a/site/app/views/admin/LateDayView.php
+++ b/site/app/views/admin/LateDayView.php
@@ -4,10 +4,15 @@ namespace app\views\admin;
 
 use app\views\AbstractView;
 use app\libraries\Utils;
+use app\libraries\FileUtils;
 
 class LateDayView extends AbstractView {
     public function displayLateDays($users) {
         $this->core->getOutput()->addInternalCss('latedays.css');
+        $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'flatpickr.min.js'));
+        $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
+        $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'shortcut-buttons-flatpickr.min.js'));
+        $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         $this->core->getOutput()->addBreadcrumb('Late Days Allowed');
 
         $students = $this->core->getQueries()->getAllUsers();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Fixes #4165 

### What is the new behavior?
`http://192.168.56.111/f19/sample/late_days` now displays correctly.

### Other information?
This bug is from an incorrect conflict resolve in https://github.com/Submitty/Submitty/pull/4114