### PR TITLE
[Bugfix:Sidebar] wrap sidebar titles when lengthy

### DIFF
--- a/site/public/css/menu.css
+++ b/site/public/css/menu.css
@@ -81,8 +81,9 @@
     font-size: 31px;
 }
 
-.icon-title { 
-    flex: 1 0 auto;
+.icon-title {
+    /* commenting this out because the sidebar text was not wrapping */
+    /*flex: 1 0 auto;*/
 }
 
 #menu-button .notification-badge {


### PR DESCRIPTION
If the instructors adds custom sidebar links that are lengthy, they would overlap the page content...

Now they wrap:

<img width="199" alt="Screen Shot 2019-08-23 at 11 21 13 PM" src="https://user-images.githubusercontent.com/5871417/63631997-ba53df00-c5fc-11e9-819a-80ea2ada074c.png">