### PR TITLE
[Feature:Autograding] expected files not in standard locations

### DIFF
--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -95,6 +95,12 @@ class GradeableAutocheck extends AbstractModel {
                 } else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }
+            // Try to find the file in the details directory. Do not print an error,
+            // as the file is likely student generated.
+            } else {
+                if(file_exists($results_path . "/details/" . $details["expected_file"])){
+                    $expected_file = $results_path . "/details/" . $details["expected_file"];
+                }
             }
         }
         


### PR DESCRIPTION
### What is the current behavior?
The autograding page's ```DiffViewer``` will only display an expected file if it resides in the ```test_output``` or ```random_output``` directories.

### What is the new behavior?
The ```DiffViewer``` is capable of displaying an expected file anywhere within the ```details``` directory.