### PR TITLE
[Bugfix : BulkUploads] Make submission for student handles previous submissions again

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -596,9 +596,16 @@
             else {
                 validateUserId("{{ csrf_token }}", "{{ gradeable_id }}", user_id)
                 .then(function(response){
-                    if(response['highest_version']){
-                        var option = displayPreviousSubmissionOptions(getSubmissionOption);
-                        function getSubmissionOption(option){
+                    if(response['data']['previous_submission']){
+                        let has_been_called = false;
+                        var option = displayPreviousSubmissionOptions(getSubmissionOptionForStudentOnly);
+
+                        return;
+
+                        function getSubmissionOptionForStudentOnly(option){
+                            if(has_been_called)
+                                return;
+
                             var merge_previous = false;
                             var clobber = false;
 
@@ -609,10 +616,10 @@
                                 clobber = true;
                             }
 
-                            makeSubmission(user_id,response['highest_version'], false, "", "", merge_previous,clobber);
+                            makeSubmission(user_id,response['data']['highest_version'], false, "", "", "", merge_previous,clobber);
                         }
                     }else{
-                        makeSubmission(user_id, response['highest_version'], false, "", "");
+                        makeSubmission(user_id, response['data']['highest_version'], false, "", "", "");
                     }
                 });
             }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If a student had a previous student and an instructor wanted to make a submission for that student through the submissions interface Submitty would always create a new version  without asking the user what to do.

### What is the new behavior?
Displays the popup menu and handles previous submission options again

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

closes #4476