### PR TITLE
[BugFix:GradeInquiry] Fixed broken grade inquiry notification for graders

### DIFF
--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -269,7 +269,7 @@ class GradeInquiryController extends AbstractController {
             }
 
             // make graders' notifications and emails
-            $metadata = json_encode(['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'grade'] . '?' . http_build_query(['who_id' => $submitter->getId()]))]);
+            $metadata = json_encode(['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'grade?'.http_build_query(['who_id' => $submitter->getId()])])]);
             if (empty($graders)) {
                 $graders = $this->core->getQueries()->getAllGraders();
             }


### PR DESCRIPTION
### What is the current behavior?
closes #4614 
Notifications Links for graders are not being correctly built.

### What is the new behavior?
Notification links for graders about grade inquiries now work with buildCourseURL.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
