### PR TITLE
[Bugfix:Autograding] Cleanup after Dispatcher Actions

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -103,6 +103,7 @@ class Container():
       status = self.container.wait()
       self.return_code = status['StatusCode']
 
+    self.socket.close()
     self.container.remove(force=True)
     self.log_function(f'{dateutils.get_current_time()} docker container {self.container.short_id} destroyed')
 


### PR DESCRIPTION
The socket used to process dispatcher actions was not being properly disposed of, leading to errors.