### PR TITLE
[Bugfix: Router] Router GET param should load default values

### DIFF
--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -152,6 +152,9 @@ class WebRouter {
             if (!isset($arguments[$param_name])) {
                 $arguments[$param_name] = $this->request->query->get($param_name);
             }
+            if (!isset($arguments[$param_name])) {
+                $arguments[$param_name] = $param->getDefaultValue();
+            }
         }
 
         return call_user_func_array([$controller, $this->method_name], $arguments);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Closes #4220 

### What is the new behavior?
The bug is fixed.

### Other information?
The function call isn't loading default values, which caused this error.

I am wondering what 'grade next student' would behave normally? It looks that it simply goes to the "details" page even I checked out an old revision. Should it go to the grading page though? @bmcutler 