### PR TITLE
[Feature:BulkUploads] Better contrasting method for QR bulk upload

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -46,9 +46,10 @@ def main(args):
 
             # increase contrast of image for better QR decoding
             cv_img = numpy.array(page)
-           
+
             img_grey = cv2.cvtColor(cv_img, cv2.COLOR_BGR2GRAY)
-            ret2, thresh = cv2.threshold(img_grey,0,255,cv2.THRESH_BINARY+cv2.THRESH_OTSU)
+            ret2, thresh = cv2.threshold(img_grey, 0, 255,
+                                         cv2.THRESH_BINARY+cv2.THRESH_OTSU)
 
             # decode img - only look for QR codes
             val = pyzbar.decode(thresh, symbols=[ZBarSymbol.QRCODE])

--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -43,12 +43,15 @@ def main(args):
             page = convert_from_bytes(
                 open(filename, 'rb').read(),
                 first_page=page_number+1, last_page=page_number+2)[0]
+
             # increase contrast of image for better QR decoding
             cv_img = numpy.array(page)
-            mask = cv2.inRange(cv_img, (0, 0, 0), (200, 200, 200))
-            inverted = 255 - cv2.cvtColor(mask, cv2.COLOR_GRAY2BGR)
+           
+            img_grey = cv2.cvtColor(cv_img, cv2.COLOR_BGR2GRAY)
+            ret2, thresh = cv2.threshold(img_grey,0,255,cv2.THRESH_BINARY+cv2.THRESH_OTSU)
+
             # decode img - only look for QR codes
-            val = pyzbar.decode(inverted, symbols=[ZBarSymbol.QRCODE])
+            val = pyzbar.decode(thresh, symbols=[ZBarSymbol.QRCODE])
             if val != []:
                 # found a new qr code, split here
                 # convert byte literal to string


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The previous method of increasing contrast missed a couple of QRs causing them to be stitched together.  

### What is the new behavior?
Replaced method with one better suited specifically for black and white exams during the preprocessing step.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
ReSubmitty all sample pdfs in more autograding examples
