### PR TITLE
Revert "[Bugfix:TAGrading] team grading statistics (#4672)"

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1102,9 +1102,9 @@ SELECT COUNT(*) from gradeable_component where g_id=?
             $user_or_team_id="team_id";
         }
         $this->course_db->query("
-SELECT COUNT(*) as cnt from gradeable_component where g_id=?
+SELECT COUNT(*) from gradeable_component where g_id=?
           ", array($g_id));
-        $count = $this->course_db->row()['cnt'];
+        $count = $this->course_db->rows()[0][0];
         $this->course_db->query("
 SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop(g_score),2) AS std_dev, round(AVG(max),2) AS max, COUNT(*) FROM(
   SELECT * FROM(

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -398,7 +398,91 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
           ", array($g_id));
         return ($this->course_db->getRowCount() > 0) ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
     }
-    
+
+    public function getAverageForGradeable($g_id, $section_key, $is_team) {
+        $u_or_t="u";
+        $users_or_teams="users";
+        $user_or_team_id="user_id";
+        if ($is_team) {
+            $u_or_t="t";
+            $users_or_teams="gradeable_teams";
+            $user_or_team_id="team_id";
+        }
+        $this->course_db->query("SELECT COUNT(*) as cnt FROM gradeable_component WHERE g_id=?", array($g_id));
+        $count = $this->course_db->row()['cnt'];
+        $this->course_db->query("
+SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop(g_score),2) AS std_dev, round(AVG(max),2) AS max, COUNT(*) FROM(
+  SELECT * FROM(
+    SELECT gd_id, SUM(comp_score) AS g_score, SUM(gc_max_value) AS max, COUNT(comp.*), autograding FROM(
+      SELECT  gd_id, gc_title, gc_max_value, gc_is_peer, gc_order, autograding,
+      CASE WHEN (gc_default + sum_points + gcd_score) > gc_upper_clamp THEN gc_upper_clamp
+      WHEN (gc_default + sum_points + gcd_score) < gc_lower_clamp THEN gc_lower_clamp
+      ELSE (gc_default + sum_points + gcd_score) END AS comp_score FROM(
+        SELECT gcd.gd_id, gc_title, gc_max_value, gc_is_peer, gc_order, gc_lower_clamp, gc_default, gc_upper_clamp,
+        CASE WHEN sum_points IS NULL THEN 0 ELSE sum_points END AS sum_points, gcd_score, CASE WHEN autograding IS NULL THEN 0 ELSE autograding END AS autograding
+        FROM gradeable_component_data AS gcd
+        LEFT JOIN gradeable_component AS gc ON gcd.gc_id=gc.gc_id
+        LEFT JOIN(
+          SELECT SUM(gcm_points) AS sum_points, gcmd.gc_id, gcmd.gd_id
+          FROM gradeable_component_mark_data AS gcmd
+          LEFT JOIN gradeable_component_mark AS gcm ON gcmd.gcm_id=gcm.gcm_id AND gcmd.gc_id=gcm.gc_id
+          GROUP BY gcmd.gc_id, gcmd.gd_id
+          )AS marks
+        ON gcd.gc_id=marks.gc_id AND gcd.gd_id=marks.gd_id
+        LEFT JOIN gradeable_data AS gd ON gd.gd_id=gcd.gd_id
+        LEFT JOIN (
+          SELECT egd.g_id, egd.{$user_or_team_id}, (autograding_non_hidden_non_extra_credit + autograding_non_hidden_extra_credit + autograding_hidden_non_extra_credit + autograding_hidden_extra_credit) AS autograding
+          FROM electronic_gradeable_version AS egv
+          LEFT JOIN electronic_gradeable_data AS egd ON egv.g_id=egd.g_id AND egv.{$user_or_team_id}=egd.{$user_or_team_id} AND active_version=g_version
+          )AS auto
+        ON gd.g_id=auto.g_id AND gd_user_id=auto.{$user_or_team_id}
+        INNER JOIN {$users_or_teams} AS {$u_or_t} ON {$u_or_t}.{$user_or_team_id} = auto.{$user_or_team_id}
+        WHERE gc.g_id=? AND {$u_or_t}.{$section_key} IS NOT NULL
+      )AS parts_of_comp
+    )AS comp
+    GROUP BY gd_id, autograding
+  )g WHERE count=?
+)AS individual
+          ", array($g_id, $count));
+
+        return ($this->course_db->getRowCount() > 0) ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
+    }
+
+    public function getGradeablesRotatingGraderHistory($gradeable_id) {
+        $params = [$gradeable_id];
+        $this->course_db->query("
+  SELECT
+    gu.g_id, gu.user_id, gu.user_group, gr.sections_rotating_id, g_grade_start_date
+  FROM (
+    SELECT g.g_id, u.user_id, u.user_group, g_grade_start_date
+    FROM (SELECT user_id, user_group FROM users WHERE user_group BETWEEN 1 AND 3) AS u
+    CROSS JOIN (
+      SELECT
+        DISTINCT g.g_id,
+        g_grade_start_date
+      FROM gradeable AS g
+      LEFT JOIN
+        grading_rotating AS gr ON g.g_id = gr.g_id
+      WHERE g_grader_assignment_method = 0 OR g.g_id = ?
+    ) AS g
+  ) as gu
+  LEFT JOIN (
+    SELECT
+      g_id, user_id, json_agg(sections_rotating_id) as sections_rotating_id
+    FROM
+      grading_rotating
+    GROUP BY g_id, user_id
+  ) AS gr ON gu.user_id=gr.user_id AND gu.g_id=gr.g_id
+  ORDER BY user_group, user_id, g_grade_start_date",$params);
+        $rows = $this->course_db->rows();
+        $modified_rows = [];
+        foreach($rows as $row) {
+            $row['sections_rotating_id'] = json_decode($row['sections_rotating_id']);
+            $modified_rows[] = $row;
+        }
+        return $modified_rows;
+    }
+
     /**
      * Gets rotating sections of each grader for a gradeable
      * @param $gradeable_id


### PR DESCRIPTION
This reverts commit 7b1fa6777ef5ea8ca5f44095a3e4ab6ff0eb6e09.


As it caused the error below when we attempt to edit an existing gradeable:

===========


app\exceptions\NotImplementedException (Code: 0) thrown in /usr/local/submitty/site/app/libraries/database/DatabaseQueries.php (Line 1385) by:
        throw new NotImplementedException();


Message:
This is not implemented yet.

Stack Trace:
#0 /usr/local/submitty/site/app/controllers/admin/AdminGradeableController.php(108): app\libraries\database\DatabaseQueries->getGradeablesRotatingGraderHistory('foo')
#1 /usr/local/submitty/site/app/controllers/admin/AdminGradeableController.php(29): app\controllers\admin\AdminGradeableController->editPage(app\models\gradeable\Gradeable, 'f19', 'blank', 0)
#2 unknown file(unknown line): app\controllers\admin\AdminGradeableController->editGradeableRequest('foo', '0')
#3 /usr/local/submitty/site/app/libraries/routers/WebRouter.php(168): call_user_func_array(Array, Array)
#4 /usr/local/submitty/site/app/libraries/routers/WebRouter.php(146): app\libraries\routers\WebRouter->run()
#5 /usr/local/submitty/site/public/index.php(125): app\libraries\routers\WebRouter::getWebResponse(Symfony\Component\HttpFoundation\Request, app\libraries\Core)
               