### PR TITLE
[Refactor:Tests] Load annotations in bootstrap.php

### DIFF
--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -5,21 +5,11 @@ namespace tests\app\libraries\routers;
 use app\libraries\routers\WebRouter;
 use tests\BaseUnitTest;
 use Symfony\Component\HttpFoundation\Request;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 
 /**
  * @runTestsInSeparateProcesses
  */
 class WebRouterTester extends BaseUnitTest {
-
-    /**
-     * Loads annotations for routers.
-     */
-    public static function setUpBeforeClass(): void {
-        $loader = require(__DIR__.'/../../../../vendor/autoload.php');
-        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
-    }
-
     public function testLogin() {
         $core = $this->createMockCore();
         $request = Request::create(
@@ -33,6 +23,8 @@ class WebRouterTester extends BaseUnitTest {
 
     public function testLogout() {
         $_COOKIE['submitty_token'] = "test";
+        $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+        $_SERVER['HTTP_USER_AGENT'] = 'test';
         $core = $this->createMockCore();
         $request = Request::create(
             "/authentication/logout"

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -1,5 +1,8 @@
 <?php
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
 define("__TEST_DATA__", __DIR__ . "/data");
 
-require_once(__DIR__.'/../vendor/autoload.php');
+$loader = require(__DIR__.'/../vendor/autoload.php');
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Previously we load annotations in `WebRouterTester.php`. In that case, when running `WebRouterTester.php` individually, it errors. That wastes time.

### What is the new behavior?
Load annotations in `bootstrap.php`.

### Other information?
I am actually not sure how that fails when run individually (the error message says test not found), but as I am working on `AccessControlTester` I find it wasting me too much time to always run the entire test suite, and modifying these code works.