### PR TITLE
[Refactor:Notification] Let notification metadata store URLs

### DIFF
--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -80,7 +80,7 @@ class NotificationController extends AbstractController {
             $this->core->getQueries()->markNotificationAsSeen($user_id, $nid, $thread_id);
         }
         return Response::RedirectOnlyResponse(
-            new RedirectResponse(Notification::getUrl($metadata))
+            new RedirectResponse(Notification::getUrl($this->core, $metadata))
         );
     }
 

--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -80,7 +80,7 @@ class NotificationController extends AbstractController {
             $this->core->getQueries()->markNotificationAsSeen($user_id, $nid, $thread_id);
         }
         return Response::RedirectOnlyResponse(
-            new RedirectResponse(Notification::getUrl($this->core, $metadata))
+            new RedirectResponse(Notification::getUrl($metadata))
         );
     }
 

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -388,7 +388,7 @@ class ForumController extends AbstractController{
 
                 }
                 $full_course_name = $this->core->getFullCourseName();
-                $metadata = json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id)));
+                $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id]), 'thread_id' => $thread_id]);
                 // notify on a new announcement
                 if ($announcement) {
                     $subject = "New Announcement: ".Notification::textShortner($thread_title);
@@ -474,7 +474,7 @@ class ForumController extends AbstractController{
                 $parent_post = $this->core->getQueries()->getPost($parent_id);
                 $parent_post_content = $parent_post['content'];
 
-                $metadata = json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id)));
+                $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id]), 'thread_id' => $thread_id]);
 
                 $subject = "New Reply: ".Notification::textShortner($thread_title);
                 $content = "A new message was posted in:\n".$full_course_name."\n\nThread Title: ".$thread_title."\nPost: ".Notification::textShortner($parent_post_content)."\n\nNew Reply:\n\n".$post_content;
@@ -560,7 +560,7 @@ class ForumController extends AbstractController{
                 // We want to reload same thread again, in both case (thread/post undelete)
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
-                $metadata = json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id), (string)$post_id));
+                $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id]) . '#' . (string)$post_id, 'thread_id' => $thread_id, 'post_id' => $post_id]);
                 $subject = "Undeleted: ".Notification::textShortner($post["content"]);
                 $content = "In ".$full_course_name."\n\nThe following post was undeleted.\n\nThread: ".$thread_title."\n\n".$post["content"];
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post_author_id, 'preference' => 'all_modifications_forum'];
@@ -611,7 +611,7 @@ class ForumController extends AbstractController{
             if($any_changes) {
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
-                $metadata = json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id), (string)$post_id));
+                $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id]) . '#' . (string)$post_id, 'thread_id' => $thread_id, 'post_id' => $post_id]);
                 if ($type == "Post") {
                     $post_content = $_POST["thread_post_content"];
                     $subject = "Post Edited: ".Notification::textShortner($post_content);
@@ -665,7 +665,7 @@ class ForumController extends AbstractController{
                     $child_thread_author = $child_thread['created_by'];
                     $child_thread_title = $child_thread['title'];
                     $parent_thread_title =$this->core->getQueries()->getThreadTitle($parent_thread_id)['title'];
-                    $metadata = json_encode(array(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $parent_thread_id), (string)$child_root_post));
+                    $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'forum', 'page' => 'view_thread', 'thread_id' => $parent_thread_id]) . '#' . (string)$child_root_post, 'thread_id' => $parent_thread_id, 'post_id' => $child_root_post]);
                     $subject = "Thread Merge: ".Notification::textShortner($child_thread_title);
                     $content = "Two threads were merged in:\n".$full_course_name."\n\nAll messages posted in Merged Thread:\n".$child_thread_title."\n\nAre now contained within Parent Thread:\n".$parent_thread_title;
                     $event = [ 'component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $child_thread_author, 'preference' => 'merge_threads'];

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -213,7 +213,7 @@ class GradeInquiryController extends AbstractController {
             }
 
             // make graders' notifications and emails
-            $metadata = json_encode(array(array('component' => 'grading', 'page' => 'electronic', 'action' => 'grade', 'gradeable_id' => $gradeable_id, 'who_id' => $submitter->getId())));
+            $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'grading', 'page' => 'electronic', 'action' => 'grade', 'gradeable_id' => $gradeable_id, 'who_id' => $submitter->getId()])]);
             foreach ($graders as $grader) {
                 if ($grader->accessFullGrading() && $grader->getId() != $user_id){
                     $details = ['component' => 'grading', 'metadata' => $metadata, 'content' => $n_content, 'body' => $email_body, 'subject' => $email_subject, 'sender_id' => $user_id, 'to_user_id' => $grader->getId()];
@@ -223,7 +223,7 @@ class GradeInquiryController extends AbstractController {
             }
 
             // make students' notifications and emails
-            $metadata = json_encode(array(array('component' => 'student', 'gradeable_id' => $gradeable_id)));
+            $metadata = json_encode(['url' => $this->core->buildUrl(['component' => 'student', 'gradeable_id' => $gradeable_id])]);
             if($submitter->isTeam()){
                 $submitting_team = $submitter->getTeam()->getMemberUsers();
                 foreach($submitting_team as $submitting_user){

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -573,7 +573,7 @@ class DatabaseQueries {
             $this->course_db->query("UPDATE posts SET content =  ?, anonymous = ? where id = ?", array($content, $anon, $post_id));
             // Insert latest version of post into forum_posts_history
             $this->course_db->query("INSERT INTO forum_posts_history(post_id, edit_author, content, edit_timestamp) SELECT id, ?, content, current_timestamp FROM posts WHERE id = ?", array($user, $post_id));
-            $this->course_db->query("UPDATE notifications SET content = substring(content from '.+?(?=from)') || 'from ' || ? where metadata::json->>1 = ? and metadata::json->>2 = ?", array(Utils::getDisplayNameForum($anon, $this->getDisplayUserInfoFromUserId($original_creator)), $this->getParentPostId($post_id), $post_id));
+            $this->course_db->query("UPDATE notifications SET content = substring(content from '.+?(?=from)') || 'from ' || ? where metadata::json->>thread_id = ? and metadata::json->>post_id = ?", array(Utils::getDisplayNameForum($anon, $this->getDisplayUserInfoFromUserId($original_creator)), $this->getParentPostId($post_id), $post_id));
             $this->course_db->commit();
         } catch(DatabaseException $dbException) {
             $this->course_db->rollback();

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -402,9 +402,9 @@ class DatabaseQueries {
 
     public function removeNotificationsPost($post_id) {
         //Deletes all children notifications i.e. this posts replies
-        $this->course_db->query("DELETE FROM notifications where metadata::json->>thread_id = ?", array($post_id));
+        $this->course_db->query("DELETE FROM notifications where metadata::json->>'thread_id' = ?", array($post_id));
         //Deletes parent notification i.e. this post is a reply
-        $this->course_db->query("DELETE FROM notifications where metadata::json->>post_id = ?", array($post_id));
+        $this->course_db->query("DELETE FROM notifications where metadata::json->>'post_id' = ?", array($post_id));
     }
 
     public function isStaffPost($author_id){
@@ -573,7 +573,7 @@ class DatabaseQueries {
             $this->course_db->query("UPDATE posts SET content =  ?, anonymous = ? where id = ?", array($content, $anon, $post_id));
             // Insert latest version of post into forum_posts_history
             $this->course_db->query("INSERT INTO forum_posts_history(post_id, edit_author, content, edit_timestamp) SELECT id, ?, content, current_timestamp FROM posts WHERE id = ?", array($user, $post_id));
-            $this->course_db->query("UPDATE notifications SET content = substring(content from '.+?(?=from)') || 'from ' || ? where metadata::json->>thread_id = ? and metadata::json->>post_id = ?", array(Utils::getDisplayNameForum($anon, $this->getDisplayUserInfoFromUserId($original_creator)), $this->getParentPostId($post_id), $post_id));
+            $this->course_db->query("UPDATE notifications SET content = substring(content from '.+?(?=from)') || 'from ' || ? where metadata::json->>'thread_id' = ? and metadata::json->>'post_id' = ?", array(Utils::getDisplayNameForum($anon, $this->getDisplayUserInfoFromUserId($original_creator)), $this->getParentPostId($post_id), $post_id));
             $this->course_db->commit();
         } catch(DatabaseException $dbException) {
             $this->course_db->rollback();

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -402,9 +402,9 @@ class DatabaseQueries {
 
     public function removeNotificationsPost($post_id) {
         //Deletes all children notifications i.e. this posts replies
-        $this->course_db->query("DELETE FROM notifications where metadata::json->>1 = ?", array($post_id));
+        $this->course_db->query("DELETE FROM notifications where metadata::json->>thread_id = ?", array($post_id));
         //Deletes parent notification i.e. this post is a reply
-        $this->course_db->query("DELETE FROM notifications where metadata::json->>2 = ?", array($post_id));
+        $this->course_db->query("DELETE FROM notifications where metadata::json->>post_id = ?", array($post_id));
     }
 
     public function isStaffPost($author_id){
@@ -2995,14 +2995,14 @@ AND gc_id IN (
     /**
      * Marks $user_id notifications as seen
      *
-     * @param sting $user_id
+     * @param string $user_id
      * @param int $notification_id  if $notification_id != -1 then marks corresponding as seen else mark all notifications as seen
      */
     public function markNotificationAsSeen($user_id, $notification_id, $thread_id = -1){
         $parameters = array();
         $parameters[] = $user_id;
         if($thread_id != -1) {
-        	$id_query = "metadata::json->0->>'thread_id' = ?";
+        	$id_query = "metadata::json->>'thread_id' = ?";
         	$parameters[] = $thread_id;
         } else if($notification_id == -1) {
             $id_query = "true";

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -107,18 +107,15 @@ class Notification extends AbstractModel {
     /**
      * Returns the corresponding url based on metadata
      *
-     * @param  Core     core
-     * @param  string   metadata
-     * @return string   url
+     * @param  string   $metadata_json
+     * @return string   $url
      */
-    public static function getUrl($core, $metadata_json) {
+    public static function getUrl($metadata_json) {
         $metadata = json_decode($metadata_json);
         if(is_null($metadata)) {
             return null;
         }
-        $parts = $metadata[0];
-        $hash = $metadata[1] ?? null;
-        return $core->buildUrl($parts, $hash);
+        return $metadata->url;
     }
 
     public static function getThreadIdIfExists($metadata_json) {
@@ -126,7 +123,7 @@ class Notification extends AbstractModel {
         if(is_null($metadata)) {
             return null;
         }
-        $thread_id = array_key_exists('thread_id', $metadata[0]) ? $metadata[0]['thread_id'] : -1;
+        $thread_id = property_exists($metadata, 'thread_id') ? $metadata->thread_id : -1;
         return $thread_id;
     }
 
@@ -146,7 +143,7 @@ class Notification extends AbstractModel {
     }
 
     public function hasEmptyMetadata() {
-        return count(json_decode($this->getNotifyMetadata())) == 0;
+        return empty(json_decode($this->getNotifyMetadata()));
     }
 
     /**

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -4,7 +4,6 @@ namespace app\models;
 
 use app\libraries\Core;
 use app\libraries\DateUtils;
-use app\libraries\Utils;
 
 /**
  * Class Notification
@@ -107,6 +106,7 @@ class Notification extends AbstractModel {
     /**
      * Returns the corresponding url based on metadata
      *
+     * @param  Core     $core
      * @param  string   $metadata_json
      * @return string   $url
      */

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -110,12 +110,15 @@ class Notification extends AbstractModel {
      * @param  string   $metadata_json
      * @return string   $url
      */
-    public static function getUrl($metadata_json) {
-        $metadata = json_decode($metadata_json);
-        if(is_null($metadata)) {
+    public static function getUrl($core, $metadata_json) {
+        $metadata = json_decode($metadata_json, true);
+        if (empty($metadata)) {
             return null;
         }
-        return $metadata->url;
+        if (!isset($metadata['url'])) {
+            return $core->buildNewCourseUrl();
+        }
+        return $metadata['url'];
     }
 
     public static function getThreadIdIfExists($metadata_json) {
@@ -123,7 +126,7 @@ class Notification extends AbstractModel {
         if(is_null($metadata)) {
             return null;
         }
-        $thread_id = property_exists($metadata, 'thread_id') ? $metadata->thread_id : -1;
+        $thread_id = $metadata['thread_id'] ?? -1;
         return $thread_id;
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
We currently store URL parts in the notification metadata, which is not compatible with the new URL because we use the old way of assembling them.

### What is the new behavior?
Notification metadata store URL directly.

### Other information?
Tested manually by making announcements & posts.

It is a breaking change - all old notifications will be unavailable. I am not sure if we need a migration, or, gracefully handling this (the code may be a bit dirty as there are database queries).

@bmcutler once said (long time ago) it's okay just let students complain and they will forget. What do you think now?