### PR TITLE
[API] Restrict student access to API

### DIFF
--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -72,6 +72,11 @@ class WebRouter {
                 return new Response(JsonResponse::getFailResponse("Unauthenticated access. Please log in."));
             }
 
+            if ($logged_in &&
+                !$core->getUser()->accessFaculty()) {
+                return new Response(JsonResponse::getFailResponse("API is open to faculty only."));
+            }
+
             /** @noinspection PhpUnhandledExceptionInspection */
             if (!$router->accessCheck()) {
                 return Response::JsonOnlyResponse(

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -72,8 +72,7 @@ class WebRouter {
                 return new Response(JsonResponse::getFailResponse("Unauthenticated access. Please log in."));
             }
 
-            if ($logged_in &&
-                !$core->getUser()->accessFaculty()) {
+            if ($logged_in && !$core->getUser()->accessFaculty()) {
                 return new Response(JsonResponse::getFailResponse("API is open to faculty only."));
             }
 

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -117,6 +117,12 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
                 $user->method('accessAdmin')->willReturn(false);
             }
 
+            if (isset($user_config['access_faculty'])) {
+                $user->method('accessFaculty')->willReturn($user_config['access_faculty'] == true);
+            } else {
+                $user->method('accessFaculty')->willReturn(false);
+            }
+
             $core->method('getUser')->willReturn($user);
         }
 

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -189,4 +189,16 @@ class WebRouterTester extends BaseUnitTest {
             'message' => "Unauthenticated access. Please log in."
         ], $response->json_response->json);
     }
+
+    public function testApiNotFaculty() {
+        $core = $this->createMockCore(['logged_in' => true, 'access_faculty' => false]);
+        $request = Request::create(
+            "/api/courses"
+        );
+        $response = WebRouter::getApiResponse($request, $core);
+        $this->assertEquals([
+            'status' => "fail",
+            'message' => "API is open to faculty only."
+        ], $response->json_response->json);
+    }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant (wait for https://github.com/Submitty/Submitty/issues/4284)

### What is the current behavior?
Closes https://github.com/Submitty/Submitty/issues/4189

### What is the new behavior?
Only faculty or superuser can access API endpoints. Students can still get a token, but they cannot go anywhere with it.