### PR TITLE
[Bugfix:Vagrant] Set proxy for Docker during vagrant up under vagrant-proxyconf

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -766,6 +766,30 @@ fi
 # DOCKER SETUP
 #################
 
+# If we are in vagrant and http_proxy is set, then vagrant-proxyconf
+# is probably being used, and it will work for the rest of this script,
+# but fail here if we do not manually set the proxy for docker
+if [[ ${VAGRANT} == 1 ]]; then
+    if [ ! -z ${http_proxy+x} ]; then
+        mkdir -p /home/${DAEMON_USER}/.docker
+        proxy="            \"httpProxy\": \"${http_proxy}\""
+        if [ ! -z ${https_proxy+x} ]; then
+            proxy="${proxy},\n            \"httpsProxy\": \"${https_proxy}\""
+        fi
+        if [ ! -z ${no_proxy+x} ]; then
+            proxy="${proxy},\n            \"noProxy\": \"${no_proxy}\""
+        fi
+        echo -e "{
+    \"proxies\": {
+        \"default\": {
+${proxy}
+        }
+    }
+}" > /home/${DAEMON_USER}/.docker/config.json
+        chown -R ${DAEMON_USER}:${DAEMON_USER} /home/${DAEMON_USER}/.docker
+    fi
+fi
+
 # WIP: creates basic container for grading CS1 & DS assignments
 # CAUTION: needs users/groups for security
 # These commands should be run manually if testing Docker integration


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #3497. If someone is using `vagrant-proxyconf`, then doing `vagrant up` will fail when it attempts to build Docker as docker does not have access to the proxy settings.

### What is the new behavior?
Sets the docker configuration file under Vagrant to reflect the proxy settings per the Docker documentation (https://docs.docker.com/network/proxy/).