### PR TITLE
[Bugfix:instructor ui] fix expected date format on latedays extension

### DIFF
--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -78,8 +78,8 @@ class LateController extends AbstractController {
                     JsonResponse::getFailResponse($error)
                 );
             }
-            if (!isset($_POST['datestamp']) || !DateUtils::validateTimestamp($_POST['datestamp'])) {
-                $error = "Datestamp must be mm/dd/yy";
+            if (!isset($_POST['datestamp']) ||  (\DateTime::createFromFormat('Y-m-d', $_POST['datestamp']) === false)) {
+                $error = "Datestamp must be Y-m-d";
                 return Response::JsonOnlyResponse(
                     JsonResponse::getFailResponse($error)
                 );


### PR DESCRIPTION
The latedays extension page now expects and checks for y-m-d format