### PR TITLE
[Bugfix:Notebooks] Turn off autocapitalization and spellcheck in submitty notebooks

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -260,6 +260,8 @@
 
                                 <div id="codebox_{{ num_codeboxes }}"
                                      name="codebox_{{ num_codeboxes }}"
+                                     autocapitalization="off"
+                                     spellcheck="false"
                                      class="codebox"
                                      data-initial_value="{{ cell.initial_value }}"
                                      data-recent_submission="{{ cell.recent_submission }}"
@@ -670,6 +672,8 @@
                 <input
                     type="text"
                     name="short_answer_{{ index }}"
+                    autocapitalization="off"
+                    spellcheck="false"
                     id="short_answer_{{ index }}"
                     class="sa-box"
                     data-initial_value="{{ short_answer.initial_value }}"


### PR DESCRIPTION
Closes #4392 
### Please check if the PR fulfills these requirements:

* [ #] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ #] Tests for the changes have been added/updated (if possible)
* [ #] Documentation has been updated/added if relevant

### What is the current behavior?
Currently, spellcheck and/or autocapitalization may be triggered for a student when typing code in a submitty notebook.
Ex:
"for (int i = 0; ..." => . "for (int I = 0; ..."
Or spell corrects:
"std::cout << x << std::endl;" => "std::count << x << std::end;"

### What is the new behavior?
Autocapitalization and spellcheck in the notebooks are permanently turned off.
