### PR TITLE
[Refactor:CourseMaterials] Ceanup Course Materials and bump max uploaded files to 100

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -491,6 +491,7 @@ EOF
     sed -i -e 's/^post_max_size = 8M/post_max_size = 10M/g' /etc/php/${PHP_VERSION}/fpm/php.ini
     sed -i -e 's/^allow_url_fopen = On/allow_url_fopen = Off/g' /etc/php/${PHP_VERSION}/fpm/php.ini
     sed -i -e 's/^session.cookie_httponly =/session.cookie_httponly = 1/g' /etc/php/${PHP_VERSION}/fpm/php.ini
+    sed -i -e 's/^max_file_uploads = 20/max_file_uploads = 20/g' /etc/php/${PHP_VERSION}/fpm/php.ini
     # This should mimic the list of disabled functions that RPI uses on the HSS machine with the sole difference
     # being that we do not disable phpinfo() on the vagrant machine as it's not a function that could be used for
     # development of some feature, but it is useful for seeing information that could help debug something going wrong

--- a/migration/migrator/migrations/system/20190910121549_increase_max_file_uploads.py
+++ b/migration/migrator/migrations/system/20190910121549_increase_max_file_uploads.py
@@ -1,0 +1,22 @@
+"""Migration for the Submitty system."""
+import os
+import subprocess
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    PHP_VERSION = subprocess.check_output("php -r 'print PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION;'", shell=True).decode("utf-8")
+   # print(php_version)
+   # print('/etc/php', php_version)
+   # print(str(os.system("php -r 'print PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION;'")))
+    
+   # print("sed -i -e 's/^max_file_uploads = 20/max_file_uploads = 20/g' /etc/php/" + PHP_VERSION + "/fpm/php.ini")
+   # os.system("sed -i '/max_file_uploads = 20/c\\max_file_uploads = 100' /etc/php" + PHP_VERSION + "/fpm/php.ini" )
+    os.system("sed -i -e 's/^max_file_uploads = 20/max_file_uploads = 100/g' /etc/php/" + PHP_VERSION + "/fpm/php.ini")
+    os.system("sudo systemctl restart php" + PHP_VERSION + "-fpm.service")
+    os.system("systemctl restart apache2.service")
+

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -156,10 +156,13 @@ class CourseMaterialsController extends AbstractController {
      * @Route("/{_semester}/{_course}/course_materials/modify_permission")
      * @AccessControl(role="INSTRUCTOR")
      */
-    public function modifyCourseMaterialsFilePermission($filenames, $checked) {
+    public function modifyCourseMaterialsFilePermission($checked) {
         $data=$_POST['fn'];
-        if(count($data)==1){
-            $filename = $filenames;
+        if(is_string($data) || count($data)==1){
+            $data = [$data];
+        }
+    
+        foreach ($data as $filename){
             if (!isset($filename) ||
                 !isset($checked)) {
                 $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
@@ -185,34 +188,7 @@ class CourseMaterialsController extends AbstractController {
                 return "Failed to write to file {$fp}";
             }
         }
-        else{
-            foreach ($data as $filename){
-                if (!isset($filename) ||
-                    !isset($checked)) {
-                    $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
-                }
-
-                $file_name = htmlspecialchars($filename);
-
-                $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-
-                $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
-                $json = FileUtils::readJsonFile($fp);
-                if ($json != false) {
-                    $release_datetime  = $json[$file_name]['release_datetime'];
-                }
-
-                if (!isset($release_datetime)) {
-                    $release_datetime = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
-                }
-
-                $json[$file_name] = array('checked' => $checked, 'release_datetime' => $release_datetime);
-
-                if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
-                    return "Failed to write to file {$fp}";
-                }
-            }
-        }
+        
 
     }
 
@@ -233,17 +209,18 @@ class CourseMaterialsController extends AbstractController {
           return $this->core->getOutput()->renderResultMessage("ERROR: Improperly formatted date", false);
         }
 
-
         //only one will not iterate correctly
         if(is_string($data) || sizeof($data) == 1){
-            //so just take the single passed in
-            $filename = $filenames;
-
+            $data = [$data];
+        }
+    
+        foreach ($data as $filename){
             if (!isset($filename)) {
                 $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
             }
 
             $file_name = htmlspecialchars($filename);
+            $new_data_time = htmlspecialchars($newdatatime);
 
             $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
 
@@ -254,35 +231,11 @@ class CourseMaterialsController extends AbstractController {
             }
 
             $json[$file_name] = array('checked' => $checked, 'release_datetime' => $new_data_time);
-
             if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
                 return $this->core->getOutput()->renderResultMessage("ERROR: Failed to update.", false);
             }
         }
-        else{
-            foreach ($data as $filename){
-                if (!isset($filename)) {
-                    $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
-                }
-
-                $file_name = htmlspecialchars($filename);
-                $new_data_time = htmlspecialchars($newdatatime);
-
-                $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-
-                $checked = '0';
-                $json = FileUtils::readJsonFile($fp);
-                if ($json != false) {
-                    $checked  = $json[$file_name]['checked'];
-                }
-
-                $json[$file_name] = array('checked' => $checked, 'release_datetime' => $new_data_time);
-                if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
-                    return $this->core->getOutput()->renderResultMessage("ERROR: Failed to update.", false);
-                }
-            }
-        }
-
+    
         return $this->core->getOutput()->renderResultMessage("Time successfully set.", true);
     }
 
@@ -334,36 +287,21 @@ class CourseMaterialsController extends AbstractController {
         if (isset($_FILES["files1"])) {
             $uploaded_files[1] = $_FILES["files1"];
         }
-        $errors = array();
-        if (isset($uploaded_files[1])) {
-            $count_item = count($uploaded_files[1]["name"]);
-            for ($j = 0; $j < $count_item[1]; $j++) {
-                if (!isset($uploaded_files[1]["tmp_name"][$j]) || $uploaded_files[1]["tmp_name"][$j] === "") {
-                    $error_message = $uploaded_files[1]["name"][$j]." failed to upload. ";
-                    if (isset($uploaded_files[1]["error"][$j])) {
-                        $error_message .= "Error message: ". ErrorMessages::uploadErrors($uploaded_files[1]["error"][$j]). ".";
-                    }
-                    $errors[] = $error_message;
-                }
-            }
-        }
-
-        if (count($errors) > 0) {
-            $error_text = implode("\n", $errors);
-            return $this->core->getOutput()->renderResultMessage("ERROR: Upload Failed: ".$error_text, false);
-        }
 
         if (empty($uploaded_files)) {
             return $this->core->getOutput()->renderResultMessage("ERROR: No files were submitted.", false);
         }
 
+        $status = FileUtils::validateUploadedFiles($_FILES["files1"]);  
+        if(array_key_exists("failed", $status)){
+            return $this->core->getOutput()->renderResultMessage("Failed to validate uploads " . $status["failed"], false);
+        }
+        
         $file_size = 0;
-        if (isset($uploaded_files[1])) {
-            for ($j = 0; $j < $count_item; $j++) {
-                if(FileUtils::isValidFileName($uploaded_files[1]["name"][$j]) === false) {
-                    return $this->core->getOutput()->renderResultMessage("ERROR: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_files[1]["name"][$j].".", false);
-                }
-                $file_size += $uploaded_files[1]["size"][$j];
+        foreach ($status as $stat) {
+            $file_size += $stat['size'];
+            if($stat['success'] === false){
+                return $this->core->getOutput()->renderResultMessage("Error " . $stat['error'], false);
             }
         }
 
@@ -387,6 +325,7 @@ class CourseMaterialsController extends AbstractController {
             $upload_path = $upload_nested_path;
         }
 
+        $count_item = count($status);   
         if (isset($uploaded_files[1])) {
             for ($j = 0; $j < $count_item; $j++) {
                 if ($this->core->isTesting() || is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Course Materials still uses a broken method of validating uploads and usually results in wrong/confusing errors. Max limit was set to 20 in the php.ini

### What is the new behavior?
Uses validateUploadedFiles from FileUtils for better error messages.  install submitty has been updated to set max_uploaded_files to 100. Refactors courseMaterialsController to remove a lot of duplicate code as well.

closes #3208

### other information
(note this is going to break one of the test in course materials so I think this should be merged first and then I can go and fix the errors in course materials.  