### PR TITLE
[Refactor:PHP] Fix PSR2.ControlStructures.SwitchDeclaration style errors

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -289,12 +289,16 @@ class Utils {
     * @param string $size_str
     * @return int
     */
-    public static function returnBytes($size_str){
-        switch (substr ($size_str, -1)){
-            case 'M': case 'm': return (int) $size_str * 1048576;
-            case 'K': case 'k': return (int) $size_str * 1024;
-            case 'G': case 'g': return (int) $size_str * 1073741824;
-            default: return (int) $size_str;
+    public static function returnBytes(string $size_str): int {
+        switch (strtolower(substr($size_str, -1))) {
+            case 'm':
+                return (int) $size_str * 1048576;
+            case 'k':
+                return (int) $size_str * 1024;
+            case 'g':
+                return (int) $size_str * 1073741824;
+            default:
+                return (int) $size_str;
         }
     }
 
@@ -305,7 +309,7 @@ class Utils {
     * @param int $bytes
     * @return string
     */
-    public static function formatBytes($format, $bytes){
+    public static function formatBytes(string $format, int $bytes): string {
         $formats = ['b' => 0, 'kb' => 1, 'mb' => 2];
         return ($bytes/pow(1024,floor($formats[strtolower($format)]))) . (strtoupper($format));
     }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -35,11 +35,7 @@
         <exclude name="PSR2.Classes.PropertyDeclaration.StaticBeforeVisibility" />
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent" />
         <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT" />
         <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket" />
         <exclude name="PSR2.Methods.FunctionCallSignature.Indent" />
         <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes `PSR2.ControlStructures.SwitchDeclaration` style errors, which is that `case` must be on its own line, the next line must be indented (unless it's another `case` statement), and block should have a `break` or `return` to end it.