### PR TITLE
[Refactor:Vagrant] Remove unused private network IP

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,6 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.box = 'bento/ubuntu-18.04'
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432
     ubuntu.vm.network 'private_network', ip: '192.168.56.111'
-    ubuntu.vm.network 'private_network', ip: '192.168.56.112'
   end
 
   config.vm.provider 'virtualbox' do |vb|


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Vagrant for Ubuntu 18.04 setups up private network on 192.168.56.111 and 192.168.56.112. The second URL was originally for what we used for Git, but that's since been folded into the first URL. All it does now is redirect to the first URL, so no need to have it.

### What is the new behavior?
Only create virtual network on 192.168.56.111 for Ubuntu 18.04. 192.168.56.112 will no longer work.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Not a breaking change, tested with vagrant halt/up.
