### PR TITLE
[Refactor:Discussion Forum] No categories in Discussion Forum improvements

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -31,7 +31,7 @@
                 <div class="option-title">Enable Discussion Forum</div>
                 <div class="option-alt">Choose whether to enable a forum for this course.</div>
                 {% if categories_empty %}
-                    <h4 id="enable-forum-warning" class="red-message">Categories must be created in order to use the Discussion Forum. Click the link below to add categories.</h4>
+                    <h4 id="forum-category-warning" class="red-message">Categories must be created in order to use the Discussion Forum. Click the link below to add categories.</h4>
                 {% endif %}
                 <a id="forum-enabled-message" href="{{ manage_categories_url }}" alt="Customize Categories">Customize categories.</a>
             </label>
@@ -231,19 +231,3 @@
         </div>
     </div>
 </div>
-
-<script type="text/javascript">
-   $(document).ready(function(){
-        $('#enable-forum-warning').hide();
-        var no_categories = "{{categories_empty}}" === "1";
-
-        if (no_categories && $('#forum-enabled').is(':checked')){
-            $('#enable-forum-warning').show();
-        }
-        $('#forum-enabled').change(function(){
-            if (no_categories) {
-                $('#enable-forum-warning').toggle();
-            }
-        });
-   });
-</script>

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -30,6 +30,9 @@
             <label for="forum-enabled">
                 <div class="option-title">Enable Discussion Forum</div>
                 <div class="option-alt">Choose whether to enable a forum for this course.</div>
+                {% if categories_empty %}
+                    <h4 id="enable-forum-warning" class="red-message">Categories must be created in order to use the Discussion Forum. Click the link below to add categories.</h4>
+                {% endif %}
                 <a id="forum-enabled-message" href="{{ manage_categories_url }}" alt="Customize Categories">Customize categories.</a>
             </label>
         </div>
@@ -228,3 +231,19 @@
         </div>
     </div>
 </div>
+
+<script type="text/javascript">
+   $(document).ready(function(){
+        $('#enable-forum-warning').hide();
+        var no_categories = "{{categories_empty}}" === "1";
+
+        if (no_categories && $('#forum-enabled').is(':checked')){
+            $('#enable-forum-warning').show();
+        }
+        $('#forum-enabled').change(function(){
+            if (no_categories) {
+                $('#enable-forum-warning').toggle();
+            }
+        });
+   });
+</script>

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -56,6 +56,30 @@
 
         </div>
     </div>
+    {# Template Category used to display new categoreis on the client side #}
+    <ul id='ui-category-template' style="padding-left: 1em; display: none;">
+        <li id="categorylistitem-0" class="category-sortable" style="color: #000000; display: none;">
+            <i class="fas fa-bars handle" aria-hidden="true" title="Drag to reorder"></i>
+            <span class="categorylistitem-desc">
+                <span style="word-wrap: break-word;">Template</span>
+                <a class="post_button" title="Edit Category Description"><i class="fas fa-edit" aria-hidden="true"></i></a>
+                </span>
+            <span class="categorylistitem-editdesc" style="display: none;">
+                <input type="text" placeholder="New Description of Category" style="padding: 0;" maxlength="50" onkeyup="checkInputMaxLength($(this))">
+                <a class="post_button" title="Save Changes"><i class="fas fa-check" aria-hidden="true"></i></a>
+                <a class="post_button" title="Cancel Changes"><i class="fas fa-times" aria-hidden="true"></i></a>
+                </span>
+            <div style="float: right;width: auto;">
+                <select class='category-color-picker' style="color: white;font-size: 14px;height: 18px;padding: 0px;">
+                    {% for color_name, color_code in category_colors %}
+                        <option value="{{ color_code }}" style="color: white;background-color: {{ color_code }};" {% if color_code == category.color %}selected="selected"{% endif %}>{{ color_name }}</option>
+                    {% endfor %}
+                </select>
+                &nbsp;
+                <a class="post_button" title="Delete Category"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            </div>
+        </li>
+    </ul>
 </div>
 
 <script type="text/javascript">

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -30,7 +30,7 @@
         <ul id='ui-category-list' style="padding-left: 1em;">
             {# TODO: scrollbar #}
             {% for category in categories %}
-                <li id="categorylistitem-{{ category.category_id }}" {% if loop.index != 1 %} class="category-sortable"{% endif %} style="color: {{ category.color }}; {% if loop.index == 1 %}display: none;{% endif %}">
+                <li id="categorylistitem-{{ category.category_id }}" class="category-sortable" style="color: {{ category.color }};">
                     <i class="fas fa-bars handle" aria-hidden="true" title="Drag to reorder"></i>
                     <span class="categorylistitem-desc">
                             <span style="word-wrap: break-word;">{{ category.category_desc }}</span>

--- a/site/app/templates/forum/ShowForumThreads.twig
+++ b/site/app/templates/forum/ShowForumThreads.twig
@@ -49,7 +49,39 @@
             "show_filter": true
         } %}
 
-        <h4 class="text-center">A thread hasn't been created yet. Be the first to do so!</h4>
+        {# discussion forum with no categories #}
+        {% if categories | length  == 0 %}
+            {% if accessGrading == true %}
+                <h4 class="text-center red-message">
+                    No categories have been created yet. Please create categories to use the Discussion Forum
+                </h4>
+                <a class= "text-center" id="forum-enabled-message" href="{{ manage_categories_url }}" alt="Customize Categories">Customize categories.</a>
+
+            {% else %}
+                <h4 class="text-center red-message">No categories have been created yet. Please contact your instructor.</h4>
+            
+            {% endif %}
+            <pre class="text-center red-message">           ,-.
+       ,--' ~.).
+     ,'         `.
+    ; (((__   __)))
+    ;  ( (#) ( (#)
+    |   \_/___\_/|
+   ,"  ,-'    `__".
+               (   ( ._   ____`.)--._        _
+                `._ `-.`-' \(`-'  _  `-. _,-' `-/`.
+                 ,')   `.`._))  ,' `.   `.  ,','  ;
+               .'  .     `--'  /     ).   `.      ;
+              ;     `-        /     '  )         ;
+              \                       ')       ,'
+               \                     ,'       ;
+                \               `~~~'       ,'
+                 `.                      _,'
+                   `.                ,--'
+                     `-._________,--'</pre> 
+        {% else %}    
+            <h4 class="text-center">A thread hasn't been created yet. Be the first to do so!</h4>
+        {% endif %} 
 
     {% else %}
 

--- a/site/app/templates/forum/ShowForumThreads.twig
+++ b/site/app/templates/forum/ShowForumThreads.twig
@@ -27,28 +27,6 @@
 <div class="full_height content forum_content forum_show_threads">
 
     {% if thread_exists == false %}
-
-        {%  include "forum/ForumBar.twig" with {
-            "current_thread" : button_params.current_thread,
-            "forum_bar_buttons_right" : button_params.forum_bar_buttons_right,
-            "show_more" : button_params.show_more,
-            "forum_bar_buttons_left" : button_params.forum_bar_buttons_left,
-            "show_threads" : button_params.show_threads,
-            "thread_exists" : button_params.thread_exists,
-            "categories" : filterFormData.categories,
-            "current_thread" : filterFormData.current_thread,
-            "current_category_ids" : filterFormData.current_category_ids,
-            "current_course" : filterFormData.current_course,
-            "cookie_selected_categories" : filterFormData.cookie_selected_categories,
-            "cookie_selected_thread_status" : filterFormData.cookie_selected_thread_status,
-            "cookie_selected_unread_value" : filterFormData.cookie_selected_unread_value,
-            "display_option" : filterFormData.display_option,
-            "thread_exists" : filterFormData.thread_exists,
-            "attachment_all_button" : generate_post_content.attachment_all_button,
-            "total_attachments" : generate_post_content.total_attachments,
-            "show_filter": true
-        } %}
-
         {# discussion forum with no categories #}
         {% if categories | length  == 0 %}
             {% if accessGrading == true %}
@@ -60,26 +38,28 @@
             {% else %}
                 <h4 class="text-center red-message">No categories have been created yet. Please contact your instructor.</h4>
             
-            {% endif %}
-            <pre class="text-center red-message">           ,-.
-       ,--' ~.).
-     ,'         `.
-    ; (((__   __)))
-    ;  ( (#) ( (#)
-    |   \_/___\_/|
-   ,"  ,-'    `__".
-               (   ( ._   ____`.)--._        _
-                `._ `-.`-' \(`-'  _  `-. _,-' `-/`.
-                 ,')   `.`._))  ,' `.   `.  ,','  ;
-               .'  .     `--'  /     ).   `.      ;
-              ;     `-        /     '  )         ;
-              \                       ')       ,'
-               \                     ,'       ;
-                \               `~~~'       ,'
-                 `.                      _,'
-                   `.                ,--'
-                     `-._________,--'</pre> 
-        {% else %}    
+            {% endif %} 
+        {% else %} 
+            {%  include "forum/ForumBar.twig" with {
+                "current_thread" : button_params.current_thread,
+                "forum_bar_buttons_right" : button_params.forum_bar_buttons_right,
+                "show_more" : button_params.show_more,
+                "forum_bar_buttons_left" : button_params.forum_bar_buttons_left,
+                "show_threads" : button_params.show_threads,
+                "thread_exists" : button_params.thread_exists,
+                "categories" : filterFormData.categories,
+                "current_thread" : filterFormData.current_thread,
+                "current_category_ids" : filterFormData.current_category_ids,
+                "current_course" : filterFormData.current_course,
+                "cookie_selected_categories" : filterFormData.cookie_selected_categories,
+                "cookie_selected_thread_status" : filterFormData.cookie_selected_thread_status,
+                "cookie_selected_unread_value" : filterFormData.cookie_selected_unread_value,
+                "display_option" : filterFormData.display_option,
+                "thread_exists" : filterFormData.thread_exists,
+                "attachment_all_button" : generate_post_content.attachment_all_button,
+                "total_attachments" : generate_post_content.total_attachments,
+                "show_filter": true
+            } %}   
             <h4 class="text-center">A thread hasn't been created yet. Be the first to do so!</h4>
         {% endif %} 
 

--- a/site/app/views/admin/ConfigurationView.php
+++ b/site/app/views/admin/ConfigurationView.php
@@ -10,9 +10,11 @@ class ConfigurationView extends AbstractView {
         $this->core->getOutput()->addInternalJs("configuration.js");
         $this->core->getOutput()->addInternalCss("configuration.css");
         $this->core->getOutput()->addBreadcrumb('Course Settings');
+        $categories = empty($this->core->getQueries()->getCategories());
         return $this->core->getOutput()->renderTwigTemplate("admin/Configuration.twig", [
             "fields" => $fields,
             "gradeable_seating_options" => $gradeable_seating_options,
+            "categories_empty" => $categories,
             "theme_url" => $this->core->buildCourseUrl(['theme']),
             "email_room_seating_url" => $this->core->buildCourseUrl(['email_room_seating']),
             "manage_categories_url" => $this->core->buildCourseUrl(['forum', 'categories']),

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -344,6 +344,8 @@ class ForumThreadView extends AbstractView {
                 "display_thread_count" => empty($displayThreadContent) ? 0 : count($displayThreadContent["thread_content"]),
                 "currentThread" => $currentThread,
                 "currentCourse" => $currentCourse,
+                "accessGrading" => $this->core->getUser()->accessGrading(),
+                "manage_categories_url" => $this->core->buildCourseUrl(['forum', 'categories']),
                 "generate_post_content" => $generatePostContent,
                 "thread_resolve_state" => $thread_resolve_state,
                 "display_option" => $display_option,
@@ -955,6 +957,10 @@ class ForumThreadView extends AbstractView {
 			$this->core->redirect($this->core->buildCourseUrl());
 			return;
 		}
+        if(empty($this->core->getQueries()->getCategories())){
+            $this->core->redirect($this->core->buildCourseUrl(["forum", "threads"]));
+            return;
+        }
 
         $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
         $this->core->getOutput()->addBreadcrumb("Create Thread", $this->core->buildCourseUrl(['forum', 'threads', 'new']));
@@ -975,8 +981,8 @@ class ForumThreadView extends AbstractView {
 
         $categories = $this->core->getQueries()->getCategories();
 
-        $dummy_category = array('color' => '#000000', 'category_desc' => 'dummy', 'category_id' => "dummy");
-        array_unshift($categories, $dummy_category);
+        // $dummy_category = array('color' => '#000000', 'category_desc' => 'dummy', 'category_id' => "dummy");
+        // array_unshift($categories, $dummy_category);
 
 
         $buttons = array(
@@ -1032,8 +1038,8 @@ class ForumThreadView extends AbstractView {
         if($this->core->getUser()->accessGrading()){
             $categories = $this->core->getQueries()->getCategories();
 
-            $dummy_category = array('color' => '#000000', 'category_desc' => 'dummy', 'category_id' => "dummy");
-            array_unshift($categories, $dummy_category);
+            // $dummy_category = array('color' => '#000000', 'category_desc' => 'dummy', 'category_id' => "dummy");
+            // array_unshift($categories, $dummy_category);
         }
 
         $buttons = array(

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -981,10 +981,6 @@ class ForumThreadView extends AbstractView {
 
         $categories = $this->core->getQueries()->getCategories();
 
-        // $dummy_category = array('color' => '#000000', 'category_desc' => 'dummy', 'category_id' => "dummy");
-        // array_unshift($categories, $dummy_category);
-
-
         $buttons = array(
             array(
                 "required_rank" => 4,
@@ -1037,9 +1033,6 @@ class ForumThreadView extends AbstractView {
 
         if($this->core->getUser()->accessGrading()){
             $categories = $this->core->getQueries()->getCategories();
-
-            // $dummy_category = array('color' => '#000000', 'category_desc' => 'dummy', 'category_id' => "dummy");
-            // array_unshift($categories, $dummy_category);
         }
 
         $buttons = array(

--- a/site/public/js/configuration.js
+++ b/site/public/js/configuration.js
@@ -3,10 +3,21 @@ $(document).ready(function() {
     updateEmailSeatingOption();
 
     function updateForumMessage() {
+        updateForumCategoryWarning();
         if ($("#forum-enabled").is(":checked")) {
             $("#forum-enabled-message").show();
         } else {
             $("#forum-enabled-message").hide();
+        }
+    }
+
+    function updateForumCategoryWarning() {
+        if ($("#forum-category-warning").length) {
+            if ($("#forum-enabled").is(":checked")) {
+                $("#forum-category-warning").show();
+            } else {
+                $("#forum-category-warning").hide();
+            }
         }
     }
 

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -703,7 +703,7 @@ function addNewCategory(csrf_token){
             var category_id = json['data']['new_id'];
             var category_color_code = "#000080";
             var category_desc = escapeSpecialChars(newCategory);
-            newelement = $($('#ui-category-list li')[0]).clone(true);
+            newelement = $($('#ui-category-template li')[0]).clone(true);
             newelement.attr('id',"categorylistitem-"+category_id);
             newelement.css('color',category_color_code);
             newelement.find(".categorylistitem-desc span").text(category_desc);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Couldn't find an issue, this was requested at the 9/14 Hackathon. 

If an instructor does not create categories, they can still view the page to create new threads which will show the "dummy" category.
 
### What is the new behavior?

 - Dummy category is removed.
 - Cannot create a thread if there are no categories (url redirects). 
 - Notification messages for graders to create categories and for students to contact an instructor to     create categories to use the forum.
- When the forum is enabled in the course settings page, the instructor is notified to create categories if they have not done so.


