### PR TITLE
[Bugfix:Confetti] Fix Confetti for notebook gradeables & 1 Test case only

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -8,14 +8,6 @@
    {% endif %}
 {% endif %}
 
-{% if num_visible_testcases == 1 %}
-    <script type="text/javascript">
-        $(document).ready(function() {
-            loadTestcaseOutput('testcase_0', '{{ gradeable_id }}', '{{ submitter_id }}', '0', '{{ display_version }}');
-        });
-    </script>
-{% endif %}
-
 {% if show_hidden_breakdown and hidden_earned >= hidden_max %}
     <canvas id="confetti_canvas"></canvas>
 {% elseif nonhidden_earned >= nonhidden_max %}
@@ -23,7 +15,7 @@
 {% endif %}
 
 
-{% if num_visible_testcases > 1 %}
+{% if num_visible_testcases > 0 %}
     {# check if instructor grades exist and change title, display hidden points when TA grades are released (if hidden tests exist) #}
 
     <div class="box">

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -52,6 +52,9 @@
             {% endif %}
         </div>
     </div>
+{% else %}
+    {# Keep the Submission date to let Confetti parse the date #}
+    <span hidden id="submission_timestamp"> submission timestamp: {{ submission_time|date('m/d/Y h:i:s A') }}</span> <br />
 {% endif %}
 {# /Submitted files #}
 

--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -37,7 +37,7 @@ function addConfetti(){
 	let gravity_const = 0.25;
 
 	let date_box = document.getElementById("submission_timestamp");
-	if(date_box)
+	if(typeof(date_box) != 'undefined' && date_box != null)
 		due_date = date_box.innerHTML.match(/\d+/g);
 
 	let d = new Date();

--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -38,14 +38,14 @@ function addConfetti(){
 
 	let date_box = document.getElementById("submission_timestamp");
 	if(typeof(date_box) != 'undefined' && date_box != null)
-		due_date = date_box.innerHTML.match(/\d+/g);
+		submission_date = date_box.innerHTML.match(/\d+/g);
 
 	let d = new Date();
 	let month = d.getMonth();
 
 	//if we parsed the submission due date, use that instead
-	if(due_date.length >= 1){
-		month = parseInt(due_date[0], 10) - 1;
+	if(submission_date.length >= 1){
+		month = parseInt(submission_date[0], 10) - 1;
 	}
 	
 	function randomColor () {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The previous method of checking if the submission box could be parsed or not in `confetti.js` wasn't correct and would think the box was always there. Notebook gradeables do not show this info and confetti.js would crash trying to parse it.  

### What is the new behavior?
Fixed parsing and hides the submission box for notebook gradeables.


closes #4464


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
