### PR TITLE
[Refactor:PHPStan] Fix not calling parent::__construct() for RainbowGrades models

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -44,7 +44,7 @@ class RainbowCustomization extends AbstractModel{
 
 
     public function __construct(Core $main_core) {
-        $this->core = $main_core;
+        parent::__construct($main_core);
         $this->has_error = "false";
         $this->error_messages = [];
 

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -40,7 +40,7 @@ class RainbowCustomizationJSON extends AbstractModel
     ];
 
     public function __construct(Core $main_core) {
-        $this->core = $main_core;
+        parent::__construct($main_core);
 
         // Items that must be initialized as objects
         // This is done so json_encode will properly encode the item when converting to json


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Continues work for #4553 

These files had the following errors:
```
------ --------------------------------------------------------------------------------------
  Line   models/RainbowCustomization.php
 ------ --------------------------------------------------------------------------------------
  46     app\models\RainbowCustomization::__construct() does not call parent constructor from
         app\models\AbstractModel.
 ------ --------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------
  Line   models/RainbowCustomizationJSON.php
 ------ ------------------------------------------------------------------------------------------
  42     app\models\RainbowCustomizationJSON::__construct() does not call parent constructor from
         app\models\AbstractModel.
 ------ ------------------------------------------------------------------------------------------
```

### What is the new behavior?
Errors are fixed, the parent class constructor is called.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
