### PR TITLE
[Refactor] Remove empty, unused, old Gradeable model

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -9,7 +9,6 @@ use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\libraries\ForumUtils;
 use app\libraries\GradeableType;
-use app\models\Gradeable;
 use app\models\gradeable\Component;
 use app\models\gradeable\GradedComponent;
 use app\models\gradeable\GradedGradeable;

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -6,7 +6,6 @@ use app\exceptions\DatabaseException;
 use app\exceptions\ValidationException;
 use app\libraries\CascadingIterator;
 use \app\libraries\GradeableType;
-use app\models\Gradeable;
 use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\Component;
 use app\models\gradeable\GradedComponent;
@@ -49,10 +48,10 @@ class PostgresqlDatabaseQueries extends DatabaseQueries{
                  ns.self_notification,
                  ns.merge_threads_email, ns.all_new_threads_email,
                  ns.all_new_posts_email, ns.all_modifications_forum_email,
-                 ns.reply_in_post_thread_email, ns.team_invite_email, 
+                 ns.reply_in_post_thread_email, ns.team_invite_email,
                  ns.team_member_submission_email, ns.team_joined_email,
                  ns.self_notification_email,sr.grading_registration_sections
-     
+
             FROM users u
             LEFT JOIN notification_settings as ns ON u.user_id = ns.user_id
             LEFT JOIN (

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -2,7 +2,6 @@
 
 namespace app\views;
 
-use app\models\Gradeable;
 use app\models\gradeable\AutoGradedTestcase;
 use app\models\gradeable\AutoGradedVersion;
 use app\models\gradeable\Component;
@@ -11,9 +10,7 @@ use app\models\gradeable\TaGradedGradeable;
 use app\models\User;
 use app\views\AbstractView;
 use app\libraries\FileUtils;
-use app\libraries\Utils;
 use app\libraries\DateUtils;
-use function GuzzleHttp\Psr7\build_query;
 
 class AutoGradingView extends AbstractView {
 

--- a/site/app/views/LateDaysTableView.php
+++ b/site/app/views/LateDaysTableView.php
@@ -2,8 +2,6 @@
 
 namespace app\views;
 
-use app\libraries\GradeableType;
-use app\models\Gradeable;
 use app\views\AbstractView;
 use app\models\gradeable\LateDays;
 
@@ -29,4 +27,3 @@ class LateDaysTableView extends AbstractView {
         ]);
     }
 }
-

--- a/site/tests/app/libraries/AccessTester.php
+++ b/site/tests/app/libraries/AccessTester.php
@@ -4,15 +4,10 @@ namespace tests\app\libraries;
 
 use app\libraries\Access;
 use app\libraries\Core;
-use app\models\Gradeable;
-use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\Submitter;
-use app\models\gradeable\TaGradedGradeable;
 use app\models\Team;
 use app\models\User;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use tests\BaseUnitTest;
 
 class AccessTester extends BaseUnitTest {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Empty file got re-introduced at some point

### What is the new behavior?
Removes the file, and all remaining references to it.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
No, not breaking, file was empty and not used beyond for a handful of `use` lines which did not execute.