### PR TITLE
[Bugfix] Do not use empty catch statements in JS

### DIFF
--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -23,7 +23,9 @@
                 localStorage.setItem('{{ filename }}/' + grader +'/annotations', annotations[grader]);
             }
         }
-    } catch {
+    }
+    catch (err) {
+        console.error(err);
         alert("Can't fetch annotations");
     }
     {% if student_popup %}

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -165,7 +165,8 @@ function createThread(e) {
     try {
         return publishFormWithAttachments($(this), true, "Something went wrong while creating thread. Please try again.");
     }
-    catch{
+    catch (err) {
+        console.error(err);
         alert("Something went wrong. Please try again.");
         return false;
     }
@@ -176,7 +177,8 @@ function publishPost(e) {
     try {
         return publishFormWithAttachments($(this), false, "Something went wrong while publishing post. Please try again.");
     }
-    catch{
+    catch (err) {
+        console.error(err);
         alert("Something went wrong. Please try again.");
         return false;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
"Old" browsers will throw an error when interacting with the forums and PDF annotator due to the use of the `catch {` idiom in JS, which is only available in newer browers (e.g. Firefox 58+).

### What is the new behavior?
Adds an error argument to all catches that did not have one to fix the regression for older browsers. Did not actually formally test as Firefox is totally broken on my machine due to macOS Catalina beta.

Fixes #4342