### PR TITLE
[Testing:Bugfix] Fix failing submission version select e2e tests

### DIFF
--- a/site/app/templates/grading/VersionChoice.twig
+++ b/site/app/templates/grading/VersionChoice.twig
@@ -1,5 +1,5 @@
 <select style="margin: 0 10px;{{ formatting|default('')|raw }}"
-        name="submission_version" onChange="{{ on_change|default('')|raw }}">
+        name="submission_version" onChange="{{ on_change|default('')|raw }}" id="submission-version-select">
 
     {% if active_version == 0 %}
         <option value="0" {{ display_version == active_version ? "selected" : "" }}></option>

--- a/tests/e2e/test_submission.py
+++ b/tests/e2e/test_submission.py
@@ -2,7 +2,7 @@ import os
 from unittest import skipIf
 
 from .base_testcase import BaseTestCase
-from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -116,8 +116,15 @@ class TestSubmission(BaseTestCase):
         self.accept_alerts(1)
 
         # wait until the page reloads to change the active version, completing the test
+        select = Select(self.driver.find_element_by_id('submission-version-select'))
+        select_idx = -1
+        for i in range(len(select.options)):
+            if select.options[i].text.endswith('GRADE THIS VERSION'):
+                select_idx = i
+        self.assertGreater(select_idx, -1)
+        select.select_by_visible_text(select.options[select_idx].text)
+
         version_xpath = "//div[@class='content']/select/option[@value='{}' and @selected and substring(text(), string-length(text())-17)='GRADE THIS VERSION']".format(new_version)
-        ActionChains(self.driver).move_to_element(self.driver.find_element_by_xpath(version_xpath)).perform()
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.XPATH, version_xpath)))
 
     # for test cases that require switching versions, make submissions to ensure they will
@@ -169,11 +176,6 @@ class TestSubmission(BaseTestCase):
 
     # test changing the submission version
     def test_change_submission_version(self):
-        ###
-        ### HACK TRAVIS
-        return
-        ###
-
         self.setup_test_start()
 
         # ensure that there are multiple versions so that switching is possible
@@ -184,12 +186,6 @@ class TestSubmission(BaseTestCase):
 
     # test cancelling the submission version
     def test_cancel_submission_version(self):
-
-        ###
-        ### HACK TRAVIS
-        return
-        ###
-
         self.setup_test_start()
 
         # ensure that there are multiple versions so that switching is possible


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

E2E tests for the version of submissions (changing version and cancelling version) were commented out due to Travis failing in a non-obvious way.

### What is the new behavior?
Rewrites the test to use a more portable method (`selenium.webdriver.support.ui.Select`) that resolves the issues having with xpath and the `ActionChain`

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
