### PR TITLE
[Refactor:Mobile] Mobile for main notifications page

### DIFF
--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -35,6 +35,8 @@
                 <div class="notification">
                     {% if notification.getComponent() == "forum" %}
                         <i class="fas fa-comments notification-type" title="Forum"></i>
+                    {% else %}
+                        <div>&NegativeMediumSpace;</div>
                     {% endif %}
                     {% if hasLink %}
                         <a class="notification-link" href="{{ notifications_url }}/{{ notification.getId() }}?seen={{ notification.isSeen() }}">

--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -1,65 +1,63 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
 <div class="content">
-    <div style="float: right; margin-bottom: 20px;">
-         <a href="{{ mark_all_as_seen_url }}" class="btn btn-primary">Mark all as seen</a>
-        {% if show_all %}
-            <a href="{{ notifications_url }}" class="btn btn-primary">Show unread only</a>
+    <header>
+        <h1>Notifications</h1>
+        <div class="btn-wrapper">
+            <a href="{{ mark_all_as_seen_url }}" class="btn btn-primary">Mark all as seen</a>
+            {% if show_all %}
+                <a href="{{ notifications_url }}" class="btn btn-primary">Show unread only</a>
+            {% else %}
+                <a href="{{ notifications_url }}?show_all=true" class="btn btn-primary">Show All</a>
+            {% endif %}
+            <a href="{{ notification_settings_url }}" class="btn btn-primary">Settings</a>
+        </div>
+    </header>
+    <div id="notifications">
+        <h2 id="notifications-caption">
+            {% if show_all %}
+                All notifications
+            {% else %}
+                New notifications
+            {% endif %}
+        </h2>
+        {% if notifications is empty %}
+            <h3>No notifications.</h3>
         {% else %}
-            <a href="{{ notifications_url }}?show_all=true" class="btn btn-primary">Show All</a>
-        {% endif %}
-        <a href="{{ notification_settings_url }}" class="btn btn-primary">Settings</a>
+            <div id="notification-header" class="notification">
+                <div>&NegativeMediumSpace;</div> {# Notification type has empty header #}
+                <div>Notification</div>
+                <div>Time</div>
+                <div class="notification-seen">Mark As Seen</div>
+            </div>
+            {% for notification in notifications %}
+                {% set hasLink = not notification.hasEmptyMetadata() %}
+                <div class="notification">
+                    {% if notification.getComponent() == "forum" %}
+                        <i class="fas fa-comments notification-type" title="Forum"></i>
+                    {% endif %}
+                    {% if hasLink %}
+                        <a class="notification-link" href="{{ notifications_url }}/{{ notification.getId() }}?seen={{ notification.isSeen() }}">
+                    {% endif %}
+                    <div class="notification-contents">
+                        {{ notification.getNotifyContent() }}
+                        <div class="mobile-notification-time">
+                            {{ notification.getNotifyTime() }}
+                        </div>
+                    </div>
+                    {% if hasLink %}
+                        </a>
+                    {% endif %}
+                    <div class="notification-time">
+                        {{ notification.getNotifyTime() }}
+                    </div>
+                    {% if not notification.isSeen() %}
+                        <a class="notification-seen black-btn" href="{{ notifications_url }}/{{ notification.getId() }}/seen" title="Mark as seen">
+                            <i class="far fa-envelope-open" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        {% endif %}     
     </div>
-    <h1>Notifications</h1>
-    {# This is a layout table #}
-    <table class="table table-bordered persist-area">
-                <tr class="info persist-header">
-                    <td colspan="8" style="text-align: center">
-                        {% if show_all %}
-                            All notifications
-                        {% else %}
-                            New notifications
-                        {% endif %}
-                    </td>
-                </tr>
-                <tbody style="text-align: left;">
-                    {% for notification in notifications %}
-                        {% set hasLink = not notification.hasEmptyMetadata() %}
-                        <tr>
-                            <td colspan="1">
-                                {% if notification.getComponent() == "forum" %}
-                                    <i class="fas fa-comments" title="Forum"></i>
-                                {% endif %}
-                            </td>
-                            <td colspan="4">
-                                {% if hasLink %}
-                                    <a href="{{ notifications_url }}/{{ notification.getId() }}?seen={{ notification.isSeen() }}">
-                                {% endif %}
-                                    <div style="height: 100%; width: 100%;">
-                                        {{ notification.getNotifyContent() }}
-                                    </div>
-                                {% if hasLink %}
-                                    </a>
-                                {% endif %}
-                            </td>
-                            <td colspan="2">
-                                {{ notification.getNotifyTime() }}
-                            </td>
-                            <td colspan="1">
-                                {% if not notification.isSeen() %}
-                                    <a href="{{ notifications_url }}/{{ notification.getId() }}/seen" title="Mark as seen">
-                                        <i class="fas fa-check" aria-hidden="true"></i>
-                                    </a>
-                                {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-
-            {% if notifications is empty %}
-            <tr>
-                <td colspan="8">No notifications.</td>
-            </tr>
-            {% endif %}        
-    </table>
 </div>

--- a/site/app/views/NotificationView.php
+++ b/site/app/views/NotificationView.php
@@ -5,6 +5,7 @@ namespace app\views;
 class NotificationView extends AbstractView {
     public function showNotifications($current_course, $show_all, $notifications, $notification_saves) {
         $this->core->getOutput()->addBreadcrumb("Notifications");
+        $this->core->getOutput()->addInternalCss('notifications.css');
         $this->core->getOutput()->renderTwigOutput("Notifications.twig", [
             'course' => $current_course,
             'show_all' => $show_all,

--- a/site/public/css/notifications.css
+++ b/site/public/css/notifications.css
@@ -1,0 +1,78 @@
+#notifications {
+    display: table;
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#notifications-caption {
+    background: var(--alert-background-blue);
+    margin: 8px -30px;
+    padding: 8px 30px;
+    display: table-caption;
+}
+
+#notification-header {
+    display: none;
+}
+
+.notification {
+    display: flex;
+    border-bottom: 1px solid var(--standard-light-gray);
+    padding: 9px 0;
+    align-items: center;
+}
+
+.notification:nth-last-child(1) {
+    border-bottom: none;
+}
+
+.notification > * {
+    display: block;
+    align-items: center;
+}
+
+.notification-type {
+    margin-right: 0.5em;
+}
+
+.notification-contents {
+    display: flex;
+    flex-wrap: wrap;
+    flex-grow: 1;
+}
+
+.mobile-notification-time {
+    font-size: 12px;
+    color: var(--standard-medium-dark-gray);
+    flex: 1 0 90%;
+}
+
+.notification-time {
+    display: none;
+}
+
+.notification-seen {
+    text-align: center;
+    flex: 0 0 auto;
+    padding: 10px 16px;
+}
+
+@media (min-width: 768px) {
+    #notification-header {
+        display: table-row;
+    }
+
+    .notification {
+        display: table-row;
+        /* padding: 0; */
+    }
+
+    .notification > * {
+        display: table-cell;
+        padding: 9px;
+    }
+
+    .mobile-notification-time {
+        display: none;
+    }
+}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1618,17 +1618,17 @@ end of styles used in the admin gradeable page
     color: var(--alert-danger-red);
 }
 
-.black-btn, .black-btn > i.fas {
+.black-btn, .black-btn > i {
     color: #000 !important;
     border-color: #000 !important;
 }
 
-.black-btn:hover, .black-btn > i.fas:hover {
+.black-btn:hover, .black-btn:hover > i, .black-btn > i:hover {
     color: #405E90 !important;
     border-color: #405E90 !important;
 }
 
-.black-btn:active, .black-btn > i.fas:active {
+.black-btn:active, .black-btn:active > i, .black-btn > i:active {
     color: var(--external-link-active) !important;
     border-color: var(--external-link-active) !important;
 }


### PR DESCRIPTION
The notifications setting page will be addressed in a future PR after some unrelated changes are made to it.

- Revamped table caption to be h2 header
- Switched from table html to `display: table` css
- Buttons collapse on smaller screens
- Changed "mark as seen" icon to open envelope
- On mobile, time of notification shrinks and grays
- "Mark as seen" button now fits wider standardization of icon button palettes

Should look something like this:
![Peek 2019-07-25 17-27](https://user-images.githubusercontent.com/32647488/61910011-7daf9d80-af01-11e9-9c35-953994f3f766.gif)
