### PR TITLE
removing double click

### DIFF
--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -146,7 +146,6 @@
     <script type="text/javascript">
         createArray(1);
         var dropzone = document.getElementById("upload1");
-        dropzone.addEventListener("click", clicked_on_box, false);
         dropzone.addEventListener("dragenter", draghandle, false);
         dropzone.addEventListener("dragover", draghandle, false);
         dropzone.addEventListener("dragleave", draghandle, false);


### PR DESCRIPTION
Solves #4711

Looks like someone added an eventhandler for clicking on the upload box that open the file explorer. This is extraneous because the input box is of a class that automatically opens the file explorer when clicked on