### PR TITLE
[BugFix:GradeInquiry] Manually Graded Component Averages tab now show

### DIFF
--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -356,7 +356,7 @@ SELECT comp.gc_id, gc_title, gc_max_value, gc_is_peer, gc_order, round(AVG(comp_
     WHERE g_id=? AND {$u_or_t}.{$section_key} IS NOT NULL
   )AS parts_of_comp
 )AS comp
-INNER JOIN (
+LEFT JOIN (
 	SELECT COUNT(*) AS active_grade_inquiry_count, rr.gc_id
 	FROM regrade_requests AS rr
 	WHERE rr.g_id=? AND rr.status=-1


### PR DESCRIPTION
## What is the current behavior?
When there is no grade inquiries that are tied to a component the Manually Graded Component Averages tab does not shows.

### What is the new behavior?
Manually Graded Component Averages tab now shows.