### PR TITLE
[Bugfix] Fix broken forum stats URL

### DIFF
--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -82,7 +82,7 @@
 
                 if($(this).data('type')=="post" || $(this).data('type')=="thread"){
                     var id = $(this).data('thread_id');
-                    var url = buildNewCourseUrl(['forum', 'threads', 'id']);
+                    var url = buildNewCourseUrl(['forum', 'threads', id]);
                     window.open(url);
                 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Stats page links to threads are broken

### What is the new behavior?
The links are fixed.

### Other information?
Saw this in the meeting notes. It is a router bug :sweat_smile: 