### PR TITLE
[Bugfix:StudentPhotos] Fix call to removed FileUtils function

### DIFF
--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -34,6 +34,7 @@ import sys
 import configparser
 import csv
 import pdb
+from tempfile import TemporaryDirectory
 
 from submitty_utils import dateutils
 
@@ -289,7 +290,7 @@ def generate_random_users(total, real_users):
             user_id = last_name.replace("'", "")[:5] + first_name[0]
             user_id = user_id.lower()
             anon_id = generate_random_user_id(15)
-            #create a binary string for the numeric ID 
+            #create a binary string for the numeric ID
             numeric_id = '{0:09b}'.format(i)
             while user_id in user_ids or user_id in real_users:
                 if user_id[-1].isdigit():
@@ -990,6 +991,16 @@ class Course(object):
         self.conn.close()
         submitty_conn.close()
         os.environ['PGPASSWORD'] = ""
+
+        if self.code == 'sample':
+            student_image_folder = os.path.join(SUBMITTY_DATA_DIR, 'courses', self.semester, self.code, 'uploads', 'student_images')
+            zip_path = os.path.join(SUBMITTY_REPOSITORY, 'sample_files', 'user_photos', 'CSCI-1300-01.zip')
+            with TemporaryDirectory() as tmpdir:
+                with ZipFile(zip_path) as open_file:
+                    open_file.extractall(tmpdir)
+                inner_folder = os.path.join(tmpdir, 'CSCI-1300-01')
+                for f in os.listdir(inner_folder):
+                    shutil.move(os.path.join(inner_folder, f), os.path.join(student_image_folder, f))
 
     def check_rotating(self, users):
         for gradeable in self.gradeables:

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1013,7 +1013,7 @@ class SubmissionController extends AbstractController {
 
             // Determine the size of the uploaded files as well as whether or not they're a zip or not.
             // We save that information for later so we know which files need unpacking or not and can save
-            // a check to getMimeType()
+            // a check for its mime type
             $file_size = 0;
             for ($i = 1; $i <= $num_parts; $i++) {
                 if (isset($uploaded_files[$i])) {

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -37,7 +37,7 @@ class ImagesView extends AbstractView {
         foreach ($dir as $fileinfo) {
             if (!$fileinfo->isDot() && !$fileinfo->isDir()) {
                 $expected_image = $fileinfo->getPathname();
-                $mime_subtype = explode('/', FileUtils::getMimeType($expected_image), 2)[1];
+                $mime_subtype = explode('/', mime_content_type($expected_image), 2)[1];
                 if (FileUtils::isValidImage($expected_image)) {
                     $img_name = $fileinfo->getBasename('.' . $fileinfo->getExtension());
                     if ($img_name === "error_image") {

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -29,7 +29,8 @@ class TestSidebar(BaseTestCase):
                 [link.find_element_by_tag_name('a').get_attribute('href'), link.text]
                 for link in links
             ]
-
+            self.assertListEqual(expected, actual)
+            
             a = links[current_idx].find_element_by_tag_name('a')
             href = a.get_attribute('href')
             if not href.startswith(base_url):
@@ -39,7 +40,6 @@ class TestSidebar(BaseTestCase):
                 current_idx += 1
                 continue
 
-            self.assertListEqual(expected, actual)
             links[current_idx].click()
             WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(
                 EC.presence_of_element_located((By.TAG_NAME, 'h1'))

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -1,0 +1,111 @@
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+
+from .base_testcase import BaseTestCase
+
+
+class TestSidebar(BaseTestCase):
+    def __init__(self, testname):
+        super().__init__(testname, log_in=False)
+
+    def sidebar_test_helper(self, expected, user_id, user_name):
+        self.log_in(user_id=user_id, user_name=user_name)
+        self.click_class('sample')
+        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+
+        title_map = {
+            'Manage Sections': 'Manage Registration Sections',
+            'Plagiarism Detection': 'Plagiarism Detection -- WORK IN PROGRESS',
+            'My Late Days/Extensions': 'My Late Day Usage'
+        }
+
+        current_idx = 0
+
+        while current_idx < len(expected):
+            nav = self.driver.find_element_by_tag_name('aside')
+            links = nav.find_elements_by_tag_name('li')
+            actual = [
+                [link.find_element_by_tag_name('a').get_attribute('href'), link.text]
+                for link in links
+            ]
+
+            a = links[current_idx].find_element_by_tag_name('a')
+            href = a.get_attribute('href')
+            if not href.startswith(base_url):
+                current_idx += 1
+                continue
+            elif a.text.startswith('Logout'):
+                current_idx += 1
+                continue
+
+            self.assertListEqual(expected, actual)
+            links[current_idx].click()
+            WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(
+                EC.presence_of_element_located((By.TAG_NAME, 'h1'))
+            )
+
+            expected_text = expected[current_idx][1]
+            if expected_text in title_map:
+                expected_text = title_map[expected_text]
+
+            self.assertEqual(
+                expected_text,
+                self.driver.find_element_by_id('main')
+                    .find_elements_by_tag_name('h1')[0].text
+            )
+            current_idx += 1
+
+    def test_click_sidebar_links_instructor(self):
+        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        expected = [
+            [base_url, 'Gradeables'],
+            [base_url + '/notifications', 'Notifications'],
+            [base_url + '/gradeable', 'New Gradeable'],
+            [base_url + '/config', 'Course Settings'],
+            [base_url + '/course_materials', 'Course Materials'],
+            [base_url + '/forum', 'Discussion Forum'],
+            [base_url + '/users', 'Manage Students'],
+            [base_url + '/graders', 'Manage Graders'],
+            [base_url + '/sections', 'Manage Sections'],
+            [base_url + '/student_photos', 'Student Photos'],
+            [base_url + '/late_days', 'Late Days Allowed'],
+            [base_url + '/extensions', 'Excused Absence Extensions'],
+            [base_url + '/grade_override', 'Grade Override'],
+            [base_url + '/plagiarism', 'Plagiarism Detection'],
+            [base_url + '/reports', 'Grade Reports'],
+            [base_url + '/late_table', 'My Late Days/Extensions'],
+            ['javascript: toggleSidebar();', 'Collapse Sidebar'],
+            [BaseTestCase.TEST_URL + '/authentication/logout', 'Logout Quinn']
+        ]
+
+        self.sidebar_test_helper(expected, 'instructor', 'Quinn')
+
+    def test_click_sidebar_links_ta(self):
+        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        expected = [
+            [base_url, 'Gradeables'],
+            [base_url + '/notifications', 'Notifications'],
+            [base_url + '/course_materials', 'Course Materials'],
+            [base_url + '/forum', 'Discussion Forum'],
+            [base_url + '/student_photos', 'Student Photos'],
+            [base_url + '/late_table', 'My Late Days/Extensions'],
+            ['javascript: toggleSidebar();', 'Collapse Sidebar'],
+            [BaseTestCase.TEST_URL + '/authentication/logout', 'Logout Jill']
+        ]
+
+        self.sidebar_test_helper(expected, 'ta', 'Jill')
+
+    def test_click_sidebar_links_student(self):
+        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        expected = [
+            [base_url, 'Gradeables'],
+            [base_url + '/notifications', 'Notifications'],
+            [base_url + '/course_materials', 'Course Materials'],
+            [base_url + '/forum', 'Discussion Forum'],
+            [base_url + '/late_table', 'My Late Days/Extensions'],
+            ['javascript: toggleSidebar();', 'Collapse Sidebar'],
+            [BaseTestCase.TEST_URL + '/authentication/logout', 'Logout Joe']
+        ]
+
+        self.sidebar_test_helper(expected, 'student', 'Joe')

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -86,7 +86,8 @@ class TestSidebar(BaseTestCase):
         expected = [
             [base_url, 'Gradeables'],
             [base_url + '/notifications', 'Notifications'],
-            [base_url + '/course_materials', 'Course Materials'],
+            # sample course has no course materials to start, so this link will not appear
+            # [base_url + '/course_materials', 'Course Materials'],
             [base_url + '/forum', 'Discussion Forum'],
             [base_url + '/student_photos', 'Student Photos'],
             [base_url + '/late_table', 'My Late Days/Extensions'],
@@ -101,7 +102,8 @@ class TestSidebar(BaseTestCase):
         expected = [
             [base_url, 'Gradeables'],
             [base_url + '/notifications', 'Notifications'],
-            [base_url + '/course_materials', 'Course Materials'],
+            # sample course has no course materials in start, so this link will not appear
+            # [base_url + '/course_materials', 'Course Materials'],
             [base_url + '/forum', 'Discussion Forum'],
             [base_url + '/late_table', 'My Late Days/Extensions'],
             ['javascript: toggleSidebar();', 'Collapse Sidebar'],

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -12,7 +12,7 @@ class TestSidebar(BaseTestCase):
     def sidebar_test_helper(self, expected, user_id, user_name):
         self.log_in(user_id=user_id, user_name=user_name)
         self.click_class('sample')
-        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        base_url = self.test_url + '/' + self.get_current_semester() + '/sample'
 
         title_map = {
             'Manage Sections': 'Manage Registration Sections',
@@ -57,7 +57,7 @@ class TestSidebar(BaseTestCase):
             current_idx += 1
 
     def test_click_sidebar_links_instructor(self):
-        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        base_url = self.test_url + '/' + self.get_current_semester() + '/sample'
         expected = [
             [base_url, 'Gradeables'],
             [base_url + '/notifications', 'Notifications'],
@@ -76,13 +76,13 @@ class TestSidebar(BaseTestCase):
             [base_url + '/reports', 'Grade Reports'],
             [base_url + '/late_table', 'My Late Days/Extensions'],
             ['javascript: toggleSidebar();', 'Collapse Sidebar'],
-            [BaseTestCase.TEST_URL + '/authentication/logout', 'Logout Quinn']
+            [self.test_url + '/authentication/logout', 'Logout Quinn']
         ]
 
         self.sidebar_test_helper(expected, 'instructor', 'Quinn')
 
     def test_click_sidebar_links_ta(self):
-        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        base_url = self.test_url + '/' + self.get_current_semester() + '/sample'
         expected = [
             [base_url, 'Gradeables'],
             [base_url + '/notifications', 'Notifications'],
@@ -91,13 +91,13 @@ class TestSidebar(BaseTestCase):
             [base_url + '/student_photos', 'Student Photos'],
             [base_url + '/late_table', 'My Late Days/Extensions'],
             ['javascript: toggleSidebar();', 'Collapse Sidebar'],
-            [BaseTestCase.TEST_URL + '/authentication/logout', 'Logout Jill']
+            [self.test_url + '/authentication/logout', 'Logout Jill']
         ]
 
         self.sidebar_test_helper(expected, 'ta', 'Jill')
 
     def test_click_sidebar_links_student(self):
-        base_url = BaseTestCase.TEST_URL + '/' + self.get_current_semester() + '/sample'
+        base_url = self.test_url + '/' + self.get_current_semester() + '/sample'
         expected = [
             [base_url, 'Gradeables'],
             [base_url + '/notifications', 'Notifications'],
@@ -105,7 +105,7 @@ class TestSidebar(BaseTestCase):
             [base_url + '/forum', 'Discussion Forum'],
             [base_url + '/late_table', 'My Late Days/Extensions'],
             ['javascript: toggleSidebar();', 'Collapse Sidebar'],
-            [BaseTestCase.TEST_URL + '/authentication/logout', 'Logout Joe']
+            [self.test_url + '/authentication/logout', 'Logout Joe']
         ]
 
         self.sidebar_test_helper(expected, 'student', 'Joe')


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4542

Messed up fixing the file merge conflicts in a previous PR that was unrelated to student images.

### What is the new behavior?
Fixes viewing the student images page. I have modified `setup_sample_courses.py` to also extract one of the zips of fake student photos into the photos directory for the sample course.

To test that this page loads with images (and other pages load minimally), I've added three basic E2E tests that clicks each link in the sidebar as a student, TA, and instructor and checks that the header of the page matches an expected value.