### PR TITLE
[Refactor:PHP] Fix using old constructor and alternative function style errors

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -418,7 +418,7 @@ class ForumThreadView extends AbstractView {
                     $place = array_search($post["parent_id"], $order_array);
                     $tmp_array = array($post["id"]);
                     $parent_reply_level = $reply_level_array[$place];
-                    while($place && $place+1 < sizeof($reply_level_array) && $reply_level_array[$place+1] > $parent_reply_level){
+                    while($place && $place+1 < count($reply_level_array) && $reply_level_array[$place+1] > $parent_reply_level){
                         $place++;
                     }
                     array_splice($order_array, $place+1, 0, $tmp_array);

--- a/site/tests/app/exceptions/testException.php
+++ b/site/tests/app/exceptions/testException.php
@@ -1,9 +1,0 @@
-<?php
-namespace tests\app\exceptions;
-
-class testException extends \PHPUnit\Framework\TestCase {
-    public function testException() {
-        $array = array();
-        $this->assertNull($array);
-    }
-}

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -29,9 +29,7 @@
         <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />
-        <exclude name="Generic.NamingConventions.ConstructorName.OldStyle" />
         <exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase" />
-        <exclude name="Generic.PHP.ForbiddenFunctions.FoundWithAlternative" />
         <exclude name="Generic.PHP.LowerCaseConstant.Found" />
         <exclude name="Generic.PHP.LowerCaseKeyword.Found" />
         <exclude name="Generic.PHP.LowerCaseType.ReturnTypeFound" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Codebase allowed for the following two violations:

* Generic.NamingConventions.ConstructorName.OldStyle (prefer `__construct` over `className`)
* Generic.PHP.ForbiddenFunctions.FoundWithAlternative (prefer to not use function alias' like count instead of sizeof)

### What is the new behavior?

Errors are fixed, and rules committed to prevent them happening again.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
