### PR TITLE
[Testing] added coveragerc file for autograder and python_submitty_utils test suites

### DIFF
--- a/autograder/.coveragerc
+++ b/autograder/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit = 
+    *_test*.py
+    test/*.py

--- a/python_submitty_utils/.coveragerc
+++ b/python_submitty_utils/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit = 
+    *_test*.py
+    test/*.py


### PR DESCRIPTION
Signed-off-by: fenn-cs <fenn25.fn@gmail.com>

### What is the current behavior?

No `.coveragerc` files available in `autograder` folder and `python_submitty_utils` hence certain files may not be ignored during consideration for coverage reports.

Fixes: #4305 

### What is the new behavior?

`coveragerc` files for each folder.
