### PR TITLE
[Bugfix: Moorthy] Home button on mobile now uses Halloween Moorthy

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -95,7 +95,7 @@
                 <div id="nav-links">
                     <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
                         <img id="submitty-mascot-home-btn"
-                         src="{{ base_url }}/img/moorthy_duck.png"
+                         src="{{ base_url }}/img/{{ duck_img }}"
                          alt="Submitty's duck mascot!"
                          height = "50px"
                          />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The home button on mobile uses the normal Moorthy

![image](https://user-images.githubusercontent.com/18558130/67794349-e9e6f380-fa52-11e9-99f1-116518b74c7a.png)


### What is the new behavior?
The home button on mobile uses Halloween Moorthy

![image](https://user-images.githubusercontent.com/18558130/67794136-8957b680-fa52-11e9-86e4-49023c0ddaf1.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
