### PR TITLE
[Refactor:PHP] Fix *.Functions style errors

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -31,7 +31,7 @@ class AuthenticationController extends AbstractController {
      * @param Core $core
      * @param bool $logged_in
      */
-    public function __construct(Core $core, $logged_in=false) {
+    public function __construct(Core $core, $logged_in = false) {
         parent::__construct($core);
         $this->logged_in = $logged_in;
     }

--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -31,7 +31,7 @@ class HomePageController extends AbstractController {
      * @Route("/current_user/change_password", methods={"POST"})
      * @return Response
      */
-    public function changePassword(){
+    public function changePassword() {
         $user = $this->core->getUser();
         if(!empty($_POST['new_password']) && !empty($_POST['confirm_new_password'])
             && $_POST['new_password'] == $_POST['confirm_new_password']) {
@@ -51,7 +51,7 @@ class HomePageController extends AbstractController {
      * @Route("/current_user/change_username", methods={"POST"})
      * @return Response
      */
-    public function changeUserName(){
+    public function changeUserName() {
         $user = $this->core->getUser();
         if(isset($_POST['user_firstname_change']) && isset($_POST['user_lastname_change'])) {
             $newFirstName = trim($_POST['user_firstname_change']);

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -32,7 +32,7 @@ class MiscController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/encode_pdf")
      * @return Response
      */
-    public function encodePDF($gradeable_id){
+    public function encodePDF($gradeable_id) {
         $id = $_POST['user_id'] ?? null;
         $file_name = $_POST['filename'] ?? null;
         $file_name = html_entity_decode($file_name);
@@ -453,7 +453,7 @@ class MiscController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/bulk/progress")
      */
-    public function checkBulkProgress($gradeable_id){
+    public function checkBulkProgress($gradeable_id) {
         $job_path = "/var/local/submitty/daemon_job_queue/";
         $result = [];
         $found = false;

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -26,7 +26,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @Route("/{_semester}/{_course}/office_hours_queue")
     * @return Response
     */
-    public function showQueue(){
+    public function showQueue() {
         if(!$this->core->getConfig()->isQueueEnabled()){
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['home']))
@@ -59,7 +59,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @Route("/{_semester}/{_course}/office_hours_queue/add", methods={"POST"})
     * @return Response
     */
-    public function addPerson(){
+    public function addPerson() {
         if(!isset($_POST['code']) || !isset($_POST['name'])){
             $this->core->addErrorMessage("Missing name or code in request");
             return Response::RedirectOnlyResponse(
@@ -101,7 +101,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @AccessControl(role="LIMITED_ACCESS_GRADER")
     * @return Response
     */
-    public function startHelpPerson(){
+    public function startHelpPerson() {
         if(!isset($_POST['entry_id'])){
             $this->core->addErrorMessage("Missing entry ID");
             return Response::RedirectOnlyResponse(
@@ -120,7 +120,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @AccessControl(role="LIMITED_ACCESS_GRADER")
     * @return Response
     */
-    public function finishHelpPerson(){
+    public function finishHelpPerson() {
         if(!isset($_POST['entry_id'])){
             $this->core->addErrorMessage("Missing entry ID");
             return Response::RedirectOnlyResponse(
@@ -139,7 +139,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @AccessControl(role="LIMITED_ACCESS_GRADER")
     * @return Response
     */
-    public function toggleQueue(){
+    public function toggleQueue() {
         if(!isset($_POST['queue_open'])){
             $this->core->addErrorMessage("Missing queue status");
             return Response::RedirectOnlyResponse(
@@ -162,7 +162,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @AccessControl(role="LIMITED_ACCESS_GRADER")
     * @return Response
     */
-    public function emptyQueue(){
+    public function emptyQueue() {
         $this->core->getQueries()->emptyQueue($this->core->getUser()->getId());
         return Response::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
@@ -174,7 +174,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @Route("/{_semester}/{_course}/office_hours_queue/remove", methods={"POST"})
     * @return Response
     */
-    public function removePerson(){
+    public function removePerson() {
         if(!isset($_POST['entry_id'])){
             $this->core->addErrorMessage("Missing entry ID");
             return Response::RedirectOnlyResponse(
@@ -200,7 +200,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @AccessControl(role="LIMITED_ACCESS_GRADER")
     * @return Response
     */
-    public function generateNewCode(){
+    public function generateNewCode() {
         $this->core->getQueries()->genNewQueueCode();
         return Response::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -159,7 +159,7 @@ class AdminGradeableController extends AbstractController {
             }
             $repo_id_number++;
         }
-        usort($all_repository_config_paths, function ($a,$b) {
+        usort($all_repository_config_paths, function ($a, $b) {
             return $a[0] > $b[0];
         });
 
@@ -458,7 +458,7 @@ class AdminGradeableController extends AbstractController {
      * @param integer $repo_id_number
      * @return array
      */
-    private function getValidPathsToConfigDirectories($dir_queue,&$error_messages,$repo_id_number) {
+    private function getValidPathsToConfigDirectories($dir_queue, &$error_messages, $repo_id_number) {
         $repository_path = $dir_queue[0];
         $count = 0;
         $return_array = array();
@@ -1089,7 +1089,7 @@ class AdminGradeableController extends AbstractController {
         return null;
     }
 
-    public static function enqueueGenerateRepos($semester,$course,$g_id) {
+    public static function enqueueGenerateRepos($semester, $course, $g_id) {
         // FIXME:  should use a variable intead of hardcoded top level path
         $config_build_file = "/var/local/submitty/daemon_job_queue/generate_repos__" . $semester . "__" . $course . "__" . $g_id . ".json";
 

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -112,7 +112,7 @@ class AutogradingConfigController extends AbstractController {
      * @Route("/{_semester}/{_course}/autograding_config/rename", methods={"POST"})
      * @return Response
      */
-    public function renameConfig(){
+    public function renameConfig() {
         $config_file_path = $_POST['curr_config_name'] ?? null;
         if($config_file_path == null){
             $this->core->addErrorMessage("Unable to find file");
@@ -144,7 +144,7 @@ class AutogradingConfigController extends AbstractController {
      * @Route("/{_semester}/{_course}/autograding_config/delete", methods={"POST"})
      * @return Response
      */
-    public function deleteConfig(){
+    public function deleteConfig() {
         $config_path = $_POST['config_path'] ?? null;
         $in_use = false;
         foreach($this->core->getQueries()->getGradeableConfigs(null) as $gradeable){

--- a/site/app/controllers/admin/EmailRoomSeatingController.php
+++ b/site/app/controllers/admin/EmailRoomSeatingController.php
@@ -39,7 +39,7 @@ Please email your instructor with any questions or concerns.';
      * @Route("/{_semester}/{_course}/email_room_seating")
      * @return Response
      */
-    public function renderEmailTemplate(){
+    public function renderEmailTemplate() {
         return Response::WebOnlyResponse(
             new WebResponse(
                 ['admin', 'EmailRoomSeating'],

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -237,7 +237,7 @@ class LateController extends AbstractController {
     /**
      * @return Response
      */
-    private function getLateDays(){
+    private function getLateDays() {
         $users = $this->core->getQueries()->getUsersWithLateDays();
         $user_table = array();
         foreach($users as $user){

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -12,7 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * @AccessControl(role="INSTRUCTOR")
  */
 class PlagiarismController extends AbstractController {
-    private function getGradeablesFromPriorTerm(){
+    private function getGradeablesFromPriorTerm() {
         $return = array();
 
         $filename = FileUtils::joinPaths(
@@ -172,7 +172,7 @@ class PlagiarismController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/plagiarism/configuration/new", methods={"POST"})
      */
-    public function saveNewPlagiarismConfiguration($new_or_edit, $gradeable_id=null) {
+    public function saveNewPlagiarismConfiguration($new_or_edit, $gradeable_id = null) {
 
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
@@ -645,7 +645,7 @@ class PlagiarismController extends AbstractController {
         return $color_info;
     }
 
-    public function getDisplayForCode($file_name , $color_info){
+    public function getDisplayForCode($file_name, $color_info) {
         $content = file_get_contents($file_name);
         return $content;
     }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -352,7 +352,7 @@ class ReportController extends AbstractController {
      * @param LateDays $ld
      * @return array
      */
-    public function generateGradeSummary(GradedGradeable $gg,User $user, LateDays $ld) {
+    public function generateGradeSummary(GradedGradeable $gg, User $user, LateDays $ld) {
         $g = $gg->getGradeable();
 
         $entry = [
@@ -501,7 +501,7 @@ class ReportController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/reports/rainbow_grades_customization")
      */
-    public function generateCustomization(){
+    public function generateCustomization() {
         //Build a new model, pull in defaults for the course
         $customization = new RainbowCustomization($this->core);
         $customization->buildCustomization();

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -230,7 +230,7 @@ class UsersController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/users", methods={"POST"})
      */
-    public function updateUser($type='users') {
+    public function updateUser($type = 'users') {
         $return_url = $this->core->buildCourseUrl([$type]) . '#user-' . $_POST['user_id'];
         $use_database = $this->core->getAuthentication() instanceof DatabaseAuthentication;
         $_POST['user_id'] = trim($_POST['user_id']);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -36,7 +36,7 @@ class ForumController extends AbstractController {
         return (isset($_COOKIE["{$currentCourse}_show_merged_thread"]) && $_COOKIE["{$currentCourse}_show_merged_thread"] == "1");
     }
 
-    private function returnUserContentToPage($error, $isThread, $thread_id){
+    private function returnUserContentToPage($error, $isThread, $thread_id) {
         //Notify User
         $this->core->addErrorMessage($error);
 
@@ -52,7 +52,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/threads/status", methods={"POST"})
      */
-    public function changeThreadStatus($status, $thread_id=null) {
+    public function changeThreadStatus($status, $thread_id = null) {
         if (is_null($thread_id)) {
             $thread_id = $_POST['thread_id'];
         }
@@ -67,7 +67,7 @@ class ForumController extends AbstractController {
         }
     }
 
-    private function checkGoodAttachment($isThread, $thread_id, $file_post){
+    private function checkGoodAttachment($isThread, $thread_id, $file_post) {
         if((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE){
             return array(0);
         }
@@ -81,7 +81,7 @@ class ForumController extends AbstractController {
         return array($imageCheck);
     }
 
-    private function isValidCategories($inputCategoriesIds = -1, $inputCategoriesName = -1){
+    private function isValidCategories($inputCategoriesIds = -1, $inputCategoriesName = -1) {
         $rows = $this->core->getQueries()->getCategories();
         if(is_array($inputCategoriesIds)) {
             if(count($inputCategoriesIds) < 1) {
@@ -120,7 +120,7 @@ class ForumController extends AbstractController {
         return true;
     }
 
-    private function isCategoryDeletionGood($category_id){
+    private function isCategoryDeletionGood($category_id) {
         // Check if not the last category which exists
         $rows = $this->core->getQueries()->getCategories();
         foreach($rows as $index => $values){
@@ -135,7 +135,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/categories/new", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
-    public function addNewCategory($category = []){
+    public function addNewCategory($category = []) {
         $result = array();
         if(!empty($_POST["newCategory"])) {
             $category = trim($_POST["newCategory"]);
@@ -169,7 +169,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/categories/delete", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
-    public function deleteCategory(){
+    public function deleteCategory() {
         if(!empty($_POST["deleteCategory"])) {
             $category = (int)$_POST["deleteCategory"];
             if(!$this->isValidCategories(array($category))) {
@@ -192,7 +192,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/categories/edit", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
-    public function editCategory(){
+    public function editCategory() {
         $category_id = $_POST["category_id"];
         $category_desc = null;
         $category_color = null;
@@ -221,7 +221,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/categories/reorder", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
-    public function reorderCategories(){
+    public function reorderCategories() {
         $rows = $this->core->getQueries()->getCategories();
 
         $current_order = array();
@@ -247,7 +247,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/threads/new", methods={"POST"})
      * @AccessControl(permission="forum.publish")
      */
-    public function publishThread(){
+    public function publishThread() {
         $markdown = !empty($_POST['markdown_status']);
         $current_user_id = $this->core->getUser()->getId();
         $result = array();
@@ -331,7 +331,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/search", methods={"POST"})
      */
-    public function search(){
+    public function search() {
         $results = $this->core->getQueries()->searchThreads($_POST['search_content']);
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'searchResult', $results);
     }
@@ -340,7 +340,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/posts/new", methods={"POST"})
      * @AccessControl(permission="forum.publish")
      */
-    public function publishPost(){
+    public function publishPost() {
         $current_user_id = $this->core->getUser()->getId();
         $result = array();
         $parent_id = (!empty($_POST["parent_id"])) ? htmlentities($_POST["parent_id"], ENT_QUOTES | ENT_HTML5, 'UTF-8') : -1;
@@ -419,7 +419,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/announcements", methods={"POST"})
      * @AccessControl(permission="forum.modify_announcement")
      */
-    public function alterAnnouncement($type){
+    public function alterAnnouncement($type) {
         $thread_id = $_POST["thread_id"];
         $this->core->getQueries()->setAnnouncement($thread_id, $type);
 
@@ -429,7 +429,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/threads/pin", methods={"POST"})
      */
-    public function pinThread($type){
+    public function pinThread($type) {
         $thread_id = $_POST["thread_id"];
         $current_user = $this->core->getUser()->getId();
         $this->core->getQueries()->addPinnedThread($current_user, $thread_id, $type);
@@ -446,7 +446,7 @@ class ForumController extends AbstractController {
      *
      * @Route("/{_semester}/{_course}/forum/posts/modify", methods={"POST"})
      */
-    public function alterPost($modify_type){
+    public function alterPost($modify_type) {
         $full_course_name = $this->core->getFullCourseName();
         $post_id = $_POST["post_id"] ?? $_POST["edit_post_id"];
         $post = $this->core->getQueries()->getPost($post_id);
@@ -568,7 +568,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/threads/merge", methods={"POST"})
      * @AccessControl(permission="forum.merge_thread")
      */
-    public function mergeThread(){
+    public function mergeThread() {
         $current_user_id = $this->core->getUser()->getId();
         $parent_thread_id = $_POST["merge_thread_parent"];
         $child_thread_id = $_POST["merge_thread_child"];
@@ -612,7 +612,7 @@ class ForumController extends AbstractController {
         $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $thread_id]));
     }
 
-    private function editThread(){
+    private function editThread() {
         // Ensure authentication before call
         if(!empty($_POST["title"])) {
             $thread_id = $_POST["edit_thread_id"];
@@ -638,7 +638,7 @@ class ForumController extends AbstractController {
         return null;
     }
 
-    private function editPost(){
+    private function editPost() {
         // Ensure authentication before call
         $new_post_content = $_POST["thread_post_content"];
         if(!empty($new_post_content)) {
@@ -666,7 +666,7 @@ class ForumController extends AbstractController {
         return null;
     }
 
-    private function getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, &$blockNumber, $thread_id = -1){
+    private function getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, &$blockNumber, $thread_id = -1) {
         $current_user = $this->core->getUser()->getId();
         if(!$this->isValidCategories($categories_ids)) {
             // No filter for category
@@ -693,7 +693,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/threads", methods={"POST"})
      */
-    public function getThreads($page_number = null){
+    public function getThreads($page_number = null) {
         $pageNumber = !empty($page_number) && is_numeric($page_number) ? (int)$page_number : 1;
         $show_deleted = $this->showDeleted();
         $currentCourse = $this->core->getConfig()->getCourse();
@@ -732,7 +732,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/threads", methods={"GET"})
      * @Route("/{_semester}/{_course}/forum/threads/{thread_id}", methods={"GET", "POST"}, requirements={"thread_id": "\d+"})
      */
-    public function showThreads($thread_id = null, $option = 'tree'){
+    public function showThreads($thread_id = null, $option = 'tree') {
         $user = $this->core->getUser()->getId();
         $currentCourse = $this->core->getConfig()->getCourse();
         $category_id = in_array('thread_category', $_POST) ? $_POST['thread_category'] : -1;
@@ -838,7 +838,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/threads/new", methods={"GET"})
      */
-    public function showCreateThread(){
+    public function showCreateThread() {
         if(empty($this->core->getQueries()->getCategories())){
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads']));
             return;
@@ -849,7 +849,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/categories", methods={"GET"})
      */
-    public function showCategories(){
+    public function showCategories() {
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'showCategories', $this->getAllowedCategoryColor());
     }
 
@@ -857,7 +857,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/posts/history", methods={"POST"})
      * @AccessControl(role="LIMITED_ACCESS_GRADER")
      */
-    public function getHistory(){
+    public function getHistory() {
         $post_id = $_POST["post_id"];
         $output = array();
         $_post = array();
@@ -898,7 +898,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/posts/get", methods={"POST"})
      */
-    public function getEditPostContent(){
+    public function getEditPostContent() {
         $post_id = $_POST["post_id"];
         if(!empty($post_id)) {
             $result = $this->core->getQueries()->getPost($post_id);
@@ -921,7 +921,7 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderJsonFail("Empty edit post content.");
     }
 
-    private function getThreadContent($thread_id, &$output){
+    private function getThreadContent($thread_id, &$output) {
         $result = $this->core->getQueries()->getThread($thread_id)[0];
         $output['lock_thread_date'] = $result['lock_thread_date'];
         $output['title'] = $result["title"];
@@ -932,7 +932,7 @@ class ForumController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/forum/stats")
      */
-    public function showStats(){
+    public function showStats() {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
         $users = array();

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -108,7 +108,7 @@ class ForumController2 extends AbstractController {
         return (isset($_COOKIE["{$currentCourse}_show_merged_thread"]) && $_COOKIE["{$currentCourse}_show_merged_thread"] == "1");
     }
 
-    private function returnUserContentToPage($error, $isThread, $thread_id){
+    private function returnUserContentToPage($error, $isThread, $thread_id) {
         //Notify User
         $this->core->addErrorMessage($error);
         if ($isThread) {
@@ -135,7 +135,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    private function isCategoryDeletionGood($category_id){
+    private function isCategoryDeletionGood($category_id) {
         // Check if not the last category which exists
         $rows = $this->core->getQueries()->getCategories();
         foreach($rows as $index => $values){
@@ -146,7 +146,7 @@ class ForumController2 extends AbstractController {
         return false;
     }
 
-    public function addNewCategory(){
+    public function addNewCategory() {
         $result = array();
         if($this->core->getUser()->accessGrading()){
             if(!empty($_REQUEST["newCategory"])) {
@@ -167,7 +167,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    public function deleteCategory(){
+    public function deleteCategory() {
         $result = array();
         if($this->core->getUser()->accessGrading()){
             if(!empty($_REQUEST["deleteCategory"])) {
@@ -193,7 +193,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    public function editCategory(){
+    public function editCategory() {
         $result = array();
         if($this->core->getUser()->accessGrading()){
             $category_id = $_REQUEST["category_id"];
@@ -228,7 +228,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    public function reorderCategories(){
+    public function reorderCategories() {
         $result = array();
         if($this->core->getUser()->accessGrading()){
             $rows = $this->core->getQueries()->getCategories();
@@ -255,13 +255,13 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    private function search(){
+    private function search() {
         $results = $this->core->getQueries()->searchThreads($_POST['search_content']);
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'searchResult', $results);
     }
 
 
-    public function alterAnnouncement($type){
+    public function alterAnnouncement($type) {
         if($this->core->getUser()->getGroup() <= 2){
             $thread_id = $_POST["thread_id"];
             $this->core->getQueries()->setAnnouncement($thread_id, $type);
@@ -309,7 +309,7 @@ class ForumController2 extends AbstractController {
      *
      * @param integer(0/1/2) $modifyType - 0 => delete, 1 => edit content, 2 => undelete
      */
-    public function alterPost($modifyType){
+    public function alterPost($modifyType) {
         $post_id = $_POST["post_id"] ?? $_POST["edit_post_id"];
         if(!($this->checkPostEditAccess($post_id))) {
                 $this->core->addErrorMessage("You do not have permissions to do that.");
@@ -397,7 +397,7 @@ class ForumController2 extends AbstractController {
         }
     }
 
-    private function editThread(){
+    private function editThread() {
         // Ensure authentication before call
         if(!empty($_POST["title"])) {
             $thread_id = $_POST["edit_thread_id"];
@@ -420,7 +420,7 @@ class ForumController2 extends AbstractController {
         return null;
     }
 
-    private function editPost(){
+    private function editPost() {
         // Ensure authentication before call
         $new_post_content = $_POST["thread_post_content"];
         if(!empty($new_post_content)) {
@@ -444,7 +444,7 @@ class ForumController2 extends AbstractController {
         return null;
     }
 
-    private function getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, &$blockNumber, $thread_id = -1){
+    private function getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, &$blockNumber, $thread_id = -1) {
         $current_user = $this->core->getUser()->getId();
         if(!ForumUtils::isValidCategories($this->core->getQueries()->getCategories(), $categories_ids)) {
             // No filter for category
@@ -468,7 +468,7 @@ class ForumController2 extends AbstractController {
         return $ordered_threads;
     }
 
-    public function getThreads(){
+    public function getThreads() {
         $pageNumber = !empty($_GET["page_number"]) && is_numeric($_GET["page_number"]) ? (int)$_GET["page_number"] : 1;
         $show_deleted = $this->showDeleted();
         $currentCourse = $this->core->getConfig()->getCourse();
@@ -502,7 +502,7 @@ class ForumController2 extends AbstractController {
             ));
     }
 
-    public function showThreads(){
+    public function showThreads() {
         $user = $this->core->getUser()->getId();
         $currentCourse = $this->core->getConfig()->getCourse();
         $category_id = in_array('thread_category', $_POST) ? $_POST['thread_category'] : -1;
@@ -593,11 +593,11 @@ class ForumController2 extends AbstractController {
         return $colors;
     }
 
-    public function showCreateThread(){
+    public function showCreateThread() {
          $this->core->getOutput()->renderOutput('forum\ForumThread', 'createThread', $this->getAllowedCategoryColor());
     }
 
-    public function getHistory(){
+    public function getHistory() {
         $post_id = $_POST["post_id"];
         $output = array();
         if($this->core->getUser()->accessGrading()){
@@ -636,7 +636,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getUser()->accessFullGrading() || $this->core->getUser()->getId() === $author;
     }
 
-    public function showStats(){
+    public function showStats() {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
         $users = array();
@@ -669,7 +669,7 @@ class ForumController2 extends AbstractController {
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'statPage', $users);
     }
 
-    public function mergeThread(){
+    public function mergeThread() {
         $parent_thread_id = $_POST["merge_thread_parent"];
         $child_thread_id = $_POST["merge_thread_child"];
         preg_match('/\((.*?)\)/', $parent_thread_id, $result);
@@ -715,7 +715,7 @@ class ForumController2 extends AbstractController {
 
     //Modified functions below...
 
-    public function publishThread(){
+    public function publishThread() {
 
         //Get post data
         $title = trim($_POST['title']);
@@ -752,7 +752,7 @@ class ForumController2 extends AbstractController {
         }
     }
 
-    public function publishPost(){
+    public function publishPost() {
         $parent_id = $_POST['parent_id'];
         $post_content = $_POST['thread_post_content'];
         $thread_id = $_POST['thread_id'];
@@ -767,7 +767,7 @@ class ForumController2 extends AbstractController {
 
 
     //Ajax endpoint
-    public function pinThread($type){
+    public function pinThread($type) {
         $thread_id = $_POST["thread_id"];
 
         $result = $this->core->getForum()->pinThread($thread_id, $type);
@@ -783,7 +783,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    public function getEditPostContent(){
+    public function getEditPostContent() {
         $post_id = $_POST["post_id"];
 
         $result = $this->core->getForum()->getEditContent($post_id);
@@ -792,7 +792,7 @@ class ForumController2 extends AbstractController {
         return $this->core->getOutput()->getOutput();
     }
 
-    private function getThreadContent($thread_id, &$output){
+    private function getThreadContent($thread_id, &$output) {
         $result = $this->core->getQueries()->getThread($thread_id)[0];
         $output['title'] = $result["title"];
         $output['categories_ids'] = $this->core->getQueries()->getCategoriesIdForThread($thread_id);

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -54,12 +54,12 @@ class ElectronicGraderController extends AbstractController {
      */
     public function ajaxRemoveEmpty(
         $gradeable_id,
-        $who_id='',
-        $index='',
-        $option='original',
-        $version='',
-        $which='actual',
-        $autocheck_cnt='0'
+        $who_id = '',
+        $index = '',
+        $option = 'original',
+        $version = '',
+        $which = 'actual',
+        $autocheck_cnt = '0'
     ) {
         //There are three options: original (Don't show empty space), escape (with escape codes), and unicode (with characters)
         if (!$this->validateDiffViewerOption($option)) {
@@ -408,7 +408,7 @@ class ElectronicGraderController extends AbstractController {
      * Shows the list of submitters
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/details")
      */
-    public function showDetails($gradeable_id, $view = null, $sort="id", $direction="ASC") {
+    public function showDetails($gradeable_id, $view = null, $sort = "id", $direction = "ASC") {
         // Default is viewing your sections
         // Limited grader does not have "View All" option
         // If nothing to grade, Instructor will see all sections
@@ -826,7 +826,7 @@ class ElectronicGraderController extends AbstractController {
      *
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/grade")
      */
-    public function showGrading($gradeable_id, $who_id='', $from="", $to=null, $gradeable_version=null, $sort="id", $direction="ASC", $to_ungraded=null, $component_id="-1") {
+    public function showGrading($gradeable_id, $who_id = '', $from = "", $to = null, $gradeable_version = null, $sort = "id", $direction = "ASC", $to_ungraded = null, $component_id = "-1") {
         /** @var Gradeable $gradeable */
         $gradeable = $this->tryGetGradeable($gradeable_id, false);
         if ($gradeable === false) {
@@ -1118,7 +1118,7 @@ class ElectronicGraderController extends AbstractController {
      * Route for getting information about a individual grader
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/graded_gradeable")
      */
-    public function ajaxGetGradedGradeable($gradeable_id, $anon_id='') {
+    public function ajaxGetGradedGradeable($gradeable_id, $anon_id = '') {
         $grader = $this->core->getUser();
 
         // Get the gradeable
@@ -1777,7 +1777,7 @@ class ElectronicGraderController extends AbstractController {
      * Route for getting the student's program output for the diff-viewer
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/student_output")
      */
-    public function ajaxGetStudentOutput($gradeable_id, $who_id='', $version='', $index='') {
+    public function ajaxGetStudentOutput($gradeable_id, $who_id = '', $version = '', $index = '') {
         // Get the gradeable
         $gradeable = $this->tryGetGradeable($gradeable_id);
         if ($gradeable === false) {
@@ -1996,7 +1996,7 @@ class ElectronicGraderController extends AbstractController {
      * Route for getting a GradedComponent
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/graded_gradeable/graded_component", methods={"GET"})
      */
-    public function ajaxGetGradedComponent($gradeable_id, $anon_id='', $component_id='') {
+    public function ajaxGetGradedComponent($gradeable_id, $anon_id = '', $component_id = '') {
         $grader = $this->core->getUser();
 
         // Get the gradeable

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -27,7 +27,7 @@ class SimpleGraderController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/print", methods={"GET"})
      * @return Response
      */
-    public function printLab($gradeable_id, $section = null, $section_type = null, $sort = "id"){
+    public function printLab($gradeable_id, $section = null, $section_type = null, $sort = "id") {
         //convert from id --> u.user_id etc for use by the database.
         if ($sort === "id") {
             $sort_by = "u.user_id";

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -19,7 +19,7 @@ class PDFController extends AbstractController {
      * @param $filename
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/pdf")
      */
-    public function showStudentPDF($gradeable_id, $filename = null){
+    public function showStudentPDF($gradeable_id, $filename = null) {
         $filename = html_entity_decode($filename);
         $id = $this->core->getUser()->getId();
         $gradeable = $this->tryGetGradeable($gradeable_id);
@@ -66,7 +66,7 @@ class PDFController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/pdf/annotations", methods={"POST"})
      * @AccessControl(role="LIMITED_ACCESS_GRADER")
      */
-    public function savePDFAnnotation($gradeable_id){
+    public function savePDFAnnotation($gradeable_id) {
         //Save the annotation layer to a folder.
         $annotation_layer = $_POST['annotation_layer'];
         $annotation_info = $_POST['GENERAL_INFORMATION'];
@@ -114,7 +114,7 @@ class PDFController extends AbstractController {
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/pdf")
      * @AccessControl(role="LIMITED_ACCESS_GRADER")
      */
-    public function showGraderPDFEmbedded($gradeable_id){
+    public function showGraderPDFEmbedded($gradeable_id) {
         //This is the embedded pdf annotator that we built.
         //User can be a team
         $id = $_POST['user_id'] ?? null;
@@ -163,7 +163,7 @@ class PDFController extends AbstractController {
     /**
      * NOT IN USE
      */
-    private function showGraderPDFFullpage(){
+    private function showGraderPDFFullpage() {
         //This shows the pdf-annotate.js library's default pdf annotator. It might be useful in the future to have
         //a full-sized annotator, so keeping this in for now.
         $this->core->getOutput()->useFooter(false);

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -485,7 +485,7 @@ class Core {
      *
      * @return bool
      */
-    public function checkCsrfToken($csrf_token=null) {
+    public function checkCsrfToken($csrf_token = null) {
         if ($csrf_token === null) {
             return isset($_POST['csrf_token']) && $this->getCsrfToken() === $_POST['csrf_token'];
         }
@@ -501,7 +501,7 @@ class Core {
      *
      * @return string
      */
-    public function buildUrl($parts=array()) {
+    public function buildUrl($parts = array()) {
         $url = $this->getConfig()->getBaseUrl() . implode("/", $parts);
         return $url;
     }
@@ -516,7 +516,7 @@ class Core {
      *
      * @return string
      */
-    public function buildCourseUrl($parts=array()) {
+    public function buildCourseUrl($parts = array()) {
         array_unshift($parts, $this->getConfig()->getSemester(), $this->getConfig()->getCourse());
         return $this->buildUrl($parts);
     }
@@ -565,7 +565,7 @@ class Core {
      *
      * @return string
      */
-    public function getDisplayedCourseName(){
+    public function getDisplayedCourseName() {
         if ($this->getConfig()->getCourseName() !== "") {
             return htmlentities($this->getConfig()->getCourseName());
         }
@@ -574,7 +574,7 @@ class Core {
         }
     }
 
-    public function getFullSemester(){
+    public function getFullSemester() {
         $semester = $this->getConfig()->getSemester();
         if ($this->getConfig()->getSemester() !== ""){
             $arr1 = str_split($semester);

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -25,7 +25,7 @@ class DateUtils {
      *
      * @return int
      */
-    public static function calculateDayDiff($date1, $date2="now"): int {
+    public static function calculateDayDiff($date1, $date2 = "now"): int {
         if (!($date1 instanceof DateTime)) {
             $date1 = new DateTime($date1);
         }

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -141,7 +141,7 @@ class DiffViewer {
      *
      * @throws \Exception
      */
-    public function __construct($actual_file, $expected_file, $diff_file, $image_difference, $id_prepend="id") {
+    public function __construct($actual_file, $expected_file, $diff_file, $image_difference, $id_prepend = "id") {
         $this->id = rtrim($id_prepend, "_") . "_";
         $this->actual_file = $actual_file;
         $this->expected_file = $expected_file;
@@ -538,7 +538,7 @@ class DiffViewer {
         return $html;
     }
 
-    public function getWhiteSpaces(){
+    public function getWhiteSpaces() {
         $return = "";
         foreach($this->white_spaces as $key => $value){
             $return .= "$value" . " = " . "$key" . " ";
@@ -554,7 +554,7 @@ class DiffViewer {
      *
      * @return string HTML after white spaces replaced with visuals
      */
-    private function replaceEmptyChar($html, $with_escape){
+    private function replaceEmptyChar($html, $with_escape) {
         $return = $html;
         if($with_escape){
             foreach(self::SPECIAL_CHARS_LIST as $name => $representations){
@@ -577,7 +577,7 @@ class DiffViewer {
      *
      * This function replaces string $text with string $what in string $which.
      */
-    private function replaceUTF($text, $what, &$which, $description){
+    private function replaceUTF($text, $what, &$which, $description) {
         $count = 0;
         $what = '<span class="whitespace">' . $what . '</span>';
         $which = str_replace($text, $what, $which, $count);

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -28,7 +28,7 @@ class FileUtils {
      * @param bool   $flatten
      * @return array
      */
-    public static function getAllFiles(string $dir, array $skip_files=[], bool $flatten=false): array {
+    public static function getAllFiles(string $dir, array $skip_files = [], bool $flatten = false): array {
         $skip_files = array_map(function ($str) {
             return strtolower($str);
         }, $skip_files);
@@ -392,7 +392,7 @@ class FileUtils {
      * @param $filename
      * @return null|string
      */
-    public static function getContentType($filename){
+    public static function getContentType($filename) {
         if ($filename === null) {
             return null;
         }

--- a/site/app/libraries/ForumUtils.php
+++ b/site/app/libraries/ForumUtils.php
@@ -16,7 +16,7 @@ class ForumUtils {
 
     const FORUM_CHAR_POST_LIMIT = 5000;
 
-    public static function checkGoodAttachment($isThread, $thread_id, $file_post){
+    public static function checkGoodAttachment($isThread, $thread_id, $file_post) {
         if((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE){
             return array(0);
         }
@@ -30,7 +30,7 @@ class ForumUtils {
         return array($imageCheck);
     }
 
-    public static function isValidCategories($rows, $inputCategoriesIds = -1, $inputCategoriesName = -1){
+    public static function isValidCategories($rows, $inputCategoriesIds = -1, $inputCategoriesName = -1) {
         if(is_array($inputCategoriesIds)) {
             if(count($inputCategoriesIds) < 1) {
                 return false;

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -47,7 +47,7 @@ class Logger {
      *
      * @param string $message
      */
-    public static function debug($message="") {
+    public static function debug($message = "") {
         Logger::logError(Logger::DEBUG, $message);
     }
 
@@ -56,7 +56,7 @@ class Logger {
      *
      * @param string $message
      */
-    public static function info($message="") {
+    public static function info($message = "") {
         Logger::logError(Logger::INFO, $message);
     }
 
@@ -65,7 +65,7 @@ class Logger {
      *
      * @param string $message
      */
-    public static function warn($message="") {
+    public static function warn($message = "") {
         Logger::logError(Logger::WARN, $message);
     }
 
@@ -74,7 +74,7 @@ class Logger {
      *
      * @param string $message
      */
-    public static function error($message="") {
+    public static function error($message = "") {
         Logger::logError(Logger::ERROR, $message);
     }
 
@@ -83,7 +83,7 @@ class Logger {
      *
      * @param string $message
      */
-    public static function fatal($message="") {
+    public static function fatal($message = "") {
         Logger::logError(Logger::FATAL, $message);
     }
 
@@ -111,7 +111,7 @@ class Logger {
      *     4. Fatal Error
      * @param $message: message to log to the file
      */
-    private static function logError($level=0, $message="") {
+    private static function logError($level = 0, $message = "") {
         if (static::$log_path === null) {
             return;
         }
@@ -209,7 +209,7 @@ class Logger {
      *
      * @param $params All the params in a key-value array
      */
-    public static function logTAGrading($params){
+    public static function logTAGrading($params) {
         $log_message[] = $params['course_semester'];
         $log_message[] = $params['course_name'];
         $log_message[] = $params['gradeable_id'];

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -95,7 +95,7 @@ class Output {
 
         $this->twig->addGlobal("core", $this->core);
 
-        $this->twig->addFunction(new \Twig\TwigFunction("render_template", function (... $args) {
+        $this->twig->addFunction(new \Twig\TwigFunction("render_template", function (...$args) {
             return call_user_func_array('self::renderTemplate', $args);
         }, ["is_safe" => ["html"]]));
         $this->twig->addFunction(new \Twig\TwigFunction('base64_image', function (string $path, string $title): string {
@@ -473,7 +473,7 @@ HTML;
         return $this->getOutput();
     }
 
-    public function addInternalCss($file, $folder='css') {
+    public function addInternalCss($file, $folder = 'css') {
         $this->addCss($this->timestampResource($file, $folder));
     }
 
@@ -485,7 +485,7 @@ HTML;
         $this->css->add($url);
     }
 
-    public function addInternalJs($file, $folder='js') {
+    public function addInternalJs($file, $folder = 'js') {
         $this->addJs($this->timestampResource($file, $folder));
     }
 
@@ -514,7 +514,7 @@ HTML;
         $this->use_footer = $bool;
     }
 
-    public function addBreadcrumb($string, $url=null, $external_link=false) {
+    public function addBreadcrumb($string, $url = null, $external_link = false) {
         $this->breadcrumbs[] = new Breadcrumb($this->core, $string, $url, $external_link);
     }
 

--- a/site/app/libraries/TokenManager.php
+++ b/site/app/libraries/TokenManager.php
@@ -26,7 +26,7 @@ class TokenManager {
         string $user_id,
         string $issuer,
         string $secret,
-        $persistent=true
+        $persistent = true
     ): Token {
         $expire_time = ($persistent) ? time() + (7 * 24 * 60 * 60) : 0;
         return (new Builder())->issuedBy($issuer)

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -158,7 +158,7 @@ class Utils {
      *
      * @return bool true if successfully able to set the cookie, else false
      */
-    public static function setCookie(string $name, $data, int $expire=0): bool {
+    public static function setCookie(string $name, $data, int $expire = 0): bool {
         if (is_array($data)) {
             $data = json_encode($data);
         }
@@ -182,7 +182,7 @@ class Utils {
             (substr($filename, -4) == ".gif");
     }
 
-    public static function checkUploadedImageFile($id){
+    public static function checkUploadedImageFile($id) {
         if (isset($_FILES[$id])) {
             foreach ($_FILES[$id]['tmp_name'] as $file_name) {
                 if (file_exists($file_name)) {

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -80,7 +80,7 @@ abstract class AbstractDatabase {
      *
      * @return array
      */
-    abstract public function fromDatabaseToPHPArray($text, $parse_bools = false, $start=0, &$end=null);
+    abstract public function fromDatabaseToPHPArray($text, $parse_bools = false, $start = 0, &$end = null);
     abstract public function fromPHPToDatabaseArray($array);
 
     /**
@@ -143,7 +143,7 @@ abstract class AbstractDatabase {
      *
      * @return boolean true if query suceeded, else false.
      */
-    public function query($query, $parameters=array()) {
+    public function query($query, $parameters = array()) {
         try {
             $this->query_count++;
             $this->all_queries[] = array($query, $parameters);
@@ -192,7 +192,7 @@ abstract class AbstractDatabase {
      *
      * @throws \app\exceptions\DatabaseException
      */
-    public function queryIterator($query, $parameters=array(), $callback=null) {
+    public function queryIterator($query, $parameters = array(), $callback = null) {
         $lower = trim(strtolower($query));
         if (!Utils::startsWith($lower, "select")) {
             return $this->query($query, $parameters);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -133,11 +133,11 @@ class DatabaseQueries {
         throw new NotImplementedException();
     }
 
-    public function getUserByNumericId($numeric_id){
+    public function getUserByNumericId($numeric_id) {
         throw new NotImplementedException();
     }
 
-    public function getUserByIdOrNumericId($id){
+    public function getUserByIdOrNumericId($id) {
         throw new NotImplementedException();
     }
 
@@ -151,7 +151,7 @@ class DatabaseQueries {
      * @param string $section_key
      * @return User[]
      */
-    public function getAllUsers($section_key="registration_section") {
+    public function getAllUsers($section_key = "registration_section") {
         throw new NotImplementedException();
     }
 
@@ -303,7 +303,7 @@ class DatabaseQueries {
      * @param  int           thread_id          If blockNumber is not known, find it using thread_id
      * @return array('block_number' => int, 'threads' => array(threads))    Ordered filtered threads
      */
-    public function loadThreadBlock($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $blockNumber, $thread_id){
+    public function loadThreadBlock($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $blockNumber, $thread_id) {
         $blockSize = 30;
         $loadLastPage = false;
 
@@ -360,7 +360,7 @@ class DatabaseQueries {
         return $categories_list;
     }
 
-    public function createPost($user, $content, $thread_id, $anonymous, $type, $first, $hasAttachment, $markdown, $parent_post = -1){
+    public function createPost($user, $content, $thread_id, $anonymous, $type, $first, $hasAttachment, $markdown, $parent_post = -1) {
         if(!$first && $parent_post == 0){
             $this->course_db->query("SELECT MIN(id) as id FROM posts where thread_id = ?", array($thread_id));
             $parent_post = $this->course_db->rows()[0]["id"];
@@ -427,17 +427,17 @@ class DatabaseQueries {
         return $this->course_db->rows()[0]['created_by'];
     }
 
-    public function getPosts(){
+    public function getPosts() {
         $this->course_db->query("SELECT * FROM posts where deleted = false ORDER BY timestamp ASC");
         return $this->course_db->rows();
     }
 
-    public function getPostHistory($post_id){
+    public function getPostHistory($post_id) {
         $this->course_db->query("SELECT * FROM forum_posts_history where post_id = ? ORDER BY edit_timestamp DESC", array($post_id));
         return $this->course_db->rows();
     }
 
-    public function getDeletedPostsByUser($user){
+    public function getDeletedPostsByUser($user) {
         $this->course_db->query("SELECT * FROM posts where deleted = true AND author_user_id = ?", array($user));
         return $this->course_db->rows();
     }
@@ -452,7 +452,7 @@ class DatabaseQueries {
         }
     }
 
-    public function getPost($post_id){
+    public function getPost($post_id) {
         $this->course_db->query("SELECT * FROM posts where id = ?", array($post_id));
         return $this->course_db->rows()[0];
     }
@@ -464,13 +464,13 @@ class DatabaseQueries {
         $this->course_db->query("DELETE FROM notifications where metadata::json->>'post_id' = ?", array($post_id));
     }
 
-    public function isStaffPost($author_id){
+    public function isStaffPost($author_id) {
         $this->course_db->query("SELECT user_group FROM users WHERE user_id=?", array($author_id));
         return intval($this->course_db->rows()[0]['user_group']) <= 3;
     }
 
 
-    public function getUnviewedPosts($thread_id, $user_id){
+    public function getUnviewedPosts($thread_id, $user_id) {
         if($thread_id == -1) {
             $this->course_db->query("SELECT MAX(id) as max from threads WHERE deleted = false and merged_thread_id = -1 GROUP BY pinned ORDER BY pinned DESC");
             $rows = $this->course_db->rows();
@@ -489,7 +489,7 @@ class DatabaseQueries {
         return $rows;
     }
 
-    public function createThread($markdown, $user, $title, $content, $anon, $prof_pinned, $status, $hasAttachment, $categories_ids, $lock_thread_date){
+    public function createThread($markdown, $user, $title, $content, $anon, $prof_pinned, $status, $hasAttachment, $categories_ids, $lock_thread_date) {
 
         $this->course_db->beginTransaction();
 
@@ -529,16 +529,16 @@ class DatabaseQueries {
         return $this->course_db->rows();
     }
 
-    public function getThreadTitle($thread_id){
+    public function getThreadTitle($thread_id) {
         $this->course_db->query("SELECT title FROM threads where id=?", array($thread_id));
         return $this->course_db->rows()[0];
     }
 
-    public function setAnnouncement($thread_id, $onOff){
+    public function setAnnouncement($thread_id, $onOff) {
         $this->course_db->query("UPDATE threads SET pinned = ? WHERE id = ?", array($onOff, $thread_id));
     }
 
-    public function addPinnedThread($user_id, $thread_id, $added){
+    public function addPinnedThread($user_id, $thread_id, $added) {
         if($added) {
             $this->course_db->query("INSERT INTO student_favorites(user_id, thread_id) VALUES (?,?)", array($user_id, $thread_id));
         } else {
@@ -546,7 +546,7 @@ class DatabaseQueries {
         }
     }
 
-    public function loadPinnedThreads($user_id){
+    public function loadPinnedThreads($user_id) {
         $this->course_db->query("SELECT * FROM student_favorites WHERE user_id = ?", array($user_id));
         $rows = $this->course_db->rows();
         $favorite_threads = array();
@@ -556,7 +556,7 @@ class DatabaseQueries {
         return $favorite_threads;
     }
 
-    private function findChildren($post_id, $thread_id, &$children, $get_deleted = false){
+    private function findChildren($post_id, $thread_id, &$children, $get_deleted = false) {
         $query_delete = $get_deleted ? "true" : "deleted = false";
         $this->course_db->query("SELECT id from posts where {$query_delete} and parent_id=?", array($post_id));
         $row = $this->course_db->rows();
@@ -567,17 +567,17 @@ class DatabaseQueries {
         }
     }
 
-    public function searchThreads($searchQuery){
+    public function searchThreads($searchQuery) {
         $this->course_db->query("SELECT post_content, p_id, p_author, thread_id, thread_title, author, pin, anonymous, timestamp_post FROM (SELECT t.id as thread_id, t.title as thread_title, p.id as p_id, t.created_by as author, t.pinned as pin, p.timestamp as timestamp_post, p.content as post_content, p.anonymous, p.author_user_id as p_author, to_tsvector(p.content) || to_tsvector(t.title) as document from posts p, threads t JOIN (SELECT thread_id, timestamp from posts where parent_id = -1) p2 ON p2.thread_id = t.id where t.id = p.thread_id and p.deleted=false and t.deleted=false) p_doc where p_doc.document @@ plainto_tsquery(:q) ORDER BY timestamp_post DESC", array(':q' => $searchQuery));
         return $this->course_db->rows();
     }
 
-    public function threadExists(){
+    public function threadExists() {
         $this->course_db->query("SELECT id from threads where deleted = false LIMIT 1");
         return count($this->course_db->rows()) == 1;
     }
 
-    public function visitThread($current_user, $thread_id){
+    public function visitThread($current_user, $thread_id) {
         $this->course_db->query("INSERT INTO viewed_responses(thread_id,user_id,timestamp) VALUES(?, ?, current_timestamp) ON CONFLICT (thread_id, user_id) DO UPDATE SET timestamp = current_timestamp", array($thread_id, $current_user));
     }
     /**
@@ -590,7 +590,7 @@ class DatabaseQueries {
      * @param integer(0/1) $newStatus - 1 implies deletion and 0 as undeletion
      * @return boolean - Is first post of thread
      */
-    public function setDeletePostStatus($post_id, $thread_id, $newStatus){
+    public function setDeletePostStatus($post_id, $thread_id, $newStatus) {
         $this->course_db->query("SELECT parent_id from posts where id=?", array($post_id));
         $parent_id = $this->course_db->rows()[0]["parent_id"];
         $children = array($post_id);
@@ -621,7 +621,7 @@ class DatabaseQueries {
         return $this->course_db->rows()[0]['parent_id'];
     }
 
-    public function editPost($original_creator, $user, $post_id, $content, $anon, $markdown){
+    public function editPost($original_creator, $user, $post_id, $content, $anon, $markdown) {
         try {
             $markdown = $markdown ? 1 : 0;
             // Before making any edit to $post_id, forum_posts_history will not have any corresponding entry
@@ -670,7 +670,7 @@ class DatabaseQueries {
      * @param string $semester
      * @param string $course
      */
-    public function updateUser(User $user, $semester=null, $course=null) {
+    public function updateUser(User $user, $semester = null, $course = null) {
         throw new NotImplementedException();
     }
 
@@ -765,7 +765,7 @@ class DatabaseQueries {
         throw new NotImplementedException();
     }
 
-    public function getUsersByRegistrationSections($sections, $orderBy="registration_section") {
+    public function getUsersByRegistrationSections($sections, $orderBy = "registration_section") {
         $return = array();
         if (count($sections) > 0) {
             $orderBy = str_replace(
@@ -782,7 +782,7 @@ class DatabaseQueries {
         return $return;
     }
 
-    public function getUsersInNullSection($orderBy="user_id") {
+    public function getUsersInNullSection($orderBy = "user_id") {
         $return = array();
         $this->course_db->query("SELECT * FROM users AS u WHERE registration_section IS NULL ORDER BY {$orderBy}");
         foreach ($this->course_db->rows() as $row) {
@@ -901,7 +901,7 @@ ORDER BY {$orderby}", $params);
      * @param string $orderBy
      * @return Team[]
      */
-    public function getTeamsByGradeableAndRegistrationSections($g_id, $sections, $orderBy="registration_section") {
+    public function getTeamsByGradeableAndRegistrationSections($g_id, $sections, $orderBy = "registration_section") {
         throw new NotImplementedException();
     }
 
@@ -912,7 +912,7 @@ ORDER BY {$orderby}", $params);
      * @param string $orderBy
      * @return Team[]
      */
-    public function getTeamsByGradeableAndRotatingSections($g_id, $sections, $orderBy="rotating_section") {
+    public function getTeamsByGradeableAndRotatingSections($g_id, $sections, $orderBy = "rotating_section") {
         throw new NotImplementedException();
     }
 
@@ -1208,7 +1208,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
      * @param $team_id
      * @return integer
      */
-    public function getActiveVersionForTeam($gradeable_id,$team_id) {
+    public function getActiveVersionForTeam($gradeable_id, $team_id) {
         $params = array($gradeable_id,$team_id);
         $this->course_db->query("SELECT active_version FROM electronic_gradeable_version WHERE g_id = ? and team_id = ?", $params);
         $query_result = $this->course_db->row();
@@ -1224,7 +1224,7 @@ WHERE g_id = ?", array($g_id));
     }
 
     //gets ids of students with non null registration section and null rotating section
-    public function getRegisteredUsersWithNoRotatingSection(){
+    public function getRegisteredUsersWithNoRotatingSection() {
         $this->course_db->query("
 SELECT user_id
 FROM users AS u
@@ -1235,7 +1235,7 @@ AND rotating_section IS NULL;");
     }
 
     //gets ids of students with non null rotating section and null registration section
-    public function getUnregisteredStudentsWithRotatingSection(){
+    public function getUnregisteredStudentsWithRotatingSection() {
         $this->course_db->query("
 SELECT user_id
 FROM users AS u
@@ -1332,7 +1332,7 @@ ORDER BY g.sections_rotating_id, g.user_id", $params);
         return $return;
     }
 
-    public function getUsersByRotatingSections($sections, $orderBy="rotating_section") {
+    public function getUsersByRotatingSections($sections, $orderBy = "rotating_section") {
         $return = array();
         if (count($sections) > 0) {
             $placeholders = $this->createParamaterList(count($sections));
@@ -1728,7 +1728,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @param $team_id
      * @param $user_id
      */
-    public function getTeamViewedTime($team_id,$user_id) {
+    public function getTeamViewedTime($team_id, $user_id) {
         $this->course_db->query("SELECT last_viewed_time FROM teams WHERE team_id = ? and user_id=?", array($team_id,$user_id));
         return $this->course_db->rows()[0]['last_viewed_time'];
     }
@@ -2014,7 +2014,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @param string $g_id
      * @param string $user_id
      */
-    public function addToSeekingTeam($g_id,$user_id) {
+    public function addToSeekingTeam($g_id, $user_id) {
         $this->course_db->query("INSERT INTO seeking_team(g_id, user_id) VALUES (?,?)", array($g_id, $user_id));
     }
 
@@ -2023,7 +2023,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @param string $g_id
      * @param string $user_id
      */
-    public function removeFromSeekingTeam($g_id,$user_id) {
+    public function removeFromSeekingTeam($g_id, $user_id) {
         $this->course_db->query("DELETE FROM seeking_team WHERE g_id=? AND user_id=?", array($g_id, $user_id));
     }
 
@@ -2301,7 +2301,7 @@ ORDER BY gt.{$section_key}", $params);
      * @param integer $days
      * @param string $csv_option value determined by selected radio button
      */
-    public function updateLateDays($user_id, $timestamp, $days, $csv_option=null) {
+    public function updateLateDays($user_id, $timestamp, $days, $csv_option = null) {
         //q.v. PostgresqlDatabaseQueries.php
         throw new NotImplementedException();
     }
@@ -2311,7 +2311,7 @@ ORDER BY gt.{$section_key}", $params);
      * @param string $user_id
      * @param string $timestamp
      */
-    public function deleteLateDays($user_id, $timestamp){
+    public function deleteLateDays($user_id, $timestamp) {
         $this->course_db->query("
           DELETE FROM late_days
           WHERE user_id=?
@@ -2324,7 +2324,7 @@ ORDER BY gt.{$section_key}", $params);
      * @param string $g_id
      * @param integer $days
      */
-    public function updateExtensions($user_id, $g_id, $days){
+    public function updateExtensions($user_id, $g_id, $days) {
         $this->course_db->query("
           UPDATE late_day_exceptions
           SET late_day_exceptions=?
@@ -2345,7 +2345,7 @@ ORDER BY gt.{$section_key}", $params);
      * @param integer $marks
      * @param string $comment
      */
-    public function updateGradeOverride($user_id, $g_id, $marks, $comment){
+    public function updateGradeOverride($user_id, $g_id, $marks, $comment) {
         $this->course_db->query("
           UPDATE grade_override
           SET marks=?, comment=?
@@ -2364,7 +2364,7 @@ ORDER BY gt.{$section_key}", $params);
      * @param string $user_id
      * @param string $g_id
      */
-    public function deleteOverriddenGrades($user_id, $g_id){
+    public function deleteOverriddenGrades($user_id, $g_id) {
         $this->course_db->query("
           DELETE FROM grade_override
           WHERE user_id=?
@@ -2505,7 +2505,7 @@ AND gc_id IN (
         return intval($this->course_db->rows()[0]['cnt']);
     }
 
-    public function getGradedPeerComponentsByRegistrationSection($gradeable_id, $sections=array()) {
+    public function getGradedPeerComponentsByRegistrationSection($gradeable_id, $sections = array()) {
         $where = "";
         $params = array();
         if(count($sections) > 0) {
@@ -2537,7 +2537,7 @@ AND gc_id IN (
         return $return;
     }
 
-    public function getGradedPeerComponentsByRotatingSection($gradeable_id, $sections=array()) {
+    public function getGradedPeerComponentsByRotatingSection($gradeable_id, $sections = array()) {
         $where = "";
         $params = array();
         if(count($sections) > 0) {
@@ -2569,31 +2569,31 @@ AND gc_id IN (
         return $return;
     }
 
-    public function existsThread($thread_id){
+    public function existsThread($thread_id) {
         $this->course_db->query("SELECT 1 FROM threads where deleted = false AND id = ?", array($thread_id));
         $result = $this->course_db->rows();
         return count($result) > 0;
     }
 
-    public function existsPost($thread_id, $post_id){
+    public function existsPost($thread_id, $post_id) {
         $this->course_db->query("SELECT 1 FROM posts where thread_id = ? and id = ? and deleted = false", array($thread_id, $post_id));
         $result = $this->course_db->rows();
         return count($result) > 0;
     }
 
-    public function existsAnnouncements($show_deleted = false){
+    public function existsAnnouncements($show_deleted = false) {
         $query_delete = $show_deleted ? "true" : "deleted = false";
         $this->course_db->query("SELECT MAX(id) FROM threads where {$query_delete} AND  merged_thread_id = -1 AND pinned = true");
         $result = $this->course_db->rows();
         return empty($result[0]["max"]) ? -1 : $result[0]["max"];
     }
 
-    public function viewedThread($user, $thread_id){
+    public function viewedThread($user, $thread_id) {
         $this->course_db->query("SELECT * FROM viewed_responses v WHERE thread_id = ? AND user_id = ? AND NOT EXISTS(SELECT thread_id FROM (posts LEFT JOIN forum_posts_history ON posts.id = forum_posts_history.post_id) AS jp WHERE jp.thread_id = ? AND (jp.timestamp > v.timestamp OR (jp.edit_timestamp IS NOT NULL AND jp.edit_timestamp > v.timestamp)))", array($thread_id, $user, $thread_id));
         return count($this->course_db->rows()) > 0;
     }
 
-    public function getDisplayUserInfoFromUserId($user_id){
+    public function getDisplayUserInfoFromUserId($user_id) {
         $this->course_db->query("SELECT user_firstname, user_preferred_firstname, user_lastname, user_preferred_lastname, user_email FROM users WHERE user_id = ?", array($user_id));
         $name_rows = $this->course_db->rows()[0];
         $ar = array();
@@ -2644,12 +2644,12 @@ AND gc_id IN (
         $this->course_db->commit();
     }
 
-    public function getCategories(){
+    public function getCategories() {
         $this->course_db->query("SELECT * from categories_list ORDER BY rank ASC NULLS LAST, category_id");
         return $this->course_db->rows();
     }
 
-    public function getPostsForThread($current_user, $thread_id, $show_deleted = false, $option = "tree", $filterOnUser = null){
+    public function getPostsForThread($current_user, $thread_id, $show_deleted = false, $option = "tree", $filterOnUser = null) {
         $query_delete = $show_deleted ? "true" : "deleted = false";
         $query_filter_on_user = '';
         $param_list = array();
@@ -2696,7 +2696,7 @@ AND gc_id IN (
         return $root_post;
     }
 
-    public function mergeThread($parent_thread_id, $child_thread_id, &$message, &$child_root_post){
+    public function mergeThread($parent_thread_id, $child_thread_id, &$message, &$child_root_post) {
         try{
             $this->course_db->beginTransaction();
             $parent_thread_title = null;
@@ -2919,7 +2919,7 @@ AND gc_id IN (
      * Sends notifications to all recipients
      * @param array $notifications
      */
-    public function insertNotifications(array $flattened_notifications, int $notification_count){
+    public function insertNotifications(array $flattened_notifications, int $notification_count) {
         // PDO Placeholders
         $row_string = "(?, ?, ?, current_timestamp, ?, ?)";
         $value_param_string = implode(', ', array_fill(0, $notification_count, $row_string));
@@ -2934,7 +2934,7 @@ AND gc_id IN (
      * @param array $flattened_emails array of params
      * @param int $email_count
      */
-    public function insertEmails(array $flattened_emails, int $email_count){
+    public function insertEmails(array $flattened_emails, int $email_count) {
         // PDO Placeholders
         $row_string = "(?, ?, current_timestamp, ?)";
         $value_param_string = implode(', ', array_fill(0, $email_count, $row_string));
@@ -2950,7 +2950,7 @@ AND gc_id IN (
      * @param bool $show_all
      * @return array(Notification)
      */
-    public function getUserNotifications($user_id, $show_all){
+    public function getUserNotifications($user_id, $show_all) {
         if($show_all){
             $seen_status_query = "true";
         } else {
@@ -2976,12 +2976,12 @@ AND gc_id IN (
         return $results;
     }
 
-    public function getNotificationInfoById($user_id, $notification_id){
+    public function getNotificationInfoById($user_id, $notification_id) {
         $this->course_db->query("SELECT metadata FROM notifications WHERE to_user_id = ? and id = ?", array($user_id, $notification_id));
         return $this->course_db->row();
     }
 
-    public function getUnreadNotificationsCount($user_id, $component){
+    public function getUnreadNotificationsCount($user_id, $component) {
         $parameters = array($user_id);
         if(is_null($component)){
             $component_query = "true";
@@ -2999,7 +2999,7 @@ AND gc_id IN (
      * @param string $user_id
      * @param int $notification_id  if $notification_id != -1 then marks corresponding as seen else mark all notifications as seen
      */
-    public function markNotificationAsSeen($user_id, $notification_id, $thread_id = -1){
+    public function markNotificationAsSeen($user_id, $notification_id, $thread_id = -1) {
         $parameters = array();
         $parameters[] = $user_id;
         if($thread_id != -1) {
@@ -3051,14 +3051,14 @@ AND gc_id IN (
         return $this->submitty_db->row()['is_instructor'];
     }
 
-    public function getRegradeRequestStatus($user_id, $gradeable_id){
+    public function getRegradeRequestStatus($user_id, $gradeable_id) {
         $row = $this->course_db->query("SELECT * FROM regrade_requests WHERE user_id = ? AND g_id = ? ", array($user_id, $gradeable_id));
         $result = ($this->course_db->row()) ? $row['status'] : 0;
         return $result;
     }
 
 
-    public function insertNewRegradeRequest(GradedGradeable $graded_gradeable, User $sender, string $initial_message,$gc_id) {
+    public function insertNewRegradeRequest(GradedGradeable $graded_gradeable, User $sender, string $initial_message, $gc_id) {
         $params = array($graded_gradeable->getGradeableId(), $graded_gradeable->getSubmitter()->getId(), RegradeRequest::STATUS_ACTIVE, $gc_id);
         $submitter_col = $graded_gradeable->getSubmitter()->isTeam() ? 'team_id' : 'user_id';
         try {
@@ -3093,7 +3093,7 @@ AND gc_id IN (
         return $result;
     }
 
-    public function insertNewRegradePost($regrade_id, $user_id, $content){
+    public function insertNewRegradePost($regrade_id, $user_id, $content) {
         $params = array($regrade_id, $user_id, $content);
         $this->course_db->query("INSERT INTO regrade_discussion(regrade_id, timestamp, user_id, content) VALUES (?, current_timestamp, ?, ?)", $params);
     }
@@ -4008,7 +4008,7 @@ AND gc_id IN (
      * @param $thread_id
      * @return bool
      */
-    public function isThreadLocked($thread_id){
+    public function isThreadLocked($thread_id) {
 
         $this->course_db->query('SELECT lock_thread_date FROM threads WHERE id = ?', [$thread_id]);
         if(empty($this->course_db->rows()[0]['lock_thread_date'])){
@@ -4080,13 +4080,13 @@ AND gc_id IN (
         return $not_fully_graded;
     }
 
-    public function getNumInQueue(){
+    public function getNumInQueue() {
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
         $this->course_db->query("SELECT * FROM queue where status = ?", array($in_queue_sc));
         return count($this->course_db->rows());
     }
 
-    public function addUserToQueue($user_id, $name){
+    public function addUserToQueue($user_id, $name) {
         $name = substr($name, 0, 20);
 
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
@@ -4099,7 +4099,7 @@ AND gc_id IN (
         return false;
     }
 
-    public function getQueueByUser($user_id){
+    public function getQueueByUser($user_id) {
         $num_in_queue = $this->getNumInQueue();
         $this->course_db->query("SELECT * FROM queue where user_id = ? order by time_in DESC limit 1", array($user_id));
         if(count($this->course_db->rows()) == 0){
@@ -4114,7 +4114,7 @@ AND gc_id IN (
         return $oh_queue;
     }
 
-    public function removeUserFromQueue($entry_id, $remover){
+    public function removeUserFromQueue($entry_id, $remover) {
         //default to user was removed by an instructor/TA/mentor
         $status_code = OfficeHoursQueueInstructor::STATUS_CODE_REMOVED_BY_INSTRUCTOR;
         if($remover == $this->getUserIdFromQueueSlot($entry_id)){
@@ -4127,31 +4127,31 @@ AND gc_id IN (
         $this->course_db->query("UPDATE queue SET status = ?, time_out = current_timestamp, removed_by = ? where entry_id = ? and (status = ? or status = ?)", array($status_code, $remover, $entry_id,$in_queue_sc,$being_helped_sc));
     }
 
-    public function startHelpUser($entry_id){
+    public function startHelpUser($entry_id) {
         $being_helped_sc = OfficeHoursQueueInstructor::STATUS_CODE_BEING_HELPED;
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
         $this->course_db->query("UPDATE queue SET status = ?, time_helped = current_timestamp where entry_id = ? and status = ?", array($being_helped_sc,$entry_id,$in_queue_sc));
     }
 
-    public function finishHelpUser($entry_id, $helper){
+    public function finishHelpUser($entry_id, $helper) {
         $successfully_helped_sc = OfficeHoursQueueInstructor::STATUS_CODE_SUCCESSFULLY_HELPED;
         $being_helped_sc = OfficeHoursQueueInstructor::STATUS_CODE_BEING_HELPED;
         $this->course_db->query("UPDATE queue SET status = ?, time_out = current_timestamp, removed_by = ? where entry_id = ? and status = ?", array($successfully_helped_sc, $helper, $entry_id, $being_helped_sc));
     }
 
-    public function isQueueOpen(){
+    public function isQueueOpen() {
         $this->course_db->query("SELECT open FROM queue_settings LIMIT 1");
         $queue_open = $this->course_db->rows()[0]['open'];
         return $queue_open;
     }
 
-    public function getQueueCode(){
+    public function getQueueCode() {
         $this->course_db->query("SELECT code FROM queue_settings");
         $rows = $this->course_db->rows();
         return $rows[0]['code'];
     }
 
-    public function getInstructorQueue(){
+    public function getInstructorQueue() {
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
         $being_helped_sc = OfficeHoursQueueInstructor::STATUS_CODE_BEING_HELPED;
 
@@ -4181,7 +4181,7 @@ AND gc_id IN (
         return $oh_queue_instr;
     }
 
-    public function isValidCode($code){
+    public function isValidCode($code) {
         $code = strtoupper($code);
         $this->course_db->query("select * from queue_settings where code = ? limit 1", array($code));
         if(count($this->course_db->rows()) != 0){
@@ -4191,22 +4191,22 @@ AND gc_id IN (
         }
     }
 
-    public function openQueue(){
+    public function openQueue() {
         $this->course_db->query("UPDATE queue_settings SET open = TRUE");
     }
 
-    public function closeQueue(){
+    public function closeQueue() {
         $this->course_db->query("UPDATE queue_settings SET open = FALSE");
     }
 
-    public function emptyQueue($remover){
+    public function emptyQueue($remover) {
         $new_sc = OfficeHoursQueueInstructor::STATUS_CODE_BULK_REMOVED;
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
         $being_helped_sc = OfficeHoursQueueInstructor::STATUS_CODE_BEING_HELPED;
         $this->course_db->query("UPDATE queue SET status = ?, removed_by = ?, time_out = current_timestamp where (status = ? or status = ?)", array($new_sc, $remover, $in_queue_sc, $being_helped_sc));
     }
 
-    public function genNewQueueCode(){
+    public function genNewQueueCode() {
         $characters = 'ABCDEFGHJKMNPQRSTUVWXYZ';
         $charactersLength = strlen($characters);
         $randomString = '';
@@ -4217,7 +4217,7 @@ AND gc_id IN (
         $this->course_db->query("UPDATE queue_settings SET code = ?", array($randomString));
     }
 
-    public function getUserIdFromQueueSlot($entry_id){
+    public function getUserIdFromQueueSlot($entry_id) {
         $this->course_db->query("SELECT * FROM queue where entry_id = ? limit 1", array($entry_id));
         $rows = $this->course_db->rows();
         if(count($rows) == 0){
@@ -4226,7 +4226,7 @@ AND gc_id IN (
         return $rows[0]['user_id'];
     }
 
-    public function genQueueSettings(){
+    public function genQueueSettings() {
         $this->course_db->query("SELECT * FROM queue_settings");
         if(count($this->course_db->rows()) == 0){
             $this->course_db->query("INSERT INTO queue_settings (open,code) VALUES (FALSE, '')");

--- a/site/app/libraries/database/DatabaseRowIterator.php
+++ b/site/app/libraries/database/DatabaseRowIterator.php
@@ -29,7 +29,7 @@ class DatabaseRowIterator implements \Iterator {
      * @param AbstractDatabase $database
      * @param null|callable    $callback
      */
-    public function __construct(\PDOStatement $statement, $database, $callback=null) {
+    public function __construct(\PDOStatement $statement, $database, $callback = null) {
         $this->statement = $statement;
         $this->database = $database;
         $this->columns = $this->database->getColumnData($this->statement);

--- a/site/app/libraries/database/ForumQueries.php
+++ b/site/app/libraries/database/ForumQueries.php
@@ -9,7 +9,7 @@ class ForumQueries {
  //extends DatabaseQueries {
 
 
-    public function createPost(Post &$p, bool $isFirst){
+    public function createPost(Post &$p, bool $isFirst) {
 
         $parent_id = $p->getParentId();
 

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -18,7 +18,7 @@ class PostgresqlDatabase extends AbstractDatabase {
      * port
      * dbname
      */
-    public function __construct($connection_params=array()) {
+    public function __construct($connection_params = array()) {
         parent::__construct($connection_params);
         if (isset($connection_params['host'])) {
             $this->host = $connection_params['host'];
@@ -60,7 +60,7 @@ class PostgresqlDatabase extends AbstractDatabase {
      *
      * @return array PHP array representation
      */
-    public function fromDatabaseToPHPArray($text, $parse_bools = false, $start=0, &$end=null) {
+    public function fromDatabaseToPHPArray($text, $parse_bools = false, $start = 0, &$end = null) {
         $text = trim($text);
 
         if(empty($text) || $text[0] != "{") {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -27,7 +27,7 @@ class PostgresqlDatabaseQueries extends DatabaseQueries {
     //given a user_id check the users table for a valid entry, returns a user object if found, null otherwise
     //if is_numeric is true, the numeric_id key will be used to lookup the user
     //this should be called through getUserById() or getUserByNumericId()
-    private function getUser($user_id, $is_numeric = false ){
+    private function getUser($user_id, $is_numeric = false) {
         if(!$is_numeric){
             $this->submitty_db->query("SELECT * FROM users WHERE user_id=?", array($user_id));
         }else{
@@ -84,7 +84,7 @@ class PostgresqlDatabaseQueries extends DatabaseQueries {
 
     //looks up if the given id is a user_id, if null will then check
     //the numerical_id table
-    public function getUserByIdOrNumericId($id){
+    public function getUserByIdOrNumericId($id) {
         $ret = $this->getUser($id);
         if($ret === null ){
             return $this->getUser($id, true);
@@ -102,7 +102,7 @@ GROUP BY user_id", array($user_id));
         return $this->course_db->row();
     }
 
-    public function getAllUsers($section_key="registration_section") {
+    public function getAllUsers($section_key = "registration_section") {
         $keys = array("registration_section", "rotating_section");
         $section_key = (in_array($section_key, $keys)) ? $section_key : "registration_section";
         $orderBy = "";
@@ -201,7 +201,7 @@ VALUES (?,?,?,?,?,?)", $params);
         $this->updateGradingRegistration($user->getId(), $user->getGroup(), $user->getGradingRegistrationSections());
     }
 
-    public function updateUser(User $user, $semester=null, $course=null) {
+    public function updateUser(User $user, $semester = null, $course = null) {
         $params = array($user->getNumericId(), $user->getLegalFirstName(), $user->getPreferredFirstName(),
                        $user->getLegalLastName(), $user->getPreferredLastName(), $user->getEmail(),
                        $this->submitty_db->convertBoolean($user->isUserUpdated()),
@@ -500,7 +500,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @param string $csv_option value determined by selected radio button
      * @todo maybe process csv uploads as a batch transaction
      */
-    public function updateLateDays($user_id, $timestamp, $days, $csv_option=null) {
+    public function updateLateDays($user_id, $timestamp, $days, $csv_option = null) {
         //Update query and values list.
         $query = "
             INSERT INTO late_days (user_id, since_timestamp, allowed_late_days)
@@ -687,7 +687,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @param string $orderBy
      * @return Team[]
      */
-    public function getTeamsByGradeableAndRegistrationSections($g_id, $sections, $orderBy="registration_section") {
+    public function getTeamsByGradeableAndRegistrationSections($g_id, $sections, $orderBy = "registration_section") {
         $return = array();
         if (count($sections) > 0) {
             $orderBy = str_replace("gt.registration_section", "SUBSTRING(gt.registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(gt.registration_section, '[0-9]+')::INT, -1), SUBSTRING(gt.registration_section, '[^0-9]*$')", $orderBy);
@@ -723,7 +723,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @param string $orderBy
      * @return Team[]
      */
-    public function getTeamsByGradeableAndRotatingSections($g_id, $sections, $orderBy="rotating_section") {
+    public function getTeamsByGradeableAndRotatingSections($g_id, $sections, $orderBy = "rotating_section") {
         $return = array();
         if (count($sections) > 0) {
             $placeholders = implode(",", array_fill(0, count($sections), "?"));

--- a/site/app/libraries/database/SqliteDatabase.php
+++ b/site/app/libraries/database/SqliteDatabase.php
@@ -8,7 +8,7 @@ class SqliteDatabase extends AbstractDatabase {
     protected $path;
     protected $memory = true;
 
-    public function __construct($connection_params=array()) {
+    public function __construct($connection_params = array()) {
         parent::__construct($connection_params);
         if (isset($connection_params['path'])) {
             $this->path = $connection_params['path'];
@@ -29,7 +29,7 @@ class SqliteDatabase extends AbstractDatabase {
         return "sqlite:{$param}";
     }
 
-    public function fromDatabaseToPHPArray($text, $parse_bools = false, $start=0, &$end=null) {
+    public function fromDatabaseToPHPArray($text, $parse_bools = false, $start = 0, &$end = null) {
         throw new NotImplementedException();
     }
 

--- a/site/app/libraries/routers/AnnotatedRouteLoader.php
+++ b/site/app/libraries/routers/AnnotatedRouteLoader.php
@@ -8,8 +8,7 @@ use Symfony\Component\Routing\Route;
 class AnnotatedRouteLoader extends AnnotationClassLoader {
 
 
-    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
-    {
+    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot) {
         $route->setDefault('_controller', $class->getName());
         $route->setDefault('_method', $method->getName());
     }

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -53,7 +53,7 @@ abstract class AbstractModel {
      * @param $check_property
      * @return mixed
      */
-    protected function parseObject($object, $check_property=true) {
+    protected function parseObject($object, $check_property = true) {
         if (is_object($object)) {
             if (is_a($object, 'app\Models\AbstractModel') || is_subclass_of($object, 'app\Models\AbstractModel')) {
                 /** @noinspection PhpUndefinedMethodInspection */
@@ -159,7 +159,7 @@ abstract class AbstractModel {
      *
      * @return string
      */
-    private function convertName($name, $prefix_length=3) {
+    private function convertName($name, $prefix_length = 3) {
         $regex_func = function ($matches) {
             return "_" . strtolower($matches[0]);
         };

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -34,7 +34,7 @@ class Course extends AbstractModel {
         $this->display_name = "";
     }
 
-    public function loadDisplayName(){
+    public function loadDisplayName() {
         $course_json_path = FileUtils::joinPaths(
             $this->core->getConfig()->getSubmittyPath(),
             "courses",

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -16,8 +16,7 @@ class CourseMaterial extends AbstractModel {
      * @return bool Indicates if the file has been released or not
      * @throws FileNotFoundException The course_materials_file_data.json was not found
      */
-    public static function isMaterialReleased(Core $core, string $path_to_file)
-    {
+    public static function isMaterialReleased(Core $core, string $path_to_file) {
         // Before students are allowed to view or download a course materials file we must ensure
         // it has been released.  To return true the file metadata must be found in course_materials_file_data.json
         // and the current time must be greater than the release_datetime
@@ -59,8 +58,7 @@ class CourseMaterial extends AbstractModel {
      * @return bool Indicates if the file has been released or not
      * @throws FileNotFoundException The course_materials_file_data.json was not found
      */
-    public static function isSectionAllowed(Core $core, string $path_to_file ,user $current_user)
-    {
+    public static function isSectionAllowed(Core $core, string $path_to_file, user $current_user) {
         // Before students are allowed to view or download a course materials file we must ensure
         // it has been released.  To return true the file metadata must be found in course_materials_file_data.json
         // and the user's section must be in the file's sections, or the file must not contain sections info, or the

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -32,7 +32,7 @@ class Email extends AbstractModel {
    * @param array $details
    */
 
-    public function __construct(Core $core, $details=array()) {
+    public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
         if (count($details) == 0) {
             return;
@@ -49,7 +49,7 @@ class Email extends AbstractModel {
     }
 
     //inject a "do not reply" note in the footer of the body
-    private function formatBody($body){
+    private function formatBody($body) {
         return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
     }
 }

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -78,7 +78,7 @@ class Notification extends AbstractModel {
         parent::__construct($core);
     }
 
-    public static function createNotification(Core $core,array $event) {
+    public static function createNotification(Core $core, array $event) {
         $instance = new self($core);
         $instance->setComponent($event['component']);
         $instance->setNotifyMetadata($event['metadata']);

--- a/site/app/models/OfficeHoursQueueInstructor.php
+++ b/site/app/models/OfficeHoursQueueInstructor.php
@@ -38,19 +38,19 @@ class OfficeHoursQueueInstructor extends AbstractModel {
         $this->code = $code;
     }
 
-    public function getEntries(){
+    public function getEntries() {
         return $this->entries;
     }
 
-    public function getEntriesHelped(){
+    public function getEntriesHelped() {
         return $this->entries_helped;
     }
 
-    public function isQueueOpen(){
+    public function isQueueOpen() {
         return $this->queue_open;
     }
 
-    public function getCode(){
+    public function getCode() {
         return $this->code;
     }
 }

--- a/site/app/models/OfficeHoursQueueStudent.php
+++ b/site/app/models/OfficeHoursQueueStudent.php
@@ -40,40 +40,40 @@ class OfficeHoursQueueStudent extends AbstractModel {
         $this->removed_by = $removed_by;
     }
 
-    public function getName(){
+    public function getName() {
         return $this->name;
     }
 
-    public function getUserId(){
+    public function getUserId() {
         return $this->user_id;
     }
 
-    public function getPositionInQueue(){
+    public function getPositionInQueue() {
         return $this->position_in_queue;
     }
 
-    public function isInQueue(){
+    public function isInQueue() {
         return $this->status == 0 || $this->status == 1;
     }
 
-    public function getStatus(){
+    public function getStatus() {
         return $this->status;
     }
 
-    public function getNumInQueue(){
+    public function getNumInQueue() {
         return $this->num_in_queue;
     }
 
-    public function getTimeIn(){
+    public function getTimeIn() {
         return $this->time_in;
     }
 
-    public function getTimeHelpedWithSeconds(){
+    public function getTimeHelpedWithSeconds() {
         return $this->time_helped_iso;
     }
 
 
-    public function getTimeBeingHelped(){
+    public function getTimeBeingHelped() {
         $diff = strtotime($this->time_out_iso) - strtotime($this->time_helped_iso);
         $h = $diff / 3600 % 24;
         $m = $diff / 60 % 60;
@@ -81,7 +81,7 @@ class OfficeHoursQueueStudent extends AbstractModel {
         return $h . "h " . $m . "m " . $s . "s";
     }
 
-    public function getTimeWaitingInQueue(){
+    public function getTimeWaitingInQueue() {
         if($this->status  == 2){
             $diff = strtotime($this->time_helped_iso) - strtotime($this->time_in_iso);
         }else{
@@ -93,11 +93,11 @@ class OfficeHoursQueueStudent extends AbstractModel {
         return $h . "h " . $m . "m " . $s . "s";
     }
 
-    public function getRemovedBy(){
+    public function getRemovedBy() {
          return $this->removed_by;
     }
 
-    public function getEntryId(){
+    public function getEntryId() {
         return $this->entry_id;
     }
 }

--- a/site/app/models/PDFGenerator.php
+++ b/site/app/models/PDFGenerator.php
@@ -8,7 +8,7 @@ use TCPDF;
 use setasign\Fpdi\Fpdi;
 
 class PDFGenerator extends AbstractModel {
-    public function __construct(Core $core){
+    public function __construct(Core $core) {
         parent::__construct($core);
 //        $pdf = new Fpdi();
 //        $test = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'submissions/open_homework/instructor/6/upload.pdf');

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -64,7 +64,7 @@ class RainbowCustomization extends AbstractModel {
         }
     }
 
-    public function buildCustomization(){
+    public function buildCustomization() {
 
         //This function should examine the DB(?) / a file(?) and if customization settings already exist, use them. Otherwise, populate with defaults.
         foreach (self::syllabus_buckets as $bucket){
@@ -128,8 +128,7 @@ class RainbowCustomization extends AbstractModel {
      *
      * @return array
      */
-    public function getBucketPercentages()
-    {
+    public function getBucketPercentages() {
         $retArray = [];
 
         if(!is_null($this->RCJSON))
@@ -154,20 +153,19 @@ class RainbowCustomization extends AbstractModel {
         return $retArray;
     }
 
-    public function getCustomizationData(){
+    public function getCustomizationData() {
         return $this->customization_data;
     }
 
-    public function getAvailableBuckets(){
+    public function getAvailableBuckets() {
         return $this->available_buckets;
     }
 
-    public function getUsedBuckets(){
+    public function getUsedBuckets() {
         return $this->used_buckets;
     }
 
-    public function getMessages()
-    {
+    public function getMessages() {
         $messages = !is_null($this->RCJSON) ? $this->RCJSON->getMessages() : [];
 
         return $messages;
@@ -181,8 +179,7 @@ class RainbowCustomization extends AbstractModel {
      *
      * @return array multidimensional array of display benchmark data
      */
-    public function getDisplayBenchmarks()
-    {
+    public function getDisplayBenchmarks() {
         // Get allowed benchmarks
         $displayBenchmarks = RainbowCustomizationJSON::allowed_display_benchmarks;
         $retArray = [];
@@ -214,8 +211,7 @@ class RainbowCustomization extends AbstractModel {
      *
      * @return object The object mapping section ids to labels
      */
-    public function getSectionsAndLabels()
-    {
+    public function getSectionsAndLabels() {
         // Get sections from db
         $db = new DatabaseQueries($this->core);
         $db_sections = $db->getRegistrationSections();
@@ -260,7 +256,7 @@ class RainbowCustomization extends AbstractModel {
     }
 
     // This function handles processing the incoming post data
-    public function processForm(){
+    public function processForm() {
 
         // Get a new customization file
         $this->RCJSON = new RainbowCustomizationJSON($this->core);
@@ -329,11 +325,11 @@ class RainbowCustomization extends AbstractModel {
 //        throw new ValidationException('Debug Rainbow Grades error', $this->error_messages);
     }
 
-    public function error(){
+    public function error() {
         return $this->has_error;
     }
 
-    public function getErrorMessages(){
+    public function getErrorMessages() {
         return $this->error_messages;
     }
 }

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -53,8 +53,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @return array
      */
-    public function getGradeables()
-    {
+    public function getGradeables() {
         return $this->gradeables;
     }
 
@@ -63,8 +62,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @return array The display benchmarks
      */
-    public function getDisplayBenchmarks()
-    {
+    public function getDisplayBenchmarks() {
         return $this->display_benchmark;
     }
 
@@ -75,8 +73,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @param string $benchmark The benchmark to add
      * @throws BadArgumentException The passed in argument is not allowed
      */
-    public function addDisplayBenchmarks(string $benchmark)
-    {
+    public function addDisplayBenchmarks(string $benchmark) {
         if(!in_array($benchmark, self::allowed_display_benchmarks))
         {
             throw new BadArgumentException('Passed in benchmark not found in the list of allowed benchmarks');
@@ -93,8 +90,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @return bool Indicates if a custom_customization.json exists
      */
-    public function doesCustomCustomizationExist()
-    {
+    public function doesCustomCustomizationExist() {
         // Get path to custom_customization.json
         $course_path = $this->core->getConfig()->getCoursePath();
         $file_path = FileUtils::joinPaths($course_path, 'rainbow_grades', 'custom_customization.json');
@@ -108,8 +104,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @throws FileReadException Failure to read the contents of the file
      * @throws MalformedDataException Failure to decode the contents of the JSON string
      */
-    public function loadFromJsonFile()
-    {
+    public function loadFromJsonFile() {
         // Get contents of file and decode
         $course_path = $this->core->getConfig()->getCoursePath();
         $course_path = FileUtils::joinPaths($course_path, 'rainbow_grades', 'customization.json');
@@ -172,8 +167,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @param $display The item to add
      * @throws BadArgumentException The passed in argument is not allowed.
      */
-    public function addDisplay($display)
-    {
+    public function addDisplay($display) {
         if(!in_array($display, self::allowed_display))
         {
             throw new BadArgumentException('Passed in display not found in the list of allowed display items');
@@ -192,8 +186,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @param $label The label you would like to assign to the sectionID
      * @throws BadArgumentException The passed in section label is empty
      */
-    public function addSection($sectionID, $label)
-    {
+    public function addSection($sectionID, $label) {
         if(empty($label))
         {
             throw new BadArgumentException('The section label may not be empty.');
@@ -207,8 +200,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @return object
      */
-    public function getSection()
-    {
+    public function getSection() {
         return $this->section;
     }
 
@@ -217,8 +209,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @param object $gradeable
      */
-    public function addGradeable(object $gradeable)
-    {
+    public function addGradeable(object $gradeable) {
         // TODO: Validate gradeable data
         // Validation of this item will be better handled when schema validation is complete, until then just make
         // sure gradeable is not empty
@@ -236,8 +227,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @return array
      */
-    public function getMessages()
-    {
+    public function getMessages() {
         return $this->messages;
     }
 
@@ -247,8 +237,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @param string $message
      */
-    public function addMessage(string $message)
-    {
+    public function addMessage(string $message) {
         if(empty($message))
         {
             throw new BadArgumentException('You may not add an empty message.');
@@ -260,8 +249,7 @@ class RainbowCustomizationJSON extends AbstractModel {
     /**
      * Save the contents in this objects properties to the customization.json for the current course
      */
-    public function saveToJsonFile()
-    {
+    public function saveToJsonFile() {
         // Get path of where to save file
         $course_path = $this->core->getConfig()->getCoursePath();
         $course_path = FileUtils::joinPaths($course_path, 'rainbow_grades', 'customization.json');

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -37,7 +37,7 @@ class SimpleStat extends AbstractModel {
     /** @property @var bool Does this component use peer grading*/
     protected $is_peer = null;
 
-    public function __construct(Core $core, $details=array()) {
+    public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
         if(isset($details['gc_id'])) {
             $this->component = true;

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -132,7 +132,7 @@ class User extends AbstractModel {
      * @param Core  $core
      * @param array $details
      */
-    public function __construct(Core $core, $details=array()) {
+    public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
         if (count($details) == 0) {
             return;
@@ -244,7 +244,7 @@ class User extends AbstractModel {
         return $this->notification_settings; //either receives it or not
     }
 
-    public function getNotificationSetting($type){
+    public function getNotificationSetting($type) {
         return $this->notification_settings[$type];
     }
 

--- a/site/app/models/forum/Forum.php
+++ b/site/app/models/forum/Forum.php
@@ -21,7 +21,7 @@ class Forum extends AbstractModel {
         //$this->forum_db = $forum_db;
     }
 
-    public function publish(array $data, bool $isThread) : bool {
+    public function publish(array $data, bool $isThread): bool {
 
         $pushFunction = null;
 
@@ -109,7 +109,7 @@ class Forum extends AbstractModel {
 
     }
 
-    private function getThreadContent($thread_id, &$output){
+    private function getThreadContent($thread_id, &$output) {
         $result = $this->core->getQueries()->getThread($thread_id)[0];
         $output['title'] = $result["title"];
         $output['categories_ids'] = $this->core->getQueries()->getCategoriesIdForThread($thread_id);
@@ -117,7 +117,7 @@ class Forum extends AbstractModel {
     }
 
     // Validation of form data
-    private function validateThreadData(array $data, bool $createObject) : array {
+    private function validateThreadData(array $data, bool $createObject): array {
 
         //Validate the post data prior to thread data
         $goodPost = $this->validatePostData($data, false, true);
@@ -134,7 +134,7 @@ class Forum extends AbstractModel {
 
     }
 
-    private function validatePostData(array $data, bool $createObject, bool $isThread) : array {
+    private function validatePostData(array $data, bool $createObject, bool $isThread): array {
 
         if( empty($data['content']) || empty($data['anon']) ||
             empty($data['thread_id']) || empty($data['parent_id']) ||

--- a/site/app/models/forum/Post.php
+++ b/site/app/models/forum/Post.php
@@ -62,7 +62,7 @@ class Post extends AbstractModel {
     //protected $post_type;
     //protected $has_attachment;
 
-    public function __construct(Core $core, $details=array()){
+    public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
 
         if(empty($details)) {

--- a/site/app/models/forum/Thread.php
+++ b/site/app/models/forum/Thread.php
@@ -32,7 +32,7 @@ class Thread extends AbstractModel {
 
     protected $post_list;
 
-    public function __construct(Core $core, $details=array()){
+    public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
         if(empty($details)) {
             return;
@@ -44,7 +44,7 @@ class Thread extends AbstractModel {
 
     }
 
-    public function getFirstPost() : Post {
+    public function getFirstPost(): Post {
         return $posts_list[0];
     }
 }

--- a/site/app/models/gradeable/AutoGradedTestcase.php
+++ b/site/app/models/gradeable/AutoGradedTestcase.php
@@ -118,7 +118,7 @@ class AutoGradedTestcase extends AbstractModel {
     }
 
     /** @internal */
-    public function setView(){
+    public function setView() {
         throw new \BadFunctionCallException('Setters disabled for AutoGradedTestcase');
     }
 

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -154,8 +154,7 @@ class AutoGradedVersion extends AbstractModel {
         }
     }
 
-    public function getTestcaseMessages()
-    {
+    public function getTestcaseMessages() {
         $this->loadTestcases();
 
         $output = array();

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -226,8 +226,7 @@ class AutogradingConfig extends AbstractModel {
         }
     }
 
-    private function getMarkdownData($cell)
-    {
+    private function getMarkdownData($cell) {
         // If markdown_string is set then just return that
         if(isset($cell['markdown_string']))
         {

--- a/site/app/models/gradeable/AutogradingTestcase.php
+++ b/site/app/models/gradeable/AutogradingTestcase.php
@@ -57,8 +57,7 @@ class AutogradingTestcase extends AbstractModel {
         $this->testcase_label = $testcase['testcase_label'] ?? '';
     }
 
-    public function getTestcaseLabel()
-    {
+    public function getTestcaseLabel() {
         return $this->testcase_label;
     }
 

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -307,7 +307,7 @@ class GradedComponent extends AbstractModel {
         $this->modified = true;
     }
 
-    public function setVerifier(User $verifier = null){
+    public function setVerifier(User $verifier = null) {
         $this->verifier = $verifier;
         $this->verifier_id = $verifier !== null ? $verifier->getId() : '';
         $this->modified = true;
@@ -317,7 +317,7 @@ class GradedComponent extends AbstractModel {
      * Gets the id of the verifier or '' if none exist
      * @return string
      */
-    public function getVerifierId(){
+    public function getVerifierId() {
         return $this->verifier_id;
     }
 
@@ -325,7 +325,7 @@ class GradedComponent extends AbstractModel {
      * Gets the verifier
      * @return User
      */
-    public function getVerifier(){
+    public function getVerifier() {
         return $this->verifier;
     }
 
@@ -333,7 +333,7 @@ class GradedComponent extends AbstractModel {
      * Sets the time for when this component was verified
      * @param string $verify_time
      */
-    public function setVerifyTime($verify_time){
+    public function setVerifyTime($verify_time) {
         if ($verify_time === null) {
             $this->verify_time = null;
         } else {
@@ -350,7 +350,7 @@ class GradedComponent extends AbstractModel {
      * Gets the time when this component was verified
      * @return \DateTime
      */
-    public function getVerifyTime(){
+    public function getVerifyTime() {
         return $this->verify_time;
     }
     /* Intentionally Unimplemented accessor methods */

--- a/site/app/views/OfficeHoursQueueView.php
+++ b/site/app/views/OfficeHoursQueueView.php
@@ -18,7 +18,7 @@ class OfficeHoursQueueView extends AbstractView {
         ]);
     }
 
-    public function showQueueInstructor($oh_queue){
+    public function showQueueInstructor($oh_queue) {
         $this->core->getOutput()->addBreadcrumb("Office Hours Queue");
         $this->core->getOutput()->renderTwigOutput("OfficeHoursQueueInstructor.twig", [
         'csrf_token' => $this->core->getCsrfToken(),

--- a/site/app/views/PDFView.php
+++ b/site/app/views/PDFView.php
@@ -15,7 +15,7 @@ class PDFView extends AbstractView {
      *
      * @return void
      */
-    public function showPDFEmbedded($params){
+    public function showPDFEmbedded($params) {
         $this->core->getOutput()->useFooter(false);
         $this->core->getOutput()->useHeader(false);
         $pdf_url = $this->core->buildCourseUrl(['gradeable',  $params["gradeable_id"], 'encode_pdf']);

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -162,7 +162,7 @@ HTML;
         return $return;
     }
 
-    public function showPlagiarismResult($semester, $course, $gradeable_id, $gradeable_title , $rankings) {
+    public function showPlagiarismResult($semester, $course, $gradeable_id, $gradeable_title, $rankings) {
         $this->core->getOutput()->addBreadcrumb('Plagiarism Detection', $this->core->buildCourseUrl(['plagiarism']));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'codemirror.css'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('codemirror', 'codemirror.js'));

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -14,7 +14,7 @@ class UsersView extends AbstractView {
      * @param bool   $use_database
      * @return string
      */
-    public function listStudents($sorted_students, $reg_sections, $rot_sections, $download_info, $use_database=false) {
+    public function listStudents($sorted_students, $reg_sections, $rot_sections, $download_info, $use_database = false) {
         $this->core->getOutput()->addBreadcrumb('Manage Students');
         $this->core->getOutput()->addInternalCss('directory.css');
         $this->core->getOutput()->addInternalCss('userform.css');
@@ -42,7 +42,7 @@ class UsersView extends AbstractView {
      * @param bool   $use_database
      * @return string
      */
-    public function listGraders($graders_sorted, $reg_sections, $rot_sections, $download_info, $use_database=false) {
+    public function listGraders($graders_sorted, $reg_sections, $rot_sections, $download_info, $use_database = false) {
         $this->core->getOutput()->addBreadcrumb('Manage Graders');
         $this->core->getOutput()->addInternalCss('directory.css');
         $this->core->getOutput()->addInternalCss('table.css');
@@ -85,7 +85,7 @@ class UsersView extends AbstractView {
      * @param bool   $use_database
      * @return string
      */
-    public function userForm($reg_sections, $rot_sections, $action, $use_database=false) {
+    public function userForm($reg_sections, $rot_sections, $action, $use_database = false) {
         return $this->core->getOutput()->renderTwigTemplate("admin/users/UserForm.twig", [
             "reg_sections" => $reg_sections,
             "rot_sections" => $rot_sections,

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -22,7 +22,7 @@ class CourseMaterialsView extends AbstractView {
         $this->core->getOutput()->addBreadcrumb("Course Materials");
         $user_group = $user->getGroup();
         $user_section = $user->getRegistrationSection();
-        $add_files = function (Core $core, &$files, &$file_datas, &$file_release_dates, $expected_path, $json, $course_materials_array, $start_dir_name, $user_group, &$in_dir,$fp, &$file_sections, &$hide_from_students) {
+        $add_files = function (Core $core, &$files, &$file_datas, &$file_release_dates, $expected_path, $json, $course_materials_array, $start_dir_name, $user_group, &$in_dir, $fp, &$file_sections, &$hide_from_students) {
             $files[$start_dir_name] = array();
             $student_access = ($user_group === 4);
             $now_date_time = $core->getDateTimeNow();

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -7,11 +7,11 @@ use app\libraries\FileUtils;
 
 class ForumThreadView extends AbstractView {
 
-    public function forumAccess(){
+    public function forumAccess() {
         return $this->core->getConfig()->isForumEnabled();
     }
 
-    public function searchResult($threads){
+    public function searchResult($threads) {
 
         $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
         $this->core->getOutput()->addBreadcrumb("Search");
@@ -109,7 +109,7 @@ class ForumThreadView extends AbstractView {
         displayed in the left panel.
     */
 
-    public function showForumThreads($user, $posts, $unviewed_posts, $threadsHead, $show_deleted, $show_merged_thread, $display_option, $max_thread, $initialPageNumber, $thread_resolve_state, $post_content_limit, $ajax=false) {
+    public function showForumThreads($user, $posts, $unviewed_posts, $threadsHead, $show_deleted, $show_merged_thread, $display_option, $max_thread, $initialPageNumber, $thread_resolve_state, $post_content_limit, $ajax = false) {
 
         if(!$this->forumAccess()){
             $this->core->redirect($this->core->buildCourseUrl([]));
@@ -386,7 +386,7 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-    public function generatePostList($currentThread, $posts, $unviewed_posts, $currentCourse, $includeReply = false, $threadExists = false, $display_option = 'time', $categories = [], $cookieSelectedCategories = [], $cookieSelectedThreadStatus = [], $cookieSelectedUnread = [], $currentCategoriesIds = [], $isCurrentFavorite = false, $render=true) {
+    public function generatePostList($currentThread, $posts, $unviewed_posts, $currentCourse, $includeReply = false, $threadExists = false, $display_option = 'time', $categories = [], $cookieSelectedCategories = [], $cookieSelectedThreadStatus = [], $cookieSelectedUnread = [], $currentCategoriesIds = [], $isCurrentFavorite = false, $render = true) {
 
         $activeThread = $this->core->getQueries()->getThread($currentThread)[0];
 
@@ -552,22 +552,21 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-    public function showAlteredDisplayList($threads, $filtering, $thread_id, $categories_ids){
+    public function showAlteredDisplayList($threads, $filtering, $thread_id, $categories_ids) {
         $tempArray = array();
         $threadAnnouncement = false;
         $activeThreadTitle = "";
         return $this->displayThreadList($threads, $filtering, $threadAnnouncement, $activeThreadTitle, $tempArray, $thread_id, $categories_ids, true);
     }
 
-    public function contentMarkdownToPlain($str){
+    public function contentMarkdownToPlain($str) {
         $str = preg_replace("/\[[^)]+\]/", "", $str);
         $str = preg_replace('/\(([^)]+)\)/s', '$1', $str);
         $str = str_replace("```", "", $str);
         return $str;
     }
 
-    public function displayThreadList($threads, $filtering, &$activeThreadAnnouncement, &$activeThreadTitle, &$activeThread, $thread_id_p, $current_categories_ids, $render)
-    {
+    public function displayThreadList($threads, $filtering, &$activeThreadAnnouncement, &$activeThreadTitle, &$activeThread, $thread_id_p, $current_categories_ids, $render) {
         $used_active = false; //used for the first one if there is not thread_id set
         $current_user = $this->core->getUser()->getId();
         $display_thread_ids = $this->core->getUser()->getGroup() <= 2;
@@ -760,8 +759,7 @@ class ForumThreadView extends AbstractView {
         return $post_content;
     }
 
-    public function createPost($thread_id, $post, $unviewed_posts, $function_date, $first, $reply_level, $display_option, $includeReply, &$totalAttachments)
-    {
+    public function createPost($thread_id, $post, $unviewed_posts, $function_date, $first, $reply_level, $display_option, $includeReply, &$totalAttachments) {
         $current_user = $this->core->getUser()->getId();
         $post_id = $post["id"];
 
@@ -954,7 +952,7 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-    public function createThread($category_colors){
+    public function createThread($category_colors) {
         if(!$this->forumAccess()){
             $this->core->redirect($this->core->buildCourseUrl());
             return;
@@ -1009,7 +1007,7 @@ class ForumThreadView extends AbstractView {
         return $return;
     }
 
-    public function showCategories($category_colors){
+    public function showCategories($category_colors) {
 
         if(!$this->forumAccess()){
             $this->core->redirect($this->core->buildCourseUrl([]));

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -583,7 +583,7 @@ HTML;
         }
 
         //sorts sections numerically, NULL always at the end
-        usort($sections, function ($a,$b) {
+        usort($sections, function ($a, $b) {
             return ($a['title'] == 'NULL' || $b['title'] == 'NULL') ? ($a['title'] == 'NULL') : ($a['title'] > $b['title']);
         });
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -27,7 +27,7 @@ class HomeworkView extends AbstractView {
      * @param bool $show_hidden_testcases
      * @return string
      */
-    public function showGradeable(Gradeable $gradeable, $graded_gradeable, int $display_version, bool $can_inquiry, bool $show_hidden_testcases = false ) {
+    public function showGradeable(Gradeable $gradeable, $graded_gradeable, int $display_version, bool $can_inquiry, bool $show_hidden_testcases = false) {
         $return = '';
 
         $this->core->getOutput()->addInternalJs('drag-and-drop.js');
@@ -804,7 +804,7 @@ class HomeworkView extends AbstractView {
         }
         // sort by most recent posts
         if (!empty($grade_inquiries_twig_array)) {
-            usort($grade_inquiries_twig_array[0]['posts'], function ($a,$b) {
+            usort($grade_inquiries_twig_array[0]['posts'], function ($a, $b) {
                 return strtotime($a['date']) - strtotime($b['date']);
             });
         }

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -26,7 +26,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
      *
      * @return Core
      */
-    protected function createMockCore($config_values=array(), $user_config=array(), $queries=array(), $access=array()) {
+    protected function createMockCore($config_values = array(), $user_config = array(), $queries = array(), $access = array()) {
         $core = $this->createMock(Core::class);
 
         $config = $this->createMockModel(Config::class);
@@ -190,8 +190,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
      * @throws ReflectionException
      * @return mixed Method return.
      */
-    public function invokeMethod(&$object, $methodName, ...$parameters)
-    {
+    public function invokeMethod(&$object, $methodName, ...$parameters) {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);

--- a/site/tests/app/controllers/AuthenticationControllerTester.php
+++ b/site/tests/app/controllers/AuthenticationControllerTester.php
@@ -21,7 +21,7 @@ class AuthenticationControllerTester extends BaseUnitTest {
         $_SERVER['HTTP_USER_AGENT'] = 'test';
     }
 
-    private function getAuthenticationCore($authenticate=false, $queries=[]) {
+    private function getAuthenticationCore($authenticate = false, $queries = []) {
         $core = $this->createMockCore(['semester' => 'f18', 'course' => 'test'], null, $queries);
         $auth = $this->createMock(AbstractAuthentication::class);
         $auth->method('setUserId')->willReturn(null);

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -16,7 +16,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
     private $json_path;
     private $upload_path;
 
-    public function setUp() : void{
+    public function setUp(): void {
         $this->config = array();
         $this->config['course_path'] = FileUtils::joinPaths(sys_get_temp_dir(), Utils::generateRandomString());
         $this->config['use_mock_time'] = true;
@@ -48,7 +48,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
     }
 
-    private function buildFakeZipFile($name, $part=1, $num_files=1, $depth = 1){
+    private function buildFakeZipFile($name, $part = 1, $num_files = 1, $depth = 1) {
         $zip = new ZipArchive();
 
         $filename_full = FileUtils::joinPaths($this->config['course_path'], $name);

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -251,7 +251,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * @param string $content
      * @param int    $part
      */
-    private function addUploadFile($filename, $content="", $part=1) {
+    private function addUploadFile($filename, $content = "", $part = 1) {
         FileUtils::createDir(FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part' . $part), true, 0777);
         $filepath = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part' . $part, $filename);
         if (file_put_contents($filepath, $content) === false) {
@@ -273,7 +273,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * @param array  $files
      * @param int    $part
      */
-    private function addUploadZip($zip_name, $files, $part=1) {
+    private function addUploadZip($zip_name, $files, $part = 1) {
         $part_path = FileUtils::joinPaths($this->config['tmp_path'], 'files', 'part' . $part);
         $root_path = FileUtils::joinPaths($part_path, $zip_name);
         FileUtils::createDir($root_path, true, 0777);
@@ -302,7 +302,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * @param string      $dir
      * @param string|null $root_dir
      */
-    private function createZip($files, $zip, $dir, $root_dir=null) {
+    private function createZip($files, $zip, $dir, $root_dir = null) {
         if ($root_dir === null) {
             $root_dir = $dir;
         }

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -14,7 +14,7 @@ class TeamControllerTester extends BaseUnitTest {
 
     private $config = array();
 
-    public function setUp() : void{
+    public function setUp(): void {
         $config['gradeable_id'] = "test";
 
         $config['semester'] = "test";
@@ -27,26 +27,26 @@ class TeamControllerTester extends BaseUnitTest {
         $this->core = $this->createMockCore($this->config);
     }
     //remove any external resources here
-    public function tearDown() : void{
+    public function tearDown(): void {
         $this->assertTrue(FileUtils::recursiveRmdir($this->config['course_path']));
     }
 
     //Test making teams
-    public function testCreateTeamOnNullGradeable(){
+    public function testCreateTeamOnNullGradeable() {
         $controller = new TeamController($this->core);
         $response = $controller->createNewTeam(false);
         $this->assertEquals(["status" => "fail", "message" => "Invalid or missing gradeable id!"], $response);
     }
 
     //create a normal gradeable, we should not be able to create a team
-    public function testCreateTeamOnNonTeamGradeable(){
+    public function testCreateTeamOnNonTeamGradeable() {
         $this->core->getQueries()->method('getGradeableConfig')->with('test')->willReturn($this->createMockGradeable(false));
         $controller = new TeamController($this->core);
         $response = $controller->createNewTeam($this->config['gradeable_id']);
         $this->assertEquals(["status" => "fail", "message" => "Test Gradeable is not a team assignment"], $response);
     }
 
-    public function testCreateTeamSuccess(){
+    public function testCreateTeamSuccess() {
         $this->config['use_mock_time'] = true;
         $this->core = $this->createMockCore($this->config);
 

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -555,7 +555,7 @@ STRING;
         );
     }
 
-    public function testvalidateUploadedFilesBig(){
+    public function testvalidateUploadedFilesBig() {
         FileUtils::createDir($this->path);
         $this->buildFakeFile("big.txt", 3, 0, 100 + Utils::returnBytes(ini_get('upload_max_filesize')));
         $stat = FileUtils::validateUploadedFiles($_FILES["files3"]);
@@ -584,7 +584,7 @@ STRING;
         );
     }
 
-    public function testvalidateUploadedFilesFail(){
+    public function testvalidateUploadedFilesFail() {
         $stat = FileUtils::validateUploadedFiles(null);
         $this->assertArrayHasKey("failed", $stat);
         $this->assertEquals($stat["failed"], "No files sent to validate" );

--- a/site/tests/app/libraries/LoggerTester.php
+++ b/site/tests/app/libraries/LoggerTester.php
@@ -103,7 +103,7 @@ class LoggerTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($log_path, Logger::getLogPath());
     }
 
-    public function testTALog(){
+    public function testTALog() {
         $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
         $_SERVER['HTTP_USER_AGENT'] = "PHPUnit";
         $logging_params = array("course_semester" => "test_semester",
@@ -165,7 +165,7 @@ class LoggerTester extends \PHPUnit\Framework\TestCase {
      *
      * This function checks if date and time given equals the current time
      */
-    public function assertTimeEqualsCurrent($date, $time){
+    public function assertTimeEqualsCurrent($date, $time) {
         $current_date = getdate(time());
         $this->assertEquals(Utils::pad($current_date['mon']), $date[0], "Month is not right");
         $this->assertEquals(Utils::pad($current_date['mday']), $date[1], "Day is not right");

--- a/site/tests/app/libraries/routers/AccessControlTester.php
+++ b/site/tests/app/libraries/routers/AccessControlTester.php
@@ -34,8 +34,8 @@ class AccessControlTester extends BaseUnitTest {
      */
     public function testAccess(
         $endpoint,
-        $method="GET",
-        $params=[],
+        $method = "GET",
+        $params = [],
         $min_role = User::LEVEL_USER,
         $min_permission = ['course.view'],
         $logged_in = true

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -20,8 +20,6 @@
         <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
         <exclude name="Generic.Files.LineLength.TooLong" />
         <exclude name="Generic.Formatting.SpaceAfterCast.NoSpace" />
-        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
-        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />
         <exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase" />
@@ -49,7 +47,6 @@
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock" />
         <exclude name="PSR12.Files.FileHeader.SpacingInsideBlock" />
         <exclude name="PSR12.Files.ImportStatement.LeadingSlash"/>
-        <exclude name="PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon" />
         <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMixed"/>
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
@@ -67,13 +64,6 @@
         <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterSecond" />
         <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceBeforeArrow" />
         <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceAfterArrow" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg" />
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeHint" />
         <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
         <exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
         <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?
This fixes all `*.Function` style errors from the `Generic`, `PSR12`, and `Squiz` standards.

Broadly, this ensures that function declarations have one space between command next argument, a space between the closing parenthesis and opening function bracket, space between a variable and it's default value, there isn't a space between the `...` and argument name for vardic arguments.