### PR TITLE
[Bugfix:TaGrading] Fix links to point at appropriate user_ids for Mark Statistics

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1565,9 +1565,11 @@ function openMarkStatsPopup(component_title, mark_title, stats) {
 
     // Create an array of links for each submitter
     let submitterHtmlElements = [];
+    let [base_url, search_params] = location.href.split('?');
+    search_params = new URLSearchParams(search_params);
     stats.submitter_ids.forEach(function (id) {
-        let href = window.location.href.replace(/&who_id=([a-z0-9_]*)/, '&who_id=' + id);
-        submitterHtmlElements.push('<a href="' + href + '">' + id + '</a>');
+        search_params.set('who_id', id);
+        submitterHtmlElements.push(`<a href="${base_url}?${search_params.toString()}">${id}</a>`);
     });
     popup.find('.student-names').html(submitterHtmlElements.join(', '));
 
@@ -1773,7 +1775,7 @@ function onGetMarkStats(me) {
         .then(function (stats) {
             let component_title = getComponentFromDOM(component_id).title;
             let mark_title = getMarkFromDOM(mark_id).title;
-            
+
             openMarkStatsPopup(component_title, mark_title, stats);
         })
         .catch(function (err) {
@@ -2459,12 +2461,12 @@ function scrollToPage(page_num){
             let page_margin_top = 0;
             let page_margin_bot = 0;
             if (page1.length) {
-                //get css attr, remove 'px' : 
+                //get css attr, remove 'px' :
                 page_height = parseInt(page1.css("height").slice(0, -2));
                 page_margin_top = parseInt(page1.css("margin-top").slice(0, -2));
                 page_margin_bot = parseInt(page1.css("margin-bottom").slice(0, -2));
             }
-            // assuming margin-top < margin-bot: it overlaps on all pages but 1st so we add it once 
+            // assuming margin-top < margin-bot: it overlaps on all pages but 1st so we add it once
             let scrollY = (page_num-1)*(page_height+page_margin_bot)+page_margin_top;
             if($("#file_view").is(":visible")){
                 $('#file_content').animate({scrollTop: scrollY}, 500);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4523 

Urls for students in the Mark Statistics box did not point at the right user_id (they all pointed at the user_id of the currently viewed student).

### What is the new behavior?
Urls now point at the appropriate student, as well as updating the JavaScript here to be a bit more "future-proof" if the URL structure or order of params changes in the future.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested by following the steps to reproduce in the issue, once to see the bug, and then after installing this patch to see if it was fixed. This is only place this function/code is used.

[URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/keys), [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), and [array destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Array_destructuring) are all available on all supported browsers.