### PR TITLE
[Feature:PDFAnnotator] Allow minimum size of pen to be 0.1

### DIFF
--- a/site/app/templates/grading/electronic/PDFAnnotationBar.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationBar.twig
@@ -21,7 +21,7 @@
     <div id="size_selector_menu" class="selection-menu">
         Pen size:
         <br>
-        <input id="pen_size_selector" type="range" min="1" max="10" step="0.1" style="width:70%" oninput="pen_size_value.value=value">
+        <input id="pen_size_selector" type="range" min="0.1" max="10" step="0.1" style="width:70%" oninput="pen_size_value.value=value">
         <output id="pen_size_value"></output>
         <br>
         Text size:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #4277 

The allowed minimum size of the pen in the UI was 1.

### What is the new behavior?
Can now set the minimum size of the pen to be 0.1.

Below shows the pen at 0.1, 0.5, 1, 1.5, 2, 2.5, and 3 width:
![Screen Shot 2019-08-31 at 4 32 50 PM](https://user-images.githubusercontent.com/1845314/64068391-eb8c6a80-cc0d-11e9-8b13-adaf53e73cff.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This patch is in conjunction with the [v2.1.0](https://github.com/Submitty/pdf-annotate.js/releases/tag/2.1.0) release of Submitty/pdf-annotate.js which added the capacity to have a pen with non-integer size to it. Prior to that release, the pen was always converted to an integer.