### PR TITLE
[Feature: GradeInquiry] Added count of grade inquiries to lateday table

### DIFF
--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -154,6 +154,10 @@ class GradedGradeable extends AbstractModel {
             });
     }
 
+    /**
+     * Gets the grade inquiry assigned to the gradeable's component supplied
+     * @param $gc_id Gradeable Component id
+     */
     public function getGradeInquiryByGcId($gc_id) {
         foreach ($this->regrade_requests as $grade_inquiry) {
             if ($grade_inquiry->getGcId() == $gc_id)
@@ -162,6 +166,10 @@ class GradedGradeable extends AbstractModel {
         return null;
     }
 
+    /**
+     * get the number of grade inquiries that are pending
+     * @return int
+     */
     public function getActiveGradeInquiryCount() {
         if (!$this->gradeable->isGradeInquiryPerComponentAllowed()) {
             return array_reduce($this->regrade_requests, function($carry, RegradeRequest $grade_inquiry) {
@@ -173,6 +181,14 @@ class GradedGradeable extends AbstractModel {
             $carry += $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
             return $carry;
         });
+    }
+
+    /**
+     * get number of grade inquiries pending and resolved for this gradeable
+     * @return int
+     */
+    public function getGradeInquiryCount() {
+        return count($this->regrade_requests);
     }
 
     /**

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -67,7 +67,8 @@ class LateDayInfo extends AbstractModel {
             'status' => $this->getStatus(),
             'late_days_remaining' => $this->late_days_remaining,
             'days_late' => $this->hasLateDaysInfo() ? $this->getDaysLate() : null,
-            'charged_late_days' => $this->hasLateDaysInfo() ? $this->getLateDaysCharged() : null
+            'charged_late_days' => $this->hasLateDaysInfo() ? $this->getLateDaysCharged() : null,
+            'grade_inquiries' => $this->graded_gradeable->getGradeInquiryCount()
         ];
     }
 
@@ -185,5 +186,13 @@ class LateDayInfo extends AbstractModel {
             return 0;
         }
         return $this->graded_gradeable->getAutoGradedGradeable()->getActiveVersionInstance()->getDaysLate();
+    }
+
+    /**
+     * Get number of grade inquiries pending and resolved for this gradeable
+     * @return int
+     */
+    public function getGradeInquiryCount() {
+        return $this->graded_gradeable->getGradeInquiryCount();
     }
 }

--- a/site/app/templates/LateDaysTablePlugin.twig
+++ b/site/app/templates/LateDaysTablePlugin.twig
@@ -27,6 +27,7 @@
             <th>Assignment submitted # of days after deadline</th>
             <th>Student granted # of days extension for this assignment</th>
             <th>Status</th>
+            <th>Grade Inquiries</th>
             <th>Late days charged for this assignment</th>
         </tr>
     </thead>
@@ -47,6 +48,7 @@
             <td class="{{ class }}">{{ (late_day_info.getDaysLate() != 0) ? late_day_info.getDaysLate() : "N/A" }}</td>
             <td class="{{ class }}">{{ (late_day_info.getLateDayException() != 0) ? late_day_info.getLateDayException() : "N/A" }}</td>
             <td class="{{ class }}" id="{{ id }}">{{ late_day_info.getStatusMessage() }}</td>
+            <td class="{{ class }}" id="{{ id }}">{{ late_day_info.getGradeInquiryCount() }}</td>
             <td class="{{ class }}">{{ (late_day_info.getLateDaysCharged() != 0 ) ? late_day_info.getLateDaysCharged() : "N/A" }}</td>
         </tr>
     {% endfor %}

--- a/site/app/templates/LateDaysTablePlugin.twig
+++ b/site/app/templates/LateDaysTablePlugin.twig
@@ -27,7 +27,9 @@
             <th>Assignment submitted # of days after deadline</th>
             <th>Student granted # of days extension for this assignment</th>
             <th>Status</th>
-            <th>Grade Inquiries</th>
+            {% if grade_inquiry_enabled %}
+                <th>Grade Inquiries</th>
+            {% endif %}
             <th>Late days charged for this assignment</th>
         </tr>
     </thead>
@@ -48,7 +50,9 @@
             <td class="{{ class }}">{{ (late_day_info.getDaysLate() != 0) ? late_day_info.getDaysLate() : "N/A" }}</td>
             <td class="{{ class }}">{{ (late_day_info.getLateDayException() != 0) ? late_day_info.getLateDayException() : "N/A" }}</td>
             <td class="{{ class }}" id="{{ id }}">{{ late_day_info.getStatusMessage() }}</td>
-            <td class="{{ class }}" id="{{ id }}">{{ late_day_info.getGradeInquiryCount() }}</td>
+            {% if grade_inquiry_enabled %}
+                <td class="{{ class }}" id="{{ id }}">{{ gradeable.isRegradeAllowed() ? late_day_info.getGradeInquiryCount() : "N/A" }}</td>
+            {% endif %}
             <td class="{{ class }}">{{ (late_day_info.getLateDaysCharged() != 0 ) ? late_day_info.getLateDaysCharged() : "N/A" }}</td>
         </tr>
     {% endfor %}

--- a/site/app/views/LateDaysTableView.php
+++ b/site/app/views/LateDaysTableView.php
@@ -12,6 +12,7 @@ class LateDaysTableView extends AbstractView {
         $preferred_name = $late_days->getUser()->getDisplayFullName();
         $table_data = $this->core->getOutput()->renderTwigTemplate('LateDaysTablePlugin.twig', [
             'late_days' => $late_days,
+            'grade_inquiry_enabled' => $this->core->getConfig()->isRegradeEnabled(),
             'highlight_gradeable' => $hightlight_gradeable,
         ]);
         $table_data = "<hr><h2>Late Day Usage by " . $preferred_name . " (" . $late_days->getUser()->getId() . ")</h2><br>" . $table_data;
@@ -23,7 +24,8 @@ class LateDaysTableView extends AbstractView {
         $this->core->getOutput()->addInternalCss('table.css');
         $this->core->getOutput()->addInternalCss('latedaystableplugin.css');
         return $this->core->getOutput()->renderTwigTemplate('LateDaysTable.twig', [
-            'late_days' => $late_days
+            'late_days' => $late_days,
+            'grade_inquiry_enabled' => $this->core->getConfig()->isRegradeEnabled()
         ]);
     }
 }


### PR DESCRIPTION
### What is the current behavior?
Late day table does not include information of grade inquiry history for the student
closes #2336 

### What is the new behavior?
Late day table now shows how many grade inquiries there are per gradeable pending or resolved
![grade-inquiry-late-day-table](https://user-images.githubusercontent.com/15002610/63979188-4abf7300-ca86-11e9-9bec-9b59cf7f6fbb.PNG)