### PR TITLE
[Testing:Bugfix] Add brief wait after jQuery.active reports 0 for ajax

### DIFF
--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 from datetime import date
 import os
+import time
 import unittest
 
 from urllib.parse import urlencode
@@ -154,6 +155,7 @@ class BaseTestCase(unittest.TestCase):
 
     def wait_after_ajax(self):
         WebDriverWait(self.driver, 10).until(lambda driver: driver.execute_script("return jQuery.active == 0"))
+        time.sleep(0.5)
 
     @staticmethod
     def wait_user_input():

--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -155,6 +155,10 @@ class BaseTestCase(unittest.TestCase):
 
     def wait_after_ajax(self):
         WebDriverWait(self.driver, 10).until(lambda driver: driver.execute_script("return jQuery.active == 0"))
+        # FIXME
+        # A hacky solution for where the response for jQuery.ajax may take a bit of time to process,
+        # which happens after jQuery.active starts returning 0 and this function returns.
+        # see #4511
         time.sleep(0.5)
 
     @staticmethod

--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -66,7 +66,7 @@ class TestForum(BaseTestCase):
         self.driver.find_element_by_xpath("//input[@value='Submit Post']").click()
         if len([cat for cat in categories_list if cat[1]]) == 0:
             # Test thread should not be created
-            self.driver.switch_to.alert.accept();
+            self.driver.switch_to.alert.accept()
             self.switch_to_page_view_thread()
             assert not self.thread_exists(title)
             return None


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Partial hack for #4511. Currently, tests may fail sporadically as the time it takes to process the completed jQuery.ajax call may extend time it takes for `wait_after_ajax` and some next line of code to complete.

### What is the new behavior?
Adds hack for getting the failing tests to pass more reliable, but should be replaced with a more concrete and permanent solution that will not fail on this race condition, regardless of AJAX response time.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
