### PR TITLE
[Testing:Travis] Remove version restrictions on pydocstyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       language: python
       python: 3.6
       install:
-        - pip3 install flake8 flake8-bugbear flake8-docstrings pydocstyle==3.0.0 sqlalchemy psycopg2-binary
+        - pip3 install flake8 flake8-bugbear flake8-docstrings pydocstyle sqlalchemy psycopg2-binary
       script: skip
     - <<: *00-python-cache
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ jobs:
       language: python
       python: 3.6
       install:
-        - pip3 install flake8 flake8-bugbear flake8-docstrings pydocstyle==3.0.0
+        - pip3 install flake8 flake8-bugbear flake8-docstrings pydocstyle
       script:
         - flake8
     - <<: *01-python-lint


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Travis had `pydocstyle==3.0.0` due to bug introduced shown in https://gitlab.com/pycqa/flake8-docstrings/issues/36.

### What is the new behavior?
Don't force `pydocstyle` to be `3.0.0` as the bug was fixed.

### Other information?
There was a conflict before but recently a new release has fixed the problem. See https://github.com/Submitty/Submitty/pull/4018.

This PR should be merged **after passing Travis CI**.