### PR TITLE
[Bugfix:Notifications] Fix broken team invitation URL notification

### DIFF
--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -194,7 +194,9 @@ class TeamController extends AbstractController {
         $this->core->getQueries()->sendTeamInvitation($team->getId(), $invite_id);
 
         // send invited user a notification
-        $metadata = json_encode(['url' => $this->core->buildCourseUrl([$gradeable_id,'team'])]);
+        $metadata = json_encode(
+            ['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id,'team'])]
+        );
         $subject = "New Team Invitation: ".$graded_gradeable->getGradeable()->getTitle();
         $content = "You have received a new invitation to join a team from $user_id";
         $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_invite', 'sender_id' => $user_id];

--- a/site/app/templates/Notifications.twig
+++ b/site/app/templates/Notifications.twig
@@ -39,7 +39,7 @@
                         <div>&NegativeMediumSpace;</div>
                     {% endif %}
                     {% if hasLink %}
-                        <a class="notification-link" href="{{ notifications_url }}/{{ notification.getId() }}?seen={{ notification.isSeen() }}">
+                        <a class="notification-link" href="{{ notifications_url }}/{{ notification.getId() }}?seen={{ notification.isSeen() == "1" ? 1 : 0}}">
                     {% endif %}
                     <div class="notification-contents">
                         {{ notification.getNotifyContent() }}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The URL that gets created for team invite notification points to the team gradeable, however you can only see team gradeables if you are on a team and the only users who can get team invites are users not on teams. 

### What is the new behavior?
The URL now points to the manage team page where the invited user can accept/reject invitations

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

fixes #4648