### PR TITLE
[Bugfix:InstructorUI] Help Icons are back

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -155,7 +155,7 @@
                     Show Rainbow Grades summaries to students.
                     <strong>Note:</strong>
                     <a target=_blank href="http://submitty.org/instructor/rainbow_grades/">
-                    You must manually run rainbow grades. <i style="font-style:normal;" class="helpicon"></i></a>
+                    You must manually run rainbow grades. <i style="font-style:normal;" class="fa-question-circle"></i></a>
                 </div>
             </label>
         </div>

--- a/site/app/templates/admin/GradeOverride.twig
+++ b/site/app/templates/admin/GradeOverride.twig
@@ -4,7 +4,7 @@
     <p>Use this form to
     <a target=_blank href="https://submitty.org/instructor/grade_override">
     override the total score
-    <i style="font-style:normal;" class="helpicon"></i></a>
+    <i style="font-style:normal;" class="fa-question-circle"></i></a>
     for a student on a specific assignment or test.
 
     <br>

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -50,7 +50,7 @@
             <tr>
                 <td width="50%">
                     <p><em><b>NOTE: Work in Progress</b></em><br>Web interface for creation and customization of Rainbow Grades for this course.<br>
-                    <a target=_blank href="https://submitty.org/instructor/rainbow_grades/">Rainbow Grades Documentation<i style="font-style:normal;" class="helpicon"></i></a></p>
+                    <a target=_blank href="https://submitty.org/instructor/rainbow_grades/">Rainbow Grades Documentation<i style="font-style:normal;" class="fa-question-circle"></i></a></p>
                 </td>
                 <td width="5%"> </td>
                 <td width="45%" style="position:relative">

--- a/site/app/templates/admin/UploadWrapperForm.twig
+++ b/site/app/templates/admin/UploadWrapperForm.twig
@@ -7,7 +7,7 @@
         Note that they are loaded in frames and will not be able to run scripts or affect the rest of Submitty.<br>
         <br>
         You can also upload a CSS file to override the default styles from Submitty.<br>
-        <a target=_blank href="http://submitty.org/instructor/website_customization">More information about Website Customization <i style="font-style:normal;" class="helpicon"></i></a>
+        <a target=_blank href="http://submitty.org/instructor/website_customization">More information about Website Customization <i style="font-style:normal;" class="fa-question-circle"></i></a>
     </div>
     <br>
     <div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -32,7 +32,7 @@
 
         <div class="option-title">Choose an autograding configuration:</div>
                 <p> You may specify your <a target=_blank href="https://submitty.org/instructor/assignment_configuration/configuration_path#course-autograding-configuration-directory">
-                    "Course Autograding Config Directory"<i style="font-style:normal;" class="helpicon"></i></a>
+                    "Course Autograding Config Directory"<i style="font-style:normal;" class="fa-question-circle"></i></a>
                     from the Course Settings Page. </p>
                 <p> Manually type the full path to a configuration file, or select from the list below. </p>
         <p> The dropdown list has all existing configurations that contain the current text. Hit the red X to clear current text.</p>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -16,7 +16,7 @@
 			</div>
             <div>
                 <b>                    
-                    <a target=_blank href="http://submitty.org/instructor/create_edit_gradeable">Need help with creating/editing a gradeable? <i style="font-style:normal;" class="helpicon"></i></a>
+                    <a target=_blank href="http://submitty.org/instructor/create_edit_gradeable">Need help with creating/editing a gradeable? <i style="font-style:normal;" class="fa-question-circle"></i></a>
                 </b>
                 <div style="float: right" id="save_status"></div>
             </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -79,7 +79,7 @@
             <!-- Gradeable Type radio buttons (readonly in edit mode) -->
             {# (VPAT) fieldset/legend required for gradeable type container radio group #}
             <fieldset><legend><div class="option-title">Gradeable Type</div></legend>
-            <div class="option-alt"><a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#types-of-gradeables">What is the type of the gradeable <i style="font-style:normal;" class="helpicon"></i></a></div>
+            <div class="option-alt"><a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#types-of-gradeables">What is the type of the gradeable <i style="font-style:normal;" class="fa-question-circle"></i></a></div>
             <span id="required_type" >(Required)</span>
         {% else %}
             <b style='font-size:18px'>Gradeable type</b>: <span id="gradeable-type-string">{{ type_string }}</span>
@@ -261,7 +261,7 @@
     <div class="option-desc col-md-6">
         <label for="syllabus_bucket">
             <div class="option-title">Syllabus Category</div>
-            <div class="option-alt"><a target=_blank href="https://submitty.org/instructor/rainbow_grades/gradeables">What syllabus category does this item belong to? <i style="font-style:normal;" class="helpicon"></i></a></div>
+            <div class="option-alt"><a target=_blank href="https://submitty.org/instructor/rainbow_grades/gradeables">What syllabus category does this item belong to? <i style="font-style:normal;" class="fa-question-circle"></i></a></div>
         </label>
     </div>
 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -76,7 +76,7 @@
                 Note: Submissions received after the deadline will be automatically recorded as a zero if late days are not allowed
                     for this assignment (or the student does not have sufficient late days to cover the submission) and no excused
                     absence extension is entered for this student for this gradeable. See
-                    <a target=_blank href="http://submitty.org/student/late_days">Late Days & Extensions. <i style="font-style:normal;" class="helpicon"></i></a>
+                    <a target=_blank href="http://submitty.org/student/late_days">Late Days & Extensions. <i style="font-style:normal;" class="fa-question-circle"></i></a>
                 </p>
             </div>
         </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -33,7 +33,7 @@ Variables
 Form
 #}
 What is the lowest privileged user group that can grade this?
-    <a class="helpicon" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-user-groups"></a>
+    <a class="fa-question-circle" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-user-groups"></a>
 <select name="min_grading_group" id="minimum_grading_group" class="int_val" style="width:180px;">
     {% for num, role in grading_groups %}
         <option value="{{ num }}" {{ gradeable.getMinGradingGroup() == num ? 'selected' : '' }}>{{ role }}</option>
@@ -44,7 +44,7 @@ What is the lowest privileged user group that can grade this?
 <fieldset>
     <legend>
         How should graders be assigned to grade this item?
-        <a class="helpicon" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section"></a>
+        <a class="fa-question-circle" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section"></a>
     </legend>
 	<input type="radio" name="grader_assignment_method" value="2" id="all_access"
         {{ (gradeable.getGraderAssignmentMethod() == 2) ? 'checked' : '' }}> All Access Grading

--- a/site/app/templates/grading/UploadImagesForm.twig
+++ b/site/app/templates/grading/UploadImagesForm.twig
@@ -5,7 +5,7 @@
     <div class="flex-col flex-col-space">
         <p>
             Instructions to download images of students: 
-            <a class="helpicon" target=_blank href="http://submitty.org/instructor/student_photos"></a>
+            <a class="fa-question-circle" target=_blank href="http://submitty.org/instructor/student_photos"></a>
         </p>
         <p>
             Upload png images by zipping up multiple course sections together,<br />

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -39,7 +39,7 @@
                         <input type='radio' id="radio-bulk" name="submission_type">
                         Bulk PDF Upload
                         <a aria-label="Bulk PDF Upload Help" href = "https://submitty.org/instructor/bulk_pdf_upload" target="_none">
-                            <i aria-hidden="true" title="Bulk PDF Upload Help" class="far fa-question-circle helpicon"></i>
+                            <i aria-hidden="true" title="Bulk PDF Upload Help" class="far fa-question-circle"></i>
                         </a>
                     </label>
                 {% endif %}
@@ -61,7 +61,7 @@
                     <label id="pages-prompt" for="num_pages"># of page(s) per PDF:</label>
                     <span id="prefix-prompt">QR code prefix/suffix:
                     <a aria-label="Split by QR Code Help" href="https://submitty.org/instructor/bulk_pdf_upload#automatic-association-of-pdfs-using-customized-exams-with-qr-codes" target="_none">
-	                    <i aria-hidden="true" title="Split by QR Code Help" class="far fa-question-circle helpicon"></i>
+	                    <i aria-hidden="true" title="Split by QR Code Help" class="far fa-question-circle"></i>
                     </a>
                     </span>
                     <input type="number" id= "num_pages" placeholder="required"/>

--- a/site/public/css/input.css
+++ b/site/public/css/input.css
@@ -70,14 +70,6 @@ input[type="checkbox"]:checked:before {
     font-weight: 900
 }
 
-.helpicon::before {
-  font-family: 'Font Awesome 5 Free';
-  content: "\f059";
-  color: #1E90FF;
-  font-weight: 300;
-  display: inline-block;
-}
-
 select.disabled,
 textarea.disabled,
 input.disabled {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -160,7 +160,7 @@ input[type="checkbox"]:checked:before {
 .fa-question-circle{
   font-family: 'Font Awesome 5 Free';
   content: "\f059";
-  color: var(--actionable-blue);
+  color: var(--external-link-blue);
   font-weight: 300;
   display: inline-block;
 }


### PR DESCRIPTION
* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Closes #4238 
The help icons disappeared

### What is the new behavior?
The help icons are back. I greped and found/fixed every instance

### Other information?
Can be tested by visiting each page rendered by the twig and looking for icons
