### PR TITLE
[Bugfix:TAGrading] fix not being able to open PDFs

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -65,15 +65,14 @@
                 // });
             </script>
         </div>
-    </div>
-    <div id="file_view" style="display: none; position: absolute; float: right; right: -100%; width:100%; height: 100%">
-        <strong id="save_status" style="position: sticky; top: 27px; margin: 10px; float:right; z-index: 30; display: none">No changes</strong>
-        <span class="grading_label" style="padding-bottom: 0px">Submissions and Results Browser ></span>
-        <span class="grading_label" style="padding-top: 5px; margin-left: -15px" id="grading_file_name"></span>
-        <a onclick='collapseFile()'><i class="fas fa-reply" style="font-size:24px" aria-hidden="true" title="Back"></i></a>
-        {% include "grading/electronic/PDFAnnotationBar.twig" %}
-        <div id="file_content" style="overflow: auto; height:90%;position: absolute;width: 100%;"></div>
-
+        <div id="file_view" style="display: none; position: absolute; float: right; right: -100%; width:100%; height: 100%">
+            <strong id="save_status" style="position: sticky; top: 27px; margin: 10px; float:right; z-index: 30; display: none">No changes</strong>
+            <span class="grading_label" style="padding-bottom: 0px">Submissions and Results Browser ></span>
+            <span class="grading_label" style="padding-top: 5px; margin-left: -15px" id="grading_file_name"></span>
+            <a onclick='collapseFile()'><i class="fas fa-reply" style="font-size:24px" aria-hidden="true" title="Back"></i></a>
+            {% include "grading/electronic/PDFAnnotationBar.twig" %}
+            <div id="file_content" style="overflow: auto; height:90%;position: absolute;width: 100%;"></div>
+        </div>
     </div>
 </div>
 

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -91,17 +91,12 @@ function render(gradeable_id, user_id, grader_id, file_name, page_num, url = "")
                                 $('#file_content').animate({scrollTop: initialPage[0].offsetTop}, 500);
                             }
                         }
-                        document.getElementById('pageContainer'+page_id).addEventListener('mousedown', function(){
-                            //Makes sure the panel don't move when writing on it.
-                            $("#submission_browser").draggable('disable');
+                        document.getElementById('pageContainer'+page_id).addEventListener('pointerdown', function(){
                             let selected = $(".tool-selected");
                             if(selected.length != 0 && $(selected[0]).attr('value') != 'cursor'){
                                 $("#save_status").text("Changes not saved");
                                 $("#save_status").css("color", "red");
                             }
-                        });
-                        document.getElementById('pageContainer'+page_id).addEventListener('mouseup', function(){
-                            $("#submission_browser").draggable('enable');
                         });
                     });
                 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -51,7 +51,7 @@ $(function() {
         snap: false,
         grid: [2, 2],
         stack: ".draggable",
-        cancel: ".draggable div#file_view div#file_content"
+        cancel: ".draggable div#file_view div#file_content, .draggable div#file_view div#pdf_annotation_bar div#size_selector_menu"
     }).resizable();
 
 

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -47,8 +47,13 @@ $(function() {
         value = progressbar.val();
     $(".progress-value").html("<b>" + value + '%</b>');
 
+    $(".draggable").draggable({
+        snap: false,
+        grid: [2, 2],
+        stack: ".draggable",
+        cancel: ".draggable div#file_view div#file_content"
+    }).resizable();
 
-    $( ".draggable" ).draggable({snap:false, grid:[2, 2], stack:".draggable"}).resizable();
 
     $("#bar_wrapper").resizable("destroy"); //We don't want the toolbar to be resizable
     // $('#pdf_annotation_bar').length != 0 && $('#pdf_annotation_bar').resizable("destroy"); //Same with PDF annotation.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Could not open PDFs (or any file) in the inline "File Viewer" in the TA Grading interface.

### What is the new behavior?

Fixes the bug, allowing PDFs (and other files) to be inlined, while also not breaking being able to scroll the browser/results window. The file viewer is draggable anywhere except for within the open file display itself and for the expanded options menu for the PDF (that has the pen size and text size), can discuss if that's alright, but I think this probably covers things well enough for now.

There remains a bug that when the pen is selected, you cannot drag the box, and various elements of the UI will not properly work until the pen is deselected, but that is separate issue from this, and was pre-existing (and has been) for some time.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

1. open all folders and check I could scroll (I could)
1. Open PDF
1. Close PDF
1. Open PDF
1. Select Pen and Draw on PDF
1. Select Eraser and erase on PDF
1. Select text and place text
1. Select pointer and move text
1. Open pen/text properties panel and change pen size + text size
1. Close PDF
1. Check could still scroll the overall browser list

Tested in Chrome and Firefox on macOS