### PR TITLE
[Bugfix:Notifications] Fixed one person team submission and limited grader grader inquiry

### DIFF
--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -3,6 +3,7 @@
 namespace app\controllers\student;
 
 use app\controllers\AbstractController;
+use app\models\gradeable\GradedGradeable;
 use app\models\Notification;
 use app\models\Email;
 use app\libraries\response\Response;
@@ -183,12 +184,18 @@ class GradeInquiryController extends AbstractController {
         }
     }
 
-    private function notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, $type)
+    /**
+     * @param GradedGradeable $graded_gradeable
+     * @param $gradeable_id
+     * @param $content
+     * @param $type
+     */
+    private function notifyGradeInquiryEvent(GradedGradeable $graded_gradeable, $gradeable_id, $content, $type)
     {
         //TODO: send notification to grader per component
         if ($graded_gradeable->hasTaGradingInfo()) {
             $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
-            $graders = $ta_graded_gradeable->getGraders();
+            $graders = $ta_graded_gradeable->getVisibleGraders();
             $submitter = $graded_gradeable->getSubmitter();
             $user_id = $this->core->getUser()->getId();
             $gradeable_title = $graded_gradeable->getGradeable()->getTitle();
@@ -234,6 +241,9 @@ class GradeInquiryController extends AbstractController {
 
             // make graders' notifications and emails
             $metadata = json_encode(['url' => $this->core->buildNewCourseUrl(['gradeable', $gradeable_id, 'grading', 'grade'] . '?' . http_build_query(['who_id' => $submitter->getId()]))]);
+            if (empty($graders)) {
+                $graders = $this->core->getQueries()->getAllGraders();
+            }
             foreach ($graders as $grader) {
                 if ($grader->accessFullGrading() && $grader->getId() != $user_id) {
                     $details = ['component' => 'grading', 'metadata' => $metadata, 'body' => $body, 'subject' => $subject, 'sender_id' => $user_id, 'to_user_id' => $grader->getId()];

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -185,6 +185,7 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
+     * Helper function to create notification/email content and aggregate recipients
      * @param GradedGradeable $graded_gradeable
      * @param $gradeable_id
      * @param $content

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1285,18 +1285,20 @@ class SubmissionController extends AbstractController {
 
         if($gradeable->isTeamAssignment()) {
             $this->core->getQueries()->insertVersionDetails($gradeable->getId(), null, $team_id, $new_version, $current_time);
-
-            // notify other team members that a submission has been made
-            $metadata = json_encode(['url' => $this->core->buildNewCourseUrl(['gradeable',$gradeable_id])]);
-            $subject = "Team Member Submission: ".$graded_gradeable->getGradeable()->getTitle();
-            $content = "A team member, $original_user_id, submitted in the gradeable, ".$graded_gradeable->getGradeable()->getTitle();
             $team_members = $graded_gradeable->getSubmitter()->getTeam()->getMembers();
             // remove submitting user from recipient list
             if (($key = array_search($original_user_id, $team_members)) !== false) {
                 array_splice($team_members, $key, 1);
             }
-            $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_member_submission', 'sender_id' => $original_user_id];
-            $this->core->getNotificationFactory()->onTeamEvent($event,$team_members);
+            if (!empty($team_members)) {
+                // notify other team members that a submission has been made
+                $metadata = json_encode(['url' => $this->core->buildNewCourseUrl(['gradeable',$gradeable_id])]);
+                $subject = "Team Member Submission: ".$graded_gradeable->getGradeable()->getTitle();
+                $content = "A team member, $original_user_id, submitted in the gradeable, ".$graded_gradeable->getGradeable()->getTitle();
+                $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_member_submission', 'sender_id' => $original_user_id];
+                $this->core->getNotificationFactory()->onTeamEvent($event,$team_members);
+            }
+
         }
         else {
             $this->core->getQueries()->insertVersionDetails($gradeable->getId(), $user_id, null, $new_version, $current_time);


### PR DESCRIPTION
### What is the current behavior?
- If a team with a single member makes a submission and tries to send a notification to other team members an exception is thrown as there are no other team members
- If a student submits a grade inquiry and a limited access grader graded the assignment an exception is thrown as there is no recipients

### What is the new behavior?
- No notifications are sent on a one person team submission
- All full access graders are sent a notification about the grade inquiry event if there is no full access grader who verified the limited access grader's grading

