### PR TITLE
[Refactor:Router] Minor URL changes

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -28,7 +28,7 @@ class HomePageController extends AbstractController {
     }
 
     /**
-     * @Route("/home/change_password", methods={"POST"})
+     * @Route("/current_user/change_password", methods={"POST"})
      * @return Response
      */
     public function changePassword(){
@@ -48,7 +48,7 @@ class HomePageController extends AbstractController {
     }
 
     /**
-     * @Route("/home/change_username", methods={"POST"})
+     * @Route("/current_user/change_username", methods={"POST"})
      * @return Response
      */
     public function changeUserName(){
@@ -77,9 +77,7 @@ class HomePageController extends AbstractController {
      * @param $user_id
      * @param $as_instructor
      * @Route("/api/courses", methods={"GET"})
-     * @Route("/api/courses/{user_id}", methods={"GET"})
      * @Route("/home/courses", methods={"GET"})
-     * @Route("/home/courses/{user_id}", methods={"GET"}, requirements={"user_id": "^(?!new)[^\/]+"})
      * @return Response
      */
     public function getCourses($user_id = null, $as_instructor = false) {

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -499,15 +499,9 @@ class ReportController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}/rainbow_grades_customization")
+     * @Route("/{_semester}/{_course}/reports/rainbow_grades_customization")
      */
     public function generateCustomization(){
-
-        // Only allow course admins to access this page
-        if (!$this->core->getUser()->accessAdmin()) {
-            $this->core->getOutput()->showError("This account cannot access admin pages");
-        }
-
         //Build a new model, pull in defaults for the course
         $customization = new RainbowCustomization($this->core);
         $customization->buildCustomization();
@@ -551,15 +545,9 @@ class ReportController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}/auto_rg_status")
+     * @Route("/{_semester}/{_course}/reports/rainbow_grades_status")
      */
-    public function autoRainbowGradesStatus()
-    {
-        // Only allow course admins to access this page
-        if (!$this->core->getUser()->accessAdmin()) {
-            $this->core->getOutput()->showError("This account cannot access admin pages");
-        }
-
+    public function autoRainbowGradesStatus() {
         // Create path to the file we expect to find in the jobs queue
         $jobs_file = '/var/local/submitty/daemon_job_queue/auto_rainbow_' .
             $this->core->getConfig()->getSemester() .

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -170,7 +170,7 @@ class UsersController extends AbstractController {
     }
 
     /**
-     * @Route("/{_semester}/{_course}/users/{user_id}", methods={"GET"})
+     * @Route("/{_semester}/{_course}/users/details", methods={"GET"})
      */
     public function ajaxGetUserDetails($user_id) {
         $user = $this->core->getQueries()->getUserById($user_id);

--- a/site/app/templates/ChangePasswordForm.twig
+++ b/site/app/templates/ChangePasswordForm.twig
@@ -9,7 +9,7 @@
     </div>
 {% endblock %}
 {% block form %}
-    <form method="post" action="{{ core.buildUrl(['home', 'change_password']) }}">
+    <form method="post" action="{{ change_password_url }}">
         {{ parent() }}
     </form>
 {% endblock %}

--- a/site/app/templates/CreateCourseForm.twig
+++ b/site/app/templates/CreateCourseForm.twig
@@ -97,7 +97,7 @@
         let headInstructor = $('#head_instructor').val();
         $.ajax({
             type: "GET",
-            url: buildUrl(['home', 'courses', headInstructor]) + '?as_instructor=true',
+            url: buildUrl(['home', 'courses']) + `?as_instructor=true&user_id=${headInstructor}`,
             success: function(data) {
                 let json = JSON.parse(data);
                 let courses = json['data']['unarchived_courses'].concat(json['data']['archived_courses']);

--- a/site/app/templates/EditNameForm.twig
+++ b/site/app/templates/EditNameForm.twig
@@ -21,7 +21,7 @@
     </div>
 {% endblock %}
 {% block form %}
-    <form method="post" action="{{ core.buildUrl(['home', 'change_username']) }}">
+    <form method="post" action="{{ change_username_url }}">
         {{ parent() }}
     </form>
 {% endblock %}

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -70,7 +70,9 @@ class HomePageView extends AbstractView {
             "show_change_password" => $this->core->getAuthentication() instanceof DatabaseAuthentication,
             "csrf_token" => $this->core->getCsrfToken(),
             "access_level" => $access_levels[$user->getAccessLevel()],
-            "display_access_level" => $user->accessFaculty()
+            "display_access_level" => $user->accessFaculty(),
+            "change_password_url" => $this->core->buildUrl(['current_user', 'change_password']),
+            "change_username_url" => $this->core->buildUrl(['current_user', 'change_username'])
         ]);
     }
 

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -9,7 +9,7 @@ class ReportView extends AbstractView {
         return $this->core->getOutput()->renderTwigTemplate("admin/Report.twig", [
             'summaries_url' => $this->core->buildCourseUrl(['reports', 'summaries']),
             'csv_url' => $this->core->buildCourseUrl(['reports', 'csv']),
-            'rainbow_grades_customization_url' => $this->core->buildCourseUrl(['rainbow_grades_customization']),
+            'rainbow_grades_customization_url' => $this->core->buildCourseUrl(['reports', 'rainbow_grades_customization']),
             'grade_summaries_last_run' => $grade_summaries_last_run
         ]);
     }

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -212,7 +212,7 @@ function checkAutoRGStatus()
     // Send request
     $.getJSON({
         type: "POST",
-        url: buildCourseUrl(['auto_rg_status']),
+        url: buildCourseUrl(['reports', 'rainbow_grades_status']),
         data: {csrf_token: csrfToken},
         success: function (response) {
             if (response.status === 'success') {
@@ -245,7 +245,7 @@ function ajaxUpdateJSON(successCallback, errorCallback) {
     {
         $('#save_status').html('Saving...');
 
-        var url = buildCourseUrl(['rainbow_grades_customization']);
+        var url = buildCourseUrl(['reports', 'rainbow_grades_customization']);
 
         $.getJSON({
             type: "POST",

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -68,7 +68,7 @@ function newUserForm() {
 
 //opens modal with initial settings for edit user
 function editUserForm(user_id) {
-    var url = buildCourseUrl(['users', user_id]);
+    var url = buildCourseUrl(['users', 'details']) + `?user_id=${user_id}`;
     $.ajax({
         url: url,
         success: function(data) {

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -129,7 +129,7 @@ class WebRouterTester extends BaseUnitTest {
     public function testNoCsrfToken() {
         $core = $this->createMockCore(['csrf_token' => false, 'logged_in' => true]);
         $request = Request::create(
-            "/home/change_username",
+            "/current_user/change_username",
             "POST"
         );
         $response = WebRouter::getWebResponse($request, $core);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Closes #4160 

### What is the new behavior?

As Preston suggested:
`/home/change_password` -> `/current_user/change_password`

`/home/change_username` -> `/current_user/change_username`

For correct semantics.
`/home/courses/{user_id}` -> `/home/courses?user_id=whatever`

Change some params to query string so that there are no conflicts. (Didn't change `gradeable_version` or `nid` as discussed in #4160 because they are numbers - no conflicts)
`/{_semester}/{_course}/users/{user_id}` -> `/{_semester}/{_course}/users/details?user_id=whatever`

For correct categorization:
`/{_semester}/{_course}/rainbow_grades_customization` -> `/{_semester}/{_course}/reports/rainbow_grades_customization`

`/{_semester}/{_course}/auto_rg_status` -> `/{_semester}/{_course}/reports/rainbow_grades_status`