### PR TITLE
[Bugfix:Gradeables] Removal of template feature from gradables

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -4,6 +4,7 @@
 #}
 {% if action == 'new' or action == 'template' %}
     <div>
+    {#
         <div class="option row">
             <div class="option-desc col-md-6">
                 <label for="gradeable_template">
@@ -21,6 +22,7 @@
                 </select>
             </div>
         </div>
+    #}
     </div>
 
 {% endif %}

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -4,7 +4,7 @@
 #}
 {% if action == 'new' or action == 'template' %}
     <div>
-    {#
+    {# temporarily remove the template feature because it is stale / needs refactoring.
         <div class="option row">
             <div class="option-desc col-md-6">
                 <label for="gradeable_template">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [#] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [#] Tests for the changes have been added/updated (if possible)
* [#] Documentation has been updated/added if relevant

Server crashes when creating a new gradable and you set the template to a type and then revert back to none.  

The template feature has been removed from gradables.

The feature is stale and is not used by anyone right now so it has been commented out for starters.

I reloaded submitty virtually after the change was made and saw that nothing had been broken.

Closes  #4477