### PR TITLE
[Bufix:Submission] Renamed instances of input_file to input-file  

### DIFF
--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -27,7 +27,7 @@
         </label>
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div id="upload-boxes">
-            {# upload1 and input_file1 required for drag-and-drop.js #}
+            {# upload1 and input-file1 required for drag-and-drop.js #}
             <div id="upload1" class="file-input">
                 <label class="label" for="input-file1">"Drag your file(s) here or click to open file browser"</label>
                 <input type="file" name="files" id="input-file1" onchange="addFilesFromInput(1,false)" multiple />

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -115,10 +115,10 @@
 <div class="form-group row thread-attachment-container">
     {% if post_box_id %}
         <span class="inline-block">
-            {# uploadID and input_fileID required for drag-and-drop.js #}
+            {# uploadID and input-file + Index required for drag-and-drop.js #}
             <div class="upload_attachment_box cursor-pointer" id="upload{{ post_box_id }}">
                 <label id="file_input_label" class="btn btn-default">Upload Attachment</label>
-                <input type="file" accept="image/*" aria-labelledby="file_input_label" id="input_file{{ post_box_id }}" style="display: none;" onchange="addFilesFromInput({{ post_box_id }});testAndGetAttachments({{ post_box_id }}, true);" multiple />
+                <input type="file" accept="image/*" aria-labelledby="file_input_label" id="input-file{{ post_box_id }}" style="display: none;" onchange="addFilesFromInput({{ post_box_id }});testAndGetAttachments({{ post_box_id }}, true);" multiple />
                 <br>
             </div>
         </span>

--- a/site/app/templates/grading/UploadImagesForm.twig
+++ b/site/app/templates/grading/UploadImagesForm.twig
@@ -13,10 +13,10 @@
         </p>
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div id="upload-boxes">
-            {# upload1 and input_file1 required for drag-and-drop.js #}
+            {# upload1 and input-file1 required for drag-and-drop.js #}
             <div id="upload1" class="file-input">
-                <label class="label" for="input-file">"Drag your file(s) here or click to open file browser"</label>
-                <input type="file" name="files" id="input_file1" onchange="addFilesFromInput(1,false)" multiple />
+                <label class="label" for="input-file1">"Drag your file(s) here or click to open file browser"</label>
+                <input type="file" name="files" id="input-file1" onchange="addFilesFromInput(1,false)" multiple />
             </div>
         </div>
         <p>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -404,7 +404,7 @@
         <div id="upload-boxes">
             {# Submit boxes #}
             {% for part in part_names %}
-                {# uploadIndex and input_fileIndex required for drag-and-drop.js #}
+                {# uploadIndex and input-file + Index required for drag-and-drop.js #}
                 <div tabindex="0"
                      id="upload{{ loop.index }}"
                      class="upload-box"
@@ -419,7 +419,7 @@
                             Drag your file(s) here or click to open file browser
                         {% endif %}
                     </h2>
-                    <input type="file" name="files" id="input_file{{ loop.index }}" class="hide" onchange="addFilesFromInput({{ loop.index }})" multiple aria-label="Select Files to upload" />
+                    <input type="file" name="files" id="input-file{{ loop.index }}" class="hide" onchange="addFilesFromInput({{ loop.index }})" multiple aria-label="Select Files to upload" />
                 </div>
             {% endfor %}
         </div>

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -58,7 +58,7 @@ function setUsePrevious() {
 //========================================================================================
 // open a file browser if clicked on drop zone
 function clicked_on_box(e){
-  document.getElementById("input_file" + get_part_number(e)).click();
+  document.getElementById("input-file" + get_part_number(e)).click();
   e.stopPropagation();
 }
 
@@ -102,11 +102,11 @@ function get_part_number(e){
 
 // copy files selected from the file browser
 function addFilesFromInput(part, check_duplicate_zip=true){
-    var filestream = document.getElementById("input_file" + part).files;
+    var filestream = document.getElementById("input-file" + part).files;
     for(var i=0; i<filestream.length; i++){
         addFile(filestream[i], part, check_duplicate_zip); // folders will not be selected in file browser, no need for check
     }
-    $('#input_file' + part).val("");
+    $('#input-file' + part).val("");
 }
 
 // Check for duplicate file names. This function returns an array.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Id for drag & drop file submission changed to meet our standard of using a hyphen instead of 
an underscore, updated all instances and matching JS code.

Also fixes course material bug where the id was changed but not the JS preventing course materials

### Other information?
Effects all drag& drop file submission parts
tested forum, course materials, student images, hw submission

fixes #4565
