### PR TITLE
[Bugfix] Fix only adding one previous file

### DIFF
--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -147,7 +147,7 @@ class AutoGradedVersion extends AbstractModel {
                 foreach ($submitted_files as $file => $details) {
                     $dir_name = "part{$i}/";
                     if (substr($file, 0, strlen($dir_name)) === "part{$i}/") {
-                        $this->files[$dir][$i][substr($file, strlen($dir_name), null)] = $details;
+                        $this->files[$dir][$i][substr($file, strlen($dir_name))] = $details;
                     }
                 }
             }
@@ -287,8 +287,10 @@ class AutoGradedVersion extends AbstractModel {
         if($this->files === null) {
             $this->loadSubmissionFiles();
         }
-        return array('submissions' => (array_key_exists($part, $this->files['submissions'])) ? $this->files['submissions'][$part] : [], 
-            'checkout' => ($this->graded_gradeable->getGradeable()->isVcs()) ? $this->files['checkout'][$part] : []);
+        return array(
+            'submissions' => (array_key_exists($part, $this->files['submissions'])) ? $this->files['submissions'][$part] : [],
+            'checkout' => ($this->graded_gradeable->getGradeable()->isVcs()) ? $this->files['checkout'][$part] : []
+        );
     }
 
     /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #4571 

The drop-zone for multi-part assignments would only populate with the first file of previous submissions.

### What is the new behavior?

All previous files should now populate the drop-zone.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
