### PR TITLE
[Refactor:PHP] Fix PSR12.Files style errors

### DIFF
--- a/site/app/authentication/AbstractAuthentication.php
+++ b/site/app/authentication/AbstractAuthentication.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\authentication;
 

--- a/site/app/authentication/DatabaseAuthentication.php
+++ b/site/app/authentication/DatabaseAuthentication.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\authentication;
 

--- a/site/app/authentication/PamAuthentication.php
+++ b/site/app/authentication/PamAuthentication.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\authentication;
 

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\controllers;
 
 use app\libraries\FileUtils;

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\controllers\admin;
 
 use app\controllers\AbstractController;

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -12,7 +12,6 @@ use app\libraries\response\WebResponse;
 use app\models\User;
 use app\libraries\routers\AccessControl;
 use Symfony\Component\Routing\Annotation\Route;
-
 //Enable us to throw, catch, and handle exceptions as needed.
 use app\exceptions\ValidationException;
 use app\exceptions\DatabaseException;

--- a/site/app/exceptions/AuthenticationException.php
+++ b/site/app/exceptions/AuthenticationException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/AuthorizationException.php
+++ b/site/app/exceptions/AuthorizationException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/BadArgumentException.php
+++ b/site/app/exceptions/BadArgumentException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/BaseException.php
+++ b/site/app/exceptions/BaseException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/ConfigException.php
+++ b/site/app/exceptions/ConfigException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/CurlException.php
+++ b/site/app/exceptions/CurlException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/DatabaseException.php
+++ b/site/app/exceptions/DatabaseException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/FileNotFoundException.php
+++ b/site/app/exceptions/FileNotFoundException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/FileReadException.php
+++ b/site/app/exceptions/FileReadException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/FileWriteException.php
+++ b/site/app/exceptions/FileWriteException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/IOException.php
+++ b/site/app/exceptions/IOException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/IniException.php
+++ b/site/app/exceptions/IniException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/MalformedDataException.php
+++ b/site/app/exceptions/MalformedDataException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/NotImplementedException.php
+++ b/site/app/exceptions/NotImplementedException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/OutputException.php
+++ b/site/app/exceptions/OutputException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/exceptions/ValidationException.php
+++ b/site/app/exceptions/ValidationException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace app\exceptions;
 

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -2,9 +2,6 @@
 
 namespace app\libraries;
 
-use \DateTime;
-use \DateTimeZone;
-
 /**
  * Class DateUtils
  *
@@ -20,17 +17,17 @@ class DateUtils {
      * up to the nearest day in the positive direction. Thus if there's a difference of 2 days and 3 hours, then
      * the function would return 3 days. Likewise, if the difference was -3 hours, then 0 days would be returned.
      *
-     * @param string|DateTime $date1
-     * @param string|DateTime $date2
+     * @param string|\DateTime $date1
+     * @param string|\DateTime $date2
      *
      * @return int
      */
     public static function calculateDayDiff($date1, $date2 = "now"): int {
-        if (!($date1 instanceof DateTime)) {
-            $date1 = new DateTime($date1);
+        if (!($date1 instanceof \DateTime)) {
+            $date1 = new \DateTime($date1);
         }
-        if (!($date2 instanceof DateTime)) {
-            $date2 = new DateTime($date2);
+        if (!($date2 instanceof \DateTime)) {
+            $date2 = new \DateTime($date2);
         }
         // Set the period as "1 day" for the interval
         if ($date1 == $date2) {
@@ -119,7 +116,7 @@ class DateUtils {
      * @param bool $add_utc_offset If the UTC offset should be part of the output
      * @return string The formatted date
      */
-    public static function dateTimeToString(DateTime $date, bool $add_utc_offset = true): string {
+    public static function dateTimeToString(\DateTime $date, bool $add_utc_offset = true): string {
         return $date->format('Y-m-d H:i:s' . ($add_utc_offset ? 'O' : ''));
     }
 

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -2,16 +2,13 @@
 
 namespace app\libraries\database;
 
-use \PDO;
-use \PDOException;
-
 use app\exceptions\DatabaseException;
 use app\libraries\Utils;
 
 abstract class AbstractDatabase {
 
     /**
-     * @var PDO
+     * @var \PDO
      */
     protected $link = null;
 
@@ -98,19 +95,19 @@ abstract class AbstractDatabase {
             $this->all_queries = array();
             try {
                 if (isset($this->username) && isset($this->password)) {
-                    $this->link = new PDO($this->getDSN(), $this->username, $this->password);
+                    $this->link = new \PDO($this->getDSN(), $this->username, $this->password);
                 }
                 else if (isset($this->username)) {
-                    $this->link = new PDO($this->getDSN(), $this->username);
+                    $this->link = new \PDO($this->getDSN(), $this->username);
                 }
                 else {
-                    $this->link = new PDO($this->getDSN());
+                    $this->link = new \PDO($this->getDSN());
                 }
 
-                $this->link->setAttribute(PDO::ATTR_EMULATE_PREPARES, $this->emulate_prepares);
-                $this->link->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                $this->link->setAttribute(\PDO::ATTR_EMULATE_PREPARES, $this->emulate_prepares);
+                $this->link->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             }
-            catch (PDOException $pdoException) {
+            catch (\PDOException $pdoException) {
                 throw new DatabaseException($pdoException->getMessage());
             }
         }
@@ -171,7 +168,7 @@ abstract class AbstractDatabase {
                 $this->row_count = count($this->results);
             }
         }
-        catch (PDOException $pdoException) {
+        catch (\PDOException $pdoException) {
             throw new DatabaseException($pdoException->getMessage(), $query, $parameters);
         }
 
@@ -205,7 +202,7 @@ abstract class AbstractDatabase {
             $this->row_count = null;
             return new DatabaseRowIterator($statement, $this, $callback);
         }
-        catch (PDOException $exception) {
+        catch (\PDOException $exception) {
             throw new DatabaseException($exception->getMessage(), $query, $parameters);
         }
     }
@@ -236,10 +233,10 @@ abstract class AbstractDatabase {
         foreach ($result as $col => $value) {
             if (isset($columns[$col])) {
                 $column = $columns[$col];
-                if ($column['native_type'] === 'integer' && $column['pdo_type'] !== PDO::PARAM_INT) {
+                if ($column['native_type'] === 'integer' && $column['pdo_type'] !== \PDO::PARAM_INT) {
                     $value = (integer) $value;
                 }
-                elseif ($column['native_type'] === 'boolean' && $column['pdo_type'] !== PDO::PARAM_BOOL) {
+                elseif ($column['native_type'] === 'boolean' && $column['pdo_type'] !== \PDO::PARAM_BOOL) {
                     $value = (boolean) $value;
                 }
                 $result[$col] = $value;

--- a/site/app/libraries/response/AbstractResponse.php
+++ b/site/app/libraries/response/AbstractResponse.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\libraries\response;
 
 use app\libraries\Core;

--- a/site/app/libraries/response/JsonResponse.php
+++ b/site/app/libraries/response/JsonResponse.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\libraries\response;
 
 use app\libraries\Core;

--- a/site/app/libraries/response/RedirectResponse.php
+++ b/site/app/libraries/response/RedirectResponse.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\libraries\response;
 
 use app\libraries\Core;

--- a/site/app/libraries/response/Response.php
+++ b/site/app/libraries/response/Response.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\libraries\response;
 
 use app\libraries\Core;

--- a/site/app/libraries/response/WebResponse.php
+++ b/site/app/libraries/response/WebResponse.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\libraries\response;
 
 use app\libraries\Core;

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\libraries\routers;
 
 use app\libraries\response\RedirectResponse;

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\models;
 
 use app\libraries\Core;

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\models;
 
 use app\exceptions\FileNotFoundException;

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\models;
 
 use app\exceptions\ValidationException;

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\models;
 
 use app\exceptions\BadArgumentException;

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -4,7 +4,7 @@ namespace app\models\gradeable;
 
 use app\exceptions\AuthorizationException;
 use app\libraries\Core;
-use \app\models\AbstractModel;
+use app\models\AbstractModel;
 use app\models\User;
 use app\libraries\FileUtils;
 use app\exceptions\FileNotFoundException;

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\views;
 
 use app\authentication\DatabaseAuthentication;

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace app\views;
 
 use app\models\Button;
-use \app\libraries\GradeableType;
+use app\libraries\GradeableType;
 use app\models\User;
 use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\Gradeable;

--- a/site/app/views/PDFView.php
+++ b/site/app/views/PDFView.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\views;
 
 use app\libraries\FileUtils;

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\views\admin;
 
 use app\views\AbstractView;

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\views\admin;
 
 use app\views\AbstractView;

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\views\forum;
 
 use app\libraries\DateUtils;

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -7,7 +7,6 @@ use app\libraries\Logger;
 use app\libraries\Utils;
 use app\libraries\routers\WebRouter;
 use app\libraries\response\Response;
-
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -6,7 +6,7 @@ use tests\BaseUnitTest;
 use app\controllers\course\CourseMaterialsController;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
-use \ZipArchive;
+use ZipArchive;
 
 class CourseMaterialsControllerTester extends BaseUnitTest {
     use \phpmock\phpunit\PHPMock;

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -2,7 +2,7 @@
 
 namespace tests\app\controllers\student;
 
-use \ZipArchive;
+use ZipArchive;
 use app\controllers\student\SubmissionController;
 use app\exceptions\IOException;
 use app\libraries\Core;

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace tests\app\controllers\student;
 
 use tests\BaseUnitTest;
@@ -6,7 +7,6 @@ use app\controllers\student\TeamController;
 use app\models\gradeable\Gradeable;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
-use \DateTime;
 
 class TeamControllerTester extends BaseUnitTest {
 

--- a/site/tests/app/exceptions/FileNotFoundExceptionTester.php
+++ b/site/tests/app/exceptions/FileNotFoundExceptionTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace tests\app\exceptions;
 
 use app\exceptions\FileNotFoundException;

--- a/site/tests/app/libraries/CascadingIteratorTester.php
+++ b/site/tests/app/libraries/CascadingIteratorTester.php
@@ -2,7 +2,7 @@
 
 namespace tests\app\libraries;
 
-use \app\libraries\CascadingIterator;
+use app\libraries\CascadingIterator;
 
 class CascadingIteratorTester extends \PHPUnit\Framework\TestCase {
     public function testNoIterators() {

--- a/site/tests/app/libraries/DiffViewerTester.php
+++ b/site/tests/app/libraries/DiffViewerTester.php
@@ -2,7 +2,7 @@
 
 namespace tests\app\libraries;
 
-use \app\libraries\DiffViewer;
+use app\libraries\DiffViewer;
 
 class DiffViewerTester extends \PHPUnit\Framework\TestCase {
 

--- a/site/tests/app/libraries/ExceptionHandlerTester.php
+++ b/site/tests/app/libraries/ExceptionHandlerTester.php
@@ -3,10 +3,10 @@
 namespace tests\app\libraries;
 
 use app\exceptions\AuthenticationException;
-use \app\exceptions\BaseException;
-use \app\libraries\ExceptionHandler;
-use \app\libraries\FileUtils;
-use \app\libraries\Logger;
+use app\exceptions\BaseException;
+use app\libraries\ExceptionHandler;
+use app\libraries\FileUtils;
+use app\libraries\Logger;
 use app\libraries\Utils;
 
 class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -3,8 +3,8 @@
 namespace tests\app\libraries;
 
 use app\exceptions\FileReadException;
-use \app\libraries\FileUtils;
-use \app\libraries\Utils;
+use app\libraries\FileUtils;
+use app\libraries\Utils;
 
 class FileUtilsTester extends \PHPUnit\Framework\TestCase {
     use \phpmock\phpunit\PHPMock;

--- a/site/tests/app/libraries/GradeableTypeTester.php
+++ b/site/tests/app/libraries/GradeableTypeTester.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\app\libraries;
 

--- a/site/tests/app/libraries/LoggerTester.php
+++ b/site/tests/app/libraries/LoggerTester.php
@@ -2,9 +2,9 @@
 
 namespace tests\app\libraries;
 
-use \app\libraries\Logger;
-use \app\libraries\Utils;
-use \app\libraries\FileUtils;
+use app\libraries\Logger;
+use app\libraries\Utils;
+use app\libraries\FileUtils;
 
 class LoggerTester extends \PHPUnit\Framework\TestCase {
     private $error;

--- a/site/tests/app/libraries/SessionManagerTester.php
+++ b/site/tests/app/libraries/SessionManagerTester.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\app\libraries;
 

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -3,7 +3,7 @@
 namespace tests\app\libraries;
 
 use app\libraries\Core;
-use \app\libraries\Utils;
+use app\libraries\Utils;
 use app\models\User;
 
 class UtilsTester extends \PHPUnit\Framework\TestCase {

--- a/site/tests/app/libraries/response/JsonResponseTester.php
+++ b/site/tests/app/libraries/response/JsonResponseTester.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\app\libraries\response;
 

--- a/site/tests/app/libraries/response/RedirectResponseTester.php
+++ b/site/tests/app/libraries/response/RedirectResponseTester.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\app\libraries\response;
 

--- a/site/tests/app/libraries/response/ResponseTester.php
+++ b/site/tests/app/libraries/response/ResponseTester.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\app\libraries\response;
 

--- a/site/tests/app/libraries/response/WebResponseTester.php
+++ b/site/tests/app/libraries/response/WebResponseTester.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\app\libraries\response;
 

--- a/site/tests/app/libraries/routers/AccessControlTester.php
+++ b/site/tests/app/libraries/routers/AccessControlTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace tests\app\libraries\routers;
 
 use app\libraries\routers\AccessControl;

--- a/site/tests/phpstan/ModelClassExtensionTester.php
+++ b/site/tests/phpstan/ModelClassExtensionTester.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace tests\phpstan;
 

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -41,12 +41,6 @@
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.LineIndent" />
-        <exclude name="PSR12.Files.OpenTag.NotAlone"/>
-        <exclude name="PSR12.Files.DeclareStatement.SpaceFoundAfterDirective"/>
-        <exclude name="PSR12.Files.DeclareStatement.SpaceFoundBeforeDirectiveValue"/>
-        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock" />
-        <exclude name="PSR12.Files.FileHeader.SpacingInsideBlock" />
-        <exclude name="PSR12.Files.ImportStatement.LeadingSlash"/>
         <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMixed"/>
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>

--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace tests\utils;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the `PSR12.Files` style errors, which is that all opening tags should be on its own line by its self, there should be exactly one newline between header blocks (opening tag, declare statements, namespace, use are all separate blocks), any `use` statement in the header should not have a leading `\` (as it's always fully qualified). Use statements within the class block (like the ones for `phpmock` have their leading slash left as without it they would be treated as unqualified imports and break.

### Other information?
A combination of the test suite and phpstan are validating that there is no behavior change in the removal of the leading slash.
