### PR TITLE
[Testing:Refactor] Refactor SubmissionControllerTester to not use run()

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -60,7 +60,7 @@ class SubmissionController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/{gradeable_version}", requirements={"gradeable_version": "\d+"})
      * @return array
      */
-    public function showHomeworkPage($gradeable_id = null, $gradeable_version = null) {
+    public function showHomeworkPage($gradeable_id, $gradeable_version = null) {
         $gradeable = $this->tryGetElectronicGradeable($gradeable_id);
         if($gradeable === null) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -56,53 +56,11 @@ class SubmissionController extends AbstractController {
     }
 
     /**
-     * This method shouldn't be called by router.
-     * It is here only because tests are not updated.
-     * @deprecated
-     */
-    public function run() {
-        switch($_REQUEST['action']) {
-            case 'upload':
-                return $this->ajaxUploadSubmission($_REQUEST['gradeable_id']);
-                break;
-            case 'update':
-                return $this->updateSubmissionVersion($_REQUEST['gradeable_id'], $_REQUEST['new_version']);
-                break;
-            case 'check_refresh':
-                return $this->checkRefresh($_REQUEST['gradeable_id'], $_REQUEST['gradeable_version']);
-                break;
-            case 'bulk':
-                return $this->ajaxBulkUpload($_REQUEST['gradeable_id']);
-                break;
-            case 'upload_split':
-                return $this->ajaxUploadSplitItem($_REQUEST['gradeable_id']);
-                break;
-            case 'delete_split':
-                return $this->ajaxDeleteSplitItem($_REQUEST['gradeable_id']);
-                break;
-            case 'verify':
-                return $this->ajaxValidGradeable($_REQUEST['gradeable_id']);
-                break;
-            case 'stat_page':
-                return $this->showBulkStats($_REQUEST['gradeable_id']);
-                break;
-            case 'display':
-            default:
-
-                return $this->showHomeworkPage(
-                    $_REQUEST['gradeable_id'] ?? null,
-                    $_REQUEST['gradeable_version'] ?? 0
-                );
-                break;
-        }
-    }
-
-    /**
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}")
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/{gradeable_version}", requirements={"gradeable_version": "\d+"})
      * @return array
      */
-    public function showHomeworkPage($gradeable_id, $gradeable_version = null) {
+    public function showHomeworkPage($gradeable_id = null, $gradeable_version = null) {
         $gradeable = $this->tryGetElectronicGradeable($gradeable_id);
         if($gradeable === null) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #4356

The SubmissionControllerTester currently uses the deprecated `run()` function on the controller which only exists for the tester itself.

### What is the new behavior?
Replaces all usages of the `run()` method with calling the specific controller method (similar to how the Router works) and removes the now completely obsolete run function.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
