### PR TITLE
[BugFix: Student UI] Fixed error where gradeable buttons were vertical

### DIFF
--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -130,7 +130,6 @@
 
     .course-button {
         max-width: 95%;
-        display: block;
         margin: auto;
     }
 }

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -47,7 +47,7 @@
     min-width: 100%;
 }
 
-.btn-nav-open, .button-placeholder {
+.btn-nav-open {
     display: none;
 }
 
@@ -124,8 +124,9 @@
         padding: 5px !important;
     }
 
-    .button-placeholder {
-        display: table-cell;
+    .course-main .button-placeholder {
+        display: inline-block;
+        width: 33px;
     }
 
     .course-button {


### PR DESCRIPTION
PRs #4239 and #4229 had a conflict where the buttons were laid out vertically, on the gradeables page. This should fix it.