### PR TITLE
[BugFix:BulkUpload] Fixed error handling for large files on Bulk Upload

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -244,9 +244,7 @@ class SubmissionController extends AbstractController {
             return $this->uploadResult("Empty POST request. This may mean that the sum size of your files are greater than {$max_size}.", false);
         }
 
-        if(isset($_POST['use_qr_codes'])){
-            $is_qr = $_POST['use_qr_codes'] === "true";
-        }
+        $is_qr = isset($_POST['use_qr_codes']) && $_POST['use_qr_codes'] === "true";
 
         if (!isset($_POST['num_pages']) && !$is_qr) {
             $msg = "Did not pass in number of pages or files were too large.";

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -239,7 +239,14 @@ class SubmissionController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/bulk", methods={"POST"})
     */
     public function ajaxBulkUpload($gradeable_id) {
-        $is_qr = $_POST['use_qr_codes'] === "true";
+        if (empty($_POST)) {
+            $max_size =  Utils::returnBytes(ini_get('post_max_size'));
+            return $this->uploadResult("Empty POST request. This may mean that the sum size of your files are greater than {$max_size}.", false);
+        }
+
+        if(isset($_POST['use_qr_codes'])){
+            $is_qr = $_POST['use_qr_codes'] === "true";
+        }
 
         if (!isset($_POST['num_pages']) && !$is_qr) {
             $msg = "Did not pass in number of pages or files were too large.";
@@ -262,42 +269,29 @@ class SubmissionController extends AbstractController {
             $uploaded_file = $_FILES["files1"];
         }
 
-        $errors = array();
-        $count = 0;
-        if (isset($uploaded_file)) {
-            $count = count($uploaded_file["name"]);
-            for ($j = 0; $j < $count; $j++) {
-                if (!isset($uploaded_file["tmp_name"][$j]) || $uploaded_file["tmp_name"][$j] === "") {
-                    $error_message = $uploaded_file["name"][$j]." failed to upload. ";
-                    if (isset($uploaded_file["error"][$j])) {
-                        $error_message .= "Error message: ". ErrorMessages::uploadErrors($uploaded_file["error"][$j]). ".";
-                    }
-                    $errors[] = $error_message;
-                }
-            }
+        $status = FileUtils::validateUploadedFiles($uploaded_file);
+        $count = count($uploaded_file["name"]);
+
+        if(array_key_exists("failed", $status)){
+            return $this->core->getOutput()->renderResultMessage("Failed to validate uploads " . $status["failed"], false);
         }
 
-        if (count($errors) > 0) {
-            $error_text = implode("\n", $errors);
-            return $this->uploadResult("Upload Failed: ".$error_text, false);
+        $file_size = 0;
+        foreach ($status as $stat) {
+            if($stat['success'] === false){
+                return $this->core->getOutput()->renderResultMessage("Error " . $stat['error'], false);
+            }
+
+            if($stat['type'] !== 'application/pdf'){
+                return $this->core->getOutput()->renderResultMessage("Error " . $stat['name'] . " is not a PDF", false);
+            }
+
+            $file_size += $stat['size'];
         }
 
         $max_size = $gradeable->getAutogradingConfig()->getMaxSubmissionSize();
         if ($max_size < 10000000) {
             $max_size = 10000000;
-        }
-        // Error checking of file name
-        $file_size = 0;
-        if (isset($uploaded_file)) {
-            for ($j = 0; $j < $count; $j++) {
-                if(FileUtils::isValidFileName($uploaded_file["name"][$j]) === false) {
-                    return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_file["name"][$j].".", false);
-                }
-                if(substr($uploaded_file["name"][$j],-3) != "pdf") {
-                    return $this->uploadResult($uploaded_file["name"][$j]." is not a PDF!", false);
-                }
-                $file_size += $uploaded_file["size"][$j];
-            }
         }
 
         if ($file_size > $max_size) {

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -590,7 +590,11 @@
             }
             // bulk upload
             if ($("#radio-bulk").is(":checked")) {
-                handleBulk("{{ gradeable_id }}", num_pages, use_qr, qr_prefix, qr_suffix );
+                handleBulk("{{ gradeable_id }}", 
+                            {{ max_post_size }}, 
+                            {{ max_file_size }},
+                            num_pages, use_qr, qr_prefix, qr_suffix 
+                          );
             }
             // no user id entered, upload for whoever is logged in
             else if (user_id == ""){

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -370,6 +370,9 @@ class HomeworkView extends AbstractView {
 
         $DATE_FORMAT = "m/d/Y @ h:i A";
 
+        $max_file_size = Utils::returnBytes(ini_get('upload_max_filesize'));
+        $max_post_size = Utils::returnBytes(ini_get('post_max_size'));  
+
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
             'base_url' => $this->core->getConfig()->getBaseUrl(),
             'gradeable_id' => $gradeable->getId(),
@@ -407,7 +410,9 @@ class HomeworkView extends AbstractView {
             'upload_message' => $this->core->getConfig()->getUploadMessage(),
             "csrf_token" => $this->core->getCsrfToken(),
             'has_overridden_grades' => $graded_gradeable ? $graded_gradeable->hasOverriddenGrades() : false,
-            'days_to_be_charged' => $days_to_be_charged
+            'days_to_be_charged' => $days_to_be_charged,
+            'max_file_size' => $max_file_size,
+            'max_post_size' => $max_post_size
         ]);
     }
 
@@ -527,8 +532,6 @@ class HomeworkView extends AbstractView {
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
         $gradeable_id = $_REQUEST['gradeable_id'] ?? '';
-        $current_time = $this->core->getDateTimeNow()->format("m-d-Y_H:i:sO");
-        $ch = curl_init();
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/BulkUploadBox.twig', [
             'gradeable_id' => $gradeable->getId(),
             'team_assignment' => $gradeable->isTeamAssignment(),

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -370,9 +370,6 @@ class HomeworkView extends AbstractView {
 
         $DATE_FORMAT = "m/d/Y @ h:i A";
 
-        $max_file_size = Utils::returnBytes(ini_get('upload_max_filesize'));
-        $max_post_size = Utils::returnBytes(ini_get('post_max_size'));  
-
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
             'base_url' => $this->core->getConfig()->getBaseUrl(),
             'gradeable_id' => $gradeable->getId(),
@@ -411,8 +408,8 @@ class HomeworkView extends AbstractView {
             "csrf_token" => $this->core->getCsrfToken(),
             'has_overridden_grades' => $graded_gradeable ? $graded_gradeable->hasOverriddenGrades() : false,
             'days_to_be_charged' => $days_to_be_charged,
-            'max_file_size' => $max_file_size,
-            'max_post_size' => $max_post_size
+            'max_file_size' => Utils::returnBytes(ini_get('upload_max_filesize')),
+            'max_post_size' => Utils::returnBytes(ini_get('post_max_size'))
         ]);
     }
 

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -642,7 +642,7 @@ function deleteSplitItem(csrf_token, gradeable_id, path) {
  * @param use_qr_codes
  * @param qr_prefix
  */
-function handleBulk(gradeable_id, num_pages, use_qr_codes = false, qr_prefix = "", qr_suffix="") {
+function handleBulk(gradeable_id, max_file_size, max_post_size, num_pages, use_qr_codes = false, qr_prefix = "", qr_suffix="") {
     $("#submit").prop("disabled", true);
 
     var formData = new FormData();
@@ -666,6 +666,7 @@ function handleBulk(gradeable_id, num_pages, use_qr_codes = false, qr_prefix = "
     formData.append('qr_suffix', encodeURIComponent(qr_suffix));
     formData.append('csrf_token', csrfToken);
 
+    var total_size = 0;
     for (var i = 0; i < file_array.length; i++) {
         for (var j = 0; j < file_array[i].length; j++) {
             if (file_array[i][j].name.indexOf("'") != -1 ||
@@ -683,6 +684,21 @@ function handleBulk(gradeable_id, num_pages, use_qr_codes = false, qr_prefix = "
                 alert("ERROR! You may not use angle brackets in your filename: " + file_array[i][j].name);
                 return;
             }
+
+            total_size += file_array[i][j].size;
+
+            if (total_size >= max_file_size){
+                alert("ERROR! Uploaded file(s) exceed max file size.\n" + 
+                      "Please visit https://submitty.org/sysadmin/system_customization for configuration instructions.");
+                return;
+            }
+
+             if (total_size >= max_post_size){
+                alert("ERROR! Uploaded file(s) exceed max PHP POST size.\n" + 
+                      "Please visit https://submitty.org/sysadmin/system_customization for configuration instructions.");
+                return;
+            }
+
             formData.append('files' + (i + 1) + '[]', file_array[i][j], file_array[i][j].name);
         }
     }
@@ -715,7 +731,7 @@ function handleBulk(gradeable_id, num_pages, use_qr_codes = false, qr_prefix = "
             catch (e) {
                 alert("Error parsing response from server. Please copy the contents of your Javascript Console and " +
                     "send it to an administrator, as well as what you were doing and what files you were uploading.");
-                console.log(data);
+                console.log(e);
             }
         },
         error: function() {

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -672,16 +672,19 @@ function handleBulk(gradeable_id, max_file_size, max_post_size, num_pages, use_q
             if (file_array[i][j].name.indexOf("'") != -1 ||
                 file_array[i][j].name.indexOf("\"") != -1) {
                 alert("ERROR! You may not use quotes in your filename: " + file_array[i][j].name);
+                $("#submit").prop("disabled", false);
                 return;
             }
             else if (file_array[i][j].name.indexOf("\\") != -1 ||
                 file_array[i][j].name.indexOf("/") != -1) {
                 alert("ERROR! You may not use a slash in your filename: " + file_array[i][j].name);
+                $("#submit").prop("disabled", false);
                 return;
             }
             else if (file_array[i][j].name.indexOf("<") != -1 ||
                 file_array[i][j].name.indexOf(">") != -1) {
                 alert("ERROR! You may not use angle brackets in your filename: " + file_array[i][j].name);
+                $("#submit").prop("disabled", false);
                 return;
             }
 
@@ -690,12 +693,14 @@ function handleBulk(gradeable_id, max_file_size, max_post_size, num_pages, use_q
             if (total_size >= max_file_size){
                 alert("ERROR! Uploaded file(s) exceed max file size.\n" + 
                       "Please visit https://submitty.org/sysadmin/system_customization for configuration instructions.");
+                $("#submit").prop("disabled", false);
                 return;
             }
 
              if (total_size >= max_post_size){
                 alert("ERROR! Uploaded file(s) exceed max PHP POST size.\n" + 
                       "Please visit https://submitty.org/sysadmin/system_customization for configuration instructions.");
+                $("#submit").prop("disabled", false);
                 return;
             }
 
@@ -731,7 +736,7 @@ function handleBulk(gradeable_id, max_file_size, max_post_size, num_pages, use_q
             catch (e) {
                 alert("Error parsing response from server. Please copy the contents of your Javascript Console and " +
                     "send it to an administrator, as well as what you were doing and what files you were uploading.");
-                console.log(e);
+                console.log(data);
             }
         },
         error: function() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Inproper checking of uploaded files would lead to incorrect/vague error messages and
Files sizes larger than the POST or max_filesize_limit would causes a crash and get no response giving a vague error message.

### What is the new behavior?
Better error handling for file uploads by using `validateUploadedFiles` on the server side for large/incorrect file types. 
 The client now checks for this and gives a correct message before it attempts to upload. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
