### PR TITLE
[Bugfix:BulkUploads] Bulk upload focus

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -98,6 +98,7 @@
     var is_team_assignment = "{{ team_assignment }}" === "1";
     //autofill data
     $(function(){
+        $("#messages").empty();
         if(sessionStorage.getItem("expected_count"))
             document.getElementById("expected_pages_input").value = sessionStorage.getItem("expected_count");
 
@@ -105,6 +106,10 @@
             source: students_full 
         });
         highlightPageCount();
+    });
+
+    window.addEventListener('onbeforeunload', function(e) {
+        $("#messages").empty();
     });
 
     //highlight pages that don't match the expected, also save the expected page count in session storage
@@ -131,6 +136,9 @@
         var submit_btn = document.getElementById("bulk_submit_" + String(index));
         var delete_btn = document.getElementById("bulk_delete_" + String(index));
         var user_id_textarea = document.getElementById("bulk_user_id_" + String(index));
+
+        if(!submit_btn || !delete_btn || !user_id_textarea)
+            return;
 
         submit_btn.disabled = disable;
         delete_btn.disabled = disable;
@@ -201,10 +209,17 @@
                 uploadSplitHelper(user_id,path, index);
             }else{
                 //user_id has previous submission give options to user first
+                let has_been_called = false;
                 var option = displayPreviousSubmissionOptions(getSubmissionOption);
+                
+                return;
 
                 //callback function once user actually picks something
                 function getSubmissionOption(option){
+                    if(has_been_called)
+                        return;
+
+                    has_been_called = true;
                     //user closes do nothing
                     if(option === -1){
                         toggleButtons(index, false);
@@ -226,7 +241,6 @@
                         merge_previous = true;
                         clobber = true;
                     }
-
                     uploadSplitHelper(user_id,path,index,merge_previous,clobber);
                 }
             }

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -151,12 +151,15 @@
     }
 
     function moveToNextSubmission(index){
-        if( (index + 1) <= num_submissions){
-            document.getElementById("bulk_user_id_" + String(index + 1)).focus();
+        let current = document.getElementById('row-' + String(index));
+        if( current ){
+            document.getElementById('row-' + String(index)).remove();
+            num_submissions -= 1;
         }
-        document.getElementById('row-' + String(index)).remove();
-        num_submissions -= 1;
-        
+        let next = document.getElementById("bulk_user_id_" + String(index + 1));
+        if( next ){
+            document.getElementById("bulk_user_id_" + String(index + 1)).focus();
+        }    
     }
 
     //if the user presses 'enter' try and make a submission as if hitting the submit button

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -469,6 +469,7 @@ function displayPreviousSubmissionOptions(callback){
             localStorage.setItem("instructor-submit-option", "2");
         }
         form.css("display", "none");
+        callback(-1);
     });
 
     $('.popup-form').css('display', 'none');

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -469,7 +469,6 @@ function displayPreviousSubmissionOptions(callback){
             localStorage.setItem("instructor-submit-option", "2");
         }
         form.css("display", "none");
-        callback(-1);
     });
 
     $('.popup-form').css('display', 'none');


### PR DESCRIPTION
Fixes bulk uploads losing focus after a bit.
The error messages popping up were caused by duplicate requests being sent and when it would fail
it would try and re-enable the submission box that it thought failed. But because the submission had
actually succeeded, it would error and lose focus. 

Clears messages on page load 

Fixes #4185