### PR TITLE
[Testing:Bugfix] Add missing type hints for NullOutput

### DIFF
--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -194,7 +194,7 @@ class NullOutput extends Output{
     public function addVendorCss($file) {
     }
 
-    public function addCss(string $url) {
+    public function addCss(string $url): void {
     }
 
     public function addInternalJs($file, $folder='js') {
@@ -203,7 +203,7 @@ class NullOutput extends Output{
     public function addVendorJs($file) {
     }
 
-    public function addJs(string $url) {
+    public function addJs(string $url): void {
     }
 
     public function timestampResource($file, $folder) {

--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -4,6 +4,7 @@ namespace tests\utils;
 
 use app\libraries\Core;
 use app\libraries\Output;
+use Ds\Set;
 
 class NullOutput extends Output{
     public function __construct(Core $core) {
@@ -224,10 +225,10 @@ class NullOutput extends Output{
     public function getBreadcrumbs() {
     }
 
-    public function getCss() {
+    public function getCss(): Set {
     }
 
-    public function getJs() {
+    public function getJs(): Set {
     }
 
     public function getRunTime() {

--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -194,7 +194,7 @@ class NullOutput extends Output{
     public function addVendorCss($file) {
     }
 
-    public function addCss($url) {
+    public function addCss(string $url) {
     }
 
     public function addInternalJs($file, $folder='js') {
@@ -203,7 +203,7 @@ class NullOutput extends Output{
     public function addVendorJs($file) {
     }
 
-    public function addJs($url) {
+    public function addJs(string $url) {
     }
 
     public function timestampResource($file, $folder) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Some typehints got added to `site/app/libraries/Output.php` for two functions that NullOutput did not have. Have updated `NullOutput` to have those type hints.