### PR TITLE
 [BugFix:GradeInquiry] fixed spotlight would turn red for component on non grade inquiry per component

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -494,7 +494,7 @@ HTML;
                 if ($graded_component === null) {
                     //not graded
                     $info["graded_groups"][] = "NULL";
-                } else if ($grade_inquiry !== null && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE) {
+                } else if ($grade_inquiry !== null && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE && $gradeable->isGradeInquiryPerComponentAllowed()) {
                     $info["graded_groups"][] = "grade-inquiry";
                 } else if(!$graded_component->getVerifier()){
                     //no verifier exists, show the grader group


### PR DESCRIPTION
### What is the current behavior?
closes #4527 
if grade inquiry per component is not enabled and a grade inquiry was made for a component spotlight still shows grade inquiry

### What is the new behavior?
fixes left over bug from #4534 