### PR TITLE
[Bugfix:Forum] Remove undefined event variable from jQuery submit function call

### DIFF
--- a/site/app/templates/forum/ShowForumThreads.twig
+++ b/site/app/templates/forum/ShowForumThreads.twig
@@ -11,7 +11,7 @@
             $(b[e]).tooltip('disable').attr('title', $(b[e]).attr('data-original-title'));
         });
         $('#'+'{{ display_option }}').attr('checked', 'checked'); //Saves the radiobutton state when refreshing the page
-        $(".post_reply_from").submit(event, publishPost);
+        $(".post_reply_from").submit(publishPost);
         $("form").areYouSure();
         loadThreadHandler();
     });

--- a/site/app/templates/forum/createThread.twig
+++ b/site/app/templates/forum/createThread.twig
@@ -38,7 +38,7 @@
 <script>
     $( document ).ready(function() {
         enableTabsInTextArea("[name=thread_post_content]");
-        $("#thread_form").submit(event, createThread);
+        $("#thread_form").submit(createThread);
         $("form").areYouSure();
     });
 </script>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

I'm not really sure what the original intention of this line was as it looks to be attempting to use the `.submit(eventData, handler)` usage of jQuery, but then doesn't actually use it as `eventData`. However, this depends on the browser supporting the `window.event` which FF historically hasn't and if a flag is not set to true, still doesn't which will cause a ReferenceError to be thrown.

### What is the new behavior?
Get rid of the unused/undefined `event` variable in the `.submit()` function as jQuery already handles passing the event to the handler in all cases for all browsers and as it breaks FF as noted above.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
To replicate on Firefox, go to `about:config` in the browser bar and set `dom.window.event.enabled` to be `false`. On submission of a forum post, you'll then see an error (`ReferenceError: event is not defined`) and then the form gets submitted via POST instead of AJAX as expected.

The variable was added in #4250 and I'm guessingthe intention was to have the handler get the `event` variable, but this is not the proper way to do it (this first variable at best would be assigned to `event.data` of the `event` object that is passed to the handler.