### PR TITLE
[Bugfix:Bulkuploads] Prevent scanned images from being shown to students

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -181,6 +181,16 @@ class MiscController extends AbstractController {
             }
         }
 
+        if($dir == 'submissions'){
+            //cannot download scanned images for bulk uploads
+            if (strpos(basename($path), "upload_page_" ) !== false &&
+                FileUtils::getContentType($path) !== "application/pdf"){
+
+                $this->core->getOutput()->showError("You do not have access to this file");
+                return false;
+            }
+        }
+
         $filename = pathinfo($path, PATHINFO_BASENAME);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -279,8 +279,14 @@ class MiscController extends AbstractController {
                         $filePath = $file->getRealPath();
                         $relativePath = substr($filePath, strlen($paths[$x]) + 1);
 
-                        // Add current file to archive
-                        $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
+                        //Only get PDFs if this is a bulk upload gradeable
+                        if ($gradeable->isScannedExam() 
+                            && FileUtils::getContentType($filePath) === "application/pdf"){
+                            // Add current file to archive
+                            $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
+                        }
+
+                       
                     }
                 }
             }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -408,8 +408,17 @@ class AutoGradingView extends AbstractView {
                 }
             }
         }
+
+        // for bulk uploads only show PDFs
+        if ($gradeable->isScannedExam() ){
+            $files = $uploaded_pdfs;
+        }else{
+            $files = array_merge($files['submissions'], $files['checkout']);
+        }
+
+
         return $this->core->getOutput()->renderTwigTemplate('autograding/TAResults.twig', [
-            'files'=> array_merge($files['submissions'], $files['checkout']),
+            'files'=> $files,
             'been_ta_graded' => $ta_graded_gradeable->isComplete(),
             'ta_graded_version' => $version_instance !== null ? $version_instance->getVersion() : 'INCONSISTENT',
             'any_late_days_used' => $version_instance !== null ? $version_instance->getDaysLate() > 0 : false,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
PDF pages that get converted to images are shown to students

### What is the new behavior?
Restrict students to only see the split pdf instead of a list of images

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
images no longer shown,
download file function uploaded
download submission zip updated

