### PR TITLE
[Testing:Python] Drop usage of flake8-docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
       language: python
       python: 3.6
       install:
-        - pip3 install flake8 flake8-bugbear flake8-docstrings sqlalchemy psycopg2-binary
+        - pip3 install flake8 flake8-bugbear sqlalchemy psycopg2-binary
       script: skip
     - <<: *00-python-cache
       python: 3.7
@@ -89,7 +89,7 @@ jobs:
       language: python
       python: 3.6
       install:
-        - pip3 install flake8 flake8-bugbear flake8-docstrings
+        - pip3 install flake8 flake8-bugbear
       script:
         - flake8
     - <<: *01-python-lint


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant: Submitty/submitty.github.io#181

### What is the current behavior?

The codebase was using flake8-docstrings to enforce that docstrings were getting written for functions.

### What is the new behavior?

flake8-docstrings is no longer used for enforcing any sort of existence of docstrings for python code. Developers would either just add the file to be ignored, or just find the easiest solution to fix why it would complain, without really bothering to learn what it was checking for, nor giving meaningful docstring comments.