### PR TITLE
[Bugfix:InstructorUI] Course Settings rows fixed on webkit browsers

### DIFF
--- a/site/public/css/configuration.css
+++ b/site/public/css/configuration.css
@@ -16,7 +16,7 @@
 }
 
 .config-row {
-    flex: 1 0 60%;
+    flex: 1 0 auto;
     margin: 0 0 1em;
 }
 


### PR DESCRIPTION
Certain browsers should no longer display rows at grossly large sizes Tested on:

Android:
Firefox 68
Chrome 75

Ubuntu:
Firefox 68.
Chrome 75

Mojave:
Safari 11