### PR TITLE
[Feature: Autograding] Assign IP Addresses when Grading Networked Applications

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -145,7 +145,6 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
     # Check for dispatcher actions (standard input)
     self.dispatcher_actions = testcase_info.get('dispatcher_actions', list())
 
-    self.ports_per_container = testcase_info.get('ports_per_container', 1)
     # As new container networks are generated, they will be appended to this list.
     self.networks = list()
 
@@ -219,7 +218,6 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
 
 
   def network_containers_routerless(self, containers):
-    self.log_message('NETWORKING WITHOUT ROUTER')
     """ If there is no router, all containers are added to the same network. """
     client = docker.from_env()
     network_name = f'{self.untrusted_user}_routerless_network'

--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -327,6 +327,10 @@
             "type" : "string",
             "description" : "The default docker image from which containers should be built."
           },
+          "number_of_ports" : {
+            "type" : "integer",
+            "description" : "A default number of ports to be assigned to each container on a network."
+          },
           "single_port_per_container" : {
             "type" : "boolean",
             "description" : "Specifies whether container communications should happen over a single port per container."
@@ -867,6 +871,10 @@
         "container_name" : {
           "type" : "string",
           "description" : "When grading using 'autograding_method' : 'docker', container_name defines 1) The name by which this container may be contacted on a network, 2. If there are more than one containers being used, the name of the folder in which the container output will be stored."
+        },
+        "number_of_ports" : {
+          "type" : "integer",
+          "description" : "The number of ports to be assigned to this container in the knownhosts.json file."
         },
         "outgoing_connections" : {
           "type" : "array",

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -171,6 +171,10 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
     whole_config["container_options"]["single_port_per_container"] = false; // connection
   }
 
+  if (!whole_config["container_options"]["number_of_ports"].is_number_integer()){
+    whole_config["container_options"]["number_of_ports"] = 1; // connection
+  }
+
   nlohmann::json::iterator tc = whole_config.find("testcases");
   assert (tc != whole_config.end());
 
@@ -250,6 +254,10 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
 
         if(this_testcase[container_type][container_num]["container_name"].is_null()){
           this_testcase[container_type][container_num]["container_name"] = "container" + std::to_string(container_num);
+        }
+
+        if (!this_testcase[container_type][container_num]["number_of_ports"].is_number_integer()){
+          this_testcase[container_type][container_num]["number_of_ports"] = whole_config["container_options"]["number_of_ports"];
         }
 
         if (this_testcase[container_type][container_num]["container_name"] == "router"){


### PR DESCRIPTION
### This PR:
1. Moves to statically assigning ip addresses when grading networked gradeables.
2. Allows instructors to specify a ```number_of_ports``` for each container, dictating a port range that will be assigned in the new ```knownhosts.json``` file.
3. Adds a ```knownhosts.json``` file, which is generated in the working directory for a submission. The json stores information about: 
   1. Hostnames on the network
   2. The port ranges on which each host will be listening for incoming connections.
   3. The ip address of each host.

### Breaking Changes:
This PR will temporarily disable use of the "autograding router" until it is updated to use the new knownhosts.json file.

### Example knownhost.json:
```
{
    "hosts": {
        "alpha": {
            "tcp_start_port": 9000,
            "tcp_end_port": 9002,
            "udp_start_port": 15000,
            "udp_end_port": 15002,
            "ip_address": "10.102.1.2"
        },
        "beta": {
            "tcp_start_port": 9003,
            "tcp_end_port": 9005,
            "udp_start_port": 15003,
            "udp_end_port": 15005,
            "ip_address": "10.102.1.3"
        }
    }
}
```