### PR TITLE
[Refactor:PHP] Fix Generic.WhiteSpace.IncrementDecrementSpacing style errors

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -486,7 +486,7 @@ class UsersController extends AbstractController {
                 }
             }
             //remove people who should not be added to rotating sections
-            for ($j = 0;$j < count($users_with_reg_section);) {
+            for ($j = 0; $j < count($users_with_reg_section);) {
                 for ($i = 0;$i < count($exclude_sections);++$i) {
                     if ($users_with_reg_section[$j]->getRegistrationSection() == $exclude_sections[$i]) {
                         array_splice($users_with_reg_section,$j,1);
@@ -497,16 +497,16 @@ class UsersController extends AbstractController {
                 ++$j;
 
             }
-            for ($i = 0;$i < count($users);) {
+            for ($i = 0; $i < count($users);) {
                 $found_in = false;
-                for ($j = 0;$j < count($users_with_reg_section);++$j) {
+                for ($j = 0; $j < count($users_with_reg_section); ++$j) {
                     if ($users[$i] == $users_with_reg_section[$j]->getId()) {
                         $found_in = true;
                         break;
                     }
                 }
                 if (!$found_in) {
-                    array_splice($users,$i,1);
+                    array_splice($users, $i, 1);
                     continue;
                 }
                 ++$i;
@@ -529,7 +529,7 @@ class UsersController extends AbstractController {
                 $section_counts[$section]++;
             }
             foreach ($teams as $g_id => $team_ids) {
-                for ($i = 0; $i < count($team_ids); $i ++) {
+                for ($i = 0; $i < count($team_ids); $i++) {
                     $section = $i % $section_count;
 
                     if (!array_key_exists($g_id, $team_section_counts)) {
@@ -572,7 +572,7 @@ class UsersController extends AbstractController {
                 $use_section = ($use_section + 1) % $section_count;
             }
             foreach ($teams as $g_id => $team_ids) {
-                for ($i = 0; $i < count($team_ids); $i ++) {
+                for ($i = 0; $i < count($team_ids); $i++) {
                     $use_section = ($use_section + 1) % $section_count;
 
                     if (!array_key_exists($g_id, $team_section_counts)) {
@@ -593,7 +593,7 @@ class UsersController extends AbstractController {
         }
 
         foreach ($team_section_counts as $g_id => $counts) {
-            for ($i = 0; $i < $section_count; $i ++) {
+            for ($i = 0; $i < $section_count; $i++) {
                 $update_teams = array_splice($teams[$g_id], 0, $team_section_counts[$g_id][$i]);
 
                 foreach ($update_teams as $team_id) {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -15,8 +15,6 @@ use app\models\gradeable\SubmissionCodeBox;
 use app\models\gradeable\SubmissionMultipleChoice;
 use Symfony\Component\Routing\Annotation\Route;
 
-
-
 class SubmissionController extends AbstractController {
 
     private $upload_details = array('version' => -1, 'version_path' => null, 'user_path' => null,
@@ -199,7 +197,7 @@ class SubmissionController extends AbstractController {
             foreach ($user_ids as $user) {
                 $tmp = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable->getId(), $user);
                 if($tmp === NULL){
-                    $null_team_count ++;
+                    $null_team_count++;
                 }else{
                     $teams[] = $tmp->getId();
                 }

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -75,44 +75,44 @@ class PostgresqlDatabase extends AbstractDatabase {
             $quot = "";
             for ($i = $start; $i < strlen($text); $i++) {
                 $ch = $text[$i];
-                if (!$in_array && !$in_string && $ch == "{") {
+                if (!$in_array && !$in_string && $ch === "{") {
                     $in_array = true;
                 }
-                else if (!$in_string && $ch == "{") {
+                else if (!$in_string && $ch === "{") {
                     $return[] = $this->fromDatabaseToPHPArray($text, $parse_bools, $i, $i);
                 }
-                else if (!$in_string && $ch == "}") {
+                else if (!$in_string && $ch === "}") {
                     $this->parsePGArrayValue($element, $have_string, $parse_bools, $return);
                     $end = $i;
                     return $return;
                 }
-                else if (($ch == '"' || $ch == "'") && !$in_string) {
+                else if (($ch === '"' || $ch === "'") && !$in_string) {
                     $in_string = true;
                     $quot = $ch;
                 }
                 else if ($in_string && $ch == "\\" && strlen($text) > $i) {
                     if ($text[$i+1] === "\\") {
                         $element .= "\\";
-                        $i ++;
+                        $i++;
                     } else if ($text[$i+1] === "\"") {
                         $element .= "\"";
-                        $i ++;
+                        $i++;
                     } else {
                         $element .= $text[$i];
                     }
                 }
-                else if (!$in_string && $ch == "\\") {
+                else if (!$in_string && $ch === "\\") {
                     //Insert literal \
                     $element .= $text[$i];
                 }
-                else if ($in_string && $ch == $quot) {
+                else if ($in_string && $ch === $quot) {
                     $in_string = false;
                     $have_string = true;
                 }
-                else if (!$in_string && $ch == " ") {
+                else if (!$in_string && $ch === " ") {
                     continue;
                 }
-                else if (!$in_string && $ch == ",") {
+                else if (!$in_string && $ch === ",") {
                     $this->parsePGArrayValue($element, $have_string, $parse_bools, $return);
                     $have_string = false;
                     $element = "";

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -323,7 +323,7 @@ class GradingOrder extends AbstractModel {
 
         //Iterate through all sections and their submitters to find this one
         foreach ($this->section_submitters as $name => $section) {
-            for ($i = 0; $i < count($section); $i ++) {
+            for ($i = 0; $i < count($section); $i++) {
                 $testSub = $section[$i];
 
                 //Found them
@@ -331,7 +331,7 @@ class GradingOrder extends AbstractModel {
                     return $count;
                 }
 
-                $count ++;
+                $count++;
             }
         }
         return false;

--- a/site/tests/app/libraries/routers/AccessControlTester.php
+++ b/site/tests/app/libraries/routers/AccessControlTester.php
@@ -41,7 +41,7 @@ class AccessControlTester extends BaseUnitTest {
         $min_permission = ['course.view'],
         $logged_in = true
     ) {
-        for ($role = User::GROUP_STUDENT; $role > $min_role; $role --) {
+        for ($role = User::GROUP_STUDENT; $role > $min_role; $role--) {
             $core = $this->getAccessTestCore($role, $min_permission, $logged_in);
             $request = Request::create(
                 $endpoint,

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -4,6 +4,7 @@
     <arg name="extensions" value="php" />
 
     <file>../app</file>
+    <file>../public/index.php</file>
     <file>../tests</file>
 
     <exclude-pattern>../app/models/Gradeable.php</exclude-pattern>
@@ -39,8 +40,6 @@
         <exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
         <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
         <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
-        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterDecrement" />
-        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement" />
 
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
 
@@ -157,5 +156,9 @@
         <exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable" />
         <exclude name="SlevomatCodingStandard.Variables.UselessVariable.UselessVariable" />
         <exclude name="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable.DuplicateAssignment" />
+    </rule>
+
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>../public/index.php</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Re-adds the `Generic.WhiteSpace.IncrementDecrementSpacing` sniff rules, disallowing `++ $i` or `$i ++`. All violations of it are fixed, along with some other violations still ignored in the immediately surrounding code.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
