### PR TITLE
[Bugfix] drag-and-drop would not print JSON.parse error to console in some cases

### DIFF
--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -949,6 +949,7 @@ function handleDownloadImages(csrf_token) {
             catch (e) {
                 alert("Error parsing response from server. Please copy the contents of your Javascript Console and " +
                     "send it to an administrator, as well as what you were doing and what files you were uploading.");
+                console.log(data);
             }
         },
         error: function(data) {
@@ -1042,6 +1043,7 @@ function handleUploadCourseMaterials(csrf_token, expand_zip, cmPath, requested_p
             catch (e) {
                 alert("Error parsing response from server. Please copy the contents of your Javascript Console and " +
                     "send it to an administrator, as well as what you were doing and what files you were uploading. - [handleUploadCourseMaterials]");
+                console.log(data);
             }
         },
         error: function(data) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Noticed while fixing #4530, that in some cases the AJAX call would fail, a message would alert saying to check JS console, but nothing would be printed.

### What is the new behavior?
Adds a print to the JS console for two JSON.parse cases that would explicitly tell users to look at the JS console in case of failure.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Not breaking, tested while fixing #4530.