### PR TITLE
[Refactor:PHP] Fix Generic.Classes.OpeningBraceSameLine style errors

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * Controller to deal with the submitty home page. Once the user has been authenticated, but before they have
  * selected which course they want to access, they are forwarded to the home page.
  */
-class ForumController extends AbstractController{
+class ForumController extends AbstractController {
     /**
      * ForumHomeController constructor.
      *

--- a/site/app/libraries/GradeableType.php
+++ b/site/app/libraries/GradeableType.php
@@ -2,7 +2,7 @@
 
 namespace app\libraries;
 
-abstract class GradeableType{
+abstract class GradeableType {
     const ELECTRONIC_FILE = 0;
     const CHECKPOINTS     = 1;
     const NUMERIC_TEXT    = 2;

--- a/site/app/libraries/database/ForumQueries.php
+++ b/site/app/libraries/database/ForumQueries.php
@@ -5,7 +5,8 @@ namespace app\libraries\database;
 use app\models\forum\Thread;
 use app\models\forum\Post;
 
-class ForumQueries { //extends DatabaseQueries {
+class ForumQueries {
+ //extends DatabaseQueries {
 
 
     public function createPost(Post &$p, bool $isFirst){

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -22,7 +22,7 @@ use app\models\SimpleLateUser;
 use app\models\Team;
 use app\models\SimpleStat;
 
-class PostgresqlDatabaseQueries extends DatabaseQueries{
+class PostgresqlDatabaseQueries extends DatabaseQueries {
 
     //given a user_id check the users table for a valid entry, returns a user object if found, null otherwise
     //if is_numeric is true, the numeric_id key will be used to lookup the user

--- a/site/app/libraries/routers/AnnotatedRouteLoader.php
+++ b/site/app/libraries/routers/AnnotatedRouteLoader.php
@@ -6,8 +6,8 @@ use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Route;
 
 
-class AnnotatedRouteLoader extends AnnotationClassLoader
-{
+class AnnotatedRouteLoader extends AnnotationClassLoader {
+
 
     protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
     {

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -7,8 +7,8 @@ namespace app\models;
 use app\exceptions\FileNotFoundException;
 use app\libraries\Core;
 
-class CourseMaterial extends AbstractModel
-{
+class CourseMaterial extends AbstractModel {
+
     /**
      * Determine if a course materials file has been released
      *

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -15,7 +15,7 @@ use app\libraries\GradeableType;
  * This class is a RainbowGrades Customization.  It may contain the data found in customization.json but it also
  * contains additional data that is used by the web user interface to aid in generation/customization.
  */
-class RainbowCustomization extends AbstractModel{
+class RainbowCustomization extends AbstractModel {
     /**/
     protected $core;
     private $customization_data = [];

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -20,8 +20,8 @@ use app\libraries\FileUtils;
  *
  * When adding to data to any property, the appropriate setter must be used as they preform additional validation.
  */
-class RainbowCustomizationJSON extends AbstractModel
-{
+class RainbowCustomizationJSON extends AbstractModel {
+
     protected $core;
 
     private $section;                   // Init in constructor

--- a/site/tests/app/exceptions/ConfigExceptionTester.php
+++ b/site/tests/app/exceptions/ConfigExceptionTester.php
@@ -4,7 +4,7 @@ namespace tests\app\exceptions;
 
 use app\exceptions\ConfigException;
 
-class ConfigExceptionTester extends \PHPUnit\Framework\TestCase  {
+class ConfigExceptionTester extends \PHPUnit\Framework\TestCase {
     public function testConfigException() {
         try {
             throw new ConfigException("exception");

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -16,9 +16,6 @@
         <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 
         <exclude name="Generic.Arrays.DisallowLongArraySyntax.Found" />
-        <exclude name="Generic.Classes.OpeningBraceSameLine.SpaceBeforeBrace" />
-        <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
-        <exclude name="Generic.Classes.OpeningBraceSameLine.ContentAfterBrace" />
         <exclude name="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed" />
         <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
         <exclude name="Generic.Files.LineLength.TooLong" />

--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -5,7 +5,7 @@ namespace tests\utils;
 use app\libraries\Core;
 use app\libraries\Output;
 
-class NullOutput extends Output{
+class NullOutput extends Output {
     private $twig_output = [];
 
     public function loadTwig($full_load = true) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the `Generic.Classes.OpeningBraceSameLine` style errors, which is that the class line is the only thing on it, and that it ends with a ` {`.