### PR TITLE
[Refactor:PHP] Fix PSR2.Namespaces style errors

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -3,7 +3,6 @@
 
 namespace app\controllers;
 
-
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 use app\models\Button;

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -2,7 +2,6 @@
 
 namespace app\controllers;
 
-
 use app\libraries\DateUtils;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
@@ -11,7 +10,6 @@ use app\libraries\routers\AccessControl;
 use app\libraries\response\Response;
 use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
-
 
 class MiscController extends AbstractController {
 

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -13,7 +13,6 @@ use app\libraries\FileUtils;
 use app\libraries\routers\AccessControl;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 /**
  * Class AdminGradeableController
  * @package app\controllers\admin

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -11,7 +11,6 @@ use app\libraries\response\WebResponse;
 use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 /**
  * Class AutogradingConfigController
  * @package app\controllers\admin

--- a/site/app/controllers/admin/EmailRoomSeatingController.php
+++ b/site/app/controllers/admin/EmailRoomSeatingController.php
@@ -12,7 +12,6 @@ use app\libraries\routers\AccessControl;
 use app\models\Email;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 /**
  * Class EmailRoomSeatingController
  * @package app\controllers\admin

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -12,7 +12,6 @@ use app\libraries\DateUtils;
 use app\libraries\routers\AccessControl;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 /**
  * Class ForumHomeController
  *

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -21,7 +21,6 @@ use app\libraries\FileUtils;
 use app\controllers\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 class ElectronicGraderController extends AbstractController {
     /**
      * Checks that a given diff viewer option is valid using DiffViewer::isValidSpecialCharsOption

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -10,7 +10,6 @@ use app\libraries\response\Response;
 use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
-
 class GradeInquiryController extends AbstractController {
     /**
      * @param $gradeable_id

--- a/site/app/controllers/student/LateDaysTableController.php
+++ b/site/app/controllers/student/LateDaysTableController.php
@@ -2,7 +2,6 @@
 
 namespace app\controllers\student;
 
-
 use app\controllers\AbstractController;
 use app\libraries\Core;
 use app\models\gradeable\LateDays;

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -2,7 +2,6 @@
 
 namespace app\controllers\student;
 
-
 use app\controllers\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -14,8 +14,6 @@ use app\models\User;
 use app\models\NotificationFactory;
 use Symfony\Component\HttpFoundation\Request;
 
-
-
 /**
  * Class Core
  *

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\libraries;
+
 use app\exceptions\FileReadException;
 
 /**

--- a/site/app/libraries/ForumUtils.php
+++ b/site/app/libraries/ForumUtils.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\libraries;
+
 use app\libraries\Utils;
 use app\libraries\FileUtils;
 use app\models\forum\Thread;

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\libraries;
+
 use app\controllers\GlobalController;
 use app\exceptions\OutputException;
 use app\libraries\FileUtils;

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -27,7 +27,6 @@ use app\models\SimpleStat;
 use app\models\OfficeHoursQueueStudent;
 use app\models\OfficeHoursQueueInstructor;
 
-
 /**
  * DatabaseQueries
  *

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -2,7 +2,6 @@
 
 namespace app\libraries\database;
 
-
 class PostgresqlDatabase extends AbstractDatabase {
     protected $host;
     protected $port;

--- a/site/app/libraries/database/SqliteDatabase.php
+++ b/site/app/libraries/database/SqliteDatabase.php
@@ -2,7 +2,6 @@
 
 namespace app\libraries\database;
 
-
 use app\exceptions\NotImplementedException;
 
 class SqliteDatabase extends AbstractDatabase {

--- a/site/app/libraries/response/AbstractResponse.php
+++ b/site/app/libraries/response/AbstractResponse.php
@@ -5,7 +5,6 @@ namespace app\libraries\response;
 
 use app\libraries\Core;
 
-
 /**
  * Class AbstractResponse
  * @package app\libraries\response

--- a/site/app/libraries/response/JsonResponse.php
+++ b/site/app/libraries/response/JsonResponse.php
@@ -5,7 +5,6 @@ namespace app\libraries\response;
 
 use app\libraries\Core;
 
-
 /**
  * Class JsonResponse
  * @package app\libraries\response

--- a/site/app/libraries/response/RedirectResponse.php
+++ b/site/app/libraries/response/RedirectResponse.php
@@ -5,7 +5,6 @@ namespace app\libraries\response;
 
 use app\libraries\Core;
 
-
 /**
  * Class RedirectResponse
  * @package app\libraries\response

--- a/site/app/libraries/response/Response.php
+++ b/site/app/libraries/response/Response.php
@@ -5,7 +5,6 @@ namespace app\libraries\response;
 
 use app\libraries\Core;
 
-
 /**
  * Class Response
  * @package app\libraries\response

--- a/site/app/libraries/response/WebResponse.php
+++ b/site/app/libraries/response/WebResponse.php
@@ -5,7 +5,6 @@ namespace app\libraries\response;
 
 use app\libraries\Core;
 
-
 /**
  * Class WebResponse
  * @package app\libraries\response

--- a/site/app/libraries/routers/AnnotatedRouteLoader.php
+++ b/site/app/libraries/routers/AnnotatedRouteLoader.php
@@ -5,7 +5,6 @@ namespace app\libraries\routers;
 use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Route;
 
-
 class AnnotatedRouteLoader extends AnnotationClassLoader {
 
 

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -2,6 +2,7 @@
 
 
 namespace app\models;
+
 use app\libraries\Core;
 use app\libraries\Utils;
 

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\models;
+
 use app\libraries\Core;
 
 /**

--- a/site/app/models/Button.php
+++ b/site/app/models/Button.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\models;
+
 use app\libraries\Core;
 
 /**

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\models;
+
 use app\libraries\Core;
 use app\libraries\FileUtils;
 

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -3,7 +3,6 @@
 
 namespace app\models;
 
-
 use app\exceptions\FileNotFoundException;
 use app\libraries\Core;
 

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\models;
+
 use app\libraries\Core;
 use app\libraries\Utils;
 

--- a/site/app/models/OfficeHoursQueueInstructor.php
+++ b/site/app/models/OfficeHoursQueueInstructor.php
@@ -6,7 +6,6 @@ use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\models\OfficeHoursQueueStudent;
 
-
 class OfficeHoursQueueInstructor extends AbstractModel {
 
     private $entries = array();

--- a/site/app/models/OfficeHoursQueueStudent.php
+++ b/site/app/models/OfficeHoursQueueStudent.php
@@ -5,7 +5,6 @@ namespace app\models;
 use app\libraries\Core;
 use app\libraries\DateUtils;
 
-
 class OfficeHoursQueueStudent extends AbstractModel {
 
     private $user_id = null;

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\models;
+
 use app\libraries\Core;
 
 /**
@@ -17,7 +18,7 @@ use app\libraries\Core;
 
  */
 class SimpleStat extends AbstractModel {
-    /** @ property @var bool is this a component */
+    /** @property @var bool is this a component */
     protected $component = true;
     /** @property @var string Title of gradeable or component */
     protected $title = "";

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\models;
+
 use app\libraries\Core;
 use app\libraries\FileUtils;
 use app\models\gradeable\Gradeable;

--- a/site/app/models/forum/Post.php
+++ b/site/app/models/forum/Post.php
@@ -7,7 +7,6 @@ use app\models\User;
 use app\libraries\DataTime;
 use app\models\AbstractModel;
 
-
 /**
  * Class Post
  *

--- a/site/app/models/forum/Thread.php
+++ b/site/app/models/forum/Thread.php
@@ -5,7 +5,6 @@ namespace app\models\forum;
 use app\libraries\Core;
 use app\models\AbstractModel;
 
-
 /**
  * Class Thread
  *

--- a/site/app/models/gradeable/AbstractGradeableInput.php
+++ b/site/app/models/gradeable/AbstractGradeableInput.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\AbstractModel;
 

--- a/site/app/models/gradeable/AbstractTextBox.php
+++ b/site/app/models/gradeable/AbstractTextBox.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\gradeable\AbstractGradeableModel;
 

--- a/site/app/models/gradeable/AutoGradedGradeable.php
+++ b/site/app/models/gradeable/AutoGradedGradeable.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\GradingQueue;
 use app\models\AbstractModel;

--- a/site/app/models/gradeable/AutoGradedTestcase.php
+++ b/site/app/models/gradeable/AutoGradedTestcase.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\Utils;
 use app\models\AbstractModel;

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\exceptions\FileNotFoundException;
 use app\libraries\Core;
 use app\libraries\DateUtils;

--- a/site/app/models/gradeable/AutoGradedVersionHistory.php
+++ b/site/app/models/gradeable/AutoGradedVersionHistory.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\models\AbstractModel;

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\exceptions\NotImplementedException;
 use app\libraries\Core;
 use app\libraries\Utils;

--- a/site/app/models/gradeable/AutogradingTestcase.php
+++ b/site/app/models/gradeable/AutogradingTestcase.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\Utils;
 use app\models\AbstractModel;

--- a/site/app/models/gradeable/Component.php
+++ b/site/app/models/gradeable/Component.php
@@ -8,7 +8,6 @@ use app\libraries\Core;
 use app\libraries\Utils;
 use app\models\AbstractModel;
 
-
 /**
  * Class Component
  * @package app\models\gradeable

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\Utils;
 use app\models\AbstractModel;

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\AbstractModel;
 use app\models\User;

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\GradeableType;
 use app\models\AbstractModel;

--- a/site/app/models/gradeable/SubmissionCodeBox.php
+++ b/site/app/models/gradeable/SubmissionCodeBox.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\gradeable\AbstractTextBox;
 

--- a/site/app/models/gradeable/SubmissionMultipleChoice.php
+++ b/site/app/models/gradeable/SubmissionMultipleChoice.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\gradeable\AbstractGradeableInput;
 

--- a/site/app/models/gradeable/SubmissionTextBox.php
+++ b/site/app/models/gradeable/SubmissionTextBox.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\gradeable\AbstractTextBox;
 

--- a/site/app/models/gradeable/Submitter.php
+++ b/site/app/models/gradeable/Submitter.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\models\AbstractModel;
 use app\models\Team;

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -2,7 +2,6 @@
 
 namespace app\models\gradeable;
 
-
 use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\libraries\Utils;

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\views;
+
 use app\models\Breadcrumb;
 
 class GlobalView extends AbstractView {

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -4,8 +4,6 @@ namespace app\views;
 use app\authentication\DatabaseAuthentication;
 use app\models\User;
 
-
-
 class HomePageView extends AbstractView {
     /**
      * @param User $user

--- a/site/app/views/MiscView.php
+++ b/site/app/views/MiscView.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\views;
+
 use app\libraries\FileUtils;
 
 class MiscView extends AbstractView {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -1,5 +1,6 @@
 <?php
 namespace app\views;
+
 use app\models\Button;
 use \app\libraries\GradeableType;
 use app\models\User;

--- a/site/app/views/PDFView.php
+++ b/site/app/views/PDFView.php
@@ -1,5 +1,6 @@
 <?php
 namespace app\views;
+
 use app\libraries\FileUtils;
 
 class PDFView extends AbstractView {

--- a/site/app/views/admin/EmailRoomSeatingView.php
+++ b/site/app/views/admin/EmailRoomSeatingView.php
@@ -3,6 +3,7 @@
 namespace app\views\admin;
 
 use app\views\AbstractView;
+
 class EmailRoomSeatingView extends AbstractView {
     public function displayPage($defaultSubject, $defaultBody) {
         $this->core->getOutput()->addBreadcrumb("Email Room Seating");

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -9,7 +9,6 @@ use app\views\AbstractView;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 
-
 class CourseMaterialsView extends AbstractView {
     /**
      * @param User $user

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -7,7 +7,6 @@ use app\views\AbstractView;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 
-
 class ImagesView extends AbstractView {
     /**
      * @param User[] $students

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1503,6 +1503,11 @@ parameters:
 			path: app/models/SimpleStat.php
 
 		-
+			message: "#^PHPDoc tag @property has invalid value \\(@var bool is this a component\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var string The id of this team of form \"\\<unique number\\>_\\<creator user id\\>\"\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/Team.php
@@ -2656,5 +2661,3 @@ parameters:
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$can_inquirye$#"
 			count: 1
 			path: app/views/submission/HomeworkView.php
-
-

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -11,7 +11,6 @@ use app\models\Config;
 use app\models\User;
 use ReflectionException;
 
-
 class BaseUnitTest extends \PHPUnit\Framework\TestCase {
     protected static $mock_builders = [];
 

--- a/site/tests/app/exceptions/AuthenticationExceptionTester.php
+++ b/site/tests/app/exceptions/AuthenticationExceptionTester.php
@@ -2,7 +2,6 @@
 
 namespace tests\app\exceptions;
 
-
 use app\exceptions\AuthenticationException;
 
 class AuthenticationExceptionTester extends \PHPUnit\Framework\TestCase {

--- a/site/tests/app/exceptions/BaseExceptionTester.php
+++ b/site/tests/app/exceptions/BaseExceptionTester.php
@@ -2,7 +2,6 @@
 
 namespace tests\app\exceptions;
 
-
 use app\exceptions\BaseException;
 
 class BaseExceptionTester extends \PHPUnit\Framework\TestCase {

--- a/site/tests/app/exceptions/FileNotFoundExceptionTester.php
+++ b/site/tests/app/exceptions/FileNotFoundExceptionTester.php
@@ -3,7 +3,6 @@
 
 namespace tests\app\exceptions;
 
-
 use app\exceptions\FileNotFoundException;
 
 class FileNotFoundExceptionTester extends \PHPUnit\Framework\TestCase {

--- a/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
+++ b/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
@@ -2,7 +2,6 @@
 
 namespace tests\app\libraries\database;
 
-
 use app\libraries\database\PostgresqlDatabase;
 
 class PostgresqlDatabaseTester extends \PHPUnit\Framework\TestCase {

--- a/site/tests/app/libraries/response/WebResponseTester.php
+++ b/site/tests/app/libraries/response/WebResponseTester.php
@@ -7,7 +7,6 @@ use app\libraries\response\WebResponse;
 use app\models\Config;
 use PHPUnit\Framework\TestCase;
 
-
 class WebResponseTester extends TestCase {
     public function testWebResponse() {
         $core = new Core();

--- a/site/tests/app/libraries/routers/AccessControlTester.php
+++ b/site/tests/app/libraries/routers/AccessControlTester.php
@@ -9,7 +9,6 @@ use app\models\User;
 use app\libraries\routers\WebRouter;
 use Symfony\Component\HttpFoundation\Request;
 
-
 class AccessControlTester extends BaseUnitTest {
     private $semester = 'test_semester';
 

--- a/site/tests/app/models/BreadcrumbTester.php
+++ b/site/tests/app/models/BreadcrumbTester.php
@@ -2,7 +2,6 @@
 
 namespace tests\app\models;
 
-
 use app\libraries\Core;
 use app\models\Breadcrumb;
 

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -42,8 +42,6 @@
         <exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine" />
         <exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments" />
         <exclude name="PSR2.Methods.MethodDeclaration.StaticBeforeVisibility" />
-        <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse" />
-        <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter" />
 
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes `PSR2.Namespaces` style errors, which mandate that there must be just a single newline between `namespace` declaration and `use` declarations and then a single blank space between the `use` declarations and the start of the class.