### PR TITLE
Zip contents now vary based on the origin of the request

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -245,12 +245,23 @@ class MiscController extends AbstractController {
             $folder_names[] = "submissions";
             $folder_names[] = "checkout";
         }
-        if ($this->core->getAccess()->canI("path.read.results", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
-            $folder_names[] = "results";
+
+        // Context of these next two checks is important
+        // If the request is coming from the submissions page, then the results and results_public folder
+        // should not be included, otherwise include them
+        $origin = $_REQUEST['origin'] ?? null;
+
+        if($origin != 'submission') {
+
+            if ($this->core->getAccess()->canI("path.read.results", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
+                $folder_names[] = "results";
+            }
+            if ($this->core->getAccess()->canI("path.read.results_public", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
+                $folder_names[] = "results_public";
+            }
+
         }
-        if ($this->core->getAccess()->canI("path.read.results_public", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
-            $folder_names[] = "results_public";
-        }
+
         //No results, no download
         if (count($folder_names) === 0) {
             $message = "You do not have access to that page.";

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -23,7 +23,7 @@
             {% if can_download and files|length > 1 %}
                 <br />
                 <br />
-                Download all files: <a onclick='downloadZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}")'><i class="fas fa-download" aria-hidden="true" title="Download zip of all files"></i></a>
+                Download all files: <a onclick='downloadZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}", "submission")'><i class="fas fa-download" aria-hidden="true" title="Download zip of all files"></i></a>
             {% endif %}
         </div>
         <div class="box col-md-6">

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1090,7 +1090,7 @@ function downloadFile(file, path, dir) {
         'path': path});
 }
 
-function downloadZip(grade_id, user_id, version = null) {
+function downloadZip(grade_id, user_id, version = null, origin = null) {
     var url_components = {
         'component': 'misc',
         'page': 'download_zip',
@@ -1102,6 +1102,11 @@ function downloadZip(grade_id, user_id, version = null) {
     if(version !== null) {
         url_components['version'] = version;
     }
+
+    if(origin !== null) {
+        url_components['origin'] = origin;
+    }
+
     window.location = buildUrl(url_components);
     return false;
 }


### PR DESCRIPTION
Closes #4177

### Please check if the PR fulfills these requirements:
* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
If an instructor goes to the submission page for a gradeable and clicks the button to download all files, then the 'results' directory is included.

### What is the new behavior?
When downloading the zip through submission page, only the submissions folder is included.  (Students and instructors now get the same zip file from this page)

### Other information?
Tested manually. I've ensured this PR doesn't make any changes to the functionality of the download zip button on the TA grading interface.