### PR TITLE
[Feature] Add support for application/json requests

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -53,7 +53,7 @@ function exception_handler($throwable) {
             $message = htmlentities($message, ENT_QUOTES);
         }
     }
-    
+
     $core->getOutput()->showException($message);
 }
 set_exception_handler("exception_handler");
@@ -61,7 +61,7 @@ set_exception_handler("exception_handler");
 function error_handler() {
     $error = error_get_last();
     if ($error['type'] === E_ERROR) {
-        exception_handler(new BaseException("Fatal Error: " . $error['message'] . " in file 
+        exception_handler(new BaseException("Fatal Error: " . $error['message'] . " in file
         " . $error['file'] . " on line " . $error['line']));
     }
 }
@@ -116,6 +116,9 @@ if (empty($_COOKIE['submitty_token'])) {
 
 $is_api = explode('/', $request->getPathInfo())[1] === 'api';
 if ($is_api) {
+    if (!empty($_SERVER['CONTENT_TYPE']) && Utils::startsWith($_SERVER['CONTENT_TYPE'], 'application/json')) {
+        $_POST = json_decode(file_get_contents('php://input'), true);
+    }
     $response = WebRouter::getApiResponse($request, $core);
 }
 else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant submitty/api.submitty.org@4b4c2aac4f356638f27ff2cfb99983593bfcf080

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The current API endpoints do not support `application/json` content-type, which is the standard for using APIs with clients. Currently, if a request is sent using `application/json`, the `$_POST` global will be empty.

### What is the new behavior?
If using the `/api` endpoint and the `content-type` header is set to `application/json`, then we read in off `php://input` to set the `$_POST` global, which is the only way to get access to it. Does not affect regular usage of the site.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
