### PR TITLE
[Refactor:PHP] Fix Generic.WhiteSpace.DisallowTabIndent style errors

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -58,11 +58,11 @@ class HomePageController extends AbstractController {
             $newLastName = trim($_POST['user_lastname_change']);
             // validateUserData() checks both for length (not to exceed 30) and for valid characters.
             if ($user->validateUserData('user_preferred_firstname', $newFirstName) === true && $user->validateUserData('user_preferred_lastname', $newLastName) === true) {
-				$user->setPreferredFirstName($newFirstName);
-				$user->setPreferredLastName($newLastName);
-				//User updated flag tells auto feed to not clobber some of the user's data.
-				$user->setUserUpdated(true);
-				$this->core->getQueries()->updateUser($user);
+                $user->setPreferredFirstName($newFirstName);
+                $user->setPreferredLastName($newLastName);
+                //User updated flag tells auto feed to not clobber some of the user's data.
+                $user->setUserUpdated(true);
+                $this->core->getQueries()->updateUser($user);
             }
             else {
                 $this->core->addErrorMessage("Preferred names must not exceed 30 chars.  Letters, spaces, hyphens, apostrophes, periods, parentheses, and backquotes permitted.");

--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -16,8 +16,8 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class NotificationController extends AbstractController {
 
-	const NOTIFICATION_SELECTIONS = [
-	    'merge_threads',
+    const NOTIFICATION_SELECTIONS = [
+        'merge_threads',
         'all_new_threads',
         'all_new_posts',
         'all_modifications_forum',
@@ -28,7 +28,7 @@ class NotificationController extends AbstractController {
         'self_notification'
     ];
 
-	const EMAIL_SELECTIONS = [
+    const EMAIL_SELECTIONS = [
         'merge_threads_email',
         'all_new_threads_email',
         'all_new_posts_email',
@@ -40,9 +40,9 @@ class NotificationController extends AbstractController {
         'self_notification_email'
     ];
 
-	protected $selections;
+    protected $selections;
 
-	public function __construct(Core $core) {
+    public function __construct(Core $core) {
         parent::__construct($core);
         $this->selections = self::NOTIFICATION_SELECTIONS;
         if ($this->core->getConfig()->isEmailEnabled()) {

--- a/site/app/controllers/admin/EmailRoomSeatingController.php
+++ b/site/app/controllers/admin/EmailRoomSeatingController.php
@@ -103,12 +103,12 @@ Please email your instructor with any questions or concerns.';
         ];
 
         foreach($replaces as $key => $variable) {
-        	if(isset($data[$key])) {
-        		$message = str_replace('{$' . $variable . '}', $data[$key], $message);
-        	}
+            if(isset($data[$key])) {
+                $message = str_replace('{$' . $variable . '}', $data[$key], $message);
+            }
         }
 
-		$message = str_replace('{$course_name}', $this->core->getConfig()->getCourse(), $message);
+        $message = str_replace('{$course_name}', $this->core->getConfig()->getCourse(), $message);
         return $message;
     }
 

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -504,108 +504,108 @@ class PlagiarismController extends AbstractController {
         $active_version_user_1 =  (string)$graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $file_path= $course_path."/lichen/ranking/".$gradeable_id.".txt";
         if(!file_exists($file_path)) {
-			$return = array('error' => 'Ranking file not exists.');
-        	$return = json_encode($return);
-        	echo($return);
-        	return;
+            $return = array('error' => 'Ranking file not exists.');
+            $return = json_encode($return);
+            echo($return);
+            return;
         }
-    	$content =file_get_contents($file_path);
-    	$content = trim(str_replace(array("\r", "\n"), '', $content));
-    	$rankings = preg_split('/ +/', $content);
-		$rankings = array_chunk($rankings,3);
-		foreach($rankings as $ranking) {
-			if($ranking[1] == $user_id_1) {
-				$max_matching_version = $ranking[2];
-			}
-		}
+        $content =file_get_contents($file_path);
+        $content = trim(str_replace(array("\r", "\n"), '', $content));
+        $rankings = preg_split('/ +/', $content);
+        $rankings = array_chunk($rankings,3);
+        foreach($rankings as $ranking) {
+            if($ranking[1] == $user_id_1) {
+                $max_matching_version = $ranking[2];
+            }
+        }
         if($version_user_1 == "max_matching") {
-        	$version_user_1 = $max_matching_version;
+            $version_user_1 = $max_matching_version;
         }
         $all_versions_user_1 = array_diff(scandir($course_path."/submissions/".$gradeable_id."/".$user_id_1), array(".", "..", "user_assignment_settings.json"));
 
         $file_name= $course_path."/lichen/concatenated/".$gradeable_id."/".$user_id_1."/".$version_user_1."/submission.concatenated";
         $data="";
-    	if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
-    		if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
-    			$color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2 , '1');
-    		}
-    		else {
-    			$color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, '', '', '1');
-    		}
-    		$data= array('display_code1'=> $this->getDisplayForCode($file_name, $color_info), 'code_version_user_1' => $version_user_1, 'max_matching_version' => $max_matching_version, 'active_version_user_1' => $active_version_user_1, 'all_versions_user_1' => $all_versions_user_1, 'ci'=> $color_info);
+        if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
+            if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
+                $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2 , '1');
+            }
+            else {
+                $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, '', '', '1');
+            }
+            $data= array('display_code1'=> $this->getDisplayForCode($file_name, $color_info), 'code_version_user_1' => $version_user_1, 'max_matching_version' => $max_matching_version, 'active_version_user_1' => $active_version_user_1, 'all_versions_user_1' => $all_versions_user_1, 'ci'=> $color_info);
         }
         else {
-        	$return = array('error' => 'User 1 submission.concatenated for specified version not found.');
-        	$return = json_encode($return);
-        	echo($return);
-        	return;
+            $return = array('error' => 'User 1 submission.concatenated for specified version not found.');
+            $return = json_encode($return);
+            echo($return);
+            return;
         }
         if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
-        	$file_name= $course_path."/lichen/concatenated/".$gradeable_id."/".$user_id_2."/".$version_user_2."/submission.concatenated";
+            $file_name= $course_path."/lichen/concatenated/".$gradeable_id."/".$user_id_2."/".$version_user_2."/submission.concatenated";
 
-	    	if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
-	    		$color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, '2');
-	  			$data['display_code2'] = $this->getDisplayForCode($file_name, $color_info);
-	        }
-	        else {
-	        	$return = array('error' => 'User 2 submission.concatenated for matching version not found.');
-		    	$return = json_encode($return);
-		    	echo($return);
-		    	return;
-	        }
+            if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
+                $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, '2');
+                $data['display_code2'] = $this->getDisplayForCode($file_name, $color_info);
+            }
+            else {
+                $return = array('error' => 'User 2 submission.concatenated for matching version not found.');
+                $return = json_encode($return);
+                echo($return);
+                return;
+            }
         }
         $data['ci'] = $color_info;
-       	$return= json_encode($data);
-    	echo($return);
+        $return= json_encode($data);
+        echo($return);
     }
 
     public function getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, $codebox) {
-    	$color_info = array();
+        $color_info = array();
 
         //Represents left and right display users
         $color_info[1] = array();
         $color_info[2] = array();
 
-		$file_path= $course_path."/lichen/matches/".$gradeable_id."/".$user_id_1."/".$version_user_1."/matches.json";
+        $file_path= $course_path."/lichen/matches/".$gradeable_id."/".$user_id_1."/".$version_user_1."/matches.json";
         if (!file_exists($file_path)) {
-        	return $color_info;
+            return $color_info;
         }
         else {
-        	$matches = json_decode(file_get_contents($file_path), true);
-        	$file_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_1."/".$version_user_1."/tokens.json";
-        	$tokens_user_1 = json_decode(file_get_contents($file_path), true);
-        	if($user_id_2 != "") {
-        		$file_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_2."/".$version_user_2."/tokens.json";
-        		$tokens_user_2 = json_decode(file_get_contents($file_path), true);
-        	}
-	    	foreach($matches as $match) {
-	    		$start_pos =$tokens_user_1[$match["start"]-1]["char"]-1;
-	    		$start_line= $tokens_user_1[$match["start"]-1]["line"]-1;
-	    		$end_pos =$tokens_user_1[$match["end"]-1]["char"]-1; //!!!!!
-	    		$end_line= $tokens_user_1[$match["end"]-1]["line"]-1;
+            $matches = json_decode(file_get_contents($file_path), true);
+            $file_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_1."/".$version_user_1."/tokens.json";
+            $tokens_user_1 = json_decode(file_get_contents($file_path), true);
+            if($user_id_2 != "") {
+                $file_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_2."/".$version_user_2."/tokens.json";
+                $tokens_user_2 = json_decode(file_get_contents($file_path), true);
+            }
+            foreach($matches as $match) {
+                $start_pos =$tokens_user_1[$match["start"]-1]["char"]-1;
+                $start_line= $tokens_user_1[$match["start"]-1]["line"]-1;
+                $end_pos =$tokens_user_1[$match["end"]-1]["char"]-1; //!!!!!
+                $end_line= $tokens_user_1[$match["end"]-1]["line"]-1;
                 $start_value = $tokens_user_1[$match["start"]-1]["value"];
-	    		$end_value =$tokens_user_1[$match["end"]-1]["value"];
+                $end_value =$tokens_user_1[$match["end"]-1]["value"];
                 $userMatchesStarts = array();
                 $userMatchesEnds = array();
-	    		if($match["type"] == "match") {
-	    			$orange_color = false;
-	    			if($user_id_2 != "") {
-		    			foreach($match['others'] as $i=>$other) {
-	    					if($other["username"] == $user_id_2) {
-	    						$orange_color = true;
+                if($match["type"] == "match") {
+                    $orange_color = false;
+                    if($user_id_2 != "") {
+                        foreach($match['others'] as $i=>$other) {
+                            if($other["username"] == $user_id_2) {
+                                $orange_color = true;
                                 $user_2_index_in_others=$i;
-	    					}
-	    				}
-	    			}
+                            }
+                        }
+                    }
 
-	    			if($orange_color) {
+                    if($orange_color) {
                         //Color is orange -- general match from selected match
                         $color = '#ffa500';
-	    			}
-	    			else if(!$orange_color) {
+                    }
+                    else if(!$orange_color) {
                         //Color is yellow -- matches other students...
                         $color = '#ffff00';
-	    			}
+                    }
 
                     if($codebox == "2" && $user_id_2 !="" && $orange_color) {
                          foreach($match['others'][$user_2_index_in_others]['matchingpositions'] as $user_2_matchingposition) {
@@ -635,17 +635,17 @@ class PlagiarismController extends AbstractController {
                 array_push($color_info[1], [$start_pos, $start_line, $end_pos, $end_line, $color, $start_value, $end_value, count($userMatchesStarts) > 0 ? $userMatchesStarts[0] : [], count($userMatchesEnds) > 0 ? $userMatchesEnds[0] : [] ]);
 
                 // foreach($color_info as $i=>$color_info_for_line) {
-                // 	ksort($color_info[$i]);
+                //  ksort($color_info[$i]);
                 // }
             }
         }
-    	return $color_info;
+        return $color_info;
     }
 
     public function getDisplayForCode($file_name , $color_info){
-    	$content = file_get_contents($file_name);
-	    return $content;
-	}
+        $content = file_get_contents($file_name);
+        return $content;
+    }
 
     /**
      * @Route("/{_semester}/{_course}/plagiarism/gradeable/{gradeable_id}/match")
@@ -659,46 +659,46 @@ class PlagiarismController extends AbstractController {
         $error="";
         $file_path= $course_path."/lichen/ranking/".$gradeable_id.".txt";
         if(!file_exists($file_path)) {
-			$return = array('error' => 'Ranking file not exists.');
-        	$return = json_encode($return);
-        	echo($return);
-        	return;
+            $return = array('error' => 'Ranking file not exists.');
+            $return = json_encode($return);
+            echo($return);
+            return;
         }
-    	$content =file_get_contents($file_path);
-    	$content = trim(str_replace(array("\r", "\n"), '', $content));
-    	$rankings = preg_split('/ +/', $content);
-		$rankings = array_chunk($rankings,3);
-		foreach($rankings as $ranking) {
-			if($ranking[1] == $user_id_1) {
-				$max_matching_version = $ranking[2];
-			}
-		}
-		$version = $version_user_1;
+        $content =file_get_contents($file_path);
+        $content = trim(str_replace(array("\r", "\n"), '', $content));
+        $rankings = preg_split('/ +/', $content);
+        $rankings = array_chunk($rankings,3);
+        foreach($rankings as $ranking) {
+            if($ranking[1] == $user_id_1) {
+                $max_matching_version = $ranking[2];
+            }
+        }
+        $version = $version_user_1;
         if($version_user_1 == "max_matching") {
-        	$version = $max_matching_version;
+            $version = $max_matching_version;
         }
         $file_path= $course_path."/lichen/matches/".$gradeable_id."/".$user_id_1."/".$version."/matches.json";
         if (!file_exists($file_path)) {
-        	echo("no_match_for_this_version");
+            echo("no_match_for_this_version");
         }
         else {
-	        $content = json_decode(file_get_contents($file_path), true);
-	    	foreach($content as $match) {
-	    		if($match["type"] == "match") {
-	    			foreach ($match["others"] as $match_info) {
-	    				if(!in_array(array($match_info["username"],$match_info["version"]), $return )) {
-	    					array_push($return, array($match_info["username"],$match_info["version"]));
-	    				}
-	    			}
-	    		}
-	    	}
-	    	foreach($return as $i => $match_user) {
-    			array_push($return[$i], $this->core->getQueries()->getUserById($match_user[0])->getDisplayedFirstName());
+            $content = json_decode(file_get_contents($file_path), true);
+            foreach($content as $match) {
+                if($match["type"] == "match") {
+                    foreach ($match["others"] as $match_info) {
+                        if(!in_array(array($match_info["username"],$match_info["version"]), $return )) {
+                            array_push($return, array($match_info["username"],$match_info["version"]));
+                        }
+                    }
+                }
+            }
+            foreach($return as $i => $match_user) {
+                array_push($return[$i], $this->core->getQueries()->getUserById($match_user[0])->getDisplayedFirstName());
                 array_push($return[$i], $this->core->getQueries()->getUserById($match_user[0])->getDisplayedLastName());
-    		}
-	    	$return = json_encode($return);
-	        echo($return);
-	    }
+            }
+            $return = json_encode($return);
+            echo($return);
+        }
     }
 
     /**

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * selected which course they want to access, they are forwarded to the home page.
  */
 class ForumController extends AbstractController{
-	/**
+    /**
      * ForumHomeController constructor.
      *
      * @param Core $core
@@ -41,9 +41,9 @@ class ForumController extends AbstractController{
             //Notify User
             $this->core->addErrorMessage($error);
             if($isThread){
-                $url = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
+            $url = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
             } else {
-                $url = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
+            $url = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
             }
             return array(-1, $url);
     }
@@ -51,20 +51,20 @@ class ForumController extends AbstractController{
     /**
      * @Route("/{_semester}/{_course}/forum/threads/status", methods={"POST"})
      */
-	public function changeThreadStatus($status, $thread_id=null) {
+    public function changeThreadStatus($status, $thread_id=null) {
         if (is_null($thread_id)) {
             $thread_id = $_POST['thread_id'];
         }
-		if($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
-			if($this->core->getQueries()->updateResolveState($thread_id, $status)) {
-			    return $this->core->getOutput()->renderJsonSuccess();
-			} else {
-			    return $this->core->getOutput()->renderJsonFail('The thread resolve state could not be updated. Please try again.');
-			}
-		} else {
-		    return $this->core->getOutput()->renderJsonFail("You do not have permissions to do that.");
-		}
-	}
+        if($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
+            if($this->core->getQueries()->updateResolveState($thread_id, $status)) {
+                return $this->core->getOutput()->renderJsonSuccess();
+            } else {
+                return $this->core->getOutput()->renderJsonFail('The thread resolve state could not be updated. Please try again.');
+            }
+        } else {
+            return $this->core->getOutput()->renderJsonFail("You do not have permissions to do that.");
+        }
+    }
 
     private function checkGoodAttachment($isThread, $thread_id, $file_post){
         if((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE){

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -41,9 +41,9 @@ class ForumController extends AbstractController{
             //Notify User
             $this->core->addErrorMessage($error);
             if($isThread){
-            $url = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
+                $url = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
             } else {
-            $url = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
+                $url = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
             }
             return array(-1, $url);
     }

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -111,10 +111,10 @@ class ForumController2 extends AbstractController {
     private function returnUserContentToPage($error, $isThread, $thread_id){
             //Notify User
             $this->core->addErrorMessage($error);
-            if($isThread){
-            $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'create_thread'));
+            if ($isThread) {
+                $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'create_thread'));
             } else {
-            $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id));
+                $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id));
             }
             return array(-1, $url);
     }
@@ -716,13 +716,13 @@ class ForumController2 extends AbstractController {
     //Modified functions below...
 
     public function publishThread(){
-        
+
         //Get post data
         $title = trim($_POST['title']);
         $thread_post_content = $_POST['thread_post_content'];
         $anon = !empty($_POST['Anon']) ? true : false;
         $thread_status = $_POST['thread_status'];
-        
+
 
         //Default to false
         $announcement = !empty($_POST['Announcement']) && $this->core->getUser()->accessGrading() && $_POST['Announcement'] == 'true' ? true : false;
@@ -733,11 +733,11 @@ class ForumController2 extends AbstractController {
             $categories_ids[] = (int)$category_id;
         }
 
-        $result = $this->core->getForum()->publish( [   'title'              => $title, 
+        $result = $this->core->getForum()->publish( [   'title'              => $title,
                                                         'content'            => $thread_post_content,
-                                                        'anon'               => $anon,  
+                                                        'anon'               => $anon,
                                                         'status'             => $thread_status,
-                                                        'announcement'       => $announcement, 
+                                                        'announcement'       => $announcement,
                                                         'email_announcement' => $email_announcement,
                                                         'categories'         => $categories_ids,
                                                         'parent_id'          => -1,
@@ -760,7 +760,7 @@ class ForumController2 extends AbstractController {
 
 
         return $this->core->getForum()->publish( [ 'content'   => $post_content,
-                                                   'anon'      => $anon,  
+                                                   'anon'      => $anon,
                                                    'thread_id' => $thread_id,
                                                    'parent_id' => $parent_id ], false );
     }
@@ -769,7 +769,7 @@ class ForumController2 extends AbstractController {
     //Ajax endpoint
     public function pinThread($type){
         $thread_id = $_POST["thread_id"];
-        
+
         $result = $this->core->getForum()->pinThread($thread_id, $type);
 
         if($result) {

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -19,7 +19,7 @@ use app\libraries\DateUtils;
  */
 class ForumController2 extends AbstractController {
 
-	/**
+    /**
      * ForumHomeController constructor.
      *
      * @param Core $core
@@ -112,28 +112,28 @@ class ForumController2 extends AbstractController {
             //Notify User
             $this->core->addErrorMessage($error);
             if($isThread){
-                $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'create_thread'));
+            $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'create_thread'));
             } else {
-                $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id));
+            $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id));
             }
             return array(-1, $url);
     }
 
-	private function changeThreadStatus($status) {
-		$thread_id = $_POST['thread_id'];
-		$result = array();
-		if($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
-			if($this->core->getQueries()->updateResolveState($thread_id, $status)) {
-				$result['success'] = 'Thread resolve state has been changed.';
-			} else {
-				$result['error'] = 'The thread resolve state could not be updated. Please try again.';
-			}
-		} else {
+    private function changeThreadStatus($status) {
+        $thread_id = $_POST['thread_id'];
+        $result = array();
+        if($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
+            if($this->core->getQueries()->updateResolveState($thread_id, $status)) {
+                $result['success'] = 'Thread resolve state has been changed.';
+            } else {
+                $result['error'] = 'The thread resolve state could not be updated. Please try again.';
+            }
+        } else {
             $result["error"] = "You do not have permissions to do that.";
-		}
+        }
         $this->core->getOutput()->renderJson($result);
-		return $this->core->getOutput()->getOutput();
-	}
+        return $this->core->getOutput()->getOutput();
+    }
 
     private function isCategoryDeletionGood($category_id){
         // Check if not the last category which exists

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -285,9 +285,9 @@ class SubmissionController extends AbstractController {
         }
 
         $max_size = $gradeable->getAutogradingConfig()->getMaxSubmissionSize();
-    	if ($max_size < 10000000) {
-    	    $max_size = 10000000;
-    	}
+        if ($max_size < 10000000) {
+            $max_size = 10000000;
+        }
         // Error checking of file name
         $file_size = 0;
         if (isset($uploaded_file)) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -369,18 +369,18 @@ class DatabaseQueries {
         return $this->course_db->rows()[0]["max_id"];
     }
 
-	public function getResolveState($thread_id) {
-		$this->course_db->query("SELECT status from threads where id = ?", array($thread_id));
-		return $this->course_db->rows();
-	}
+    public function getResolveState($thread_id) {
+        $this->course_db->query("SELECT status from threads where id = ?", array($thread_id));
+        return $this->course_db->rows();
+    }
 
-	public function updateResolveState($thread_id, $state) {
-		if(in_array($state, array(-1, 0, 1))) {
-			$this->course_db->query("UPDATE threads set status = ? where id = ?", array($state, $thread_id));
-			return true;
-		}
-		return false;
-	}
+    public function updateResolveState($thread_id, $state) {
+        if(in_array($state, array(-1, 0, 1))) {
+            $this->course_db->query("UPDATE threads set status = ? where id = ?", array($state, $thread_id));
+            return true;
+        }
+        return false;
+    }
 
     public function updateNotificationSettings($results) {
         $values = implode(', ', array_fill(0, count($results)+1, '?'));
@@ -408,10 +408,10 @@ class DatabaseQueries {
                                         SET $updates", $test);
     }
 
-	public function getAuthorOfThread($thread_id) {
-		$this->course_db->query("SELECT created_by from threads where id = ?", array($thread_id));
-		return $this->course_db->rows()[0]['created_by'];
-	}
+    public function getAuthorOfThread($thread_id) {
+        $this->course_db->query("SELECT created_by from threads where id = ?", array($thread_id));
+        return $this->course_db->rows()[0]['created_by'];
+    }
 
     public function getPosts(){
         $this->course_db->query("SELECT * FROM posts where deleted = false ORDER BY timestamp ASC");
@@ -552,13 +552,13 @@ class DatabaseQueries {
     }
 
     public function searchThreads($searchQuery){
-    	$this->course_db->query("SELECT post_content, p_id, p_author, thread_id, thread_title, author, pin, anonymous, timestamp_post FROM (SELECT t.id as thread_id, t.title as thread_title, p.id as p_id, t.created_by as author, t.pinned as pin, p.timestamp as timestamp_post, p.content as post_content, p.anonymous, p.author_user_id as p_author, to_tsvector(p.content) || to_tsvector(t.title) as document from posts p, threads t JOIN (SELECT thread_id, timestamp from posts where parent_id = -1) p2 ON p2.thread_id = t.id where t.id = p.thread_id and p.deleted=false and t.deleted=false) p_doc where p_doc.document @@ plainto_tsquery(:q) ORDER BY timestamp_post DESC", array(':q' => $searchQuery));
-    	return $this->course_db->rows();
+        $this->course_db->query("SELECT post_content, p_id, p_author, thread_id, thread_title, author, pin, anonymous, timestamp_post FROM (SELECT t.id as thread_id, t.title as thread_title, p.id as p_id, t.created_by as author, t.pinned as pin, p.timestamp as timestamp_post, p.content as post_content, p.anonymous, p.author_user_id as p_author, to_tsvector(p.content) || to_tsvector(t.title) as document from posts p, threads t JOIN (SELECT thread_id, timestamp from posts where parent_id = -1) p2 ON p2.thread_id = t.id where t.id = p.thread_id and p.deleted=false and t.deleted=false) p_doc where p_doc.document @@ plainto_tsquery(:q) ORDER BY timestamp_post DESC", array(':q' => $searchQuery));
+        return $this->course_db->rows();
     }
 
     public function threadExists(){
-		$this->course_db->query("SELECT id from threads where deleted = false LIMIT 1");
-		return count($this->course_db->rows()) == 1;
+        $this->course_db->query("SELECT id from threads where deleted = false LIMIT 1");
+        return count($this->course_db->rows()) == 1;
     }
 
     public function visitThread($current_user, $thread_id){
@@ -752,7 +752,7 @@ class DatabaseQueries {
     public function getUsersByRegistrationSections($sections, $orderBy="registration_section") {
         $return = array();
         if (count($sections) > 0) {
-        	$orderBy = str_replace("registration_section","SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')",$orderBy);
+            $orderBy = str_replace("registration_section","SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')",$orderBy);
             $values = $this->createParamaterList(count($sections));
             $this->course_db->query("SELECT * FROM users AS u WHERE registration_section IN {$values} ORDER BY {$orderBy}", $sections);
             foreach ($this->course_db->rows() as $row) {
@@ -1521,7 +1521,7 @@ ORDER BY user_id ASC");
     }
 
     public function deleteRegistrationSection($section) {
-       	$semester = $this->core->getConfig()->getSemester();
+        $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
         $this->submitty_db->query("DELETE FROM courses_registration_sections WHERE semester=? AND course=? AND registration_section_id=?", array($semester, $course, $section));
         return $this->submitty_db->getRowCount();
@@ -2103,12 +2103,12 @@ ORDER BY {$section_key}", $params);
             $params = array_merge($sections, $params);
         }
         $orderBy="";
- 		if($section_key == "registration_section") {
- 			$orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
- 		}
- 		else {
- 			$orderBy = $section_key;
- 		}
+        if($section_key == "registration_section") {
+            $orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
+        }
+        else {
+            $orderBy = $section_key;
+        }
         $this->course_db->query("
 SELECT count(*) as cnt, {$section_key}
 FROM users
@@ -2140,12 +2140,12 @@ ORDER BY {$orderBy}", $params);
             $params = array_merge($sections, $params);
         }
         $orderBy="";
- 		if($section_key == "registration_section") {
- 			$orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
- 		}
- 		else {
- 			$orderBy = $section_key;
- 		}
+        if($section_key == "registration_section") {
+            $orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
+        }
+        else {
+            $orderBy = $section_key;
+        }
 
         $this->course_db->query("
 SELECT count(*) as cnt, {$section_key}
@@ -2284,9 +2284,9 @@ ORDER BY gt.{$section_key}", $params);
      * @param string $csv_option value determined by selected radio button
      */
     public function updateLateDays($user_id, $timestamp, $days, $csv_option=null) {
-		//q.v. PostgresqlDatabaseQueries.php
-		throw new NotImplementedException();
-	}
+        //q.v. PostgresqlDatabaseQueries.php
+        throw new NotImplementedException();
+    }
 
     /**
      * Delete a given user's allowed late days entry at given effective time
@@ -2371,16 +2371,16 @@ ORDER BY gt.{$section_key}", $params);
         $this->course_db->query("INSERT INTO peer_assign(grader_id, user_id, g_id) VALUES (?,?,?)", array($grader, $student, $gradeable_id));
     }
 
-	/**
-	 * Retrieves all unarchived courses (and details) that are accessible by $user_id
-	 *
-	 * (u.user_id=? AND c.status=1) checks if a course is active
-	 * An active course may be accessed by all users
-	 *
-	 * @param string $user_id
-	 * @param string $submitty_path
-	 * @return array - unarchived courses (and their details) accessible by $user_id
-	 */
+    /**
+     * Retrieves all unarchived courses (and details) that are accessible by $user_id
+     *
+     * (u.user_id=? AND c.status=1) checks if a course is active
+     * An active course may be accessed by all users
+     *
+     * @param string $user_id
+     * @param string $submitty_path
+     * @return array - unarchived courses (and their details) accessible by $user_id
+     */
     public function getUnarchivedCoursesById($user_id) {
         $this->submitty_db->query("
 SELECT u.semester, u.course
@@ -2983,8 +2983,8 @@ AND gc_id IN (
         $parameters = array();
         $parameters[] = $user_id;
         if($thread_id != -1) {
-        	$id_query = "metadata::json->>'thread_id' = ?";
-        	$parameters[] = $thread_id;
+            $id_query = "metadata::json->>'thread_id' = ?";
+            $parameters[] = $thread_id;
         } else if($notification_id == -1) {
             $id_query = "true";
         } else {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -545,7 +545,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
      */
     public function updateLateDays($user_id, $timestamp, $days, $csv_option=null) {
         //Update query and values list.
-		$query = "
+        $query = "
             INSERT INTO late_days (user_id, since_timestamp, allowed_late_days)
             VALUES(?,?,?)
             ON CONFLICT (user_id, since_timestamp) DO UPDATE
@@ -558,12 +558,12 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
                 //Does NOT overwrite a higher (or same) value of allowed late days.
                 $query .= "AND late_days.allowed_late_days<?";
                 $vals[] = $days;
-        	    break;
+                break;
             case 'csv_option_overwrite_all':
             default:
                 //Default behavior: overwrite all late days for user and timestamp.
                 //No adjustment to SQL query.
-    	}
+        }
 
         $this->course_db->query($query, $vals);
     }

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -324,36 +324,36 @@ class User extends AbstractModel {
 
         switch($field) {
         case 'user_id':
-                //Username / user_id must contain only lowercase alpha, numbers, underscores, hyphens
+             //Username / user_id must contain only lowercase alpha, numbers, underscores, hyphens
             return preg_match("~^[a-z0-9_\-]+$~", $data) === 1;
         case 'user_legal_firstname':
         case 'user_legal_lastname':
-                //First and last name must be alpha characters, white-space, or certain punctuation.
+            //First and last name must be alpha characters, white-space, or certain punctuation.
             return preg_match("~^[a-zA-Z'`\-\.\(\) ]+$~", $data) === 1;
         case 'user_preferred_firstname':
         case 'user_preferred_lastname':
-                //Preferred first and last name may be "", alpha chars, white-space, certain punctuation AND between 0 and 30 chars.
+            //Preferred first and last name may be "", alpha chars, white-space, certain punctuation AND between 0 and 30 chars.
             return preg_match("~^[a-zA-Z'`\-\.\(\) ]{0,30}$~", $data) === 1;
         case 'user_email':
-                    // emails are allowed to be the empty string...
-                    if ($data === "") return true;
-                    // -- or ---
-                    // Check email address for appropriate format. e.g. "user@university.edu", "user@cs.university.edu", etc.
-                    return preg_match("~^[^(),:;<>@\\\"\[\]]+@(?!\-)[a-zA-Z0-9\-]+(?<!\-)(\.[a-zA-Z0-9]+)+$~", $data) === 1;
+            // emails are allowed to be the empty string...
+            if ($data === "") return true;
+            // -- or ---
+            // Check email address for appropriate format. e.g. "user@university.edu", "user@cs.university.edu", etc.
+            return preg_match("~^[^(),:;<>@\\\"\[\]]+@(?!\-)[a-zA-Z0-9\-]+(?<!\-)(\.[a-zA-Z0-9]+)+$~", $data) === 1;
         case 'user_group':
-                //user_group check is a digit between 1 - 4.
+            //user_group check is a digit between 1 - 4.
             return preg_match("~^[1-4]{1}$~", $data) === 1;
         case 'registration_section':
-                //Registration section must contain only alpha (upper and lower permitted), numbers, underscores, hyphens.
-                //"NULL" registration section should be validated as a datatype, not as a string.
+            //Registration section must contain only alpha (upper and lower permitted), numbers, underscores, hyphens.
+            //"NULL" registration section should be validated as a datatype, not as a string.
             return preg_match("~^(?!^null$)[a-z0-9_\-]+$~i", $data) === 1 || is_null($data);
         case 'user_password':
-                //Database password cannot be blank, no check on format
+            //Database password cannot be blank, no check on format
             return $data !== "";
         default:
-                //$data can't be validated since $field is unknown.  Notify developer with an exception (also protectes data record integrity).
-                $ex_field = '$field: ' . var_export(htmlentities($field), true);
-                $ex_data = '$data:  ' . var_export(htmlentities($data), true);
+            //$data can't be validated since $field is unknown.  Notify developer with an exception (also protectes data record integrity).
+            $ex_field = '$field: ' . var_export(htmlentities($field), true);
+            $ex_data = '$data:  ' . var_export(htmlentities($data), true);
             throw new ValidationException('User::validateUserData() called with unknown $field.  See extra details, below.', array($ex_field, $ex_data));
         }
     }

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -104,20 +104,20 @@ class User extends AbstractModel {
      */
     protected $manual_registration = false;
 
-	/**
-	 * @property
-	 * @var bool This flag is set TRUE when a user edits their own preferred firstname.  When TRUE, preferred firstname
-	 *           is supposed to be locked from changes via student auto feed script.  Note that auto feed is still
-	 *           permitted to change (correct?) a user's legal firstname/lastname and email address.
-	 */
+    /**
+     * @property
+     * @var bool This flag is set TRUE when a user edits their own preferred firstname.  When TRUE, preferred firstname
+     *           is supposed to be locked from changes via student auto feed script.  Note that auto feed is still
+     *           permitted to change (correct?) a user's legal firstname/lastname and email address.
+     */
     protected $user_updated = false;
 
-	/**
-	 * @property
-	 * @var bool This flag is set TRUE when the instructor edits another user's record.  When TRUE, preferred firstname
-	 *           is supposed to be locked from changes via student auto feed script.  Note that auto feed is still
-	 *           permitted to change (correct?) a user's legal firstname/lastname and email address.
-	 */
+    /**
+     * @property
+     * @var bool This flag is set TRUE when the instructor edits another user's record.  When TRUE, preferred firstname
+     *           is supposed to be locked from changes via student auto feed script.  Note that auto feed is still
+     *           permitted to change (correct?) a user's legal firstname/lastname and email address.
+     */
     protected $instructor_updated = false;
 
     /** @property @var array */
@@ -322,40 +322,40 @@ class User extends AbstractModel {
      */
     static public function validateUserData($field, $data) {
 
-    	switch($field) {
-		case 'user_id':
-			//Username / user_id must contain only lowercase alpha, numbers, underscores, hyphens
-			return preg_match("~^[a-z0-9_\-]+$~", $data) === 1;
-		case 'user_legal_firstname':
-		case 'user_legal_lastname':
-			//First and last name must be alpha characters, white-space, or certain punctuation.
-        	return preg_match("~^[a-zA-Z'`\-\.\(\) ]+$~", $data) === 1;
-   		case 'user_preferred_firstname':
-   		case 'user_preferred_lastname':
-   		    //Preferred first and last name may be "", alpha chars, white-space, certain punctuation AND between 0 and 30 chars.
-   		    return preg_match("~^[a-zA-Z'`\-\.\(\) ]{0,30}$~", $data) === 1;
-		case 'user_email':
+        switch($field) {
+        case 'user_id':
+                //Username / user_id must contain only lowercase alpha, numbers, underscores, hyphens
+            return preg_match("~^[a-z0-9_\-]+$~", $data) === 1;
+        case 'user_legal_firstname':
+        case 'user_legal_lastname':
+                //First and last name must be alpha characters, white-space, or certain punctuation.
+            return preg_match("~^[a-zA-Z'`\-\.\(\) ]+$~", $data) === 1;
+        case 'user_preferred_firstname':
+        case 'user_preferred_lastname':
+                //Preferred first and last name may be "", alpha chars, white-space, certain punctuation AND between 0 and 30 chars.
+            return preg_match("~^[a-zA-Z'`\-\.\(\) ]{0,30}$~", $data) === 1;
+        case 'user_email':
                     // emails are allowed to be the empty string...
                     if ($data === "") return true;
                     // -- or ---
                     // Check email address for appropriate format. e.g. "user@university.edu", "user@cs.university.edu", etc.
                     return preg_match("~^[^(),:;<>@\\\"\[\]]+@(?!\-)[a-zA-Z0-9\-]+(?<!\-)(\.[a-zA-Z0-9]+)+$~", $data) === 1;
-		case 'user_group':
-            //user_group check is a digit between 1 - 4.
-			return preg_match("~^[1-4]{1}$~", $data) === 1;
-		case 'registration_section':
-			//Registration section must contain only alpha (upper and lower permitted), numbers, underscores, hyphens.
-			//"NULL" registration section should be validated as a datatype, not as a string.
-			return preg_match("~^(?!^null$)[a-z0-9_\-]+$~i", $data) === 1 || is_null($data);
-		case 'user_password':
-	        //Database password cannot be blank, no check on format
-			return $data !== "";
-		default:
-			//$data can't be validated since $field is unknown.  Notify developer with an exception (also protectes data record integrity).
-			$ex_field = '$field: ' . var_export(htmlentities($field), true);
-			$ex_data = '$data:  ' . var_export(htmlentities($data), true);
-			throw new ValidationException('User::validateUserData() called with unknown $field.  See extra details, below.', array($ex_field, $ex_data));
-    	}
+        case 'user_group':
+                //user_group check is a digit between 1 - 4.
+            return preg_match("~^[1-4]{1}$~", $data) === 1;
+        case 'registration_section':
+                //Registration section must contain only alpha (upper and lower permitted), numbers, underscores, hyphens.
+                //"NULL" registration section should be validated as a datatype, not as a string.
+            return preg_match("~^(?!^null$)[a-z0-9_\-]+$~i", $data) === 1 || is_null($data);
+        case 'user_password':
+                //Database password cannot be blank, no check on format
+            return $data !== "";
+        default:
+                //$data can't be validated since $field is unknown.  Notify developer with an exception (also protectes data record integrity).
+                $ex_field = '$field: ' . var_export(htmlentities($field), true);
+                $ex_data = '$data:  ' . var_export(htmlentities($data), true);
+            throw new ValidationException('User::validateUserData() called with unknown $field.  See extra details, below.', array($ex_field, $ex_data));
+        }
     }
 
     static public function constructNotificationSettings($details) {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -589,8 +589,8 @@ class Gradeable extends AbstractModel {
         // Blacklist the dates checked by validation
         $black_list = $this->getDateValidationSet();
 
-		// First coerce in the forward direction, then in the reverse direction
-		return $coerce_dates(array_reverse(self::date_validated_properties), $black_list,
+        // First coerce in the forward direction, then in the reverse direction
+        return $coerce_dates(array_reverse(self::date_validated_properties), $black_list,
             $coerce_dates(self::date_validated_properties, $black_list, $dates,
                 function (\DateTime $val, \DateTime $cmp) {
                     return $val < $cmp;

--- a/site/app/views/MiscView.php
+++ b/site/app/views/MiscView.php
@@ -31,5 +31,5 @@ class MiscView extends AbstractView {
             "code_css" => $code_css,
             "code_js" => $code_js
         ]);
-	}
+    }
 }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -105,7 +105,7 @@ class NavigationView extends AbstractView {
         // ======================================================================================
         // DISPLAY ROOM SEATING (used to display room seating assignments)
         // ======================================================================================
-    $seating_only_for_instructor = $this->core->getConfig()->isSeatingOnlyForInstructor();
+        $seating_only_for_instructor = $this->core->getConfig()->isSeatingOnlyForInstructor();
         if ($seating_only_for_instructor && !$this->core->getUser()->accessAdmin()) {
             $display_room_seating = false;
         }
@@ -679,7 +679,7 @@ class NavigationView extends AbstractView {
     private function getDeleteButton(Gradeable $gradeable) {
         $button = new Button($this->core, [
             "title" => "Delete Gradeable",
-            "href" => "javascript:newDeleteGradeableForm('" . 
+            "href" => "javascript:newDeleteGradeableForm('" .
                 $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'delete'])
                 . "', '{$gradeable->getTitle()}');",
             "class" => "fas fa-trash fa-fw black-btn",

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -82,22 +82,22 @@ class NavigationView extends AbstractView {
         // ======================================================================================
         $display_custom_message = $this->core->getConfig()->displayCustomMessage();
         $message_file_details = null;
-		//Course settings have enabled displaying custom (banner) message
+        //Course settings have enabled displaying custom (banner) message
         if($display_custom_message) {
             $message_file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "reports", "summary_html", $this->core->getUser()->getId() . ".json");
             $display_custom_message = is_file($message_file_path);
-			//If statement seems redundant, but will help in case we ever decouple the is_file check from $display_custom_message
+            //If statement seems redundant, but will help in case we ever decouple the is_file check from $display_custom_message
             if ($display_custom_message && is_file($message_file_path)) {
-				$message_json = json_decode(file_get_contents($message_file_path));
-				if(property_exists($message_json, 'special_message')){
-					$message_file_details = $message_json->special_message;
+                $message_json = json_decode(file_get_contents($message_file_path));
+                if(property_exists($message_json, 'special_message')){
+                    $message_file_details = $message_json->special_message;
 
-					//If any fields are missing, treat this as though we just didn't have a message for this user.
-					if(!property_exists($message_file_details,'title') || !property_exists($message_file_details,'description') || !property_exists($message_file_details,'filename') ){
-						$display_custom_message = false;
-						$messsage_file_details = null;
-					}
-				}
+                    //If any fields are missing, treat this as though we just didn't have a message for this user.
+                    if(!property_exists($message_file_details,'title') || !property_exists($message_file_details,'description') || !property_exists($message_file_details,'filename') ){
+                        $display_custom_message = false;
+                        $messsage_file_details = null;
+                    }
+                }
             }
         }
 
@@ -105,7 +105,7 @@ class NavigationView extends AbstractView {
         // ======================================================================================
         // DISPLAY ROOM SEATING (used to display room seating assignments)
         // ======================================================================================
-	$seating_only_for_instructor = $this->core->getConfig()->isSeatingOnlyForInstructor();
+    $seating_only_for_instructor = $this->core->getConfig()->isSeatingOnlyForInstructor();
         if ($seating_only_for_instructor && !$this->core->getUser()->accessAdmin()) {
             $display_room_seating = false;
         }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -18,13 +18,13 @@ class ForumThreadView extends AbstractView {
 
         $buttons = array(
             array(
-            "required_rank" => 4,
-            "display_text" => 'Create Thread',
-            "style" => 'position:relative;float:right;top:3px;',
-            "link" => array(true, $this->core->buildCourseUrl(['forum', 'threads', 'new'])),
-            "optional_class" => '',
-            "title" => 'Create Thread',
-            "onclick" => array(false)
+                "required_rank" => 4,
+                "display_text" => 'Create Thread',
+                "style" => 'position:relative;float:right;top:3px;',
+                "link" => array(true, $this->core->buildCourseUrl(['forum', 'threads', 'new'])),
+                "optional_class" => '',
+                "title" => 'Create Thread',
+                "onclick" => array(false)
             ),
             array(
                 "required_rank" => 4,

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -7,78 +7,78 @@ use app\libraries\FileUtils;
 
 class ForumThreadView extends AbstractView {
 
-	public function forumAccess(){
+    public function forumAccess(){
         return $this->core->getConfig()->isForumEnabled();
     }
 
     public function searchResult($threads){
 
-    	$this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
-    	$this->core->getOutput()->addBreadcrumb("Search");
+        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+        $this->core->getOutput()->addBreadcrumb("Search");
 
-		$buttons = array(
-			array(
-			"required_rank" => 4,
-			"display_text" => 'Create Thread',
-			"style" => 'position:relative;float:right;top:3px;',
-			"link" => array(true, $this->core->buildCourseUrl(['forum', 'threads', 'new'])),
-			"optional_class" => '',
-			"title" => 'Create Thread',
-			"onclick" => array(false)
-			),
-			array(
-				"required_rank" => 4,
-				"display_text" => 'Back to Threads',
-				"style" => 'position:relative;float:right;top:3px;margin-right:5px;',
-				"link" => array(true, $this->core->buildCourseUrl(['forum', 'threads'])),
-				"optional_class" => '',
-				"title" => 'Back to threads',
-				"onclick" => array(false)
-			)
-		);
+        $buttons = array(
+            array(
+            "required_rank" => 4,
+            "display_text" => 'Create Thread',
+            "style" => 'position:relative;float:right;top:3px;',
+            "link" => array(true, $this->core->buildCourseUrl(['forum', 'threads', 'new'])),
+            "optional_class" => '',
+            "title" => 'Create Thread',
+            "onclick" => array(false)
+            ),
+            array(
+                "required_rank" => 4,
+                "display_text" => 'Back to Threads',
+                "style" => 'position:relative;float:right;top:3px;margin-right:5px;',
+                "link" => array(true, $this->core->buildCourseUrl(['forum', 'threads'])),
+                "optional_class" => '',
+                "title" => 'Back to threads',
+                "onclick" => array(false)
+            )
+        );
 
-		$threadArray = array();
-		$fromIdtoTitle = array();
-		foreach($threads as $thread){
-			if(!array_key_exists($thread["thread_id"], $threadArray)) {
-				$threadArray[$thread["thread_id"]] = array();
-				$fromIdtoTitle[$thread["thread_id"]] = $thread["thread_title"];
-			}
-			$threadArray[$thread["thread_id"]][] = $thread;
-		}
-		$count = 1;
+        $threadArray = array();
+        $fromIdtoTitle = array();
+        foreach($threads as $thread){
+            if(!array_key_exists($thread["thread_id"], $threadArray)) {
+                $threadArray[$thread["thread_id"]] = array();
+                $fromIdtoTitle[$thread["thread_id"]] = $thread["thread_title"];
+            }
+            $threadArray[$thread["thread_id"]][] = $thread;
+        }
+        $count = 1;
 
-		$thread_list = [];
+        $thread_list = [];
 
-		foreach($threadArray as $thread_id => $data){
-			$thread_title = $fromIdtoTitle[$thread_id];
+        foreach($threadArray as $thread_id => $data){
+            $thread_title = $fromIdtoTitle[$thread_id];
 
             $thread_link = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
 
             $thread_list[$count-1] = Array("thread_title" => $thread_title, "thread_link" => $thread_link, "posts" => Array());
 
-			foreach($data as $post) {
-				$author = $post['author'];
-				$user_info = $this->core->getQueries()->getDisplayUserInfoFromUserId($post["p_author"]);
-				$first_name = trim($user_info["first_name"]);
-				$last_name = trim($user_info["last_name"]);
-				$visible_username = $first_name . " " . substr($last_name, 0 , 1) . ".";
+            foreach($data as $post) {
+                $author = $post['author'];
+                $user_info = $this->core->getQueries()->getDisplayUserInfoFromUserId($post["p_author"]);
+                $first_name = trim($user_info["first_name"]);
+                $last_name = trim($user_info["last_name"]);
+                $visible_username = $first_name . " " . substr($last_name, 0 , 1) . ".";
 
-				if($post["anonymous"]){
-					$visible_username = 'Anonymous';
-				}
+                if($post["anonymous"]){
+                    $visible_username = 'Anonymous';
+                }
 
-				//convert legacy htmlentities being saved in db
+                //convert legacy htmlentities being saved in db
                 $post_content = html_entity_decode($post["post_content"], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $pre_post = preg_replace('#(<a href=[\'"])(.*?)([\'"].*>)(.*?)(</a>)#', '[url=$2]$4[/url]', $post_content);
 
                 if(!empty($pre_post)){
                     $post_content = $pre_post;
-				}
+                }
 
                 $post_link = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . "#" . $post['p_id'];
 
-				$posted_on = date_format(DateUtils::parseDateTime($post['timestamp_post'], $this->core->getConfig()->getTimezone()), "n/j g:i A");
+                $posted_on = date_format(DateUtils::parseDateTime($post['timestamp_post'], $this->core->getConfig()->getTimezone()), "n/j g:i A");
 
                 $thread_list[$count-1]["posts"][] = Array(
                     "post_link" => $post_link,
@@ -88,9 +88,9 @@ class ForumThreadView extends AbstractView {
                     "posted_on" => $posted_on
                 );
 
-				$count++;
-			}
-		}
+                $count++;
+            }
+        }
 
 
         $return = $this->core->getOutput()->renderTwigTemplate("forum/searchResults.twig", [
@@ -100,14 +100,14 @@ class ForumThreadView extends AbstractView {
             "search_url" => $this->core->buildCourseUrl(['forum', 'search'])
         ]);
 
-    	return $return;
+        return $return;
     }
 
-	/** Shows Forums thread splash page, including all posts
-		for a specific thread, in addition to head of the threads
-		that have been created after applying filter and to be
-		displayed in the left panel.
-	*/
+    /** Shows Forums thread splash page, including all posts
+        for a specific thread, in addition to head of the threads
+        that have been created after applying filter and to be
+        displayed in the left panel.
+    */
 
     public function showForumThreads($user, $posts, $unviewed_posts, $threadsHead, $show_deleted, $show_merged_thread, $display_option, $max_thread, $initialPageNumber, $thread_resolve_state, $post_content_limit, $ajax=false) {
 
@@ -550,14 +550,14 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-	public function showAlteredDisplayList($threads, $filtering, $thread_id, $categories_ids){
-		$tempArray = array();
-		$threadAnnouncement = false;
-		$activeThreadTitle = "";
-		return $this->displayThreadList($threads, $filtering, $threadAnnouncement, $activeThreadTitle, $tempArray, $thread_id, $categories_ids, true);
-	}
+    public function showAlteredDisplayList($threads, $filtering, $thread_id, $categories_ids){
+        $tempArray = array();
+        $threadAnnouncement = false;
+        $activeThreadTitle = "";
+        return $this->displayThreadList($threads, $filtering, $threadAnnouncement, $activeThreadTitle, $tempArray, $thread_id, $categories_ids, true);
+    }
 
-	public function contentMarkdownToPlain($str){
+    public function contentMarkdownToPlain($str){
         $str = preg_replace("/\[[^)]+\]/","",$str);
         $str = preg_replace('/\(([^)]+)\)/s', '$1', $str);
         $str = str_replace("```","", $str);
@@ -718,47 +718,47 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-	public function filter_post_content($original_post_content) {
-		$post_content = html_entity_decode($original_post_content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-		$pre_post = preg_replace('#(<a href=[\'"])(.*?)([\'"].*>)(.*?)(</a>)#', '[url=$2]$4[/url]', $post_content);
+    public function filter_post_content($original_post_content) {
+        $post_content = html_entity_decode($original_post_content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $pre_post = preg_replace('#(<a href=[\'"])(.*?)([\'"].*>)(.*?)(</a>)#', '[url=$2]$4[/url]', $post_content);
 
-		if(!empty($pre_post)){
-			$post_content = $pre_post;
-		}
+        if(!empty($pre_post)){
+            $post_content = $pre_post;
+        }
 
-		preg_match_all('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', $post_content, $result);
-		$accepted_schemes = array("https", "http");
-		$pos = 0;
-		if(count($result) > 0) {
-			foreach($result[1] as $url){
-				$decoded_url = filter_var(trim(strip_tags(html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8'))), FILTER_SANITIZE_URL);
-				$parsed_url = parse_url($decoded_url, PHP_URL_SCHEME);
-				if(filter_var($decoded_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== false && in_array($parsed_url, $accepted_schemes, true)){
-					$pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', '<a href="' . htmlspecialchars($decoded_url, ENT_QUOTES) . '" target="_blank" rel="noopener nofollow">'. $result[2][$pos] .'</a>', $post_content, 1);
-				} else {
-					$pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', htmlentities(htmlspecialchars($decoded_url), ENT_QUOTES | ENT_HTML5, 'UTF-8'), $post_content, 1);
-				}
-				if(!empty($pre_post)){
-					$post_content = $pre_post;
-				}
+        preg_match_all('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', $post_content, $result);
+        $accepted_schemes = array("https", "http");
+        $pos = 0;
+        if(count($result) > 0) {
+            foreach($result[1] as $url){
+                $decoded_url = filter_var(trim(strip_tags(html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8'))), FILTER_SANITIZE_URL);
+                $parsed_url = parse_url($decoded_url, PHP_URL_SCHEME);
+                if(filter_var($decoded_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== false && in_array($parsed_url, $accepted_schemes, true)){
+                    $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', '<a href="' . htmlspecialchars($decoded_url, ENT_QUOTES) . '" target="_blank" rel="noopener nofollow">'. $result[2][$pos] .'</a>', $post_content, 1);
+                } else {
+                    $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', htmlentities(htmlspecialchars($decoded_url), ENT_QUOTES | ENT_HTML5, 'UTF-8'), $post_content, 1);
+                }
+                if(!empty($pre_post)){
+                    $post_content = $pre_post;
+                }
 
-				$pos++;
-			}
-		}
-		//This code is for legacy posts that had an extra \r per newline
-		if(strpos($original_post_content, "\r") !== false){
-			$post_content = str_replace("\r","", $post_content);
-		}
+                $pos++;
+            }
+        }
+        //This code is for legacy posts that had an extra \r per newline
+        if(strpos($original_post_content, "\r") !== false){
+            $post_content = str_replace("\r","", $post_content);
+        }
 
-		//end link handling
+        //end link handling
 
-		//handle converting code segments
-		$post_content = preg_replace('/&lbrack;code&rsqb;(.*?)&lbrack;&sol;code&rsqb;/', '<textarea class="code">$1</textarea>', $post_content);
+        //handle converting code segments
+        $post_content = preg_replace('/&lbrack;code&rsqb;(.*?)&lbrack;&sol;code&rsqb;/', '<textarea class="code">$1</textarea>', $post_content);
 
-		return $post_content;
-	}
+        return $post_content;
+    }
 
-	public function createPost($thread_id, $post, $unviewed_posts, $function_date, $first, $reply_level, $display_option, $includeReply, &$totalAttachments)
+    public function createPost($thread_id, $post, $unviewed_posts, $function_date, $first, $reply_level, $display_option, $includeReply, &$totalAttachments)
     {
         $current_user = $this->core->getUser()->getId();
         $post_id = $post["id"];
@@ -832,46 +832,46 @@ class ForumThreadView extends AbstractView {
 
         $post_button = [];
 
-		if($this->core->getUser()->getGroup() <= 3 || $post['author_user_id'] === $current_user) {
-			if(!($this->core->getQueries()->isThreadLocked($thread_id) != 1 || $this->core->getUser()->accessFullGrading() )){
+        if($this->core->getUser()->getGroup() <= 3 || $post['author_user_id'] === $current_user) {
+            if(!($this->core->getQueries()->isThreadLocked($thread_id) != 1 || $this->core->getUser()->accessFullGrading() )){
 
-			} else {
-				if($deleted && $this->core->getUser()->getGroup() <= 3){
-					$ud_toggle_status = "false";
-					$ud_button_title = "Undelete post";
-					$ud_button_icon = "fa-undo";
-				} else {
-					$ud_toggle_status = "true";
-					$ud_button_title = "Remove post";
-					$ud_button_icon = "fa-trash";
-				}
+            } else {
+                if($deleted && $this->core->getUser()->getGroup() <= 3){
+                    $ud_toggle_status = "false";
+                    $ud_button_title = "Undelete post";
+                    $ud_button_icon = "fa-undo";
+                } else {
+                    $ud_toggle_status = "true";
+                    $ud_button_title = "Remove post";
+                    $ud_button_icon = "fa-trash";
+                }
 
-				$post_button["delete"] = [
-				    "ud_toggle_status" => $ud_toggle_status,
+                $post_button["delete"] = [
+                    "ud_toggle_status" => $ud_toggle_status,
                     "csrf_token" => $this->core->getCsrfToken(),
                     "ud_button_title" => $ud_button_title,
                     "ud_button_icon" => $ud_button_icon
                 ];
 
-				$shouldEditThread = null;
+                $shouldEditThread = null;
 
-				if($first) {
-					$shouldEditThread = "true";
-					$edit_button_title = "Edit thread and post";
-				} else {
-					$shouldEditThread = "false";
-					$edit_button_title = "Edit post";
-				}
+                if($first) {
+                    $shouldEditThread = "true";
+                    $edit_button_title = "Edit thread and post";
+                } else {
+                    $shouldEditThread = "false";
+                    $edit_button_title = "Edit post";
+                }
 
-				$post_button["edit"] = [
-				    "shouldEditThread" => $shouldEditThread,
+                $post_button["edit"] = [
+                    "shouldEditThread" => $shouldEditThread,
                     "edit_button_title" => $edit_button_title,
                     "csrf_token" => $this->core->getCsrfToken()
                 ];
-			}
+            }
         }
 
-		$post_attachment = ["exist" => false];
+        $post_attachment = ["exist" => false];
 
         if ($post["has_attachment"]) {
             $post_attachment["exist"] = true;
@@ -947,14 +947,14 @@ class ForumThreadView extends AbstractView {
             "render_markdown" => $markdown
         ];
 
-		return $return;
-	}
+        return $return;
+    }
 
     public function createThread($category_colors){
-		if(!$this->forumAccess()){
-			$this->core->redirect($this->core->buildCourseUrl());
-			return;
-		}
+        if(!$this->forumAccess()){
+            $this->core->redirect($this->core->buildCourseUrl());
+            return;
+        }
 
         $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
         $this->core->getOutput()->addBreadcrumb("Create Thread", $this->core->buildCourseUrl(['forum', 'threads', 'new']));
@@ -1067,59 +1067,59 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-	public function statPage($users) {
-		if(!$this->forumAccess()){
-			$this->core->redirect($this->core->buildCourseUrl());
-			return;
-		}
+    public function statPage($users) {
+        if(!$this->forumAccess()){
+            $this->core->redirect($this->core->buildCourseUrl());
+            return;
+        }
 
-		if(!$this->core->getUser()->accessFullGrading()){
-			$this->core->redirect($this->core->buildCourseUrl(['forum', 'threads']));
-			return;
-		}
+        if(!$this->core->getUser()->accessFullGrading()){
+            $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads']));
+            return;
+        }
 
-		$this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
-		$this->core->getOutput()->addBreadcrumb("Statistics", $this->core->buildCourseUrl(['forum', 'stats']));
+        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+        $this->core->getOutput()->addBreadcrumb("Statistics", $this->core->buildCourseUrl(['forum', 'stats']));
 
         $this->core->getOutput()->addInternalJs('forum.js');
         $this->core->getOutput()->addInternalCss('forum.css');
 
-		$buttons = array(
-			array(
-				"required_rank" => 4,
-				"display_text" => 'Back to Threads',
-				"style" => 'position:relative;float:right;top:3px;',
-				"link" => array(true, $this->core->buildCourseUrl(['forum', 'threads'])),
-				"optional_class" => '',
-				"title" => 'Back to threads',
-				"onclick" => array(false)
-			)
-		);
+        $buttons = array(
+            array(
+                "required_rank" => 4,
+                "display_text" => 'Back to Threads',
+                "style" => 'position:relative;float:right;top:3px;',
+                "link" => array(true, $this->core->buildCourseUrl(['forum', 'threads'])),
+                "optional_class" => '',
+                "title" => 'Back to threads',
+                "onclick" => array(false)
+            )
+        );
 
-		$thread_exists = $this->core->getQueries()->threadExists();
+        $thread_exists = $this->core->getQueries()->threadExists();
 
-		$forumBarData = [
+        $forumBarData = [
             "forum_bar_buttons_right" => $buttons,
             "forum_bar_buttons_left" => [],
             "show_threads" => false,
             "thread_exists" => $thread_exists
-		];
+        ];
 
-		$userData = [];
+        $userData = [];
 
-		foreach($users as $user => $details){
-			$first_name = $details["first_name"];
-			$last_name = $details["last_name"];
+        foreach($users as $user => $details){
+            $first_name = $details["first_name"];
+            $last_name = $details["last_name"];
             $post_count = count($details["posts"]);
-			$posts = json_encode($details["posts"]);
-			$ids = json_encode($details["id"]);
-			$timestamps = json_encode($details["timestamps"]);
-			$thread_ids = json_encode($details["thread_id"]);
-			$thread_titles = json_encode($details["thread_title"]);
-			$num_deleted = ($details["num_deleted_posts"]);
+            $posts = json_encode($details["posts"]);
+            $ids = json_encode($details["id"]);
+            $timestamps = json_encode($details["timestamps"]);
+            $thread_ids = json_encode($details["thread_id"]);
+            $thread_titles = json_encode($details["thread_title"]);
+            $num_deleted = ($details["num_deleted_posts"]);
 
-			$userData[] = [
-			    "last_name" => $last_name,
+            $userData[] = [
+                "last_name" => $last_name,
                 "first_name" => $first_name,
                 "post_count" => $post_count,
                 "details_total_threads" => $details["total_threads"],
@@ -1130,7 +1130,7 @@ class ForumThreadView extends AbstractView {
                 "thread_ids" => $thread_ids,
                 "thread_titles" => $thread_titles
             ];
-		}
+        }
 
     $return = $this->core->getOutput()->renderTwigTemplate("forum/StatPage.twig", [
         "forumBarData" => $forumBarData,
@@ -1138,8 +1138,8 @@ class ForumThreadView extends AbstractView {
         "search_url" => $this->core->buildCourseUrl(['forum', 'search'])
     ]);
 
-		return $return;
+        return $return;
 
-	}
+    }
 
 }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -35,8 +35,6 @@
         <exclude name="Generic.PHP.LowerCaseKeyword.Found" />
         <exclude name="Generic.PHP.LowerCaseType.ReturnTypeFound" />
         <exclude name="Generic.PHP.LowerCaseType.ParamTypeFound" />
-        <exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed" />
-        <exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
         <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
         <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
         <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterDecrement" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes the following two rule violations:

* Generic.WhiteSpace.DisallowTabIndent.TabsUsed
* Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed

### What is the new behavior?

Converts any used tabs into spaces. Enforces rules through Travis and PHPCS.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
