### PR TITLE
[Bugfix:InstructorUI] web GUI for adding existing student

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -273,10 +273,6 @@ class UsersController extends AbstractController {
             }
         }
         else {
-            if ($user->getRegistrationSection() !== null) {
-                $this->core->addErrorMessage("A user with that ID already exists");
-                $this->core->redirect($return_url);
-            }
             $user = $this->core->loadModel(User::class);
             $user->setId(trim($_POST['user_id']));
         }

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -273,7 +273,7 @@ class UsersController extends AbstractController {
             }
         }
         else {
-            if ($user !== null) {
+            if ($user->getRegistrationSection() !== null) {
                 $this->core->addErrorMessage("A user with that ID already exists");
                 $this->core->redirect($return_url);
             }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Fixes #4367 

### What is the new behavior?
It works as normal.

### Other information?
This bug is from #4225 . In the past we decide if a user is in a course or not by calling `loadUser` to load it from the **course db**. However, after #4225, the **master db** info is loaded too. That makes `loadUser($user_id) === null` fail to work when the user exists in the **master db** but not in **course db**.

The changes are made so that we don't check if user exists - frontend knows it and prevents regular instructors from doing so. If malicious instructors try to directly send a POST, it will fail when the user is inserted as `user_id` is a primary key.