### PR TITLE
[Bugfix:RainbowGrades] ensure directory is writable

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -62,6 +62,13 @@ class ReportController extends AbstractController {
         }
 
         $base_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'reports', 'all_grades');
+
+        // Check that the directory is writable, fail if not
+        if(!is_writable($base_path)) {
+            $this->core->addErrorMessage('Unable to write to the grade summaries directory');
+            $this->core->redirect($this->core->buildNewCourseUrl(['reports']));
+        }
+
         $g_sort_keys = [
             'type',
             'CASE WHEN submission_due_date IS NOT NULL THEN submission_due_date ELSE g.g_grade_released_date END',


### PR DESCRIPTION
Closes #1657

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
When clicking the generate grade summaries button a green popup will report that they were successfully generated in all cases (even if they failed).

### What is the new behavior?
A red error pop up will be displayed if grade summaries cannot be created.

### Other information?
Tested manually
