### PR TITLE
[Testing:Refactor] Remove Core::isTesting shim and use php-mock instead

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -143,21 +143,19 @@ class MiscController extends AbstractController {
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
 
-        if (!$this->core->isTesting()) {
-            $mime_type = mime_content_type($path);
-            if ($mime_type === 'text/plain') {
-                if (substr($path, '-3') === '.js') {
-                    $mime_type = 'application/javascript';
-                }
-                elseif (substr($path, '-4') === '.css') {
-                    $mime_type = 'text/css';
-                }
-                else if (substr($path, '-5') === '.html') {
-                    $mime_type = 'text/html';
-                }
+        $mime_type = mime_content_type($path);
+        if ($mime_type === 'text/plain') {
+            if (substr($path, '-3') === '.js') {
+                $mime_type = 'application/javascript';
             }
-            header('Content-type: ' . $mime_type);
+            elseif (substr($path, '-4') === '.css') {
+                $mime_type = 'text/css';
+            }
+            else if (substr($path, '-5') === '.html') {
+                $mime_type = 'text/html';
+            }
         }
+        header('Content-type: ' . $mime_type);
         readfile($path);
         return true;
     }

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -324,7 +324,7 @@ class CourseMaterialsController extends AbstractController {
         $count_item = count($status);
         if (isset($uploaded_files[1])) {
             for ($j = 0; $j < $count_item; $j++) {
-                if ($this->core->isTesting() || is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {
+                if (is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {
                     $dst = FileUtils::joinPaths($upload_path, $uploaded_files[1]["name"][$j]);
 
                     $is_zip_file = false;

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -144,7 +144,7 @@ class ImagesController extends AbstractController {
                     }
                 }
                 else {
-                    if ($this->core->isTesting() || is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {
+                    if (is_uploaded_file($uploaded_files[1]["tmp_name"][$j])) {
                         $dst = FileUtils::joinPaths($upload_img_path, $uploaded_files[1]["name"][$j]);
                         if (!@copy($uploaded_files[1]["tmp_name"][$j], $dst)) {
                             return $this->core->getOutput()->renderResultMessage("Failed to copy uploaded file {$uploaded_files[1]["name"][$j]} to current location.", false);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -325,7 +325,7 @@ class SubmissionController extends AbstractController {
         // delete the temporary file
         if (isset($uploaded_file)) {
             for ($j = 0; $j < $count; $j++) {
-                if ($this->core->isTesting() || is_uploaded_file($uploaded_file["tmp_name"][$j])) {
+                if (is_uploaded_file($uploaded_file["tmp_name"][$j])) {
                     $dst = FileUtils::joinPaths($version_path, $uploaded_file["name"][$j]);
                     if (!@copy($uploaded_file["tmp_name"][$j], $dst)) {
                         return $this->uploadResult("Failed to copy uploaded file {$uploaded_file["name"][$j]} to current submission.", false);
@@ -1077,7 +1077,7 @@ class SubmissionController extends AbstractController {
                             }
                         }
                         else {
-                            if ($this->core->isTesting() || is_uploaded_file($uploaded_files[$i]["tmp_name"][$j])) {
+                            if (is_uploaded_file($uploaded_files[$i]["tmp_name"][$j])) {
                                 $dst = FileUtils::joinPaths($part_path[$i], $uploaded_files[$i]["name"][$j]);
                                 if (!@copy($uploaded_files[$i]["tmp_name"][$j], $dst)) {
                                     return $this->uploadResult("Failed to copy uploaded file {$uploaded_files[$i]["name"][$j]} to current submission.", false);

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -75,12 +75,6 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
         else {
             $core->method('checkCsrfToken')->willReturn(true);
         }
-        if (isset($config_values['testing'])) {
-            $core->method('isTesting')->willReturn($config_values['testing'] === true);
-        }
-        else {
-            $core->method('isTesting')->willReturn(true);
-        }
 
         $mock_access = $this->createMock(Access::class);
         $mock_access->expects($this->any())->method('canI')->willReturnCallback(

--- a/site/tests/app/controllers/MiscControllerTester.php
+++ b/site/tests/app/controllers/MiscControllerTester.php
@@ -12,6 +12,8 @@ use app\models\User;
 use tests\utils\NullOutput;
 
 class MiscControllerTester extends \PHPUnit\Framework\TestCase {
+    use \phpmock\phpunit\PHPMock;
+
     private $tmp_dir = '';
 
     public function tearDown(): void {
@@ -35,10 +37,14 @@ class MiscControllerTester extends \PHPUnit\Framework\TestCase {
 
     /**
      * @dataProvider userDataProvider
+     * @runInSeparateProcess
      */
     public function testReadFileSite($user_details): void {
+        $this->getFunctionMock('app\controllers', 'header')
+            ->expects($this->once())
+            ->with('Content-type: text/css');
+
         $core = new Core();
-        $core->setTesting(true);
         $user = new User($core, $user_details);
         $core->setUser($user);
         $core->setOutput(new NullOutput($core));
@@ -68,7 +74,6 @@ class MiscControllerTester extends \PHPUnit\Framework\TestCase {
      */
     public function testReadFileDirectoryTraversal($user_details): void {
         $core = new Core();
-        $core->setTesting(true);
         $user = new User($core, $user_details);
         $core->setUser($user);
         $core->setOutput(new NullOutput($core));

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -6,12 +6,10 @@ use tests\BaseUnitTest;
 use app\controllers\course\CourseMaterialsController;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
-use app\libraries\Core;
-use app\libraries\Access;
-use \DateTime;
 use \ZipArchive;
 
-class CourseMaterialsTester extends BaseUnitTest{
+class CourseMaterialsControllerTester extends BaseUnitTest {
+    use \phpmock\phpunit\PHPMock;
 
     private $core;
     private $config;
@@ -85,7 +83,14 @@ class CourseMaterialsTester extends BaseUnitTest{
         return $files;
     }
 
-    public function testCourseMaterialsUpload(){
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCourseMaterialsUpload() {
+        $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $controller = new CourseMaterialsController($this->core);
 
         $name = "foo.txt";
@@ -119,7 +124,14 @@ class CourseMaterialsTester extends BaseUnitTest{
         $this->assertEquals($expected_files, $files);
     }
 
-    public function testZipCourseUpload(){
+    /**
+     * @runInSeparateProcess
+     */
+    public function testZipCourseUpload() {
+        $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $controller = new CourseMaterialsController($this->core);
 
         $_FILES = array();
@@ -152,7 +164,13 @@ class CourseMaterialsTester extends BaseUnitTest{
 
     }
 
-    public function testModifyCourseMaterials(){
+    /**
+     * @runInSeparateProcess
+     */
+    public function testModifyCourseMaterials() {
+        $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
         $controller = new CourseMaterialsController($this->core);
 
         $_FILES = array();
@@ -214,7 +232,14 @@ class CourseMaterialsTester extends BaseUnitTest{
         $this->assertEquals($expected_json2, $json[$_POST['fn'][1]]);
     }
 
-    public function testDeleteCourseMaterial(){
+    /**
+     * @runInSeparateProcess
+     */
+    public function testDeleteCourseMaterial() {
+        $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $controller = new CourseMaterialsController($this->core);
 
         $_FILES = array();
@@ -240,7 +265,14 @@ class CourseMaterialsTester extends BaseUnitTest{
         $this->assertEquals(0, count($files));
     }
 
-    public function testModifyCourseMaterialsPermission(){
+    /**
+     * @runInSeparateProcess
+     */
+    public function testModifyCourseMaterialsPermission() {
+        $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $controller = new CourseMaterialsController($this->core);
 
         $_FILES = array();

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -26,6 +26,8 @@ use tests\utils\NullOutput;
  * @runTestsInSeparateProcesses
  */
 class SubmissionControllerTester extends BaseUnitTest {
+    use \phpmock\phpunit\PHPMock;
+
     private static $annotations = [];
 
     /**
@@ -63,7 +65,6 @@ class SubmissionControllerTester extends BaseUnitTest {
 
         $this->core = new Core();
         $this->core->setOutput(new NullOutput($this->core));
-        $this->core->setTesting(true);
 
         $this->core->setUser(new User($this->core, [
             'user_id' => 'testUser',
@@ -337,8 +338,13 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * Basic upload, only one part and one file, simple sanity check.
+     * @runInSeparateProcess
      */
     public function testUploadOneBucket() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt', 'a');
 
         $controller = new SubmissionController($this->core);
@@ -385,8 +391,13 @@ class SubmissionControllerTester extends BaseUnitTest {
      * Test what happens if we have two parts
      *
      * @numParts 2
+     * @runInSeparateProcess
      */
     public function testUploadTwoBuckets() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt', 'a');
         $this->addUploadFile('test2.txt', 'b');
         $this->addUploadFile('test2.txt', 'c', 2);
@@ -446,8 +457,13 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * Test what happens if we're uploading a zip that contains a directory.
+     * @runInSeparateProcess
      */
     public function testZipWithDirectory() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $zip = array(
             'testDir' => array(
                 'test1.txt' => ''
@@ -503,8 +519,13 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * Upload a second version of a gradeable with no previous files and different files per upload. Test
      * that both versions exist and neither bled over to the other.
+     * @runInSeparateProcess
      */
     public function testSecondVersionNoPrevious() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt');
 
         $controller = new SubmissionController($this->core);
@@ -570,8 +591,13 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @numParts 2
+     * @runInSeparateProcess
      */
     public function testSecondVersionPreviousTwoParts() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile("test1.txt", "", 1);
         $this->addUploadFile("test1.txt", "", 2);
 
@@ -603,8 +629,13 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * Upload a second version of a gradeable that includes previous files, but there's no overlap in file names
      * so we should have one file in version 1 and two files in version 2
+     * @runInSeparateProcess
      */
     public function testSecondVersionPreviousNoOverlap() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt');
 
         $controller = new SubmissionController($this->core);
@@ -650,8 +681,14 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * Upload a second version that has previous files that has the same filename as the file that's being uploaded.
      * This should only include the version that was uploaded (and not use the previous).
+     *
+     * @runInSeparateProcess
      */
     public function testSecondVersionPreviousOverlap() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt', 'old_file');
 
         $controller = new SubmissionController($this->core);
@@ -702,8 +739,14 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * This tests what happens when we upload a second version of the gradeable that is a zip that contains a file
      * that overlaps the file from the first version.
+     *
+     * @runInSeparateProcess
      */
     public function testSecondVersionPreviousOverlapZip() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt', 'old_file');
 
         $controller = new SubmissionController($this->core);
@@ -754,8 +797,14 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * Test uploading a zip that contains a file and a zip. We only unzip one level so we the inner zip should
      * be left alone.
+     *
+     * @runInSeparateProcess
      */
     public function testZipInsideZip() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $zip = array(
             'test1.txt' => 'a',
             'basic_zip.zip'
@@ -792,8 +841,14 @@ class SubmissionControllerTester extends BaseUnitTest {
      * This tests what happens if we upload a zip that contains "test.txt" and "test2.txt" and try
      * uploading "test.txt" to the server, in that order. The free "test.txt" file should overwrite the one
      * in the zip (the one not in a zip contains a single 'a' while the two files in the zip are blank).
+     *
+     * @runInSeparateProcess
      */
     public function testSameFilenameInZip() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadZip('zippedfiles', array('test.txt' => 'zip_file', 'test2.txt' => 'zip_file2'));
         $this->addUploadFile('test.txt', 'non_zip_file');
 
@@ -810,8 +865,14 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * This tests the same thing as testSameFilenameInZip(), however we submit "test.txt" before "zippedfiles.zip"
+     *
+     * @runInSeparateProcess
      */
     public function testSameFilenameInZipReversed() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test.txt', 'non_zip_file');
         $this->addUploadZip('zippedfiles', array('test.txt' => 'zip_file', 'test2.txt' => 'zip_file2'));
 
@@ -834,7 +895,14 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testFilenameWithSpaces() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile("filename with spaces.txt");
 
         $controller = new SubmissionController($this->core);
@@ -853,7 +921,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertEquals(array('.submit.timestamp', 'filename with spaces.txt'), $files);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testZipContaingFilesWithSpaces() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $zip = array(
             'folder with spaces' => array('filename with spaces2.txt'),
             'filename with spaces.txt'
@@ -1053,7 +1128,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertFalse($return['status'] == 'success');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorMissingPreviousFile() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->once())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt');
 
         $controller = new SubmissionController($this->core);
@@ -1154,8 +1236,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertFalse($return['status'] == 'success');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorOnCopyingPrevious() {
         $this->addUploadFile('test1.txt');
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->once())
+            ->willReturn(true);
 
         $controller = new SubmissionController($this->core);
         $return = $controller->ajaxUploadSubmission('test');
@@ -1184,7 +1272,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         chmod($prev, 0777);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorOnCopyingFile() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt');
         FileUtils::createDir(FileUtils::joinPaths($this->config['course_path'], "submissions", "test", "testUser"), true);
         FileUtils::createDir(FileUtils::joinPaths($this->config['course_path'], "submissions", "test", "testUser", "1"), false, 0444);
@@ -1197,7 +1292,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertFalse($return['status'] == 'success');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorCleanupTempFiles() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $dst_dir = FileUtils::joinPaths($this->config['tmp_path'], "files");
         $dst_file = FileUtils::joinPaths($dst_dir, "test.txt");
         FileUtils::createDir($dst_dir);
@@ -1224,7 +1326,6 @@ class SubmissionControllerTester extends BaseUnitTest {
      */
     public function testErrorFakeFiles() {
         $this->addUploadFile('test1.txt');
-        $this->core->setTesting(false);
 
         $database_queries = $this->createMock(DatabaseQueries::class);
         $gradeable = $this->createMockGradeable();
@@ -1256,6 +1357,10 @@ class SubmissionControllerTester extends BaseUnitTest {
     }
 
     public function testErrorCreateQueueFile() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
         $this->addUploadFile('test1.txt');
         $dir = FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_queue");
         $this->assertTrue(FileUtils::recursiveRmdir($dir));
@@ -1269,7 +1374,13 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertFalse($return['status'] == 'success');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorBrokenHistoryFile() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
         $tmp = FileUtils::joinPaths($this->config['course_path'], "submissions", "test", "testUser");
         FileUtils::createDir($tmp, true);
         file_put_contents(FileUtils::joinPaths($tmp, "user_assignment_settings.json"), "]invalid_json[");
@@ -1285,8 +1396,13 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * We're testing that rolling back the history works on failure to upload the second version of the file
+     *
+     * @runInSeparateProcess
      */
     public function testErrorHistorySecondVersion() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->exactly(2))
+            ->willReturn(true);
         $this->addUploadFile('test1.txt');
 
         $controller = new SubmissionController($this->core);
@@ -1326,7 +1442,13 @@ class SubmissionControllerTester extends BaseUnitTest {
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorWriteSettingsFile() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
         $this->addUploadFile('test1.txt');
         $dir = FileUtils::joinPaths($this->config['course_path'], "submissions", "test", "testUser");
         FileUtils::createDir($dir, true);
@@ -1343,7 +1465,13 @@ class SubmissionControllerTester extends BaseUnitTest {
         chmod($settings, 0777);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testErrorWriteTimestampFile() {
+        $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
         $this->addUploadFile('test1.txt');
         $dir = FileUtils::joinPaths($this->config['course_path'], "submissions", "test", "testUser", "1");
         FileUtils::createDir($dir, true);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant (covered in Submitty/submitty.github.io#166)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
We used `Core::isTesting()` function to avoid dealing with some PHP builtin functions.

### What is the new behavior?
Replaced the usage of that shim function with the usage of php-mock and mocked the builtins instead, allowing for a bit cleaner code. `Core::redirect()` still relies on it (as it calls `die()`) and php-mock throws an error when attempting to mock `die`, so that remains (for now). Removes the usage of `isTesting` from a handful of production code spots.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is purely a testing refactor. For the changes to production, the `isTesting()` function already always returned false, and so removing it has no effect on how it functioned.