### PR TITLE
[Bugfix:LateDays] Factor in number of extensions in showing lateday banner

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -205,7 +205,7 @@ class HomeworkView extends AbstractView {
                     $messages[] = ['type' => 'would_get_zero'];
                 } // SUBMISSION NOW WOULD BE LATE
                 else {
-                    $new_late_charged = $would_be_days_late-$active_days_late;
+                    $new_late_charged = $would_be_days_late-$active_days_late - $extensions;
                     $new_late_days_remaining = $late_days_remaining-$new_late_charged;
                     $messages[] = ['type' => 'would_allowed', 'info' => [
                         'charged' => $new_late_charged,

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -205,7 +205,7 @@ class HomeworkView extends AbstractView {
                     $messages[] = ['type' => 'would_get_zero'];
                 } // SUBMISSION NOW WOULD BE LATE
                 else {
-                    $new_late_charged = $would_be_days_late-$active_days_late - $extensions;
+                    $new_late_charged = max(0,$would_be_days_late-$active_days_late - $extensions);
                     $new_late_days_remaining = $late_days_remaining-$new_late_charged;
                     $messages[] = ['type' => 'would_allowed', 'info' => [
                         'charged' => $new_late_charged,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If a student is granted an extension the late day banner will warn they will be charged a late day when in reality they won't

### What is the new behavior?
Now uses number of extensions to display to the student how many late days they'll be charged 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

closes #4483
