### PR TITLE
[Refactor] Fix static analysis errors in DatabaseQueries

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -5,10 +5,10 @@ namespace app\libraries\database;
 use app\exceptions\DatabaseException;
 use app\exceptions\ValidationException;
 use app\libraries\CascadingIterator;
-use \app\libraries\GradeableType;
-use app\models\Gradeable;
+use app\libraries\GradeableType;
 use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\Component;
+use app\models\gradeable\Gradeable;
 use app\models\gradeable\GradedComponent;
 use app\models\gradeable\GradedComponentContainer;
 use app\models\gradeable\GradedGradeable;
@@ -49,10 +49,10 @@ class PostgresqlDatabaseQueries extends DatabaseQueries{
                  ns.self_notification,
                  ns.merge_threads_email, ns.all_new_threads_email,
                  ns.all_new_posts_email, ns.all_modifications_forum_email,
-                 ns.reply_in_post_thread_email, ns.team_invite_email, 
+                 ns.reply_in_post_thread_email, ns.team_invite_email,
                  ns.team_member_submission_email, ns.team_joined_email,
                  ns.self_notification_email,sr.grading_registration_sections
-     
+
             FROM users u
             LEFT JOIN notification_settings as ns ON u.user_id = ns.user_id
             LEFT JOIN (
@@ -1214,7 +1214,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
 
 
         $constructGradedGradeable = function ($row) use ($gradeables_by_id) {
-            /** @var \app\models\gradeable\Gradeable $gradeable */
+            /** @var Gradeable $gradeable */
             $gradeable = $gradeables_by_id[$row['g_id']];
 
             // Get the submitter
@@ -1610,7 +1610,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             $gradeable_constructor);
     }
 
-    public function getActiveVersions(Gradeable\Gradeable $gradeable, array $submitter_ids) {
+    public function getActiveVersions(Gradeable $gradeable, array $submitter_ids) {
         if (count($submitter_ids) === 0) {
             return [];
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Continued work for #4553 

This file had the following issues:
```
 ------ ------------------------------------------------------------------------------------------------------------
  Line   libraries/database/DatabaseQueries.php
 ------ ------------------------------------------------------------------------------------------------------------
  1652   Parameter $gradeable of method app\libraries\database\DatabaseQueries::getSubmittersWhoGotMarkBySection()
         has invalid typehint type app\models\Gradeable.
  1700   Parameter $mark of method app\libraries\database\DatabaseQueries::insertGradeableComponentMarkData() has
         invalid typehint type app\models\GradeableComponentMark.
  1707   Parameter $component of method app\libraries\database\DatabaseQueries::createNewGradeableComponent() has
         invalid typehint type app\models\GradeableComponent.
  1719   Parameter $component of method app\libraries\database\DatabaseQueries::updateGradeableComponent() has
         invalid typehint type app\models\GradeableComponent.
  1729   Parameter $component of method app\libraries\database\DatabaseQueries::deleteGradeableComponent() has
         invalid typehint type app\models\GradeableComponent.
  1734   Parameter $mark of method app\libraries\database\DatabaseQueries::createGradeableComponentMark() has
         invalid typehint type app\models\GradeableComponentMark.
  1744   Parameter $mark of method app\libraries\database\DatabaseQueries::updateGradeableComponentMark() has
         invalid typehint type app\models\GradeableComponentMark.
  1752   Parameter $mark of method app\libraries\database\DatabaseQueries::deleteGradeableComponentMark() has
         invalid typehint type app\models\GradeableComponentMark.
  1757   Parameter $component of method
         app\libraries\database\DatabaseQueries::getGreatestGradeableComponentMarkOrder() has invalid typehint type
         app\models\GradeableComponent.
  1770   Parameter $gradeable of method app\libraries\database\DatabaseQueries::updateUserViewedDate() has invalid
         typehint type app\models\Gradeable.
  1786   Parameter $gradeable of method app\libraries\database\DatabaseQueries::resetUserViewedDate() has invalid
         typehint type app\models\Gradeable.
 ------ ------------------------------------------------------------------------------------------------------------
```

The files 
### What is the new behavior?
The above static issues are fixed, as well as the usage of the `Gradeable\Gradeable` namespace reference in some functions.

The deleted functions are not used anywhere else in the codebase, and reference long since deleted models.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I tested with the following sequences:
1. Submission to Gradeable
1. View gradeable status Page
1. View gradeable index Page
1. View gradeable grading page and submit grades
1. Edit gradeable config
1. Create gradeable
1. View gradeable as student after grading
