### PR TITLE
[Bugfix:Submission] Fix zip downloads being empty for students

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -290,14 +290,14 @@ class MiscController extends AbstractController {
                     if (!$file->isDir()) {
                         // Get real and relative path for current file
                         $file_path = $file->getRealPath();
-                        $relative_path = substr($filePath, strlen($paths[$x]) + 1);
+                        $relative_path = substr($file_path, strlen($paths[$x]) + 1);
                         if ($gradeable->isScannedExam()) {
-                            if (mime_content_type($filePath) === 'application/pdf') {
-                                $zip->addFile($filePath, $folder_names[$x] . '/' . $relativePath);
+                            if (mime_content_type($file_path) === 'application/pdf') {
+                                $zip->addFile($file_path, $folder_names[$x] . '/' . $relative_path);
                             }
                         }
                         else {
-                            $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
+                            $zip->addFile($file_path, $folder_names[$x] . "/" . $relative_path);
                         }
                     }
                 }

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -2,7 +2,6 @@
 
 namespace app\controllers;
 
-
 use app\libraries\DateUtils;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
@@ -285,27 +284,21 @@ class MiscController extends AbstractController {
                     new \RecursiveDirectoryIterator($paths[$x]),
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 );
-                $zip -> addEmptyDir($folder_names[$x]);
-                foreach ($files as $name => $file)
-                {
+                $zip->addEmptyDir($folder_names[$x]);
+                foreach ($files as $name => $file) {
                     // Skip directories (they would be added automatically)
-                    if (!$file->isDir())
-                    {
+                    if (!$file->isDir()) {
                         // Get real and relative path for current file
-                        $filePath = $file->getRealPath();
-                        $relativePath = substr($filePath, strlen($paths[$x]) + 1);
-
-                        if($this->core->getUser()->accessGrading()){
-                            // Add current file to archive
-                            $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
-                        }else if ($gradeable->isScannedExam()
-                                  && FileUtils::getContentType($filePath) === "application/pdf"){
-                            //If the user is a student, only get PDFs if this is a bulk upload gradeable
-                            // Add current file to archive
+                        $file_path = $file->getRealPath();
+                        $relative_path = substr($filePath, strlen($paths[$x]) + 1);
+                        if ($gradeable->isScannedExam()) {
+                            if (mime_content_type($filePath) === 'application/pdf') {
+                                $zip->addFile($filePath, $folder_names[$x] . '/' . $relativePath);
+                            }
+                        }
+                        else {
                             $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
                         }
-
-
                     }
                 }
             }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4689 

When a student goes to download a zip, the zip is empty of all files, unless it's a bulk upload.

### What is the new behavior?

The zip will contain all submitted files, unless it's a bulk upload type, in which case it will only contain the PDFs. Additionally, I use the `mime_content_type` function to do a proper check of the file's content type based on file contents, and not `FileUtils::getContentType` which only does a content type check based on the extension.

This fixes a bug introduced in #4627, and encompasses the fix added in #4673.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This should not be a breaking change unless it was intentional that students were not able to download any files. Tested it with bulk uploads, regular submissions, and as TA in TA grading interface.