### PR TITLE
Finer pdf zoom, fixed pdf autoscroll

### DIFF
--- a/site/public/css/pdf/pdf_embedded.css
+++ b/site/public/css/pdf/pdf_embedded.css
@@ -8,9 +8,19 @@
     cursor: default;
 }
 
+.pdfViewer {
+    display: flex;
+    flex-direction: column;
+}
+
 .pdfViewer .canvasWrapper {
     box-shadow: 0 0 3px var(--standard-light-medium-gray);
 }
 .pdfViewer .page {
-    margin-bottom: 10px;
+    /* describe all css properties independantly so js can read it easily across all platforms */
+    margin-top: 5px !important;
+    margin-right: auto !important;
+    margin-bottom: 5px !important;
+    margin-left: auto !important;
+    border: none !important;
 }

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -86,15 +86,10 @@ function render(gradeable_id, user_id, grader_id, file_name, page_num, url = "")
                     PDFAnnotate.UI.renderPage(page_id, window.RENDER_OPTIONS).then(function(){
                         if (i == page_num) {
                             // scroll to page on load
-                            let zoom = parseInt(localStorage.getItem('scale')) || 1;
-                            let page1 = $(".page").filter(":first");
-                            //get css attr, remove 'px' :
-                            let page_height = parseInt(page1.css("height").slice(0, -2));
-                            let page_margin_top = parseInt(page1.css("margin-top").slice(0, -2));
-                            let page_margin_bot = parseInt(page1.css("margin-bottom").slice(0, -2));
-                            // assuming margin-top < margin-bot: it overlaps on all pages but 1st so we add it once
-                            let scrollY = zoom*(page_num)*(page_height+page_margin_bot)+page_margin_top;
-                            $('#file_content').animate({scrollTop: scrollY}, 500);
+                            let initialPage = $("#pageContainer" + page_id);
+                            if(initialPage.length) {
+                                $('#file_content').animate({scrollTop: initialPage[0].offsetTop}, 500);
+                            }
                         }
                         document.getElementById('pageContainer'+page_id).addEventListener('mousedown', function(){
                             //Makes sure the panel don't move when writing on it.

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -104,9 +104,9 @@ window.onbeforeunload = function() {
         let zoom_flag = true;
         let zoom_level = window.RENDER_OPTIONS.scale;
         if(option == 'in'){
-            zoom_level += 1;
+            zoom_level += 0.1;
         } else if(option == 'out'){
-            zoom_level -= 1;
+            zoom_level -= 0.1;
         } else {
             if(custom_val != null){
                 zoom_level = custom_val/100;

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2451,25 +2451,14 @@ function openComponentGrading(component_id) {
  * @return {void}
  */
 function scrollToPage(page_num){
-    let files = $('.openable-element-submissions');
+    let files = $(".openable-element-submissions");
     for(let i = 0; i < files.length; i++){
-        let zoom = parseInt(localStorage.getItem('scale')) || 1;
         if(files[i].innerText.trim() == "upload.pdf"){
-            let page1 = $(".page").filter(":first");
-            // default to 0 if no pages
-            let page_height = 0;
-            let page_margin_top = 0;
-            let page_margin_bot = 0;
-            if (page1.length) {
-                //get css attr, remove 'px' :
-                page_height = parseInt(page1.css("height").slice(0, -2));
-                page_margin_top = parseInt(page1.css("margin-top").slice(0, -2));
-                page_margin_bot = parseInt(page1.css("margin-bottom").slice(0, -2));
-            }
-            // assuming margin-top < margin-bot: it overlaps on all pages but 1st so we add it once
-            let scrollY = (page_num-1)*(page_height+page_margin_bot)+page_margin_top;
+            let page = $("#pageContainer" + page_num);
             if($("#file_view").is(":visible")){
-                $('#file_content').animate({scrollTop: scrollY}, 500);
+                if(page.length) {
+                    $('#file_content').animate({scrollTop: page[0].offsetTop}, 500);
+                }
             } else {
                 expandFile("upload.pdf", files[i].getAttribute("file-url"), page_num-1);
             }


### PR DESCRIPTION
Closes #4528 

Previously zoom buttons on TA embedded PDFs would change by 100%, now it changes by 10% per click.

Attempted to fix a bug where zoom levels weren't working on all machines. I wasn't able to reproduce this on linux firefox, linux chrome, or windows firefox, but I slimmed some questionable code so hopefully it works now.