### PR TITLE
[Bugfix:TAGrading] Fix broken ordering of first/last name for grading

### DIFF
--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -33,10 +33,10 @@ class SimpleGraderController extends AbstractController {
             $sort_by = "u.user_id";
         }
         else if($sort === "first"){
-            $sort_by = "coalesce(u.user_preferred_firstname, u.user_firstname)";
+            $sort_by = "coalesce(NULLIF(u.user_preferred_firstname, ''), u.user_firstname)";
         }
         else {
-            $sort_by = "coalesce(u.user_preferred_lastname, u.user_lastname)";
+            $sort_by = "coalesce(NULLIF(u.user_preferred_lastname, ''), u.user_lastname)";
         }
 
         //Figure out what section we are supposed to print
@@ -121,10 +121,10 @@ class SimpleGraderController extends AbstractController {
             $sort_key = "u.user_id";
         }
         elseif ($sort === "first") {
-            $sort_key = "coalesce(u.user_preferred_firstname, u.user_firstname)";
+            $sort_key = "coalesce(NULLIF(u.user_preferred_firstname, ''), u.user_firstname)";
         }
         else {
-            $sort_key = "coalesce(u.user_preferred_lastname, u.user_lastname)";
+            $sort_key = "coalesce(NULLIF(u.user_preferred_lastname, ''), u.user_lastname)";
         }
 
         if ($gradeable->isGradeByRegistration()) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -757,7 +757,11 @@ class DatabaseQueries {
     public function getUsersByRegistrationSections($sections, $orderBy="registration_section") {
         $return = array();
         if (count($sections) > 0) {
-            $orderBy = str_replace("registration_section","SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')",$orderBy);
+            $orderBy = str_replace(
+                "registration_section",
+                "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')",
+                $orderBy
+            );
             $values = $this->createParamaterList(count($sections));
             $this->course_db->query("SELECT * FROM users AS u WHERE registration_section IN {$values} ORDER BY {$orderBy}", $sections);
             foreach ($this->course_db->rows() as $row) {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -830,12 +830,20 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     ];
 
     /**
-     * Generates the ORDER BY clause with the provided sorting keys
+     * Generates the ORDER BY clause with the provided sorting keys.
+     *
+     * For every element in $sort_keys, checks if the first word is in $key_map,
+     * and if so, replaces it with the list of clauses in $key_map, and then joins that
+     * list together using the second word (if it exists, assuming it is an order direction)
+     * or blank otherwise. If the first word is not, return the clause as is. Finally,
+     * join the resulting set of clauses together as appropriate for valid ORDER BY.
+     *
      * @param string[]|null $sort_keys
      * @param array $key_map A map from sort keys to arrays of expressions to sort by instead
      *          (see self::graded_gradeable_key_map for example)
      * @return string
      */
+
     private static function generateOrderByClause($sort_keys, array $key_map) {
         if ($sort_keys !== null) {
             if (!is_array($sort_keys)) {
@@ -852,15 +860,20 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
                 array_map(function ($key_ext) use ($key_map) {
                     $split_key = explode(' ', $key_ext);
                     $key = $split_key[0];
-                    $order = '';
-                    if (count($split_key) > 1) {
-                        $order = $split_key[1];
+                    if (isset($key_map[$key])) {
+                        // Map any keys with special requirements to the proper statements and preserve specified order
+                        $order = '';
+                        if (count($split_key) > 1) {
+                            $order = $split_key[1];
+                        }
+                        if (count($key_map[$key]) === 0) {
+                            return '';
+                        }
+                        return implode(" $order,", $key_map[$key]) . " $order";
                     }
-                    if (isset($key_map[$key]) && count($key_map[$key]) === 0) {
-                        return '';
+                    else {
+                        return $key_ext;
                     }
-                    // Map any keys with special requirements to the proper statements and preserve specified order
-                    return implode(" $order,", $key_map[$key] ?? [$key]) . " $order";
                 }, $sort_keys),
                 function($a) {
                     return $a !== '';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4454 

If a student had an empty string set for their preferred first or last name, then the ordering for that name would be broken with that student always at the top.

### What is the new behavior?

Students are now appropriately sorted if they have a null or empty string set for the preferred name (as the empty string is set to null for purposes of our ordering). This also fixes a bug in the code where any order by clause with more than two words separated by spaces would cause an error and have everything after the second space truncated.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Set a student's preferred first and last name to an empty string, observe the broken ordering on simple grading page. Applied fix, ordering was fixed.

Due to #4620, have to go through the DB to do this, running `UPDATE users SET user_preferred_firstname='',user_preferred_lastname='' WHERE user_id='bitdiddle';` on `submitty` DB directly (on whatever user_id).