### PR TITLE
[Refactor:PHP] Fix PSR(?:12|2).Classes style errors

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -443,5 +443,4 @@ class GlobalController extends AbstractController {
 
         return true;
     }
-
 }

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -206,5 +206,4 @@ class OfficeHoursQueueController extends AbstractController {
             new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
         );
     }
-
 }

--- a/site/app/controllers/admin/EmailRoomSeatingController.php
+++ b/site/app/controllers/admin/EmailRoomSeatingController.php
@@ -108,5 +108,4 @@ Please email your instructor with any questions or concerns.';
 
         return $message;
     }
-
 }

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -771,5 +771,4 @@ class PlagiarismController extends AbstractController {
         $this->core->getOutput()->renderString("NO_REFRESH");
         return;
     }
-
 }

--- a/site/app/controllers/admin/WrapperController.php
+++ b/site/app/controllers/admin/WrapperController.php
@@ -114,5 +114,4 @@ class WrapperController extends AbstractController {
             new RedirectResponse($this->core->buildCourseUrl(['theme']))
         );
     }
-
 }

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -798,5 +798,4 @@ class ForumController2 extends AbstractController {
         $output['categories_ids'] = $this->core->getQueries()->getCategoriesIdForThread($thread_id);
         $output['thread_status'] = $result["status"];
     }
-
 }

--- a/site/app/controllers/student/LateDaysTableController.php
+++ b/site/app/controllers/student/LateDaysTableController.php
@@ -27,5 +27,4 @@ class LateDaysTableController extends AbstractController {
     public function showLateTablePage() {
         $this->core->getOutput()->renderOutput(array('LateDaysTable'), 'showLateTablePage', LateDays::fromUser($this->core, $this->core->getUser()));
     }
-
 }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1483,5 +1483,4 @@ class SubmissionController extends AbstractController {
 
         $this->core->getOutput()->renderOutput('grading\ElectronicGrader', 'statPage', $users);
     }
-
 }

--- a/site/app/libraries/ForumUtils.php
+++ b/site/app/libraries/ForumUtils.php
@@ -74,5 +74,4 @@ class ForumUtils {
         }
         return $real_name['first_name'] . substr($real_name['last_name'], 0, 2) . '.';
     }
-
 }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -313,5 +313,4 @@ class Utils {
         $formats = ['b' => 0, 'kb' => 1, 'mb' => 2];
         return ($bytes / pow(1024, floor($formats[strtolower($format)]))) . (strtoupper($format));
     }
-
 }

--- a/site/app/libraries/database/ForumQueries.php
+++ b/site/app/libraries/database/ForumQueries.php
@@ -71,6 +71,4 @@ class ForumQueries {
         //Will change...
         return [true, 'thread_id' => $id, 'post_id' => $post_id];
     }
-
-
 }

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -1622,5 +1622,4 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         }
         return $versions;
     }
-
 }

--- a/site/app/libraries/database/SqliteDatabase.php
+++ b/site/app/libraries/database/SqliteDatabase.php
@@ -36,5 +36,4 @@ class SqliteDatabase extends AbstractDatabase {
     public function fromPHPToDatabaseArray($array) {
         throw new NotImplementedException();
     }
-
 }

--- a/site/app/libraries/routers/AccessControl.php
+++ b/site/app/libraries/routers/AccessControl.php
@@ -106,7 +106,7 @@ class AccessControl {
             $this->role = $role;
         }
         else {
-            throw new \InvalidArgumentException;
+            throw new \InvalidArgumentException();
         }
     }
 
@@ -130,5 +130,4 @@ class AccessControl {
     public function getPermission() {
         return $this->permission;
     }
-
 }

--- a/site/app/libraries/routers/AnnotatedRouteLoader.php
+++ b/site/app/libraries/routers/AnnotatedRouteLoader.php
@@ -13,5 +13,4 @@ class AnnotatedRouteLoader extends AnnotationClassLoader {
         $route->setDefault('_controller', $class->getName());
         $route->setDefault('_method', $method->getName());
     }
-
 }

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -15,7 +15,7 @@ use app\libraries\Utils;
  */
 abstract class AbstractModel {
 
-    static protected $properties = array();
+    protected static $properties = array();
 
     /** @var Core */
     protected $core;

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -45,5 +45,4 @@ class Breadcrumb extends AbstractModel {
         $this->url = $url;
         $this->external_url = $external_url;
     }
-
 }

--- a/site/app/models/Button.php
+++ b/site/app/models/Button.php
@@ -89,5 +89,4 @@ class Button extends AbstractModel {
     public function hasOnclick() {
         return !($this->getOnclick() == null);
     }
-
 }

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -80,5 +80,4 @@ class Course extends AbstractModel {
             "display_semester" => $this->getLongSemester()
         ];
     }
-
 }

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -52,5 +52,4 @@ class Email extends AbstractModel {
     private function formatBody($body){
         return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
     }
-
 }

--- a/site/app/models/SimpleGradeOverriddenUser.php
+++ b/site/app/models/SimpleGradeOverriddenUser.php
@@ -66,5 +66,4 @@ class SimpleGradeOverriddenUser extends AbstractModel {
             $this->comment = $details['comment'];
         }
     }
-
 }

--- a/site/app/models/forum/Forum.php
+++ b/site/app/models/forum/Forum.php
@@ -146,7 +146,4 @@ class Forum extends AbstractModel {
         return $createObject ? [true, new Post($this->core, $data)] : [true, null];
 
     }
-
-
-
 }

--- a/site/app/models/forum/Post.php
+++ b/site/app/models/forum/Post.php
@@ -79,5 +79,4 @@ class Post extends AbstractModel {
         //setType($details['type']);
         //setAttachment($details['has_attachment']);
     }
-
 }

--- a/site/app/models/forum/Thread.php
+++ b/site/app/models/forum/Thread.php
@@ -47,5 +47,4 @@ class Thread extends AbstractModel {
     public function getFirstPost() : Post {
         return $posts_list[0];
     }
-
 }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1138,5 +1138,4 @@ class ForumThreadView extends AbstractView {
         return $return;
 
     }
-
 }

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -49,7 +49,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
     }
 
     private function buildFakeZipFile($name, $part=1, $num_files=1, $depth = 1){
-        $zip = new ZipArchive;
+        $zip = new ZipArchive();
 
         $filename_full = FileUtils::joinPaths($this->config['course_path'], $name);
         $files = array();

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -1680,5 +1680,4 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertTrue($return['refresh']);
         $this->assertEquals("REFRESH_ME", $return['string']);
     }
-
 }

--- a/site/tests/app/libraries/LoggerTester.php
+++ b/site/tests/app/libraries/LoggerTester.php
@@ -173,5 +173,4 @@ class LoggerTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals(Utils::pad($current_date['hours']), $time[0], "Hours place is not right");
         $this->assertEquals(Utils::pad($current_date['minutes']), $time[1], "Minutes place is not right");
     }
-
 }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -28,8 +28,6 @@
 
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
 
-        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
-        <exclude name="PSR2.Classes.PropertyDeclaration.StaticBeforeVisibility" />
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
         <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
@@ -52,7 +50,6 @@
         <exclude name="PSR12.Files.FileHeader.SpacingInsideBlock" />
         <exclude name="PSR12.Files.ImportStatement.LeadingSlash"/>
         <exclude name="PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon" />
-        <exclude name="PSR12.Classes.ClassInstantiation.MissingParentheses" />
         <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMixed"/>
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the `PSR2.Classes` and `PSR12.Classes` style errors, which is that the closing brace for a class must come immediately after the last line of the body (no empty lines between them), class properties should have visibility before `static` keyword, and that all class instantiations must have the `()`, even if there are no arguments to the constructor.