### PR TITLE
[Refactor:PHP] Fix PEAR.Functions.ValidDefaultValue style errors

### DIFF
--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -4,8 +4,7 @@ namespace app\views;
 use app\models\Breadcrumb;
 
 class GlobalView extends AbstractView {
-    public function header($breadcrumbs, $wrapper_urls, $sidebar_buttons, $notifications_info, $css=array(), $js=array(), $duck_img) {
-
+    public function header($breadcrumbs, $wrapper_urls, $sidebar_buttons, $notifications_info, $css, $js, $duck_img) {
         $messages = [];
         foreach (array('error', 'notice', 'success') as $type) {
             foreach ($_SESSION['messages'][$type] as $key => $error) {

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -7,12 +7,13 @@ use app\models\User;
 
 
 class HomePageView extends AbstractView {
-
-
-    /*
-    *@param List of courses the student is in.
-    */
-    public function showHomePage(User $user, $unarchived_courses = array(), $archived_courses = array(), $change_name_text) {
+    /**
+     * @param User $user
+     * @param array $unarchived_courses
+     * @param array $archived_courses
+     * @param string $change_name_text
+     */
+    public function showHomePage(User $user, $unarchived_courses, $archived_courses, $change_name_text) {
         $statuses = array();
         $course_types = [$unarchived_courses, $archived_courses];
         $rank_titles = [

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -426,7 +426,7 @@ HTML;
         return $return;
     }
 
-    public function configureGradeableForPlagiarismForm($new_or_edit, $gradeable_ids_titles = null, $prior_term_gradeables, $saved_config = null) {
+    public function configureGradeableForPlagiarismForm($new_or_edit, $gradeable_ids_titles, $prior_term_gradeables, $saved_config) {
         $this->core->getOutput()->addBreadcrumb('Plagiarism Detection', $this->core->buildCourseUrl(['plagiarism']));
         $this->core->getOutput()->addBreadcrumb('Configure New Gradeable');
         $prior_term_gradeables_json = json_encode($prior_term_gradeables);

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -73,8 +73,6 @@
         <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceAfter"/>
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
 
-        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
-
         <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceAfterBracket" />
         <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceBeforeBracket" />
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the `PEAR.Functions.ValidDefaultValue` style errors, which is that any functions with default values must have the default values at the end of the definition. The functions that violated this behavior never relied on the default arguments.
