### PR TITLE
[Testing:Refactor] Remove much of the mocks from SubmissionControllerTester

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -84,7 +84,6 @@ class SubmissionController extends AbstractController {
 
         // ORIGINAL
         //if (!$gradeable->isSubmissionOpen() && !$this->core->getUser()->accessAdmin()) {
-
         // TEMPORARY - ALLOW LIMITED & FULL ACCESS GRADERS TO PRACTICE ALL FUTURE HOMEWORKS
         if (!$this->core->getUser()->accessGrading() && (
                 !$gradeable->isSubmissionOpen()

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -69,6 +69,8 @@ class Core {
     /** @var bool */
     private $redirect = true;
 
+    private $testing = false;
+
 
     /**
      * Core constructor.
@@ -77,7 +79,7 @@ class Core {
      * need. This should be called first, then loadConfig() and then loadDatabases().
      */
     public function __construct() {
-        $this->output = new Output($this);
+        $this->setOutput(new Output($this));
         $this->access = new Access($this);
 
         // initialize our alert queue if it doesn't exist
@@ -583,8 +585,12 @@ class Core {
     /**
      * @return Output
      */
-    public function getOutput() {
+    public function getOutput(): Output {
         return $this->output;
+    }
+
+    public function setOutput(Output $output): void {
+        $this->output = $output;
     }
 
     /**
@@ -649,14 +655,15 @@ class Core {
 
     /**
      * We use this function to allow us to bypass certain "safe" PHP functions that we cannot
-     * bypass via mocking or some other method (like is_uploaded_file). This method, which normally
-     * ALWAYS returns FALSE we can mock to return TRUE for testing. It's probably not "best practices",
-     * and the proper way is using "phpt" files, but
-     *
+     * bypass via mocking or some other method (like is_uploaded_file).
      * @return bool
      */
-    public function isTesting() {
-        return false;
+    public function isTesting(): bool {
+        return $this->testing;
+    }
+
+    public function setTesting(bool $testing): void {
+        $this->testing = $testing;
     }
 
     public function getNotificationFactory() {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -747,9 +747,8 @@ class Gradeable extends AbstractModel {
         throw new NotImplementedException('Individual date setters are disabled, use "setDates" instead');
     }
 
-    /** @internal */
-    public function setAutogradingConfig() {
-        throw new \BadFunctionCallException('Cannot set the autograding config data');
+    public function setAutogradingConfig(AutogradingConfig $autograding_config): void {
+        $this->autograding_config = $autograding_config;
     }
 
     /**

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -13,6 +13,7 @@ use ReflectionException;
 
 
 class BaseUnitTest extends \PHPUnit\Framework\TestCase {
+    protected static $mock_builders = [];
 
     /** @noinspection PhpDocSignatureInspection */
     /**
@@ -156,30 +157,33 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
      *
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    public function createMockModel($class) {
-        $builder = $this->getMockBuilder($class)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes();
+    public function createMockModel(string $class) {
+        if (!isset(static::$mock_builders[$class])) {
+            $builder = $this->getMockBuilder($class)
+                ->disableOriginalConstructor()
+                ->disableOriginalClone()
+                ->disableArgumentCloning()
+                ->disallowMockingUnknownTypes();
 
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $reflection = new \ReflectionClass($class);
-        $methods = array();
-        $matches = array();
-        preg_match_all("/@method.* (.*)\(.*\)/", $reflection->getDocComment(), $matches);
-        foreach ($matches[1] as $match) {
-            if (strlen($match) > 0) {
-                $methods[] = $match;
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $reflection = new \ReflectionClass($class);
+            $methods = array();
+            $matches = array();
+            preg_match_all("/@method.* (.*)\(.*\)/", $reflection->getDocComment(), $matches);
+            foreach ($matches[1] as $match) {
+                if (strlen($match) > 0) {
+                    $methods[] = $match;
+                }
             }
-        }
-        foreach ($reflection->getMethods() as $method) {
-            if (!Utils::startsWith($method->getName(), "__")) {
-                $methods[] = $method->getName();
+            foreach ($reflection->getMethods() as $method) {
+                if (!Utils::startsWith($method->getName(), "__")) {
+                    $methods[] = $method->getName();
+                }
             }
+            $builder->setMethods(array_unique($methods));
+            static::$mock_builders[$class] = $builder;
         }
-        $builder->setMethods(array_unique($methods));
-        return $builder->getMock();
+        return static::$mock_builders[$class]->getMock();
     }
 
     /**

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -410,7 +410,7 @@ class GradeableListTester extends BaseUnitTest {
             'ta_grading' => $ta_grading,
             'scanned_exam' => false,
             'student_view' => true,
-            'student_view_after_grades' => true,
+            'student_view_after_grades' => false,
             'student_submit' => $student_submit,
             'has_due_date' => $has_due_date,
             'peer_grading' => false,

--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -1,0 +1,235 @@
+<?php declare(strict_types = 1);
+
+namespace tests\utils;
+
+use app\libraries\Core;
+use app\libraries\Output;
+
+class NullOutput extends Output{
+    public function __construct(Core $core) {
+        $this->core = $core;
+    }
+
+    public function disableRender() {
+    }
+
+    public function getRender() {
+    }
+
+    public function loadTwig($full_load = true) {
+    }
+
+    public function setInternalResources() {
+    }
+
+    public function renderOutput() {
+    }
+
+    public function renderTemplate() {
+    }
+
+    /**
+     * Please avoid using this function unless absolutely necessary.
+     * Please use renderJsonSuccess, renderJsonFail and renderJsonError
+     * instead to ensure JSON responses have consistent format.
+     * @param $json
+     */
+    public function renderJson($json) {
+        $this->output_buffer = json_encode($json, JSON_PRETTY_PRINT);
+        $this->useFooter(false);
+        $this->useHeader(false);
+    }
+
+    /**
+     * Renders a json response for the "success" case
+     *  (see http://submitty.org/developer/json_responses)
+     * @param mixed|null $data Response data
+     * @return array the unencoded response
+     */
+    public function renderJsonSuccess($data = null) {
+        $response = [
+            'status' => 'success',
+            'data' => $data
+        ];
+
+        $this->renderJson($response);
+
+        // Because sometimes the controllers want to return the response array
+        return $response;
+    }
+
+    /**
+     * Renders a json response for the "fail" case
+     *  (see http://submitty.org/developer/json_responses)
+     * @param string $message A non-blank failure message
+     * @param mixed|null $data Response data
+     * @param array $extra Extra data merged into the response array
+     * @return array the unencoded response
+     */
+    public function renderJsonFail($message, $data = null, $extra = []) {
+        $response = [
+            'status' => 'fail',
+            'message' => $message,
+        ];
+
+        if ($data !== null) {
+            $response['data'] = $data;
+        }
+
+        // Merge $response second so it overwrites conflicting keys in $extra
+        $response = array_merge($extra, $response);
+        $this->renderJson($response);
+
+        // Because sometimes the controllers want to return the response array
+        return $response;
+    }
+
+    /**
+     * Renders a json response for the "error" case
+     *  (see http://submitty.org/developer/json_responses)
+     * @param string $message A non-blank error message
+     * @param mixed|null $data Response data
+     * @param int $code Code to identify error case
+     * @return array the unencoded response
+     */
+    public function renderJsonError($message, $data = null, $code = null) {
+        $response = [
+            'status' => 'error',
+            'message' => $message,
+        ];
+
+        if ($data !== null) {
+            $response['data'] = $data;
+        }
+        if ($code !== null) {
+            $response['code'] = $code;
+        }
+        $this->renderJson($response);
+
+        // Because sometimes the controllers want to return the response array
+        return $response;
+    }
+
+    /**
+     * Renders success/error messages and/or JSON responses.
+     * @param $message
+     * @param bool $success
+     * @param bool $show_msg
+     * @return array
+     */
+    public function renderResultMessage($message, $success = true, $show_msg = true) {
+        if ($show_msg == true) {
+            if ($success) {
+                $this->core->addSuccessMessage($message);
+            }
+            else {
+                $this->core->addErrorMessage($message);
+            }
+        }
+
+        if ($success === true) {
+            return $this->renderJsonSuccess($message);
+        } else {
+            return $this->renderJsonFail($message);
+        }
+    }
+
+    public function renderString($string) {
+    }
+
+    public function renderFile($contents, $filename, $filetype = "text/plain") {
+    }
+
+    /**
+     * Render a Twig template from the templates directory
+     * @param string $filename Template file basename, file should be in site/app/templates
+     * @param array $context Associative array of variables to pass into the Twig renderer
+     * @return string Rendered page content
+     */
+    public function renderTwigTemplate($filename, $context = []) {
+    }
+
+    public function renderTwigOutput($filename, $context = []) {
+    }
+
+    public function getOutput() {
+        $return = "";
+        $return .= $this->renderHeader();
+        $return .= $this->output_buffer;
+        $return .= $this->renderFooter();
+        return $return;
+    }
+
+    private function renderHeader() {
+    }
+
+    private function renderFooter() {
+    }
+
+    public function bufferOutput() {
+        return $this->buffer_output;
+    }
+
+    public function disableBuffer() {
+    }
+
+    /**
+     * Returns the stored output buffer that we've been building
+     *
+     * @return string
+     */
+    public function displayOutput() {
+        echo($this->getOutput());
+    }
+
+    public function showException($exception = "", $die = true) {
+    }
+
+    public function showError($error = "", $die = true) {
+    }
+
+    public function addInternalCss($file, $folder='css') {
+    }
+
+    public function addVendorCss($file) {
+    }
+
+    public function addCss($url) {
+    }
+
+    public function addInternalJs($file, $folder='js') {
+    }
+
+    public function addVendorJs($file) {
+    }
+
+    public function addJs($url) {
+    }
+
+    public function timestampResource($file, $folder) {
+    }
+
+    public function useHeader($bool = true) {
+    }
+
+    public function useFooter($bool = true) {
+    }
+
+    public function addBreadcrumb($string, $url=null, $external_link=false) {
+    }
+
+    public function addRoomTemplatesTwigPath() {
+    }
+
+    public function getBreadcrumbs() {
+    }
+
+    public function getCss() {
+    }
+
+    public function getJs() {
+    }
+
+    public function getRunTime() {
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Similar to #4411 

The SubmissionControllerTester used a lot of mock objects which are expensive to create.

### What is the new behavior?
Remove mocks for actual concrete implementations as possible. Running the test suite decreased from 5.5 minutes to ~2.5 minutes.