### PR TITLE
[Feature:InstructorUI] rotating section warning on edit gradeable

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -175,6 +175,16 @@ class AdminGradeableController extends AbstractController {
             $type_string = self::gradeable_type_strings['checkpoint'];
         }
 
+        //true if there are no students in any rotating sections.
+        //Can sometimes be true even if $num_rotating_sections > 0 (if no students are in any section)
+        $no_rotating_sections = true;
+        foreach ($this->core->getQueries()->getCountUsersRotatingSections() as $section) {
+            if ($section['rotating_section'] != null && $section['count'] > 0) {
+                $no_rotating_sections = false;
+                break;
+            }
+        }
+
         // $this->inherit_teams_list = $this->core->getQueries()->getAllElectronicGradeablesWithBaseTeams();
 
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
@@ -205,6 +215,7 @@ class AdminGradeableController extends AbstractController {
             // Non-Gradeable-model data
             'gradeable_section_history' => $gradeable_section_history,
             'num_rotating_sections' => $num_rotating_sections,
+            'no_rotating_sections' => $no_rotating_sections,
             'rotating_gradeables' => $rotating_gradeables,
             'graders_from_usertypes' => $graders_from_usertypes,
             //'inherit_teams_list' => $inherit_teams_list

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -159,19 +159,19 @@ What is the lowest privileged user group that can grade this?
         }
     }
 
-	function onSectionTypeChange() {
-		if ($('#rotating_section').is(':checked')) {
-			disableElementChildren('#rotating_data', false);
-			disableElementChildren('#grader-warning',false);
-		}
-		else if ($('#all_access').is(':checked')) {
-			disableElementChildren('#rotating_data', true);
-			disableElementChildren('#grader-warning',false);
-		}
-		else {
-			disableElementChildren('#rotating_data', true);
-			disableElementChildren('#grader-warning',true);
-		}
+    function onSectionTypeChange() {
+        if ($('#rotating_section').is(':checked')) {
+            disableElementChildren('#rotating_data', false);
+            disableElementChildren('#grader-warning',false);
+        }
+        else if ($('#all_access').is(':checked')) {
+            disableElementChildren('#rotating_data', true);
+            disableElementChildren('#grader-warning',false);
+        }
+        else {
+            disableElementChildren('#rotating_data', true);
+            disableElementChildren('#grader-warning',true);
+        }
     }
 
     function onMinGraderChange() {

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -32,6 +32,16 @@ Variables
 {# 
 Form
 #}
+
+{% if no_rotating_sections %}
+	<div name="grader-warning-popup edit-gradeable" id="grader-warning" hidden>
+		<p> WARNING: Rotating Sections are not set up yet.  <br />
+			All Access Grading and Grading by Rotating Section rely on rotating sections. <br />
+			To set them up, go to the Manage Sections page. <br />
+		</p>
+	</div>
+{% endif %}
+
 What is the lowest privileged user group that can grade this?
     <a class="helpicon" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-user-groups"></a>
 <select name="min_grading_group" id="minimum_grading_group" class="int_val" style="width:180px;">
@@ -150,11 +160,17 @@ What is the lowest privileged user group that can grade this?
     }
 
     function onSectionTypeChange() {
-        if($('#rotating_section').is(':checked')) {
+        if ($('#rotating_section').is(':checked')) {
             disableElementChildren('#rotating_data', false);
+			disableElementChildren('#grader-warning',false);
         }
+		else if ($('#all_access').is(':checked')) {
+			disableElementChildren('#rotating_data', true);
+			disableElementChildren('#grader-warning',false);
+		}
         else {
             disableElementChildren('#rotating_data', true);
+			disableElementChildren('#grader-warning',true);
         }
     }
 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -160,18 +160,18 @@ What is the lowest privileged user group that can grade this?
     }
 
 	function onSectionTypeChange() {
-	if ($('#rotating_section').is(':checked')) {
+		if ($('#rotating_section').is(':checked')) {
 			disableElementChildren('#rotating_data', false);
 			disableElementChildren('#grader-warning',false);
-        }
+		}
 		else if ($('#all_access').is(':checked')) {
 			disableElementChildren('#rotating_data', true);
 			disableElementChildren('#grader-warning',false);
 		}
-        else {
-            disableElementChildren('#rotating_data', true);
+		else {
+			disableElementChildren('#rotating_data', true);
 			disableElementChildren('#grader-warning',true);
-        }
+		}
     }
 
     function onMinGraderChange() {

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -159,9 +159,9 @@ What is the lowest privileged user group that can grade this?
         }
     }
 
-    function onSectionTypeChange() {
-        if ($('#rotating_section').is(':checked')) {
-            disableElementChildren('#rotating_data', false);
+	function onSectionTypeChange() {
+	if ($('#rotating_section').is(':checked')) {
+			disableElementChildren('#rotating_data', false);
 			disableElementChildren('#grader-warning',false);
         }
 		else if ($('#all_access').is(':checked')) {

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -108,7 +108,7 @@
     <h1>Status of {{ gradeable_title }}</h1>
 
     {% if rotating_sections_error %}
-        <div class='content' style="background-color:#e84848">
+        <div name="grader-warning-popup status">
             <p> WARNING: This page may be inaccurate.  <br />
                 This gradeable assigns graders by Rotating Section, but Rotating Sections are not set up properly. <br />
                 To fix Rotating Sections, go to the Manage Sections page. <br />

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1197,6 +1197,16 @@ div.full_height {
     display: inline-block;
 }
 
+[name^="grader-warning-popup"] {
+    background:var(--danger-red);
+    box-shadow: 0 2px 15px -5px var(--standard-light-gray);
+    border-radius: 3px;
+    overflow: auto;
+    margin: 10px;;
+    padding: 30px;
+    flex-grow: 1;
+}
+
 .fill-available {
     width: 100%;
     width: -webkit-fill-available;


### PR DESCRIPTION
* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the new behavior?
If an instructor selects All Access Grading or Rotating Section on the edit gradeable page, a warning will appear if no students are in any non-null section. (Similar banner shows on the status page of gradeables under these conditions)
![banner](https://user-images.githubusercontent.com/34327811/62740992-55e32e00-ba07-11e9-9224-3b83a51db292.png)
