### PR TITLE
[Bugfix:Autograding] Error when Custom Grader Assigns Score > 1

### DIFF
--- a/grading/dispatch.cpp
+++ b/grading/dispatch.cpp
@@ -1077,6 +1077,14 @@ TestResults* dispatch::custom_doit(const TestCase &tc, const nlohmann::json& j, 
   }
   float score = result["data"]["score"];
 
+  // Clamp the score between 0 and 1
+  if(score > 1){
+    score = 1;
+  }
+  else if(score < 0){
+    score = 0;
+  }
+
   std::string message = "";
   if(result["data"]["message"].is_string()){
       message = result["data"]["message"];


### PR DESCRIPTION
### What is the current behavior?
If a python custom grader assigns a score greater than 1, the system silently crashes.

### What is the new behavior?
Scores are clamped between 0 and 1.

### Other information?
Only goes into affect for rebuilt gradeables. However, should not require a rebuild of all gradeables. 
