### PR TITLE
[Testing:Bugfix] Fix error in regex in testGetServerTime

### DIFF
--- a/site/tests/app/libraries/DateUtilsTester.php
+++ b/site/tests/app/libraries/DateUtilsTester.php
@@ -142,10 +142,10 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
         $config = new Config($core);
         $core->setConfig($config);
         $time = DateUtils::getServerTimeJson($core);
-        $this->assertRegExp("/20[1-9]{2}/", $time['year']);
+        $this->assertRegExp("/20[0-9]{2}/", $time['year']);
         $this->assertRegExp("/[0-1][0-9]/", $time['month']);
         $this->assertRegExp("/([0-9]|[1-3][0-9])/", $time['day']);
-        $this->assertRegExp("/([0-1][0-9]|2[0-3])/", $time['hour']);
+        $this->assertRegExp("/^([0-9]|1[0-9]|2[0-3])$/", $time['hour']);
         $this->assertRegExp("/[0-5][0-9]/", $time['minute']);
         $this->assertRegExp("/[0-5][0-9]/", $time['second']);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

`DateUtilsTester::testGetServerTime` was failing when the time was in early morning as we use format `G` which is 24 hour time without the leading zero. I misread the docs assuming it was `H`.

### What is the new behavior?
Fixes the regex to properly take account of the the `0-9` hours.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
