### PR TITLE
[Testing:Style] Move PHPCS from testing certain files to testing certain rules

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "8.3.5",
-    "submitty/php-codesniffer": "2.0.0",
+    "submitty/php-codesniffer": "2.0.1",
     "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
     "php-mock/php-mock-phpunit": "^2.4"
   }

--- a/site/composer.json
+++ b/site/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "8.3.5",
-    "submitty/php-codesniffer": "1.1.0",
+    "submitty/php-codesniffer": "2.0.0",
     "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
     "php-mock/php-mock-phpunit": "^2.4"
   }

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "591eec59dcd85351ee14cd0728d1832e",
+    "content-hash": "455cff71907b1966ec06c0fd2db2cdd6",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1319,87 +1319,6 @@
                 "object graph"
             ],
             "time": "2019-08-09T12:45:53+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/97e59c7a16464196a8b9c77c47df68e4a39a45c4",
-                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "time": "2019-09-01T07:51:21+00:00"
-        },
-        {
-            "name": "pcov/clobber",
-            "version": "v2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/krakjoe/pcov-clobber.git",
-                "reference": "191f54df9a60fc38f1891248d9e3220121a43e6b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/krakjoe/pcov-clobber/zipball/191f54df9a60fc38f1891248d9e3220121a43e6b",
-                "reference": "191f54df9a60fc38f1891248d9e3220121a43e6b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcov": "^1.0",
-                "nikic/php-parser": "^4.2"
-            },
-            "bin": [
-                "bin/pcov"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "pcov\\Clobber\\": "src/pcov/clobber"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "time": "2019-08-02T04:24:11+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2974,26 +2893,26 @@
         },
         {
             "name": "submitty/php-codesniffer",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Submitty/submitty-php-codesniffer.git",
-                "reference": "1bb8f1fa69584316b3514253b70fe97e339fa030"
+                "reference": "2d83803e9c7248803f04433ad62bd9669243b9c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/1bb8f1fa69584316b3514253b70fe97e339fa030",
-                "reference": "1bb8f1fa69584316b3514253b70fe97e339fa030",
+                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/2d83803e9c7248803f04433ad62bd9669243b9c8",
+                "reference": "2d83803e9c7248803f04433ad62bd9669243b9c8",
                 "shasum": ""
             },
             "require": {
-                "pcov/clobber": "^2.0",
                 "php": ">=7.1",
                 "slevomat/coding-standard": "^5.0",
                 "squizlabs/php_codesniffer": "^3.5.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "pcov/clobber": "^2.0",
                 "phpunit/phpunit": "^7.5.12"
             },
             "suggest": {
@@ -3016,7 +2935,7 @@
                 }
             ],
             "description": "Submitty PHP CodeSniffer Standard",
-            "time": "2019-09-29T14:34:50+00:00"
+            "time": "2019-09-29T17:13:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89559359d6b07bb5fc2142b1a5abc9e5",
+    "content-hash": "591eec59dcd85351ee14cd0728d1832e",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1321,6 +1321,87 @@
             "time": "2019-08-09T12:45:53+00:00"
         },
         {
+            "name": "nikic/php-parser",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/97e59c7a16464196a8b9c77c47df68e4a39a45c4",
+                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2019-09-01T07:51:21+00:00"
+        },
+        {
+            "name": "pcov/clobber",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/krakjoe/pcov-clobber.git",
+                "reference": "191f54df9a60fc38f1891248d9e3220121a43e6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/krakjoe/pcov-clobber/zipball/191f54df9a60fc38f1891248d9e3220121a43e6b",
+                "reference": "191f54df9a60fc38f1891248d9e3220121a43e6b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcov": "^1.0",
+                "nikic/php-parser": "^4.2"
+            },
+            "bin": [
+                "bin/pcov"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "pcov\\Clobber\\": "src/pcov/clobber"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "time": "2019-08-02T04:24:11+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "1.0.3",
             "source": {
@@ -1852,16 +1933,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.7",
+            "version": "7.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7743bbcfff2a907e9ee4a25be13d0f8ec5e73800"
+                "reference": "aa0d179a13284c7420fc281fc32750e6cc7c9e2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7743bbcfff2a907e9ee4a25be13d0f8ec5e73800",
-                "reference": "7743bbcfff2a907e9ee4a25be13d0f8ec5e73800",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa0d179a13284c7420fc281fc32750e6cc7c9e2f",
+                "reference": "aa0d179a13284c7420fc281fc32750e6cc7c9e2f",
                 "shasum": ""
             },
             "require": {
@@ -1870,7 +1951,7 @@
                 "php": "^7.2",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.0",
+                "phpunit/php-token-stream": "^3.1.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
@@ -1911,7 +1992,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-25T05:31:54+00:00"
+            "time": "2019-09-17T06:24:36+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2055,16 +2136,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e899757bb3df5ff6e95089132f32cd59aac2220a",
-                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
@@ -2100,7 +2181,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2019-07-25T05:29:42+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -2842,16 +2923,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0afebf16a2e7f1e434920fa976253576151effe9",
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9",
                 "shasum": ""
             },
             "require": {
@@ -2889,30 +2970,30 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "time": "2019-09-26T23:12:26+00:00"
         },
         {
             "name": "submitty/php-codesniffer",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Submitty/submitty-php-codesniffer.git",
-                "reference": "7bbbbe422e4bdfb1260cb30d660c8822b0bb05f3"
+                "reference": "1bb8f1fa69584316b3514253b70fe97e339fa030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/7bbbbe422e4bdfb1260cb30d660c8822b0bb05f3",
-                "reference": "7bbbbe422e4bdfb1260cb30d660c8822b0bb05f3",
+                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/1bb8f1fa69584316b3514253b70fe97e339fa030",
+                "reference": "1bb8f1fa69584316b3514253b70fe97e339fa030",
                 "shasum": ""
             },
             "require": {
+                "pcov/clobber": "^2.0",
                 "php": ">=7.1",
                 "slevomat/coding-standard": "^5.0",
-                "squizlabs/php_codesniffer": "^3.4.2"
+                "squizlabs/php_codesniffer": "^3.5.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-                "php-coveralls/php-coveralls": "^2.1",
                 "phpunit/phpunit": "^7.5.12"
             },
             "suggest": {
@@ -2935,7 +3016,7 @@
                 }
             ],
             "description": "Submitty PHP CodeSniffer Standard",
-            "time": "2019-08-31T18:17:29+00:00"
+            "time": "2019-09-29T14:34:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-define("__TEST_DATA__", __DIR__ . "/data");
+require_once(__DIR__.'/constants.php');
 
 $loader = require(__DIR__.'/../vendor/autoload.php');
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);

--- a/site/tests/constants.php
+++ b/site/tests/constants.php
@@ -1,0 +1,3 @@
+<?php
+
+define("__TEST_DATA__", __DIR__ . "/data");

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -1,12 +1,163 @@
 <?xml version="1.0"?>
 <ruleset name="SubmittyStandard">
     <description>Non-Complete Standard for the Submitty Project</description>
-    <rule ref="Submitty" />
+    <arg name="extensions" value="php" />
 
     <file>../app</file>
-    <exclude-pattern>*/controllers/*</exclude-pattern>
-    <exclude-pattern>*/libraries/*</exclude-pattern>
-    <exclude-pattern>*/models/*</exclude-pattern>
-    <exclude-pattern>*/templates/*</exclude-pattern>
-    <exclude-pattern>*/views/*</exclude-pattern>
+    <file>../tests</file>
+
+    <exclude-pattern>../app/models/Gradeable.php</exclude-pattern>
+
+    <rule ref="Submitty">
+        <exclude name="SubmittyStandard.ControlStructures.StroustrupStructure.Found" />
+        <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.NotSnakeCase" />
+        <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
+
+        <exclude name="Generic.Arrays.DisallowLongArraySyntax.Found" />
+        <exclude name="Generic.Classes.OpeningBraceSameLine.SpaceBeforeBrace" />
+        <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
+        <exclude name="Generic.Classes.OpeningBraceSameLine.ContentAfterBrace" />
+        <exclude name="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed" />
+        <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine" />
+        <exclude name="Generic.Formatting.SpaceAfterCast.NoSpace" />
+        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
+        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace" />
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma" />
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma" />
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma" />
+        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
+        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />
+        <exclude name="Generic.NamingConventions.ConstructorName.OldStyle" />
+        <exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase" />
+        <exclude name="Generic.PHP.ForbiddenFunctions.FoundWithAlternative" />
+        <exclude name="Generic.PHP.LowerCaseConstant.Found" />
+        <exclude name="Generic.PHP.LowerCaseKeyword.Found" />
+        <exclude name="Generic.PHP.LowerCaseType.ReturnTypeFound" />
+        <exclude name="Generic.PHP.LowerCaseType.ParamTypeFound" />
+        <exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed" />
+        <exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
+        <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+        <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterDecrement" />
+        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement" />
+
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace" />
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+
+        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
+        <exclude name="PSR2.Classes.PropertyDeclaration.StaticBeforeVisibility" />
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent" />
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT" />
+        <exclude name="PSR2.Files.EndFileNewline.NoneFound" />
+        <exclude name="PSR2.Files.EndFileNewline.TooMany" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.Indent" />
+        <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeOpenBracket" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine" />
+        <exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments" />
+        <exclude name="PSR2.Methods.MethodDeclaration.StaticBeforeVisibility" />
+        <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse" />
+        <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter" />
+
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent" />
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.LineIndent" />
+        <exclude name="PSR12.Files.OpenTag.NotAlone"/>
+        <exclude name="PSR12.Files.DeclareStatement.SpaceFoundAfterDirective"/>
+        <exclude name="PSR12.Files.DeclareStatement.SpaceFoundBeforeDirectiveValue"/>
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock" />
+        <exclude name="PSR12.Files.FileHeader.SpacingInsideBlock" />
+        <exclude name="PSR12.Files.ImportStatement.LeadingSlash"/>
+        <exclude name="PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon" />
+        <exclude name="PSR12.Classes.ClassInstantiation.MissingParentheses" />
+        <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMixed"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine" />
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
+        <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMiddle"/>
+        <exclude name="PSR12.Keywords.ShortFormTypeKeywords.LongFound" />
+        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceBefore"/>
+        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceAfter"/>
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
+
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+
+        <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceAfterBracket" />
+        <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceBeforeBracket" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar" />
+        <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar" />
+        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterFirst" />
+        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterSecond" />
+        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceBeforeArrow" />
+        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceAfterArrow" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeHint" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterUse" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.OneParamPerLine" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnNewLine" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.Indent" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceBeforeBrace" />
+        <exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed" />
+        <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
+        <exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
+        <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
+        <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
+        <exclude name="Squiz.Scope.MethodScope.Missing" />
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
+        <excldue name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
+        <exclude name="Squiz.WhiteSpace.LanguageConstructSpacing.IncorrectSingle" />
+        <exclude name="Squiz.WhiteSpace.LogicalOperatorSpacing.TooMuchSpaceAfter" />
+        <exclude name="Squiz.WhiteSpace.LogicalOperatorSpacing.TooMuchSpaceBefore" />
+        <exclude name="Squiz.WhiteSpace.LogicalOperatorSpacing.NoSpaceBefore" />
+        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore" />
+        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
+        <exclude name="Squiz.WhiteSpace.SemicolonSpacing.Incorrect" />
+        <exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
+
+        <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall" />
+        <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant" />
+        <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator.UselessTernaryOperator" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
+        <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException" />
+        <exclude name="SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter" />
+        <exclude name="SlevomatCodingStandard.Functions.UselessParameterDefaultValue.UselessParameterDefaultValue" />
+        <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse" />
+        <exclude name="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash.UseStartsWithBackslash" />
+        <exclude name="SlevomatCodingStandard.Namespaces.UseFromSameNamespace.UseFromSameNamespace" />
+        <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity" />
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator" />
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator" />
+        <exclude name="SlevomatCodingStandard.PHP.ShortList.LongListUsed" />
+        <exclude name="SlevomatCodingStandard.PHP.UselessSemicolon.UselessSemicolon" />
+        <exclude name="SlevomatCodingStandard.PHP.TypeCast.InvalidCastUsed" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceBeforeColon" />
+        <exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable" />
+        <exclude name="SlevomatCodingStandard.Variables.UselessVariable.UselessVariable" />
+        <exclude name="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable.DuplicateAssignment" />
+    </rule>
 </ruleset>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Right now, we only test `site/app/authentication` and `site/app/exceptions` for style with the original thought of going directory at a time to clean up the other spots.

### What is the new behavior?
Cleaning up by directory is troublesome as there's a lot of errors with each directory, making such a cleanup not exactly super feasible, especially in balancing with other PRs and such. Additionally, for every PR merged in the meantime, it's that much potential work to fix things. Instead, I've moved the list to be the all rules that currently result in an error, with the expectation of cleaning up a rule at a time across the entire codebase. Many of these are automatically fixable by `phpcbf` which should help speed things along, though will be doing them one PR at a time to both make it easier to spot check the changes and hopefully reduce the potential of conflicts in PRs.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
