### PR TITLE
[Bugfix] Set site exception and log handling immediately after loading config

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -75,16 +75,16 @@ register_shutdown_function("error_handler");
 
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadMasterConfig();
+Logger::setLogPath($core->getConfig()->getLogPath());
+ExceptionHandler::setLogExceptions($core->getConfig()->shouldLogExceptions());
+ExceptionHandler::setDisplayExceptions($core->getConfig()->isDebug());
+
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadMasterDatabase();
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadAuthentication();
 //Load Twig templating engine after the config is loaded but before any output is shown
 $core->getOutput()->loadTwig();
-
-Logger::setLogPath($core->getConfig()->getLogPath());
-ExceptionHandler::setLogExceptions($core->getConfig()->shouldLogExceptions());
-ExceptionHandler::setDisplayExceptions($core->getConfig()->isDebug());
 
 $core->getOutput()->setInternalResources();
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If an exception is thrown in `$core->loadMasterDatabase()`, `$core->loadAuthentication()` or `$core->getOutput()->loadTwig()`, the system would just output a generic exception screen with no information and not log the exceptions anywhere, making it hard for a sysadmin/developer to be able to take action to fix the problem. An example might be if they supplied the wrong DB credentials, or if they misconfigured the authentication behavior, etc.

### What is the new behavior?
Makes it so any exceptions from these functions are properly handled/logged as appropriate.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested it by adding a `throw new \Exception('test');` to top of `$core->loadMasterDatabase()` and observed the behavior before this patch and after this patch. Not a breaking change.