### PR TITLE
[Bugfix:StudentUI] missing CSRF token on viewing PDFS

### DIFF
--- a/site/app/views/PDFView.php
+++ b/site/app/views/PDFView.php
@@ -45,7 +45,8 @@ class PDFView extends AbstractView {
             'page_num' => $params["page_num"],
             'pdf_url_base' => $pdf_url,
             'localcss' => $localcss,
-            'localjs' => $localjs
+            'localjs' => $localjs,
+            'csrfToken' => $this->core->getCsrfToken()
         ]);
     }
 }


### PR DESCRIPTION
adds missing csrf token when viewing pdfs