### PR TITLE
[Feature:API] Add endpoint for token invalidation

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -171,6 +171,28 @@ class AuthenticationController extends AbstractController {
     }
 
     /**
+     * @Route("/api/token/invalidate", methods={"POST"})
+     *
+     * @return Response
+     */
+    public function invalidateToken() {
+        if (!isset($_POST['user_id']) || !isset($_POST['password'])) {
+            $msg = 'Cannot leave user id or password blank';
+            return Response::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
+        }
+        $this->core->getAuthentication()->setUserId($_POST['user_id']);
+        $this->core->getAuthentication()->setPassword($_POST['password']);
+        $success = $this->core->invalidateJwt();
+        if ($success) {
+            return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
+        }
+        else {
+            $msg = "Could not login using that user id or password";
+            return Response::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
+        }
+    }
+
+    /**
      * Handle stateless authentication for the VCS endpoints.
      *
      * This endpoint is unique from the other authentication methods in

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -440,6 +440,32 @@ class Core {
     }
 
     /**
+     * Invalidates user's token by refreshing user's api key.
+     *
+     * @return bool
+     *
+     * @throws AuthenticationException
+     */
+    public function invalidateJwt() {
+        $user_id = $this->authentication->getUserId();
+        try {
+            if ($this->authentication->authenticate()) {
+                $this->database_queries->refreshUserApiKey($user_id);
+                return true;
+            }
+        }
+        catch (\Exception $e) {
+            // We wrap all non AuthenticationExceptions so that they get specially processed in the
+            // ExceptionHandler to remove password details
+            if ($e instanceof AuthenticationException) {
+                throw $e;
+            }
+            throw new AuthenticationException($e->getMessage(), $e->getCode(), $e);
+        }
+        return false;
+    }
+
+    /**
      * Checks the inputted $csrf_token against the one that is loaded from the session table for the particular
      * signed in user.
      *


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Partially addresses #4189

### What is the new behavior?
`POST /api/token/invalidate` with `user_id` and `password`.
If a success message is returned, you will (computationally) no longer have any valid token.