### PR TITLE
[Feature:Forum] Added a notice when too many announcements and pinned threads

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -528,6 +528,11 @@ class DatabaseQueries {
         $this->course_db->query("UPDATE threads SET pinned = ? WHERE id = ?", array($onOff, $thread_id));
     }
 
+    public function getNumberOfPinnedThreadsAndAttachments() {
+        $this->course_db->query("SELECT COUNT(*) FROM threads WHERE pinned=true");
+        return $this->course_db->row();
+    }
+
     public function addPinnedThread($user_id, $thread_id, $added){
         if($added) {
             $this->course_db->query("INSERT INTO student_favorites(user_id, thread_id) VALUES (?,?)", array($user_id, $thread_id));


### PR DESCRIPTION
### What is the current behavior?
When there are too many announcements and pinned threads in the forum, new threads will be drowned.
closes #4432 

### What is the new behavior?
When a new announcement is created, a thread is made into an announcement, or a thread is pinned and there are more than 5 pinned threads and announcements this message will appear.

![too_many_announcements](https://user-images.githubusercontent.com/15002610/65087908-7a76e200-d985-11e9-9ad8-d6342b3e5548.PNG)
