### PR TITLE
[Bugfix:Autograding] Adjusts rlimit heap size to scale with container image

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -66,7 +66,6 @@ class Container():
 
     # Only pass container name to testcases with greater than one container. (Doing otherwise breaks compilation)
     container_name_argument = ['--container_name', self.name] if more_than_one else list()
-    container_ulimits = rlimit_utils.build_ulimit_argument(self.container_rlimits)
     # A server container does not run student code, but instead hosts a service (e.g. a database.)
 
     try:
@@ -74,6 +73,7 @@ class Container():
         self.container = client.containers.create(self.image, stdin_open = True, tty = True, network = 'none', 
                                                   volumes = mount, working_dir = self.directory, name = self.full_name)
       else:
+        container_ulimits = rlimit_utils.build_ulimit_argument(self.container_rlimits, self.image)
         command = [execution_script,] + arguments + container_name_argument
         self.container = client.containers.create(self.image, command = command, ulimits = container_ulimits, stdin_open = True, 
                                                   tty = True, network = 'none', user = self.container_user_argument, volumes=mount,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently the default `RLIMIT_HEAP` is set to 1 GB.  This is problematic for instructors who wish to use larger custom images for their testcase since the docker container fails to startup if insufficient stack/heap memory is provided.

If instructors specify custom resource limits, defaults do not get populated. (Ex: Instructor only specifies `CPU`, default for `STACK` and `DATA` are not filled)

### What is the new behavior?
When an image is specified, the size of that image is taken into account to set `RLIMIT_DATA`. Currently it takes the size of the image and adds our default 1GB of heap that we provide to students. 

Default stack size is extended to 100MB, for some containers, having insufficient stack size may cause a failure in startup.

If an instructor specifies rlimits but excludes one of `CPU, STACK, DATA`, default values are populated. 
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested with the [gradeable](https://github.com/Submitty/Submitty/tree/master/more_autograding_examples/python_custom_docker_rlimits) with custom docker rlimits.
Specified large docker image in the config file. One used for [RPI CSCI4430](https://hub.docker.com/r/submittyrpi/csci4430). 