### PR TITLE
[Bugfix:Forum] Fixed unread highlight seen by poster for new post/thread.

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -291,6 +291,8 @@ class ForumController extends AbstractController{
                 $thread_id = $result["thread_id"];
                 $post_id = $result["post_id"];
 
+                $this->core->getQueries()->visitThread($current_user_id, $thread_id);
+
                 if($hasGoodAttachment[0] == 1) {
                     $thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $thread_id);
                     FileUtils::createDir($thread_dir);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -291,8 +291,6 @@ class ForumController extends AbstractController{
                 $thread_id = $result["thread_id"];
                 $post_id = $result["post_id"];
 
-                $this->core->getQueries()->visitThread($current_user_id, $thread_id);
-
                 if($hasGoodAttachment[0] == 1) {
                     $thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $thread_id);
                     FileUtils::createDir($thread_dir);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -360,6 +360,7 @@ class DatabaseQueries {
         try {
             $this->course_db->query("INSERT INTO posts (thread_id, parent_id, author_user_id, content, timestamp, anonymous, deleted, endorsed_by, type, has_attachment, render_markdown) VALUES (?, ?, ?, ?, current_timestamp, ?, ?, ?, ?, ?, ?)", array($thread_id, $parent_post, $user, $content, $anonymous, 0, NULL, $type, $hasAttachment, $markdown));
             $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", array($thread_id, $user));
+            $this->visitThread($user, $thread_id);
         } catch (DatabaseException $dbException){
             if($this->course_db->inTransaction()){
                 $this->course_db->rollback();

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -500,6 +500,8 @@ class DatabaseQueries {
 
         $this->course_db->commit();
 
+        $this->visitThread($user, $id);
+
         return array("thread_id" => $id, "post_id" => $post_id);
     }
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -790,7 +790,9 @@ class ForumThreadView extends AbstractView {
             $classes[] = " first_post";
         }
         if (in_array($post_id, $unviewed_posts)) {
-            $classes[] = " new_post";
+            if($current_user != $post["author_user_id"]) {
+                $classes[] = " new_post";
+            }
         } else {
             $classes[] = " viewed_post";
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4431 
When a poster creates a new post/thread, the new thread in the thread list or the new post will be highlighted as if the poster did not read their own post/thread.

### What is the new behavior?
The poster will not see their new post/thread highlighted but others will still be able to.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested by creating new posts/threads and viewing them between different users.
