### PR TITLE
[Testing:Travis] Remove pydocstyle dependency declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       language: python
       python: 3.6
       install:
-        - pip3 install flake8 flake8-bugbear flake8-docstrings pydocstyle sqlalchemy psycopg2-binary
+        - pip3 install flake8 flake8-bugbear flake8-docstrings sqlalchemy psycopg2-binary
       script: skip
     - <<: *00-python-cache
       python: 3.7
@@ -80,7 +80,7 @@ jobs:
       language: python
       python: 3.6
       install:
-        - pip3 install flake8 flake8-bugbear flake8-docstrings pydocstyle
+        - pip3 install flake8 flake8-bugbear flake8-docstrings
       script:
         - flake8
     - <<: *01-python-lint


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
`pydocstyle` is specified in the Travis-CI configuration. This was necessary as it was broken after a new version of it was released that broke `flake8-docstrings`. We added the specific version in #4018 and then resolved in #4279.

### What is the new behavior?
Given that we're installing any version of pydocstyle, there's no need to specify it anymore as it's pulled in automatically as part of `flake8-docstrings`.