### PR TITLE
[Bugfix:Forum] Fix empty forum warnings

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -341,7 +341,7 @@ class ForumThreadView extends AbstractView {
                 "prev_page" => $prev_page,
                 "arrowup_visibility" => $arrowup_visibility,
                 "display_thread_content" => $displayThreadContent,
-                "display_thread_count" => count($displayThreadContent["thread_content"]),
+                "display_thread_count" => empty($displayThreadContent) ? 0 : count($displayThreadContent["thread_content"]),
                 "currentThread" => $currentThread,
                 "currentCourse" => $currentCourse,
                 "generate_post_content" => $generatePostContent,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Fixes #4289

### What is the new behavior?
No warnings.
