### PR TITLE
[Bugfix:InstructorUI] Edit teams modal improvement

### DIFF
--- a/site/app/templates/grading/AdminTeamForm.twig
+++ b/site/app/templates/grading/AdminTeamForm.twig
@@ -41,5 +41,5 @@
 {% endblock %}
 {% block buttons %}
     {{ block('close_button') }}
-    <input class="btn btn-primary" type="submit" value="Submit" />
+    <input class="btn btn-primary" type="submit" value="Submit" id="admin-team-form-submit" />
 {% endblock %}

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -149,7 +149,7 @@
                         {{ self.render_student(self, _context, section, info.graded_gradeable, loop.index, info, columns, team_gradeable_view_history) }}
                     {% endfor %}
                     {% for info in section.teamless_users %}
-                        {{ self.render_teamless_user(self, _context, section, info.user, info.new_team_onclick, loop.index+section.rows|length) }}
+                        {{ self.render_teamless_user(self, _context, section, info.user, info.new_team_onclick, loop.index+section.rows|length, columns) }}
                     {% endfor %}
                 </tbody>
                 {# /Student list #}

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -49,6 +49,7 @@
     --alert-info-blue: #3a87ad;
     --alert-background-blue: #d9edf7;
     --alert-border-blue: #bce8f1;
+    --alert-invalid-entry-pink: #FFDDDD;
 
     --standard-pale-blue-gray: #e8f0f7;
     --standard-light-blue-gray: #ddddff;

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1416,6 +1416,14 @@ end of styles used in the admin gradeable page
     font-size: 1.5em;
 }
 
+[name^="user_id_"]:valid {
+    background-color: transparent;
+}
+
+[name^="user_id_"] {
+    background-color: var(--date-picker-red);
+}
+
 /* color for nav page edit button for rebuild error on gradeable */
 .edit-build-error {
     color: var(--badge-backgroud-red);

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1421,7 +1421,7 @@ end of styles used in the admin gradeable page
 }
 
 [name^="user_id_"] {
-    background-color: var(--date-picker-red);
+    background-color: var(--alert-invalid-entry-pink);
 }
 
 /* color for nav page edit button for rebuild error on gradeable */

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -805,6 +805,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
     var form = $("#admin-team-form");
     form.css("display", "block");
 
+    $("#admin-team-form-submit").prop('disabled',false);
     $('[name="new_team"]', form).val(new_team);
     $('[name="reg_section"] option[value="' + reg_section + '"]', form).prop('selected', true);
     $('[name="rot_section"] option[value="' + rot_section + '"]', form).prop('selected', true);
@@ -838,6 +839,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
             $('[name="user_id_'+i+'"]', form).autocomplete({
                 source: student_full
             });
+            $('[name="user_id_'+i+'"]').autocomplete( "option", "appendTo", form );
         }
         members_div.find('[name="reg_section"]').val(reg_section);
         members_div.find('[name="rot_section"]').val(rot_section);
@@ -894,6 +896,34 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
         }
 
     }
+    $(":text",form).change(function() {
+        var found = false;
+        for (var i = 0; i < student_full.length; i++) {
+            if (student_full[i]['value'] == $(this).val()) {
+                found = true;
+                break;
+            }
+        }
+        if (found || $(this).val() == '') {
+            $(this)[0].setCustomValidity('');
+        }
+        else {
+            $(this)[0].setCustomValidity("Invalid user_id");
+        }
+
+        var invalid_entry = false;
+        $(":text",form).each( function() {
+            if (!this.checkValidity())  {
+                invalid_entry = true;
+            }
+        });
+        if (invalid_entry) {
+            $("#admin-team-form-submit").prop('disabled',true);
+        }
+        else {
+            $("#admin-team-form-submit").prop('disabled',false);
+        }
+    });
     var param = (new_team ? 3 : members.length+2);
     members_div.append('<span style="cursor: pointer;" onclick="addTeamMemberInput(this, '+param+');"><i class="fas fa-plus-square" aria-hidden="true"></i> \
         Add More Users</span>');

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -866,36 +866,39 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
             });
             $('[name="user_id_'+i+'"]').autocomplete( "option", "appendTo", form );
         }
-        var team_history_len=user_assignment_setting_json.team_history.length;
-        team_history_title_div.append('Team History: ');
-        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="team_formation_date_left" readonly="readonly" value="Team formed on: " /><br />');
-        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="team_formation_date_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[0].time+ '" /><br />');
-        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="last_edit_left" readonly="readonly" value="Last edited on: " /><br />');
-        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="last_edit_date_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[team_history_len-1].time+ '" /><br />');
-        for (var j = 0; j <=team_history_len-1; j++) {
-            if(user_assignment_setting_json.team_history[j].action == "admin_create"){
-                for (var i = 0; i < members.length; i++) {
-                    if(user_assignment_setting_json.team_history[j].first_user == members[i] || user_assignment_setting_json.team_history[j].added_user == members[i]){
-                        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
-                        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+
+        if (user_assignment_setting_json != false) {
+            var team_history_len=user_assignment_setting_json.team_history.length;
+            team_history_title_div.append('Team History: ');
+            team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="team_formation_date_left" readonly="readonly" value="Team formed on: " /><br />');
+            team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="team_formation_date_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[0].time+ '" /><br />');
+            team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="last_edit_left" readonly="readonly" value="Last edited on: " /><br />');
+            team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="last_edit_date_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[team_history_len-1].time+ '" /><br />');
+            for (var j = 0; j <=team_history_len-1; j++) {
+                if(user_assignment_setting_json.team_history[j].action == "admin_create"){
+                    for (var i = 0; i < members.length; i++) {
+                        if(user_assignment_setting_json.team_history[j].first_user == members[i] || user_assignment_setting_json.team_history[j].added_user == members[i]){
+                            team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
+                            team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+                        }
                     }
                 }
-            }
-            if(user_assignment_setting_json.team_history[j].action == "admin_add_user"){
-                for (var i = 0; i < members.length; i++) {
-                    if(user_assignment_setting_json.team_history[j].added_user == members[i]){
-                        team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
-                        team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+                if(user_assignment_setting_json.team_history[j].action == "admin_add_user"){
+                    for (var i = 0; i < members.length; i++) {
+                        if(user_assignment_setting_json.team_history[j].added_user == members[i]){
+                            team_history_div_left.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_left" readonly="readonly" value="'+members[i]+ ' added on: " /><br />');
+                            team_history_div_right.append('<input class="readonly" type="text" style="width:100%;" name="user_id_' +i+ '_right" readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+                        }
                     }
                 }
-            }
-            if(user_assignment_setting_json.team_history[j].action == "admin_remove_user"){
-                team_history_div_left.append('<input class="readonly" type="text" style="width:100%;"  readonly="readonly" value="'+user_assignment_setting_json.team_history[j].removed_user+ ' removed on: " /><br />');
-                team_history_div_right.append('<input class="readonly" type="text" style="width:100%;"  readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+                if(user_assignment_setting_json.team_history[j].action == "admin_remove_user"){
+                    team_history_div_left.append('<input class="readonly" type="text" style="width:100%;"  readonly="readonly" value="'+user_assignment_setting_json.team_history[j].removed_user+ ' removed on: " /><br />');
+                    team_history_div_right.append('<input class="readonly" type="text" style="width:100%;"  readonly="readonly" value="' +user_assignment_setting_json.team_history[j].time+ '" /><br />');
+                }
             }
         }
-
     }
+    
     $(":text",form).change(function() {
         var found = false;
         for (var i = 0; i < student_full.length; i++) {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -851,7 +851,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
         title_div.append('Edit Team: ' + who_id);
         for (var i = 0; i < members.length; i++) {
             members_div.append('<input class="readonly" type="text" name="user_id_' + i + '" readonly="readonly" value="' + members[i] + '" /> \
-                <input id="remove_member_'+i+'" class = "btn btn-danger" type="submit" value="Remove" onclick="removeTeamMemberInput('+i+');" \
+                <input id="remove_member_'+i+'" class = "btn btn-danger" value="Remove" onclick="removeTeamMemberInput('+i+');" \
                 style="cursor:pointer; width:80px; padding-top:3px; padding-bottom:3px;" aria-hidden="true"></input><br />');
         }
         for (var i = members.length; i < members.length+pending_members.length; i++) {


### PR DESCRIPTION
Closes #4163
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Users with no team don't show up at all on the details page, seems to be a new bug.
The dropdown menu appears behind the modal when edit team is clicked for a user with No Team.
The behavior when an invalid user_id is entered is inconvenient. 

### What is the new behavior?
- Fixed bug that stops users with no team from being displayed
- Added check for team history section of the modal in case no history data is available
- Made dropdown menu appear in the modal rather than behind for teamless users
- If an invalid user_id is entered, the background of the textbox will turn red and the submit button is disabled
- Previously if a textbox to add a new user is selected, pressing the enter key will click the "delete" button for a user on the team.  The enter key now submits the form instead (unless the submit is disabled).

![EditTeamModalPic](https://user-images.githubusercontent.com/34327811/61904446-ddec1280-aef4-11e9-8617-bbb228529183.png)

