### PR TITLE
[Bugfix:Autograding] Don't Pull in a Router for Single Container Testcases

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -295,6 +295,7 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
         assert(router_container == -1);
       }
 
+      // If we are using the router, and it isn't specified, and this testcase is a valid candidate for a router (2 or more containers specified).
       if(this_testcase["use_router"] && router_container == -1 && this_testcase[container_type].size() > 1){
         nlohmann::json insert_router = nlohmann::json::object();
         insert_router["outgoing_connections"] = nlohmann::json::array();

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -289,7 +289,13 @@ void AddDockerConfiguration(nlohmann::json &whole_config) {
         }
       }
 
-      if(this_testcase["use_router"] && router_container == -1){
+      if(this_testcase[container_type].size() <= 2 && this_testcase["use_router"]){
+        // If there are only two containers specified, make sure that neither is the router.
+        // The router MUST go between at least two containers.
+        assert(router_container == -1);
+      }
+
+      if(this_testcase["use_router"] && router_container == -1 && this_testcase[container_type].size() > 1){
         nlohmann::json insert_router = nlohmann::json::object();
         insert_router["outgoing_connections"] = nlohmann::json::array();
         insert_router["commands"] = nlohmann::json::array();


### PR DESCRIPTION
At present, if ```use_router``` is set to ```true```, a router is pulled in even for single container testcases (e.g. a ```FileCheck``` or ```Compilation``` testcase). This PR stops a router from being added for such testcases at assignment build time, and further disallows manually pulling in a router for testcases which involve only a single container.
