### PR TITLE
[Refactor:PHP] Fix Generic.Functions.FunctionCallArgumentSpacing style errors

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -20,7 +20,7 @@ class GlobalController extends AbstractController {
                 'file' => pathinfo($file, PATHINFO_FILENAME),
                 'csrf_token' => $this->core->getCsrfToken()
             ]);
-        },  $wrapper_files);
+        }, $wrapper_files);
 
         $breadcrumbs = $this->core->getOutput()->getBreadcrumbs();
         $css = $this->core->getOutput()->getCss();
@@ -367,7 +367,7 @@ class GlobalController extends AbstractController {
                 'file' => pathinfo($file, PATHINFO_FILENAME),
                 'csrf_token' => $this->core->getCsrfToken()
             ]);
-        },  $wrapper_files);
+        }, $wrapper_files);
         // Get additional links to display in the global footer.
         $footer_links = [];
         $footer_links_json_file = FileUtils::joinPaths($this->core->getConfig()->getConfigPath(), "footer_links.json");

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -468,7 +468,7 @@ class MiscController extends AbstractController {
                 else
                     continue;
                 //remove 'bulk_upload_' and '.json' from job file name
-                $result[] = substr($job,11,-5);
+                $result[] = substr($job, 11, -5);
             }
             //look in the split upload folder to see what is complete
             $split_uploads = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf", $gradeable_id);

--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -46,7 +46,7 @@ class NotificationController extends AbstractController {
         parent::__construct($core);
         $this->selections = self::NOTIFICATION_SELECTIONS;
         if ($this->core->getConfig()->isEmailEnabled()) {
-            $this->selections = array_merge($this->selections,self::EMAIL_SELECTIONS);
+            $this->selections = array_merge($this->selections, self::EMAIL_SELECTIONS);
         }
     }
     /**

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -116,7 +116,7 @@ class AdminGradeableController extends AbstractController {
         // The current gradeable will always load its grader history,
         // but if it is grade by registration it should not be in $rotating_gradeables array
         if ($gradeable->getGraderAssignmentMethod() == Gradeable::REGISTRATION_SECTION) {
-            $current_g_id_key = array_search($gradeable->getId(),$rotating_gradeables);
+            $current_g_id_key = array_search($gradeable->getId(), $rotating_gradeables);
             unset($rotating_gradeables[$current_g_id_key]);
             $rotating_gradeables = array_values($rotating_gradeables);
         }
@@ -141,22 +141,22 @@ class AdminGradeableController extends AbstractController {
         $all_uploaded_configs = FileUtils::getAllFiles($uploaded_configs_dir);
         $all_uploaded_config_paths = array();
         foreach ($all_uploaded_configs as $file) {
-            $all_uploaded_config_paths[] = [ 'UPLOADED: ' . substr($file['path'],strlen($uploaded_configs_dir) + 1) , $file['path'] ];
+            $all_uploaded_config_paths[] = [ 'UPLOADED: ' . substr($file['path'], strlen($uploaded_configs_dir) + 1) , $file['path'] ];
         }
         // Configs stored in a private repository (specified in course config)
         $config_repo_string = $this->core->getConfig()->getPrivateRepository();
         $all_repository_config_paths = array();
         $repository_error_messages = array();
         $repo_id_number = 1;
-        foreach (explode(',',$config_repo_string) as $config_repo_name) {
+        foreach (explode(',', $config_repo_string) as $config_repo_name) {
             $config_repo_name = str_replace(' ', '', $config_repo_name);
             if ($config_repo_name == '') {
                 continue;
             }
             $directory_queue = array($config_repo_name);
-            $repo_paths = $this->getValidPathsToConfigDirectories($directory_queue,$repository_error_messages,$repo_id_number);
+            $repo_paths = $this->getValidPathsToConfigDirectories($directory_queue, $repository_error_messages, $repo_id_number);
             if (isset($repo_paths)) {
-                $all_repository_config_paths = array_merge($all_repository_config_paths,$repo_paths);
+                $all_repository_config_paths = array_merge($all_repository_config_paths, $repo_paths);
             }
             $repo_id_number++;
         }
@@ -234,7 +234,7 @@ class AdminGradeableController extends AbstractController {
             'show_edit_warning' => $gradeable->anyManualGrades(),
 
             // Config selection data
-            'all_config_paths' => array_merge($default_config_paths,$all_uploaded_config_paths,$all_repository_config_paths),
+            'all_config_paths' => array_merge($default_config_paths, $all_uploaded_config_paths, $all_repository_config_paths),
             'repository_error_messages' => $repository_error_messages,
             'currently_valid_repository' => $this->checkPathToConfigFile($gradeable->getAutogradingConfigPath()),
 
@@ -487,7 +487,7 @@ class AdminGradeableController extends AbstractController {
             }
 
             if ($this->checkPathToConfigFile($dir)) {
-                $return_array[] = ["DIRECTORY " . $repo_id_number . ": " . substr($dir,strlen($repository_path)),$dir];
+                $return_array[] = ["DIRECTORY " . $repo_id_number . ": " . substr($dir, strlen($repository_path)),$dir];
             }
             else {
                 while($iter->valid()) {
@@ -700,7 +700,7 @@ class AdminGradeableController extends AbstractController {
         ];
         // Make sure the template exists if we're using one
         $template_gradeable = null;
-        if (array_key_exists('gradeable_template',$details) && $details['gradeable_template'] !== '--None--') {
+        if (array_key_exists('gradeable_template', $details) && $details['gradeable_template'] !== '--None--') {
             $template_id = $details['gradeable_template'];
             $template_gradeable = $this->core->getQueries()->getGradeableConfig($template_id);
             if ($template_gradeable === null) {
@@ -864,7 +864,7 @@ class AdminGradeableController extends AbstractController {
 
         $config = $this->core->getConfig();
         if ($build_status == null && $gradeable->isVcs() && !$gradeable->isTeamAssignment()) {
-            $this->enqueueGenerateRepos($config->getSemester(),$config->getCourse(),$gradeable_id);
+            $this->enqueueGenerateRepos($config->getSemester(), $config->getCourse(), $gradeable_id);
         }
 
         return $build_status;

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -29,14 +29,14 @@ class PlagiarismController extends AbstractController {
 
             while(!feof($file)) {
                 $line = fgets($file);
-                $line = trim($line," ");
-                $line = explode("/",$line);
+                $line = trim($line, " ");
+                $line = explode("/", $line);
                 $sem = $line[5];
                 $course = $line[6];
                 $gradeables = array();
                 while (!feof($file)) {
                     $line = fgets($file);
-                    if (trim(trim($line, " "),"\n") === "") {
+                    if (trim(trim($line, " "), "\n") === "") {
                         break;
                     }
                     array_push($gradeables, trim(trim($line, " "), "\n"));
@@ -140,7 +140,7 @@ class PlagiarismController extends AbstractController {
         $content = file_get_contents($file_path);
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
-        $rankings = array_chunk($rankings,3);
+        $rankings = array_chunk($rankings, 3);
         foreach($rankings as $i => $ranking) {
             array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedFirstName());
             array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedLastName());
@@ -432,9 +432,9 @@ class PlagiarismController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
-        $saved_config = json_decode(file_get_contents("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json"),true);
+        $saved_config = json_decode(file_get_contents("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json"), true);
 
-        $this->core->getOutput()->renderOutput(array('admin', 'Plagiarism'), 'configureGradeableForPlagiarismForm', 'edit', null , $prior_term_gradeables, $saved_config);
+        $this->core->getOutput()->renderOutput(array('admin', 'Plagiarism'), 'configureGradeableForPlagiarismForm', 'edit', null, $prior_term_gradeables, $saved_config);
 
     }
 
@@ -515,7 +515,7 @@ class PlagiarismController extends AbstractController {
         $content = file_get_contents($file_path);
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
-        $rankings = array_chunk($rankings,3);
+        $rankings = array_chunk($rankings, 3);
         foreach($rankings as $ranking) {
             if($ranking[1] == $user_id_1) {
                 $max_matching_version = $ranking[2];
@@ -530,7 +530,7 @@ class PlagiarismController extends AbstractController {
         $data = "";
         if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
             if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
-                $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2 , '1');
+                $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, '1');
             }
             else {
                 $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, '', '', '1');
@@ -670,7 +670,7 @@ class PlagiarismController extends AbstractController {
         $content = file_get_contents($file_path);
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
-        $rankings = array_chunk($rankings,3);
+        $rankings = array_chunk($rankings, 3);
         foreach($rankings as $ranking) {
             if($ranking[1] == $user_id_1) {
                 $max_matching_version = $ranking[2];

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -531,7 +531,7 @@ class ReportController extends AbstractController {
             $this->core->getOutput()->addBreadcrumb('Rainbow Grades Customization');
 
             // Print the form
-            $this->core->getOutput()->renderTwigOutput('admin/RainbowCustomization.twig',[
+            $this->core->getOutput()->renderTwigOutput('admin/RainbowCustomization.twig', [
                 "customization_data" => $customization->getCustomizationData(),
                 "available_buckets" => $customization->getAvailableBuckets(),
                 "used_buckets" => $customization->getUsedBuckets(),

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -147,8 +147,8 @@ class UsersController extends AbstractController {
         $new_registration_information = array();
 
         foreach ($_POST as $key => $value) {
-            $key_array = explode("_",$key,2);
-            if (!array_key_exists($key_array[0],$new_registration_information)) {
+            $key_array = explode("_", $key, 2);
+            if (!array_key_exists($key_array[0], $new_registration_information)) {
                 $new_registration_information[$key_array[0]] = array();
             }
             if ($key_array[1] != 'all') {
@@ -158,7 +158,7 @@ class UsersController extends AbstractController {
 
         foreach($this->core->getQueries()->getAllGraders() as $grader) {
             $grader_id = $grader->getId();
-            if (array_key_exists($grader_id,$new_registration_information)) {
+            if (array_key_exists($grader_id, $new_registration_information)) {
                 $grader->setGradingRegistrationSections($new_registration_information[$grader_id]);
             }
             else {
@@ -205,7 +205,7 @@ class UsersController extends AbstractController {
         //uses more thorough course information if it exists, if not uses database information
         $user_information = array();
         foreach ($user_ids as $user_id) {
-            $already_in_course = array_key_exists($user_id,$course_users);
+            $already_in_course = array_key_exists($user_id, $course_users);
             $user = $already_in_course ? $course_users[$user_id] : $submitty_users[$user_id];
             $user_information[$user_id] = array(
                 'already_in_course' => $already_in_course,
@@ -348,7 +348,7 @@ class UsersController extends AbstractController {
                     continue;
                 }
                 if ($gradeable->isVcs() && !$gradeable->isTeamAssignment()) {
-                    AdminGradeableController::enqueueGenerateRepos($semester,$course,$g_id);
+                    AdminGradeableController::enqueueGenerateRepos($semester, $course, $g_id);
                 }
             }
 
@@ -367,11 +367,11 @@ class UsersController extends AbstractController {
         //Adds "invisible" sections: rotating sections that exist but have no students assigned to them
         $sections_with_students = array();
         foreach ($non_null_counts as $rows) {
-            array_push($sections_with_students,$rows['rotating_section']);
+            array_push($sections_with_students, $rows['rotating_section']);
         }
         for ($i = 1; $i <= $this->core->getQueries()->getMaxRotatingSection(); $i++) {
-            if ( !in_array($i,$sections_with_students) ) {
-                array_push($non_null_counts,[
+            if ( !in_array($i, $sections_with_students) ) {
+                array_push($non_null_counts, [
                     "rotating_section" => $i,
                     "count" => 0
                 ]);
@@ -494,14 +494,14 @@ class UsersController extends AbstractController {
             foreach ($reg_sections as $row) {
                 $test = $row['sections_registration_id'];
                 if (isset($_POST[$test])) {
-                    array_push($exclude_sections,$_POST[$row['sections_registration_id']]);
+                    array_push($exclude_sections, $_POST[$row['sections_registration_id']]);
                 }
             }
             //remove people who should not be added to rotating sections
             for ($j = 0; $j < count($users_with_reg_section);) {
                 for ($i = 0;$i < count($exclude_sections);++$i) {
                     if ($users_with_reg_section[$j]->getRegistrationSection() == $exclude_sections[$i]) {
-                        array_splice($users_with_reg_section,$j,1);
+                        array_splice($users_with_reg_section, $j, 1);
                         $j--;
                         break;
                     }
@@ -891,7 +891,7 @@ class UsersController extends AbstractController {
                     // Preferred first and last name must be alpha characters, white-space, or certain punctuation.
                     // Automatically validate if not set (this field is optional).
                 case !isset($vals[$pref_firstname_idx]) || User::validateUserData('user_preferred_firstname', $vals[$pref_firstname_idx]):
-                case !isset($vals[$pref_lastname_idx]) || User::validateUserData('user_preferred_lastname',  $vals[$pref_lastname_idx] ):
+                case !isset($vals[$pref_lastname_idx]) || User::validateUserData('user_preferred_lastname', $vals[$pref_lastname_idx] ):
                     // Validation failed somewhere.  Record which row failed.
                     // $row_num is zero based.  ($row_num+1) will better match spreadsheet labeling.
                     $bad_rows[] = ($row_num + 1);

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -23,18 +23,18 @@ class CourseMaterialsController extends AbstractController {
     }
 
     public function deleteHelper($file, &$json) {
-        if ((array_key_exists('name',$file))) {
+        if ((array_key_exists('name', $file))) {
             $filename = $file['path'];
             unset($json[$filename]);
             return;
         }
         else {
-            if(array_key_exists('files',$file)) {
-                $this->deleteHelper($file['files'],$json);
+            if(array_key_exists('files', $file)) {
+                $this->deleteHelper($file['files'], $json);
             }
             else {
                 foreach ($file as $f) {
-                    $this->deleteHelper($f,$json);
+                    $this->deleteHelper($f, $json);
                 }
             }
         }
@@ -62,7 +62,7 @@ class CourseMaterialsController extends AbstractController {
             $all_files = is_dir($path) ? FileUtils::getAllFiles($path) : [$path];
             foreach($all_files as $file) {
                 if(is_array($file)){
-                    $this->deleteHelper($file,$json);
+                    $this->deleteHelper($file, $json);
                 }
                 else{
                     unset($json[$file]);
@@ -470,7 +470,7 @@ class CourseMaterialsController extends AbstractController {
             }
         }
 
-        FileUtils::writeJsonFile($fp,$json);
+        FileUtils::writeJsonFile($fp, $json);
         return $this->core->getOutput()->renderResultMessage("Successfully uploaded!", true);
     }
 }

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -608,14 +608,14 @@ class ForumController2 extends AbstractController {
             $anon = $current_post["anonymous"];
             foreach ($older_posts as $post) {
                 $_post['user'] = !$this->modifyAnonymous($oc) && $oc == $post["edit_author"] && $anon ? '' : $post["edit_author"];
-                $_post['content'] = $this->core->getOutput()->renderTemplate('forum\ForumThread', 'filter_post_content',  $post["content"]);
+                $_post['content'] = $this->core->getOutput()->renderTemplate('forum\ForumThread', 'filter_post_content', $post["content"]);
                 $_post['post_time'] = DateUtils::parseDateTime($post['edit_timestamp'], $this->core->getConfig()->getTimezone())->format("n/j g:i A");
                 $output[] = $_post;
             }
             if(count($output) == 0) {
                 // Current post
                 $_post['user'] = !$this->modifyAnonymous($oc) && $anon ? '' : $oc;
-                $_post['content'] = $this->core->getOutput()->renderTemplate('forum\ForumThread', 'filter_post_content',  $current_post["content"]);
+                $_post['content'] = $this->core->getOutput()->renderTemplate('forum\ForumThread', 'filter_post_content', $current_post["content"]);
                 $_post['post_time'] = DateUtils::parseDateTime($current_post['timestamp'], $this->core->getConfig()->getTimezone())->format("n/j g:i A");
                 $output[] = $_post;
             }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -388,8 +388,8 @@ class ElectronicGraderController extends AbstractController {
             foreach ($order->getSortedGradedGradeables() as $g) {
                 $team = $g->getSubmitter()->getTeam();
                 $team_section = $gradeable->isGradeByRegistration() ? $team->getRegistrationSection() : $team->getRotatingSection();
-                if (array_key_exists($team_section,$total_users)) {
-                    if ($this->core->getQueries()->getActiveVersionForTeam($gradeable->getId(),$team->getId()) != 0) {
+                if (array_key_exists($team_section, $total_users)) {
+                    if ($this->core->getQueries()->getActiveVersionForTeam($gradeable->getId(), $team->getId()) != 0) {
                         $total_students_submitted += count($team->getMembers());
                     }
                 }
@@ -681,7 +681,7 @@ class ElectronicGraderController extends AbstractController {
 
         $cur_group = 1;
         foreach ($teams as $team_id) {
-            $this->core->getQueries()->updateTeamRotatingSection($team_id,$cur_group);
+            $this->core->getQueries()->updateTeamRotatingSection($team_id, $cur_group);
             $cur_group++;
             if ($cur_group > $section_count) {
                 $cur_group = 1;
@@ -928,7 +928,7 @@ class ElectronicGraderController extends AbstractController {
                 }
             }
             if($team){
-                $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'registration_section',$team));
+                $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'registration_section', $team));
                 $total = array_sum($this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
                 $total_submitted = array_sum($this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
             }
@@ -2157,7 +2157,7 @@ class ElectronicGraderController extends AbstractController {
         $total_graded_component_count   = 0;
         $total_total_component_count    = 0;
 
-        $this->getStats($gradeable, $grader, true,  $total_graded_component_count,   $total_total_component_count);
+        $this->getStats($gradeable, $grader, true, $total_graded_component_count, $total_total_component_count);
         $this->getStats($gradeable, $grader, false, $section_graded_component_count, $section_total_component_count);
 
         return [

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -15,7 +15,7 @@ class ImagesController extends AbstractController {
     public function viewImagesPage() {
         $user_group = $this->core->getUser()->getGroup();
         $images_course_path = $this->core->getConfig()->getCoursePath();
-        $images_path = Fileutils::joinPaths($images_course_path,"uploads/student_images");
+        $images_path = Fileutils::joinPaths($images_course_path, "uploads/student_images");
         $any_images_files = FileUtils::getAllFiles($images_path, array(), true);
         if ($user_group === USER::GROUP_STUDENT || (($user_group === USER::GROUP_FULL_ACCESS_GRADER || $user_group === USER::GROUP_LIMITED_ACCESS_GRADER) && count($any_images_files) === 0)) { // student has no permissions to view image page
             $this->core->addErrorMessage("You have no permissions to see images.");

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -109,7 +109,7 @@ class GradeInquiryController extends AbstractController {
 
         try {
             $this->core->getQueries()->insertNewRegradePost($grade_inquiry_id, $user->getId(), $content);
-            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, 'reply',$gc_id);
+            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, 'reply', $gc_id);
             return Response::JsonOnlyResponse(
                 JsonResponse::getSuccessResponse()
             );
@@ -181,7 +181,7 @@ class GradeInquiryController extends AbstractController {
             if ($content != "") {
                 $this->core->getQueries()->insertNewRegradePost($grade_inquiry->getId(), $user->getId(), $content);
             }
-            $this->notifyGradeInquiryEvent($graded_gradeable,$gradeable_id,$content,$type,$gc_id);
+            $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, $type, $gc_id);
             return Response::JsonOnlyResponse(
                 JsonResponse::getSuccessResponse()
             );

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -111,7 +111,7 @@ class SubmissionController extends AbstractController {
                     $graded_gradeable->getOrCreateTaGradedGradeable()->setUserViewedDate($now);
                     $this->core->getQueries()->saveTaGradedGradeable($graded_gradeable->getTaGradedGradeable());
                     if ($graded_gradeable->getSubmitter()->isTeam()) {
-                        $this->core->getQueries()->updateTeamViewedTime($graded_gradeable->getSubmitter()->getId(),$this->core->getUser()->getId());
+                        $this->core->getQueries()->updateTeamViewedTime($graded_gradeable->getSubmitter()->getId(), $this->core->getUser()->getId());
                     }
                 }
 
@@ -519,7 +519,7 @@ class SubmissionController extends AbstractController {
         //images are order <original>_<split-number>_<page-number>, so grab everuthing with the same suffixes
         preg_match("/\d*$/", pathinfo($path, PATHINFO_FILENAME), $matches);
         $split_number = count($matches) >= 1 ? reset($matches) : "-1";
-        $image_files = glob(FileUtils::joinPaths(  dirname($uploaded_file)   , "*.*"));
+        $image_files = glob(FileUtils::joinPaths(  dirname($uploaded_file), "*.*"));
 
         $regex = "/.*_{$split_number}_\d*\.\w*$/";
         $image_files = preg_grep($regex, $image_files);
@@ -883,9 +883,9 @@ class SubmissionController extends AbstractController {
             $short_answer_objects    = $_POST['short_answer_answers'] ?? "";
             $codebox_objects         = $_POST['codebox_answers'] ?? "";
             $multiple_choice_objects = $_POST['multiple_choice_answers'] ?? "";
-            $short_answer_objects    = json_decode($short_answer_objects,true);
-            $codebox_objects         = json_decode($codebox_objects,true);
-            $multiple_choice_objects = json_decode($multiple_choice_objects,true);
+            $short_answer_objects    = json_decode($short_answer_objects, true);
+            $codebox_objects         = json_decode($codebox_objects, true);
+            $multiple_choice_objects = json_decode($multiple_choice_objects, true);
 
             $this_config_inputs = $gradeable->getAutogradingConfig()->getInputs() ?? array();
 
@@ -1090,9 +1090,9 @@ class SubmissionController extends AbstractController {
             $vcs_path = $gradeable->getVcsSubdirectory();
 
             if ($gradeable->getVcsHostType() == 0 || $gradeable->getVcsHostType() == 1) {
-                $vcs_path = str_replace("{\$gradeable_id}",$gradeable_id,$vcs_path);
-                $vcs_path = str_replace("{\$user_id}",$who_id,$vcs_path);
-                $vcs_path = str_replace("{\$team_id}",$who_id,$vcs_path);
+                $vcs_path = str_replace("{\$gradeable_id}", $gradeable_id, $vcs_path);
+                $vcs_path = str_replace("{\$user_id}", $who_id, $vcs_path);
+                $vcs_path = str_replace("{\$team_id}", $who_id, $vcs_path);
                 $vcs_full_path = $vcs_base_url . $vcs_path;
             }
 
@@ -1107,13 +1107,13 @@ class SubmissionController extends AbstractController {
             }
             // use base url + path with variable string replacements
             else {
-                if (strpos($vcs_path,"\$repo_id") !== false && $repo_id == "") {
+                if (strpos($vcs_path, "\$repo_id") !== false && $repo_id == "") {
                     return $this->uploadResult("repository id input cannot be blank.", false);
                 }
-                $vcs_path = str_replace("{\$gradeable_id}",$gradeable_id,$vcs_path);
-                $vcs_path = str_replace("{\$user_id}",$who_id,$vcs_path);
-                $vcs_path = str_replace("{\$team_id}",$who_id,$vcs_path);
-                $vcs_path = str_replace("{\$repo_id}",$repo_id,$vcs_path);
+                $vcs_path = str_replace("{\$gradeable_id}", $gradeable_id, $vcs_path);
+                $vcs_path = str_replace("{\$user_id}", $who_id, $vcs_path);
+                $vcs_path = str_replace("{\$team_id}", $who_id, $vcs_path);
+                $vcs_path = str_replace("{\$repo_id}", $repo_id, $vcs_path);
                 $vcs_full_path = $vcs_base_url . $vcs_path;
             }
 
@@ -1248,7 +1248,7 @@ class SubmissionController extends AbstractController {
             $subject = "Team Member Submission: " . $graded_gradeable->getGradeable()->getTitle();
             $content = "A team member, $original_user_id, submitted in the gradeable, " . $graded_gradeable->getGradeable()->getTitle();
             $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_member_submission', 'sender_id' => $original_user_id];
-            $this->core->getNotificationFactory()->onTeamEvent($event,$team_members);
+            $this->core->getNotificationFactory()->onTeamEvent($event, $team_members);
         }
         else {
             $this->core->getQueries()->insertVersionDetails($gradeable->getId(), $user_id, null, $new_version, $current_time);

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -66,7 +66,7 @@ class TeamController extends AbstractController {
 
         if ($gradeable->isVcs()) {
             $config = $this->core->getConfig();
-            AdminGradeableController::enqueueGenerateRepos($config->getSemester(),$config->getCourse(),$gradeable_id);
+            AdminGradeableController::enqueueGenerateRepos($config->getSemester(), $config->getCourse(), $gradeable_id);
         }
 
         $this->core->redirect($return_url);
@@ -200,7 +200,7 @@ class TeamController extends AbstractController {
         $subject = "New Team Invitation: " . $graded_gradeable->getGradeable()->getTitle();
         $content = "You have received a new invitation to join a team from $user_id";
         $event = ['component' => 'team', 'metadata' => $metadata, 'subject' => $subject, 'content' => $content, 'type' => 'team_invite', 'sender_id' => $user_id];
-        $this->core->getNotificationFactory()->onTeamEvent($event,[$invite_id]);
+        $this->core->getNotificationFactory()->onTeamEvent($event, [$invite_id]);
 
         $this->core->addSuccessMessage("Invitation sent to {$invite_id}");
 
@@ -265,7 +265,7 @@ class TeamController extends AbstractController {
 
         $this->core->getQueries()->declineAllTeamInvitations($gradeable_id, $user_id);
         $this->core->getQueries()->acceptTeamInvitation($accept_team_id, $user_id);
-        $this->core->getQueries()->removeFromSeekingTeam($gradeable_id,$user_id);
+        $this->core->getQueries()->removeFromSeekingTeam($gradeable_id, $user_id);
         $team_members = $accept_team->getMembers();
         // send notification to team members that user joined
         $metadata =  json_encode(
@@ -368,7 +368,7 @@ class TeamController extends AbstractController {
 
         $return_url = $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'team']);
 
-        $this->core->getQueries()->addToSeekingTeam($gradeable_id,$user_id);
+        $this->core->getQueries()->addToSeekingTeam($gradeable_id, $user_id);
         $this->core->addSuccessMessage("Added to list of users seeking team/partner");
         $this->core->redirect($return_url);
     }
@@ -392,7 +392,7 @@ class TeamController extends AbstractController {
 
         $return_url = $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'team']);
 
-        $this->core->getQueries()->removeFromSeekingTeam($gradeable_id,$user_id);
+        $this->core->getQueries()->removeFromSeekingTeam($gradeable_id, $user_id);
         $this->core->addSuccessMessage("Removed from list of users seeking team/partner");
         $this->core->redirect($return_url);
     }

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -580,7 +580,7 @@ class DiffViewer {
     private function replaceUTF($text, $what, &$which, $description){
         $count = 0;
         $what = '<span class="whitespace">' . $what . '</span>';
-        $which = str_replace($text, $what, $which,$count);
+        $which = str_replace($text, $what, $which, $count);
         if($count > 0) $this->white_spaces[$description] = strip_tags($what);
         return $what;
     }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -311,7 +311,7 @@ class Utils {
     */
     public static function formatBytes(string $format, int $bytes): string {
         $formats = ['b' => 0, 'kb' => 1, 'mb' => 2];
-        return ($bytes / pow(1024,floor($formats[strtolower($format)]))) . (strtoupper($format));
+        return ($bytes / pow(1024, floor($formats[strtolower($format)]))) . (strtoupper($format));
     }
 
 }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1211,9 +1211,9 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
      */
     public function getActiveVersionForTeam($gradeable_id,$team_id) {
         $params = array($gradeable_id,$team_id);
-        $this->course_db->query("SELECT active_version FROM electronic_gradeable_version WHERE g_id = ? and team_id = ?",$params);
+        $this->course_db->query("SELECT active_version FROM electronic_gradeable_version WHERE g_id = ? and team_id = ?", $params);
         $query_result = $this->course_db->row();
-        return array_key_exists('active_version',$query_result) ? $query_result['active_version'] : 0;
+        return array_key_exists('active_version', $query_result) ? $query_result['active_version'] : 0;
     }
 
     public function getNumUsersGraded($g_id) {
@@ -1570,7 +1570,7 @@ ORDER BY user_id ASC");
     public function getUsersOnTeamsForGradeable($gradeable) {
         $params = array($gradeable->getId());
         $this->course_db->query("SELECT user_id FROM teams WHERE
-                team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)",$params);
+                team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)", $params);
 
         $users = [];
         foreach ($this->course_db->rows() as $row){
@@ -1730,7 +1730,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @param $user_id
      */
     public function getTeamViewedTime($team_id,$user_id) {
-        $this->course_db->query("SELECT last_viewed_time FROM teams WHERE team_id = ? and user_id=?",array($team_id,$user_id));
+        $this->course_db->query("SELECT last_viewed_time FROM teams WHERE team_id = ? and user_id=?", array($team_id,$user_id));
         return $this->course_db->rows()[0]['last_viewed_time'];
     }
 
@@ -1764,7 +1764,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
     public function getAllTeamViewedTimesForGradeable($gradeable) {
         $params = array($gradeable->getId());
         $this->course_db->query("SELECT team_id,user_id,last_viewed_time FROM teams WHERE
-                team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)",$params);
+                team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)", $params);
 
         $user_viewed_info = [];
         foreach ($this->course_db->rows() as $row){
@@ -1772,7 +1772,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
             $user = $row['user_id'];
             $time = $row['last_viewed_time'];
 
-            if (!array_key_exists($team,$user_viewed_info)) {
+            if (!array_key_exists($team, $user_viewed_info)) {
                 $user_viewed_info[$team] = array();
             }
             $user_viewed_info[$team][$user] = $time;
@@ -1994,7 +1994,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
     public function getTeamsWithMembersFromGradeableID($g_id) {
         $team_map = $this->core->getQueries()->getTeamIdsAllGradeables();
 
-        if (!array_key_exists( $g_id ,$team_map)) {
+        if (!array_key_exists( $g_id, $team_map)) {
             return array();
         }
 
@@ -2006,7 +2006,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
             $teams_with_members[] = $row['team_id'];
         }
 
-        return array_intersect($teams,$teams_with_members);
+        return array_intersect($teams, $teams_with_members);
     }
 
 
@@ -2043,7 +2043,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
 
         $users_seeking_team = array();
         foreach($this->course_db->rows() as $row) {
-            array_push($users_seeking_team,$row['user_id']);
+            array_push($users_seeking_team, $row['user_id']);
         }
         return $users_seeking_team;
     }
@@ -2590,7 +2590,7 @@ AND gc_id IN (
     }
 
     public function viewedThread($user, $thread_id){
-        $this->course_db->query("SELECT * FROM viewed_responses v WHERE thread_id = ? AND user_id = ? AND NOT EXISTS(SELECT thread_id FROM (posts LEFT JOIN forum_posts_history ON posts.id = forum_posts_history.post_id) AS jp WHERE jp.thread_id = ? AND (jp.timestamp > v.timestamp OR (jp.edit_timestamp IS NOT NULL AND jp.edit_timestamp > v.timestamp)))" , array($thread_id, $user, $thread_id));
+        $this->course_db->query("SELECT * FROM viewed_responses v WHERE thread_id = ? AND user_id = ? AND NOT EXISTS(SELECT thread_id FROM (posts LEFT JOIN forum_posts_history ON posts.id = forum_posts_history.post_id) AS jp WHERE jp.thread_id = ? AND (jp.timestamp > v.timestamp OR (jp.edit_timestamp IS NOT NULL AND jp.edit_timestamp > v.timestamp)))", array($thread_id, $user, $thread_id));
         return count($this->course_db->rows()) > 0;
     }
 
@@ -2837,7 +2837,7 @@ AND gc_id IN (
         ];
         $query = "SELECT user_id FROM notification_settings WHERE {$column} = 'true'";
         $this->course_db->query($query);
-        if (!in_array($column,$preferences)) {
+        if (!in_array($column, $preferences)) {
             throw new DatabaseException("Given column, {$column}, is not a valid column", $query);
         }
         return $this->rowsToArray($this->course_db->rows());
@@ -2852,7 +2852,7 @@ AND gc_id IN (
         $params = $user_ids;
         $user_id_query = $this->createParamaterList(count($user_ids));
         $query = "SELECT * FROM notification_settings WHERE user_id in " . $user_id_query;
-        $this->course_db->query($query,$params);
+        $this->course_db->query($query, $params);
         return $this->course_db->rows();
     }
 
@@ -2878,7 +2878,7 @@ AND gc_id IN (
                     author_user_id AS user_id
                   FROM
                     parents) AS parents;";
-        $this->course_db->query($query,$params);
+        $this->course_db->query($query, $params);
         return $this->rowsToArray($this->course_db->rows());
     }
 
@@ -2897,7 +2897,7 @@ AND gc_id IN (
         if ($column != 'reply_in_post_thread' && $column != 'reply_in_post_thread_email') {
             throw new DatabaseException("Given column, {$column}, is not a valid column", $query, $params);
         }
-        $this->course_db->query($query,$params);
+        $this->course_db->query($query, $params);
         return $this->rowsToArray($this->course_db->rows());
 
     }
@@ -3083,7 +3083,7 @@ AND gc_id IN (
         $grade_inquiry_ids = $this->createParamaterList(count($grade_inquiries));
         $params = array_map(function ($grade_inquiry) {
             return $grade_inquiry->getId();
-        },$grade_inquiries);
+        }, $grade_inquiries);
         $this->course_db->query("SELECT * FROM regrade_discussion WHERE regrade_id IN $grade_inquiry_ids AND deleted=false ORDER BY timestamp ASC ", $params);
         $result = [];
         foreach ($params as $id) {
@@ -4105,7 +4105,7 @@ AND gc_id IN (
         $this->course_db->query("SELECT * FROM queue where user_id = ? order by time_in DESC limit 1", array($user_id));
         if(count($this->course_db->rows()) == 0){
             $name = $this->core->getUser()->getDisplayedFirstName() . " " . $this->core->getUser()->getDisplayedLastName();
-            return new OfficeHoursQueueStudent($this->core, -1, $this->core->getUser()->getId(), $name, -1, $num_in_queue, -1, null,null,null,null);
+            return new OfficeHoursQueueStudent($this->core, -1, $this->core->getUser()->getId(), $name, -1, $num_in_queue, -1, null, null, null, null);
         }
         $row = $this->course_db->rows()[0];
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -473,7 +473,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
       grading_rotating
     GROUP BY g_id, user_id
   ) AS gr ON gu.user_id=gr.user_id AND gu.g_id=gr.g_id
-  ORDER BY user_group, user_id, g_grade_start_date",$params);
+  ORDER BY user_group, user_id, g_grade_start_date", $params);
         $rows = $this->course_db->rows();
         $modified_rows = [];
         foreach($rows as $row) {
@@ -502,7 +502,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         u.user_id
     ORDER BY
         u.user_group ASC
-    ",array($gradeable_id));
+    ", array($gradeable_id));
 
         // Split arrays into php arrays
         $rows = $this->course_db->rows();
@@ -738,7 +738,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     public function getTeamsByGradeableAndRegistrationSections($g_id, $sections, $orderBy="registration_section") {
         $return = array();
         if (count($sections) > 0) {
-            $orderBy = str_replace("gt.registration_section","SUBSTRING(gt.registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(gt.registration_section, '[0-9]+')::INT, -1), SUBSTRING(gt.registration_section, '[^0-9]*$')",$orderBy);
+            $orderBy = str_replace("gt.registration_section", "SUBSTRING(gt.registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(gt.registration_section, '[0-9]+')::INT, -1), SUBSTRING(gt.registration_section, '[^0-9]*$')", $orderBy);
             $placeholders = implode(",", array_fill(0, count($sections), "?"));
             $params = [$g_id];
             $params = array_merge($params, $sections);
@@ -1295,7 +1295,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             $graded_gradeable->setAutoGradedGradeable($auto_graded_gradeable);
 
             if (isset($row['array_grade_inquiries'])) {
-                $grade_inquiries = json_decode($row['array_grade_inquiries'],true);
+                $grade_inquiries = json_decode($row['array_grade_inquiries'], true);
                 $grade_inquiries_arr = array();
                 foreach ($grade_inquiries as $grade_inquiry) {
                     $grade_inquiries_arr[] = new RegradeRequest($this->core, $grade_inquiry);

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -448,7 +448,7 @@ class Config extends AbstractModel {
         }
         $users_file_contents = json_decode(file_get_contents($users_file));
         $submitty_admin_user = "";
-        if (property_exists($users_file_contents,"verified_submitty_admin_user")) {
+        if (property_exists($users_file_contents, "verified_submitty_admin_user")) {
             $submitty_admin_user = $users_file_contents->verified_submitty_admin_user;
         }
         return $submitty_admin_user;

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -55,13 +55,13 @@ class Course extends AbstractModel {
     public function getLongSemester() {
         if (strlen($this->semester) == 3) {
             if (strtolower($this->semester[0]) === 'f') {
-                return "Fall 20" . substr($this->semester,1,2);
+                return "Fall 20" . substr($this->semester, 1, 2);
             }
             elseif (strtolower($this->semester[0]) === 's') {
-                return "Spring 20" . substr($this->semester,1,2);
+                return "Spring 20" . substr($this->semester, 1, 2);
             }
             elseif (strtolower($this->semester[0]) === 'u') {
-                return "Summer 20" . substr($this->semester,1,2);
+                return "Summer 20" . substr($this->semester, 1, 2);
             }
         }
         return $this->semester;

--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -83,13 +83,13 @@ class GradeableAutocheck extends AbstractModel {
         
     
         if(isset($details["expected_file"])) {
-            if(substr($details["expected_file"],0,11) == "test_output"){
+            if(substr($details["expected_file"], 0, 11) == "test_output"){
                 if(file_exists($course_path . "/" . $details["expected_file"])){
                     $expected_file = $course_path . "/" . $details["expected_file"];
                 } else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }
-            } else if(substr($details["expected_file"],0,13) == "random_output"){
+            } else if(substr($details["expected_file"], 0, 13) == "random_output"){
                 if(file_exists($results_path . "/" . $details["expected_file"])){
                     $expected_file = $results_path . "/" . $details["expected_file"];
                 } else {

--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -31,10 +31,10 @@ class NotificationFactory {
      */
     public function onNewAnnouncement(array $event) {
         $recipients = $this->core->getQueries()->getAllUsersIds();
-        $notifications = $this->createNotificationsArray($event,$recipients);
+        $notifications = $this->createNotificationsArray($event, $recipients);
         $this->sendNotifications($notifications);
         if ($this->core->getConfig()->isEmailEnabled()) {
-            $emails = $this->createEmailsArray($event,$recipients);
+            $emails = $this->createEmailsArray($event, $recipients);
             $this->sendEmails($emails);
         }
     }
@@ -46,13 +46,13 @@ class NotificationFactory {
         $recipients = $this->core->getQueries()->getAllUsersWithPreference("all_new_threads");
         $recipients[] = $this->core->getUser()->getId();
         $recipients = array_unique($recipients);
-        $notifications = $this->createNotificationsArray($event,$recipients);
+        $notifications = $this->createNotificationsArray($event, $recipients);
         $this->sendNotifications($notifications);
         if ($this->core->getConfig()->isEmailEnabled()) {
             $recipients = $this->core->getQueries()->getAllUsersWithPreference("all_new_threads_email");
             $recipients[] = $this->core->getUser()->getId();
             $recipients = array_unique($recipients);
-            $emails = $this->createEmailsArray($event,$recipients);
+            $emails = $this->createEmailsArray($event, $recipients);
             $this->sendEmails($emails);
         }
     }
@@ -66,22 +66,22 @@ class NotificationFactory {
         $post_id = $event["post_id"];
         $thread_id = $event["thread_id"];
 
-        $parent_authors = $this->core->getQueries()->getAllParentAuthors($current_user_id,$post_id);
+        $parent_authors = $this->core->getQueries()->getAllParentAuthors($current_user_id, $post_id);
         $users_with_notification_preference = $this->core->getQueries()->getAllUsersWithPreference("all_new_posts");
-        $thread_authors_notification_preference = $this->core->getQueries()->getAllThreadAuthors($thread_id,"reply_in_post_thread");
+        $thread_authors_notification_preference = $this->core->getQueries()->getAllThreadAuthors($thread_id, "reply_in_post_thread");
         $notification_recipients = array_merge($parent_authors, $users_with_notification_preference, $thread_authors_notification_preference);
         $notification_recipients[] = $current_user_id;
         $notification_recipients = array_unique($notification_recipients);
-        $notifications = $this->createNotificationsArray($event,$notification_recipients);
+        $notifications = $this->createNotificationsArray($event, $notification_recipients);
         $this->sendNotifications($notifications);
 
         if ($this->core->getConfig()->isEmailEnabled()) {
             $users_with_email_preference = $this->core->getQueries()->getAllUsersWithPreference("all_new_posts_email");
-            $thread_authors_email_preference = $this->core->getQueries()->getAllThreadAuthors($thread_id,"reply_in_post_thread_email");
+            $thread_authors_email_preference = $this->core->getQueries()->getAllThreadAuthors($thread_id, "reply_in_post_thread_email");
             $email_recipients = array_merge($parent_authors, $users_with_email_preference, $thread_authors_email_preference);
             $email_recipients[] = $current_user_id;
             $email_recipients = array_unique($email_recipients);
-            $emails = $this->createEmailsArray($event,$email_recipients);
+            $emails = $this->createEmailsArray($event, $email_recipients);
             $this->sendEmails($emails);
         }
     }
@@ -103,7 +103,7 @@ class NotificationFactory {
             $email_recipients[] = $event['recipient'];
             $email_recipients[] = $this->core->getUser()->getId();
             $email_recipients = array_unique($email_recipients);
-            $emails = $this->createEmailsArray($event,$email_recipients);
+            $emails = $this->createEmailsArray($event, $email_recipients);
             $this->sendEmails($emails);
         }
     }
@@ -137,7 +137,7 @@ class NotificationFactory {
         $notifications = $this->createNotificationsArray($event, $notification_recipients);
         $this->sendNotifications($notifications);
         if ($this->core->getConfig()->isEmailEnabled()) {
-            $emails = $this->createEmailsArray($event,$email_recipients);
+            $emails = $this->createEmailsArray($event, $email_recipients);
             $this->sendEmails($emails);
         }
 
@@ -155,7 +155,7 @@ class NotificationFactory {
         $notifications = array();
         foreach ($recipients as $recipient) {
             $event['to_user_id'] = $recipient;
-            $notifications[] = Notification::createNotification($this->core,$event);
+            $notifications[] = Notification::createNotification($this->core, $event);
         }
         return $notifications;
     }
@@ -173,7 +173,7 @@ class NotificationFactory {
                 'subject' => $event['subject'],
                 'body' => $event['content']
             ];
-            $emails[] = new Email($this->core,$details);
+            $emails[] = new Email($this->core, $details);
         }
         return $emails;
     }
@@ -193,7 +193,7 @@ class NotificationFactory {
         $flattened_notifications = [];
         foreach ($notifications as $notification) {
             // check if user is in the null section
-            if (!$this->core->getQueries()->checkStudentActiveInCourse($notification->getNotifyTarget(),$this->core->getConfig()->getCourse(),$this->core->getConfig()->getSemester())) {
+            if (!$this->core->getQueries()->checkStudentActiveInCourse($notification->getNotifyTarget(), $this->core->getConfig()->getCourse(), $this->core->getConfig()->getSemester())) {
                 continue;
             }
             if ($notification->getNotifyTarget() != $current_user->getId() || $current_user->getNotificationSetting('self_notification')) {
@@ -208,7 +208,7 @@ class NotificationFactory {
         if (!empty($flattened_notifications)) {
             // some notifications may not have been added to the flattened notifications
             // so to calculate the number of notifications we must use flattened notifications
-            $this->core->getQueries()->insertNotifications($flattened_notifications,count($flattened_notifications) / 5);
+            $this->core->getQueries()->insertNotifications($flattened_notifications, count($flattened_notifications) / 5);
         }
 
     }
@@ -229,7 +229,7 @@ class NotificationFactory {
         $flattened_emails = [];
         foreach ($emails as $email) {
             // check if user is in the null section
-            if (!$this->core->getQueries()->checkStudentActiveInCourse($email->getUserId(),$this->core->getConfig()->getCourse(),$this->core->getConfig()->getSemester())) {
+            if (!$this->core->getQueries()->checkStudentActiveInCourse($email->getUserId(), $this->core->getConfig()->getCourse(), $this->core->getConfig()->getSemester())) {
                 continue;
             }
             if ($email->getUserId() != $current_user->getId() || $current_user->getNotificationSetting('self_notification_email')) {
@@ -239,7 +239,7 @@ class NotificationFactory {
             }
         }
         if (!empty($flattened_emails)) {
-            $this->core->getQueries()->insertEmails($flattened_emails,count($flattened_emails) / 3);
+            $this->core->getQueries()->insertEmails($flattened_emails, count($flattened_emails) / 3);
         }
 
     }

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -112,7 +112,7 @@ class RainbowCustomization extends AbstractModel {
         }
 
         //XXX: Assuming that the contents of these buckets will be lowercase
-        $this->available_buckets = array_diff(self::syllabus_buckets,$this->used_buckets);
+        $this->available_buckets = array_diff(self::syllabus_buckets, $this->used_buckets);
     }
 
     /**

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1683,7 +1683,7 @@ class Gradeable extends AbstractModel {
 
         if ($this->isVcs()) {
             $config = $this->core->getConfig();
-            AdminGradeableController::enqueueGenerateRepos($config->getSemester(),$config->getCourse(),$gradeable_id);
+            AdminGradeableController::enqueueGenerateRepos($config->getSemester(), $config->getCourse(), $gradeable_id);
         }
     }
 
@@ -1733,7 +1733,7 @@ class Gradeable extends AbstractModel {
      * @return bool
      */
     public function hasOverriddenGrades(Submitter $submitter) {
-        $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->getId(),$submitter->getId());
+        $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->getId(), $submitter->getId());
         if($userWithOverriddenGrades === null ){
             return false;
         }

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -238,7 +238,7 @@ class GradedGradeable extends AbstractModel {
      */
     public function getTotalScore() {
         if ($this->hasOverriddenGrades()){
-            $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(),$this->submitter->getId());
+            $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(), $this->submitter->getId());
             return floatval(max(0.0, $userWithOverriddenGrades->getMarks()));
         } else {
             return floatval(max(0.0, $this->getTaGradingScore() + $this->getAutoGradingScore()));
@@ -247,7 +247,7 @@ class GradedGradeable extends AbstractModel {
 
     public function getOverriddenComment() {
         $overridden_comment = "";
-        $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(),$this->submitter->getId());
+        $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(), $this->submitter->getId());
         if ($userWithOverriddenGrades !== null){
             $overridden_comment = $userWithOverriddenGrades->getComment();
         }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -371,12 +371,12 @@ class AutoGradingView extends AbstractView {
 
         $uploaded_pdfs = [];
         foreach($uploaded_files['submissions'] as $file){
-            if(array_key_exists('path',$file) && mime_content_type($file['path']) === "application/pdf"){
+            if(array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf"){
                 $uploaded_pdfs[] = $file;
             }
         }
         foreach($uploaded_files['checkout'] as $file){
-            if(array_key_exists('path',$file) && mime_content_type($file['path']) === "application/pdf"){
+            if(array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf"){
                 $uploaded_pdfs[] = $file;
             }
         }

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -93,7 +93,7 @@ class NavigationView extends AbstractView {
                     $message_file_details = $message_json->special_message;
 
                     //If any fields are missing, treat this as though we just didn't have a message for this user.
-                    if(!property_exists($message_file_details,'title') || !property_exists($message_file_details,'description') || !property_exists($message_file_details,'filename') ){
+                    if(!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename') ){
                         $display_custom_message = false;
                         $messsage_file_details = null;
                     }
@@ -427,7 +427,7 @@ class NavigationView extends AbstractView {
                 $list_section === GradeableList::GRADED;
             if ($gradeable->isTeamAssignment()) {
                 if ($grade_ready_for_view &&
-                    $this->core->getQueries()->getTeamViewedTime($graded_gradeable->getSubmitter()->getId(),$this->core->getUser()->getId()) === null) {
+                    $this->core->getQueries()->getTeamViewedTime($graded_gradeable->getSubmitter()->getId(), $this->core->getUser()->getId()) === null) {
                     $class = "btn-success";
                 }
             }

--- a/site/app/views/OfficeHoursQueueView.php
+++ b/site/app/views/OfficeHoursQueueView.php
@@ -9,7 +9,7 @@ use app\models\OfficeHoursQueueInstructor;
 class OfficeHoursQueueView extends AbstractView {
     public function showQueueStudent($oh_queue) {
         $this->core->getOutput()->addBreadcrumb("Office Hours Queue");
-        $this->core->getOutput()->renderTwigOutput("OfficeHoursQueueStudent.twig",[
+        $this->core->getOutput()->renderTwigOutput("OfficeHoursQueueStudent.twig", [
         'csrf_token' => $this->core->getCsrfToken(),
         'add_url' => $this->core->buildCourseUrl(["office_hours_queue/add"]),
         'remove_url' => $this->core->buildCourseUrl(["office_hours_queue/remove"]),
@@ -20,7 +20,7 @@ class OfficeHoursQueueView extends AbstractView {
 
     public function showQueueInstructor($oh_queue){
         $this->core->getOutput()->addBreadcrumb("Office Hours Queue");
-        $this->core->getOutput()->renderTwigOutput("OfficeHoursQueueInstructor.twig",[
+        $this->core->getOutput()->renderTwigOutput("OfficeHoursQueueInstructor.twig", [
         'csrf_token' => $this->core->getCsrfToken(),
         'entries' => $oh_queue->getEntries(),
         'entries_helped' => $oh_queue->getEntriesHelped(),

--- a/site/app/views/admin/GradeOverrideView.php
+++ b/site/app/views/admin/GradeOverrideView.php
@@ -12,7 +12,7 @@ class GradeOverrideView extends AbstractView {
         $students = $this->core->getQueries()->getAllUsers();
         $student_full = Utils::getAutoFillData($students);
 
-        return $this->core->getOutput()->renderTwigTemplate("admin/GradeOverride.twig",[
+        return $this->core->getOutput()->renderTwigTemplate("admin/GradeOverride.twig", [
             "gradeables" => $gradeables,
             "student_full" => $student_full,
             "csrf_token" => $this->core->getCsrfToken()

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -28,7 +28,7 @@ HTML;
             $delete_form_action = $this->core->buildCourseUrl(['plagiarism', 'gradeable', $id, 'delete']);
 
             if(file_exists($course_path . "/lichen/ranking/" . $id . ".txt")) {
-                $timestamp = date("F d Y H:i:s.",filemtime($course_path . "/lichen/ranking/" . $id . ".txt"));
+                $timestamp = date("F d Y H:i:s.", filemtime($course_path . "/lichen/ranking/" . $id . ".txt"));
                 $students = array_diff(scandir($course_path . "/lichen/concatenated/" . $id), array('.', '..'));
                 $submissions = 0;
                 foreach($students as $student) {
@@ -104,7 +104,7 @@ HTML;
                     $content = file_get_contents($ranking_file_path);
                     $content = trim(str_replace(array("\r", "\n"), '', $content));
                     $rankings = preg_split('/ +/', $content);
-                    $rankings = array_chunk($rankings,3);
+                    $rankings = array_chunk($rankings, 3);
                     $matches_and_topmatch = count($rankings) . " students matched, " . $rankings[0][0] . " top match";
 
                     $return .= <<<HTML

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -33,7 +33,7 @@ class CourseMaterialsView extends AbstractView {
 
                 $expected_file_path = FileUtils::joinPaths($expected_path, $file);
 
-                array_push($in_dir,$expected_file_path);
+                array_push($in_dir, $expected_file_path);
 
                 // Check whether the file is shared to student or not
                 // If shared, will add to courseMaterialsArray
@@ -82,7 +82,7 @@ class CourseMaterialsView extends AbstractView {
                     $ex_file_path['checked'] = '1';
                     $isShareToOther = $ex_file_path['checked'];
                     $date = $now_date_time->format("Y-m-d H:i:sO");
-                    $date = substr_replace($date,"9999",0,4);
+                    $date = substr_replace($date, "9999", 0, 4);
                     $ex_file_path['release_datetime'] = $date;
                     $ex_file_path['hide_from_students'] = "on";
                     $releaseData = $ex_file_path['release_datetime'];
@@ -116,7 +116,7 @@ class CourseMaterialsView extends AbstractView {
                 if( $releaseData == $now_date_time->format("Y-m-d H:i:sO")){
                     //for uploaded files that have had no manually set date to be set to never and maintained as never
                     //also permission set to yes
-                    $releaseData = substr_replace($releaseData,"9999",0,4);
+                    $releaseData = substr_replace($releaseData, "9999", 0, 4);
                     $json[$expected_file_path]['checked'] = '1';
                     $json[$expected_file_path]['release_datetime'] = $releaseData;
                 }
@@ -124,7 +124,7 @@ class CourseMaterialsView extends AbstractView {
             }
 
             if($json == false){
-                FileUtils::writeJsonFile($fp,$no_json);
+                FileUtils::writeJsonFile($fp, $no_json);
             }
             $can_write = is_writable($fp);
             if(!$can_write){
@@ -149,7 +149,7 @@ class CourseMaterialsView extends AbstractView {
 
         $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
         $json = FileUtils::readJsonFile($fp);
-        $add_files($this->core, $submissions, $file_shares, $file_release_dates, $expected_path, $json, $course_materials_array, 'course_materials', $user_group,$in_dir,$fp, $file_sections, $hide_from_students);
+        $add_files($this->core, $submissions, $file_shares, $file_release_dates, $expected_path, $json, $course_materials_array, 'course_materials', $user_group, $in_dir, $fp, $file_sections, $hide_from_students);
 
         //Check if user has permissions to access page (not instructor when no course materials available)
         if ($user_group !== 1 && count($course_materials_array) == 0) {

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -62,7 +62,7 @@ class ForumThreadView extends AbstractView {
                 $user_info = $this->core->getQueries()->getDisplayUserInfoFromUserId($post["p_author"]);
                 $first_name = trim($user_info["first_name"]);
                 $last_name = trim($user_info["last_name"]);
-                $visible_username = $first_name . " " . substr($last_name, 0 , 1) . ".";
+                $visible_username = $first_name . " " . substr($last_name, 0, 1) . ".";
 
                 if($post["anonymous"]){
                     $visible_username = 'Anonymous';
@@ -560,9 +560,9 @@ class ForumThreadView extends AbstractView {
     }
 
     public function contentMarkdownToPlain($str){
-        $str = preg_replace("/\[[^)]+\]/","",$str);
+        $str = preg_replace("/\[[^)]+\]/", "", $str);
         $str = preg_replace('/\(([^)]+)\)/s', '$1', $str);
-        $str = str_replace("```","", $str);
+        $str = str_replace("```", "", $str);
         return $str;
     }
 
@@ -749,7 +749,7 @@ class ForumThreadView extends AbstractView {
         }
         //This code is for legacy posts that had an extra \r per newline
         if(strpos($original_post_content, "\r") !== false){
-            $post_content = str_replace("\r","", $post_content);
+            $post_content = str_replace("\r", "", $post_content);
         }
 
         //end link handling
@@ -939,7 +939,7 @@ class ForumThreadView extends AbstractView {
             "current_user" => $current_user,
             "author_email" => $author_email,
             "post_user_info" => $post_user_info,
-            "post_date" => $function_date($date,'n/j g:i A'),
+            "post_date" => $function_date($date, 'n/j g:i A'),
             "edit_date" => $edit_date,
             "post_buttons" => $post_button,
             "visible_username" => $visible_username,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -148,7 +148,7 @@ class ElectronicGraderView extends AbstractView {
                     $viewed_total = $total / $num_components;
                     $viewed_percent = number_format(($viewed_grade / max($viewed_total, 1)) * 100, 1);
                     $individual_viewed_percent = $total_students_submitted == 0 ? 0 :
-                        number_format(($individual_viewed_grade / $total_students_submitted) * 100,1);
+                        number_format(($individual_viewed_grade / $total_students_submitted) * 100, 1);
                 }
             }
             if(!$peer) {

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -98,7 +98,7 @@ class HomeworkView extends AbstractView {
             $return .= $this->renderTAResultsBox($graded_gradeable, $regrade_available);
         }
         if ($regrade_available || $graded_gradeable !== null && $graded_gradeable->hasRegradeRequest()) {
-            $return .= $this->renderRegradeBox($graded_gradeable,$can_inquiry);
+            $return .= $this->renderRegradeBox($graded_gradeable, $can_inquiry);
         }
         return $return;
     }
@@ -205,7 +205,7 @@ class HomeworkView extends AbstractView {
                     $messages[] = ['type' => 'would_get_zero'];
                 } // SUBMISSION NOW WOULD BE LATE
                 else {
-                    $new_late_charged = max(0,$would_be_days_late - $active_days_late - $extensions);
+                    $new_late_charged = max(0, $would_be_days_late - $active_days_late - $extensions);
                     $new_late_days_remaining = $late_days_remaining - $new_late_charged;
                     $messages[] = ['type' => 'would_allowed', 'info' => [
                         'charged' => $new_late_charged,
@@ -349,7 +349,7 @@ class HomeworkView extends AbstractView {
 
         // instructors can access this page even if they aren't on a team => don't create errors
         $my_team = $graded_gradeable !== null ? $graded_gradeable->getSubmitter()->getTeam() : "";
-        $my_repository = $graded_gradeable !== null ? $gradeable->getRepositoryPath($this->core->getUser(),$my_team) : "";
+        $my_repository = $graded_gradeable !== null ? $gradeable->getRepositoryPath($this->core->getUser(), $my_team) : "";
         $notebook_data = $graded_gradeable !== null ? $graded_gradeable->getUpdatedNotebook() : array();
         $testcase_messages = $version_instance !== null ? $version_instance->getTestcaseMessages() : array();
 
@@ -471,7 +471,7 @@ class HomeworkView extends AbstractView {
                 $count_array[$count] = FileUtils::joinPaths($timestamp, rawurlencode($filename_full));
                 //decode the filename after to display correctly for users
                 $filename_full = rawurldecode($filename_full);
-                $cover_image_name = substr($filename,0,-3) . "jpg";
+                $cover_image_name = substr($filename, 0, -3) . "jpg";
                 $cover_image = [];
                 foreach ($cover_images as $img) {
                     if($img['filename'] === $cover_image_name)

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -58,7 +58,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
             for($i = 0; $i < $depth; $i++){
                 for($j = 0; $j < $num_files; $j++){
                     $fname = "test" . $j . ".txt";
-                    $tmpfile = fopen($this->config['course_path'] . $lev . "/" . $fname , "w");
+                    $tmpfile = fopen($this->config['course_path'] . $lev . "/" . $fname, "w");
                     $zip->addFile( $this->config['course_path'] . $lev . "/" . $fname  );
                     $files[] = $this->config['course_path'] . $lev . "/" . $fname;
                 }
@@ -199,7 +199,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
         $ret = $controller->modifyCourseMaterialsFileTimeStamp($_POST['fn'][0], $new_date );
 
-        $this->assertEquals( ['status' => 'success', 'data' => 'Time successfully set.']  , $ret);
+        $this->assertEquals( ['status' => 'success', 'data' => 'Time successfully set.'], $ret);
         $json = FileUtils::readJsonFile($this->json_path);
 
         //check the date has been updated to the new time

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -35,7 +35,7 @@ class TeamControllerTester extends BaseUnitTest {
     public function testCreateTeamOnNullGradeable(){
         $controller = new TeamController($this->core);
         $response = $controller->createNewTeam(false);
-        $this->assertEquals(["status" => "fail", "message" => "Invalid or missing gradeable id!"] , $response);
+        $this->assertEquals(["status" => "fail", "message" => "Invalid or missing gradeable id!"], $response);
     }
 
     //create a normal gradeable, we should not be able to create a team
@@ -43,7 +43,7 @@ class TeamControllerTester extends BaseUnitTest {
         $this->core->getQueries()->method('getGradeableConfig')->with('test')->willReturn($this->createMockGradeable(false));
         $controller = new TeamController($this->core);
         $response = $controller->createNewTeam($this->config['gradeable_id']);
-        $this->assertEquals(["status" => "fail", "message" => "Test Gradeable is not a team assignment"] , $response);
+        $this->assertEquals(["status" => "fail", "message" => "Test Gradeable is not a team assignment"], $response);
     }
 
     public function testCreateTeamSuccess(){
@@ -63,7 +63,7 @@ class TeamControllerTester extends BaseUnitTest {
         $this->assertTrue(FileUtils::createDir($tmp, true));
 
         $response = $controller->createNewTeam($this->config['gradeable_id']);
-        $this->assertEquals(["status" => "success", "data" => null] , $response);
+        $this->assertEquals(["status" => "success", "data" => null], $response);
 
         $settings_file = FileUtils::joinPaths($this->config['gradeable_path'], "test", "user_assignment_settings.json");
         $this->assertTrue(file_exists($settings_file));

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -197,7 +197,7 @@ class FileUtilsTester extends \PHPUnit\Framework\TestCase {
         file_put_contents(FileUtils::joinPaths($this->path, "b", "test.txt"), "aa");
         FileUtils::emptyDir($this->path);
         $this->assertFileExists($this->path);
-        $this->assertCount(2,scandir($this->path));
+        $this->assertCount(2, scandir($this->path));
     }
 
     public function testReadJsonFile() {

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -139,7 +139,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'email_server_hostname' => 'localhost',
             'email_server_port' => 25
         );
-        $config = array_replace($config,$extra);
+        $config = array_replace($config, $extra);
         FileUtils::writeJsonFile(FileUtils::joinPaths($this->config_path, "email.json"), $config);
 
         // Create version json
@@ -148,7 +148,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             "short_installed_commit" => "d150131c",
             "most_recent_git_tag" => "v19.07.00"
         );
-        $config = array_replace($config,$extra);
+        $config = array_replace($config, $extra);
         FileUtils::writeJsonFile(FileUtils::joinPaths($this->config_path, "version.json"), $config);
 
     }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -22,9 +22,6 @@
         <exclude name="Generic.Formatting.SpaceAfterCast.NoSpace" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace" />
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma" />
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma" />
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />
         <exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes violations of the `Generic.Functions.FunctionCallArgumentSpacing` style rules, where for two+ arguments, the first argument does not have a space between it and the comma and there is a single space between the comma and second argument (e.g. `func(a, b)`, not `func(a,b)` or `func(a , b)`).