### PR TITLE
[Feature:AutoGrading] whitelist oz & haskell

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -105,6 +105,7 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     // for Programming Languages
     { "swipl",                   "/usr/bin/swipl" },
     { "plt-r5rs",                "/usr/bin/plt-r5rs" },
+    { "oz",                      "/usr/bin/oz" },
 
     // for Program Analysis course
     { "ghc",                     "/usr/bin/ghc" },

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -107,8 +107,6 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     { "plt-r5rs",                "/usr/bin/plt-r5rs" },
     { "ozc",                     "/usr/bin/ozc" },
     { "ozengine",                "/usr/bin/ozengine" },
-    { "cabal",                   "/usr/bin/cabal" },
-    { "stack",                   "/usr/bin/stack" },
 
     // for Program Analysis course
     { "ghc",                     "/usr/bin/ghc" },

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -105,7 +105,10 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     // for Programming Languages
     { "swipl",                   "/usr/bin/swipl" },
     { "plt-r5rs",                "/usr/bin/plt-r5rs" },
-    { "oz",                      "/usr/bin/oz" },
+    { "ozc",                     "/usr/bin/ozc" },
+    { "ozengine",                "/usr/bin/ozengine" },
+    { "cabal",                   "/usr/bin/cabal" },
+    { "stack",                   "/usr/bin/stack" },
 
     // for Program Analysis course
     { "ghc",                     "/usr/bin/ghc" },


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Programming Languages at RPI would like to the use the Oz and GHC stacks for evaluating assignments. While `ghc` itself was whitelisted, `cabal` and `stack` were not which are used for package installation and such for the `ghc`.

### What is the new behavior?

Whitelists programs from compiling and running `oz` assignments and whitelists `cabal` and `stack` for GHC, per their request.