### PR TITLE
[Feature:Instructor UI] specify datetime on course material upload

### DIFF
--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -15,6 +15,12 @@
             </p>
             <input type="text" id="input-provide-full-path" class="full-width" name="eg_config_path" value="" placeholder="optional/subdirectory"/>
         </label>
+        <label id="upload_dt">
+            <p>
+                <strong>Choose a time to release the files being uploaded:</strong>
+            </p>
+            <input id="upload_picker" class="date_picker" type="text" size="26" value='9998-01-01 00:00:00'/>
+        </label>
         <label>
             <input id="expand-zip-checkbox" type="checkbox" value="off"/>
             Unzip zip files (Note: If checked, will replace all folders/files)
@@ -30,21 +36,23 @@
         <p>Total files cannot exceed 10 mb or 10240 kb.</p>
     </div>
     <script type="text/javascript">
-        function makeSubmission(expandZip,cmPath, requestedPath) {
-            handleUploadCourseMaterials("{{ csrf_token }}", expandZip, cmPath, requestedPath);
+
+        function makeSubmission(expandZip,cmPath, requestedPath,cmTime) {
+            handleUploadCourseMaterials("{{ csrf_token }}", expandZip, cmPath, requestedPath,cmTime);
         }
         $(function() {
             $("#submit-materials").click(function(e){ // Submit button
+                var cmTime = document.getElementById("upload_picker").value;
                 var cb = $("input#expand_zip_checkbox");
                 var expandZip = 'off';
-                if (cb.is(":checked")) {
+                if  ($('#expand-zip-checkbox').is(':checked'))  {
                     expandZip = 'on';
                 }
 
                 var cmPath = document.getElementById('cm_path').innerHTML;
 
                 var requestedPath = document.getElementById("input-provide-full-path").value;
-                makeSubmission(expandZip, cmPath, requestedPath);
+                makeSubmission(expandZip, cmPath, requestedPath,cmTime);
                 e.stopPropagation();
             });
         });

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -22,7 +22,7 @@ class CourseMaterialsView extends AbstractView {
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'shortcut-buttons-flatpickr.min.js'));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         $this->core->getOutput()->addBreadcrumb("Course Materials");
-        function add_files(Core $core, &$files, &$file_datas, &$file_release_dates, $expected_path, $json, $course_materials_array, $start_dir_name, $user_group, &$in_dir) {
+        function add_files(Core $core, &$files, &$file_datas, &$file_release_dates, $expected_path, $json, $course_materials_array, $start_dir_name, $user_group, &$in_dir,$fp) {
             $files[$start_dir_name] = array();
             $student_access = ($user_group === 4);
             $now_date_time = $core->getDateTimeNow();
@@ -44,12 +44,20 @@ class CourseMaterialsView extends AbstractView {
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
 
-                        $release_date = DateUtils::parseDateTime($json[$expected_file_path]['release_datetime'], $core->getConfig()->getTimezone());
+                       $release_date = DateUtils::parseDateTime($json[$expected_file_path]['release_datetime'], $core->getConfig()->getTimezone());
 
-                        if ($isShareToOther == '1' && $release_date > $now_date_time)
+                       if ($isShareToOther == '1' && $release_date > $now_date_time)
                             $isShareToOther = '0';
 
                         $releaseData  = $json[$expected_file_path]['release_datetime'];
+                    }
+                    else{
+                        //fill with upload time for new files add all files to json when uploaded
+                        $json[$expected_file_path]['checked'] = '1';
+                        $isShareToOther = $json[$expected_file_path]['checked'];
+                        $release_date = $json['release_time'];
+                        $json[$expected_file_path]['release_datetime'] = $release_date;
+                        $releaseData = $json[$expected_file_path]['release_datetime'];
                     }
 
                 }
@@ -86,6 +94,9 @@ class CourseMaterialsView extends AbstractView {
                 }
                 $file_release_dates[$expected_file_path] = $releaseData;
             }
+            if($json == true){
+                FileUtils::writeJsonFile($fp,$json);
+            }
         }
 
         $submissions = array();
@@ -105,7 +116,7 @@ class CourseMaterialsView extends AbstractView {
         $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
         $json = FileUtils::readJsonFile($fp);
 
-        add_files($this->core, $submissions, $file_shares, $file_release_dates, $expected_path, $json, $course_materials_array, 'course_materials', $user_group,$in_dir);
+        add_files($this->core, $submissions, $file_shares, $file_release_dates, $expected_path, $json, $course_materials_array, 'course_materials', $user_group,$in_dir,$fp);
 
         //Check if user has permissions to access page (not instructor when no course materials available)
         if ($user_group !== 1 && count($course_materials_array) == 0) {

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -950,7 +950,7 @@ function handleDownloadImages(csrf_token) {
  * @param csrf_token
  */
 
-function handleUploadCourseMaterials(csrf_token, expand_zip, cmPath, requested_path) {
+function handleUploadCourseMaterials(csrf_token, expand_zip, cmPath, requested_path,cmTime) {
     var submit_url = buildCourseUrl(['course_materials', 'upload']);
     var return_url = buildCourseUrl(['course_materials']);
     var formData = new FormData();
@@ -958,7 +958,7 @@ function handleUploadCourseMaterials(csrf_token, expand_zip, cmPath, requested_p
     formData.append('csrf_token', csrf_token);
     formData.append('expand_zip', expand_zip);
     formData.append('requested_path', requested_path);
-
+    formData.append('release_time',cmTime);
     var target_path = cmPath; // this one has slash at the end.
     if (requested_path && requested_path.trim().length) {
         target_path = cmPath + requested_path;
@@ -1007,11 +1007,9 @@ function handleUploadCourseMaterials(csrf_token, expand_zip, cmPath, requested_p
             filesToBeAdded = true;
         }
     }
-
     if (filesToBeAdded == false){
         return;
     }
-
 
     $.ajax({
         url: submit_url,


### PR DESCRIPTION
* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Closes #4261 
Currently, you cannot set the release time of the newly uploaded course materials as you upload them. The delete function also doesn't remove data from the json, especially for single files and folders with many subdirectories. This is related to a bug where if you deleted something and reuploaded, the old date would still be there, which is problematic as if you had chosen to release it at a date in the near future, deleted, and reuploaded after that date, it would be instantly released. I just don't think an issue was made for that.

### What is the new behavior?
Now, there is an option to set the release time of course materials as you upload them, with the date/time set to the year 9999 by default. So with this and my other PR, no only will you have the tomorrow button option, you have the ability to immediately set the release. This is applied to all files uploaded at the same time. Then you can edit the times of every folder/file after. If you delete and reupload, the date will again default to year 9999, preventing any accidental releases. The json file is also edited correctly now, and able to delete almost infinite subfolders (given enough time).

New upload page:
![Screenshot_2019-08-08 Submitty Sample Course Materials](https://user-images.githubusercontent.com/36307579/62719300-a9d51f00-b9d5-11e9-9c72-72217b7cebe4.png)

Page filled out:
![Screenshot_2019-08-08 Submitty Sample Course Materials(1)](https://user-images.githubusercontent.com/36307579/62719346-c40efd00-b9d5-11e9-99bd-badf346c456d.png)

Uploaded files with specified date:
![Screenshot_2019-08-08 Submitty Sample Course Materials(2)](https://user-images.githubusercontent.com/36307579/62719386-d852fa00-b9d5-11e9-8427-67feedefeab6.png)

Delete files:
![Screenshot_2019-08-08 Submitty Sample Course Materials(3)](https://user-images.githubusercontent.com/36307579/62719525-2ff16580-b9d6-11e9-9985-5aada96353e3.png)

Files gone:
![Screenshot_2019-08-08 Submitty Sample Course Materials(4)](https://user-images.githubusercontent.com/36307579/62719592-4d263400-b9d6-11e9-8d65-9cf93ad25e31.png)

Reupload with new times:
![Peek 2019-08-08 12-17](https://user-images.githubusercontent.com/36307579/62719733-9f675500-b9d6-11e9-82f8-991db386b340.gif)


### Other information?
This shouldn't break anything
Upload and delete from the course materials page. check the json b:
vagrant ssh
cd /var/local/submitty/courses/f19/sample/uploads
cat or open with preferred method the course_materials-file_data.json
watch files appear and disappear
testing with single files/folders is okay, folders with lots of subfolders/files is ideal


