### PR TITLE
[Testing:CourseMaterials] Adds a test for uploading with a requested path

### DIFF
--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -11,6 +11,7 @@ use \ZipArchive;
 class CourseMaterialsControllerTester extends BaseUnitTest {
     use \phpmock\phpunit\PHPMock;
 
+
     private $core;
     private $config;
     private $json_path;
@@ -292,6 +293,33 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
             $this->upload_path . '/' . $name => [
                 'checked' => 0,
                 'release_datetime' => $_POST['release_time']
+            ]
+        ];
+
+        $this->assertEquals($expected_json, $json);
+    }
+
+    public function testRequestedPathUpload() {
+         $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
+            ->expects($this->any())
+            ->willReturn(true);
+
+        $controller = new CourseMaterialsController($this->core);
+        $_FILES = array();
+        $_POST['requested_path'] = 'foo/foo2';
+
+        $name = "foo.txt";
+        file_put_contents($this->upload_path . "/" .  $name, 'a');
+        $this->buildFakeFile($name);
+
+        $ret = $controller->ajaxUploadCourseMaterialsFiles();
+        $json = FileUtils::readJsonFile($this->json_path);
+
+        $filename_full = FileUtils::joinPaths( $this->upload_path, "foo/foo2", $name );
+        $expected_json = [
+            $filename_full => [
+                "checked" => 1,
+                "release_datetime" => $_POST['release_time']
             ]
         ];
 

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -11,7 +11,6 @@ use \ZipArchive;
 class CourseMaterialsControllerTester extends BaseUnitTest {
     use \phpmock\phpunit\PHPMock;
 
-
     private $core;
     private $config;
     private $json_path;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Course materials tester does not have any tests for when an instructor wants to specify 
and additional path on top of the course materials uploads path.

### What is the new behavior?
Adds a small test to upload a file to a requested path

I tried adding the @runinseperate process annotation but got an error from PHPUnit saying cannot serialize closure? So I left it out for now
