### PR TITLE
[Bugfix:PDFAnnotate] Fix setting csrfToken for embedded PDF annotate

### DIFF
--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -57,7 +57,7 @@
                             <p style="text-align:center">
                                 {# download icon if student can download files #}
                                 {% if can_download %}
-                                    <button class = 'btn btn-default' onclick='downloadFile("{{ file.relative_name|url_encode }}","{{ file.path|url_encode }}", "submissions")'> Download
+                                    <button class = 'btn btn-default' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")'> Download
                                         <i class="fas fa-download" aria-hidden="true" title="Download the file"></i></button>
                                 {% endif %}
                                 <a class="btn btn-primary" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.relative_name }}')">View Popup <i class="fas fa-window-restore"></i></a>

--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -10,7 +10,7 @@
 </div>
 
 <script>
-    let csrfToken = "{{ csrfToken }}";
+    window['csrfToken'] = "{{ csrfToken }}";
     try {
         for(let i = 0 ; i < localStorage.length; i++){
             if(localStorage.key(i).includes('annotations')){


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Could not open the PDF annotate tool in the grading interface as it would throw a JS error about the csrfToken variable already being defined.

### What is the new behavior?
Fixes not being able to open PDF annotate tool in the grader interface. The ability to open the PDF annotate tool on the submission page remains fixed from @shailpatels' earlier fixes.

This replicates behavior for how `csrfToken` is defined on non-popup pages in that doing `var csrfToken` in the code is equivalent to `window['csrfToken']`, and that setting `window['csrfToken']` implicitly sets `var csrfToken`.