### PR TITLE
[Bugfix] Do not directly assign to Array.prototype

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1160,24 +1160,34 @@ var filters_applied = [];
 
 // Taken from https://stackoverflow.com/a/1988361/2650341
 
-Array.prototype.inArray = function(comparer) {
-    for(var i=0; i < this.length; i++) {
-        if(comparer(this[i])) return i;
-    }
-    return false;
-};
+if (!Array.prototype.inArray) {
+    Object.defineProperty(Array.prototype, 'inArray', {
+        value: function(comparer) {
+            for (let i=0; i < this.length; i++) {
+                if (comparer(this[i])) {
+                    return i;
+                }
+            }
+            return false;
+        }
+    });
+}
 
 // adds an element to the array if it does not already exist using a comparer
 // function
-Array.prototype.toggleElement = function(element, comparer) {
-    var index = this.inArray(comparer);
-    if ((typeof(index) == "boolean" && !index) || (typeof(index) == "int" && index === 0)){
-        this.push(element);
-    }
-    else{
-        this.splice(index, 1);
-    }
-};
+if (!Array.prototype.toggleElement) {
+    Object.defineProperty(Array.prototype, 'toggleElement', {
+        value: function(element, comparer) {
+            var index = this.inArray(comparer);
+            if ((typeof(index) == "boolean" && !index) || (typeof(index) == "int" && index === 0)) {
+                this.push(element);
+            }
+            else {
+                this.splice(index, 1);
+            }
+        }
+    });
+}
 
 function clearForumFilter(){
     if(checkUnread()){


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #4287 

forum.js was directly creating new forums on `Array.prototype` which was messing up usages of `for ... of ...` on Arrays in other parts of the JavaScript if they didn't guard against `ownProperty`, which I don't believe most places do in the code base do (nor should they).

### What is the new behavior?
Uses `Object.defineProperty` to add functions to the prototype so that they're not enumerable and will not show up normally in any `for ... of ...` loops elsewhere. An additional guard was placed around these to prevent duplicate definition as `forums.js` was imported twice in some places.

### Other Information

This is also a bugfix for the PDF Annotator where it was throwing an error as it used a `for ... of ...` syntax to iterate through an array and which was including these two functions (causing the annotator to not load).