### PR TITLE
[Bugfix:Submission] Notebook short answer whitespace

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -690,8 +690,7 @@
                     data-initial_value="{{ short_answer.initial_value }}"
                     data-recent_submission="{{ short_answer.recent_submission }}"
                     onKeyPress="handle_input_keypress()"
-                >{% if core.getConfig().keepPreviousFiles() %}{{ short_answer.recent_submission }}{% else %}{{ short_answer.initial_value }}{% endif %}
-                </textarea>
+                >{% if core.getConfig().keepPreviousFiles() %}{{ short_answer.recent_submission }}{% else %}{{ short_answer.initial_value }}{% endif %}</textarea>
             </label>
             {#
                 Allow tab in the larger text boxes (normally tab moves to the next textbox)


### PR DESCRIPTION
Closes #4391

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Notebook short answer textareas would have an extra 16 white spaces in them.

### What is the new behavior?
Notebook short answer textareas now start off completely empty unless the instructor specifies an initial value.

### Other information?
Tested with Development->Paragraph Textboxes and also with the C++ crash course gradeable.
