### PR TITLE
[Bugfix:TAGradingUI] Fix not being able to click on custom marks

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -51,7 +51,7 @@ $(function() {
         snap: false,
         grid: [2, 2],
         stack: ".draggable",
-        cancel: ".draggable div#file_view div#file_content, .draggable div#file_view div#pdf_annotation_bar div#size_selector_menu"
+        cancel: "input,textarea,button,select,option,div#file_content,div#size_selector_menu"
     }).resizable();
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Cannot click to enter text or change the number for custom mark

### What is the new behavior?

Allows you to deal with custom marks, without breaking the prior series of fixes on the UI.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Tested same series of functionality as #4597, with the addition of:
1. adding custom mark
1. saving component
1. opening component and removing custom mark
1. saving
1. clicking "Edit Rubric" and adding new marks
1. click on new marks
1. saving
1. changing submission version
1. cancelling submission