### PR TITLE
[Refactor:API] One token for one user

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -419,6 +419,7 @@ class Core {
         $user_id = $this->authentication->getUserId();
         try {
             if ($this->authentication->authenticate()) {
+                $this->database_queries->refreshUserApiKey($user_id);
                 $token = (string) TokenManager::generateApiToken(
                     $this->database_queries->getSubmittyUserApiKey($user_id),
                     $this->getConfig()->getBaseUrl(),

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -93,6 +93,14 @@ class DatabaseQueries {
     }
 
     /**
+     * Refreshes some user's api key from the submitty database given a user_id.
+     * @param $user_id
+     */
+    public function refreshUserApiKey($user_id) {
+        $this->submitty_db->query("UPDATE users SET api_key=encode(gen_random_bytes(16), 'hex') WHERE user_id=?", array($user_id));
+    }
+
+    /**
      * Gets a user from their api key.
      * @param $api_key
      *


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Partially addresses https://github.com/Submitty/Submitty/issues/4189.

### What is the new behavior?
Automatically refreshes `api_key` before generation token each time, thus invalidating previous tokens the user requested.