### PR TITLE
[Bugfix:Notifications] Fix new team member notification link

### DIFF
--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -268,7 +268,9 @@ class TeamController extends AbstractController {
         $this->core->getQueries()->removeFromSeekingTeam($gradeable_id,$user_id);
         $team_members = $accept_team->getMembers();
         // send notification to team members that user joined
-        $metadata =  json_encode(['url' => $this->core->buildCourseUrl([$gradeable_id,'team'])]);
+        $metadata =  json_encode(
+            ['url' => $this->core->buildCourseUrl(['gradeable',$gradeable_id,'team'])]
+        );
         $subject = "New Team Member: ".$gradeable->getTitle();
         $content = "A new team member with the user name, $user_id, joined your team for gradeable, ".$gradeable->getTitle();
         $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_joined', 'sender_id' => $user_id];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
When a new team member joins a team, the existing members get notified of this,
like before the url being constructed was broken and would bounce people to the
course list page 

### What is the new behavior?
Correct URL is being used, this should be the last URL from the 
team controller sending the wrong link.
