### PR TITLE
[Feature:RainbowGrades] last timestamp for generate grade summaries

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -47,7 +47,9 @@ class ReportController extends AbstractController {
             $this->core->getOutput()->showError("This account cannot access admin pages");
         }
 
-        $this->core->getOutput()->renderOutput(array('admin', 'Report'), 'showReportUpdates');
+        $grade_summaries_last_run = $this->getGradeSummariesLastRun();
+
+        $this->core->getOutput()->renderOutput(array('admin', 'Report'), 'showReportUpdates', $grade_summaries_last_run);
     }
 
     /**
@@ -79,6 +81,38 @@ class ReportController extends AbstractController {
         $this->core->addSuccessMessage("Successfully Generated Grade Summaries");
         $this->core->redirect($this->core->buildNewCourseUrl(['reports']));
         return $this->core->getOutput()->renderJsonSuccess();
+    }
+
+
+    public function getGradeSummariesLastRun() {
+
+        // Build path to the grade summaries folder
+        $summaries_dir = $this->core->getConfig()->getCoursePath() . '/reports/all_grades';
+
+        // Get contents of directory
+        $files = scandir($summaries_dir);
+
+        // Get file count
+        // Subtract 2 to account for '.' and '..'
+        $file_count = count($files) - 2;
+
+        // If folder is empty return never
+        if($file_count == 0)
+        {
+            return 'Never';
+        }
+        // Else folder has contents return the time stamp off the first file
+        else
+        {
+            // Get file modification time of first student json
+            $time_stamp = filemtime($summaries_dir . '/' . $files[2]);
+
+            // Format it
+            $time_stamp = date("F d Y - g:i:s A", $time_stamp);
+            $time_stamp = $time_stamp . ' - ' . $this->core->getConfig()->getTimezone()->getName();
+
+            return $time_stamp;
+        }
     }
 
     /**

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -13,6 +13,14 @@
                     <button onclick="location.href='{{ summaries_url }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
                 </td>
             </tr>
+            <tr>
+                <td width="50%">
+                </td>
+                <td width="5%"> </td>
+                <td width="45%" style="text-align: center">
+                    Last ran: <span id="grade-summaries-last-run">{{ grade_summaries_last_run }}</span>
+                </td>
+            </tr>
             <tr class="bar"></tr>
             <tr class="bar"></tr>
             <tr>

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -1,4 +1,18 @@
 <div class="content">
+
+    <script>
+
+        $(document).ready(function() {
+
+            // Bind click listener to grade summaries button
+            $('#grade-summaries-button').click(function() {
+                $('#grade-summaries-last-run').html('Running...');
+            });
+
+        });
+
+    </script>
+
     <h1>Grade Reports</h1>
     {# This is a layout table #}
     <table>
@@ -10,12 +24,11 @@
                 </td>
                 <td width="5%"> </td>
                 <td width="45%" style="position:relative">
-                    <button onclick="location.href='{{ summaries_url }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
+                    <button id="grade-summaries-button" onclick="location.href='{{ summaries_url }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
                 </td>
             </tr>
             <tr>
-                <td width="50%">
-                </td>
+                <td width="50%"> </td>
                 <td width="5%"> </td>
                 <td width="45%" style="text-align: center">
                     Last ran: <span id="grade-summaries-last-run">{{ grade_summaries_last_run }}</span>

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -4,12 +4,13 @@ namespace app\views\admin;
 use app\views\AbstractView;
 
 class ReportView extends AbstractView {
-    public function showReportUpdates() {
+    public function showReportUpdates($grade_summaries_last_run) {
         $this->core->getOutput()->addBreadcrumb('Grade Reports');
         return $this->core->getOutput()->renderTwigTemplate("admin/Report.twig", [
             'summaries_url' => $this->core->buildNewCourseUrl(['reports', 'summaries']),
             'csv_url' => $this->core->buildNewCourseUrl(['reports', 'csv']),
-            'rainbow_grades_customization_url' => $this->core->buildNewCourseUrl(['rainbow_grades_customization'])
+            'rainbow_grades_customization_url' => $this->core->buildNewCourseUrl(['rainbow_grades_customization']),
+            'grade_summaries_last_run' => $grade_summaries_last_run
         ]);
     }
 }


### PR DESCRIPTION
Partially Addresses #1372

### Please check if the PR fulfills these requirements:
* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Instructors have no way of knowing the last time grade summaries were generated

### What is the new behavior?
A timestamp is now displayed below the generated grade summaries button.  When the button is clicked, it changes to 'Running...' to alert the user that a process is running server-side.

### Other information?
Tested manually

![last_ran](https://user-images.githubusercontent.com/7605020/61723777-ae91a600-ad3a-11e9-8c2d-5ae0b95c2928.png)

