### PR TITLE
Remove 'Grade Next Student' button

### DIFF
--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -135,10 +135,6 @@
             </a>
             {% if core.getUser().getGradingRegistrationSections()|length != 0 %}
                 <a class="btn btn-primary"
-                   href="{{ grade_url }}">
-                    Grade Next Student
-                </a>
-                <a class="btn btn-primary"
                    href="{{ core.buildUrl({'component': 'misc', 'page': 'download_all_assigned', 'dir': 'submissions', 'gradeable_id': gradeable_id}) }}">
                     Download Zip of All Assigned Students
                 </a>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
There is a "Grade Next Student" button, pointing to the details page.

### What is the new behavior?
Removed the button. As discussed in https://github.com/Submitty/Submitty/pull/4222