### PR TITLE
[Refactor:PHPStan] Remove extra passed parameters from HomeworkView:renderTAResultsBox call

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -95,7 +95,7 @@ class HomeworkView extends AbstractView {
             && $gradeable->isTaGrading()
             && $submission_count !== 0
             && $active_version !== 0) {
-            $return .= $this->renderTAResultsBox($graded_gradeable, $regrade_available,$version_instance);
+            $return .= $this->renderTAResultsBox($graded_gradeable, $regrade_available);
         }
         if ($regrade_available || $graded_gradeable !== null && $graded_gradeable->hasRegradeRequest()) {
             $return .= $this->renderRegradeBox($graded_gradeable,$can_inquiry);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Continues work for #4553

Fixes the following phpstan error:
```
 ------ -------------------------------------------------------------------------------------------------------
  Line   views/submission/HomeworkView.php
 ------ -------------------------------------------------------------------------------------------------------
  98     Method app\views\submission\HomeworkView::renderTAResultsBox() invoked with 3 parameters, 2 required.
 ------ -------------------------------------------------------------------------------------------------------
```
The change was introduced in #4133 where it looks like the intermediary commit 3fc6cc652dafc1e71dd1b87bfaf90b1722269efd added it, and then 2616eb747c99f565a87baa76ec824a2ce7616734 removed that change to the function, but did not update the caller.

### What is the new behavior?

Removes the extra parameter as it was not being used, nor does it look like it was supposed to be there anymore.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
