### PR TITLE
[Testing:Travis] Switch to pcov instead of xdebug for php code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,9 @@ jobs:
             - google-chrome-stable
             - libpam-passwdqc
             - libboost-all-dev
-      before_install: source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
+      before_install:
+        - source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
+        - phpenv config-rm xdebug.ini
       install:
         - pecl install ds
         - PHP_VERSION=${TRAVIS_PHP_VERSION:0:3}

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,11 +98,16 @@ jobs:
     - &02-php-unit
       stage: 02 unit test
       php: 7.2
+      before_install:
+        - phpenv config-rm xdebug.ini
       install:
         - pecl install ds
-      script:
+        - pecl install pcov
         - pushd site
         - travis_retry composer install --prefer-dist --no-interaction
+        - popd
+      script:
+        - pushd site
         - vendor/bin/phpunit --version
         - vendor/bin/phpunit -c tests/phpunit.xml
         - popd

--- a/site/tests/app/libraries/response/RedirectResponseTester.php
+++ b/site/tests/app/libraries/response/RedirectResponseTester.php
@@ -15,10 +15,7 @@ class RedirectResponseTester extends TestCase {
         $core->setTesting(true);
         $response = new RedirectResponse('http://example.com');
         $response->render($core);
-        $this->assertTrue(function_exists('xdebug_get_headers'), 'Make sure the xdebug extension is loaded');
-        $headers = xdebug_get_headers();
-        $this->assertCount(1, $headers);
-        $this->assertEquals("Location: http://example.com", $headers[0]);
+        $this->assertEquals("http://example.com", $response->url);
         $this->assertEquals(302, http_response_code());
     }
 }

--- a/site/tests/app/libraries/response/ResponseTester.php
+++ b/site/tests/app/libraries/response/ResponseTester.php
@@ -49,11 +49,7 @@ EOD;
         $this->assertEquals($expected, $this->core->getOutput()->getOutput());
     }
 
-    private function validateRedirectResponse(): void {
-        $this->assertTrue(function_exists('xdebug_get_headers'), 'Make sure the xdebug extension is loaded');
-        $headers = xdebug_get_headers();
-        $this->assertCount(1, $headers);
-        $this->assertEquals("Location: http://example.com", $headers[0]);
+    private function validateRedirectResponse(RedirectRes $redirect_response): void {
         $this->assertEquals(302, http_response_code());
     }
 

--- a/site/tests/app/libraries/response/ResponseTester.php
+++ b/site/tests/app/libraries/response/ResponseTester.php
@@ -49,7 +49,7 @@ EOD;
         $this->assertEquals($expected, $this->core->getOutput()->getOutput());
     }
 
-    private function validateRedirectResponse(RedirectRes $redirect_response): void {
+    private function validateRedirectResponse(): void {
         $this->assertEquals(302, http_response_code());
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Travis uses xdebug for unit testing so as to be able to generate code coverage. This however slows things down a lot as xdebug has to be initialized and loaded and it's a rather heavy debugger.

### What is the new behavior?

Uses the [pcov](https://github.com/krakjoe/pcov) which is substantially faster (going from ~13-14 minutes to < 1min).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

The redirect tests are weaked by this, but the performance gain is too much to worry about it.
