### PR TITLE
[Refactor:PHP] Fix PSR12.Operators.OperatorSpacing style errors

### DIFF
--- a/site/app/authentication/PamAuthentication.php
+++ b/site/app/authentication/PamAuthentication.php
@@ -27,7 +27,7 @@ class PamAuthentication extends AbstractAuthentication {
             // Open a cURL connection so we don't have to do a weird redirect chain to authenticate
             // as that would require some hacky path handling specific to PAM authentication
             $output = $this->core->curlRequest(
-                $this->core->getConfig()->getCgiUrl()."pam_check.cgi",
+                $this->core->getConfig()->getCgiUrl() . "pam_check.cgi",
                 [
                     'username' => $this->user_id,
                     'password' => $this->password,
@@ -36,7 +36,7 @@ class PamAuthentication extends AbstractAuthentication {
 
             $output_after = json_decode($output, true);
             if ($output_after === null) {
-                throw new AuthenticationException("Error JSON response for PAM: ".json_last_error_msg());
+                throw new AuthenticationException("Error JSON response for PAM: " . json_last_error_msg());
             }
             elseif (!isset($output_after['authenticated'])) {
                 throw new AuthenticationException('Missing response in JSON for PAM');
@@ -46,7 +46,7 @@ class PamAuthentication extends AbstractAuthentication {
             }
         }
         catch (CurlException $exc) {
-            throw new AuthenticationException('Error attempting to authenticate against PAM: '.$exc->getMessage());
+            throw new AuthenticationException('Error attempting to authenticate against PAM: ' . $exc->getMessage());
         }
 
         return true;

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -112,7 +112,7 @@ class AuthenticationController extends AbstractController {
         $this->core->getAuthentication()->setPassword($_POST['password']);
         if ($this->core->authenticate($_POST['stay_logged_in']) === true) {
             Logger::logAccess($_POST['user_id'], $_COOKIE['submitty_token'], "login");
-            $msg = "Successfully logged in as ".htmlentities($_POST['user_id']);
+            $msg = "Successfully logged in as " . htmlentities($_POST['user_id']);
 
             $this->core->addSuccessMessage($msg);
             return new Response(

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -317,7 +317,7 @@ class GlobalController extends AbstractController {
 
             $sidebar_buttons[] = new Button($this->core, [
                 "href" => $this->core->buildUrl(['authentication', 'logout']),
-                "title" => "Logout ".$this->core->getUser()->getDisplayedFirstName(),
+                "title" => "Logout " . $this->core->getUser()->getDisplayedFirstName(),
                 "id" => "logout",
                 "class" => "nav-row",
                 "icon" => "fa-power-off"

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -114,7 +114,7 @@ class MiscController extends AbstractController {
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
-            header("Content-type: ".$mime_type);
+            header("Content-type: " . $mime_type);
             header('Content-Disposition: inline; filename="' . $file_name . '"');
             readfile($corrected_name);
             $this->core->getOutput()->renderString($path);

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -141,7 +141,7 @@ class AdminGradeableController extends AbstractController {
         $all_uploaded_configs = FileUtils::getAllFiles($uploaded_configs_dir);
         $all_uploaded_config_paths = array();
         foreach ($all_uploaded_configs as $file) {
-            $all_uploaded_config_paths[] = [ 'UPLOADED: '.substr($file['path'],strlen($uploaded_configs_dir)+1) , $file['path'] ];
+            $all_uploaded_config_paths[] = [ 'UPLOADED: ' . substr($file['path'],strlen($uploaded_configs_dir) + 1) , $file['path'] ];
         }
         // Configs stored in a private repository (specified in course config)
         $config_repo_string = $this->core->getConfig()->getPrivateRepository();
@@ -466,7 +466,7 @@ class AdminGradeableController extends AbstractController {
 
         while(count($dir_queue) != 0) {
             if ($count >= 1000) {
-                $error_messages[] = "Repository #".$repo_id_number." entered on the \"Course Settings\" is too large to parse.";
+                $error_messages[] = "Repository #" . $repo_id_number . " entered on the \"Course Settings\" is too large to parse.";
                 return array();
             }
 
@@ -475,19 +475,19 @@ class AdminGradeableController extends AbstractController {
             $dir_queue = array_values($dir_queue);
 
             if (!file_exists($dir) || !is_dir($dir)) {
-                $error_messages[] = "An error occured when parsing repository #".$repo_id_number." entered on the \"Course Settings\" page";
+                $error_messages[] = "An error occured when parsing repository #" . $repo_id_number . " entered on the \"Course Settings\" page";
                 return array();
             }
 
             try {
                 $iter = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
             } catch(\Exception $e) {
-                $error_messages[] = "An error occured when parsing repository #".$repo_id_number." entered on the \"Course Settings\" page";
+                $error_messages[] = "An error occured when parsing repository #" . $repo_id_number . " entered on the \"Course Settings\" page";
                 return array();
             }
 
             if ($this->checkPathToConfigFile($dir)) {
-                $return_array[] = ["DIRECTORY ".$repo_id_number.": ".substr($dir,strlen($repository_path)),$dir];
+                $return_array[] = ["DIRECTORY " . $repo_id_number . ": " . substr($dir,strlen($repository_path)),$dir];
             }
             else {
                 while($iter->valid()) {
@@ -1027,7 +1027,7 @@ class AdminGradeableController extends AbstractController {
             $this->core->redirect($this->core->buildNewCourseUrl());
         }
         if (!$gradeable->canDelete()) {
-            $this->core->addErrorMessage("Gradeable ".$gradeable_id." cannot be deleted.");
+            $this->core->addErrorMessage("Gradeable " . $gradeable_id . " cannot be deleted.");
             $this->core->redirect($this->core->buildNewCourseUrl());
         }
 
@@ -1144,8 +1144,8 @@ class AdminGradeableController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/build_status", methods={"GET"})
      */
     public function getBuildStatusOfGradeable($gradeable_id) {
-        $queued_filename = $this->core->getConfig()->getSemester().'__'.$this->core->getConfig()->getCourse().'__'.$gradeable_id.'.json';
-        $rebuilding_filename = 'PROCESSING_'.$this->core->getConfig()->getSemester().'__'.$this->core->getConfig()->getCourse().'__'.$gradeable_id.'.json';
+        $queued_filename = $this->core->getConfig()->getSemester() . '__' . $this->core->getConfig()->getCourse() . '__' . $gradeable_id . '.json';
+        $rebuilding_filename = 'PROCESSING_' . $this->core->getConfig()->getSemester() . '__' . $this->core->getConfig()->getCourse() . '__' . $gradeable_id . '.json';
         $queued_path = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), 'daemon_job_queue', $queued_filename);
         $rebuilding_path = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), 'daemon_job_queue', $rebuilding_filename);
 
@@ -1239,11 +1239,11 @@ class AdminGradeableController extends AbstractController {
         $gradeable->setDates($dates);
         $this->core->getQueries()->updateGradeable($gradeable);
         if ($success === true) {
-            $this->core->addSuccessMessage($message.$gradeable_id);
+            $this->core->addSuccessMessage($message . $gradeable_id);
         } else if ($success === false) {
-            $this->core->addErrorMessage($message.$gradeable_id);
+            $this->core->addErrorMessage($message . $gradeable_id);
         } else {
-            $this->core->addErrorMessage("Failed to update status of ".$gradeable_id);
+            $this->core->addErrorMessage("Failed to update status of " . $gradeable_id);
         }
 
         $this->core->redirect($this->core->buildCourseUrl());

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -69,7 +69,7 @@ class AutogradingConfigController extends AbstractController {
         }
 
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
-        $counter = count(scandir($target_dir))-1;
+        $counter = count(scandir($target_dir)) - 1;
         $try_dir = FileUtils::joinPaths($target_dir, $counter);
         while(is_dir($try_dir)){
             $counter++;

--- a/site/app/controllers/admin/GradeOverrideController.php
+++ b/site/app/controllers/admin/GradeOverrideController.php
@@ -55,7 +55,7 @@ class GradeOverrideController extends AbstractController {
             return $this->core->getOutput()->renderJsonFail($error);
         }
         
-        if (((!isset($_POST['marks'])) || $_POST['marks'] == ""  || is_float($_POST['marks'])) ) {
+        if (((!isset($_POST['marks'])) || $_POST['marks'] == "" || is_float($_POST['marks'])) ) {
             $error = "Marks be a integer";
             return $this->core->getOutput()->renderJsonFail($error);
         }

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -194,7 +194,7 @@ class LateController extends AbstractController {
                 }
             }
             if (($simple_late_user == null && intval($late_days) == 0) || $no_change) {
-                $this->core->addNoticeMessage("User already has " . $late_days ." extensions; no changes made");
+                $this->core->addNoticeMessage("User already has " . $late_days . " extensions; no changes made");
                 return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
             }
 

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -78,7 +78,7 @@ class LateController extends AbstractController {
                 );
             }
 
-            if (!isset($_POST['datestamp']) ||  (\DateTime::createFromFormat('Y-m-d', $_POST['datestamp']) === false)) {
+            if (!isset($_POST['datestamp']) || (\DateTime::createFromFormat('Y-m-d', $_POST['datestamp']) === false)) {
                 $error = "Datestamp must be Y-m-d";
                 $this->core->addErrorMessage($error);
                 return Response::JsonOnlyResponse(

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -33,7 +33,7 @@ class PlagiarismController extends AbstractController {
                 $line = explode("/",$line);
                 $sem = $line[5];
                 $course = $line[6];
-                $gradeables= array();
+                $gradeables = array();
                 while (!feof($file)) {
                     $line = fgets($file);
                     if (trim(trim($line, " "),"\n") === "") {
@@ -55,7 +55,7 @@ class PlagiarismController extends AbstractController {
                     return 1;
                 }
                 else {
-                    return ($semester_a[0] === 'f')? 0 : 1 ;
+                    return ($semester_a[0] === 'f') ? 0 : 1 ;
                 }
             });
         }
@@ -68,14 +68,14 @@ class PlagiarismController extends AbstractController {
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
 
-        $gradeables_with_plagiarism_result= $this->core->getQueries()->getAllGradeablesIdsAndTitles();
+        $gradeables_with_plagiarism_result = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
         foreach($gradeables_with_plagiarism_result as $i => $gradeable_id_title) {
-            if(!file_exists("/var/local/submitty/courses/".$semester."/".$course."/lichen/ranking/".$gradeable_id_title['g_id'].".txt") && !file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") && !file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
+            if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id_title['g_id'] . ".txt") && !file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") && !file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
                 unset($gradeables_with_plagiarism_result[$i]);
             }
         }
 
-        $nightly_rerun_info_file ="/var/local/submitty/courses/".$semester."/".$course."/lichen/nightly_rerun.json";
+        $nightly_rerun_info_file = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/nightly_rerun.json";
         if(!file_exists($nightly_rerun_info_file)) {
             $nightly_rerun_info = array();
             foreach($gradeables_with_plagiarism_result as $gradeable_id_title) {
@@ -125,10 +125,10 @@ class PlagiarismController extends AbstractController {
     public function showPlagiarismResult($gradeable_id) {
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
-        $gradeable_title= ($this->core->getQueries()->getGradeableConfig($gradeable_id))->getTitle();
-        $return_url= $this->core->buildCourseUrl(['plagiarism']);
+        $gradeable_title = ($this->core->getQueries()->getGradeableConfig($gradeable_id))->getTitle();
+        $return_url = $this->core->buildCourseUrl(['plagiarism']);
 
-        $file_path= "/var/local/submitty/courses/".$semester."/".$course."/lichen/ranking/".$gradeable_id.".txt";
+        $file_path = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id . ".txt";
         if(!file_exists($file_path)) {
             $this->core->addErrorMessage("Plagiarism Detection job is running for this gradeable.");
             $this->core->redirect($return_url);
@@ -157,9 +157,9 @@ class PlagiarismController extends AbstractController {
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
         $gradeable_with_submission = array_diff(scandir("/var/local/submitty/courses/$semester/$course/submissions/"), array('.', '..'));
-        $gradeable_ids_titles= $this->core->getQueries()->getAllGradeablesIdsAndTitles();
+        $gradeable_ids_titles = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
         foreach($gradeable_ids_titles as $i => $gradeable_id_title) {
-            if(!in_array($gradeable_id_title['g_id'], $gradeable_with_submission) || file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/courses/".$semester."/".$course."/lichen/config/lichen_".$semester."_".$course."_".$gradeable_id_title['g_id'].".json")) {
+            if(!in_array($gradeable_id_title['g_id'], $gradeable_with_submission) || file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id_title['g_id'] . ".json")) {
                 unset($gradeable_ids_titles[$i]);
             }
         }
@@ -179,11 +179,11 @@ class PlagiarismController extends AbstractController {
 
         $return_url = $this->core->buildCourseUrl(['plagiarism', 'configuration', 'new']);
         if($new_or_edit == "new") {
-            $gradeable_id= $_POST['gradeable_id'];
+            $gradeable_id = $_POST['gradeable_id'];
         }
 
         if ($new_or_edit == "edit") {
-            $return_url = $this->core->buildCourseUrl(['plagiarism', 'configuration', 'edit']) . '?' . http_build_query(['gradeable_id'=> $gradeable_id]);
+            $return_url = $this->core->buildCourseUrl(['plagiarism', 'configuration', 'edit']) . '?' . http_build_query(['gradeable_id' => $gradeable_id]);
 
         }
 
@@ -219,7 +219,7 @@ class PlagiarismController extends AbstractController {
             }
         }
 
-        $language= $_POST['language'];
+        $language = $_POST['language'];
         if( isset($_POST['threshold']) && $_POST['threshold'] !== '') {
             $threshold = $_POST['threshold'];
         }
@@ -237,8 +237,8 @@ class PlagiarismController extends AbstractController {
 
         $prev_term_gradeables = array();
         for( $i = 0; $i < $prev_gradeable_number; $i++ ) {
-            if($_POST['prev_sem_'.$i]!= "" && $_POST['prev_course_'.$i]!= "" && $_POST['prev_gradeable_'.$i]!= "") {
-                array_push($prev_term_gradeables, "/var/local/submitty/course/".$_POST['prev_sem_'.$i]."/".$_POST['prev_course_'.$i]."/submissions/".$_POST['prev_gradeable_'.$i]);
+            if($_POST['prev_sem_' . $i] != "" && $_POST['prev_course_' . $i] != "" && $_POST['prev_gradeable_' . $i] != "") {
+                array_push($prev_term_gradeables, "/var/local/submitty/course/" . $_POST['prev_sem_' . $i] . "/" . $_POST['prev_course_' . $i] . "/submissions/" . $_POST['prev_gradeable_' . $i]);
             }
         }
 
@@ -246,8 +246,8 @@ class PlagiarismController extends AbstractController {
         $ignore_submission_option = $_POST['ignore_submission_option'];
         if ($ignore_submission_option == "ignore") {
             for( $i = 0; $i < $ignore_submission_number; $i++ ) {
-                if(isset($_POST['ignore_submission_'.$i]) && $_POST['ignore_submission_'.$i] !== '') {
-                    array_push($ignore_submissions, $_POST['ignore_submission_'.$i]);
+                if(isset($_POST['ignore_submission_' . $i]) && $_POST['ignore_submission_' . $i] !== '') {
+                    array_push($ignore_submissions, $_POST['ignore_submission_' . $i]);
                 }
             }
         }
@@ -255,13 +255,13 @@ class PlagiarismController extends AbstractController {
         $gradeable_path =  FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions", $gradeable_id);
         $provided_code_option = $_POST['provided_code_option'];
         if($provided_code_option == "code_provided") {
-            $instructor_provided_code= true;
+            $instructor_provided_code = true;
         }
         else {
             if(is_dir(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen/provided_code", $gradeable_id))) {
                 FileUtils::emptyDir(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen/provided_code", $gradeable_id));
             }
-            $instructor_provided_code= false;
+            $instructor_provided_code = false;
         }
 
         if($instructor_provided_code == true) {
@@ -308,16 +308,16 @@ class PlagiarismController extends AbstractController {
             }
         }
 
-        $config_dir = "/var/local/submitty/courses/".$semester."/".$course."/lichen/config/";
-        $json_file = "/var/local/submitty/courses/".$semester."/".$course."/lichen/config/lichen_".$semester."_".$course."_".$gradeable_id.".json";
+        $config_dir = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/";
+        $json_file = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json";
         $json_data = array("semester" =>    $semester,
                             "course" =>     $course,
                             "gradeable" =>  $gradeable_id,
                             "version" =>    $version_option,
-                            "file_option" =>$file_option,
+                            "file_option" => $file_option,
                             "language" =>   $language,
                             "threshold" =>  $threshold,
-                            "sequence_length"=> $sequence_length,
+                            "sequence_length" => $sequence_length,
                             "prev_term_gradeables" => $prev_term_gradeables,
                             "ignore_submissions" =>   $ignore_submissions,
                             "instructor_provided_code" =>   $instructor_provided_code,
@@ -341,7 +341,7 @@ class PlagiarismController extends AbstractController {
         $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
         $current_time_string_tz = $current_time . " " . $this->core->getConfig()->getTimezone()->getName();
         $course_path = $this->core->getConfig()->getCoursePath();
-        if (!@file_put_contents(FileUtils::joinPaths($course_path, "lichen", "config", ".".$gradeable_id.".lichenrun.timestamp"), $current_time_string_tz."\n")) {
+        if (!@file_put_contents(FileUtils::joinPaths($course_path, "lichen", "config", "." . $gradeable_id . ".lichenrun.timestamp"), $current_time_string_tz . "\n")) {
             $this->core->addErrorMessage("Failed to save timestamp file for this Lichen Run. Create the configuration again.");
             $this->core->redirect($return_url);
         }
@@ -354,8 +354,8 @@ class PlagiarismController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
-        $this->core->addSuccessMessage("Lichen Plagiarism Detection configuration created for ".$gradeable_id);
-        $this->core->redirect($this->core->buildCourseUrl(['plagiarism']) . '?' . http_build_query(['refresh_page'=> 'REFRESH_ME']));
+        $this->core->addSuccessMessage("Lichen Plagiarism Detection configuration created for " . $gradeable_id);
+        $this->core->redirect($this->core->buildCourseUrl(['plagiarism']) . '?' . http_build_query(['refresh_page' => 'REFRESH_ME']));
     }
 
     private function enqueueLichenJob($job, $gradeable_id) {
@@ -394,7 +394,7 @@ class PlagiarismController extends AbstractController {
                 $this->core->redirect($return_url);
         }
 
-        if(!file_exists("/var/local/submitty/courses/".$semester."/".$course."/lichen/config/lichen_".$semester."_".$course."_".$gradeable_id.".json")) {
+        if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
             $this->core->addErrorMessage("Plagiarism results have been deleted. Add new configuration for the gradeable.");
             $this->core->redirect($return_url);
         }
@@ -402,7 +402,7 @@ class PlagiarismController extends AbstractController {
         $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
         $current_time_string_tz = $current_time . " " . $this->core->getConfig()->getTimezone()->getName();
         $course_path = $this->core->getConfig()->getCoursePath();
-        if (!@file_put_contents(FileUtils::joinPaths($course_path, "lichen", "config", ".".$gradeable_id.".lichenrun.timestamp"), $current_time_string_tz."\n")) {
+        if (!@file_put_contents(FileUtils::joinPaths($course_path, "lichen", "config", "." . $gradeable_id . ".lichenrun.timestamp"), $current_time_string_tz . "\n")) {
             $this->core->addErrorMessage("Failed to save timestamp file for this Lichen Run. Re-run the detector.");
             $this->core->redirect($return_url);
         }
@@ -413,8 +413,8 @@ class PlagiarismController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
-        $this->core->addSuccessMessage("Re-Run of Lichen Plagiarism for ".$gradeable_id);
-        $this->core->redirect($this->core->buildCourseUrl(['plagiarism']) . '?' . http_build_query(['refresh_page'=> 'REFRESH_ME']));
+        $this->core->addSuccessMessage("Re-Run of Lichen Plagiarism for " . $gradeable_id);
+        $this->core->redirect($this->core->buildCourseUrl(['plagiarism']) . '?' . http_build_query(['refresh_page' => 'REFRESH_ME']));
     }
 
     /**
@@ -427,12 +427,12 @@ class PlagiarismController extends AbstractController {
 
         $prior_term_gradeables = $this->getGradeablesFromPriorTerm();
 
-        if(!file_exists("/var/local/submitty/courses/".$semester."/".$course."/lichen/config/lichen_".$semester."_".$course."_".$gradeable_id.".json")) {
+        if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
             $this->core->addErrorMessage("Saved configuration not found.");
             $this->core->redirect($return_url);
         }
 
-        $saved_config= json_decode(file_get_contents("/var/local/submitty/courses/".$semester."/".$course."/lichen/config/lichen_".$semester."_".$course."_".$gradeable_id.".json"),true);
+        $saved_config = json_decode(file_get_contents("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json"),true);
 
         $this->core->getOutput()->renderOutput(array('admin', 'Plagiarism'), 'configureGradeableForPlagiarismForm', 'edit', null , $prior_term_gradeables, $saved_config);
 
@@ -451,7 +451,7 @@ class PlagiarismController extends AbstractController {
                 $this->core->redirect($return_url);
         }
 
-        if(!file_exists("/var/local/submitty/courses/".$semester."/".$course."/lichen/config/lichen_".$semester."_".$course."_".$gradeable_id.".json")) {
+        if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
             $this->core->addErrorMessage("Plagiarism results for the gradeable are already deleted. Refresh the page.");
             $this->core->redirect($return_url);
         }
@@ -463,7 +463,7 @@ class PlagiarismController extends AbstractController {
         }
 
         $this->core->addSuccessMessage("Lichen results and saved configuration for the gradeable will be deleted.");
-        $this->core->redirect($this->core->buildCourseUrl(['plagiarism']) . '?' . http_build_query(['refresh_page'=> 'REFRESH_ME']));
+        $this->core->redirect($this->core->buildCourseUrl(['plagiarism']) . '?' . http_build_query(['refresh_page' => 'REFRESH_ME']));
     }
 
     /**
@@ -474,7 +474,7 @@ class PlagiarismController extends AbstractController {
         $course = $this->core->getConfig()->getCourse();
         $return_url = $this->core->buildCourseUrl(['plagiarism']);
 
-        $nightly_rerun_info_file ="/var/local/submitty/courses/".$semester."/".$course."/lichen/nightly_rerun.json";
+        $nightly_rerun_info_file = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/nightly_rerun.json";
 
         $nightly_rerun_info = json_decode(file_get_contents($nightly_rerun_info_file), true);
         $nightly_rerun_info[$gradeable_id] = !$nightly_rerun_info[$gradeable_id];
@@ -503,16 +503,16 @@ class PlagiarismController extends AbstractController {
             return;
         }
 
-        $return="";
+        $return = "";
         $active_version_user_1 =  (string)$graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
-        $file_path= $course_path."/lichen/ranking/".$gradeable_id.".txt";
+        $file_path = $course_path . "/lichen/ranking/" . $gradeable_id . ".txt";
         if(!file_exists($file_path)) {
             $return = array('error' => 'Ranking file not exists.');
             $return = json_encode($return);
             echo($return);
             return;
         }
-        $content =file_get_contents($file_path);
+        $content = file_get_contents($file_path);
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
         $rankings = array_chunk($rankings,3);
@@ -524,10 +524,10 @@ class PlagiarismController extends AbstractController {
         if($version_user_1 == "max_matching") {
             $version_user_1 = $max_matching_version;
         }
-        $all_versions_user_1 = array_diff(scandir($course_path."/submissions/".$gradeable_id."/".$user_id_1), array(".", "..", "user_assignment_settings.json"));
+        $all_versions_user_1 = array_diff(scandir($course_path . "/submissions/" . $gradeable_id . "/" . $user_id_1), array(".", "..", "user_assignment_settings.json"));
 
-        $file_name= $course_path."/lichen/concatenated/".$gradeable_id."/".$user_id_1."/".$version_user_1."/submission.concatenated";
-        $data="";
+        $file_name = $course_path . "/lichen/concatenated/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/submission.concatenated";
+        $data = "";
         if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
             if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
                 $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2 , '1');
@@ -535,7 +535,7 @@ class PlagiarismController extends AbstractController {
             else {
                 $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, '', '', '1');
             }
-            $data= array('display_code1'=> $this->getDisplayForCode($file_name, $color_info), 'code_version_user_1' => $version_user_1, 'max_matching_version' => $max_matching_version, 'active_version_user_1' => $active_version_user_1, 'all_versions_user_1' => $all_versions_user_1, 'ci'=> $color_info);
+            $data = array('display_code1' => $this->getDisplayForCode($file_name, $color_info), 'code_version_user_1' => $version_user_1, 'max_matching_version' => $max_matching_version, 'active_version_user_1' => $active_version_user_1, 'all_versions_user_1' => $all_versions_user_1, 'ci' => $color_info);
         }
         else {
             $return = array('error' => 'User 1 submission.concatenated for specified version not found.');
@@ -544,7 +544,7 @@ class PlagiarismController extends AbstractController {
             return;
         }
         if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
-            $file_name= $course_path."/lichen/concatenated/".$gradeable_id."/".$user_id_2."/".$version_user_2."/submission.concatenated";
+            $file_name = $course_path . "/lichen/concatenated/" . $gradeable_id . "/" . $user_id_2 . "/" . $version_user_2 . "/submission.concatenated";
 
             if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
                 $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, '2');
@@ -558,7 +558,7 @@ class PlagiarismController extends AbstractController {
             }
         }
         $data['ci'] = $color_info;
-        $return= json_encode($data);
+        $return = json_encode($data);
         echo($return);
     }
 
@@ -569,34 +569,34 @@ class PlagiarismController extends AbstractController {
         $color_info[1] = array();
         $color_info[2] = array();
 
-        $file_path= $course_path."/lichen/matches/".$gradeable_id."/".$user_id_1."/".$version_user_1."/matches.json";
+        $file_path = $course_path . "/lichen/matches/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/matches.json";
         if (!file_exists($file_path)) {
             return $color_info;
         }
         else {
             $matches = json_decode(file_get_contents($file_path), true);
-            $file_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_1."/".$version_user_1."/tokens.json";
+            $file_path = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/tokens.json";
             $tokens_user_1 = json_decode(file_get_contents($file_path), true);
             if($user_id_2 != "") {
-                $file_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_2."/".$version_user_2."/tokens.json";
+                $file_path = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $user_id_2 . "/" . $version_user_2 . "/tokens.json";
                 $tokens_user_2 = json_decode(file_get_contents($file_path), true);
             }
             foreach($matches as $match) {
-                $start_pos =$tokens_user_1[$match["start"]-1]["char"]-1;
-                $start_line= $tokens_user_1[$match["start"]-1]["line"]-1;
-                $end_pos =$tokens_user_1[$match["end"]-1]["char"]-1; //!!!!!
-                $end_line= $tokens_user_1[$match["end"]-1]["line"]-1;
-                $start_value = $tokens_user_1[$match["start"]-1]["value"];
-                $end_value =$tokens_user_1[$match["end"]-1]["value"];
+                $start_pos = $tokens_user_1[$match["start"] - 1]["char"] - 1;
+                $start_line = $tokens_user_1[$match["start"] - 1]["line"] - 1;
+                $end_pos = $tokens_user_1[$match["end"] - 1]["char"] - 1; //!!!!!
+                $end_line = $tokens_user_1[$match["end"] - 1]["line"] - 1;
+                $start_value = $tokens_user_1[$match["start"] - 1]["value"];
+                $end_value = $tokens_user_1[$match["end"] - 1]["value"];
                 $userMatchesStarts = array();
                 $userMatchesEnds = array();
                 if($match["type"] == "match") {
                     $orange_color = false;
                     if($user_id_2 != "") {
-                        foreach($match['others'] as $i=>$other) {
+                        foreach($match['others'] as $i => $other) {
                             if($other["username"] == $user_id_2) {
                                 $orange_color = true;
-                                $user_2_index_in_others=$i;
+                                $user_2_index_in_others = $i;
                             }
                         }
                     }
@@ -610,14 +610,14 @@ class PlagiarismController extends AbstractController {
                         $color = '#ffff00';
                     }
 
-                    if($codebox == "2" && $user_id_2 !="" && $orange_color) {
+                    if($codebox == "2" && $user_id_2 != "" && $orange_color) {
                         foreach($match['others'][$user_2_index_in_others]['matchingpositions'] as $user_2_matchingposition) {
-                            $start_pos_2 =$tokens_user_2[$user_2_matchingposition["start"]-1]["char"]-1;
-                            $start_line_2 = $tokens_user_2[$user_2_matchingposition["start"]-1]["line"]-1;
-                            $end_pos_2 =$tokens_user_2[$user_2_matchingposition["end"]-1]["char"]-1; //!!!!
-                            $end_line_2 = $tokens_user_2[$user_2_matchingposition["end"]-1]["line"]-1;
-                            $start_value_2 = $tokens_user_2[$user_2_matchingposition["start"]-1]["value"];
-                            $end_value_2 =$tokens_user_2[$user_2_matchingposition["end"]-1]["value"];
+                            $start_pos_2 = $tokens_user_2[$user_2_matchingposition["start"] - 1]["char"] - 1;
+                            $start_line_2 = $tokens_user_2[$user_2_matchingposition["start"] - 1]["line"] - 1;
+                            $end_pos_2 = $tokens_user_2[$user_2_matchingposition["end"] - 1]["char"] - 1; //!!!!
+                            $end_line_2 = $tokens_user_2[$user_2_matchingposition["end"] - 1]["line"] - 1;
+                            $start_value_2 = $tokens_user_2[$user_2_matchingposition["start"] - 1]["value"];
+                            $end_value_2 = $tokens_user_2[$user_2_matchingposition["end"] - 1]["value"];
                             $color_info[2][] = [$start_pos_2, $start_line_2, $end_pos_2, $end_line_2, '#ffa500', $start_value_2, $end_value_2, $user_2_matchingposition["start"], $user_2_matchingposition["end"]];
 
                             $userMatchesStarts[] = $user_2_matchingposition["start"];
@@ -659,15 +659,15 @@ class PlagiarismController extends AbstractController {
         $this->core->getOutput()->useFooter(false);
 
         $return = array();
-        $error="";
-        $file_path= $course_path."/lichen/ranking/".$gradeable_id.".txt";
+        $error = "";
+        $file_path = $course_path . "/lichen/ranking/" . $gradeable_id . ".txt";
         if(!file_exists($file_path)) {
             $return = array('error' => 'Ranking file not exists.');
             $return = json_encode($return);
             echo($return);
             return;
         }
-        $content =file_get_contents($file_path);
+        $content = file_get_contents($file_path);
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
         $rankings = array_chunk($rankings,3);
@@ -680,7 +680,7 @@ class PlagiarismController extends AbstractController {
         if($version_user_1 == "max_matching") {
             $version = $max_matching_version;
         }
-        $file_path= $course_path."/lichen/matches/".$gradeable_id."/".$user_id_1."/".$version."/matches.json";
+        $file_path = $course_path . "/lichen/matches/" . $gradeable_id . "/" . $user_id_1 . "/" . $version . "/matches.json";
         if (!file_exists($file_path)) {
             echo("no_match_for_this_version");
         }
@@ -710,7 +710,7 @@ class PlagiarismController extends AbstractController {
     public function ajaxGetMatchesForClickedMatch($gradeable_id, $user_id_1, $version_user_1, $start, $end) {
         $course_path = $this->core->getConfig()->getCoursePath();
 
-        $token_path= $course_path."/lichen/tokenized/".$gradeable_id."/".$user_id_1."/".$version_user_1."/tokens.json";
+        $token_path = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/tokens.json";
         $tokens_user_1 = json_decode(file_get_contents($token_path), true);
 
         $this->core->getOutput()->useHeader(false);
@@ -718,25 +718,25 @@ class PlagiarismController extends AbstractController {
 
         $return = array();
 
-        $file_path= $course_path."/lichen/matches/".$gradeable_id."/".$user_id_1."/".$version_user_1."/matches.json";
+        $file_path = $course_path . "/lichen/matches/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/matches.json";
         if (!file_exists($file_path)) {
-            echo(json_encode(array("error"=>"user 1 matches.json does not exists")));
+            echo(json_encode(array("error" => "user 1 matches.json does not exists")));
         }
         else {
             $content = json_decode(file_get_contents($file_path), true);
             foreach($content as $match) {
-                if($tokens_user_1[$match["start"]-1]["line"]-1 == $start && $tokens_user_1[$match["end"]-1]["line"]-1 == $end) { //also do char place
+                if($tokens_user_1[$match["start"] - 1]["line"] - 1 == $start && $tokens_user_1[$match["end"] - 1]["line"] - 1 == $end) { //also do char place
                     foreach ($match["others"] as $match_info) {
-                        $matchingpositions= array();
-                        $token_path_2= $course_path."/lichen/tokenized/".$gradeable_id."/".$match_info['username']."/".$match_info['version']."/tokens.json";
+                        $matchingpositions = array();
+                        $token_path_2 = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $match_info['username'] . "/" . $match_info['version'] . "/tokens.json";
                         $tokens_user_2 = json_decode(file_get_contents($token_path_2), true);
                         foreach($match_info['matchingpositions'] as $matchingpos) {
 
-                            array_push($matchingpositions, array("start_line"=> $tokens_user_2[$matchingpos["start"]-1]["line"]-1 , "start_ch" => $tokens_user_2[$matchingpos["start"]-1]["char"]-1,
-                                 "end_line"=> $tokens_user_2[$matchingpos["end"]-1]["line"]-1, "end_ch" => $tokens_user_2[$matchingpos["end"]-1]["char"]-1 ));
+                            array_push($matchingpositions, array("start_line" => $tokens_user_2[$matchingpos["start"] - 1]["line"] - 1 , "start_ch" => $tokens_user_2[$matchingpos["start"] - 1]["char"] - 1,
+                                 "end_line" => $tokens_user_2[$matchingpos["end"] - 1]["line"] - 1, "end_ch" => $tokens_user_2[$matchingpos["end"] - 1]["char"] - 1 ));
                         }
-                        $first_name= $this->core->getQueries()->getUserById($match_info["username"])->getDisplayedFirstName();
-                        $last_name= $this->core->getQueries()->getUserById($match_info["username"])->getDisplayedLastName();
+                        $first_name = $this->core->getQueries()->getUserById($match_info["username"])->getDisplayedFirstName();
+                        $last_name = $this->core->getQueries()->getUserById($match_info["username"])->getDisplayedLastName();
                         array_push($return, array($match_info["username"],$match_info["version"], $matchingpositions, $first_name, $last_name));
                     }
                 }
@@ -759,7 +759,7 @@ class PlagiarismController extends AbstractController {
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
 
-        $gradeable_ids_titles= $this->core->getQueries()->getAllGradeablesIdsAndTitles();
+        $gradeable_ids_titles = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
 
         foreach ($gradeable_ids_titles as $gradeable_id_title) {
             if (file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -585,7 +585,7 @@ class ReportController extends AbstractController {
         }
 
         // Check the course auto_debug_output.txt to ensure no exceptions were thrown
-        $debug_output_path = '/var/local/submitty/courses/'.
+        $debug_output_path = '/var/local/submitty/courses/' .
             $this->core->getConfig()->getSemester() . '/' .
             $this->core->getConfig()->getCourse() .
             '/rainbow_grades/auto_debug_output.txt';

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -891,7 +891,7 @@ class UsersController extends AbstractController {
                     // Preferred first and last name must be alpha characters, white-space, or certain punctuation.
                     // Automatically validate if not set (this field is optional).
                 case !isset($vals[$pref_firstname_idx]) || User::validateUserData('user_preferred_firstname', $vals[$pref_firstname_idx]):
-                case !isset($vals[$pref_lastname_idx])  || User::validateUserData('user_preferred_lastname',  $vals[$pref_lastname_idx] ):
+                case !isset($vals[$pref_lastname_idx]) || User::validateUserData('user_preferred_lastname',  $vals[$pref_lastname_idx] ):
                     // Validation failed somewhere.  Record which row failed.
                     // $row_num is zero based.  ($row_num+1) will better match spreadsheet labeling.
                     $bad_rows[] = ($row_num + 1);

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -245,18 +245,18 @@ class UsersController extends AbstractController {
 
         $error_message = "";
         //Username must contain only lowercase alpha, numbers, underscores, hyphens
-        $error_message .= User::validateUserData('user_id', trim($_POST['user_id'])) ? "" : "Error in username: \"".strip_tags($_POST['user_id'])."\"<br>";
+        $error_message .= User::validateUserData('user_id', trim($_POST['user_id'])) ? "" : "Error in username: \"" . strip_tags($_POST['user_id']) . "\"<br>";
         //First and Last name must be alpha characters, white-space, or certain punctuation.
-        $error_message .= User::validateUserData('user_legal_firstname', trim($_POST['user_firstname'])) ? "" : "Error in first name: \"".strip_tags($_POST['user_firstname'])."\"<br>";
-        $error_message .= User::validateUserData('user_legal_lastname', trim($_POST['user_lastname'])) ? "" : "Error in last name: \"".strip_tags($_POST['user_lastname'])."\"<br>";
+        $error_message .= User::validateUserData('user_legal_firstname', trim($_POST['user_firstname'])) ? "" : "Error in first name: \"" . strip_tags($_POST['user_firstname']) . "\"<br>";
+        $error_message .= User::validateUserData('user_legal_lastname', trim($_POST['user_lastname'])) ? "" : "Error in last name: \"" . strip_tags($_POST['user_lastname']) . "\"<br>";
         //Check email address for appropriate format. e.g. "user@university.edu", "user@cs.university.edu", etc.
-        $error_message .= User::validateUserData('user_email', trim($_POST['user_email'])) ? "" : "Error in email: \"".strip_tags($_POST['user_email'])."\"<br>";
+        $error_message .= User::validateUserData('user_email', trim($_POST['user_email'])) ? "" : "Error in email: \"" . strip_tags($_POST['user_email']) . "\"<br>";
         //Preferred first name must be alpha characters, white-space, or certain punctuation.
         if (!empty($_POST['user_preferred_firstname']) && trim($_POST['user_preferred_firstname']) !== "") {
-            $error_message .= User::validateUserData('user_preferred_firstname', trim($_POST['user_preferred_firstname'])) ? "" : "Error in preferred first name: \"".strip_tags($_POST['user_preferred_firstname'])."\"<br>";
+            $error_message .= User::validateUserData('user_preferred_firstname', trim($_POST['user_preferred_firstname'])) ? "" : "Error in preferred first name: \"" . strip_tags($_POST['user_preferred_firstname']) . "\"<br>";
         }
         if (!empty($_POST['user_preferred_lastname']) && trim($_POST['user_preferred_lastname']) !== "") {
-            $error_message .= User::validateUserData('user_preferred_lastname', trim($_POST['user_preferred_lastname'])) ? "" : "Error in preferred last name: \"".strip_tags($_POST['user_preferred_lastname'])."\"<br>";
+            $error_message .= User::validateUserData('user_preferred_lastname', trim($_POST['user_preferred_lastname'])) ? "" : "Error in preferred last name: \"" . strip_tags($_POST['user_preferred_lastname']) . "\"<br>";
         }
 
         //Database password cannot be blank, no check on format
@@ -265,7 +265,7 @@ class UsersController extends AbstractController {
         }
 
         if (!empty($error_message)) {
-            $this->core->addErrorMessage($error_message." Contact your sysadmin if this should not cause an error.");
+            $this->core->addErrorMessage($error_message . " Contact your sysadmin if this should not cause an error.");
             $this->core->redirect($return_url);
         }
 
@@ -662,7 +662,7 @@ class UsersController extends AbstractController {
                 $xlsx_tmp = basename($xlsx_file);
                 $csv_tmp = basename($csv_file);
                 $ch = curl_init();
-                curl_setopt($ch, CURLOPT_URL, $this->core->getConfig()->getCgiUrl()."xlsx_to_csv.cgi?xlsx_file={$xlsx_tmp}&csv_file={$csv_tmp}");
+                curl_setopt($ch, CURLOPT_URL, $this->core->getConfig()->getCgiUrl() . "xlsx_to_csv.cgi?xlsx_file={$xlsx_tmp}&csv_file={$csv_tmp}");
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 $output = curl_exec($ch);
 
@@ -673,13 +673,13 @@ class UsersController extends AbstractController {
 
                 $output = json_decode($output, true);
                 if ($output === null) {
-                    $this->core->addErrorMessage("Error parsing JSON response: ".json_last_error_msg());
+                    $this->core->addErrorMessage("Error parsing JSON response: " . json_last_error_msg());
                     $this->core->redirect($return_url);
                 } else if ($output['error'] === true) {
-                    $this->core->addErrorMessage("Error parsing xlsx to csv: ".$output['error_message']);
+                    $this->core->addErrorMessage("Error parsing xlsx to csv: " . $output['error_message']);
                     $this->core->redirect($return_url);
                 } else if ($output['success'] !== true) {
-                    $this->core->addErrorMessage("Error on response on parsing xlsx: ".curl_error($ch));
+                    $this->core->addErrorMessage("Error on response on parsing xlsx: " . curl_error($ch));
                     $this->core->redirect($return_url);
                 }
 
@@ -894,7 +894,7 @@ class UsersController extends AbstractController {
                 case !isset($vals[$pref_lastname_idx])  || User::validateUserData('user_preferred_lastname',  $vals[$pref_lastname_idx] ):
                     // Validation failed somewhere.  Record which row failed.
                     // $row_num is zero based.  ($row_num+1) will better match spreadsheet labeling.
-                    $bad_rows[] = ($row_num+1);
+                    $bad_rows[] = ($row_num + 1);
                     break;
             }
         }

--- a/site/app/controllers/admin/WrapperController.php
+++ b/site/app/controllers/admin/WrapperController.php
@@ -76,7 +76,7 @@ class WrapperController extends AbstractController {
             );
         }
 
-        $this->core->addSuccessMessage("Uploaded ".$upload['name']." as ".$filename);
+        $this->core->addSuccessMessage("Uploaded " . $upload['name'] . " as " . $filename);
         return Response::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildCourseUrl(['theme']))
         );
@@ -109,7 +109,7 @@ class WrapperController extends AbstractController {
             );
         }
 
-        $this->core->addSuccessMessage("Deleted ".$filename);
+        $this->core->addSuccessMessage("Deleted " . $filename);
         return Response::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildCourseUrl(['theme']))
         );

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -165,7 +165,7 @@ class CourseMaterialsController extends AbstractController {
      * @AccessControl(role="INSTRUCTOR")
      */
     public function modifyCourseMaterialsFilePermission($checked) {
-        $data=$_POST['fn'];
+        $data = $_POST['fn'];
         if(is_string($data)){
             $data = [$data];
         }
@@ -213,7 +213,7 @@ class CourseMaterialsController extends AbstractController {
      * @AccessControl(role="INSTRUCTOR")
      */
     public function modifyCourseMaterialsFileTimeStamp($filenames, $newdatatime) {
-        $data=$_POST['fn'];
+        $data = $_POST['fn'];
         $hide_from_students = null;
 
         if(!isset($newdatatime)) {
@@ -289,7 +289,7 @@ class CourseMaterialsController extends AbstractController {
             $requested_path = $_POST['requested_path'];
         }
 
-        $release_time ="";
+        $release_time = "";
         if(isset($_POST['release_time'])){
             $release_time = $_POST['release_time'];
         }
@@ -346,7 +346,7 @@ class CourseMaterialsController extends AbstractController {
 
         $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
         if ($file_size > $max_size) {
-            return $this->core->getOutput()->renderResultMessage("ERROR: File(s) uploaded too large.  Maximum size is ".($max_size/1024)." kb. Uploaded file(s) was ".($file_size/1024)." kb.", false);
+            return $this->core->getOutput()->renderResultMessage("ERROR: File(s) uploaded too large.  Maximum size is " . ($max_size / 1024) . " kb. Uploaded file(s) was " . ($file_size / 1024) . " kb.", false);
         }
 
         // creating uploads/course_materials directory
@@ -374,7 +374,7 @@ class CourseMaterialsController extends AbstractController {
 
                     if (mime_content_type($uploaded_files[1]["tmp_name"][$j]) == "application/zip") {
                         if(FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
-                            return $this->core->getOutput()->renderResultMessage("ERROR: You may not use quotes, backslashes or angle brackets in your filename for files inside ".$uploaded_files[1]["name"][$j].".", false);
+                            return $this->core->getOutput()->renderResultMessage("ERROR: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[1]["name"][$j] . ".", false);
                         }
                         $is_zip_file = true;
                     }

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -741,7 +741,7 @@ class ForumController extends AbstractController {
         $thread_status = array();
         $new_posts = array();
         $unread_threads = false;
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) &&  $category_id[0] == -1 ) {
+        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1 ) {
             $category_id = explode('|', $_COOKIE[$currentCourse . '_forum_categories']);
         }
         if(!empty($_COOKIE['forum_thread_status'])){

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -143,7 +143,7 @@ class ForumController extends AbstractController {
             if($this->isValidCategories(-1, array($category))) {
                 return $this->core->getOutput()->renderJsonFail("That category already exists.");
             } else {
-                if(strlen($category)>50){
+                if(strlen($category) > 50){
                     return $this->core->getOutput()->renderJsonFail("Category name is more than 50 characters.");
                 }
                 else {
@@ -310,15 +310,15 @@ class ForumController extends AbstractController {
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]), 'thread_id' => $thread_id));
                 // notify on a new announcement
                 if ($announcement) {
-                    $subject = "New Announcement: ".Notification::textShortner($thread_title);
-                    $content = "An Instructor or Teaching Assistant made an announcement in:\n".$full_course_name."\n\n".$thread_title."\n\n".$thread_post_content;
+                    $subject = "New Announcement: " . Notification::textShortner($thread_title);
+                    $content = "An Instructor or Teaching Assistant made an announcement in:\n" . $full_course_name . "\n\n" . $thread_title . "\n\n" . $thread_post_content;
                     $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject];
                     $this->core->getNotificationFactory()->onNewAnnouncement($event);
                 }
                 // notify on a new thread
                 else {
-                    $subject = "New Thread: ".Notification::textShortner($thread_title);
-                    $content = "A new discussion thread was created in:\n".$full_course_name."\n\n".$thread_title."\n\n".$thread_post_content;
+                    $subject = "New Thread: " . Notification::textShortner($thread_title);
+                    $content = "A new discussion thread was created in:\n" . $full_course_name . "\n\n" . $thread_title . "\n\n" . $thread_post_content;
                     $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject];
                     $this->core->getNotificationFactory()->onNewThread($event);
                 }
@@ -352,7 +352,7 @@ class ForumController extends AbstractController {
 
         if(strlen($post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT ){
             $result['next_page'] = $this->core->buildUrl(['forum', 'threads']);
-            return $this->core->getOutput()->renderJsonFail("Posts cannot be over ". ForumUtils::FORUM_CHAR_POST_LIMIT ." characters long", $result);
+            return $this->core->getOutput()->renderJsonFail("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long", $result);
         }
 
         if(isset($_POST['thread_status'])){
@@ -361,7 +361,7 @@ class ForumController extends AbstractController {
 
         $markdown = !empty($_POST['markdown_status']);
 
-        setcookie("markdown_enabled", ($markdown?1:0), time() + (86400 * 30), "/");
+        setcookie("markdown_enabled", ($markdown ? 1 : 0), time() + (86400 * 30), "/");
 
         $display_option = (!empty($_POST["display_option"])) ? htmlentities($_POST["display_option"], ENT_QUOTES | ENT_HTML5, 'UTF-8') : "tree";
         $anon = (isset($_POST["Anon"]) && $_POST["Anon"] == "Anon") ? 1 : 0;
@@ -405,8 +405,8 @@ class ForumController extends AbstractController {
 
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]), 'thread_id' => $thread_id));
 
-                $subject = "New Reply: ".Notification::textShortner($thread_title);
-                $content = "A new message was posted in:\n".$full_course_name."\n\nThread Title: ".$thread_title."\nPost: ".Notification::textShortner($parent_post_content)."\n\nNew Reply:\n\n".$post_content;
+                $subject = "New Reply: " . Notification::textShortner($thread_title);
+                $content = "A new message was posted in:\n" . $full_course_name . "\n\nThread Title: " . $thread_title . "\nPost: " . Notification::textShortner($parent_post_content) . "\n\nNew Reply:\n\n" . $post_content;
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'post_id' => $post_id, 'thread_id' => $thread_id];
                 $this->core->getNotificationFactory()->onNewPost($event);
 
@@ -475,8 +475,8 @@ class ForumController extends AbstractController {
 
             $post_author_id = $post['author_user_id'];
             $metadata = json_encode(array());
-            $subject = "Deleted: ".Notification::textShortner($post["content"]);
-            $content = "In ".$full_course_name."\n\nThread: ".$thread_title."\n\nPost:\n".$post["content"]." was deleted.";
+            $subject = "Deleted: " . Notification::textShortner($post["content"]);
+            $content = "In " . $full_course_name . "\n\nThread: " . $thread_title . "\n\nPost:\n" . $post["content"] . " was deleted.";
             $event = [ 'component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post_author_id, 'preference' => 'all_modifications_forum'];
             $this->core->getNotificationFactory()->onPostModified($event);
 
@@ -493,8 +493,8 @@ class ForumController extends AbstractController {
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string)$post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
-                $subject = "Undeleted: ".Notification::textShortner($post["content"]);
-                $content = "In ".$full_course_name."\n\nThe following post was undeleted.\n\nThread: ".$thread_title."\n\n".$post["content"];
+                $subject = "Undeleted: " . Notification::textShortner($post["content"]);
+                $content = "In " . $full_course_name . "\n\nThe following post was undeleted.\n\nThread: " . $thread_title . "\n\n" . $post["content"];
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post_author_id, 'preference' => 'all_modifications_forum'];
                 $this->core->getNotificationFactory()->onPostModified($event);
                 $type = "post";
@@ -513,7 +513,7 @@ class ForumController extends AbstractController {
             if(is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
             } else if(is_null($status_edit_thread) || is_null($status_edit_post)) {
-                $type = is_null($status_edit_thread)?"Post":"Thread";
+                $type = is_null($status_edit_thread) ? "Post" : "Thread";
                 if($status_edit_thread || $status_edit_post) {
                     //$type is true
                     $messageString = "{$type} updated successfully.";
@@ -528,8 +528,8 @@ class ForumController extends AbstractController {
                     $messageString = "Thread and post updated successfully.";
                     $any_changes = true;
                 } else {
-                    $type = ($status_edit_thread)?"Thread":"Post";
-                    $type_opposite = (!$status_edit_thread)?"Thread":"Post";
+                    $type = ($status_edit_thread) ? "Thread" : "Post";
+                    $type_opposite = (!$status_edit_thread) ? "Thread" : "Post";
                     $isError = true;
                     if($status_edit_thread || $status_edit_post) {
                         //$type is true
@@ -546,13 +546,13 @@ class ForumController extends AbstractController {
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string)$post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
                 if ($type == "Post") {
                     $post_content = $_POST["thread_post_content"];
-                    $subject = "Post Edited: ".Notification::textShortner($post_content);
-                    $content = "A message was edited in:\n".$full_course_name."\n\nThread Title: ".$thread_title."\n\nEdited Post: \n\n".$post_content;
+                    $subject = "Post Edited: " . Notification::textShortner($post_content);
+                    $content = "A message was edited in:\n" . $full_course_name . "\n\nThread Title: " . $thread_title . "\n\nEdited Post: \n\n" . $post_content;
                 }
                 else if ($type == "Thread and Post") {
                     $post_content = $_POST["thread_post_content"];
-                    $subject = "Thread Edited: ".Notification::textShortner($thread_title);
-                    $content = "A thread was edited in:\n".$full_course_name."\n\nEdited Thread: ".$thread_title."\n\nEdited Post: \n\n".$post_content;
+                    $subject = "Thread Edited: " . Notification::textShortner($thread_title);
+                    $content = "A thread was edited in:\n" . $full_course_name . "\n\nEdited Thread: " . $thread_title . "\n\nEdited Post: \n\n" . $post_content;
                 }
 
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post_author_id, 'preference' => 'all_modifications_forum'];
@@ -598,16 +598,16 @@ class ForumController extends AbstractController {
                 $child_thread = $this->core->getQueries()->getThread($child_thread_id)[0];
                 $child_thread_author = $child_thread['created_by'];
                 $child_thread_title = $child_thread['title'];
-                $parent_thread_title =$this->core->getQueries()->getThreadTitle($parent_thread_id)['title'];
+                $parent_thread_title = $this->core->getQueries()->getThreadTitle($parent_thread_id)['title'];
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $parent_thread_id]) . '#' . (string)$child_root_post, 'thread_id' => $parent_thread_id, 'post_id' => $child_root_post));
-                $subject = "Thread Merge: ".Notification::textShortner($child_thread_title);
-                $content = "Two threads were merged in:\n".$full_course_name."\n\nAll messages posted in Merged Thread:\n".$child_thread_title."\n\nAre now contained within Parent Thread:\n".$parent_thread_title;
+                $subject = "Thread Merge: " . Notification::textShortner($child_thread_title);
+                $content = "Two threads were merged in:\n" . $full_course_name . "\n\nAll messages posted in Merged Thread:\n" . $child_thread_title . "\n\nAre now contained within Parent Thread:\n" . $parent_thread_title;
                 $event = [ 'component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $child_thread_author, 'preference' => 'merge_threads'];
                 $this->core->getNotificationFactory()->onPostModified($event);
                 $this->core->addSuccessMessage("Threads merged!");
                 $thread_id = $parent_thread_id;
             } else {
-                $this->core->addErrorMessage("Merging Failed! ".$message);
+                $this->core->addErrorMessage("Merging Failed! " . $message);
             }
         }
         $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $thread_id]));
@@ -937,7 +937,7 @@ class ForumController extends AbstractController {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
         $users = array();
-        for($i=0;$i<$num_posts;$i++){
+        for($i = 0;$i < $num_posts;$i++){
             $user = $posts[$i]["author_user_id"];
             $content = $posts[$i]["content"];
             if(!isset($users[$user])){
@@ -945,13 +945,13 @@ class ForumController extends AbstractController {
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["first_name"] = htmlspecialchars($u -> getDisplayedFirstName());
                 $users[$user]["last_name"] = htmlspecialchars($u -> getDisplayedLastName());
-                $users[$user]["posts"]=array();
-                $users[$user]["id"]=array();
-                $users[$user]["timestamps"]=array();
-                $users[$user]["total_threads"]=0;
+                $users[$user]["posts"] = array();
+                $users[$user]["id"] = array();
+                $users[$user]["timestamps"] = array();
+                $users[$user]["total_threads"] = 0;
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
             }
-            if($posts[$i]["parent_id"]==-1){
+            if($posts[$i]["parent_id"] == -1){
                 $users[$user]["total_threads"]++;
             }
             $users[$user]["posts"][] = $content;

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -356,7 +356,7 @@ class ForumController2 extends AbstractController {
             if(is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
             } else if(is_null($status_edit_thread) || is_null($status_edit_post)) {
-                $type = is_null($status_edit_thread)?"Post":"Thread";
+                $type = is_null($status_edit_thread) ? "Post" : "Thread";
                 if($status_edit_thread || $status_edit_post) {
                     //$type is true
                     $messageString = "{$type} updated successfully.";
@@ -370,8 +370,8 @@ class ForumController2 extends AbstractController {
                     $messageString = "Thread and post updated successfully.";
                     $any_changes = true;
                 } else {
-                    $type = ($status_edit_thread)?"Thread":"Post";
-                    $type_opposite = (!$status_edit_thread)?"Thread":"Post";
+                    $type = ($status_edit_thread) ? "Thread" : "Post";
+                    $type_opposite = (!$status_edit_thread) ? "Thread" : "Post";
                     $isError = true;
                     if($status_edit_thread || $status_edit_post) {
                         //$type is true
@@ -640,7 +640,7 @@ class ForumController2 extends AbstractController {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
         $users = array();
-        for($i=0;$i<$num_posts;$i++){
+        for($i = 0;$i < $num_posts;$i++){
             $user = $posts[$i]["author_user_id"];
             $content = $posts[$i]["content"];
             if(!isset($users[$user])){
@@ -648,13 +648,13 @@ class ForumController2 extends AbstractController {
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["first_name"] = htmlspecialchars($u -> getDisplayedFirstName());
                 $users[$user]["last_name"] = htmlspecialchars($u -> getDisplayedLastName());
-                $users[$user]["posts"]=array();
-                $users[$user]["id"]=array();
-                $users[$user]["timestamps"]=array();
-                $users[$user]["total_threads"]=0;
+                $users[$user]["posts"] = array();
+                $users[$user]["id"] = array();
+                $users[$user]["timestamps"] = array();
+                $users[$user]["total_threads"] = 0;
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
             }
-            if($posts[$i]["parent_id"]==-1){
+            if($posts[$i]["parent_id"] == -1){
                 $users[$user]["total_threads"]++;
             }
             $users[$user]["posts"][] = $content;
@@ -697,13 +697,13 @@ class ForumController2 extends AbstractController {
                     $child_thread = $this->core->getQueries()->getThread($child_thread_id)[0];
                     $child_thread_author = $child_thread['created_by'];
                     $child_thread_title = $child_thread['title'];
-                    $parent_thread_title =$this->core->getQueries()->getThreadTitle($parent_thread_id)['title'];
+                    $parent_thread_title = $this->core->getQueries()->getThreadTitle($parent_thread_id)['title'];
                     $notification = new Notification($this->core, array('component' => 'forum', 'type' => 'merge_thread', 'child_thread_id' => $child_thread_id, 'parent_thread_id' => $parent_thread_id, 'child_thread_title' => $child_thread_title, 'parent_thread_title' => $parent_thread_title, 'child_thread_author' => $child_thread_author, 'child_root_post' => $child_root_post));
                     $this->core->getQueries()->pushNotification($notification);
                     $this->core->addSuccessMessage("Threads merged!");
                     $thread_id = $parent_thread_id;
                 } else {
-                    $this->core->addErrorMessage("Merging Failed! ".$message);
+                    $this->core->addErrorMessage("Merging Failed! " . $message);
                 }
             }
         } else {

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -510,7 +510,7 @@ class ForumController2 extends AbstractController {
         $thread_status = array();
         $new_posts = array();
         $unread_threads = false;
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) &&  $category_id[0] == -1 ) {
+        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1 ) {
             $category_id = explode('|', $_COOKIE[$currentCourse . '_forum_categories']);
         }
         if(!empty($_COOKIE['forum_thread_status'])){

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -246,7 +246,7 @@ class ElectronicGraderController extends AbstractController {
             $autograded_average = null;
             $overall_average = null;
             $overall_scores = null;
-            $section_key='registration_section';
+            $section_key = 'registration_section';
         }
         else if ($gradeable->isGradeByRegistration()) {
             if(!$this->core->getAccess()->canI("grading.electronic.status.full")) {
@@ -258,7 +258,7 @@ class ElectronicGraderController extends AbstractController {
                     $sections[$i] = $section['sections_registration_id'];
                 }
             }
-            $section_key='registration_section';
+            $section_key = 'registration_section';
             if (count($sections) > 0) {
                 $graders = $this->core->getQueries()->getGradersForRegistrationSections($sections);
             }
@@ -275,7 +275,7 @@ class ElectronicGraderController extends AbstractController {
                     $sections[$i] = $section['sections_rotating_id'];
                 }
             }
-            $section_key='rotating_section';
+            $section_key = 'rotating_section';
             if (count($sections) > 0) {
                 $graders = $this->core->getQueries()->getGradersForRotatingSections($gradeable_id, $sections);
             }
@@ -306,7 +306,7 @@ class ElectronicGraderController extends AbstractController {
             $overall_average = $this->core->getQueries()->getAverageForGradeable($gradeable_id, $section_key, $gradeable->isTeamAssignment());
             $order = new GradingOrder($this->core, $gradeable, $this->core->getUser(), true);
             $overall_scores = [];
-            $overall_scores=$order->getSortedGradedGradeables();
+            $overall_scores = $order->getSortedGradedGradeables();
             $num_components = count($gradeable->getNonPeerComponents());
             $viewed_grade = $this->core->getQueries()->getNumUsersWhoViewedGradeBySections($gradeable, $sections);
         }
@@ -332,10 +332,10 @@ class ElectronicGraderController extends AbstractController {
                 );
                 foreach($total_users as $key => $value) {
                     if($key == 'NULL') continue;
-                    $sections['all']['total_components'] += $value *$num_components*$peer_grade_set;
+                    $sections['all']['total_components'] += $value * $num_components * $peer_grade_set;
                     $sections['all']['graded_components'] += isset($graded_components[$key]) ? $graded_components[$key] : 0;
                 }
-                $sections['all']['total_components'] -= $peer_grade_set*$num_components;
+                $sections['all']['total_components'] -= $peer_grade_set * $num_components;
                 $sections['all']['graded_components'] -= $my_grading;
             }
             else {
@@ -930,12 +930,12 @@ class ElectronicGraderController extends AbstractController {
             if($team){
                 $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'registration_section',$team));
                 $total = array_sum($this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
-                $total_submitted=array_sum($this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
+                $total_submitted = array_sum($this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
             }
             else {
                 $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'registration_section', $team));
                 $total = array_sum($this->core->getQueries()->getTotalUserCountByGradingSections($sections, 'registration_section'));
-                $total_submitted=array_sum($this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($gradeable_id, $sections, 'registration_section'));
+                $total_submitted = array_sum($this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($gradeable_id, $sections, 'registration_section'));
             }
         }
         else {
@@ -948,10 +948,10 @@ class ElectronicGraderController extends AbstractController {
             }
             if ($team) {
                 //$total = array_sum($this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, 'rotating_section'));
-                $total_submitted=array_sum($this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'rotating_section'));
+                $total_submitted = array_sum($this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'rotating_section'));
             }
             else {
-                $total_submitted=array_sum($this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($gradeable->getId(), $sections, 'rotating_section'));
+                $total_submitted = array_sum($this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($gradeable->getId(), $sections, 'rotating_section'));
             }
             $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'rotating_section', $team));
         }

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -88,17 +88,17 @@ class ImagesController extends AbstractController {
             for ($j = 0; $j < $count_item; $j++) {
                 if (mime_content_type($uploaded_files[1]["tmp_name"][$j]) == "application/zip") {
                     if(FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
-                        return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside ".$uploaded_files[1]["name"][$j].".", false);
+                        return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[1]["name"][$j] . ".", false);
                     }
                     $uploaded_files[1]["is_zip"][$j] = true;
                     $file_size += FileUtils::getZipSize($uploaded_files[1]["tmp_name"][$j]);
                 }
                 else {
                     if (FileUtils::isValidFileName($uploaded_files[1]["name"][$j]) === false) {
-                        return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_files[1]["name"][$j].".", false);
+                        return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your file name " . $uploaded_files[1]["name"][$j] . ".", false);
                     }
                     elseif (!FileUtils::isValidImage($uploaded_files[1]["tmp_name"][$j])) {
-                        return $this->core->getOutput()->renderResultMessage("Error: ".$uploaded_files[1]['name'][$j]." is not a valid image file.", false);
+                        return $this->core->getOutput()->renderResultMessage("Error: " . $uploaded_files[1]['name'][$j] . " is not a valid image file.", false);
                     }
                     $uploaded_files[1]["is_zip"][$j] = false;
                     $file_size += $uploaded_files[1]["size"][$j];
@@ -108,7 +108,7 @@ class ImagesController extends AbstractController {
 
         $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
         if ($file_size > $max_size) {
-            return $this->core->getOutput()->renderResultMessage("File(s) uploaded too large.  Maximum size is ".($max_size/1024)." kb. Uploaded file(s) was ".($file_size/1024)." kb.", false);
+            return $this->core->getOutput()->renderResultMessage("File(s) uploaded too large.  Maximum size is " . ($max_size / 1024) . " kb. Uploaded file(s) was " . ($file_size / 1024) . " kb.", false);
         }
 
         // creating uploads/student_images directory
@@ -140,7 +140,7 @@ class ImagesController extends AbstractController {
                         // so we have that string hardcoded, otherwise we can just get the status string as
                         // normal.
                         $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
-                        return $this->core->getOutput()->renderResultMessage("Could not properly unpack zip file. Error message: ".$error_message.".", false);
+                        return $this->core->getOutput()->renderResultMessage("Could not properly unpack zip file. Error message: " . $error_message . ".", false);
                     }
                 }
                 else {

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -42,7 +42,7 @@ class PDFController extends AbstractController {
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = $pdf_info[0];
                         $grader_id = $pdf_info[1];
-                        if($pdf_id.'.pdf' === $filename){
+                        if($pdf_id . '.pdf' === $filename){
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }
                     }
@@ -103,7 +103,7 @@ class PDFController extends AbstractController {
             return false;
         }
 
-        $new_file_name = preg_replace('/\\.[^.\\s]{3,4}$/', '', $annotation_info['file_name']) . "_" .$grader_id .'.json';
+        $new_file_name = preg_replace('/\\.[^.\\s]{3,4}$/', '', $annotation_info['file_name']) . "_" . $grader_id . '.json';
         file_put_contents(FileUtils::joinPaths($annotation_version_path, $new_file_name), $annotation_layer);
         $this->core->getOutput()->renderJsonSuccess('Annotation saved successfully!');
         return true;
@@ -142,7 +142,7 @@ class PDFController extends AbstractController {
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = $pdf_info[0];
                         $grader_id = $pdf_info[1];
-                        if($pdf_id.'.pdf' === $filename){
+                        if($pdf_id . '.pdf' === $filename){
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }
                     }

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -269,7 +269,7 @@ class GradeInquiryController extends AbstractController {
             }
 
             // make graders' notifications and emails
-            $metadata = json_encode(['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'grade?'.http_build_query(['who_id' => $submitter->getId()])])]);
+            $metadata = json_encode(['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'grade?' . http_build_query(['who_id' => $submitter->getId()])])]);
             if (empty($graders)) {
                 $graders = $this->core->getQueries()->getAllGraders();
             }

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -11,8 +11,8 @@ class RainbowGradesController extends AbstractController {
      * @Route("/{_semester}/{_course}/grades")
      */
     public function run() {
-        $grade_path = $this->core->getConfig()->getCoursePath()."/reports/summary_html/"
-            .$this->core->getUser()->getId()."_summary.html";
+        $grade_path = $this->core->getConfig()->getCoursePath() . "/reports/summary_html/"
+            . $this->core->getUser()->getId() . "_summary.html";
 
         $grade_file = null;
         if (file_exists($grade_path)) {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -293,7 +293,7 @@ class SubmissionController extends AbstractController {
         }
 
         if ($file_size > $max_size) {
-            return $this->uploadResult("File(s) uploaded too large.  Maximum size is ".($max_size/1000)." kb. Uploaded file(s) was ".($file_size/1000)." kb.", false);
+            return $this->uploadResult("File(s) uploaded too large.  Maximum size is " . ($max_size / 1000) . " kb. Uploaded file(s) was " . ($file_size / 1000) . " kb.", false);
         }
 
         // creating uploads/bulk_pdf/gradeable_id directory
@@ -537,7 +537,7 @@ class SubmissionController extends AbstractController {
                     $file_base_name = basename($file);
                     if(!$clobber && $file_base_name === $uploaded_file_base_name) {
                         $parts = explode(".", $file_base_name);
-                        $parts[0] .= "_version_".$old_version;
+                        $parts[0] .= "_version_" . $old_version;
                         $file_base_name = implode(".", $parts);
                     }
 
@@ -606,7 +606,7 @@ class SubmissionController extends AbstractController {
                 return $this->uploadResult("Failed to open settings file.", false);
             }
             $json["active_version"] = $new_version;
-            $json["history"][] = array("version"=> $new_version, "time" => $current_time_string_tz, "who" => $original_user_id, "type" => "upload");
+            $json["history"][] = array("version" => $new_version, "time" => $current_time_string_tz, "who" => $original_user_id, "type" => "upload");
         }
 
         // TODO: If any of these fail, should we "cancel" (delete) the entire submission attempt or just leave it?
@@ -616,7 +616,7 @@ class SubmissionController extends AbstractController {
 
         $this->upload_details['assignment_settings'] = true;
 
-        if (!@file_put_contents(FileUtils::joinPaths($version_path, ".submit.timestamp"), $current_time_string_tz."\n")) {
+        if (!@file_put_contents(FileUtils::joinPaths($version_path, ".submit.timestamp"), $current_time_string_tz . "\n")) {
             return $this->uploadResult("Failed to save timestamp file for this submission.", false);
         }
 
@@ -829,7 +829,7 @@ class SubmissionController extends AbstractController {
         $num_parts = $gradeable->getAutogradingConfig()->getNumParts();
         if ($num_parts > 1) {
             for ($i = 1; $i <= $num_parts; $i++) {
-                $part_path[$i] = FileUtils::joinPaths($version_path, "part".$i);
+                $part_path[$i] = FileUtils::joinPaths($version_path, "part" . $i);
                 if (!FileUtils::createDir($part_path[$i])) {
                     return $this->uploadResult("Failed to make the folder for part {$i}.", false);
                 }
@@ -859,9 +859,9 @@ class SubmissionController extends AbstractController {
                     $count[$i] = count($uploaded_files[$i]["name"]);
                     for ($j = 0; $j < $count[$i]; $j++) {
                         if (!isset($uploaded_files[$i]["tmp_name"][$j]) || $uploaded_files[$i]["tmp_name"][$j] === "") {
-                            $error_message = $uploaded_files[$i]["name"][$j]." failed to upload. ";
+                            $error_message = $uploaded_files[$i]["name"][$j] . " failed to upload. ";
                             if (isset($uploaded_files[$i]["error"][$j])) {
-                                $error_message .= "Error message: ". ErrorMessages::uploadErrors($uploaded_files[$i]["error"][$j]). ".";
+                                $error_message .= "Error message: " . ErrorMessages::uploadErrors($uploaded_files[$i]["error"][$j]) . ".";
                             }
                             $errors[] = $error_message;
                         }
@@ -871,7 +871,7 @@ class SubmissionController extends AbstractController {
 
             if (count($errors) > 0) {
                 $error_text = implode("\n", $errors);
-                return $this->uploadResult("Upload Failed: ".$error_text, false);
+                return $this->uploadResult("Upload Failed: " . $error_text, false);
             }
 
             // save the contents of the text boxes to files
@@ -948,7 +948,7 @@ class SubmissionController extends AbstractController {
                 $previous_path = FileUtils::joinPaths($user_path, $highest_version);
                 if ($num_parts > 1) {
                     for ($i = 1; $i <= $num_parts; $i++) {
-                        $previous_part_path[$i] = FileUtils::joinPaths($previous_path, "part".$i);
+                        $previous_part_path[$i] = FileUtils::joinPaths($previous_path, "part" . $i);
                     }
                 }
                 else {
@@ -977,7 +977,7 @@ class SubmissionController extends AbstractController {
                                 $previous_files_src[$i][$j] = $file_base_name;
                                 if(!$clobber && isset($current_files_set[$file_base_name])) {
                                     $parts = explode(".", $file_base_name);
-                                    $parts[0] .= "_version_".$highest_version;
+                                    $parts[0] .= "_version_" . $highest_version;
                                     $file_base_name = implode(".", $parts);
                                 }
                                 $previous_files_dst[$i][$j] = $file_base_name;
@@ -1011,14 +1011,14 @@ class SubmissionController extends AbstractController {
                     for ($j = 0; $j < $count[$i]; $j++) {
                         if (mime_content_type($uploaded_files[$i]["tmp_name"][$j]) == "application/zip") {
                             if(FileUtils::checkFileInZipName($uploaded_files[$i]["tmp_name"][$j]) === false) {
-                                return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside ".$uploaded_files[$i]["name"][$j].".", false);
+                                return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[$i]["name"][$j] . ".", false);
                             }
                             $uploaded_files[$i]["is_zip"][$j] = true;
                             $file_size += FileUtils::getZipSize($uploaded_files[$i]["tmp_name"][$j]);
                         }
                         else {
                             if(FileUtils::isValidFileName($uploaded_files[$i]["name"][$j]) === false) {
-                                return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your file name ".$uploaded_files[$i]["name"][$j].".", false);
+                                return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your file name " . $uploaded_files[$i]["name"][$j] . ".", false);
                             }
                             $uploaded_files[$i]["is_zip"][$j] = false;
                             $file_size += $uploaded_files[$i]["size"][$j];
@@ -1033,13 +1033,13 @@ class SubmissionController extends AbstractController {
             }
 
             if ($file_size > $max_size) {
-                return $this->uploadResult("File(s) uploaded too large.  Maximum size is ".($max_size/1000)." kb. Uploaded file(s) was ".($file_size/1000)." kb.", false);
+                return $this->uploadResult("File(s) uploaded too large.  Maximum size is " . ($max_size / 1000) . " kb. Uploaded file(s) was " . ($file_size / 1000) . " kb.", false);
             }
 
             for ($i = 1; $i <= $num_parts; $i++) {
                 // copy selected previous submitted files
                 if (isset($previous_files_src[$i])){
-                    for ($j=0; $j < count($previous_files_src[$i]); $j++){
+                    for ($j = 0; $j < count($previous_files_src[$i]); $j++){
                         $src = FileUtils::joinPaths($previous_part_path[$i], $previous_files_src[$i][$j]);
                         $dst = FileUtils::joinPaths($part_path[$i], $previous_files_dst[$i][$j]);
                         if (!@copy($src, $dst)) {
@@ -1063,7 +1063,7 @@ class SubmissionController extends AbstractController {
                                 // so we have that string hardcoded, otherwise we can just get the status string as
                                 // normal.
                                 $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
-                                return $this->uploadResult("Could not properly unpack zip file. Error message: ".$error_message.".", false);
+                                return $this->uploadResult("Could not properly unpack zip file. Error message: " . $error_message . ".", false);
                             }
                         }
                         else {
@@ -1093,7 +1093,7 @@ class SubmissionController extends AbstractController {
                 $vcs_path = str_replace("{\$gradeable_id}",$gradeable_id,$vcs_path);
                 $vcs_path = str_replace("{\$user_id}",$who_id,$vcs_path);
                 $vcs_path = str_replace("{\$team_id}",$who_id,$vcs_path);
-                $vcs_full_path = $vcs_base_url.$vcs_path;
+                $vcs_full_path = $vcs_base_url . $vcs_path;
             }
 
             // use entirely student input
@@ -1114,7 +1114,7 @@ class SubmissionController extends AbstractController {
                 $vcs_path = str_replace("{\$user_id}",$who_id,$vcs_path);
                 $vcs_path = str_replace("{\$team_id}",$who_id,$vcs_path);
                 $vcs_path = str_replace("{\$repo_id}",$repo_id,$vcs_path);
-                $vcs_full_path = $vcs_base_url.$vcs_path;
+                $vcs_full_path = $vcs_base_url . $vcs_path;
             }
 
             if (!@touch(FileUtils::joinPaths($version_path, ".submit.VCS_CHECKOUT"))) {
@@ -1170,7 +1170,7 @@ class SubmissionController extends AbstractController {
                 return $this->uploadResult("Failed to open settings file.", false);
             }
             $json["active_version"] = $new_version;
-            $json["history"][] = array("version"=> $new_version, "time" => $current_time_string_tz, "who" => $original_user_id, "type" => "upload");
+            $json["history"][] = array("version" => $new_version, "time" => $current_time_string_tz, "who" => $original_user_id, "type" => "upload");
         }
 
         // TODO: If any of these fail, should we "cancel" (delete) the entire submission attempt or just leave it?
@@ -1180,7 +1180,7 @@ class SubmissionController extends AbstractController {
 
         $this->upload_details['assignment_settings'] = true;
 
-        if (!@file_put_contents(FileUtils::joinPaths($version_path, ".submit.timestamp"), $current_time_string_tz."\n")) {
+        if (!@file_put_contents(FileUtils::joinPaths($version_path, ".submit.timestamp"), $current_time_string_tz . "\n")) {
             return $this->uploadResult("Failed to save timestamp file for this submission.", false);
         }
 
@@ -1195,7 +1195,7 @@ class SubmissionController extends AbstractController {
             $vcs_queue_file = FileUtils::joinPaths(
                 $this->core->getConfig()->getSubmittyPath(),
                 "to_be_graded_queue",
-                "VCS__".$queue_file_helper
+                "VCS__" . $queue_file_helper
             );
         }
 
@@ -1245,8 +1245,8 @@ class SubmissionController extends AbstractController {
 
             // notify other team members that a submission has been made
             $metadata = json_encode(['url' => $this->core->buildCourseUrl(['gradeable',$gradeable_id])]);
-            $subject = "Team Member Submission: ".$graded_gradeable->getGradeable()->getTitle();
-            $content = "A team member, $original_user_id, submitted in the gradeable, ".$graded_gradeable->getGradeable()->getTitle();
+            $subject = "Team Member Submission: " . $graded_gradeable->getGradeable()->getTitle();
+            $content = "A team member, $original_user_id, submitted in the gradeable, " . $graded_gradeable->getGradeable()->getTitle();
             $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_member_submission', 'sender_id' => $original_user_id];
             $this->core->getNotificationFactory()->onTeamEvent($event,$team_members);
         }
@@ -1396,7 +1396,7 @@ class SubmissionController extends AbstractController {
             $this->core->addSuccessMessage($msg);
         }
         if($ta) {
-            $this->core->redirect($this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'grade']). '?'
+            $this->core->redirect($this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'grade']) . '?'
                 . http_build_query(['who_id' => $who, 'gradeable_version' => $new_version]));
         }
         else {

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -197,14 +197,14 @@ class TeamController extends AbstractController {
         $metadata = json_encode(
             ['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id,'team'])]
         );
-        $subject = "New Team Invitation: ".$graded_gradeable->getGradeable()->getTitle();
+        $subject = "New Team Invitation: " . $graded_gradeable->getGradeable()->getTitle();
         $content = "You have received a new invitation to join a team from $user_id";
         $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_invite', 'sender_id' => $user_id];
         $this->core->getNotificationFactory()->onTeamEvent($event,[$invite_id]);
 
         $this->core->addSuccessMessage("Invitation sent to {$invite_id}");
 
-        $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")." ".$this->core->getConfig()->getTimezone()->getName();
+        $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO") . " " . $this->core->getConfig()->getTimezone()->getName();
         $settings_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions", $gradeable_id, $team->getId(), "user_assignment_settings.json");
         $json = FileUtils::readJsonFile($settings_file);
         if ($json === false) {
@@ -269,14 +269,14 @@ class TeamController extends AbstractController {
         $team_members = $accept_team->getMembers();
         // send notification to team members that user joined
         $metadata =  json_encode(['url' => $this->core->buildCourseUrl([$gradeable_id,'team'])]);
-        $subject = "New Team Member: ".$gradeable->getTitle();
-        $content = "A new team member with the user name, $user_id, joined your team for gradeable, ".$gradeable->getTitle();
+        $subject = "New Team Member: " . $gradeable->getTitle();
+        $content = "A new team member with the user name, $user_id, joined your team for gradeable, " . $gradeable->getTitle();
         $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_joined', 'sender_id' => $user_id];
         $this->core->getNotificationFactory()->onTeamEvent($event, $team_members);
 
         $this->core->addSuccessMessage("Accepted invitation from {$accept_team->getMemberList()}");
 
-        $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")." ".$this->core->getConfig()->getTimezone()->getName();
+        $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO") . " " . $this->core->getConfig()->getTimezone()->getName();
         $settings_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions", $gradeable_id, $accept_team_id, "user_assignment_settings.json");
         $json = FileUtils::readJsonFile($settings_file);
         if ($json === false) {
@@ -332,7 +332,7 @@ class TeamController extends AbstractController {
         $this->core->getQueries()->cancelTeamInvitation($team->getId(), $cancel_id);
         $this->core->addSuccessMessage("Cancelled invitation to {$cancel_id}");
 
-        $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO")." ".$this->core->getConfig()->getTimezone()->getName();
+        $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO") . " " . $this->core->getConfig()->getTimezone()->getName();
         $settings_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions", $gradeable_id, $team->getId(), "user_assignment_settings.json");
         $json = FileUtils::readJsonFile($settings_file);
         if ($json === false) {

--- a/site/app/exceptions/CurlException.php
+++ b/site/app/exceptions/CurlException.php
@@ -5,7 +5,7 @@ namespace app\exceptions;
 class CurlException extends \RuntimeException {
     public function __construct($curl_handle, $curl_return) {
         if ($curl_return === false) {
-            parent::__construct("cURL error ".curl_error($curl_handle));
+            parent::__construct("cURL error " . curl_error($curl_handle));
         }
         else {
             $http_code = curl_getinfo($curl_handle, CURLINFO_RESPONSE_CODE);

--- a/site/app/exceptions/DatabaseException.php
+++ b/site/app/exceptions/DatabaseException.php
@@ -6,7 +6,7 @@ class DatabaseException extends BaseException {
     public function __construct($message, $query = null, $parameters = [], $code = 0, $previous = null) {
         $extra = [];
         if ($query !== null) {
-            $extra =["query" => $query, "parameters" => $parameters];
+            $extra = ["query" => $query, "parameters" => $parameters];
         }
         parent::__construct($message, $extra, $code, $previous);
     }

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -183,7 +183,7 @@ class Access {
         $this->permissions["path.write.checkout"] = self::DENY_ALL | self::CHECK_CSRF;
         $this->permissions["path.write.results"] = self::DENY_ALL | self::CHECK_CSRF;
         $this->permissions["path.write.results_public"] = self::DENY_ALL | self::CHECK_CSRF;
-        $this->permissions["path.write.course_materials"] = self::ALLOW_MIN_INSTRUCTOR  | self::CHECK_CSRF| self::CHECK_FILE_DIRECTORY;
+        $this->permissions["path.write.course_materials"] = self::ALLOW_MIN_INSTRUCTOR  | self::CHECK_CSRF | self::CHECK_FILE_DIRECTORY;
         $this->permissions["path.write.rainbow_grades"] = self::ALLOW_INSTRUCTOR | self::CHECK_CSRF | self::CHECK_FILE_DIRECTORY;
         $this->permissions["path.write.forum_attachments"] = self::ALLOW_MIN_STUDENT | self::CHECK_CSRF;
 

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -153,7 +153,7 @@ class Core {
     }
 
     public function loadAuthentication() {
-        $auth_class = "\\app\\authentication\\".$this->config->getAuthentication();
+        $auth_class = "\\app\\authentication\\" . $this->config->getAuthentication();
         if (!is_subclass_of($auth_class, 'app\authentication\AbstractAuthentication')) {
             throw new \Exception("Invalid module specified for Authentication. All modules should implement the AbstractAuthentication interface.");
         }
@@ -504,7 +504,7 @@ class Core {
      * @return string
      */
     public function buildUrl($parts=array()) {
-        $url = $this->getConfig()->getBaseUrl().implode("/", $parts);
+        $url = $this->getConfig()->getBaseUrl() . implode("/", $parts);
         return $url;
     }
 
@@ -557,7 +557,7 @@ class Core {
     public function getFullCourseName() {
         $course_name = strtoupper($this->getConfig()->getCourse());
         if ($this->getConfig()->getCourseName() !== "") {
-            $course_name .= ": ".htmlentities($this->getConfig()->getCourseName());
+            $course_name .= ": " . htmlentities($this->getConfig()->getCourseName());
         }
         return $course_name;
     }
@@ -585,7 +585,7 @@ class Core {
             else if($arr1[0] == "s")  $semester .= "Spring ";
             else if ($arr1[0] == "u") $semester .= "Summer ";
 
-            $semester .= "20". $arr1[1]. $arr1[2];
+            $semester .= "20" . $arr1[1] . $arr1[2];
         }
         return $semester;
     }

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -142,7 +142,7 @@ class DiffViewer {
      * @throws \Exception
      */
     public function __construct($actual_file, $expected_file, $diff_file, $image_difference, $id_prepend="id") {
-        $this->id = rtrim($id_prepend, "_")."_";
+        $this->id = rtrim($id_prepend, "_") . "_";
         $this->actual_file = $actual_file;
         $this->expected_file = $expected_file;
         $this->diff_file = $diff_file;
@@ -183,7 +183,7 @@ class DiffViewer {
                 if(filesize($actual_file) < $size_limit){
                     $this->actual_file_name = $actual_file;
                     $this->actual = file_get_contents($actual_file);
-                    $this->has_actual = trim($this->actual) !== "" ? true: false;
+                    $this->has_actual = trim($this->actual) !== "" ? true : false;
                     $this->actual = explode("\n", $this->actual);
                     $this->display_actual = true;
                 }
@@ -192,7 +192,7 @@ class DiffViewer {
                     $can_diff = false;
                     //load in the first sizelimit characters of the file (TEMP VALUE)
                     $this->actual = file_get_contents($actual_file, null, null, 0, $size_limit);
-                    $this->has_actual = trim($this->actual) !== "" ? true: false;
+                    $this->has_actual = trim($this->actual) !== "" ? true : false;
                     $this->actual = explode("\n", $this->actual);
                     $this->display_actual = true;
                 }
@@ -475,19 +475,19 @@ class DiffViewer {
                     $test2 = str_replace("\0", "null", $html_orig_error);
                     if($option == self::SPECIAL_CHARS_ORIGINAL){
                         $html .= $html_orig;
-                        $html .= "<span class='highlight-char'>".$html_orig_error."</span>";
+                        $html .= "<span class='highlight-char'>" . $html_orig_error . "</span>";
                     } else if($option == self::SPECIAL_CHARS_UNICODE) {
                         $html_no_empty = $this->replaceEmptyChar($html_orig, false);
                         $html_no_empty_error = $this->replaceEmptyChar($html_orig_error, false);
                         $html .= $html_no_empty;
-                        $html .= "<span class='highlight-char'>".$html_no_empty_error."</span>";
+                        $html .= "<span class='highlight-char'>" . $html_no_empty_error . "</span>";
                     } else if($option == self::SPECIAL_CHARS_ESCAPE) {
                         $html_no_empty = $this->replaceEmptyChar($html_orig, true);
                         $html_no_empty_error = $this->replaceEmptyChar($html_orig_error, true);
                         $html .= $html_no_empty;
-                        $html .= "<span class='highlight-char'>".$html_no_empty_error."</span>";
+                        $html .= "<span class='highlight-char'>" . $html_no_empty_error . "</span>";
                     }
-                    $current = $diff[1]+1;
+                    $current = $diff[1] + 1;
                 }
                 $html .= "<span class='line_code_inner'>";
                 $inner = htmlentities(substr($lines[$i], $current));
@@ -529,7 +529,7 @@ class DiffViewer {
                 }
             }
 
-            if ($start !== null && !isset($this->diff[$type][($i+1)])) {
+            if ($start !== null && !isset($this->diff[$type][($i + 1)])) {
                 $start = null;
                 $html .= "\t</div>\n";
             }
@@ -541,7 +541,7 @@ class DiffViewer {
     public function getWhiteSpaces(){
         $return = "";
         foreach($this->white_spaces as $key => $value){
-            $return .= "$value" . " = " . "$key". " ";
+            $return .= "$value" . " = " . "$key" . " ";
         }
         return $this->white_spaces;
     }
@@ -579,7 +579,7 @@ class DiffViewer {
      */
     private function replaceUTF($text, $what, &$which, $description){
         $count = 0;
-        $what = '<span class="whitespace">'.$what.'</span>';
+        $what = '<span class="whitespace">' . $what . '</span>';
         $which = str_replace($text, $what, $which,$count);
         if($count > 0) $this->white_spaces[$description] = strip_tags($what);
         return $what;
@@ -604,7 +604,7 @@ class DiffViewer {
         $return = array();
         $temp = array();
         foreach ($range as $number) {
-            if ($number != $last+1) {
+            if ($number != $last + 1) {
                 if (count($temp) > 0) {
                     $return[] = array($temp[0], end($temp));
                     $temp = array();

--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -76,7 +76,7 @@ class ExceptionHandler {
                              $elem,
                              isset($frame['file']) ? $frame['file'] : 'unknown file',
                              isset($frame['line']) ? $frame['line'] : 'unknown line',
-                             (isset($frame['class']))  ? $frame['class'].$frame['type'].$frame['function'] : $frame['function'],
+                             (isset($frame['class']))  ? $frame['class'] . $frame['type'] . $frame['function'] : $frame['function'],
                              static::parseArgs(is_a($exception, '\app\exceptions\AuthenticationException') ? array() : $frame['args']));
         }
         $trace_string = implode("\n", $trace_string);

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -51,8 +51,8 @@ class FileUtils {
                     $temp = FileUtils::getAllFiles($path, $skip_files, $flatten);
                     if ($flatten) {
                         foreach ($temp as $file => $details) {
-                            $details['relative_name'] = $entry."/".$details['relative_name'];
-                            $return[$entry."/".$file] = $details;
+                            $details['relative_name'] = $entry . "/" . $details['relative_name'];
+                            $return[$entry . "/" . $file] = $details;
                         }
                     }
                     else {
@@ -377,7 +377,7 @@ class FileUtils {
         }
 
         $sep = DIRECTORY_SEPARATOR;
-        return preg_replace('#'.preg_quote($sep).'+#', $sep, join($sep, $paths));
+        return preg_replace('#' . preg_quote($sep) . '+#', $sep, join($sep, $paths));
     }
 
     /**
@@ -522,8 +522,8 @@ class FileUtils {
 
             $ret[] = [
                 'name' => $name,
-                'type'=> $type,
-                'error'=> $err_msg,
+                'type' => $type,
+                'error' => $err_msg,
                 'size' => $size,
                 'success' => $success
             ];

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -137,12 +137,12 @@ class Logger {
                 break;
         }
 
-        $log_message .= "\n".$message."\n";
+        $log_message .= "\n" . $message . "\n";
         if (isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
             $log_message .= 'URL: http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://';
             $log_message .= "{$_SERVER['HTTP_HOST']}/{$_SERVER['REQUEST_URI']}\n";
         }
-        $log_message .= str_repeat("=-", 30)."="."\n";
+        $log_message .= str_repeat("=-", 30) . "=" . "\n";
 
         // Appends to the file using a locking mechanism, and supressing any potential error from this
         @file_put_contents(FileUtils::joinPaths(static::$log_path, 'site_errors', "{$filename}.log"), $log_message, FILE_APPEND | LOCK_EX);
@@ -157,7 +157,7 @@ class Logger {
     private static function getFilename() {
         FileUtils::createDir(static::$log_path);
         $date = getdate(time());
-        return $date['year']. Utils::pad($date['mon']) . Utils::pad($date['mday']);
+        return $date['year'] . Utils::pad($date['mon']) . Utils::pad($date['mday']);
     }
 
     /**
@@ -167,9 +167,9 @@ class Logger {
      */
     private static function getTimestamp() {
         $date = getdate(time());
-        $log_message = Utils::pad($date['hours']).":".Utils::pad($date['minutes']).":".Utils::pad($date['seconds']);
+        $log_message = Utils::pad($date['hours']) . ":" . Utils::pad($date['minutes']) . ":" . Utils::pad($date['seconds']);
         $log_message .= " ";
-        $log_message .= Utils::pad($date['mon'])."/".Utils::pad($date['mday'])."/".$date['year'];
+        $log_message .= Utils::pad($date['mon']) . "/" . Utils::pad($date['mday']) . "/" . $date['year'];
         return $log_message;
     }
 
@@ -224,7 +224,7 @@ class Logger {
         $filename = static::getFilename();
         array_unshift($log_message, static::getTimestamp());
         $log_message[] = $_SERVER['HTTP_USER_AGENT'];
-        $log_message = implode(" | ", $log_message)."\n";
+        $log_message = implode(" | ", $log_message) . "\n";
         @file_put_contents(FileUtils::joinPaths(static::$log_path, $folder, "{$filename}.log"), $log_message, FILE_APPEND | LOCK_EX);
     }
 }

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -315,8 +315,8 @@ HTML;
         $this->useFooter(false);
         $this->useHeader(false);
         $this->output_buffer = $contents;
-        header("Content-Type: ".$filetype);
-        header("Content-Disposition: attachment; filename=".$filename);
+        header("Content-Type: " . $filetype);
+        header("Content-Disposition: attachment; filename=" . $filename);
         header("Content-Length: " . strlen($contents));
     }
 
@@ -498,7 +498,7 @@ HTML;
 
     public function timestampResource($file, $folder) {
         $timestamp = filemtime(FileUtils::joinPaths(__DIR__, '..', '..', 'public', $folder, $file));
-        return $this->core->getConfig()->getBaseUrl().$folder."/".$file.(($timestamp !== 0) ? "?v={$timestamp}" : "");
+        return $this->core->getConfig()->getBaseUrl() . $folder . "/" . $file . (($timestamp !== 0) ? "?v={$timestamp}" : "");
     }
 
     /**

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -143,7 +143,7 @@ class Utils {
      * @return bool
      */
     public static function endsWith(string $haystack, string $needle): bool {
-        return substr($haystack, (-1*strlen($needle)), strlen($needle)) === $needle;
+        return substr($haystack, (-1 * strlen($needle)), strlen($needle)) === $needle;
     }
 
     /**
@@ -178,7 +178,7 @@ class Utils {
     public static function isImage(string $filename): bool {
         return (substr($filename, -4) == ".png") ||
             (substr($filename, -4) == ".jpg") ||
-            (substr($filename, -5) == ".jpeg")||
+            (substr($filename, -5) == ".jpeg") ||
             (substr($filename, -4) == ".gif");
     }
 
@@ -311,7 +311,7 @@ class Utils {
     */
     public static function formatBytes(string $format, int $bytes): string {
         $formats = ['b' => 0, 'kb' => 1, 'mb' => 2];
-        return ($bytes/pow(1024,floor($formats[strtolower($format)]))) . (strtoupper($format));
+        return ($bytes / pow(1024,floor($formats[strtolower($format)]))) . (strtoupper($format));
     }
 
 }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -212,12 +212,12 @@ class DatabaseQueries {
         if(count($categories_ids) == 0) {
             $query_multiple_qmarks = "NULL";
         } else {
-            $query_multiple_qmarks = "?".str_repeat(",?", count($categories_ids)-1);
+            $query_multiple_qmarks = "?" . str_repeat(",?", count($categories_ids) - 1);
         }
         if(count($thread_status) == 0) {
             $query_status = "true";
         } else {
-            $query_status = "status in (?".str_repeat(",?", count($thread_status)-1).")";
+            $query_status = "status in (?" . str_repeat(",?", count($thread_status) - 1) . ")";
         }
         $query_favorite = "case when sf.user_id is NULL then false else true end";
 
@@ -321,7 +321,7 @@ class DatabaseQueries {
             $this->course_db->query($query, $query_parameters);
             $results = $this->course_db->rows();
             $row_count = $results[0]['count'];
-            $blockNumber = 1 + floor(($row_count-1)/$blockSize);
+            $blockNumber = 1 + floor(($row_count - 1) / $blockSize);
         } else if($blockNumber == 0) {
             // Load first block as default
             $blockNumber = 1;
@@ -335,11 +335,11 @@ class DatabaseQueries {
                 $results = $this->course_db->rows();
                 if(count($results) > 0) {
                     $row_number = $results[0]['row_number'];
-                    $blockNumber = 1 + floor(($row_number-1)/$blockSize);
+                    $blockNumber = 1 + floor(($row_number - 1) / $blockSize);
                 }
             }
         }
-        $query_offset = ($blockNumber-1) * $blockSize;
+        $query_offset = ($blockNumber - 1) * $blockSize;
         $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, true, true);
         $query = "SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where} ORDER BY {$query_order} LIMIT ? OFFSET ?";
         $query_parameters[] = $blockSize;
@@ -398,7 +398,7 @@ class DatabaseQueries {
     }
 
     public function updateNotificationSettings($results) {
-        $values = implode(', ', array_fill(0, count($results)+1, '?'));
+        $values = implode(', ', array_fill(0, count($results) + 1, '?'));
         $keys = implode(', ', array_keys($results));
         $updates = '';
 
@@ -558,7 +558,7 @@ class DatabaseQueries {
     }
 
     private function findChildren($post_id, $thread_id, &$children, $get_deleted = false){
-        $query_delete = $get_deleted?"true":"deleted = false";
+        $query_delete = $get_deleted ? "true" : "deleted = false";
         $this->course_db->query("SELECT id from posts where {$query_delete} and parent_id=?", array($post_id));
         $row = $this->course_db->rows();
         for($i = 0; $i < count($row); $i++){
@@ -595,12 +595,12 @@ class DatabaseQueries {
         $this->course_db->query("SELECT parent_id from posts where id=?", array($post_id));
         $parent_id = $this->course_db->rows()[0]["parent_id"];
         $children = array($post_id);
-        $get_deleted = ($newStatus?false:true);
+        $get_deleted = ($newStatus ? false : true);
         $this->findChildren($post_id, $thread_id, $children, $get_deleted);
 
         if(!$newStatus) {
             // On undelete, parent post must have deleted = false
-            if($parent_id!=-1) {
+            if($parent_id != -1) {
                 if($this->getPost($parent_id)['deleted']) {
                     return null;
                 }
@@ -624,7 +624,7 @@ class DatabaseQueries {
 
     public function editPost($original_creator, $user, $post_id, $content, $anon, $markdown){
         try {
-            $markdown = $markdown?1:0;
+            $markdown = $markdown ? 1 : 0;
             // Before making any edit to $post_id, forum_posts_history will not have any corresponding entry
             // forum_posts_history will store all history state of the post(if edited at any point of time)
             $this->course_db->beginTransaction();
@@ -844,7 +844,7 @@ FROM users
 INNER JOIN electronic_gradeable_version
 ON
 users.user_id = electronic_gradeable_version.user_id
-AND users.". $section_key . " IS NOT NULL
+AND users." . $section_key . " IS NOT NULL
 AND electronic_gradeable_version.active_version>0
 AND electronic_gradeable_version.g_id=?
 {$where}
@@ -923,13 +923,13 @@ ORDER BY {$orderby}", $params);
     }
 
     public function getGradedComponentsCountByGradingSections($g_id, $sections, $section_key, $is_team) {
-         $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+         $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team){
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $return = array();
         $params = array($g_id);
@@ -961,13 +961,13 @@ ORDER BY {$u_or_t}.{$section_key}", $params);
     }
 
     public function getAverageComponentScores($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team){
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $return = array();
         $this->course_db->query("
@@ -1014,13 +1014,13 @@ ORDER BY gc_order
         return $return;
     }
     public function getAverageAutogradedScores($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team){
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $this->course_db->query("
 SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) FROM(
@@ -1046,13 +1046,13 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
     public function getScoresForGradeable($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team){
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $this->course_db->query("
 SELECT COUNT(*) from gradeable_component where g_id=?
@@ -1093,13 +1093,13 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
     public function getAverageForGradeable($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team){
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $this->course_db->query("
 SELECT COUNT(*) from gradeable_component where g_id=?
@@ -1154,7 +1154,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
 
         $sections_query = "";
         if (count($sections) > 0) {
-            $sections_query= "{$grade_type}_section IN " . $this->createParamaterList(count($sections));
+            $sections_query = "{$grade_type}_section IN " . $this->createParamaterList(count($sections));
             $params = array_merge($sections, $params);
         }
 
@@ -1186,7 +1186,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
 
         $sections_query = "";
         if (count($sections) > 0) {
-            $sections_query= "{$grade_type}_section IN " . $this->createParamaterList(count($sections));
+            $sections_query = "{$grade_type}_section IN " . $this->createParamaterList(count($sections));
             $params = array_merge($sections, $params);
         }
 
@@ -1880,7 +1880,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
     public function createTeam($g_id, $user_id, $registration_section, $rotating_section) {
         $this->course_db->query("SELECT COUNT(*) AS cnt FROM gradeable_teams");
         $team_id_prefix = strval($this->course_db->row()['cnt']);
-        if (strlen($team_id_prefix) < 5) $team_id_prefix = str_repeat("0", 5-strlen($team_id_prefix)) . $team_id_prefix;
+        if (strlen($team_id_prefix) < 5) $team_id_prefix = str_repeat("0", 5 - strlen($team_id_prefix)) . $team_id_prefix;
         $team_id = "{$team_id_prefix}_{$user_id}";
 
         $params = array($team_id, $g_id, $registration_section, $rotating_section);
@@ -2100,7 +2100,7 @@ FROM gradeable_teams
 INNER JOIN electronic_gradeable_version
 ON
 gradeable_teams.team_id = electronic_gradeable_version.team_id
-AND gradeable_teams.". $section_key . " IS NOT NULL
+AND gradeable_teams." . $section_key . " IS NOT NULL
 AND electronic_gradeable_version.active_version>0
 AND electronic_gradeable_version.g_id=?
 {$where}
@@ -2118,10 +2118,10 @@ ORDER BY {$section_key}", $params);
         $params = array($g_id);
         $sections_query = "";
         if (count($sections) > 0) {
-            $sections_query= "{$section_key} IN " . $this->createParamaterList(count($sections)) . " AND";
+            $sections_query = "{$section_key} IN " . $this->createParamaterList(count($sections)) . " AND";
             $params = array_merge($sections, $params);
         }
-        $orderBy="";
+        $orderBy = "";
         if($section_key == "registration_section") {
             $orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
         }
@@ -2155,10 +2155,10 @@ ORDER BY {$orderBy}", $params);
         $params = array($g_id);
         $sections_query = "";
         if (count($sections) > 0) {
-            $sections_query= "{$section_key} IN " . $this->createParamaterList(count($sections)) . " AND";
+            $sections_query = "{$section_key} IN " . $this->createParamaterList(count($sections)) . " AND";
             $params = array_merge($sections, $params);
         }
-        $orderBy="";
+        $orderBy = "";
         if($section_key == "registration_section") {
             $orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
         }
@@ -2583,7 +2583,7 @@ AND gc_id IN (
     }
 
     public function existsAnnouncements($show_deleted = false){
-        $query_delete = $show_deleted?"true":"deleted = false";
+        $query_delete = $show_deleted ? "true" : "deleted = false";
         $this->course_db->query("SELECT MAX(id) FROM threads where {$query_delete} AND  merged_thread_id = -1 AND pinned = true");
         $result = $this->course_db->rows();
         return empty($result[0]["max"]) ? -1 : $result[0]["max"];
@@ -2651,7 +2651,7 @@ AND gc_id IN (
     }
 
     public function getPostsForThread($current_user, $thread_id, $show_deleted = false, $option = "tree", $filterOnUser = null){
-        $query_delete = $show_deleted?"true":"deleted = false";
+        $query_delete = $show_deleted ? "true" : "deleted = false";
         $query_filter_on_user = '';
         $param_list = array();
         if (!empty($filterOnUser)) {
@@ -2711,7 +2711,7 @@ AND gc_id IN (
                 return false;
             }
 
-            $child_thread_title = "Merged Thread Title: ".$child_thread_title."\n";
+            $child_thread_title = "Merged Thread Title: " . $child_thread_title . "\n";
 
             if($child_root_post <= $parent_root_post) {
                 $message = "Child thread must be newer than parent thread";
@@ -2851,7 +2851,7 @@ AND gc_id IN (
     public function getUsersNotificationSettings(array $user_ids) {
         $params = $user_ids;
         $user_id_query = $this->createParamaterList(count($user_ids));
-        $query = "SELECT * FROM notification_settings WHERE user_id in ".$user_id_query;
+        $query = "SELECT * FROM notification_settings WHERE user_id in " . $user_id_query;
         $this->course_db->query($query,$params);
         return $this->course_db->rows();
     }
@@ -2926,7 +2926,7 @@ AND gc_id IN (
         $value_param_string = implode(', ', array_fill(0, $notification_count, $row_string));
         $this->course_db->query("
             INSERT INTO notifications(component, metadata, content, created_at, from_user_id, to_user_id)
-            VALUES ".$value_param_string, $flattened_notifications);
+            VALUES " . $value_param_string, $flattened_notifications);
 
     }
 
@@ -2941,7 +2941,7 @@ AND gc_id IN (
         $value_param_string = implode(', ', array_fill(0, $email_count, $row_string));
         $this->submitty_db->query("
             INSERT INTO emails(subject, body, created, user_id)
-            VALUES ".$value_param_string, $flattened_emails);
+            VALUES " . $value_param_string, $flattened_emails);
     }
 
     /**
@@ -3073,7 +3073,7 @@ AND gc_id IN (
     }
     public function getNumberGradeInquiries($gradeable_id, $is_grade_inquiry_per_component_allowed = true) {
         $grade_inquiry_all_only_query = !$is_grade_inquiry_per_component_allowed ? ' AND gc_id IS NULL' : '';
-        $this->course_db->query("SELECT COUNT(*) AS cnt FROM regrade_requests WHERE g_id = ? AND status = -1".$grade_inquiry_all_only_query, array($gradeable_id));
+        $this->course_db->query("SELECT COUNT(*) AS cnt FROM regrade_requests WHERE g_id = ? AND status = -1" . $grade_inquiry_all_only_query, array($gradeable_id));
         return ($this->course_db->row()['cnt']);
     }
     public function getRegradeDiscussions(array $grade_inquiries) {

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -45,7 +45,7 @@ class PostgresqlDatabase extends AbstractDatabase {
             $params[] = "dbname={$this->dbname}";
         }
 
-        return 'pgsql:'.implode(';', $params);
+        return 'pgsql:' . implode(';', $params);
     }
 
     /**
@@ -91,10 +91,10 @@ class PostgresqlDatabase extends AbstractDatabase {
                     $quot = $ch;
                 }
                 else if ($in_string && $ch == "\\" && strlen($text) > $i) {
-                    if ($text[$i+1] === "\\") {
+                    if ($text[$i + 1] === "\\") {
                         $element .= "\\";
                         $i++;
-                    } else if ($text[$i+1] === "\"") {
+                    } else if ($text[$i + 1] === "\"") {
                         $element .= "\"";
                         $i++;
                     } else {
@@ -184,7 +184,7 @@ class PostgresqlDatabase extends AbstractDatabase {
             }
             else if (is_string($e)) {
                 //Turn every \ into \\ that's either preceding a " another \ or the end
-                $elements[] = '"'. str_replace('"', '\"', preg_replace('/\\\\(?=["\\\\]|$)/', '\\\\\\\\', $e)) .'"';
+                $elements[] = '"' . str_replace('"', '\"', preg_replace('/\\\\(?=["\\\\]|$)/', '\\\\\\\\', $e)) . '"';
             }
             else if (is_bool($e)) {
                 $elements[] = ($e === true) ? "true" : "false";
@@ -193,7 +193,7 @@ class PostgresqlDatabase extends AbstractDatabase {
                 $elements[] = "{$e}";
             }
         }
-        $text = "{".implode(", ", $elements)."}";
+        $text = "{" . implode(", ", $elements) . "}";
         return $text;
     }
 

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -105,7 +105,7 @@ GROUP BY user_id", array($user_id));
     public function getAllUsers($section_key="registration_section") {
         $keys = array("registration_section", "rotating_section");
         $section_key = (in_array($section_key, $keys)) ? $section_key : "registration_section";
-        $orderBy="";
+        $orderBy = "";
         if($section_key == "registration_section") {
             $orderBy = "SUBSTRING(u.registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(u.registration_section, '[0-9]+')::INT, -1), SUBSTRING(u.registration_section, '[^0-9]*$'), u.user_id";
         }
@@ -299,7 +299,7 @@ WHERE semester=? AND course=? AND user_id=?", $params);
                       AND submissions.user_id = lde.user_id";
         if($user_id !== null) {
             if (is_array($user_id)) {
-                $query .= " WHERE submissions.user_id IN (".implode(", ", array_fill(0, count($user_id), '?')).")";
+                $query .= " WHERE submissions.user_id IN (" . implode(", ", array_fill(0, count($user_id), '?')) . ")";
                 $params = array_merge($params, $user_id);
             }
             else {
@@ -312,13 +312,13 @@ WHERE semester=? AND course=? AND user_id=?", $params);
     }
 
     public function getAverageComponentScores($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team) {
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $return = array();
         $this->course_db->query("
@@ -372,13 +372,13 @@ ORDER BY gc_order
     }
 
     public function getAverageAutogradedScores($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if($is_team){
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $this->course_db->query("
 SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) FROM(
@@ -400,13 +400,13 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
     }
 
     public function getAverageForGradeable($g_id, $section_key, $is_team) {
-        $u_or_t="u";
-        $users_or_teams="users";
-        $user_or_team_id="user_id";
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
         if ($is_team) {
-            $u_or_t="t";
-            $users_or_teams="gradeable_teams";
-            $user_or_team_id="team_id";
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
         }
         $this->course_db->query("SELECT COUNT(*) as cnt FROM gradeable_component WHERE g_id=?", array($g_id));
         $count = $this->course_db->row()['cnt'];
@@ -1003,7 +1003,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
                team.registration_section,
                team.rotating_section';
 
-            $submitter_inject ='
+            $submitter_inject = '
               JOIN (
                 SELECT gt.team_id,
                   gt.registration_section,

--- a/site/app/libraries/routers/AccessControl.php
+++ b/site/app/libraries/routers/AccessControl.php
@@ -80,7 +80,7 @@ class AccessControl {
      */
     public function __construct(array $data) {
         foreach ($data as $key => $value) {
-            $method = 'set'.str_replace('_', '', $key);
+            $method = 'set' . str_replace('_', '', $key);
             if (!method_exists($this, $method)) {
                 throw new \BadMethodCallException(sprintf('Unknown property "%s" on annotation "%s".', $key, \get_class($this)));
             }

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -145,7 +145,7 @@ abstract class AbstractModel {
             return $this->$property_name === true;
         }
 
-        throw new \BadMethodCallException('Call to undefined method '.__CLASS__.'::'.$name.'()');
+        throw new \BadMethodCallException('Call to undefined method ' . __CLASS__ . '::' . $name . '()');
     }
 
     /**
@@ -160,7 +160,7 @@ abstract class AbstractModel {
      */
     private function convertName($name, $prefix_length=3) {
         $regex_func = function ($matches) {
-            return "_".strtolower($matches[0]);
+            return "_" . strtolower($matches[0]);
         };
         $name = preg_replace_callback("/([A-Z])/", $regex_func, lcfirst((substr($name, $prefix_length))));
         return $name;

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -224,7 +224,7 @@ class Config extends AbstractModel {
 
     public function loadMasterConfigs($config_path) {
         if (!is_dir($config_path)) {
-            throw new ConfigException("Could not find config directory: ". $config_path, true);
+            throw new ConfigException("Could not find config directory: " . $config_path, true);
         }
         $this->config_path = $config_path;
         // Load config details from the master config file
@@ -286,20 +286,20 @@ class Config extends AbstractModel {
             $this->system_message = strval($submitty_json['system_message']);
         }
 
-        $this->base_url = rtrim($this->base_url, "/")."/";
+        $this->base_url = rtrim($this->base_url, "/") . "/";
 
         if (!empty($submitty_json['cgi_url'])){
-            $this->cgi_url = rtrim($submitty_json['cgi_url'], "/")."/";
+            $this->cgi_url = rtrim($submitty_json['cgi_url'], "/") . "/";
         }
         else {
-            $this->cgi_url = $this->base_url."cgi-bin/";
+            $this->cgi_url = $this->base_url . "cgi-bin/";
         }
 
         if (empty($submitty_json['vcs_url'])) {
             $this->vcs_url = $this->base_url . '{$vcs_type}/';
         }
         else {
-            $this->vcs_url = rtrim($submitty_json['vcs_url'], '/').'/';
+            $this->vcs_url = rtrim($submitty_json['vcs_url'], '/') . '/';
         }
 
         $this->cgi_tmp_path = FileUtils::joinPaths($this->submitty_path, "tmp", "cgi");
@@ -361,12 +361,12 @@ class Config extends AbstractModel {
         $this->course_path = FileUtils::joinPaths($this->getSubmittyPath(), "courses", $semester, $course);
 
         if (!file_exists($course_json_path)) {
-            throw new ConfigException("Could not find course config file: ".$course_json_path, true);
+            throw new ConfigException("Could not find course config file: " . $course_json_path, true);
         }
         $this->course_json_path = $course_json_path;
         $this->course_json = json_decode(file_get_contents($course_json_path), true);
         if ($this->course_json === null) {
-            throw new ConfigException("Error parsing the config file: ".json_last_error_msg());
+            throw new ConfigException("Error parsing the config file: " . json_last_error_msg());
         }
 
         if (!isset($this->course_json['database_details']) || !is_array($this->course_json['database_details'])) {
@@ -388,12 +388,12 @@ class Config extends AbstractModel {
             $this->vcs_base_url = $this->vcs_url . $this->semester . '/' . $this->course;
         }
 
-        $this->vcs_base_url = rtrim($this->vcs_base_url, "/")."/";
+        $this->vcs_base_url = rtrim($this->vcs_base_url, "/") . "/";
 
         if (isset($this->course_json['hidden_details'])) {
             $this->hidden_details = $this->course_json['hidden_details'];
             if (isset($this->course_json['hidden_details']['course_url'])) {
-                $this->base_url = rtrim($this->course_json['hidden_details']['course_url'], "/")."/";
+                $this->base_url = rtrim($this->course_json['hidden_details']['course_url'], "/") . "/";
             }
         }
 

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -55,13 +55,13 @@ class Course extends AbstractModel {
     public function getLongSemester() {
         if (strlen($this->semester) == 3) {
             if (strtolower($this->semester[0]) === 'f') {
-                return "Fall 20".substr($this->semester,1,2);
+                return "Fall 20" . substr($this->semester,1,2);
             }
             elseif (strtolower($this->semester[0]) === 's') {
-                return "Spring 20".substr($this->semester,1,2);
+                return "Spring 20" . substr($this->semester,1,2);
             }
             elseif (strtolower($this->semester[0]) === 'u') {
-                return "Summer 20".substr($this->semester,1,2);
+                return "Summer 20" . substr($this->semester,1,2);
             }
         }
         return $this->semester;

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -44,12 +44,12 @@ class Email extends AbstractModel {
     //inject course label into subject
     private function formatSubject($subject) {
         $course = $this->core->getConfig()->getCourse();
-        return "[Submitty $course]: ".$subject;
+        return "[Submitty $course]: " . $subject;
     }
 
     //inject a "do not reply" note in the footer of the body
     private function formatBody($body){
-        return $body."\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
+        return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
     }
 
 }

--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -69,7 +69,7 @@ class GradeableAutocheck extends AbstractModel {
             $this->display_as_sequence_diagram = false;
         }
 
-        $actual_file = $expected_file = $difference_file = $image_difference ="";
+        $actual_file = $expected_file = $difference_file = $image_difference = "";
 
         if(isset($details["actual_file"])) {
             $this->public = (isset($details["results_public"]) && $details["results_public"]);
@@ -91,7 +91,7 @@ class GradeableAutocheck extends AbstractModel {
                 }
             } else if(substr($details["expected_file"],0,13) == "random_output"){
                 if(file_exists($results_path . "/" . $details["expected_file"])){ 
-                    $expected_file = $results_path. "/" . $details["expected_file"];
+                    $expected_file = $results_path . "/" . $details["expected_file"];
                 } else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -164,13 +164,13 @@ class Notification extends AbstractModel {
         if($elapsed_time < 60){
             return "Less than a minute ago";
         } else if($elapsed_time < 3600){
-            $minutes = floor($elapsed_time/60);
+            $minutes = floor($elapsed_time / 60);
             if($minutes == 1)
                 return "1 minute ago";
             else
                 return "{$minutes} minutes ago";
-        } else if($elapsed_time < 3600*24){
-            $hours = floor($elapsed_time/3600);
+        } else if($elapsed_time < 3600 * 24){
+            $hours = floor($elapsed_time / 3600);
             if($hours == 1)
                 return "1 hour ago";
             else

--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -34,7 +34,7 @@ class NotificationFactory {
         $notifications = $this->createNotificationsArray($event,$recipients);
         $this->sendNotifications($notifications);
         if ($this->core->getConfig()->isEmailEnabled()) {
-            $emails =$this->createEmailsArray($event,$recipients);
+            $emails = $this->createEmailsArray($event,$recipients);
             $this->sendEmails($emails);
         }
     }
@@ -52,7 +52,7 @@ class NotificationFactory {
             $recipients = $this->core->getQueries()->getAllUsersWithPreference("all_new_threads_email");
             $recipients[] = $this->core->getUser()->getId();
             $recipients = array_unique($recipients);
-            $emails =$this->createEmailsArray($event,$recipients);
+            $emails = $this->createEmailsArray($event,$recipients);
             $this->sendEmails($emails);
         }
     }
@@ -81,7 +81,7 @@ class NotificationFactory {
             $email_recipients = array_merge($parent_authors, $users_with_email_preference, $thread_authors_email_preference);
             $email_recipients[] = $current_user_id;
             $email_recipients = array_unique($email_recipients);
-            $emails =$this->createEmailsArray($event,$email_recipients);
+            $emails = $this->createEmailsArray($event,$email_recipients);
             $this->sendEmails($emails);
         }
     }
@@ -99,7 +99,7 @@ class NotificationFactory {
         $this->sendNotifications($notifications);
 
         if ($this->core->getConfig()->isEmailEnabled()) {
-            $email_recipients =  $this->core->getQueries()->getAllUsersWithPreference($event['preference'].'_email');
+            $email_recipients =  $this->core->getQueries()->getAllUsersWithPreference($event['preference'] . '_email');
             $email_recipients[] = $event['recipient'];
             $email_recipients[] = $this->core->getUser()->getId();
             $email_recipients = array_unique($email_recipients);
@@ -130,7 +130,7 @@ class NotificationFactory {
             if ($user_settings[$event['type']]) {
                 $notification_recipients[] = $recipient;
             }
-            if ($user_settings[$event['type'].'_email']) {
+            if ($user_settings[$event['type'] . '_email']) {
                 $email_recipients[] = $recipient;
             }
         }
@@ -208,7 +208,7 @@ class NotificationFactory {
         if (!empty($flattened_notifications)) {
             // some notifications may not have been added to the flattened notifications
             // so to calculate the number of notifications we must use flattened notifications
-            $this->core->getQueries()->insertNotifications($flattened_notifications,count($flattened_notifications)/5);
+            $this->core->getQueries()->insertNotifications($flattened_notifications,count($flattened_notifications) / 5);
         }
 
     }
@@ -239,7 +239,7 @@ class NotificationFactory {
             }
         }
         if (!empty($flattened_emails)) {
-            $this->core->getQueries()->insertEmails($flattened_emails,count($flattened_emails)/3);
+            $this->core->getQueries()->insertEmails($flattened_emails,count($flattened_emails) / 3);
         }
 
     }

--- a/site/app/models/OfficeHoursQueueStudent.php
+++ b/site/app/models/OfficeHoursQueueStudent.php
@@ -75,23 +75,23 @@ class OfficeHoursQueueStudent extends AbstractModel {
 
 
     public function getTimeBeingHelped(){
-        $diff = strtotime($this->time_out_iso)-strtotime($this->time_helped_iso);
+        $diff = strtotime($this->time_out_iso) - strtotime($this->time_helped_iso);
         $h = $diff / 3600 % 24;
         $m = $diff / 60 % 60;
         $s = $diff % 60;
-        return $h."h ".$m."m ".$s."s";
+        return $h . "h " . $m . "m " . $s . "s";
     }
 
     public function getTimeWaitingInQueue(){
         if($this->status  == 2){
-            $diff = strtotime($this->time_helped_iso)-strtotime($this->time_in_iso);
+            $diff = strtotime($this->time_helped_iso) - strtotime($this->time_in_iso);
         }else{
-            $diff = strtotime($this->time_out_iso)-strtotime($this->time_in_iso);
+            $diff = strtotime($this->time_out_iso) - strtotime($this->time_in_iso);
         }
         $h = $diff / 3600 % 24;
         $m = $diff / 60 % 60;
         $s = $diff % 60;
-        return $h."h ".$m."m ".$s."s";
+        return $h . "h " . $m . "m " . $s . "s";
     }
 
     public function getRemovedBy(){

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -88,7 +88,7 @@ class RainbowCustomization extends AbstractModel {
             $max_score = $gradeable->getTAPoints();
             //If the gradeable has autograding points, load the config and add the non-extra-credit autograder total
             if ($gradeable->hasAutogradingConfig()){
-                $last_index = count($this->customization_data[$bucket])-1;
+                $last_index = count($this->customization_data[$bucket]) - 1;
                 $max_score += $gradeable->getAutogradingConfig()->getTotalNonExtraCredit();
             }
 

--- a/site/app/models/forum/Forum.php
+++ b/site/app/models/forum/Forum.php
@@ -88,7 +88,7 @@ class Forum extends AbstractModel {
 
     private function sendEmailAnnouncement(Thread $thread) {
         $class_list = $this->core->getQueries()->getEmailListWithIds();
-        $formatted_body = "An Instructor/TA made an announcement in the Submitty discussion forum:\n\n".$thread->getContent();
+        $formatted_body = "An Instructor/TA made an announcement in the Submitty discussion forum:\n\n" . $thread->getContent();
 
         foreach($class_list as $user) {
             $user_id = $user['user_id'];

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -515,7 +515,7 @@ class Gradeable extends AbstractModel {
             // Only add in submission due date if student submission is enabled
             if ($this->isStudentSubmit() && $this->hasDueDate()) {
                 // Make sure we insert the due date into the correct location (after the open date)
-                array_splice($result, array_search('submission_open_date', $result)+1, 0, 'submission_due_date');
+                array_splice($result, array_search('submission_open_date', $result) + 1, 0, 'submission_due_date');
             }
 
             // Only add in grade inquiry date if its allowed & enabled
@@ -573,7 +573,7 @@ class Gradeable extends AbstractModel {
                 }
 
                 // Get a value for the date to compare against
-                $prev_date = $date_values[$date_properties[$i-1]];
+                $prev_date = $date_values[$date_properties[$i - 1]];
 
                 // This may be null / not set
                 $date = $date_values[$property] ?? null;
@@ -1040,7 +1040,7 @@ class Gradeable extends AbstractModel {
         $num_sections = $this->core->getQueries()->getNumberRotatingSections();
 
         $parsed_graders_sections = [];
-        foreach($rotating_grader_sections as $user=>$grader_sections) {
+        foreach($rotating_grader_sections as $user => $grader_sections) {
             if($grader_sections !== null) {
                 if(!is_array($grader_sections)) {
                     throw new \InvalidArgumentException('Rotating grader section for grader was not array');
@@ -1603,7 +1603,7 @@ class Gradeable extends AbstractModel {
      * @return bool
      */
     public function isRegradeOpen() {
-        if ($this->core->getConfig()->isRegradeEnabled()==true && $this->isTaGradeReleased() && $this->regrade_allowed && ($this->regrade_request_date > $this->core->getDateTimeNow())) {
+        if ($this->core->getConfig()->isRegradeEnabled() == true && $this->isTaGradeReleased() && $this->regrade_allowed && ($this->regrade_request_date > $this->core->getDateTimeNow())) {
             return true;
         }
         return false;

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -143,7 +143,7 @@ class AutoGradingView extends AbstractView {
                     "name" => $file_name,
                     "path" => $file_path,
                     "url" => $this->core->buildCourseUrl(['display_file']) . '?' . http_build_query([
-                        "dir" => $public ? "results_public": "results",
+                        "dir" => $public ? "results_public" : "results",
                         "file" => $file_name,
                         "path" => $file_path
                     ])
@@ -334,7 +334,7 @@ class AutoGradingView extends AbstractView {
         $late_days_url = $this->core->buildCourseUrl(['late_table']);
         $regrade_allowed = $gradeable->isRegradeAllowed();
         $regrade_date = $gradeable->getRegradeRequestDate();
-        $regrade_date=DateUtils::dateTimeToString($gradeable->getRegradeRequestDate());
+        $regrade_date = DateUtils::dateTimeToString($gradeable->getRegradeRequestDate());
         // Get the number of decimal places for floats to display nicely
         $num_decimals = 0;
         $precision_parts = explode('.', strval($gradeable->getPrecision()));
@@ -400,9 +400,9 @@ class AutoGradingView extends AbstractView {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = $pdf_info[0];
-                        if(file_get_contents($fileinfo->getPathname())!=""){
-                            $pdf_id=$pdf_id.'.pdf';
-                            $annotated_file_names[]=$pdf_id;
+                        if(file_get_contents($fileinfo->getPathname()) != ""){
+                            $pdf_id = $pdf_id . '.pdf';
+                            $annotated_file_names[] = $pdf_id;
                         }
                     }
                 }
@@ -418,7 +418,7 @@ class AutoGradingView extends AbstractView {
 
 
         return $this->core->getOutput()->renderTwigTemplate('autograding/TAResults.twig', [
-            'files'=> $files,
+            'files' => $files,
             'been_ta_graded' => $ta_graded_gradeable->isComplete(),
             'ta_graded_version' => $version_instance !== null ? $version_instance->getVersion() : 'INCONSISTENT',
             'any_late_days_used' => $version_instance !== null ? $version_instance->getDaysLate() > 0 : false,
@@ -441,7 +441,7 @@ class AutoGradingView extends AbstractView {
             'uploaded_pdfs' => $uploaded_pdfs,
             'user_id' => $this->core->getUser()->getId(),
             'gradeable_id' => $gradeable->getId(),
-            'can_download' =>$can_download,
+            'can_download' => $can_download,
             'display_version' => $display_version,
             'student_pdf_view_url' => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'pdf']),
             "annotated_file_names" =>  $annotated_file_names

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -30,7 +30,7 @@ class GlobalView extends AbstractView {
         if ($this->core->getUser() === null) {
             $page_title = "Submitty Login";
         } else if ($this->core->getConfig()->isCourseLoaded()) {
-            $page_title = "Submitty ".$course_name." ".$page_name;
+            $page_title = "Submitty " . $course_name . " " . $page_name;
         }
 
         $config_data = json_decode(file_get_contents("/usr/local/submitty/config/submitty.json"), true);

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -410,7 +410,7 @@ class NavigationView extends AbstractView {
 
 
             //If the button is autograded and has been submitted once, give a progress bar.
-            if (!is_nan($points_percent) &&  $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
+            if (!is_nan($points_percent) && $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
                 ($list_section == GradeableList::CLOSED || $list_section == GradeableList::OPEN)) {
                 $progress = $points_percent * 100;
             }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -545,10 +545,10 @@ class NavigationView extends AbstractView {
     private function getGradeButton(Gradeable $gradeable, int $list_section) {
         //Location, location never changes
         if($this->core->getUser()->accessAdmin()){
-            $view="all";
+            $view = "all";
         }
         else{
-            $view=null;
+            $view = null;
         }
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'status']);
@@ -744,7 +744,7 @@ class NavigationView extends AbstractView {
 
             $button = new Button($this->core, [
                 "subtitle" => "CLOSE SUBMISSIONS NOW",
-                "onclick" => "displayCloseSubmissionsWarning(\"".$url."\",\"".$gradeable->getTitle()."\");",
+                "onclick" => "displayCloseSubmissionsWarning(\"" . $url . "\",\"" . $gradeable->getTitle() . "\");",
                 "class" => "btn btn-default btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -27,12 +27,12 @@ HTML;
 
             $delete_form_action = $this->core->buildCourseUrl(['plagiarism', 'gradeable', $id, 'delete']);
 
-            if(file_exists($course_path."/lichen/ranking/".$id.".txt")) {
-                $timestamp = date("F d Y H:i:s.",filemtime($course_path."/lichen/ranking/".$id.".txt"));
-                $students = array_diff(scandir($course_path."/lichen/concatenated/".$id), array('.', '..'));
-                $submissions =0;
+            if(file_exists($course_path . "/lichen/ranking/" . $id . ".txt")) {
+                $timestamp = date("F d Y H:i:s.",filemtime($course_path . "/lichen/ranking/" . $id . ".txt"));
+                $students = array_diff(scandir($course_path . "/lichen/concatenated/" . $id), array('.', '..'));
+                $submissions = 0;
                 foreach($students as $student) {
-                    $submissions += count(array_diff(scandir($course_path."/lichen/concatenated/".$id."/".$student), array('.', '..')));
+                    $submissions += count(array_diff(scandir($course_path . "/lichen/concatenated/" . $id . "/" . $student), array('.', '..')));
                 }
                 $students = count($students);
             }
@@ -41,8 +41,8 @@ HTML;
                 $students = "N/A";
                 $submissions = "N/A";
             }
-            $night_rerun_status= "";
-            if($nightly_rerun_info[$id] ==true) {
+            $night_rerun_status = "";
+            if($nightly_rerun_info[$id] == true) {
                 $night_rerun_status = "checked";
             }
 
@@ -90,9 +90,9 @@ HTML;
 
             #no lichen job
             else {
-                $ranking_file_path= "/var/local/submitty/courses/".$semester."/".$course."/lichen/ranking/".$id.".txt";
+                $ranking_file_path = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $id . ".txt";
                 if(file_get_contents($ranking_file_path) == "") {
-                    $matches_and_topmatch= "0 students matched, N/A top match";
+                    $matches_and_topmatch = "0 students matched, N/A top match";
 
                     $return .= <<<HTML
         <tr>
@@ -101,11 +101,11 @@ HTML;
 HTML;
                 }
                 else {
-                    $content =file_get_contents($ranking_file_path);
+                    $content = file_get_contents($ranking_file_path);
                     $content = trim(str_replace(array("\r", "\n"), '', $content));
                     $rankings = preg_split('/ +/', $content);
                     $rankings = array_chunk($rankings,3);
-                    $matches_and_topmatch = count($rankings)." students matched, ".$rankings[0][0]." top match";
+                    $matches_and_topmatch = count($rankings) . " students matched, " . $rankings[0][0] . " top match";
 
                     $return .= <<<HTML
         <tr>
@@ -434,51 +434,51 @@ HTML;
         $course = $this->core->getConfig()->getCourse();
 
         #default values for the form
-        $gradeable_id="";
-        $all_version="checked";
-        $active_version="";
-        $all_files="checked";
-        $regex_matching_files="";
-        $regex="";
-        $language =["python"=>"selected", "java"=>"", "plaintext"=>"", "cpp"=>""];
-        $provided_code="";
-        $no_provided_code="checked";
-        $provided_code_filename="";
-        $threshold="5";
-        $sequence_length="10";
-        $prior_term_gradeables_number = $saved_config['prev_term_gradeables'] ? count($saved_config['prev_term_gradeables'])+1 : 1;
-        $ignore_submission_number = $saved_config['ignore_submissions'] ? count($saved_config['ignore_submissions'])+1 : 1;
-        $ignore="";
-        $no_ignore="checked";
+        $gradeable_id = "";
+        $all_version = "checked";
+        $active_version = "";
+        $all_files = "checked";
+        $regex_matching_files = "";
+        $regex = "";
+        $language = ["python" => "selected", "java" => "", "plaintext" => "", "cpp" => ""];
+        $provided_code = "";
+        $no_provided_code = "checked";
+        $provided_code_filename = "";
+        $threshold = "5";
+        $sequence_length = "10";
+        $prior_term_gradeables_number = $saved_config['prev_term_gradeables'] ? count($saved_config['prev_term_gradeables']) + 1 : 1;
+        $ignore_submission_number = $saved_config['ignore_submissions'] ? count($saved_config['ignore_submissions']) + 1 : 1;
+        $ignore = "";
+        $no_ignore = "checked";
 
 
         #values which are in saved configuration
         if($new_or_edit == "edit") {
             $gradeable_id = $saved_config['gradeable'];
-            $all_version = ($saved_config['version'] == "all_version")?"checked":"";
-            $active_version = ($saved_config['version'] == "active_version")?"checked":"";
+            $all_version = ($saved_config['version'] == "all_version") ? "checked" : "";
+            $active_version = ($saved_config['version'] == "active_version") ? "checked" : "";
             if($saved_config['file_option'] == "matching_regex") {
-                $all_files="";
-                $regex_matching_files="checked";
-                $regex=$saved_config['regex'];
+                $all_files = "";
+                $regex_matching_files = "checked";
+                $regex = $saved_config['regex'];
             }
             $language[$saved_config['language']] = "selected";
 
             if($saved_config["instructor_provided_code"] == true) {
                 $provided_code_filename_array = (array_diff(scandir($saved_config["instructor_provided_code_path"]), array(".", "..")));
                 foreach($provided_code_filename_array as $filename) {
-                    $provided_code_filename= $filename;
+                    $provided_code_filename = $filename;
                 }
-                $provided_code="checked";
-                $no_provided_code="";
+                $provided_code = "checked";
+                $no_provided_code = "";
             }
 
             $threshold = $saved_config['threshold'];
             $sequence_length = $saved_config['sequence_length'];
 
             if(count($saved_config['ignore_submissions']) > 0) {
-                $ignore="checked";
-                $no_ignore="";
+                $ignore = "checked";
+                $no_ignore = "";
             }
         }
 
@@ -598,7 +598,7 @@ HTML;
                 <div style="width:20%;float:left">Prior Terms Gradeables:</div>
                 <div style="width:70%;float:right;overflow:auto;" name= "prev_gradeable_div">
 HTML;
-        $count=0;
+        $count = 0;
         if($new_or_edit == "edit") {
             foreach ($saved_config['prev_term_gradeables'] as $saved_prev_term_gradeable_path) {
                 $saved_prev_sem = strrev((explode("/", strrev($saved_prev_term_gradeable_path)))[3]);
@@ -696,7 +696,7 @@ HTML;
                     <label for="ignore_id">Yes</label><br />
 HTML;
 
-        $count=0;
+        $count = 0;
         if($new_or_edit == "edit") {
             foreach ($saved_config['ignore_submissions'] as $saved_ignore_submission) {
                 $return .= <<<HTML

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -100,7 +100,7 @@ class UsersView extends AbstractView {
         foreach ($students as $student) {
             $registration = ($student->getRegistrationSection() === null) ? "NULL" : $student->getRegistrationSection();
             if (array_key_exists($registration, $reg_sections_count)) {
-                $reg_sections_count[$registration] = $reg_sections_count[$registration]+1;
+                $reg_sections_count[$registration] = $reg_sections_count[$registration] + 1;
             }
             else {
                 $reg_sections_count[$registration] = 1;

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -82,7 +82,7 @@ class CourseMaterialsView extends AbstractView {
                     $ex_file_path['checked'] = '1';
                     $isShareToOther = $ex_file_path['checked'];
                     $date = $now_date_time->format("Y-m-d H:i:sO");
-                    $date=substr_replace($date,"9999",0,4);
+                    $date = substr_replace($date,"9999",0,4);
                     $ex_file_path['release_datetime'] = $date;
                     $ex_file_path['hide_from_students'] = "on";
                     $releaseData = $ex_file_path['release_datetime'];
@@ -116,9 +116,9 @@ class CourseMaterialsView extends AbstractView {
                 if( $releaseData == $now_date_time->format("Y-m-d H:i:sO")){
                     //for uploaded files that have had no manually set date to be set to never and maintained as never
                     //also permission set to yes
-                    $releaseData=substr_replace($releaseData,"9999",0,4);
-                    $json[$expected_file_path]['checked']='1';
-                    $json[$expected_file_path]['release_datetime']= $releaseData;
+                    $releaseData = substr_replace($releaseData,"9999",0,4);
+                    $json[$expected_file_path]['checked'] = '1';
+                    $json[$expected_file_path]['release_datetime'] = $releaseData;
                 }
                 $file_release_dates[$expected_file_path] = $releaseData;
             }
@@ -126,7 +126,7 @@ class CourseMaterialsView extends AbstractView {
             if($json == false){
                 FileUtils::writeJsonFile($fp,$no_json);
             }
-            $can_write =is_writable($fp);
+            $can_write = is_writable($fp);
             if(!$can_write){
                 $core->addErrorMessage("This json does not have write permissions, and therefore you cannot change the release date. Please change the permissions or contact someone who can.");
             }
@@ -141,7 +141,7 @@ class CourseMaterialsView extends AbstractView {
         //Get the expected course materials path and files
         $upload_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads");
         $expected_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "course_materials");
-        $path_length = strlen($expected_path)+1;
+        $path_length = strlen($expected_path) + 1;
         $course_materials_array = FileUtils::getAllFilesTrimSearchPath($expected_path, $path_length);
         $this->core->getOutput()->addInternalJs("drag-and-drop.js");
         //Sort the files/folders in alphabetical order

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -55,7 +55,7 @@ class ForumThreadView extends AbstractView {
 
             $thread_link = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
 
-            $thread_list[$count-1] = array("thread_title" => $thread_title, "thread_link" => $thread_link, "posts" => array());
+            $thread_list[$count - 1] = array("thread_title" => $thread_title, "thread_link" => $thread_link, "posts" => array());
 
             foreach($data as $post) {
                 $author = $post['author'];
@@ -80,7 +80,7 @@ class ForumThreadView extends AbstractView {
 
                 $posted_on = date_format(DateUtils::parseDateTime($post['timestamp_post'], $this->core->getConfig()->getTimezone()), "n/j g:i A");
 
-                $thread_list[$count-1]["posts"][] = array(
+                $thread_list[$count - 1]["posts"][] = array(
                     "post_link" => $post_link,
                     "count" => $count,
                     "post_content" => $post_content,
@@ -116,7 +116,7 @@ class ForumThreadView extends AbstractView {
             return;
         }
         $threadExists = $this->core->getQueries()->threadExists();
-        $filteredThreadExists = (count($threadsHead)>0);
+        $filteredThreadExists = (count($threadsHead) > 0);
         $currentThread = -1;
         $currentCategoriesIds = array();
         $show_deleted_thread_title = null;
@@ -304,8 +304,8 @@ class ForumThreadView extends AbstractView {
             $button_params["more_data"] = $more_data;
             $button_params["forum_bar_buttons_left"] = $other_buttons;
             $next_page = $initialPageNumber + 1;
-            $prev_page = ($initialPageNumber == 1)?0:($initialPageNumber - 1);
-            $arrowup_visibility = ($initialPageNumber == 1)?"display:none;":"";
+            $prev_page = ($initialPageNumber == 1) ? 0 : ($initialPageNumber - 1);
+            $arrowup_visibility = ($initialPageNumber == 1) ? "display:none;" : "";
             $activeThreadAnnouncement = false;
             $activeThreadTitle = "";
             $activeThread = array();
@@ -380,7 +380,7 @@ class ForumThreadView extends AbstractView {
                 "post_content_limit" => $post_content_limit
             ]);
 
-            $return = $this->core->getOutput()->renderJsonSuccess(["html"=> json_encode($return)]);
+            $return = $this->core->getOutput()->renderJsonSuccess(["html" => json_encode($return)]);
         }
 
         return $return;
@@ -413,18 +413,18 @@ class ForumThreadView extends AbstractView {
                     $thread_id = $post["thread_id"];
                 }
                 if($first){
-                    $first= false;
+                    $first = false;
                     $first_post_id = $post["id"];
                 }
                 if($post["parent_id"] > $first_post_id){
                     $place = array_search($post["parent_id"], $order_array);
                     $tmp_array = array($post["id"]);
                     $parent_reply_level = $reply_level_array[$place];
-                    while($place && $place+1 < count($reply_level_array) && $reply_level_array[$place+1] > $parent_reply_level){
+                    while($place && $place + 1 < count($reply_level_array) && $reply_level_array[$place + 1] > $parent_reply_level){
                         $place++;
                     }
-                    array_splice($order_array, $place+1, 0, $tmp_array);
-                    array_splice($reply_level_array, $place+1, 0, $parent_reply_level+1);
+                    array_splice($order_array, $place + 1, 0, $tmp_array);
+                    array_splice($reply_level_array, $place + 1, 0, $parent_reply_level + 1);
                 } else {
                     array_push($order_array, $post["id"]);
                     array_push($reply_level_array, 1);
@@ -448,7 +448,7 @@ class ForumThreadView extends AbstractView {
                     }
                 }
                 if($first){
-                    $first= false;
+                    $first = false;
                 }
                 $i++;
             }
@@ -463,7 +463,7 @@ class ForumThreadView extends AbstractView {
                 $post_data[] = $this->createPost($thread_id, $post, $unviewed_posts, $function_date, $first, 1, $display_option, $includeReply, $totalAttachments);
 
                 if($first){
-                    $first= false;
+                    $first = false;
                 }
             }
         }
@@ -623,7 +623,7 @@ class ForumThreadView extends AbstractView {
                 $first_post_content = $temp_first_post_content;
             }
 
-            if($first_post['render_markdown']==1) {
+            if($first_post['render_markdown'] == 1) {
                 $first_post_content = $this->contentMarkdownToPlain($first_post_content);
             }
 
@@ -736,7 +736,7 @@ class ForumThreadView extends AbstractView {
                 $decoded_url = filter_var(trim(strip_tags(html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8'))), FILTER_SANITIZE_URL);
                 $parsed_url = parse_url($decoded_url, PHP_URL_SCHEME);
                 if(filter_var($decoded_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== false && in_array($parsed_url, $accepted_schemes, true)){
-                    $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', '<a href="' . htmlspecialchars($decoded_url, ENT_QUOTES) . '" target="_blank" rel="noopener nofollow">'. $result[2][$pos] .'</a>', $post_content, 1);
+                    $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', '<a href="' . htmlspecialchars($decoded_url, ENT_QUOTES) . '" target="_blank" rel="noopener nofollow">' . $result[2][$pos] . '</a>', $post_content, 1);
                 } else {
                     $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', htmlentities(htmlspecialchars($decoded_url), ENT_QUOTES | ENT_HTML5, 'UTF-8'), $post_content, 1);
                 }
@@ -894,7 +894,7 @@ class ForumThreadView extends AbstractView {
             foreach ($files as $file) {
                 $path = rawurlencode($file['path']);
                 $name = rawurlencode($file['name']);
-                $url = $this->core->buildCourseUrl(['display_file']).'?dir=forum_attachments&path='.$path;
+                $url = $this->core->buildCourseUrl(['display_file']) . '?dir=forum_attachments&path=' . $path;
 
                 $post_attachment["files"][] = [
                     "file_viewer_id" => "file_viewer_" . $post_id . "_" . $attachment_file_count

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -102,35 +102,35 @@ class ElectronicGraderView extends AbstractView {
                 $total_students = $total_submissions;
             }
             $num_components = count($gradeable->getNonPeerComponents());
-            $submitted_total = $total/$num_components;
-            $graded_total = round($graded/$num_components, 2);
+            $submitted_total = $total / $num_components;
+            $graded_total = round($graded / $num_components, 2);
             if($peer) {
                 $num_components = count($gradeable->getPeerComponents()) * $gradeable->getPeerGradeSet();
-                $graded_total = $graded/$num_components;
-                $submitted_total = $total/$num_components;
+                $graded_total = $graded / $num_components;
+                $submitted_total = $total / $num_components;
             }
-            if($total_submissions!=0){
+            if($total_submissions != 0){
                 $submitted_percentage = round(($submitted_total / $total_submissions) * 100, 1);
             }
             //Add warnings to the warnings array to display them to the instructor.
             $warnings = array();
             if($section_type === "rotating_section" && $show_warnings){
                 if ($registered_but_not_rotating > 0){
-                    array_push($warnings, "There are ".$registered_but_not_rotating." registered students without a rotating section.");
+                    array_push($warnings, "There are " . $registered_but_not_rotating . " registered students without a rotating section.");
                 }
                 if($rotating_but_not_registered > 0){
-                    array_push($warnings, "There are ".$rotating_but_not_registered." unregistered students with a rotating section.");
+                    array_push($warnings, "There are " . $rotating_but_not_registered . " unregistered students with a rotating section.");
                 }
             }
 
             if($gradeable->isTeamAssignment()){
-                $team_percentage = $total_students != 0 ? round(($team_total/$total_students) * 100, 1) : 0;
+                $team_percentage = $total_students != 0 ? round(($team_total / $total_students) * 100, 1) : 0;
             }
             if ($peer) {
                 $peer_count = count($gradeable->getPeerComponents());
-                $peer_total = floor($sections['stu_grad']['total_components']/$peer_count);
-                $peer_graded = floor($sections['stu_grad']['graded_components']/$peer_count);
-                $peer_percentage = number_format(($sections['stu_grad']['graded_components']/$sections['stu_grad']['total_components']) * 100, 1);
+                $peer_total = floor($sections['stu_grad']['total_components'] / $peer_count);
+                $peer_graded = floor($sections['stu_grad']['graded_components'] / $peer_count);
+                $peer_percentage = number_format(($sections['stu_grad']['graded_components'] / $sections['stu_grad']['total_components']) * 100, 1);
             } else {
                 foreach ($sections as $key => &$section) {
                     if ($section['total_components'] == 0) {
@@ -138,17 +138,17 @@ class ElectronicGraderView extends AbstractView {
                     } else {
                         $section['percentage'] = number_format(($section['graded_components'] / $section['total_components']) * 100, 1);
                     }
-                    $section['graded'] = round($section['graded_components']/$num_components, 1);
-                    $section['total'] = $section['total_components']/$num_components;
+                    $section['graded'] = round($section['graded_components'] / $num_components, 1);
+                    $section['total'] = $section['total_components'] / $num_components;
 
                 }
                 unset($section); // Clean up reference
 
                 if ($gradeable->isTaGradeReleased()) {
-                    $viewed_total = $total/$num_components;
+                    $viewed_total = $total / $num_components;
                     $viewed_percent = number_format(($viewed_grade / max($viewed_total, 1)) * 100, 1);
                     $individual_viewed_percent = $total_students_submitted == 0 ? 0 :
-                        number_format(($individual_viewed_grade/$total_students_submitted)*100,1);
+                        number_format(($individual_viewed_grade / $total_students_submitted) * 100,1);
                 }
             }
             if(!$peer) {
@@ -192,7 +192,7 @@ class ElectronicGraderView extends AbstractView {
             if ($gradeable->isTeamAssignment()) {
                 $valid_teams_or_students = 0;
                 foreach ($sections as $section) {
-                    $valid_teams_or_students+= $section['no_team']+$section['team'];
+                    $valid_teams_or_students += $section['no_team'] + $section['team'];
                 }
                 $no_rotating_sections = $valid_teams_or_students === 0;
             }
@@ -610,10 +610,10 @@ HTML;
                 if ($value != null) {
                     $not_viewed_yet = false;
                     $date_object = new \DateTime($value);
-                    $hover_over_string.= "Viewed by ".$user." at ".$date_object->format('F d, Y g:i')."\n";
+                    $hover_over_string .= "Viewed by " . $user . " at " . $date_object->format('F d, Y g:i') . "\n";
                 }
                 else {
-                    $hover_over_string.= "Not viewed by ".$user."\n";
+                    $hover_over_string .= "Not viewed by " . $user . "\n";
                 }
             }
 
@@ -689,7 +689,7 @@ HTML;
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
     public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $sort, $direction, $from) {
         $peer = false;
-        if($this->core->getUser()->getGroup()==User::GROUP_STUDENT && $gradeable->isPeerGrading()) {
+        if($this->core->getUser()->getGroup() == User::GROUP_STUDENT && $gradeable->isPeerGrading()) {
             $peer = true;
         }
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('mermaid', 'mermaid.min.js'));
@@ -1013,7 +1013,7 @@ HTML;
     public function renderRegradePanel(GradedGradeable $graded_gradeable, bool $can_inquiry) {
         return  $this->core->getOutput()->renderTwigTemplate("grading/electronic/RegradePanel.twig", [
             "graded_gradeable" => $graded_gradeable,
-            "can_inquiry" =>$can_inquiry
+            "can_inquiry" => $can_inquiry
         ]);
     }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -205,8 +205,8 @@ class HomeworkView extends AbstractView {
                     $messages[] = ['type' => 'would_get_zero'];
                 } // SUBMISSION NOW WOULD BE LATE
                 else {
-                    $new_late_charged = max(0,$would_be_days_late-$active_days_late - $extensions);
-                    $new_late_days_remaining = $late_days_remaining-$new_late_charged;
+                    $new_late_charged = max(0,$would_be_days_late - $active_days_late - $extensions);
+                    $new_late_days_remaining = $late_days_remaining - $new_late_charged;
                     $messages[] = ['type' => 'would_allowed', 'info' => [
                         'charged' => $new_late_charged,
                         'remaining' => $new_late_days_remaining
@@ -251,7 +251,7 @@ class HomeworkView extends AbstractView {
             $active_version_instance = $graded_gradeable->getAutoGradedGradeable()->getActiveVersionInstance();
         }
         $active_days_late =  $active_version_instance !== null ? $active_version_instance->getDaysLate() : 0;
-        $days_to_be_charged = $would_be_days_late-$active_days_late;
+        $days_to_be_charged = $would_be_days_late - $active_days_late;
         $old_files = [];
         $display_version = 0;
 
@@ -831,7 +831,7 @@ class HomeworkView extends AbstractView {
             'make_request_post_url' => $make_regrade_post_url,
             'has_submission' => $graded_gradeable->hasSubmission(),
             'submitter_id' => $graded_gradeable->getSubmitter()->getId(),
-            'g_id' =>$graded_gradeable->getGradeable()->getId(),
+            'g_id' => $graded_gradeable->getGradeable()->getId(),
             'regrade_message' => $regrade_message,
             'can_inquiry' => $can_inquiry,
             'is_grading' => $this->core->getUser()->accessGrading(),

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -27,7 +27,7 @@ session_start();
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-$loader = require_once(__DIR__.'/../vendor/autoload.php');
+$loader = require_once(__DIR__ . '/../vendor/autoload.php');
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
 $request = Request::createFromGlobals();

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -252,8 +252,8 @@ class SubmissionControllerTester extends BaseUnitTest {
      * @param int    $part
      */
     private function addUploadFile($filename, $content="", $part=1) {
-        FileUtils::createDir(FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part'.$part), true, 0777);
-        $filepath = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part'.$part, $filename);
+        FileUtils::createDir(FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part' . $part), true, 0777);
+        $filepath = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part' . $part, $filename);
         if (file_put_contents($filepath, $content) === false) {
             throw new IOException("Could not write file to {$filepath}");
         }
@@ -274,15 +274,15 @@ class SubmissionControllerTester extends BaseUnitTest {
      * @param int    $part
      */
     private function addUploadZip($zip_name, $files, $part=1) {
-        $part_path = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part'.$part);
+        $part_path = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part' . $part);
         $root_path = FileUtils::joinPaths($part_path, $zip_name);
         FileUtils::createDir($root_path, true, 0777);
-        $zip_path =  FileUtils::joinPaths($part_path, $zip_name.'.zip');
+        $zip_path =  FileUtils::joinPaths($part_path, $zip_name . '.zip');
         $zip = new ZipArchive();
         $zip->open($zip_path, ZipArchive::CREATE || ZipArchive::OVERWRITE);
         $this->createZip($files, $zip, $root_path);
         $zip->close();
-        $_FILES["files{$part}"]['name'][] = $zip_name.'.zip';
+        $_FILES["files{$part}"]['name'][] = $zip_name . '.zip';
         $_FILES["files{$part}"]['type'][] = mime_content_type($zip_path);
         $_FILES["files{$part}"]['size'][] = filesize($zip_path);
         $_FILES["files{$part}"]['tmp_name'][] = $zip_path;
@@ -987,7 +987,7 @@ class SubmissionControllerTester extends BaseUnitTest {
         sort($files);
         $this->assertEquals(array('.submit.VCS_CHECKOUT', '.submit.timestamp'), $files);
         $touch_file = implode("__", array($this->config['semester'], $this->config['course'], "test", "testUser", "1"));
-        $this->assertFileExists(FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_queue", "VCS__".$touch_file));
+        $this->assertFileExists(FileUtils::joinPaths($this->config['tmp_path'], "to_be_graded_queue", "VCS__" . $touch_file));
     }
 
     public function testEmptyPost() {
@@ -1104,7 +1104,7 @@ class SubmissionControllerTester extends BaseUnitTest {
     }
 
     public function testErrorPreviousFilesFirstVersion() {
-        $_POST['previous_files'] = json_encode(array(0=>array('test.txt')));
+        $_POST['previous_files'] = json_encode(array(0 => array('test.txt')));
 
         $controller = new SubmissionController($this->core);
         $return = $controller->ajaxUploadSubmission('test');
@@ -1228,7 +1228,7 @@ class SubmissionControllerTester extends BaseUnitTest {
             $this->fail('cannot open the file');
         }
         $stat = fstat($fh);
-        ftruncate($fh, $stat['size']-1);
+        ftruncate($fh, $stat['size'] - 1);
         fclose($fh);
 
         $controller = new SubmissionController($this->core);

--- a/site/tests/app/libraries/DiffViewerTester.php
+++ b/site/tests/app/libraries/DiffViewerTester.php
@@ -15,17 +15,17 @@ class DiffViewerTester extends \PHPUnit\Framework\TestCase {
     public function diffDir() {
         $needed_files = array('input_actual.txt', 'input_expected.txt',
             'input_differences.json', 'output_actual.txt', 'output_expected.txt');
-        $dir = __TEST_DATA__.'/diffs';
+        $dir = __TEST_DATA__ . '/diffs';
         $files = scandir($dir);
         $diffs = array();
         foreach ($files as $file) {
-            if (is_dir($dir."/".$file) && strpos($file, '.') === false) {
+            if (is_dir($dir . "/" . $file) && strpos($file, '.') === false) {
                 foreach($needed_files as $needed_file) {
-                    if (!file_exists($dir."/".$file."/".$needed_file)) {
+                    if (!file_exists($dir . "/" . $file . "/" . $needed_file)) {
                         continue 2;
                     }
                 }
-                $diffs[] = array($dir."/".$file);
+                $diffs[] = array($dir . "/" . $file);
             }
         }
         return $diffs;
@@ -38,8 +38,8 @@ class DiffViewerTester extends \PHPUnit\Framework\TestCase {
      */
     public function testDiffViewer($diffDir) {
         $diff = new DiffViewer("{$diffDir}/input_actual.txt", "{$diffDir}/input_expected.txt", "{$diffDir}/input_differences.json", "");
-        $this->assertStringEqualsFile($diffDir."/output_actual.txt", $diff->getDisplayActual());
-        $this->assertStringEqualsFile($diffDir."/output_expected.txt", $diff->getDisplayExpected());
+        $this->assertStringEqualsFile($diffDir . "/output_actual.txt", $diff->getDisplayActual());
+        $this->assertStringEqualsFile($diffDir . "/output_expected.txt", $diff->getDisplayExpected());
         $this->assertTrue($diff->existsDifference());
     }
 
@@ -50,15 +50,15 @@ class DiffViewerTester extends \PHPUnit\Framework\TestCase {
     }
 
     public function testExpectedException() {
-        $diff = new DiffViewer(__TEST_DATA__."/diffs/diff_test_01/input_actual.txt",
+        $diff = new DiffViewer(__TEST_DATA__ . "/diffs/diff_test_01/input_actual.txt",
                                "file_that_doesnt_exist", "", "");
         $this->expectException(\Exception::class);
         $diff->buildViewer();
     }
 
     public function testDifferencesException() {
-        $diff = new DiffViewer(__TEST_DATA__."/diffs/diff_test_01/input_actual.txt",
-                               __TEST_DATA__."/diffs/diff_test_01/input_expected.txt",
+        $diff = new DiffViewer(__TEST_DATA__ . "/diffs/diff_test_01/input_actual.txt",
+                               __TEST_DATA__ . "/diffs/diff_test_01/input_expected.txt",
                                "file_that_doesnt_exist", "");
         $this->expectException(\Exception::class);
         $diff->buildViewer();

--- a/site/tests/app/libraries/ExceptionHandlerTester.php
+++ b/site/tests/app/libraries/ExceptionHandlerTester.php
@@ -40,10 +40,10 @@ class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {
         Logger::setLogPath($tmp_dir);
 
         $date = getdate(time());
-        $filename = $date['year'].Utils::pad($date['mon']).Utils::pad($date['mday']).'.log';
+        $filename = $date['year'] . Utils::pad($date['mon']) . Utils::pad($date['mday']) . '.log';
         ExceptionHandler::setDisplayExceptions(false);
         ExceptionHandler::setLogExceptions(true);
-        ExceptionHandler::handleException(new BaseException("test", array("test"=>"b", "test2"=>array('a','c'))));
+        ExceptionHandler::handleException(new BaseException("test", array("test" => "b", "test2" => array('a','c'))));
         $file = FileUtils::joinPaths($tmp_dir, 'site_errors', $filename);
         $this->assertFileExists($file);
         $actual = file_get_contents($file);
@@ -54,7 +54,7 @@ class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {
     }
 
     private function authenticate($username, $password) {
-        throw new AuthenticationException($username. "  ". $password);
+        throw new AuthenticationException($username . "  " . $password);
     }
 
     public function testScrubPassword() {

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -496,9 +496,9 @@ STRING;
         $this->assertEquals($stat[0],
             ['name' => 'bad.txt',
              'type' => 'text/plain',
-             'error'=> 'The file was only partially uploaded',
+             'error' => 'The file was only partially uploaded',
              'size' => 100,
-             'success'=> false
+             'success' => false
              ]
         );
 
@@ -509,9 +509,9 @@ STRING;
         $this->assertEquals($stat[1],
             ['name' => 'bad2.txt',
              'type' => 'text/plain',
-             'error'=> 'No file was uploaded.',
+             'error' => 'No file was uploaded.',
              'size' => 100,
-             'success'=> false
+             'success' => false
              ]
         );
 
@@ -526,18 +526,18 @@ STRING;
         $this->assertEquals($stat[1],
             ['name' => 'bad2.txt',
              'type' => 'text/plain',
-             'error'=> 'No file was uploaded.',
+             'error' => 'No file was uploaded.',
              'size' => 100,
-             'success'=> false
+             'success' => false
              ]
         );
 
         $this->assertEquals($stat[2],
             ['name' => 'bad3.txt',
              'type' => 'text/plain',
-             'error'=> 'Unknown error code.',
+             'error' => 'Unknown error code.',
              'size' => 100,
-             'success'=> false
+             'success' => false
              ]
         );
 
@@ -548,9 +548,9 @@ STRING;
         $this->assertEquals($stat[6],
             ['name' => '\?<>.txt',
              'type' => 'text/plain',
-             'error'=> 'Invalid filename',
+             'error' => 'Invalid filename',
              'size' => 100,
-             'success'=> false
+             'success' => false
              ]
         );
     }
@@ -564,9 +564,9 @@ STRING;
         $this->assertEquals($stat[0],
             ['name' => 'big.txt',
              'type' => 'text/plain',
-             'error'=> 'File "big.txt" too large got (2.0000953674316MB)',
-             'size' => 100+ Utils::returnBytes(ini_get('upload_max_filesize')),
-             'success'=> false
+             'error' => 'File "big.txt" too large got (2.0000953674316MB)',
+             'size' => 100 + Utils::returnBytes(ini_get('upload_max_filesize')),
+             'success' => false
              ]
         );
 
@@ -577,9 +577,9 @@ STRING;
         $this->assertEquals($stat[1],
             ['name' => 'just_big_enough.txt',
              'type' => 'text/plain',
-             'error'=> 'No error.',
+             'error' => 'No error.',
              'size' =>  Utils::returnBytes(ini_get('upload_max_filesize')),
-             'success'=> true
+             'success' => true
              ]
         );
     }
@@ -597,7 +597,7 @@ STRING;
     private function getAllFilesSetup(): void {
         FileUtils::createDir($this->path);
         foreach (['a', 'b'] as $name) {
-            file_put_contents(FileUtils::joinPaths($this->path, $name.'.txt'), $name);
+            file_put_contents(FileUtils::joinPaths($this->path, $name . '.txt'), $name);
         }
         foreach (['c', 'd'] as $name) {
             FileUtils::createDir(FileUtils::joinPaths($this->path, $name));

--- a/site/tests/app/libraries/LoggerTester.php
+++ b/site/tests/app/libraries/LoggerTester.php
@@ -33,10 +33,10 @@ class LoggerTester extends \PHPUnit\Framework\TestCase {
         $this->assertDirectoryExists($this->directory);
         Logger::setLogPath($this->directory);
         $date = getdate(time());
-        $filename = $date['year'].Utils::pad($date['mon']).Utils::pad($date['mday']);
-        $this->access = FileUtils::joinPaths($this->directory, 'access', $filename.".log");
-        $this->error = FileUtils::joinPaths($this->directory, 'site_errors', $filename.".log");
-        $this->ta_grading = FileUtils::joinPaths($this->directory, 'ta_grading', $filename.".log");
+        $filename = $date['year'] . Utils::pad($date['mon']) . Utils::pad($date['mday']);
+        $this->access = FileUtils::joinPaths($this->directory, 'access', $filename . ".log");
+        $this->error = FileUtils::joinPaths($this->directory, 'site_errors', $filename . ".log");
+        $this->ta_grading = FileUtils::joinPaths($this->directory, 'ta_grading', $filename . ".log");
     }
 
     public function tearDown(): void {

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -231,9 +231,9 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
 
     public function uploadedImageProvider() {
         return [
-            [__TEST_DATA__.'/images/test_image.png', true],
-            [__TEST_DATA__.'/images/test_image.jpg', true],
-            [__TEST_DATA__.'/.gitkeep', false]
+            [__TEST_DATA__ . '/images/test_image.png', true],
+            [__TEST_DATA__ . '/images/test_image.jpg', true],
+            [__TEST_DATA__ . '/.gitkeep', false]
         ];
     }
     /**
@@ -261,8 +261,8 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
     public function testCheckUploadedImageFileImageSizeFalse() {
         try {
             $_FILES['test'] = [
-                'name' => [basename(__TEST_DATA__.'/images/test_image.png')],
-                'tmp_name' => [__TEST_DATA__.'/images/test_image.png'],
+                'name' => [basename(__TEST_DATA__ . '/images/test_image.png')],
+                'tmp_name' => [__TEST_DATA__ . '/images/test_image.png'],
                 'type' => ['image/png'],
                 'error' => [UPLOAD_ERR_OK],
                 'size' => [123]

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -131,7 +131,7 @@ SELECT * FROM test");
     }
 
     public function testTransactionCommitOnDisconnect() {
-        $db = FileUtils::joinPaths(sys_get_temp_dir(), uniqid().".sq3");
+        $db = FileUtils::joinPaths(sys_get_temp_dir(), uniqid() . ".sq3");
         $database = new SqliteDatabase(array('path' => $db));
         $database->connect();
         $this->setupDatabase($database);

--- a/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
+++ b/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
@@ -35,7 +35,7 @@ class PostgresqlDatabaseTester extends \PHPUnit\Framework\TestCase {
             array('{"M5"}', array('M5')),
             array('{"aa", null, "null", null}', array('aa', null, "null", null)),
             array('{"aaa\"bbb\nccc"}', array('aaa"bbb\nccc')),
-            array('{"yes?{}", "", "blah/yes(more).'."\n".'", "\"aaaa. \""}', array("yes?{}", "", "blah/yes(more).\n", '"aaaa. "')),
+            array('{"yes?{}", "", "blah/yes(more).' . "\n" . '", "\"aaaa. \""}', array("yes?{}", "", "blah/yes(more).\n", '"aaaa. "')),
             array('{"\\\\"}', array("\\")),
             array('{"a,b,c\\\\"}', array("a,b,c\\")),
             array('{"a,b,c\'"}', array("a,b,c'")),

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -135,7 +135,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'email_user' => '',
             'email_password' => '',
             'email_sender' => 'submitty@myuniversity.edu',
-            'email_reply_to'=> 'submitty_do_not_reply@myuniversity.edu',
+            'email_reply_to' => 'submitty_do_not_reply@myuniversity.edu',
             'email_server_hostname' => 'localhost',
             'email_server_port' => 25
         );
@@ -169,8 +169,8 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals("http://example.com/", $config->getBaseUrl());
         $this->assertEquals("http://example.com/cgi-bin/", $config->getCgiUrl());
         $this->assertEquals($this->temp_dir, $config->getSubmittyPath());
-        $this->assertEquals($this->temp_dir."/courses/s17/csci0000", $config->getCoursePath());
-        $this->assertEquals($this->temp_dir."/logs", $config->getLogPath());
+        $this->assertEquals($this->temp_dir . "/courses/s17/csci0000", $config->getCoursePath());
+        $this->assertEquals($this->temp_dir . "/logs", $config->getLogPath());
         $this->assertEquals(FileUtils::joinPaths($this->temp_dir, "tmp", "cgi"), $config->getCgiTmpPath());
         $this->assertTrue($config->shouldLogExceptions());
         $this->assertEquals("pgsql", $config->getDatabaseDriver());
@@ -215,8 +215,8 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'base_url' => 'http://example.com/',
             'cgi_url' => 'http://example.com/cgi-bin/',
             'submitty_path' => $this->temp_dir,
-            'course_path' => $this->temp_dir.'/courses/s17/csci0000',
-            'submitty_log_path' => $this->temp_dir.'/logs',
+            'course_path' => $this->temp_dir . '/courses/s17/csci0000',
+            'submitty_log_path' => $this->temp_dir . '/logs',
             'log_exceptions' => true,
             'cgi_tmp_path' => FileUtils::joinPaths($this->temp_dir, "tmp", "cgi"),
             'database_driver' => 'pgsql',
@@ -224,7 +224,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'course_database_params' => array_merge($db_params, array('dbname' => 'submitty_s17_csci0000')),
             'course_name' => 'Test Course',
             'config_path' => FileUtils::joinPaths($this->temp_dir, 'config'),
-            'course_json_path' => $this->temp_dir.'/courses/s17/csci0000/config/config.json',
+            'course_json_path' => $this->temp_dir . '/courses/s17/csci0000/config/config.json',
             'authentication' => 'PamAuthentication',
             'timezone' => 'DateTimeZone',
             'course_home_url' => '',

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-require_once(__DIR__.'/constants.php');
+require_once(__DIR__ . '/constants.php');
 
-$loader = require(__DIR__.'/../vendor/autoload.php');
+$loader = require(__DIR__ . '/../vendor/autoload.php');
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);

--- a/site/tests/phpstan/ModelClassExtension.php
+++ b/site/tests/phpstan/ModelClassExtension.php
@@ -18,7 +18,7 @@ class ModelClassExtension implements MethodsClassReflectionExtension {
             return strtolower($match[2]);
         }, $method_name);
         $method_name = preg_replace_callback('/([A-Z])/', function ($match) {
-            return '_'.strtolower($match[0]);
+            return '_' . strtolower($match[0]);
         }, $method_name);
         return $reflection->hasProperty($method_name);
     }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -94,9 +94,6 @@
         <excldue name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
         <exclude name="Squiz.WhiteSpace.LanguageConstructSpacing.IncorrectSingle" />
-        <exclude name="Squiz.WhiteSpace.LogicalOperatorSpacing.TooMuchSpaceAfter" />
-        <exclude name="Squiz.WhiteSpace.LogicalOperatorSpacing.TooMuchSpaceBefore" />
-        <exclude name="Squiz.WhiteSpace.LogicalOperatorSpacing.NoSpaceBefore" />
         <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore" />
         <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
         <exclude name="Squiz.WhiteSpace.SemicolonSpacing.Incorrect" />

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -65,8 +65,6 @@
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
         <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMiddle"/>
         <exclude name="PSR12.Keywords.ShortFormTypeKeywords.LongFound" />
-        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceBefore"/>
-        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceAfter"/>
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
 
         <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the `PSR12.Operators.OperatorSpacing` style errors. [PSR-12](https://www.php-fig.org/psr/psr-12/#6-operators) defines the spacing for operators as having one space before and after the operator (e.g. `1 + 2` is valid, `1+2` is not).