### PR TITLE
[Bugfix: Submission] Fix Error When Uploading Team Assignments

### DIFF
--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -115,7 +115,7 @@ class NotificationFactory {
      * @param array $recipients
      */
     public function onTeamEvent(array $event, array $recipients) {
-        $current_user_id = $this->core->getUser();
+        $current_user_id = $this->core->getUser()->getId();
         $notification_recipients = [$current_user_id];
         $email_recipients = [$current_user_id];
         $users_settings = $this->core->getQueries()->getUsersNotificationSettings($recipients);


### PR DESCRIPTION
Fixes a bug which caused team assignment upload to throw an error when a notification was errantly sent to a user object rather than a user id.