### PR TITLE
[Bugfix:Tests] Created a version file in config tester

### DIFF
--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -139,6 +139,16 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         );
         $config = array_replace($config,$extra);
         FileUtils::writeJsonFile(FileUtils::joinPaths($this->config_path, "email.json"), $config);
+
+        // Create version json
+        $config = array(
+            "installed_commit" => "d150131c19e3e8084b25cddcc32e6c40a8e93a2b",
+            "short_installed_commit" => "d150131c",
+            "most_recent_git_tag" => "v19.07.00"
+        );
+        $config = array_replace($config,$extra);
+        FileUtils::writeJsonFile(FileUtils::joinPaths($this->config_path, "version.json"), $config);
+
     }
 
     public function testConfig() {


### PR DESCRIPTION
### What is the current behavior?
ConfigTester.php is missing a version file causing all config tests to fail.

### What is the new behavior?
A version.json is created in ConfigTester.php
