### PR TITLE
[Refactor] Get rid of unnecessary call to core->getOutput in Output class

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -290,10 +290,10 @@ HTML;
             }
         }
 
-        if ($success == true) {
-            return $this->core->getOutput()->renderJsonSuccess($message);
+        if ($success === true) {
+            return $this->renderJsonSuccess($message);
         } else {
-            return $this->core->getOutput()->renderJsonFail($message);
+            return $this->renderJsonFail($message);
         }
     }
     


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Gets the instance of Output (from inside the instance of Output) from the core to execute the function.

### What is the new behavior?
Just use the current Output instance that we're inside of

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
