### PR TITLE
[Bugfix:GradingUI] Fix submissions and results browser not scrolling

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -1,7 +1,7 @@
 {% import _self as self %}
 <div id="submission_browser" class="draggable rubric_panel">
-    <div id="directory_view">
-        <div class="draggable_content">
+    <div class="draggable_content">
+        <div id="directory_view">
             <span class="grading_label">Submissions and Results Browser</span>
             <button class="btn btn-default expand-button" data-linked-type="submissions" data-clicked-state="wasntClicked" id="toggleSubmissionButton">Open/Close Submissions</button>
 


### PR DESCRIPTION
Closes #4560

 Now you can scroll in the Submissions and Results Browser in TA grading UI.