### PR TITLE
[Bugfix:UI] Breadcrumb bar wrapping & link

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -56,14 +56,16 @@
                             {% if loop.index0 > 0 %}
                                 <span>&gt;</span> {# span required to give conditional rendering #}
                             {% endif %}
-                            {% if b.getUrl() is not empty and not loop.last %}
-                                <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
-                            {% else %}
-                                <span>{{ b.getTitle() }}</span>
-                            {% endif %}
-                            {% if b.getExternalUrl() is not empty %}
-                                <a class="external" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
-                            {% endif %}
+                            <div class="breadcrumb">
+                                {% if b.getUrl() is not empty and not loop.last %}
+                                    <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
+                                {% else %}
+                                    <span>{{ b.getTitle() }}</span>
+                                {% endif %}
+                                {% if b.getExternalUrl() is not empty %}
+                                    <a class="external-breadcrumb" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
+                                {% endif %}
+                            </div>
                         {% endfor %}
                     </div>
                 </div>

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -51,14 +51,17 @@ nav a > i.f {
 #breadcrumbs {
     display: flex;
     width: 1px;
-    overflow-x: auto;
     flex: 1 1 auto;
-    white-space: nowrap;
+    flex-wrap: wrap;
 }
 
 #breadcrumbs > *:not(:last-child) {
     padding-right: 7px;
     display: none;
+}
+
+.external-breadcrumb {
+    padding-left: 7px;
 }
 
 #logout-button {

--- a/site/public/css/menu.css
+++ b/site/public/css/menu.css
@@ -4,6 +4,7 @@
     background: transparent;
     margin: 15px;
     padding: 6px 12px;
+    position: relative;
 }
 
 #mobile-menu {
@@ -86,8 +87,8 @@
 
 #menu-button .notification-badge {
     position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
+    right: -10%;
+    top: -30%;
 }
 
 #mobile-menu .notification-badge {


### PR DESCRIPTION
Closes #4262

Before:
- Breadcrumbs would scroll if they got too long
- If an external link was attached to the last breadcrumb, it wouldn't display properly on mobile

Now:
- Breadcrumbs wrap
- External links and the text are properly displayed

Expected behavior:
![Peek 2019-08-02 12-23](https://user-images.githubusercontent.com/32647488/62384522-a139a000-b520-11e9-90f4-50a3a896c8d7.gif)