### PR TITLE
[Bugfix:TAGrading] download zip of files for one student

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -290,13 +290,15 @@ class MiscController extends AbstractController {
                         $relativePath = substr($filePath, strlen($paths[$x]) + 1);
 
                         //Only get PDFs if this is a bulk upload gradeable
-                        if ($gradeable->isScannedExam() 
-                            && FileUtils::getContentType($filePath) === "application/pdf"){
+                        if($this->core->getUser()->accessGrading()){
+                            $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
+                        }else if ($gradeable->isScannedExam()
+                                  && FileUtils::getContentType($filePath) === "application/pdf"){
                             // Add current file to archive
                             $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
                         }
 
-                       
+
                     }
                 }
             }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ x] Tests for the changes have been added/updated (if possible)
* [ x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The "download zip file" button, when grading, downloads a zip file but it is completely empty
![image](https://user-images.githubusercontent.com/18558130/67629378-116b6f80-f84b-11e9-94ba-469cf881888f.png)


### What is the new behavior?
The zip file now actually has all the student's files in it

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
