### PR TITLE
[Refactor:PHP] Fix PSR2.Methods.MethodDeclaration.StaticBeforeVisibility style errors

### DIFF
--- a/site/app/libraries/response/Response.php
+++ b/site/app/libraries/response/Response.php
@@ -39,7 +39,7 @@ class Response extends AbstractResponse {
      * @param WebResponse $web_response
      * @return Response
      */
-    static public function WebOnlyResponse(WebResponse $web_response): Response {
+    public static function WebOnlyResponse(WebResponse $web_response): Response {
         return new self(null, $web_response, null);
     }
 
@@ -47,7 +47,7 @@ class Response extends AbstractResponse {
      * @param JsonResponse $json_response
      * @return Response
      */
-    static public function JsonOnlyResponse(JsonResponse $json_response): Response {
+    public static function JsonOnlyResponse(JsonResponse $json_response): Response {
         return new self($json_response, null, null);
     }
 
@@ -55,7 +55,7 @@ class Response extends AbstractResponse {
      * @param RedirectResponse $redirect_response
      * @return Response
      */
-    static public function RedirectOnlyResponse(RedirectResponse $redirect_response): Response {
+    public static function RedirectOnlyResponse(RedirectResponse $redirect_response): Response {
         return new self(null, null, $redirect_response);
     }
 

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -57,7 +57,7 @@ class WebRouter {
      * @param Core $core
      * @return Response|mixed should be of type Response only in the future
      */
-    static public function getApiResponse(Request $request, Core $core) {
+    public static function getApiResponse(Request $request, Core $core) {
         try {
             $router = new self($request, $core);
             $router->loadCourse();
@@ -102,7 +102,7 @@ class WebRouter {
      * @return Response|mixed should be of type Response only in the future
      * @throws \ReflectionException|\Exception
      */
-    static public function getWebResponse(Request $request, Core $core) {
+    public static function getWebResponse(Request $request, Core $core) {
         $logged_in = false;
         try {
             $router = new self($request, $core);

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -320,7 +320,7 @@ class User extends AbstractModel {
      * @param mixed $data
      * @return bool
      */
-    static public function validateUserData($field, $data) {
+    public static function validateUserData($field, $data) {
 
         switch($field) {
             case 'user_id':
@@ -358,7 +358,7 @@ class User extends AbstractModel {
         }
     }
 
-    static public function constructNotificationSettings($details) {
+    public static function constructNotificationSettings($details) {
         $notification_settings = [];
         $notification_settings['reply_in_post_thread'] = $details['reply_in_post_thread'] ?? false;
         $notification_settings['merge_threads'] = $details['merge_threads'] ?? false;

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -41,7 +41,6 @@
         <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket" />
         <exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine" />
         <exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments" />
-        <exclude name="PSR2.Methods.MethodDeclaration.StaticBeforeVisibility" />
 
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the `PSR2.Methods.MethodDeclaration.StaticBeforeVisibility` style errors. Means that all function definitions must have visibility before the `static` keyword. 