### PR TITLE
[Refactor:Installation] Remove current courses' index

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -175,14 +175,6 @@ if [[ "$#" -ge 1 && $1 == "clean" ]] ; then
 
     echo -e "\nDeleting submitty installation directories, ${SUBMITTY_INSTALL_DIR}, for a clean installation\n"
 
-    # save the course index page
-    originalcurrentcourses=/usr/local/submitty/site/app/views/current_courses.php
-    if [ -f $originalcurrentcourses ]; then
-        mytempcurrentcourses=`mktemp`
-        echo "save this file! ${originalcurrentcourses} ${mytempcurrentcourses}"
-        mv ${originalcurrentcourses} ${mytempcurrentcourses}
-    fi
-
     rm -rf ${SUBMITTY_INSTALL_DIR}/site
     rm -rf ${SUBMITTY_INSTALL_DIR}/src
     rm -rf ${SUBMITTY_INSTALL_DIR}/bin

--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -169,13 +169,6 @@ def main():
     if today.month < 7:
         semester = 'Spring'
 
-    list_of_courses_file = "/usr/local/submitty/site/app/views/current_courses.php"
-    with open(list_of_courses_file, "w") as courses_file:
-        courses_file.write("")
-        for course_id in courses.keys():
-            courses_file.write('<a href="'+args.submission_url+'/'+get_current_semester()+'/'+course_id+'">'+course_id+', '+semester+' '+str(today.year)+'</a>')
-            courses_file.write('<br />')
-
     for course_id in sorted(courses.keys()):
         course = courses[course_id]
         students = random.sample(extra_students, course.registered_students + course.no_registration_students +


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
`INSTALL_SUBMITTY_HELPER.sh` and `setup_sample_courses.py` still deal with `current_courses.php` which we removed in https://github.com/Submitty/Submitty/pull/3955

### What is the new behavior?
Removed those references.
