### PR TITLE
[Feature:UITweak] Redid desktop view of MyLateDays

### DIFF
--- a/site/app/templates/LateDaysTablePlugin.twig
+++ b/site/app/templates/LateDaysTablePlugin.twig
@@ -30,7 +30,7 @@
             <th>Late days charged for this assignment</th>
         </tr>
     </thead>
-    <tbody id="late-day-table">
+    <tbody>
     {% for late_day_info in late_days.getLateDayInfo() %}
         {% set graded_gradeable = late_day_info.getGradedGradeable() %}
         {% set gradeable = graded_gradeable.getGradeable() %}

--- a/site/public/css/latedays.css
+++ b/site/public/css/latedays.css
@@ -11,27 +11,34 @@ fieldset > * {
     margin-left: 30px;
 }
 
-#late-day-table {
-    margin: 1em 0 0;
-}
-
 #late-day-table th,
 #late-day-table td {
-    border: 1px solid black;
     text-align: center;
-    padding: 5px;
+    padding: 5px 10px;
 }
 
-@media (max-width: 800px) {
-    #late-day-table {
-        margin: 0;
-    }
+#late-day-table td:nth-of-type(1):before { content: "Assignment"; }
+#late-day-table td:nth-of-type(2):before { content: "Due date"; }
+#late-day-table td:nth-of-type(3):before { content: "Max late days"; }
+#late-day-table td:nth-of-type(4):before { content: "Days submitted late"; }
+#late-day-table td:nth-of-type(5):before { content: "Days from extensions"; }
+#late-day-table td:nth-of-type(6):before { content: "Status"; }
+#late-day-table td:nth-of-type(7):before { content: "Late days used here"; }
 
-    #late-day-table td:nth-of-type(1):before { content: "Assignment"; }
-    #late-day-table td:nth-of-type(2):before { content: "Due date"; }
-    #late-day-table td:nth-of-type(3):before { content: "Max late days"; }
-    #late-day-table td:nth-of-type(4):before { content: "Days submitted late"; }
-    #late-day-table td:nth-of-type(5):before { content: "Days from extensions"; }
-    #late-day-table td:nth-of-type(6):before { content: "Status"; }
-    #late-day-table td:nth-of-type(7):before { content: "Late days used here"; }
+@media (min-width: 831px) {   
+    #late-day-table {
+        margin: 1em 0 0;
+    }
+        
+    #late-day-table thead tr {
+        background: var(--standard-light-gray);
+    }
+    
+    #late-day-table tbody tr:nth-child(even) {
+        background: var(--standard-hover-light-gray);
+    }
+    
+    #late-day-table td:before {
+        content: none !important;
+    }
 }

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -2,7 +2,7 @@ table.mobile-table {
     width: 100%;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 830px) {
     table.mobile-table, 
     .mobile-table thead, 
     .mobile-table tbody, 


### PR DESCRIPTION
Some global CSS rules had messed up the appearance of this page, so I fixed them and redid the desktop view. I also redid latedays.css to be mobile first in rendering (media queries only trigger desktop rules).

Old:
![Screenshot from 2019-07-29 11-56-02](https://user-images.githubusercontent.com/32647488/62062884-e0ea4a00-b1f7-11e9-8ef0-d555495b6a5a.png)
![Screenshot from 2019-07-29 11-55-49](https://user-images.githubusercontent.com/32647488/62062893-e3e53a80-b1f7-11e9-8bce-ed27836ca865.png)

New:
![Screenshot from 2019-07-29 11-52-42](https://user-images.githubusercontent.com/32647488/62062663-6f120080-b1f7-11e9-8998-2c6bff20af81.png)
![Screenshot from 2019-07-29 11-52-55](https://user-images.githubusercontent.com/32647488/62062671-733e1e00-b1f7-11e9-83c7-4fe225ab8e90.png)
