### PR TITLE
[Bugfix:InstructorUI] Fix JS error when viewing empty status page

### DIFF
--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -780,5 +780,8 @@
 
     }
     // Get the element with id="defaultOpen" and click on it
-    document.getElementById("defaultOpen").click();
+    let defaultOpen = document.getElementById('defaultOpen');
+    if (defaultOpen) {
+        defaultOpen.click();
+    }
 </script>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Going to status page for gradeable with no submissions or anything gives following JS error:

![Screenshot 2019-08-23 07 58 13](https://user-images.githubusercontent.com/1845314/63588000-c64b8c80-c57b-11e9-8e0c-97d59f61e7fd.png)

### What is the new behavior?
Checks the existence of the JS variable before attempting to click on it.