### PR TITLE
Revert "[Refactor] Remove empty, unused, old Gradeable model (#4532)"

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -9,6 +9,7 @@ use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\libraries\ForumUtils;
 use app\libraries\GradeableType;
+use app\models\Gradeable;
 use app\models\gradeable\Component;
 use app\models\gradeable\GradedComponent;
 use app\models\gradeable\GradedGradeable;

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -6,6 +6,7 @@ use app\exceptions\DatabaseException;
 use app\exceptions\ValidationException;
 use app\libraries\CascadingIterator;
 use \app\libraries\GradeableType;
+use app\models\Gradeable;
 use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\Component;
 use app\models\gradeable\GradedComponent;
@@ -48,10 +49,10 @@ class PostgresqlDatabaseQueries extends DatabaseQueries{
                  ns.self_notification,
                  ns.merge_threads_email, ns.all_new_threads_email,
                  ns.all_new_posts_email, ns.all_modifications_forum_email,
-                 ns.reply_in_post_thread_email, ns.team_invite_email,
+                 ns.reply_in_post_thread_email, ns.team_invite_email, 
                  ns.team_member_submission_email, ns.team_joined_email,
                  ns.self_notification_email,sr.grading_registration_sections
-
+     
             FROM users u
             LEFT JOIN notification_settings as ns ON u.user_id = ns.user_id
             LEFT JOIN (

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -2,6 +2,7 @@
 
 namespace app\views;
 
+use app\models\Gradeable;
 use app\models\gradeable\AutoGradedTestcase;
 use app\models\gradeable\AutoGradedVersion;
 use app\models\gradeable\Component;
@@ -10,7 +11,9 @@ use app\models\gradeable\TaGradedGradeable;
 use app\models\User;
 use app\views\AbstractView;
 use app\libraries\FileUtils;
+use app\libraries\Utils;
 use app\libraries\DateUtils;
+use function GuzzleHttp\Psr7\build_query;
 
 class AutoGradingView extends AbstractView {
 

--- a/site/app/views/LateDaysTableView.php
+++ b/site/app/views/LateDaysTableView.php
@@ -2,6 +2,8 @@
 
 namespace app\views;
 
+use app\libraries\GradeableType;
+use app\models\Gradeable;
 use app\views\AbstractView;
 use app\models\gradeable\LateDays;
 
@@ -27,3 +29,4 @@ class LateDaysTableView extends AbstractView {
         ]);
     }
 }
+

--- a/site/tests/app/libraries/AccessTester.php
+++ b/site/tests/app/libraries/AccessTester.php
@@ -4,10 +4,15 @@ namespace tests\app\libraries;
 
 use app\libraries\Access;
 use app\libraries\Core;
+use app\models\Gradeable;
+use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\Submitter;
+use app\models\gradeable\TaGradedGradeable;
 use app\models\Team;
 use app\models\User;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use tests\BaseUnitTest;
 
 class AccessTester extends BaseUnitTest {


### PR DESCRIPTION
Oh no! Something irrecoverable has happened...

Reverting this PR.  It 



When I go here:  (also for other gradeables)
http://192.168.56.111/f19/sample/gradeable/grading_homework/grading/status


I get this frog robot.

TypeError (Code: 0) thrown in /usr/local/submitty/site/app/libraries/database/PostgresqlDatabaseQueries.php (Line 1612) by:
    public function getActiveVersions(Gradeable\Gradeable $gradeable, array $submitter_ids) {


Message:
Argument 1 passed to app\libraries\database\PostgresqlDatabaseQueries::getActiveVersions() must be an instance of app\libraries\database\Gradeable\Gradeable, instance of app\models\gradeable\Gradeable given, called in /usr/local/submitty/site/app/models/GradingOrder.php on line 100

Stack Trace:
#0 /usr/local/submitty/site/app/models/GradingOrder.php(100): app\libraries\database\PostgresqlDatabaseQueries->getActiveVersions(app\models\gradeable\Gradeable, Array)
#1 /usr/local/submitty/site/app/controllers/grading/ElectronicGraderController.php(307): app\models\GradingOrder->__construct(app\libraries\Core, app\models\gradeable\Gradeable, app\models\User, true)
#2 unknown file(unknown line): app\controllers\grading\ElectronicGraderController->showStatus('grading_homework')
#3 /usr/local/submitty/site/app/libraries/routers/WebRouter.php(169): call_user_func_array(Array, Array)
#4 /usr/local/submitty/site/app/libraries/routers/WebRouter.php(147): app\libraries\routers\WebRouter->run()
#5 /usr/local/submitty/site/public/index.php(122): app\libraries\routers\WebRouter::getWebResponse(Symfony\Component\HttpFoundation\Request, app\libraries\Core)

