### PR TITLE
[Bugfix:InstructorUI] Fix being able to set visible only to instructors for seating chart

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -202,7 +202,7 @@
             </select>
             <label id="seating-only-label" class="option-alt" for="seating-only-for-instructor">
                 Visible only to Instructors?
-                <input type="checkbox" name="seating-only-for-instructor" id="seating-only-for-instructor" value="true"{{ fields['seating_only_for_instructor'] ? 'checked' : '' }} />
+                <input type="checkbox" name="seating_only_for_instructor" id="seating-only-for-instructor" value="true"{{ fields['seating_only_for_instructor'] ? 'checked' : '' }} />
             </label>
         </div>
 
@@ -212,10 +212,10 @@
         {% if not email_enabled %}
             <p class="yellow-message">Emails are disabled: contact your System Admin to enable emails</p>
         {% else %}
-            <button id="email-seating-assignment" class ="option-alt bare-button"> 
+            <button id="email-seating-assignment" class ="option-alt bare-button">
                 <a href="{{ email_room_seating_url }}" class="btn btn-primary">
                     Email Seating Assignments
-                </a> 
+                </a>
             </button>
         {% endif %}
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4451. Would see an alert when attempting to toggle the checkbox for "Visible only to instructor?".

### What is the new behavior?
Can now toggle the checkbox for that setting without seeing the alert. The relevant setting in `/var/local/submitty/courses/<semester>/<course>/config/config.json` is updated properly.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
