### PR TITLE
[Bugfix] Could not click upper half of items in footer

### DIFF
--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -137,8 +137,4 @@ footer .footer-separator {
         min-width: 450px;
         transform: translateX(-50%);
     }
-
-    footer {
-        margin-top: -20px; /* 30px content padding and 10px footer padding */
-    }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When on screens with a width of over 541px (when on a computer/laptop) the top half of the footer would be covered by the "wrapper" div above it. This means the user could not click on the top half of the button/links in the footer. 
![image](https://user-images.githubusercontent.com/18558130/66081844-e1c09480-e536-11e9-84b4-0b4956bb7981.png)
Note how the "wrapper" div covers up part of the footer and so you cannot click on the footer buttons where it overlaps.

### What is the new behavior?

You can now click on any part of the footer
![image](https://user-images.githubusercontent.com/18558130/66081870-f1d87400-e536-11e9-8f21-33a2354dde96.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I could not find a reason why this css was there in the first place so I just removed it but there may be a reason I did not see.