### PR TITLE
[Feature] Allow multiple different authentication methods to be used in a stack

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -37,6 +37,15 @@ def get_input(question, default=""):
     return user
 
 
+def get_boolean_input(question, default=True):
+    while True:
+        user = input(f"{question} [y/n]: [{'y' if default is True else 'n'}] ")
+        user = user.strip().lower()
+        if len(user) > 0 and user[0] in ['y', 'n']:
+            break
+    return user[0] == 'y'
+
+
 ##############################################################################
 # this script must be run by root or sudo
 if os.getuid() != 0:
@@ -243,7 +252,8 @@ else:
 
     USERNAME_TEXT = defaults['username_change_text']
 
-    print("What authentication method to use:\n1. PAM\n2. Database\n")
+    options = ['Pam', 'Database', 'Ldap']
+    print("What authentication method to use:\n0. Done Adding 1. PAM\n2. Database\n")
     while True:
         try:
             auth = int(get_input('Enter number?', defaults['authentication_method']))
@@ -268,30 +278,26 @@ else:
             continue
         break
 
-    while True:
-        is_email_enabled = get_input("Will Submitty use email notifications? [y/n]", 'y')
-        if (is_email_enabled.lower() in ['yes', 'y']):
-            EMAIL_ENABLED = True
-            EMAIL_USER = get_input("What is the email user?", defaults['email_user'])
-            EMAIL_PASSWORD = get_input("What is the email password",defaults['email_password'])
-            EMAIL_SENDER = get_input("What is the email sender address (the address that will appear in the From: line)?",defaults['email_sender'])
-            EMAIL_REPLY_TO = get_input("What is the email reply to address?", defaults['email_reply_to'])
-            EMAIL_SERVER_HOSTNAME = get_input("What is the email server hostname?", defaults['email_server_hostname'])
-            try:
-                EMAIL_SERVER_PORT = int(get_input("What is the email server port?", defaults['email_server_port']))
-            except ValueError:
-                EMAIL_SERVER_PORT = defaults['email_server_port']
-            break
-            
-        elif (is_email_enabled.lower() in ['no', 'n']):
-            EMAIL_ENABLED = False
-            EMAIL_USER = defaults['email_user']
-            EMAIL_PASSWORD = defaults['email_password']
-            EMAIL_SENDER = defaults['email_sender']
-            EMAIL_REPLY_TO = defaults['email_reply_to']
-            EMAIL_SERVER_HOSTNAME = defaults['email_server_hostname']
+    is_email_enabled = get_boolean_input("Will Submitty use email notifications? [y/n]", 'y')
+    if is_email_enabled is True:
+        EMAIL_ENABLED = True
+        EMAIL_USER = get_input("What is the email user?", defaults['email_user'])
+        EMAIL_PASSWORD = get_input("What is the email password",defaults['email_password'])
+        EMAIL_SENDER = get_input("What is the email sender address (the address that will appear in the From: line)?",defaults['email_sender'])
+        EMAIL_REPLY_TO = get_input("What is the email reply to address?", defaults['email_reply_to'])
+        EMAIL_SERVER_HOSTNAME = get_input("What is the email server hostname?", defaults['email_server_hostname'])
+        try:
+            EMAIL_SERVER_PORT = int(get_input("What is the email server port?", defaults['email_server_port']))
+        except ValueError:
             EMAIL_SERVER_PORT = defaults['email_server_port']
-            break
+    else:
+        EMAIL_ENABLED = False
+        EMAIL_USER = defaults['email_user']
+        EMAIL_PASSWORD = defaults['email_password']
+        EMAIL_SENDER = defaults['email_sender']
+        EMAIL_REPLY_TO = defaults['email_reply_to']
+        EMAIL_SERVER_HOSTNAME = defaults['email_server_hostname']
+        EMAIL_SERVER_PORT = defaults['email_server_port']
     print()
 
 

--- a/site/app/authentication/AbstractAuthentication.php
+++ b/site/app/authentication/AbstractAuthentication.php
@@ -2,6 +2,7 @@
 
 namespace app\authentication;
 
+use app\libraries\AuthenticationManager;
 use app\libraries\Core;
 
 /**
@@ -16,8 +17,16 @@ abstract class AbstractAuthentication {
     protected $user_id = null;
     protected $password = null;
 
-    public function __construct(Core $core) {
+    public function __construct(Core $core, AuthenticationManager $manager) {
         $this->core = $core;
+    }
+
+    public function setUserId(string $user_id): void {
+        $this->user_id = $user_id;
+    }
+
+    public function setPassword(string $password): void {
+        $this->password = $password;
     }
 
     /**
@@ -27,17 +36,5 @@ abstract class AbstractAuthentication {
      *
      * @return bool
      */
-    abstract public function authenticate();
-
-    public function setUserId($user_id) {
-        $this->user_id = trim(strtolower($user_id));
-    }
-
-    public function setPassword($password) {
-        $this->password = $password;
-    }
-
-    public function getUserId() {
-        return $this->user_id;
-    }
+    abstract public function authenticate(): bool;
 }

--- a/site/app/authentication/DatabaseAuthentication.php
+++ b/site/app/authentication/DatabaseAuthentication.php
@@ -13,8 +13,7 @@ namespace app\authentication;
  * @link http://php.net/manual/en/function.password-verify.php
  */
 class DatabaseAuthentication extends AbstractAuthentication {
-
-    public function authenticate() {
+    public function authenticate(): bool {
         if ($this->user_id === null || $this->password === null) {
             return false;
         }

--- a/site/app/authentication/LdapAuthentication.php
+++ b/site/app/authentication/LdapAuthentication.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace app\authentication;
+
+use app\exceptions\AuthenticationException;
+use app\exceptions\CurlException;
+use app\libraries\FileUtils;
+
+/**
+ * Class LdapAuthentication
+ *
+ */
+class LdapAuthentication extends AbstractAuthentication {
+    public function authenticate(): bool {
+        // Check for $this->user_id and $this->password to be non empty
+        if (empty($this->user_id) || empty($this->password) ||
+            $this->core->getQueries()->getSubmittyUser($this->user_id) === null) {
+            return false;
+        }
+
+        $settings = $this->core->getConfig()->getAuthenticationSettings()['ldap'];
+
+        $ldap = ldap_connect($settings['url']);
+        ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
+        ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+
+        return @ldap_bind($ldap, "{$settings['uid']}={$this->username},{$settings['bind_dn']}", $this->password);
+    }
+}

--- a/site/app/authentication/PamAuthentication.php
+++ b/site/app/authentication/PamAuthentication.php
@@ -4,8 +4,6 @@ namespace app\authentication;
 
 use app\exceptions\AuthenticationException;
 use app\exceptions\CurlException;
-use app\libraries\Core;
-use app\libraries\FileUtils;
 
 /**
  * Class PamAuthentication
@@ -18,7 +16,7 @@ use app\libraries\FileUtils;
  * the filename via GET to this page, all using the cURL library.
  */
 class PamAuthentication extends AbstractAuthentication {
-    public function authenticate() {
+    public function authenticate(): bool {
         // Check for $this->user_id and $this->>password to be non empty
         if (empty($this->user_id) || empty($this->password) ||
             $this->core->getQueries()->getSubmittyUser($this->user_id) === null) {

--- a/site/app/libraries/AuthenticationManager.php
+++ b/site/app/libraries/AuthenticationManager.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace app\authentication;
-
-use app\libraries\Core;
+namespace app\libraries;
 
 class AuthenticationManager {
     private $settings;
@@ -19,7 +17,7 @@ class AuthenticationManager {
             if (!is_subclass_of($auth_class, 'app\authentication\AbstractAuthentication')) {
                 throw new \Exception("Invalid method specified for Authentication. All method should implement the AbstractAuthentication interface.");
             }
-            $this->methods[] = new $auth_class($this);
+            $this->methods[] = new $auth_class($core, $this);
         }
     }
 

--- a/site/app/libraries/AuthenticationManager.php
+++ b/site/app/libraries/AuthenticationManager.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace app\authentication;
+
+use app\libraries\Core;
+
+class AuthenticationManager {
+    private $settings;
+    /** @var AbstractAuthentication[] */
+    private $methods = [];
+
+    private $user_id;
+    private $password;
+
+    public function __constructor(Core $core) {
+        $this->settings = $core->getConfig()->getAuthenticationSettings();
+        foreach ($this->settings['methods'] as $method) {
+            $auth_class = "\\app\\authentication\\".$method;
+            if (!is_subclass_of($auth_class, 'app\authentication\AbstractAuthentication')) {
+                throw new \Exception("Invalid method specified for Authentication. All method should implement the AbstractAuthentication interface.");
+            }
+            $this->methods[] = new $auth_class($this);
+        }
+    }
+
+    public function authenticate(): bool {
+        foreach ($this->methods as $method) {
+            $method->setUserId($this->user_id);
+            $method->setPassword($this->password);
+            if ($method->authenticate()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function setUserId(string $user_id): void {
+        $this->user_id = trim(strtolower($user_id));
+    }
+
+    public function setPassword(string $password): void {
+        $this->password = $password;
+    }
+
+    public function getUserId(): string {
+        return $this->user_id;
+    }
+}

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -34,8 +34,8 @@ class Core {
     /** @var AbstractDatabase */
     private $course_db = null;
 
-    /** @var AbstractAuthentication */
-    private $authentication;
+    /** @var AuthenticationManager */
+    private $authentication_manager;
 
     /** @var SessionManager */
     private $session_manager;
@@ -146,11 +146,7 @@ class Core {
     }
 
     public function loadAuthentication() {
-        $auth_class = "\\app\\authentication\\".$this->config->getAuthentication();
-        if (!is_subclass_of($auth_class, 'app\authentication\AbstractAuthentication')) {
-            throw new \Exception("Invalid module specified for Authentication. All modules should implement the AbstractAuthentication interface.");
-        }
-        $this->authentication = new $auth_class($this);
+        $this->authentication_manager = new AuthenticationManager($this);
         $this->session_manager = new SessionManager($this);
     }
 
@@ -332,10 +328,10 @@ class Core {
     }
 
     /**
-     * @return AbstractAuthentication
+     * @return AbstractAuthentication[]
      */
     public function getAuthentication() {
-        return $this->authentication;
+        return $this->authentication_manager;
     }
 
     /**
@@ -394,9 +390,9 @@ class Core {
      * @throws AuthenticationException
      */
     public function authenticate(bool $persistent_cookie = true): bool {
-        $user_id = $this->authentication->getUserId();
+        $user_id = $this->authentication_manager->getUserId();
         try {
-            if ($this->authentication->authenticate()) {
+            if ($this->authentication_manager->authenticate()) {
                 // Set the cookie to last for 7 days
                 $token = TokenManager::generateSessionToken(
                     $this->session_manager->newSession($user_id),

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -367,9 +367,9 @@ class Config extends AbstractModel {
         }
 
         $this->authentication_settings = array_replace_recursive($auth_json);
-        if (empty($authentication_settings['methods'])) {
+        if (empty($this->authentication_settings['methods'])) {
             throw new ConfigException("Must specify an authentication method to use");
-        }    
+        }
     }
 
     public function loadCourseJson($semester, $course, $course_json_path) {

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -366,7 +366,10 @@ class Config extends AbstractModel {
             throw new ConfigException("Could not find authentication file: {$this->config_path}/authentication.json");
         }
 
-        $this->authentication_settings = array_replace_recursive($auth_json);
+        $this->authentication_settings = array_replace_recursive(
+            $this->authentication_settings,
+            $auth_json
+        );
         if (empty($this->authentication_settings['methods'])) {
             throw new ConfigException("Must specify an authentication method to use");
         }

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -75,16 +75,17 @@ register_shutdown_function("error_handler");
 
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadMasterConfig();
+
+Logger::setLogPath($core->getConfig()->getLogPath());
+ExceptionHandler::setLogExceptions($core->getConfig()->shouldLogExceptions());
+ExceptionHandler::setDisplayExceptions($core->getConfig()->isDebug());
+
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadMasterDatabase();
 /** @noinspection PhpUnhandledExceptionInspection */
 $core->loadAuthentication();
 //Load Twig templating engine after the config is loaded but before any output is shown
 $core->getOutput()->loadTwig();
-
-Logger::setLogPath($core->getConfig()->getLogPath());
-ExceptionHandler::setLogExceptions($core->getConfig()->shouldLogExceptions());
-ExceptionHandler::setDisplayExceptions($core->getConfig()->isDebug());
 
 $core->getOutput()->setInternalResources();
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #2054, #4304.

Currently, Submitty does not support LDAP, as well as requiring that users select one authentication method to use, which generally means using PAM itself which can be confusing to configure.

### What is the new behavior?
Extends the authentication to be a stack where each method is tried in the stack to authenticate a user. As such, can make it so that a user exists only in the DB and have DatabaseAuthentication enabled purely for that user while all other users would use PAM/LDAP method in the authentication stack.

Adds LDAP as a method for authentication.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This change requires rethinking how `./CONFIGURE_SUBMITTY.py` works due to having to ask questions about configuring a given authentication method, as well as dealing with questions of ordering them, or removing one, all via CLI. Still working on that part before marking this as ready to merge.