### PR TITLE
[Feature:Installation] Always reload PHP-FPM on site installation

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -176,8 +176,14 @@ chmod 550 ${SUBMITTY_INSTALL_DIR}/site/cgi-bin/git-http-backend
 # cache needs to be writable
 find ${SUBMITTY_INSTALL_DIR}/site/cache -type d -exec chmod u+w {} \;
 
-# reload PHP-FPM before we re-enable website
+# reload PHP-FPM before we re-enable website, but only if PHP-FPM is actually being used
+# as expected (Travis for example will fail here otherwise).
 PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
-systemctl reload php${PHP_VERSION}-fpm
+set +e
+systemctl is-active --quiet php${PHP_VERSION}-fpm
+if [[ "$?" == "0" ]]; then
+    systemctl reload php${PHP_VERSION}-fpm
+fi
+set -e
 
 rm -f ${SUBMITTY_INSTALL_DIR}/site/public/index.html

--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -176,4 +176,8 @@ chmod 550 ${SUBMITTY_INSTALL_DIR}/site/cgi-bin/git-http-backend
 # cache needs to be writable
 find ${SUBMITTY_INSTALL_DIR}/site/cache -type d -exec chmod u+w {} \;
 
+# reload PHP-FPM before we re-enable website
+PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
+systemctl reload php${PHP_VERSION}-fpm
+
 rm -f ${SUBMITTY_INSTALL_DIR}/site/public/index.html


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Currently, PHP-FPM is only reloaded/restarted if using `./INSTALL_SUBMITTY.sh restart_web` or through `systemctl`/`service`. This makes changing certain things (like adding `DS\Set` (#4352)) require sysadmin action.

### What is the new behavior?
Always reload PHP-FPM before we remove the `index.html` placeholder. This is a graceful operation so should not affect any other PHP site running on a server and is done for Submitty while we're not serving any PHP files to people. Removes some potential amount of sysadmin action and inline with discussions surrounding the larger meta-issue of #4011.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
