### PR TITLE
[Bugfix:Navigation] Fixes gradeable category behavior for gradeables with no due date

### DIFF
--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -84,10 +84,7 @@ class GradeableList extends AbstractModel {
             else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->hasDueDate()) {
                 // Filter out gradeables with no due date
                 if ($gradeable->isStudentSubmit()) {
-                    if ($gradeable->hasSubmission($submitter)) {
-                        // Once the user has a submission for this gradeable, move it to the 'closed' section
-                        $this->closed_gradeables[$gradeable->getId()] = $gradeable;
-                    } else if ($gradeable->getGradeStartDate() < $this->core->getDateTimeNow() && $this->core->getUser()->accessGrading()) {
+                    if ($gradeable->getGradeStartDate() < $this->core->getDateTimeNow() && $this->core->getUser()->accessGrading()) {
                         // Put in 'grading' category only if user is a grader
                         $this->grading_gradeables[$gradeable->getId()] = $gradeable;
                     } else {

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -280,19 +280,19 @@ class GradeableListTester extends BaseUnitTest {
         $this->assertCount(0, $actual);
 
         $actual = $list->getOpenGradeables();
-        $this->assertCount(1, $actual);
+        $this->assertCount(2, $actual);
         $this->assertArrayHasKey('01_no_submit_no_due', $actual);
-        $this->assertEquals($gradeables['01_no_submit_no_due'], $actual['01_no_submit_no_due']);
-
-        $actual = $list->getClosedGradeables();
-        $this->assertCount(1, $actual);
         $this->assertArrayHasKey('02_submitted_no_due', $actual);
+        $this->assertEquals($gradeables['01_no_submit_no_due'], $actual['01_no_submit_no_due']);
         $this->assertEquals($gradeables['02_submitted_no_due'], $actual['02_submitted_no_due']);
 
         $actual = $list->getGradingGradeables();
         $this->assertCount(1, $actual);
         $this->assertArrayHasKey('03_ta_submit_no_due', $actual);
         $this->assertEquals($gradeables['03_ta_submit_no_due'], $actual['03_ta_submit_no_due']);
+
+        $actual = $list->getClosedGradeables();
+        $this->assertCount(0, $actual);
 
         $actual = $list->getGradedGradeables();
         $this->assertCount(0, $actual);

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -266,12 +266,18 @@ class GradeableListTester extends BaseUnitTest {
         $gradeables['03_ta_submit_no_due'] = $this->mockGradeable($core, "03_ta_submit_no_due",
             GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
             '9999-01-01', true, false, false);
+        $gradeables['04_no_submit_grades_released'] = $this->mockGradeable($core, "04_no_submit_grades_released",
+            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
+            '1004-01-01', true, true, false);
+        $gradeables['05_submitted_grades_released'] = $this->mockGradeable($core, "05_submitted_grades_released",
+            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
+            '1004-01-01', true, true, false);
 
         $this->mockGetGradeables($core, $gradeables);
-        $core->getQueries()->method('getHasSubmission')->will($this->onConsecutiveCalls(false, true, false));
+        $core->getQueries()->method('getHasSubmission')->will($this->onConsecutiveCalls(false, true, false, false, true));
 
         $list = new GradeableList($core);
-        $this->assertCount(3, $list->getSubmittableElectronicGradeables());
+        $this->assertCount(5, $list->getSubmittableElectronicGradeables());
 
         $actual = $list->getFutureGradeables();
         $this->assertCount(0, $actual);
@@ -295,7 +301,11 @@ class GradeableListTester extends BaseUnitTest {
         $this->assertCount(0, $actual);
 
         $actual = $list->getGradedGradeables();
-        $this->assertCount(0, $actual);
+        $this->assertCount(2, $actual);
+        $this->assertArrayHasKey('04_no_submit_grades_released', $actual);
+        $this->assertArrayHasKey('05_submitted_grades_released', $actual);
+        $this->assertEquals($gradeables['04_no_submit_grades_released'], $actual['04_no_submit_grades_released']);
+        $this->assertEquals($gradeables['05_submitted_grades_released'], $actual['05_submitted_grades_released']);
     }
 
     public function testNoSubmittableGradeables() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4379 
Once a student makes a submission for a gradeable with no due date, the gradeable is moved to the "past due" category.

### What is the new behavior?
The gradeable for students, stays in the "open" category until the grades released date. Then it gets moved to the "grades available category"

### Other information?

To test, I created an autograding gradeable with no due date and made a submission as a student to observe the behavior. I then changed the grades released date as an instructor to see the gradeable move into the "grades available" category.

@KevinMackenzie I noticed [here](https://github.com/Submitty/Submitty/blob/4470a7f188a42ce0f5d4a3f31d6e6fe5dc399ceb/site/app/models/gradeable/GradeableList.php#L87) that there was a check for a student submission on gradeables with no due date. Was the original intention to create a type of gradeable that only allows for 1 submission?
