### PR TITLE
[Refactor:PHP] Fix Squiz.Operators.ValidLogicalOperators style errors

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -93,7 +93,7 @@ class MiscController extends AbstractController {
             if($dir == 'course_materials')
             {
                 // If the user attempting to access the file is not at least a grader then ensure the file has been released
-                if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path))
+                if(!$this->core->getUser()->accessGrading() && !CourseMaterial::isMaterialReleased($this->core, $path))
                 {
                     $this->core->getOutput()->showError("You may not access this file until it is released.");
                     return false;
@@ -173,18 +173,18 @@ class MiscController extends AbstractController {
         }
 
         // If attempting to obtain course materials
-        if($dir == 'course_materials') {
+        if ($dir == 'course_materials') {
             // If the user attempting to access the file is not at least a grader then ensure the file has been released
-            if(!$this->core->getUser()->accessGrading() AND !CourseMaterial::isMaterialReleased($this->core, $path)) {
+            if (!$this->core->getUser()->accessGrading() && !CourseMaterial::isMaterialReleased($this->core, $path)) {
                 $this->core->getOutput()->showError("You may not access this file until it is released.");
                 return false;
             }
         }
 
-        if($dir == 'submissions'){
+        if ($dir == 'submissions') {
             //cannot download scanned images for bulk uploads
             if (strpos(basename($path), "upload_page_" ) !== false &&
-                FileUtils::getContentType($path) !== "application/pdf"){
+                FileUtils::getContentType($path) !== "application/pdf") {
 
                 $this->core->getOutput()->showError("You do not have access to this file");
                 return false;
@@ -290,13 +290,13 @@ class MiscController extends AbstractController {
                         $relativePath = substr($filePath, strlen($paths[$x]) + 1);
 
                         //Only get PDFs if this is a bulk upload gradeable
-                        if ($gradeable->isScannedExam() 
+                        if ($gradeable->isScannedExam()
                             && FileUtils::getContentType($filePath) === "application/pdf"){
                             // Add current file to archive
                             $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
                         }
 
-                       
+
                     }
                 }
             }

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -22,7 +22,10 @@ class PlagiarismController extends AbstractController {
         );
 
         if (file_exists($filename)) {
-            $file = fopen($filename, "r") or exit("Unable to open file!");
+            $file = fopen($filename, "r");
+            if (!$file) {
+                exit("Unable to open file!");
+            }
 
             while(!feof($file)) {
                 $line = fgets($file);

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -303,7 +303,7 @@ class ReportController extends AbstractController {
             /** @var GradedGradeable $gg */
             //Append one gradeable score to row.  Scores are indexed by gradeable's ID.
             $row[$gg->getGradeableId()] = $gg->getTotalScore();
-            
+
             if (!$gg->hasOverriddenGrades()){
                 // Check if the score should be a zero
                 if ($gg->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE) {
@@ -374,7 +374,7 @@ class ReportController extends AbstractController {
 
         if ($gg->hasOverriddenGrades()){
             $entry['status'] = 'Overridden';
-            $entry['comment'] = $gg->getOverriddenComment(); 
+            $entry['comment'] = $gg->getOverriddenComment();
         }
         else {
             // Add information special to electronic file submissions
@@ -567,7 +567,7 @@ class ReportController extends AbstractController {
         $max_wait_time = self::MAX_AUTO_RG_WAIT_TIME;
 
         // Check the jobs queue every second to see if the job has finished yet
-        while(file_exists($jobs_file) AND $max_wait_time)
+        while(file_exists($jobs_file) && $max_wait_time)
         {
             sleep(1);
             $max_wait_time--;
@@ -577,7 +577,7 @@ class ReportController extends AbstractController {
         // Jobs queue daemon actually changes the name of the job by prepending PROCESSING onto the filename
         // We must also wait for that file to be removed
         // Check the jobs queue every second to see if the job has finished yet
-        while(file_exists($processing_jobs_file) AND $max_wait_time)
+        while(file_exists($processing_jobs_file) && $max_wait_time)
         {
             sleep(1);
             $max_wait_time--;
@@ -604,7 +604,7 @@ class ReportController extends AbstractController {
 
         // If we finished the previous loops before max_wait_time hit 0 then the file successfully left the jobs queue
         // implying that it finished
-        if($max_wait_time AND $failure_detected == false)
+        if ($max_wait_time && $failure_detected == false)
         {
             $this->core->getOutput()->renderJsonSuccess($debug_contents);
         }

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -261,7 +261,7 @@ class ForumController extends AbstractController{
             return $this->core->getOutput()->renderJsonFail("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long", $result);
         }
 
-        if( !empty($_POST['lock_thread_date'])  and $this->core->getUser()->accessAdmin() ){
+        if( !empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin() ){
             $lock_thread_date = $_POST['lock_thread_date'];
         } else {
             $lock_thread_date = null;
@@ -374,7 +374,7 @@ class ForumController extends AbstractController{
         } else if(!$this->core->getQueries()->existsPost($thread_id, $parent_id)) {
             $this->core->addErrorMessage("There was an error submitting your post. Parent post doesn't exist in given thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } else if($this->core->getQueries()->isThreadLocked($thread_id) and !$this->core->getUser()->accessAdmin() ) {
+        } else if($this->core->getQueries()->isThreadLocked($thread_id) && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Thread is locked.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
         } else {
@@ -458,10 +458,10 @@ class ForumController extends AbstractController{
         if(!$this->core->getAccess()->canI("forum.modify_post", ['post_author' => $post['author_user_id']])) {
                 return $this->core->getOutput()->renderJsonFail('You do not have permissions to do that.');
         }
-        if(!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) and !$this->core->getUser()->accessAdmin() ){
+        if(!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) && !$this->core->getUser()->accessAdmin() ){
             $this->core->addErrorMessage("Thread is locked.");
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $_POST['edit_thread_id']]));
-        } else if($this->core->getQueries()->isThreadLocked($_POST['thread_id']) and !$this->core->getUser()->accessAdmin() ){
+        } else if($this->core->getQueries()->isThreadLocked($_POST['thread_id']) && !$this->core->getUser()->accessAdmin() ){
             return $this->core->getOutput()->renderJsonFail('Thread is locked');
         }
         else if($modify_type == 0) { //delete post or thread
@@ -617,7 +617,7 @@ class ForumController extends AbstractController{
         // Ensure authentication before call
         if(!empty($_POST["title"])) {
             $thread_id = $_POST["edit_thread_id"];
-            if( !empty($_POST['lock_thread_date']) and $this->core->getUser()->accessAdmin()){
+            if( !empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()){
                 $lock_thread_date = $_POST['lock_thread_date'];
             }
             else{

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -672,7 +672,7 @@ class ElectronicGraderController extends AbstractController {
         $teams = $this->core->getQueries()->getTeamsWithMembersFromGradeableID($gradeable_id);
 
         //Does nothing if there are no sections or no teams
-        if ($section_count <= 0 or empty($teams)) {
+        if ($section_count <= 0 || empty($teams)) {
             $this->core->redirect($return_url);
             return;
         }

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -215,7 +215,7 @@ class GradingOrder extends AbstractModel {
         $this->initUsersNotFullyGraded($component_id);
 
         return $this->getNextSubmitterMatching($submitter, function (Submitter $sub) {
-            return in_array($sub->getId(), $this->not_fully_graded) AND $this->getHasSubmission($sub);
+            return in_array($sub->getId(), $this->not_fully_graded) && $this->getHasSubmission($sub);
         });
     }
 
@@ -236,7 +236,7 @@ class GradingOrder extends AbstractModel {
         $this->initUsersNotFullyGraded($component_id);
 
         return $this->getPrevSubmitterMatching($submitter, function (Submitter $sub) {
-            return in_array($sub->getId(), $this->not_fully_graded) AND $this->getHasSubmission($sub);
+            return in_array($sub->getId(), $this->not_fully_graded) && $this->getHasSubmission($sub);
         });
     }
 
@@ -464,17 +464,17 @@ class GradingOrder extends AbstractModel {
      */
     public static function getGradingOrderMessage($sort, $direction) {
 
-        if($sort == 'first' AND $direction == 'ASC') {
+        if($sort == 'first' && $direction == 'ASC') {
             $msg = 'First Name Ascending';
-        } else if ($sort == 'first' AND $direction == 'DESC') {
+        } else if ($sort == 'first' && $direction == 'DESC') {
             $msg = 'First Name Descending';
-        } else if ($sort == 'last' AND $direction == 'ASC') {
+        } else if ($sort == 'last' && $direction == 'ASC') {
             $msg = 'Last Name Ascending';
-        } else if ($sort == 'last' AND $direction == 'DESC') {
+        } else if ($sort == 'last' && $direction == 'DESC') {
             $msg = 'Last Name Descending';
-        } else if ($sort == 'id' AND $direction == 'ASC') {
+        } else if ($sort == 'id' && $direction == 'ASC') {
             $msg = 'ID Ascending';
-        } else if ($sort == 'id' AND $direction == 'DESC') {
+        } else if ($sort == 'id' && $direction == 'DESC') {
             $msg = 'ID Descending';
         } else if ($sort == 'random') {
             $msg = 'Randomized';

--- a/site/app/models/OfficeHoursQueueStudent.php
+++ b/site/app/models/OfficeHoursQueueStudent.php
@@ -52,7 +52,7 @@ class OfficeHoursQueueStudent extends AbstractModel {
     }
 
     public function isInQueue(){
-        return $this->status == 0 or $this->status == 1;
+        return $this->status == 0 || $this->status == 1;
     }
 
     public function getStatus(){

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -280,8 +280,7 @@ class RainbowCustomizationJSON extends AbstractModel
         foreach($this as $key => $value)
         {
             // Dont include $core or $modified
-            if($key != 'core' AND $key != 'modified')
-            {
+            if ($key != 'core' && $key != 'modified') {
                 $json->$key = $value;
             }
         }

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -82,7 +82,7 @@ class AutogradingConfig extends AbstractModel {
 
     public function __construct(Core $core, array $details) {
         parent::__construct($core);
-        
+
         // Was there actually a config file to read from
         if ($details === null || $details === []) {
             throw new \InvalidArgumentException('Provided details were blank or null');
@@ -164,11 +164,11 @@ class AutogradingConfig extends AbstractModel {
                     $notebook_cell['markdown_data'] = $markdown;
 
                     // If next entry is an input type, we assign this as a label - otherwise it is plain markdown
-                    if ($i < count($details['notebook']) - 1) 
+                    if ($i < count($details['notebook']) - 1)
                     {
                         $next_cell = &$details['notebook'][$i + 1];
                         if (isset($next_cell['type']) &&
-                            ($next_cell['type'] == 'short_answer' OR $next_cell['type'] == 'multiple_choice')) 
+                            ($next_cell['type'] == 'short_answer' || $next_cell['type'] == 'multiple_choice'))
                         {
                             $next_cell['label'] = $markdown;
                             // Do not add current cell to notebook, since it is embedded in the label
@@ -184,7 +184,7 @@ class AutogradingConfig extends AbstractModel {
 
                 // If cell is a type of input add it to the $actual_inputs array
                 if(isset($notebook_cell['type']) &&
-                   ($notebook_cell['type'] == 'short_answer' OR $notebook_cell['type'] == 'multiple_choice'))
+                   ($notebook_cell['type'] === 'short_answer' || $notebook_cell['type'] === 'multiple_choice'))
                 {
                     array_push($actual_input, $notebook_cell);
                 }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -204,8 +204,8 @@ class ElectronicGraderView extends AbstractView {
             "gradeable_title" => $gradeable->getTitle(),
             "team_assignment" => $gradeable->isTeamAssignment(),
             "ta_grades_released" => $gradeable->isTaGradeReleased(),
-            "rotating_sections_error" => (!$gradeable->isGradeByRegistration()) and $no_rotating_sections
-                and $this->core->getUser()->getGroup() == User::GROUP_INSTRUCTOR,
+            "rotating_sections_error" => (!$gradeable->isGradeByRegistration()) && $no_rotating_sections
+                && $this->core->getUser()->getGroup() == User::GROUP_INSTRUCTOR,
             "autograding_non_extra_credit" => $gradeable->getAutogradingConfig()->getTotalNonExtraCredit(),
             "peer" => $peer,
             "team_total" => $team_total,

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -1223,7 +1223,10 @@ class SubmissionControllerTester extends BaseUnitTest {
     public function testErrorOnBrokenZip() {
         $this->addUploadZip('broken', array('test1.txt'));
         $path = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part1', 'broken.zip');
-        $fh = fopen($path, 'r+') or die("can't open file");
+        $fh = fopen($path, 'r+');
+        if (!$fh) {
+            $this->fail('cannot open the file');
+        }
         $stat = fstat($fh);
         ftruncate($fh, $stat['size']-1);
         fclose($fh);

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -98,7 +98,6 @@
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeHint" />
-        <exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed" />
         <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
         <exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
         <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?
Fixes all instances of the `Squiz.Operators.ValidLogicalOperators` style errors. This sniff prevents the usage of the `and` and `or` logical comparators, mandating only usage of `&&` and `||`. The two are not equivalent, and have different operator precedence, which can introduce subtle bugs from surprising behavior, hence most people (including us going forward) forbid usage of the former and only allow the latter.

A demonstrative case of why the former are bad:
```php
$a = true and false;
var_dump($a); // true
$a = true && false;
var_dump($a); // false
```
this is because the `and` operator has a lower precedence than the `=` operator, which I'm not sure anyone really expects or wants.