### PR TITLE
[Refactor:PHP] Fix Squiz.Functions.MultiLineFunctionDeclaration style errors

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -13,7 +13,7 @@ class GlobalController extends AbstractController {
 
     public function header() {
         $wrapper_files = $this->core->getConfig()->getWrapperFiles();
-        $wrapper_urls = array_map(function($file) {
+        $wrapper_urls = array_map(function ($file) {
             return $this->core->buildCourseUrl(['read_file']) . '?' . http_build_query([
                 'dir' => 'site',
                 'path' => $file,
@@ -98,23 +98,24 @@ class GlobalController extends AbstractController {
             }
 
             if ($this->core->getConfig()->isQueueEnabled()) {
-              if ($this->core->getQueries()->isQueueOpen()) {
-                $sidebar_buttons[] = new Button($this->core, [
-                  "href" => $this->core->buildCourseUrl(['office_hours_queue']),
-                  "title" => "Office Hours",
-                  "class" => "nav-row",
-                  "id" => "nav-sidebar-queue",
-                  "icon" => "fa-door-open"
-                ]);
-              }else{
-                $sidebar_buttons[] = new Button($this->core, [
-                  "href" => $this->core->buildCourseUrl(['office_hours_queue']),
-                  "title" => "Office Hours",
-                  "class" => "nav-row",
-                  "id" => "nav-sidebar-queue",
-                  "icon" => "fa-door-closed"
-                ]);
-              }
+                if ($this->core->getQueries()->isQueueOpen()) {
+                    $sidebar_buttons[] = new Button($this->core, [
+                        "href" => $this->core->buildCourseUrl(['office_hours_queue']),
+                        "title" => "Office Hours",
+                        "class" => "nav-row",
+                        "id" => "nav-sidebar-queue",
+                        "icon" => "fa-door-open"
+                    ]);
+                }
+                else {
+                    $sidebar_buttons[] = new Button($this->core, [
+                        "href" => $this->core->buildCourseUrl(['office_hours_queue']),
+                        "title" => "Office Hours",
+                        "class" => "nav-row",
+                        "id" => "nav-sidebar-queue",
+                        "icon" => "fa-door-closed"
+                    ]);
+                }
             }
 
             $course_path = $this->core->getConfig()->getCoursePath();
@@ -347,7 +348,7 @@ class GlobalController extends AbstractController {
 
     public function footer() {
         $wrapper_files = $this->core->getConfig()->getWrapperFiles();
-        $wrapper_urls = array_map(function($file) {
+        $wrapper_urls = array_map(function ($file) {
             return $this->core->buildCourseUrl(['read_file']) . '?' . http_build_query([
                 'dir' => 'site',
                 'path' => $file,
@@ -410,10 +411,10 @@ class GlobalController extends AbstractController {
         $query_a = array_filter(explode("&", $query_a));
         $query_b = array_filter(explode("&", $query_b));
 
-        $query_a = array_filter($query_a, function($param) use($ignored_params) {
+        $query_a = array_filter($query_a, function ($param) use ($ignored_params) {
             return !in_array(explode("=", $param)[0], $ignored_params);
         });
-        $query_b = array_filter($query_b, function($param) use($ignored_params) {
+        $query_b = array_filter($query_b, function ($param) use ($ignored_params) {
             return !in_array(explode("=", $param)[0], $ignored_params);
         });
 

--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -96,14 +96,14 @@ class HomePageController extends AbstractController {
         // Filter out any courses a student has dropped so they do not appear on the homepage.
         // Do not filter courses for non-students.
 
-        $unarchived_courses = array_filter($unarchived_courses, function(Course $course) use($user_id, $as_instructor) {
+        $unarchived_courses = array_filter($unarchived_courses, function (Course $course) use ($user_id, $as_instructor) {
             return $as_instructor ?
                 $this->core->getQueries()->checkIsInstructorInCourse($user_id, $course->getTitle(), $course->getSemester())
                 :
                 $this->core->getQueries()->checkStudentActiveInCourse($user_id, $course->getTitle(), $course->getSemester());
         });
 
-        $archived_courses = array_filter($archived_courses, function(Course $course) use($user_id, $as_instructor) {
+        $archived_courses = array_filter($archived_courses, function (Course $course) use ($user_id, $as_instructor) {
             return $as_instructor ?
                 $this->core->getQueries()->checkIsInstructorInCourse($user_id, $course->getTitle(), $course->getSemester())
                 :
@@ -113,13 +113,13 @@ class HomePageController extends AbstractController {
         return Response::JsonOnlyResponse(
             JsonResponse::getSuccessResponse([
                 "unarchived_courses" => array_map(
-                    function(Course $course) {
+                    function (Course $course) {
                         return $course->getCourseInfo();
                     },
                     $unarchived_courses
                 ),
                 "archived_courses" => array_map(
-                    function(Course $course) {
+                    function (Course $course) {
                         return $course->getCourseInfo();
                     },
                     $archived_courses

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -90,7 +90,7 @@ class AdminGradeableController extends AbstractController {
         $this->core->getOutput()->addBreadcrumb('Edit Gradeable');
 
         // Serialize the components for numeric/checkpoint rubrics
-        $gradeable_components_enc = array_map(function(Component $c) {
+        $gradeable_components_enc = array_map(function (Component $c) {
             return $c->toArray();
         }, $gradeable->getComponents());
 
@@ -160,7 +160,7 @@ class AdminGradeableController extends AbstractController {
             }
             $repo_id_number++;
         }
-        usort($all_repository_config_paths, function($a,$b) {
+        usort($all_repository_config_paths, function ($a,$b) {
             return $a[0] > $b[0];
         });
 

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -188,7 +188,7 @@ class ConfigurationController extends AbstractController {
 
         $seating_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'reports', 'seating');
 
-        $gradeable_seating_options = array_filter($gradeable_seating_options, function($seating_option) use($seating_dir) {
+        $gradeable_seating_options = array_filter($gradeable_seating_options, function ($seating_option) use ($seating_dir) {
             return is_dir(FileUtils::joinPaths($seating_dir, $seating_option['g_id']));
         });
 

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -273,7 +273,7 @@ class LateController extends AbstractController {
         foreach($rows as $row) {
             $fields = explode(',', $row);
             //Remove any extraneous whitespace at beginning/end of all fields.
-            $fields = array_map(function($k) {
+            $fields = array_map(function ($k) {
                 return trim($k);
             }, $fields);
 

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -42,7 +42,7 @@ class PlagiarismController extends AbstractController {
             }
 
             fclose($file);
-            uksort($return, function($semester_a, $semester_b) {
+            uksort($return, function ($semester_a, $semester_b) {
                 $year_a = (int) substr($semester_a, 1);
                 $year_b = (int) substr($semester_b, 1);
                 if($year_a > $year_b) {

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -17,27 +17,28 @@ class CourseMaterialsController extends AbstractController {
         $this->core->getOutput()->renderOutput(
             ['course', 'CourseMaterials'],
             'listCourseMaterials',
-            $user_group = $this->core->getUser()->getGroup()
+            $this->core->getUser()->getGroup()
         );
     }
 
-    public function deleteHelper($file,&$json){
-            if ((array_key_exists('name',$file))){
-                $filename = $file['path'];
-                unset($json[$filename]);
-                return;
+    public function deleteHelper($file, &$json) {
+        if ((array_key_exists('name',$file))) {
+            $filename = $file['path'];
+            unset($json[$filename]);
+            return;
+        }
+        else {
+            if(array_key_exists('files',$file)) {
+                $this->deleteHelper($file['files'],$json);
             }
-            else{
-                if(array_key_exists('files',$file)){
-                    $this->deleteHelper($file['files'],$json);
-                }
-                else{
-                    foreach ($file as $f){
-                        $this->deleteHelper($f,$json);
-                    }
+            else {
+                foreach ($file as $f) {
+                    $this->deleteHelper($f,$json);
                 }
             }
+        }
     }
+
     /**
      * @Route("/{_semester}/{_course}/course_materials/delete")
      */
@@ -353,7 +354,7 @@ class CourseMaterialsController extends AbstractController {
                         for ($i = 0; $i < $zip->numFiles; $i++) {
                             $entries[] = $zip->getNameIndex($i);
                         }
-                        $entries = array_filter($entries, function($entry) use ($disallowed_folders, $disallowed_files) {
+                        $entries = array_filter($entries, function ($entry) use ($disallowed_folders, $disallowed_files) {
                             $name = strtolower($entry);
                             foreach ($disallowed_folders as $folder) {
                                 if (Utils::startsWith($folder, $name)) {
@@ -369,7 +370,7 @@ class CourseMaterialsController extends AbstractController {
                             }
                             return true;
                         });
-                        $zfiles = array_filter($entries, function($entry) {
+                        $zfiles = array_filter($entries, function ($entry) {
                             return substr($entry, -1) !== '/';
                         });
 

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -447,7 +447,7 @@ class ElectronicGraderController extends AbstractController {
 
         $student_ids = [];
         foreach ($section_submitters as $section) {
-            $student_ids = array_merge($student_ids, array_map(function(Submitter $submitter) {
+            $student_ids = array_merge($student_ids, array_map(function (Submitter $submitter) {
                 return $submitter->getId();
             }, $section));
         }

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -151,7 +151,7 @@ class SimpleGraderController extends AbstractController {
         foreach ($sections as $section) {
             $students = array_merge($students, $section->getUsers());
         }
-        $student_ids = array_map(function(User $user) {
+        $student_ids = array_map(function (User $user) {
             return $user->getId();
         }, $students);
 

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -28,7 +28,7 @@ class FileUtils {
      * @return array
      */
     public static function getAllFiles(string $dir, array $skip_files=[], bool $flatten=false): array {
-        $skip_files = array_map(function($str) {
+        $skip_files = array_map(function ($str) {
             return strtolower($str);
         }, $skip_files);
 
@@ -144,7 +144,7 @@ class FileUtils {
      * off the string.
      */
     public static function getAllFilesTrimSearchPath(string $search_path, int $path_length): array {
-        $files = array_map(function($entry) use ($path_length) {
+        $files = array_map(function ($entry) use ($path_length) {
             return substr($entry['path'], $path_length, strlen($entry['path']) - $path_length);
         }, array_values(FileUtils::getAllFiles($search_path, [], true)));
         return $files;

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -94,10 +94,10 @@ class Output {
 
         $this->twig->addGlobal("core", $this->core);
 
-        $this->twig->addFunction(new \Twig\TwigFunction("render_template", function(... $args) {
+        $this->twig->addFunction(new \Twig\TwigFunction("render_template", function (... $args) {
             return call_user_func_array('self::renderTemplate', $args);
         }, ["is_safe" => ["html"]]));
-        $this->twig->addFunction(new \Twig\TwigFunction('base64_image', function(string $path, string $title): string {
+        $this->twig->addFunction(new \Twig\TwigFunction('base64_image', function (string $path, string $title): string {
             $valid_image_subtypes = ['png', 'jpg', 'jpeg', 'gif'];
             list($mime_type, $mime_subtype) = explode('/', mime_content_type($path), 2);
             if ($mime_type === "image" && in_array($mime_subtype, $valid_image_subtypes)) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -187,9 +187,21 @@ class DatabaseQueries {
     /**
      * Helper function for generating sql query according to the given requirements
      */
-    public function buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user,
-                                        &$query_select, &$query_join, &$query_where, &$query_order, &$query_parameters,
-                                        $want_categories, $want_order) {
+    public function buildLoadThreadQuery(
+        $categories_ids,
+        $thread_status,
+        $unread_threads,
+        $show_deleted,
+        $show_merged_thread,
+        $current_user,
+        &$query_select,
+        &$query_join,
+        &$query_where,
+        &$query_order,
+        &$query_parameters,
+        $want_categories,
+        $want_order
+    ) {
         $query_raw_select = array();
         $query_raw_join   = array();
         $query_raw_where  = array("true");
@@ -744,7 +756,7 @@ class DatabaseQueries {
             $this->course_db->query("SELECT * FROM late_days");
         }
         // Parse the date-times
-        return array_map(function ($arr)  {
+        return array_map(function ($arr) {
             $arr['since_timestamp'] = DateUtils::parseDateTime($arr['since_timestamp'], $this->core->getConfig()->getTimezone());
             return $arr;
         }, $this->course_db->rows());
@@ -1431,7 +1443,7 @@ SELECT user_id
 FROM users
 WHERE rotating_section IS NULL AND registration_section IS NOT NULL
 ORDER BY user_id ASC");
-        return array_map(function($elem) {
+        return array_map(function ($elem) {
             return $elem['user_id'];
         }, $this->course_db->rows());
     }
@@ -1442,7 +1454,7 @@ SELECT user_id
 FROM users
 WHERE registration_section IS NOT NULL
 ORDER BY user_id ASC");
-        return array_map(function($elem) {
+        return array_map(function ($elem) {
             return $elem['user_id'];
         }, $this->course_db->rows());
     }
@@ -3176,7 +3188,7 @@ AND gc_id IN (
      */
     public function getSubmittersById(array $ids) {
         //Get Submitter for each id in ids
-        return array_map(function($id) {
+        return array_map(function ($id) {
             return $this->getSubmitterById($id);
         }, $ids);
     }
@@ -3555,7 +3567,7 @@ AND gc_id IN (
 
         // sort components by order
         $components = $gradeable->getComponents();
-        usort($components, function(Component $a, Component $b) {
+        usort($components, function (Component $a, Component $b) {
             return $a->getOrder() - $b->getOrder();
         });
 

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -862,7 +862,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
                     // Map any keys with special requirements to the proper statements and preserve specified order
                     return implode(" $order,", $key_map[$key] ?? [$key]) . " $order";
                 }, $sort_keys),
-                function($a) {
+                function ($a) {
                     return $a !== '';
                 }));
         }
@@ -1529,7 +1529,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
              $selector
              $order";
 
-        $gradeable_constructor = function($row) {
+        $gradeable_constructor = function ($row) {
             if (!isset($row['eg_g_id']) && $row['type'] === GradeableType::ELECTRONIC_FILE) {
                 throw new DatabaseException("Electronic gradeable didn't have an entry in the electronic_gradeable table!");
             }

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -159,7 +159,7 @@ abstract class AbstractModel {
      * @return string
      */
     private function convertName($name, $prefix_length=3) {
-        $regex_func = function($matches) {
+        $regex_func = function ($matches) {
             return "_".strtolower($matches[0]);
         };
         $name = preg_replace_callback("/([A-Z])/", $regex_func, lcfirst((substr($name, $prefix_length))));

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -109,18 +109,18 @@ class GradingOrder extends AbstractModel {
      */
     public function sort($type, $direction) {
         //Function to turn submitters into "keys" that are sorted (like python's list.sort)
-        $keyFn = function(Submitter $a) {
+        $keyFn = function (Submitter $a) {
             return $a->getId();
         };
 
         switch ($type) {
             case "id":
-                $keyFn = function(Submitter $a) {
+                $keyFn = function (Submitter $a) {
                     return $a->getId();
                 };
                 break;
             case "first":
-                $keyFn = function(Submitter $a) {
+                $keyFn = function (Submitter $a) {
                     if ($a->isTeam()) {
                         return $a->getId();
                     } else {
@@ -129,7 +129,7 @@ class GradingOrder extends AbstractModel {
                 };
                 break;
             case "last":
-                $keyFn = function(Submitter $a) {
+                $keyFn = function (Submitter $a) {
                     if ($a->isTeam()) {
                         return $a->getId();
                     } else {
@@ -138,7 +138,7 @@ class GradingOrder extends AbstractModel {
                 };
                 break;
             case "random":
-                $keyFn = function(Submitter $a) {
+                $keyFn = function (Submitter $a) {
                     //So it's (pseudo) randomly ordered, and will be different for each gradeable
                     return md5($a->getId() . $this->gradeable->getId());
                 };
@@ -155,7 +155,7 @@ class GradingOrder extends AbstractModel {
 
             $directionMult = ($direction === "DESC" ? -1 : 1);
 
-            usort($section, function(Submitter $a, Submitter $b) use ($keys, $directionMult) {
+            usort($section, function (Submitter $a, Submitter $b) use ($keys, $directionMult) {
                 return strcmp($keys[$a->getId()], $keys[$b->getId()]) * $directionMult;
             });
         }
@@ -169,7 +169,7 @@ class GradingOrder extends AbstractModel {
      * @return Submitter Previous submitter to grade
      */
     public function getPrevSubmitter(Submitter $submitter) {
-        return $this->getPrevSubmitterMatching($submitter, function(Submitter $sub) {
+        return $this->getPrevSubmitterMatching($submitter, function (Submitter $sub) {
             return $this->getHasSubmission($sub);
         });
     }
@@ -181,7 +181,7 @@ class GradingOrder extends AbstractModel {
      * @return Submitter Next submitter to grade
      */
     public function getNextSubmitter(Submitter $submitter) {
-        return $this->getNextSubmitterMatching($submitter, function(Submitter $sub) {
+        return $this->getNextSubmitterMatching($submitter, function (Submitter $sub) {
             return $this->getHasSubmission($sub);
         });
 
@@ -214,7 +214,7 @@ class GradingOrder extends AbstractModel {
         // Query database to find out which users have not been completely graded
         $this->initUsersNotFullyGraded($component_id);
 
-        return $this->getNextSubmitterMatching($submitter, function(Submitter $sub) {
+        return $this->getNextSubmitterMatching($submitter, function (Submitter $sub) {
             return in_array($sub->getId(), $this->not_fully_graded) AND $this->getHasSubmission($sub);
         });
     }
@@ -235,7 +235,7 @@ class GradingOrder extends AbstractModel {
         // Query database to find out which users have not been completely graded
         $this->initUsersNotFullyGraded($component_id);
 
-        return $this->getPrevSubmitterMatching($submitter, function(Submitter $sub) {
+        return $this->getPrevSubmitterMatching($submitter, function (Submitter $sub) {
             return in_array($sub->getId(), $this->not_fully_graded) AND $this->getHasSubmission($sub);
         });
     }

--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -84,11 +84,11 @@ class GradingSection extends AbstractModel {
      */
     public function getSubmitters() {
         if ($this->users !== null) {
-            return array_map(function(User $user) {
+            return array_map(function (User $user) {
                 return new Submitter($this->core, $user);
             }, $this->users);
         } else if ($this->teams !== null) {
-            return array_map(function(Team $team) {
+            return array_map(function (Team $team) {
                 return new Submitter($this->core, $team);
             }, $this->teams);
         } else {

--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -120,7 +120,7 @@ class NotificationFactory {
         $email_recipients = [$current_user_id];
         $users_settings = $this->core->getQueries()->getUsersNotificationSettings($recipients);
         foreach ($recipients as $recipient) {
-            $user_settings_row = array_values(array_filter($users_settings, function($v) use ($recipient) {
+            $user_settings_row = array_values(array_filter($users_settings, function ($v) use ($recipient) {
                 return $v['user_id'] === $recipient;
             }));
             if (!empty($user_settings_row)) {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -559,7 +559,7 @@ class Gradeable extends AbstractModel {
         //  and returns the modified date values to comply with the provided order, using
         //  a compare function, which returns true when first parameter should be coerced
         //  into the second parameter.
-        $coerce_dates = function(array $date_properties, array $black_list, array $date_values, $compare) {
+        $coerce_dates = function (array $date_properties, array $black_list, array $date_values, $compare) {
             // coerce them to be in increasing order (and fill in nulls)
             foreach ($date_properties as $i => $property) {
                 // Don't coerce the first date
@@ -595,7 +595,7 @@ class Gradeable extends AbstractModel {
                 function (\DateTime $val, \DateTime $cmp) {
                     return $val < $cmp;
                 }),
-            function(\DateTime $val, \DateTime $cmp) {
+            function (\DateTime $val, \DateTime $cmp) {
                 return $val > $cmp;
             }
         );
@@ -792,7 +792,7 @@ class Gradeable extends AbstractModel {
 
     /**
      * Sets the gradeable type
-     * @param GradeableType $type Must be a valid GradeableType
+     * @param int $type Must be a valid GradeableType
      */
     private function setTypeInternal($type) {
         // Call this to make an exception if the type is invalid
@@ -908,8 +908,18 @@ class Gradeable extends AbstractModel {
      * @param int $pdf_page set to Component::PDF_PAGE_NONE if not a pdf assignment
      * @return Component the created component
      */
-    public function addComponent(string $title, string $ta_comment, string $student_comment, float $lower_clamp,
-                                 float $default, float $max_value, float $upper_clamp, bool $text, bool $peer, int $pdf_page) {
+    public function addComponent(
+        string $title,
+        string $ta_comment,
+        string $student_comment,
+        float $lower_clamp,
+        float $default,
+        float $max_value,
+        float $upper_clamp,
+        bool $text,
+        bool $peer,
+        int $pdf_page
+    ) {
         $component = new Component($this->core, $this, [
             'title' => $title,
             'ta_comment' => $ta_comment,

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -128,7 +128,7 @@ class GradeableList extends AbstractModel {
             // We have to use @ since on calling Mocked PHPUnit classes within this
             // causes a warning to be raised as the mocked object tracks some debug
             // information which changes the internal object in PHP < 7.0. Annoying!
-            @uasort($this->$list, function(Gradeable $a, Gradeable $b) use ($function) {
+            @uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
                 if ($a->$function() == $b->$function()) {
                     if ($a->getId() < $b->getId()) {
                         return -1;

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -172,12 +172,12 @@ class GradedGradeable extends AbstractModel {
      */
     public function getActiveGradeInquiryCount() {
         if (!$this->gradeable->isGradeInquiryPerComponentAllowed()) {
-            return array_reduce($this->regrade_requests, function($carry, RegradeRequest $grade_inquiry) {
+            return array_reduce($this->regrade_requests, function ($carry, RegradeRequest $grade_inquiry) {
                 $carry += is_null($grade_inquiry->getGcId()) && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
                 return $carry;
             });
         }
-        return array_reduce($this->regrade_requests, function($carry, RegradeRequest $grade_inquiry) {
+        return array_reduce($this->regrade_requests, function ($carry, RegradeRequest $grade_inquiry) {
             $carry += $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
             return $carry;
         });

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -39,7 +39,7 @@ class HomePageView extends AbstractView {
             }
 
             //Filter any ranks with no courses
-            $ranks = array_filter($ranks, function($rank) {
+            $ranks = array_filter($ranks, function ($rank) {
                 return count($rank["courses"]) > 0;
             });
             $statuses[] = $ranks;

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -145,7 +145,7 @@ class ForumThreadView extends AbstractView {
             $currentCategoriesIds = $this->core->getQueries()->getCategoriesIdForThread($currentThread);
         }
 
-        $currentThreadArr = array_filter($threadsHead, function($ar) use($currentThread) {
+        $currentThreadArr = array_filter($threadsHead, function ($ar) use ($currentThread) {
             return ($ar['id'] == $currentThread);
         });
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -46,7 +46,8 @@ class ElectronicGraderView extends AbstractView {
         int $viewed_grade,
         string $section_type,
         int $regrade_requests,
-        bool $show_warnings) {
+        bool $show_warnings
+) {
 
         $peer = false;
         if($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
@@ -582,7 +583,7 @@ HTML;
         }
 
         //sorts sections numerically, NULL always at the end
-        usort($sections, function($a,$b) {
+        usort($sections, function ($a,$b) {
             return ($a['title'] == 'NULL' || $b['title'] == 'NULL') ? ($a['title'] == 'NULL') : ($a['title'] > $b['title']);
         });
 
@@ -928,7 +929,7 @@ HTML;
         }
 
         // TODO: this is duplicated in Homework View
-        $version_data = array_map(function(AutoGradedVersion $version) use ($gradeable) {
+        $version_data = array_map(function (AutoGradedVersion $version) use ($gradeable) {
             return [
                 'points' => $version->getNonHiddenPoints(),
                 'days_late' => $gradeable->isStudentSubmit() && $gradeable->hasDueDate() ? $version->getDaysLate() : 0

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -337,11 +337,11 @@ class HomeworkView extends AbstractView {
             }
         }
 
-        $component_names = array_map(function(Component $component) {
+        $component_names = array_map(function (Component $component) {
             return $component->getTitle();
         }, $gradeable->getComponents());
 
-        $input_data = array_map(function(AbstractGradeableInput $inp) {
+        $input_data = array_map(function (AbstractGradeableInput $inp) {
             return $inp->toArray();
         }, $inputs);
 
@@ -573,7 +573,7 @@ class HomeworkView extends AbstractView {
         $active_version_number = $auto_graded_gradeable->getActiveVersion();
         $display_version = 0;
 
-        $version_data = array_map(function(AutoGradedVersion $version) use ($gradeable) {
+        $version_data = array_map(function (AutoGradedVersion $version) use ($gradeable) {
             return [
                 'points' => $version->getNonHiddenPoints(),
                 'days_late' => $gradeable->isStudentSubmit() && $gradeable->hasDueDate() ? $version->getDaysLate() : 0

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -56,7 +56,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
         if (isset($config_values['use_mock_time']) && $config_values['use_mock_time'] === true ){
             $core->method('getDateTimeNow')->willReturn(new \DateTime('2001-01-01', $config->getTimezone()));
         }else{
-            $core->method('getDateTimeNow')->willReturnCallback(function() use($config) {
+            $core->method('getDateTimeNow')->willReturnCallback(function () use ($config) {
                 return new \DateTime('now', $config->getTimezone());
             });
         }

--- a/site/tests/app/libraries/AccessTester.php
+++ b/site/tests/app/libraries/AccessTester.php
@@ -124,7 +124,7 @@ class AccessTester extends BaseUnitTest {
 
         $team1 = $this->createMockModel(Team::class);
         $team1->method("getId")->willReturn("team1");
-        $team1->method("hasMember")->willReturnCallback(function($test) {
+        $team1->method("hasMember")->willReturnCallback(function ($test) {
             return in_array($test, ["user1", "user2"]);
         });
 
@@ -154,7 +154,7 @@ class AccessTester extends BaseUnitTest {
 
         $team1 = $this->createMockModel(Team::class);
         $team1->method("getId")->willReturn("team1");
-        $team1->method("hasMember")->willReturnCallback(function($test) {
+        $team1->method("hasMember")->willReturnCallback(function ($test) {
             return in_array($test, ["user1", "user2"]);
         });
 

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -133,7 +133,7 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
         $cookie
             ->expects($this->once())
             ->willReturnCallback(
-                function($name, $value, $expires, $path, $domain, $secure) {
+                function ($name, $value, $expires, $path, $domain, $secure) {
                     $this->assertEquals('test', $name);
                     $this->assertEquals('data', $value);
                     $this->assertEquals(100, $expires);
@@ -151,7 +151,7 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
         $cookie
             ->expects($this->once())
             ->willReturnCallback(
-                function($name, $value, $expires, $path, $domain, $secure) {
+                function ($name, $value, $expires, $path, $domain, $secure) {
                     $this->assertEquals('test', $name);
                     $this->assertEquals('{"a":true}', $value);
                     $this->assertEquals(100, $expires);
@@ -171,7 +171,7 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
             $cookie
                 ->expects($this->once())
                 ->willReturnCallback(
-                    function($name, $value, $expires, $path, $domain, $secure) {
+                    function ($name, $value, $expires, $path, $domain, $secure) {
                         $this->assertEquals('test', $name);
                         $this->assertEquals('{"a":true}', $value);
                         $this->assertEquals(100, $expires);
@@ -195,7 +195,7 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
             $cookie
                 ->expects($this->once())
                 ->willReturnCallback(
-                    function($name, $value, $expires, $path, $domain, $secure) {
+                    function ($name, $value, $expires, $path, $domain, $secure) {
                         $this->assertEquals('test', $name);
                         $this->assertEquals('{"a":true}', $value);
                         $this->assertEquals(100, $expires);
@@ -332,7 +332,7 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
             $array1[] = $obj;
             $array2[] = $obj;
         }
-        $inferior_func = function($a, $b) {
+        $inferior_func = function ($a, $b) {
             return $a === $b ? -1 : 1;
         };
         $this->assertCount(5, array_udiff($array1, $array2, $inferior_func));

--- a/site/tests/app/libraries/database/AbstractDatabaseQueriesTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseQueriesTester.php
@@ -8,7 +8,7 @@ abstract class AbstractDatabaseQueriesTester extends \PHPUnit\Framework\TestCase
     protected static $expected_functions;
 
     public static function setUpBeforeClass(): void {
-        $filter = function($name) {
+        $filter = function ($name) {
             return $name !== '__construct';
         };
         self::$expected_functions = array_filter(get_class_methods(DatabaseQueries::class), $filter);

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -242,7 +242,7 @@ SELECT * FROM test ORDER BY pid");
         $this->setupDatabase($database);
         $result = $database->queryIterator('INSERT INTO test VALUES (?, ?)', array(3, 'c'));
         $this->assertTrue($result);
-        $iterator = $database->queryIterator('SELECT * FROM test ORDER BY pid', array(), function($result) {
+        $iterator = $database->queryIterator('SELECT * FROM test ORDER BY pid', array(), function ($result) {
             return array('id' => $result['pid']);
         });
         $expected = array(0 => array('id' => 1), 1 => array('id' => 2), 2 => array('id' => 3));

--- a/site/tests/app/libraries/database/PostgresqlDatabaseQueriesTester.php
+++ b/site/tests/app/libraries/database/PostgresqlDatabaseQueriesTester.php
@@ -6,7 +6,7 @@ use app\libraries\database\PostgresqlDatabaseQueries;
 
 class PostgresqlDatabaseQueriesTester extends AbstractDatabaseQueriesTester {
     public function testHasAllFunctions() {
-        $filter = function($name) {
+        $filter = function ($name) {
             return $name !== '__construct';
         };
         $actual = array_filter(get_class_methods(PostgresqlDatabaseQueries::class), $filter);

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -398,8 +398,17 @@ class GradeableListTester extends BaseUnitTest {
      * @return Gradeable
      */
     private function mockGradeable(
-        Core $core, $id, $type, $ta_view_start_date, $submission_open_date, $submission_due_date, $grade_start_date,
-        $grade_released_date, $ta_grading = true, $student_submit = true, $has_due_date = true
+        Core $core,
+        $id,
+        $type,
+        $ta_view_start_date,
+        $submission_open_date,
+        $submission_due_date,
+        $grade_start_date,
+        $grade_released_date,
+        $ta_grading = true,
+        $student_submit = true,
+        $has_due_date = true
     ) {
         $timezone = new \DateTimeZone('America/New_York');
         $details = [

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -2,6 +2,7 @@
 <ruleset name="SubmittyStandard">
     <description>Non-Complete Standard for the Submitty Project</description>
     <arg name="extensions" value="php" />
+    <arg value="p" />
 
     <file>../app</file>
     <file>../public/index.php</file>
@@ -99,15 +100,6 @@
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeHint" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterUse" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.OneParamPerLine" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnNewLine" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.Indent" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing" />
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceBeforeBrace" />
         <exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed" />
         <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
         <exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the new behavior?

Fixes all of the `Squiz.Functions.MultiLineFunctionDeclaration` errors in the codebase, which is stuff like not having a space after `function` or `use` in an anonymous function declaration, if a function parameters split over multiple lines, they must all be on their own line, etc, per the [PSR-12](https://www.php-fig.org/psr/psr-12/) spec.

Also fixed a handful of indentation problems in some of the affected areas.