### PR TITLE
[Testing:CodeCov] Reduce codecov notifications

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,4 +13,4 @@ coverage:
 
 comment:
   layout: "reach, diff, flags"
-  behavior: default
+  behavior: once


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

CodeCov bot is posting 6 times on issues for some reason (number of different lines that report a build?). `default` should mean `post new if none exist, otherwise update`, but it doesn't look like it's quite working as well as I'd hope.

### What is the new behavior?
Use `once` which maybe is more explicit about what CodeCov should be doing?