### PR TITLE
[Refactor:Installation] Remove unused PDFAnnotator version variable and do not grab its repo

### DIFF
--- a/.setup/bin/update_repos.sh
+++ b/.setup/bin/update_repos.sh
@@ -97,4 +97,3 @@ clone_or_update_repo  AnalysisTools  ${AnalysisTools_Version}
 clone_or_update_repo  Lichen  ${Lichen_Version}
 clone_or_update_repo  RainbowGrades  ${RainbowGrades_Version}
 clone_or_update_repo  Tutorial  ${Tutorial_Version}
-clone_or_update_repo  pdf-annotate.js  ${Pdf_Annotate_Js_Version}

--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -9,7 +9,6 @@ export AnalysisTools_Version=v.18.06.00
 export Lichen_Version=v.18.12.00
 export RainbowGrades_Version=v19.07.00
 export Tutorial_Version=v.19.02.00
-export Pdf_Annotate_Js_Version=v.18.10.00
 
 # JAVA
 export JUNIT_VERSION=4.12


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This variable is unused as we switched to using `npm` to manage the pdf-annotator (and other JS dependencies) some time ago. Removing it so as to not be confusing.

@bmcutler I held off deleting the repo entirely in-case someone was actually using it, but I'm not sure anyone was and so is probably safe to delete if so desired.