### PR TITLE
[Refactor:Forum] Use join twig filter for post classes array

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -1,4 +1,4 @@
-<div class="{% for class in classes %} {{ class }} {% endfor %}" id="{{ post_id }}" style="margin-left:{{ offset }}px;" reply-level="{{ reply_level }}">
+<div class="{{ classes|join(" ") }}" id="{{ post_id }}" style="margin-left:{{ offset }}px;" reply-level="{{ reply_level }}">
     {% if first == true %}
         <h2 class="create-post-head">
 
@@ -118,4 +118,3 @@
 
     </form>
 {% endif %}
-

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -789,18 +789,18 @@ class ForumThreadView extends AbstractView {
         }
         $classes = ["post_box"];
         if ($first && $display_option != 'alpha') {
-            $classes[] = " first_post";
+            $classes[] = "first_post";
         }
         if (in_array($post_id, $unviewed_posts)) {
-            $classes[] = " new_post";
+            $classes[] = "new_post";
         } else {
-            $classes[] = " viewed_post";
+            $classes[] = "viewed_post";
         }
         if ($this->core->getQueries()->isStaffPost($post["author_user_id"])) {
-            $classes[] = " important";
+            $classes[] = "important";
         }
         if ($post["deleted"]) {
-            $classes[] = " deleted";
+            $classes[] = "deleted";
             $deleted = true;
         } else {
             $deleted = false;

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -793,7 +793,7 @@ class ForumThreadView extends AbstractView {
         }
         if (in_array($post_id, $unviewed_posts)) {
             if($current_user != $post["author_user_id"]) {
-                $classes[] = " new_post";
+                $classes[] = "new_post";
             }
         } else {
             $classes[] = "viewed_post";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently uses a for loop in the twig template to print out the classes. Requires classes to have spaces in their name to prevent any issues.

### What is the new behavior?
Uses the [twig join filter](https://twig.symfony.com/doc/2.x/filters/join.html) which is cleaner and less possibility of any issues with spacing in class names.