### PR TITLE
[Bugfix: Grading] fixed crash when going to .../grading/grade without any parameters

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -827,7 +827,7 @@ class ElectronicGraderController extends AbstractController {
      *
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/grade")
      */
-    public function showGrading($gradeable_id, $who_id='', $from=null, $to=null, $gradeable_version=null, $sort="id", $direction="ASC", $to_ungraded=null, $component_id="-1") {
+    public function showGrading($gradeable_id, $who_id='', $from="", $to=null, $gradeable_version=null, $sort="id", $direction="ASC", $to_ungraded=null, $component_id="-1") {
         /** @var Gradeable $gradeable */
         $gradeable = $this->tryGetGradeable($gradeable_id, false);
         if ($gradeable === false) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

closes #4557


### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There is a crash when going to  http://192.168.56.111/f19/sample/gradeable/open_homework/grading/grade

See #4557 for more details

### What is the new behavior?

The page will now redirect to http://192.168.56.111/f19/sample/gradeable/open_homework/grading/details instead


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
When you click on the normal grading index button the url you go to ends with `?view=all`, however currently the redirect is set up to go to http://192.168.56.111/f19/sample/gradeable/open_homework/grading/details and leave out `?view=all`
Is this difference intentional? Otherwise I can fix it by changing /home/eli/documents/Submitty/site/app/controllers/grading/ElectronicGraderController.php line 855 to `$this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])."?view=all");`