### PR TITLE
[Refactor] Set proper namespace for NotificationFactory

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -11,7 +11,7 @@ use app\libraries\database\DatabaseQueries;
 use app\models\Config;
 use app\models\forum\Forum;
 use app\models\User;
-use app\NotificationFactory;
+use app\models\NotificationFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 

--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace app;
+namespace app\models;
 
 use app\libraries\Core;
 use app\models\Email;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
NotificationFactory had the wrong namespace for where it was located.

### What is the new behavior?
Correct the namespace to match the other files under `app/models`.