### PR TITLE
[Refactor:PHP] Fix PSR2.ControlStructures style errors

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -207,7 +207,7 @@ class AuthenticationController extends AbstractController {
             $msg = "Could not find that user for that course";
             return Response::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
         }
-        else if ($user->accessFullGrading()) {
+        elseif ($user->accessFullGrading()) {
             $msg = "Successfully logged in as {$_POST['user_id']}";
             return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse(['message' => $msg, 'authenticated' => true]));
         }

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -215,7 +215,7 @@ class GlobalController extends AbstractController {
                         "id" => "nav-sidebar-photos",
                         "icon" => "fa-id-card"
                     ]);
-                } else if (count($any_images_files) !== 0 && $this->core->getUser()->accessGrading()) {
+                } elseif (count($any_images_files) !== 0 && $this->core->getUser()->accessGrading()) {
                     $sections = $this->core->getUser()->getGradingRegistrationSections();
                     if (!empty($sections) || $this->core->getUser()->getGroup() !== User::GROUP_LIMITED_ACCESS_GRADER) {
                         $at_least_one_grader_link = true;
@@ -230,7 +230,7 @@ class GlobalController extends AbstractController {
                 }
             }
 
-            if ($this->core->getUser()->accessGrading() && $at_least_one_grader_link === true ) {
+            if ($this->core->getUser()->accessGrading() && $at_least_one_grader_link === true) {
                 $sidebar_buttons[] = new Button($this->core, [
                     "class" => "nav-row short-line"
                 ]);
@@ -346,7 +346,7 @@ class GlobalController extends AbstractController {
         $day = $now['mday'];
 
         $duck_img = 'moorthy_duck.png';
-        if($month === 10 && ($day >= 27 && $day <= 31)  ){
+        if($month === 10 && ($day >= 27 && $day <= 31)){
             //halloween
             $duck_img = 'moorthy_halloween.png';
         }

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -155,7 +155,7 @@ class MiscController extends AbstractController {
             elseif (substr($path, '-4') === '.css') {
                 $mime_type = 'text/css';
             }
-            else if (substr($path, '-5') === '.html') {
+            elseif (substr($path, '-5') === '.html') {
                 $mime_type = 'text/html';
             }
         }
@@ -296,7 +296,7 @@ class MiscController extends AbstractController {
                         if($this->core->getUser()->accessGrading()){
                             // Add current file to archive
                             $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
-                        }else if ($gradeable->isScannedExam()
+                        }elseif ($gradeable->isScannedExam()
                                   && FileUtils::getContentType($filePath) === "application/pdf"){
                             //If the user is a student, only get PDFs if this is a bulk upload gradeable
                             // Add current file to archive

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -83,9 +83,9 @@ class OfficeHoursQueueController extends AbstractController {
         }else{
             if($_POST['name'] == ""){
                 $this->core->addErrorMessage("Invalid Name");
-            }else if(is_null($section_id)){
+            }elseif(is_null($section_id)){
                 $this->core->addErrorMessage("Invalid Code");
-            }else if(!$this->core->getQueries()->isQueueOpen()){
+            }elseif(!$this->core->getQueries()->isQueueOpen()){
                 $this->core->addErrorMessage("Queue is closed");
             }
 

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -167,14 +167,14 @@ class AdminGradeableController extends AbstractController {
         if($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             if($gradeable->isScannedExam()) {
                 $type_string = self::gradeable_type_strings['electronic_exam'];
-            } else if($gradeable->isVcs()) {
+            } elseif($gradeable->isVcs()) {
                 $type_string = self::gradeable_type_strings['electronic_hw_vcs'];
             } else {
                 $type_string = self::gradeable_type_strings['electronic_hw'];
             }
-        } else if($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        } elseif($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             $type_string = self::gradeable_type_strings['numeric'];
-        } else if($gradeable->getType() === GradeableType::CHECKPOINTS) {
+        } elseif($gradeable->getType() === GradeableType::CHECKPOINTS) {
             $type_string = self::gradeable_type_strings['checkpoint'];
         }
 
@@ -325,10 +325,10 @@ class AdminGradeableController extends AbstractController {
             $mark0 = $this->newMark($component);
             $mark0->setTitle('No Credit');
             $component->setMarks([$mark0]);
-        } else if ($gradeable->getType() === GradeableType::CHECKPOINTS) {
+        } elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
             $component->setTitle('Checkpoint 1');
             $component->setPoints(['lower_clamp' => 0, 'default' => 0, 'max_value' => 1, 'upper_clamp' => 1]);
-        } else if ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        } elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             // Add a new mark to the db if its electronic
             $mark = $this->newMark($component);
             $component->setMarks([$mark]);
@@ -514,7 +514,7 @@ class AdminGradeableController extends AbstractController {
         //  with a unified interface with TA grading and share a separate "rubric" controller for it.
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             throw new \InvalidArgumentException('Attempt to update rubric using outdated method!');
-        } else if ($gradeable->getType() === GradeableType::CHECKPOINTS) {
+        } elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
             if (!isset($details['checkpoints'])) {
                 $details['checkpoints'] = [];
             }
@@ -540,7 +540,7 @@ class AdminGradeableController extends AbstractController {
                 $component->setOrder($x);
                 $new_components[] = $component;
             }
-        } else if ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        } elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             if (!isset($details['numeric'])) {
                 $details['numeric'] = [];
             }
@@ -745,9 +745,9 @@ class AdminGradeableController extends AbstractController {
             // Find which radio button is pressed and what host type to use
             $host_type = -1;
             if      ($host_button === 'submitty-hosted')     { $host_type = 0; }
-            else if ($host_button === 'submitty-hosted-url') { $host_type = 1; }
-            else if ($host_button === 'public-github')       { $host_type = 2; }
-            else if ($host_button === 'private-github')      { $host_type = 3; }
+            elseif ($host_button === 'submitty-hosted-url') { $host_type = 1; }
+            elseif ($host_button === 'public-github')       { $host_type = 2; }
+            elseif ($host_button === 'private-github')      { $host_type = 3; }
 
             $subdir = '';
             // Submitty hosted -> this gradeable subdirectory
@@ -1151,7 +1151,7 @@ class AdminGradeableController extends AbstractController {
         if (is_file($queued_path)) {
             $status = 'queued';
         }
-        else if (is_file($rebuilding_path)) {
+        elseif (is_file($rebuilding_path)) {
             $status = 'processing';
         }
         else {
@@ -1198,7 +1198,7 @@ class AdminGradeableController extends AbstractController {
                 $message .= "Grades already released for";
                 $success = false;
             }
-        } else if ($action === "open_ta_now") {
+        } elseif ($action === "open_ta_now") {
             if ($dates['ta_view_start_date'] > $now) {
                 $this->shiftDates($dates, 'ta_view_start_date', $now);
                 $message .= "Opened TA access to ";
@@ -1207,7 +1207,7 @@ class AdminGradeableController extends AbstractController {
                 $message .= "TA access already open for ";
                 $success = false;
             }
-        } else if ($action === "open_grading_now") {
+        } elseif ($action === "open_grading_now") {
             if ($dates['grade_start_date'] > $now) {
                 $this->shiftDates($dates, 'grade_start_date', $now);
                 $message .= "Opened grading for ";
@@ -1216,7 +1216,7 @@ class AdminGradeableController extends AbstractController {
                 $message .= "Grading already open for ";
                 $success = false;
             }
-        } else if ($action === "open_students_now") {
+        } elseif ($action === "open_students_now") {
             if ($dates['submission_open_date'] > $now) {
                 $this->shiftDates($dates, 'submission_open_date', $now);
                 $message .= "Opened student access to ";
@@ -1225,7 +1225,7 @@ class AdminGradeableController extends AbstractController {
                 $message .= "Student access already open for ";
                 $success = false;
             }
-        } else if ($action === "close_submissions") {
+        } elseif ($action === "close_submissions") {
             if ($dates['submission_due_date'] > $now) {
                 $this->shiftDates($dates, 'submission_due_date', $now);
                 $message .= "Closed assignment ";
@@ -1239,7 +1239,7 @@ class AdminGradeableController extends AbstractController {
         $this->core->getQueries()->updateGradeable($gradeable);
         if ($success === true) {
             $this->core->addSuccessMessage($message . $gradeable_id);
-        } else if ($success === false) {
+        } elseif ($success === false) {
             $this->core->addErrorMessage($message . $gradeable_id);
         } else {
             $this->core->addErrorMessage("Failed to update status of " . $gradeable_id);

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -116,7 +116,7 @@ class AutogradingConfigController extends AbstractController {
         $config_file_path = $_POST['curr_config_name'] ?? null;
         if($config_file_path == null){
             $this->core->addErrorMessage("Unable to find file");
-        } else if (strpos($config_file_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
+        } elseif (strpos($config_file_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
             $this->core->addErrorMessage("This action can't be completed.");
         } else {
             $new_name = $_POST['new_config_name'] ?? "";
@@ -155,9 +155,9 @@ class AutogradingConfigController extends AbstractController {
         }
         if ($config_path == null) {
             $this->core->addErrorMessage("Selecting config failed.");
-        } else if (strpos($config_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
+        } elseif (strpos($config_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
             $this->core->addErrorMessage("This action can't be completed.");
-        } else if ($in_use){
+        } elseif ($in_use){
             $this->core->addErrorMessage("This config is currently in use.");
         } else {
             if(FileUtils::recursiveRmdir($config_path)){

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -103,7 +103,7 @@ class ConfigurationController extends AbstractController {
                 );
             }
         }
-        else if(in_array($name, array('default_hw_late_days', 'default_student_late_days'))) {
+        elseif(in_array($name, array('default_hw_late_days', 'default_student_late_days'))) {
             if(!ctype_digit($entry)) {
                 return Response::JsonOnlyResponse(
                     JsonResponse::getFailResponse('Must enter a number for this field')
@@ -111,17 +111,17 @@ class ConfigurationController extends AbstractController {
             }
             $entry = intval($entry);
         }
-        else if(in_array($name, array('zero_rubric_grades', 'keep_previous_files', 'display_rainbow_grades_summary',
+        elseif(in_array($name, array('zero_rubric_grades', 'keep_previous_files', 'display_rainbow_grades_summary',
                                       'display_custom_message', 'forum_enabled', 'regrade_enabled', 'seating_only_for_instructor'))) {
             $entry = $entry === "true" ? true : false;
-        }else if($name === 'queue_enabled'){
+        }elseif($name === 'queue_enabled'){
             $entry = $entry === "true" ? true : false;
             $this->core->getQueries()->genQueueSettings();
         }
-        else if($name === 'upload_message') {
+        elseif($name === 'upload_message') {
             $entry = nl2br($entry);
         }
-        else if($name == "course_home_url") {
+        elseif($name == "course_home_url") {
             if(!filter_var($entry, FILTER_VALIDATE_URL) && !empty($entry)){
                 return Response::JsonOnlyResponse(
                     JsonResponse::getFailResponse($entry . ' is not a valid URL')
@@ -129,7 +129,7 @@ class ConfigurationController extends AbstractController {
             }
         }
         // Special validation for auto_rainbow_grades checkbox
-        else if($name === 'auto_rainbow_grades') {
+        elseif($name === 'auto_rainbow_grades') {
 
             // Get a new customization json object
             $customization_json = new RainbowCustomizationJSON($this->core);

--- a/site/app/controllers/admin/GradeOverrideController.php
+++ b/site/app/controllers/admin/GradeOverrideController.php
@@ -55,7 +55,7 @@ class GradeOverrideController extends AbstractController {
             return $this->core->getOutput()->renderJsonFail($error);
         }
         
-        if (((!isset($_POST['marks'])) || $_POST['marks'] == "" || is_float($_POST['marks'])) ) {
+        if (((!isset($_POST['marks'])) || $_POST['marks'] == "" || is_float($_POST['marks']))) {
             $error = "Marks be a integer";
             return $this->core->getOutput()->renderJsonFail($error);
         }

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -206,7 +206,7 @@ class LateController extends AbstractController {
                     $this->core->getQueries()->updateExtensions($_POST['user_id'], $_POST['g_id'], $late_days);
                     $this->core->addSuccessMessage("Extensions have been updated");
                     return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
-                } else if($option == 1){
+                } elseif($option == 1){
                     $team_member_ids = explode(", ", $team->getMemberList());
                     for($i = 0; $i < count($team_member_ids); $i++) {
                         $this->core->getQueries()->updateExtensions($team_member_ids[$i], $_POST['g_id'], $late_days);

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -52,7 +52,7 @@ class PlagiarismController extends AbstractController {
                 if($year_a > $year_b) {
                     return 0;
                 }
-                else if ($year_a < $year_b) {
+                elseif ($year_a < $year_b) {
                     return 1;
                 }
                 else {
@@ -211,7 +211,7 @@ class PlagiarismController extends AbstractController {
             $file_option = "all";
         }
         if($file_option == "matching_regex") {
-            if( isset($_POST['regex_to_select_files']) && $_POST['regex_to_select_files'] !== '') {
+            if(isset($_POST['regex_to_select_files']) && $_POST['regex_to_select_files'] !== '') {
                 $regex_for_selecting_files = $_POST['regex_to_select_files'];
             }
             else {
@@ -221,14 +221,14 @@ class PlagiarismController extends AbstractController {
         }
 
         $language = $_POST['language'];
-        if( isset($_POST['threshold']) && $_POST['threshold'] !== '') {
+        if(isset($_POST['threshold']) && $_POST['threshold'] !== '') {
             $threshold = $_POST['threshold'];
         }
         else {
             $this->core->addErrorMessage("No input provided for threshold");
             $this->core->redirect($return_url);
         }
-        if( isset($_POST['sequence_length']) && $_POST['sequence_length'] !== '') {
+        if(isset($_POST['sequence_length']) && $_POST['sequence_length'] !== '') {
             $sequence_length = $_POST['sequence_length'];
         }
         else {
@@ -237,7 +237,7 @@ class PlagiarismController extends AbstractController {
         }
 
         $prev_term_gradeables = array();
-        for( $i = 0; $i < $prev_gradeable_number; $i++ ) {
+        for($i = 0; $i < $prev_gradeable_number; $i++) {
             if($_POST['prev_sem_' . $i] != "" && $_POST['prev_course_' . $i] != "" && $_POST['prev_gradeable_' . $i] != "") {
                 array_push($prev_term_gradeables, "/var/local/submitty/course/" . $_POST['prev_sem_' . $i] . "/" . $_POST['prev_course_' . $i] . "/submissions/" . $_POST['prev_gradeable_' . $i]);
             }
@@ -246,7 +246,7 @@ class PlagiarismController extends AbstractController {
         $ignore_submissions = array();
         $ignore_submission_option = $_POST['ignore_submission_option'];
         if ($ignore_submission_option == "ignore") {
-            for( $i = 0; $i < $ignore_submission_number; $i++ ) {
+            for($i = 0; $i < $ignore_submission_number; $i++) {
                 if(isset($_POST['ignore_submission_' . $i]) && $_POST['ignore_submission_' . $i] !== '') {
                     array_push($ignore_submissions, $_POST['ignore_submission_' . $i]);
                 }
@@ -606,7 +606,7 @@ class PlagiarismController extends AbstractController {
                         //Color is orange -- general match from selected match
                         $color = '#ffa500';
                     }
-                    else if(!$orange_color) {
+                    elseif(!$orange_color) {
                         //Color is yellow -- matches other students...
                         $color = '#ffff00';
                     }
@@ -627,11 +627,11 @@ class PlagiarismController extends AbstractController {
                         }
                     }
                 }
-                else if($match["type"] == "common") {
+                elseif($match["type"] == "common") {
                     //Color is grey -- common matches among all students
                     $color = '#cccccc';
                 }
-                else if($match["type"] == "provided") {
+                elseif($match["type"] == "provided") {
                     //Color is green -- instructor provided code #b5e3b5
                     $color = '#b5e3b5';
                 }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -310,7 +310,7 @@ class ReportController extends AbstractController {
                     if ($gg->getGradeable()->isTaGrading() && ($gg->getOrCreateTaGradedGradeable()->hasVersionConflict() || !$gg->isTaGradingComplete())) {
                         // Version conflict or incomplete grading, so zero score
                         $row[$gg->getGradeableId()] = 0;
-                    } else if ($late_days->getLateDayInfoByGradeable($gg->getGradeable())->getStatus() === LateDayInfo::STATUS_BAD) {
+                    } elseif ($late_days->getLateDayInfoByGradeable($gg->getGradeable())->getStatus() === LateDayInfo::STATUS_BAD) {
                         // BAD submission, so zero score
                         $row[$gg->getGradeableId()] = 0;
                     }
@@ -416,7 +416,7 @@ class ReportController extends AbstractController {
                         //  but to keep the rest of the report generation sane, they can be users if the
                         //  user is not on a team
                         $entry['note'] = 'User is not on a team';
-                    } else if (!$ta_gg->isComplete()) {
+                    } elseif (!$ta_gg->isComplete()) {
                         $entry['note'] = 'This has not been graded yet.';
                     } else {
                         $entry['note'] = 'Score is set to 0 because there are version conflicts.';

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -369,7 +369,7 @@ class UsersController extends AbstractController {
             array_push($sections_with_students, $rows['rotating_section']);
         }
         for ($i = 1; $i <= $this->core->getQueries()->getMaxRotatingSection(); $i++) {
-            if ( !in_array($i, $sections_with_students) ) {
+            if (!in_array($i, $sections_with_students)) {
                 array_push($non_null_counts, [
                     "rotating_section" => $i,
                     "count" => 0
@@ -406,7 +406,7 @@ class UsersController extends AbstractController {
                 $_SESSION['request'] = $_POST;
             }
         }
-        else if (isset($_POST['delete_reg_section']) && $_POST['delete_reg_section'] !== "") {
+        elseif (isset($_POST['delete_reg_section']) && $_POST['delete_reg_section'] !== "") {
             if (User::validateUserData('registration_section', $_POST['delete_reg_section'])) {
                 // DELETE trigger function in master DB will catch integrity violation exceptions (such as FK violations when users/graders are still enrolled in section).
                 // $num_del_sections indicates how many DELETEs were performed.  0 DELETEs means either the section didn't exist or there are users still enrolled.
@@ -449,12 +449,12 @@ class UsersController extends AbstractController {
             $this->core->addErrorMessage("Must select one of the four options for setting up rotating sections");
             $this->core->redirect($return_url);
         }
-        else if ($_POST['sort_type'] === "drop_null") {
+        elseif ($_POST['sort_type'] === "drop_null") {
             $this->core->getQueries()->setNonRegisteredUsersRotatingSectionNull();
             $this->core->addSuccessMessage("Non registered students removed from rotating sections");
             $this->core->redirect($return_url);
         }
-        else if ($_POST['sort_type'] === "drop_all") {
+        elseif ($_POST['sort_type'] === "drop_all") {
             $this->core->getQueries()->setAllUsersRotatingSectionNull();
             $this->core->getQueries()->setAllTeamsRotatingSectionNull();
             $this->core->addSuccessMessage("All students removed from rotating sections");
@@ -557,7 +557,7 @@ class UsersController extends AbstractController {
             if ($max_section === null) {
                 $this->core->addErrorMessage("No rotating sections have been added to the system, cannot use fewest");
             }
-            else if ($max_section != $section_count) {
+            elseif ($max_section != $section_count) {
                 $this->core->addErrorMessage("Cannot use a different number of sections when setting up via fewest");
                 $this->core->redirect($return_url);
             }
@@ -674,10 +674,10 @@ class UsersController extends AbstractController {
                 if ($output === null) {
                     $this->core->addErrorMessage("Error parsing JSON response: " . json_last_error_msg());
                     $this->core->redirect($return_url);
-                } else if ($output['error'] === true) {
+                } elseif ($output['error'] === true) {
                     $this->core->addErrorMessage("Error parsing xlsx to csv: " . $output['error_message']);
                     $this->core->redirect($return_url);
-                } else if ($output['success'] !== true) {
+                } elseif ($output['success'] !== true) {
                     $this->core->addErrorMessage("Error on response on parsing xlsx: " . curl_error($ch));
                     $this->core->redirect($return_url);
                 }
@@ -688,7 +688,7 @@ class UsersController extends AbstractController {
                 $this->core->redirect($return_url);
             }
 
-        } else if ($content_type === 'text/csv' && $mime_type === 'text/plain') {
+        } elseif ($content_type === 'text/csv' && $mime_type === 'text/plain') {
             $csv_file = $tmp_name;
         } else {
             $this->core->addErrorMessage("Must upload xlsx or csv");

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -174,7 +174,7 @@ class ForumController extends AbstractController {
             $category = (int)$_POST["deleteCategory"];
             if(!$this->isValidCategories(array($category))) {
                 return $this->core->getOutput()->renderJsonFail("That category doesn't exists.");
-            } else if(!$this->isCategoryDeletionGood($category)) {
+            } elseif(!$this->isCategoryDeletionGood($category)) {
                 return $this->core->getOutput()->renderJsonFail("Last category can't be deleted.");
             } else {
                 if($this->core->getQueries()->deleteCategory($category)) {
@@ -202,7 +202,7 @@ class ForumController extends AbstractController {
             if($this->isValidCategories(-1, array($category_desc))) {
                 return $this->core->getOutput()->renderJsonFail("That category already exists.");
             }
-            else if(strlen($category_desc) > 50){
+            elseif(strlen($category_desc) > 50){
                 return $this->core->getOutput()->renderJsonFail("Category name is more than 50 characters.");
             }
         }
@@ -255,12 +255,12 @@ class ForumController extends AbstractController {
         $thread_post_content = str_replace("\r", "", $_POST["thread_post_content"]);
         $anon = (isset($_POST["Anon"]) && $_POST["Anon"] == "Anon") ? 1 : 0;
 
-        if(strlen($thread_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT ){
+        if(strlen($thread_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
             $result['next_page'] = $this->core->buildUrl(['forum', 'threads', 'new']);
             return $this->core->getOutput()->renderJsonFail("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long", $result);
         }
 
-        if( !empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin() ){
+        if(!empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()){
             $lock_thread_date = $_POST['lock_thread_date'];
         } else {
             $lock_thread_date = null;
@@ -278,7 +278,7 @@ class ForumController extends AbstractController {
         if(empty($thread_title) || empty($thread_post_content)){
             $this->core->addErrorMessage("One of the fields was empty or bad. Please re-submit your thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
-        } else if(!$this->isValidCategories($categories_ids)){
+        } elseif(!$this->isValidCategories($categories_ids)){
             $this->core->addErrorMessage("You must select valid categories. Please re-submit your thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
         } else {
@@ -349,7 +349,7 @@ class ForumController extends AbstractController {
         $post_content = str_replace("\r", "", $_POST[$post_content_tag]);
         $thread_id = htmlentities($_POST["thread_id"], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
-        if(strlen($post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT ){
+        if(strlen($post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
             $result['next_page'] = $this->core->buildUrl(['forum', 'threads']);
             return $this->core->getOutput()->renderJsonFail("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long", $result);
         }
@@ -367,13 +367,13 @@ class ForumController extends AbstractController {
         if(empty($post_content) || empty($thread_id)){
             $this->core->addErrorMessage("There was an error submitting your post. Please re-submit your post.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } else if(!$this->core->getQueries()->existsThread($thread_id)) {
+        } elseif(!$this->core->getQueries()->existsThread($thread_id)) {
             $this->core->addErrorMessage("There was an error submitting your post. Thread doesn't exist.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } else if(!$this->core->getQueries()->existsPost($thread_id, $parent_id)) {
+        } elseif(!$this->core->getQueries()->existsPost($thread_id, $parent_id)) {
             $this->core->addErrorMessage("There was an error submitting your post. Parent post doesn't exist in given thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } else if($this->core->getQueries()->isThreadLocked($thread_id) && !$this->core->getUser()->accessAdmin()) {
+        } elseif($this->core->getQueries()->isThreadLocked($thread_id) && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Thread is locked.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
         } else {
@@ -457,13 +457,13 @@ class ForumController extends AbstractController {
         if(!$this->core->getAccess()->canI("forum.modify_post", ['post_author' => $post['author_user_id']])) {
                 return $this->core->getOutput()->renderJsonFail('You do not have permissions to do that.');
         }
-        if(!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) && !$this->core->getUser()->accessAdmin() ){
+        if(!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) && !$this->core->getUser()->accessAdmin()){
             $this->core->addErrorMessage("Thread is locked.");
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $_POST['edit_thread_id']]));
-        } else if($this->core->getQueries()->isThreadLocked($_POST['thread_id']) && !$this->core->getUser()->accessAdmin() ){
+        } elseif($this->core->getQueries()->isThreadLocked($_POST['thread_id']) && !$this->core->getUser()->accessAdmin()){
             return $this->core->getOutput()->renderJsonFail('Thread is locked');
         }
-        else if($modify_type == 0) { //delete post or thread
+        elseif($modify_type == 0) { //delete post or thread
             $thread_id = $_POST["thread_id"];
             $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
             if($this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 1)){
@@ -481,7 +481,7 @@ class ForumController extends AbstractController {
 
             $this->core->getQueries()->removeNotificationsPost($post_id);
             return $this->core->getOutput()->renderJsonSuccess(array('type' => $type));
-        } else if($modify_type == 2) { //undelete post or thread
+        } elseif($modify_type == 2) { //undelete post or thread
             $thread_id = $_POST["thread_id"];
             $result = $this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 0);
             if(is_null($result)) {
@@ -499,7 +499,7 @@ class ForumController extends AbstractController {
                 $type = "post";
                 return $this->core->getOutput()->renderJsonSuccess(array('type' => $type));
             }
-        } else if($modify_type == 1) { //edit post or thread
+        } elseif($modify_type == 1) { //edit post or thread
             $thread_id = $_POST["edit_thread_id"];
             $status_edit_thread = $this->editThread();
             $status_edit_post   = $this->editPost();
@@ -511,7 +511,7 @@ class ForumController extends AbstractController {
              // Author of first post and thread must be same
             if(is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
-            } else if(is_null($status_edit_thread) || is_null($status_edit_post)) {
+            } elseif(is_null($status_edit_thread) || is_null($status_edit_post)) {
                 $type = is_null($status_edit_thread) ? "Post" : "Thread";
                 if($status_edit_thread || $status_edit_post) {
                     //$type is true
@@ -548,7 +548,7 @@ class ForumController extends AbstractController {
                     $subject = "Post Edited: " . Notification::textShortner($post_content);
                     $content = "A message was edited in:\n" . $full_course_name . "\n\nThread Title: " . $thread_title . "\n\nEdited Post: \n\n" . $post_content;
                 }
-                else if ($type == "Thread and Post") {
+                elseif ($type == "Thread and Post") {
                     $post_content = $_POST["thread_post_content"];
                     $subject = "Thread Edited: " . Notification::textShortner($thread_title);
                     $content = "A thread was edited in:\n" . $full_course_name . "\n\nEdited Thread: " . $thread_title . "\n\nEdited Post: \n\n" . $post_content;
@@ -616,7 +616,7 @@ class ForumController extends AbstractController {
         // Ensure authentication before call
         if(!empty($_POST["title"])) {
             $thread_id = $_POST["edit_thread_id"];
-            if( !empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()){
+            if(!empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()){
                 $lock_thread_date = $_POST['lock_thread_date'];
             }
             else{
@@ -643,7 +643,7 @@ class ForumController extends AbstractController {
         $new_post_content = $_POST["thread_post_content"];
         if(!empty($new_post_content)) {
 
-            if(strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT ){
+            if(strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
                 $this->core->addErrorMessage("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long");
                 return null;
             }
@@ -680,7 +680,7 @@ class ForumController extends AbstractController {
 
         foreach ($ordered_threads as &$thread) {
             $list = array();
-            foreach(explode("|", $thread['categories_ids']) as $id ) {
+            foreach(explode("|", $thread['categories_ids']) as $id) {
                 $list[] = (int)$id;
             }
             $thread['categories_ids'] = $list;
@@ -740,7 +740,7 @@ class ForumController extends AbstractController {
         $thread_status = array();
         $new_posts = array();
         $unread_threads = false;
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1 ) {
+        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1) {
             $category_id = explode('|', $_COOKIE[$currentCourse . '_forum_categories']);
         }
         if(!empty($_COOKIE['forum_thread_status'])){
@@ -788,7 +788,7 @@ class ForumController extends AbstractController {
                 }
                 if($option == "alpha"){
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'alpha');
-                } else if($option == "reverse-time") {
+                } elseif($option == "reverse-time") {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'reverse-time');
                 }else {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'tree');

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -174,7 +174,7 @@ class ForumController2 extends AbstractController {
                 $category = (int)$_REQUEST["deleteCategory"];
                 if(!$this->isValidCategories(array($category))) {
                     $result["error"] = "That category doesn't exists.";
-                } else if(!$this->isCategoryDeletionGood($category)) {
+                } elseif(!$this->isCategoryDeletionGood($category)) {
                     $result["error"] = "Last category can't be deleted.";
                 } else {
                     if($this->core->getQueries()->deleteCategory($category)) {
@@ -218,7 +218,7 @@ class ForumController2 extends AbstractController {
             if($should_update) {
                 $this->core->getQueries()->editCategory($category_id, $category_desc, $category_color);
                 $result["success"] = "OK";
-            } else if(!isset($result["error"])) {
+            } elseif(!isset($result["error"])) {
                 $result["error"] = "No category data updated. Please try again.";
             }
         } else {
@@ -329,7 +329,7 @@ class ForumController2 extends AbstractController {
             $this->core->getQueries()->removeNotificationsPost($post_id);
             $this->core->getOutput()->renderJson($response = array('type' => $type));
             return $this->core->getOutput()->getOutput();
-        } else if($modifyType == 2) { //undelete post or thread
+        } elseif($modifyType == 2) { //undelete post or thread
             $thread_id = $_POST["thread_id"];
             $result = $this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 0);
             if(is_null($result)) {
@@ -345,7 +345,7 @@ class ForumController2 extends AbstractController {
                 $this->core->getOutput()->renderJson($response = array('type' => $type));
             }
             return $this->core->getOutput()->getOutput();
-        } else if($modifyType == 1) { //edit post or thread
+        } elseif($modifyType == 1) { //edit post or thread
             $thread_id = $_POST["edit_thread_id"];
             $status_edit_thread = $this->editThread();
             $status_edit_post   = $this->editPost();
@@ -355,7 +355,7 @@ class ForumController2 extends AbstractController {
              // Author of first post and thread must be same
             if(is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
-            } else if(is_null($status_edit_thread) || is_null($status_edit_post)) {
+            } elseif(is_null($status_edit_thread) || is_null($status_edit_post)) {
                 $type = is_null($status_edit_thread) ? "Post" : "Thread";
                 if($status_edit_thread || $status_edit_post) {
                     //$type is true
@@ -424,7 +424,7 @@ class ForumController2 extends AbstractController {
         // Ensure authentication before call
         $new_post_content = $_POST["thread_post_content"];
         if(!empty($new_post_content)) {
-            if(strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT ){
+            if(strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
                 $this->core->addErrorMessage("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long");
                 return null;
             }
@@ -458,7 +458,7 @@ class ForumController2 extends AbstractController {
 
         foreach ($ordered_threads as &$thread) {
             $list = array();
-            foreach(explode("|", $thread['categories_ids']) as $id ) {
+            foreach(explode("|", $thread['categories_ids']) as $id) {
                 $list[] = (int)$id;
             }
             $thread['categories_ids'] = $list;
@@ -510,7 +510,7 @@ class ForumController2 extends AbstractController {
         $thread_status = array();
         $new_posts = array();
         $unread_threads = false;
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1 ) {
+        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1) {
             $category_id = explode('|', $_COOKIE[$currentCourse . '_forum_categories']);
         }
         if(!empty($_COOKIE['forum_thread_status'])){
@@ -535,7 +535,7 @@ class ForumController2 extends AbstractController {
         $option = 'tree';
         if(!empty($_REQUEST['option'])) {
             $option = $_REQUEST['option'];
-        } else if(!empty($_COOKIE['forum_display_option'])) {
+        } elseif(!empty($_COOKIE['forum_display_option'])) {
             $option = $_COOKIE['forum_display_option'];
         }
         $option = ($this->core->getUser()->accessGrading() || $option != 'alpha') ? $option : 'tree';

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -247,7 +247,7 @@ class ElectronicGraderController extends AbstractController {
             $overall_scores = null;
             $section_key = 'registration_section';
         }
-        else if ($gradeable->isGradeByRegistration()) {
+        elseif ($gradeable->isGradeByRegistration()) {
             if(!$this->core->getAccess()->canI("grading.electronic.status.full")) {
                 $sections = $this->core->getUser()->getGradingRegistrationSections();
             }
@@ -865,23 +865,23 @@ class ElectronicGraderController extends AbstractController {
 
                 $goToStudent = $order_all_sections->getPrevSubmitter($from_id);
 
-            } else if($to === 'prev' && $to_ungraded === 'false') {
+            } elseif($to === 'prev' && $to_ungraded === 'false') {
 
                 $goToStudent = $order_grading_sections->getPrevSubmitter($from_id);
 
-            } else if($to === 'next' && $to_ungraded === 'false' && $this->core->getUser()->accessFullGrading()) {
+            } elseif($to === 'next' && $to_ungraded === 'false' && $this->core->getUser()->accessFullGrading()) {
 
                 $goToStudent = $order_all_sections->getNextSubmitter($from_id);
 
-            } else if($to === 'next' && $to_ungraded === 'false') {
+            } elseif($to === 'next' && $to_ungraded === 'false') {
 
                 $goToStudent = $order_grading_sections->getNextSubmitter($from_id);
 
-            } else if($to === 'prev' && $to_ungraded === 'true') {
+            } elseif($to === 'prev' && $to_ungraded === 'true') {
 
                 $goToStudent = $order_grading_sections->getPrevUngradedSubmitter($from_id, $component_id);
 
-            } else if($to === 'next' && $to_ungraded === 'true') {
+            } elseif($to === 'next' && $to_ungraded === 'true') {
 
                 $goToStudent = $order_grading_sections->getNextUngradedSubmitter($from_id, $component_id);
 
@@ -917,7 +917,7 @@ class ElectronicGraderController extends AbstractController {
             $total = $gradeable->getPeerGradeSet();
             $graded = $this->core->getQueries()->getNumGradedPeerComponents($gradeable->getId(), $this->core->getUser()->getId()) / count($gradeable->getPeerComponents());
         }
-        else if ($gradeable->isGradeByRegistration()) {
+        elseif ($gradeable->isGradeByRegistration()) {
             $section_key = "registration_section";
             $sections = $this->core->getUser()->getGradingRegistrationSections();
             if ($this->core->getAccess()->canI("grading.electronic.grade.if_no_sections_exist") && $sections == null) {
@@ -2182,7 +2182,7 @@ class ElectronicGraderController extends AbstractController {
         $sections = array();
         if ($full_stats) {
             $sections = $this->core->getQueries()->getAllSectionsForGradeable($gradeable);
-        } else if ($gradeable->isGradeByRegistration()) {
+        } elseif ($gradeable->isGradeByRegistration()) {
             $sections = $grader->getGradingRegistrationSections();
         } else {
             $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable->getId(), $grader->getId());

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -32,7 +32,7 @@ class SimpleGraderController extends AbstractController {
         if ($sort === "id") {
             $sort_by = "u.user_id";
         }
-        else if($sort === "first"){
+        elseif($sort === "first"){
             $sort_by = "coalesce(NULLIF(u.user_preferred_firstname, ''), u.user_firstname)";
         }
         else {
@@ -205,11 +205,11 @@ class SimpleGraderController extends AbstractController {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Invalid gradeable ID")
             );
-        } else if ($user === null) {
+        } elseif ($user === null) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Invalid user ID")
             );
-        } else if (!isset($_POST['scores']) || empty($_POST['scores'])) {
+        } elseif (!isset($_POST['scores']) || empty($_POST['scores'])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Didn't submit any scores")
             );

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -236,7 +236,7 @@ class GradeInquiryController extends AbstractController {
                     $subject = "New Grade Inquiry: $gradeable_title - $user_id";
                     $body = "A student has submitted a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
                 }
-            } else if ($type == 'reply') {
+            } elseif ($type == 'reply') {
                 if ($this->core->getUser()->accessGrading()) {
                     $subject = "New Grade Inquiry Reply: $gradeable_title - $user_id";
                     $body = "An Instructor/TA/Mentor made a post in a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
@@ -245,7 +245,7 @@ class GradeInquiryController extends AbstractController {
                     $body = "A student has made a post in a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
                 }
 
-            } else if ($type == 'resolve') {
+            } elseif ($type == 'resolve') {
                 if ($this->core->getUser()->accessGrading()) {
                     $included_post_content = !empty($content) ? "$user_id writes:\n$content" : "";
                     $subject = "Grade Inquiry Resolved: $gradeable_title - $user_id";
@@ -255,7 +255,7 @@ class GradeInquiryController extends AbstractController {
                     $subject = "Grade Inquiry Resolved: $gradeable_title - $user_id";
                     $body = "A student has cancelled a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$included_post_content";
                 }
-            } else if ($type == 'reopen') {
+            } elseif ($type == 'reopen') {
                 if ($this->core->getUser()->accessGrading()) {
                     $included_post_content = !empty($content) ? "$user_id writes:\n$content" : "";
                     $subject = "Grade Inquiry Reopened: $gradeable_title - $user_id";

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -90,7 +90,7 @@ class SubmissionController extends AbstractController {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
             return array('error' => true, 'message' => 'No gradeable with that id.');
         }
-        else if ($gradeable->isTeamAssignment() && $graded_gradeable === null && !$this->core->getUser()->accessAdmin()) {
+        elseif ($gradeable->isTeamAssignment() && $graded_gradeable === null && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage('Must be on a team to access submission');
             $this->core->redirect($this->core->buildCourseUrl());
             return array('error' => true, 'message' => 'Must be on a team to access submission.');
@@ -358,7 +358,7 @@ class SubmissionController extends AbstractController {
                 $bulk_upload_job  = "/var/local/submitty/daemon_job_queue/bulk_upload_" . $uploaded_file["name"][$i] . ".json";
 
                 //add new job to queue
-                if(!file_put_contents($bulk_upload_job, json_encode($qr_upload_data, JSON_PRETTY_PRINT)) ){
+                if(!file_put_contents($bulk_upload_job, json_encode($qr_upload_data, JSON_PRETTY_PRINT))){
                     $this->core->getOutput()->renderJsonFail("Failed to write BulkQRSplit job");
                     return $this->uploadResult("Failed to write BulkQRSplit job", false);
                 }
@@ -379,7 +379,7 @@ class SubmissionController extends AbstractController {
                 $bulk_upload_job  = "/var/local/submitty/daemon_job_queue/bulk_upload_" . $uploaded_file["name"][$i] . ".json";
 
                 //add new job to queue
-                if(!file_put_contents($bulk_upload_job, json_encode($job_data, JSON_PRETTY_PRINT)) ){
+                if(!file_put_contents($bulk_upload_job, json_encode($job_data, JSON_PRETTY_PRINT))){
                     $this->core->getOutput()->renderJsonFail("Failed to write Bulk upload job");
                     return $this->uploadResult("Failed to write Bulk upload job", false);
                 }
@@ -545,7 +545,7 @@ class SubmissionController extends AbstractController {
                     preg_match("/\d*$/", $image_name, $matches);
                     $image_num = count($matches) > 0 ? intval(reset($matches)) : -1;
 
-                    if(!$clobber && strpos($image_name, "_page_") !== false && $image_num >= 0 ){
+                    if(!$clobber && strpos($image_name, "_page_") !== false && $image_num >= 0){
                         $file_base_name = "upload_version_"  . $old_version . "_page_" . $image_num . "." . $image_extension;
                     }
 
@@ -894,11 +894,11 @@ class SubmissionController extends AbstractController {
                     $answers = $short_answer_objects["short_answer_" .  $num_short_answers] ?? array();
                     $num_short_answers += 1;
                 }
-                else if ($this_input instanceof SubmissionCodeBox) {
+                elseif ($this_input instanceof SubmissionCodeBox) {
                     $answers = $codebox_objects["codebox_" .  $num_codeboxes] ?? array();
                     $num_codeboxes += 1;
                 }
-                else if ($this_input instanceof SubmissionMultipleChoice) {
+                elseif ($this_input instanceof SubmissionMultipleChoice) {
                     $answers = $multiple_choice_objects["multiple_choice_" .  $num_multiple_choice] ?? array();
                     $num_multiple_choice += 1;
                 }
@@ -910,7 +910,7 @@ class SubmissionController extends AbstractController {
                 $filename = $this_input->getFileName();
                 $dst = FileUtils::joinPaths($version_path, $filename);
 
-                if ( count($answers) > 0)  $empty_inputs = false;
+                if (count($answers) > 0)  $empty_inputs = false;
 
                 // FIXME: add error checking
                 $file = fopen($dst, "w");
@@ -1275,7 +1275,7 @@ class SubmissionController extends AbstractController {
 
             }
             // @codeCoverageIgnoreEnd
-            else if ($this->upload_details['assignment_settings'] === true) {
+            elseif ($this->upload_details['assignment_settings'] === true) {
                 $settings_file = FileUtils::joinPaths($this->upload_details['user_path'], "user_assignment_settings.json");
                 $settings = json_decode(file_get_contents($settings_file), true);
                 if (count($settings['history']) == 1) {

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -352,11 +352,11 @@ class Access {
         //Check user group first
         if ($group === User::GROUP_STUDENT && !self::checkBits($checks, self::ALLOW_STUDENT)) {
             return false;
-        } else if ($group === User::GROUP_LIMITED_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_LIMITED_ACCESS_GRADER)) {
+        } elseif ($group === User::GROUP_LIMITED_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_LIMITED_ACCESS_GRADER)) {
             return false;
-        } else if ($group === User::GROUP_FULL_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_FULL_ACCESS_GRADER)) {
+        } elseif ($group === User::GROUP_FULL_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_FULL_ACCESS_GRADER)) {
             return false;
-        } else if ($group === User::GROUP_INSTRUCTOR && !self::checkBits($checks, self::ALLOW_INSTRUCTOR)) {
+        } elseif ($group === User::GROUP_INSTRUCTOR && !self::checkBits($checks, self::ALLOW_INSTRUCTOR)) {
             return false;
         }
 
@@ -521,11 +521,11 @@ class Access {
                     return false;
                 }
                 // only students with a non-null registration section should be able to view courses (and only active==1 courses)
-                else if($group === User::GROUP_STUDENT && ($course_status !== 1 || $user->getRegistrationSection() === null)) {
+                elseif($group === User::GROUP_STUDENT && ($course_status !== 1 || $user->getRegistrationSection() === null)) {
                     return false;
                 }
                 // no one can view courses with status greater than 2
-                else if ($course_status > 2) {
+                elseif ($course_status > 2) {
                     return false;
                 }
             }
@@ -748,7 +748,7 @@ class Access {
                             //If we already have a graded gradeable in the args, make sure this file
                             // actually belongs to it
                             $graded_gradeable = $args["graded_gradeable"];
-                        } else if (array_key_exists("gradeable", $args)) {
+                        } elseif (array_key_exists("gradeable", $args)) {
                             $gradeable = $args["gradeable"];
                             $graded_gradeable = $this->core->getQueries()->getGradedGradeableForSubmitter($gradeable, $submitter);
                             $args["graded_gradeable"] = $graded_gradeable;

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -580,8 +580,8 @@ class Core {
             $arr1 = str_split($semester);
             $semester = "";
             if($arr1[0] == "f")  $semester .= "Fall ";
-            else if($arr1[0] == "s")  $semester .= "Spring ";
-            else if ($arr1[0] == "u") $semester .= "Summer ";
+            elseif($arr1[0] == "s")  $semester .= "Spring ";
+            elseif ($arr1[0] == "u") $semester .= "Summer ";
 
             $semester .= "20" . $arr1[1] . $arr1[2];
         }

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -97,7 +97,7 @@ class DateUtils {
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
-        } else if (!($date instanceof \DateTime)) {
+        } elseif (!($date instanceof \DateTime)) {
             throw new \InvalidArgumentException('Passed object was not a DateTime object or a date string');
         }
 

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -174,7 +174,7 @@ class DiffViewer {
         if (!file_exists($actual_file) && $actual_file != "") {
             throw new \Exception("'{$actual_file}' could not be found.");
         }
-        else if ($actual_file != "") {
+        elseif ($actual_file != "") {
             // TODO: fix this hacky way to deal with images
             if (Utils::isImage($actual_file)) {
                 $this->actual_file_image = $actual_file;
@@ -202,7 +202,7 @@ class DiffViewer {
         if (!file_exists($expected_file) && $expected_file != "") {
             throw new \Exception("'{$expected_file}' could not be found.");
         }
-        else if ($expected_file != "") {
+        elseif ($expected_file != "") {
             if (Utils::isImage($expected_file)) {
                 $this->expected_file_image = $expected_file;
             }
@@ -227,7 +227,7 @@ class DiffViewer {
         if (!file_exists($image_difference) && $image_difference != "") {
             throw new \Exception("'{$expected_file}' could not be found.");
         }
-        else if ($image_difference != "") {
+        elseif ($image_difference != "") {
             if (Utils::isImage($image_difference)) {
                 $this->difference_file_image = $image_difference;
             }
@@ -236,7 +236,7 @@ class DiffViewer {
         if (!file_exists($diff_file) && $diff_file != "") {
             throw new \Exception("'{$diff_file}' could not be found.");
         }
-        else if ($diff_file != "") {
+        elseif ($diff_file != "") {
             $diff = FileUtils::readJsonFile($diff_file);
         }
 
@@ -291,7 +291,7 @@ class DiffViewer {
                 if ($act_ins < $exp_ins) {
                     $this->add[self::ACTUAL][($act_final)] = $exp_ins - $act_ins;
                 } // Or into expected?
-                else if ($act_ins > $exp_ins) {
+                elseif ($act_ins > $exp_ins) {
                     $this->add[self::EXPECTED][($exp_final)] = $act_ins - $exp_ins;
                 }
             }
@@ -476,12 +476,12 @@ class DiffViewer {
                     if($option == self::SPECIAL_CHARS_ORIGINAL){
                         $html .= $html_orig;
                         $html .= "<span class='highlight-char'>" . $html_orig_error . "</span>";
-                    } else if($option == self::SPECIAL_CHARS_UNICODE) {
+                    } elseif($option == self::SPECIAL_CHARS_UNICODE) {
                         $html_no_empty = $this->replaceEmptyChar($html_orig, false);
                         $html_no_empty_error = $this->replaceEmptyChar($html_orig_error, false);
                         $html .= $html_no_empty;
                         $html .= "<span class='highlight-char'>" . $html_no_empty_error . "</span>";
-                    } else if($option == self::SPECIAL_CHARS_ESCAPE) {
+                    } elseif($option == self::SPECIAL_CHARS_ESCAPE) {
                         $html_no_empty = $this->replaceEmptyChar($html_orig, true);
                         $html_no_empty_error = $this->replaceEmptyChar($html_orig_error, true);
                         $html .= $html_no_empty;
@@ -503,16 +503,16 @@ class DiffViewer {
                 if (isset($lines[$i])) {
                     if($option == self::SPECIAL_CHARS_ORIGINAL){
                         $html .= htmlentities($lines[$i]);
-                    } else if($option == self::SPECIAL_CHARS_UNICODE){
+                    } elseif($option == self::SPECIAL_CHARS_UNICODE){
                         $html .= $this->replaceEmptyChar(htmlentities($lines[$i]), false);
-                    } else if($option == self::SPECIAL_CHARS_ESCAPE){
+                    } elseif($option == self::SPECIAL_CHARS_ESCAPE){
                         $html .= $this->replaceEmptyChar(htmlentities($lines[$i]), true);
                     }
                 }
             }
             if($option == self::SPECIAL_CHARS_UNICODE) {
                 $html .= '<span class="whitespace">&#9166;</span>';
-            } else if($option == self::SPECIAL_CHARS_ESCAPE) {
+            } elseif($option == self::SPECIAL_CHARS_ESCAPE) {
                 $html .= '<span class="whitespace">\\n</span>';
             }
             $html .= "</span></div>\n";

--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -125,7 +125,7 @@ class ExceptionHandler {
         if (static::$display_exceptions) {
             return $message;
         }
-        else if ($display_message) {
+        elseif ($display_message) {
             return $exception->getMessage();
         }
         else {

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -60,7 +60,7 @@ class FileUtils {
                         $return[$entry] = ['files' => $temp, 'path' => $path];
                     }
                 }
-                else if (is_file($path) && !in_array(strtolower($entry), $disallowed_files)) {
+                elseif (is_file($path) && !in_array(strtolower($entry), $disallowed_files)) {
                     // add file to array
                     $return[$entry] = [
                         'name' => $entry,
@@ -130,7 +130,7 @@ class FileUtils {
                     copy($iter->getPathname(), FileUtils::joinPaths($dst, strtolower($iter->getFilename())));
                 }
             }
-            else if ($iter->isDir()) {
+            elseif ($iter->isDir()) {
                 if (in_array(strtolower($iter->getFilename()), FileUtils::IGNORE_FOLDERS)) {
                     continue;
                 }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -225,7 +225,7 @@ class Utils {
 
         if ($result > 1.0 && $clamp === true) {
             return 1.0;
-        } else if ($result < 0.0 && $clamp === true) {
+        } elseif ($result < 0.0 && $clamp === true) {
             return 0.0;
         }
         return $result;

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -97,7 +97,7 @@ abstract class AbstractDatabase {
                 if (isset($this->username) && isset($this->password)) {
                     $this->link = new \PDO($this->getDSN(), $this->username, $this->password);
                 }
-                else if (isset($this->username)) {
+                elseif (isset($this->username)) {
                     $this->link = new \PDO($this->getDSN(), $this->username);
                 }
                 else {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -321,7 +321,7 @@ class DatabaseQueries {
             $results = $this->course_db->rows();
             $row_count = $results[0]['count'];
             $blockNumber = 1 + floor(($row_count - 1) / $blockSize);
-        } else if($blockNumber == 0) {
+        } elseif($blockNumber == 0) {
             // Load first block as default
             $blockNumber = 1;
             if($thread_id >= 1)
@@ -2673,7 +2673,7 @@ AND gc_id IN (
         if($option == 'alpha') {
             $this->course_db->query("SELECT posts.*, fph.edit_timestamp, users.user_lastname FROM posts INNER JOIN users ON posts.author_user_id=users.user_id {$history_query} WHERE thread_id=? AND {$query_delete} ORDER BY user_lastname, posts.timestamp;", array($thread_id));
         }
-        else if ( $option == 'reverse-time' ) {
+        elseif ($option == 'reverse-time') {
             $this->course_db->query("SELECT posts.*, fph.edit_timestamp FROM posts {$history_query} WHERE thread_id=? AND {$query_delete} {$query_filter_on_user} ORDER BY timestamp DESC ", array_reverse($param_list));
         }
         else {
@@ -3005,7 +3005,7 @@ AND gc_id IN (
         if($thread_id != -1) {
             $id_query = "metadata::json->>'thread_id' = ?";
             $parameters[] = $thread_id;
-        } else if($notification_id == -1) {
+        } elseif($notification_id == -1) {
             $id_query = "true";
         } else {
             $id_query = "id = ?";

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -65,7 +65,7 @@ class PostgresqlDatabase extends AbstractDatabase {
 
         if(empty($text) || $text[0] != "{") {
             return array();
-        } else if(is_string($text)) {
+        } elseif(is_string($text)) {
             $return = array();
             $element = "";
             $in_string = false;
@@ -77,41 +77,41 @@ class PostgresqlDatabase extends AbstractDatabase {
                 if (!$in_array && !$in_string && $ch === "{") {
                     $in_array = true;
                 }
-                else if (!$in_string && $ch === "{") {
+                elseif (!$in_string && $ch === "{") {
                     $return[] = $this->fromDatabaseToPHPArray($text, $parse_bools, $i, $i);
                 }
-                else if (!$in_string && $ch === "}") {
+                elseif (!$in_string && $ch === "}") {
                     $this->parsePGArrayValue($element, $have_string, $parse_bools, $return);
                     $end = $i;
                     return $return;
                 }
-                else if (($ch === '"' || $ch === "'") && !$in_string) {
+                elseif (($ch === '"' || $ch === "'") && !$in_string) {
                     $in_string = true;
                     $quot = $ch;
                 }
-                else if ($in_string && $ch == "\\" && strlen($text) > $i) {
+                elseif ($in_string && $ch == "\\" && strlen($text) > $i) {
                     if ($text[$i + 1] === "\\") {
                         $element .= "\\";
                         $i++;
-                    } else if ($text[$i + 1] === "\"") {
+                    } elseif ($text[$i + 1] === "\"") {
                         $element .= "\"";
                         $i++;
                     } else {
                         $element .= $text[$i];
                     }
                 }
-                else if (!$in_string && $ch === "\\") {
+                elseif (!$in_string && $ch === "\\") {
                     //Insert literal \
                     $element .= $text[$i];
                 }
-                else if ($in_string && $ch === $quot) {
+                elseif ($in_string && $ch === $quot) {
                     $in_string = false;
                     $have_string = true;
                 }
-                else if (!$in_string && $ch === " ") {
+                elseif (!$in_string && $ch === " ") {
                     continue;
                 }
-                else if (!$in_string && $ch === ",") {
+                elseif (!$in_string && $ch === ",") {
                     $this->parsePGArrayValue($element, $have_string, $parse_bools, $return);
                     $have_string = false;
                     $element = "";
@@ -138,7 +138,7 @@ class PostgresqlDatabase extends AbstractDatabase {
         if ($have_string) {
             $return[] = $element;
         }
-        else if (strlen($element) > 0) {
+        elseif (strlen($element) > 0) {
             if (is_numeric($element)) {
                 $return[] = ($element + 0);
             }
@@ -147,7 +147,7 @@ class PostgresqlDatabase extends AbstractDatabase {
                 if ($parse_bools && in_array($lower, array("true", "t", "false", "f"))) {
                     $return[] = ($lower === "true" || $lower === "t") ? true : false;
                 }
-                else if ($lower == "null") {
+                elseif ($lower == "null") {
                     $return[] = null;
                 }
                 else {
@@ -178,14 +178,14 @@ class PostgresqlDatabase extends AbstractDatabase {
             if ($e === null) {
                 $elements[] = "null";
             }
-            else if (is_array($e)) {
+            elseif (is_array($e)) {
                 $elements[] = $this->fromPHPToDatabaseArray($e);
             }
-            else if (is_string($e)) {
+            elseif (is_string($e)) {
                 //Turn every \ into \\ that's either preceding a " another \ or the end
                 $elements[] = '"' . str_replace('"', '\"', preg_replace('/\\\\(?=["\\\\]|$)/', '\\\\\\\\', $e)) . '"';
             }
-            else if (is_bool($e)) {
+            elseif (is_bool($e)) {
                 $elements[] = ($e === true) ? "true" : "false";
             }
             else {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -86,7 +86,7 @@ class PostgresqlDatabaseQueries extends DatabaseQueries {
     //the numerical_id table
     public function getUserByIdOrNumericId($id) {
         $ret = $this->getUser($id);
-        if($ret === null ){
+        if($ret === null){
             return $this->getUser($id, true);
         }
 

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -62,7 +62,7 @@ abstract class AbstractModel {
                 $return = get_class($object);
             }
         }
-        else if (is_array($object)) {
+        elseif (is_array($object)) {
             $return = array();
             foreach ($object as $key => $value) {
                 if (is_numeric($key) || (!$check_property || isset(static::$properties[get_class($this)][$key]))) {

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -329,7 +329,7 @@ class Config extends AbstractModel {
             if (empty($secrets_json[$key])) {
                 throw new ConfigException("Missing secret var: {$key}");
             }
-            else if (strlen($secrets_json[$key]) < 32) {
+            elseif (strlen($secrets_json[$key]) < 32) {
                 // enforce a minimum 32 bytes for the secrets
                 throw new ConfigException("Secret {$key} is too weak. It should be at least 32 bytes.");
             }

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -82,7 +82,7 @@ class CourseMaterial extends AbstractModel {
         else
         {
             $current_user_group = $current_user->getGroup();
-            if ( !isset( $meta_data->$path_to_file->sections ) ){
+            if (!isset( $meta_data->$path_to_file->sections )){
                 $retVal = true;
                 return $retVal;
             }

--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -89,7 +89,7 @@ class GradeableAutocheck extends AbstractModel {
                 } else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }
-            } else if(substr($details["expected_file"], 0, 13) == "random_output"){
+            } elseif(substr($details["expected_file"], 0, 13) == "random_output"){
                 if(file_exists($results_path . "/" . $details["expected_file"])){
                     $expected_file = $results_path . "/" . $details["expected_file"];
                 } else {

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -466,17 +466,17 @@ class GradingOrder extends AbstractModel {
 
         if($sort == 'first' && $direction == 'ASC') {
             $msg = 'First Name Ascending';
-        } else if ($sort == 'first' && $direction == 'DESC') {
+        } elseif ($sort == 'first' && $direction == 'DESC') {
             $msg = 'First Name Descending';
-        } else if ($sort == 'last' && $direction == 'ASC') {
+        } elseif ($sort == 'last' && $direction == 'ASC') {
             $msg = 'Last Name Ascending';
-        } else if ($sort == 'last' && $direction == 'DESC') {
+        } elseif ($sort == 'last' && $direction == 'DESC') {
             $msg = 'Last Name Descending';
-        } else if ($sort == 'id' && $direction == 'ASC') {
+        } elseif ($sort == 'id' && $direction == 'ASC') {
             $msg = 'ID Ascending';
-        } else if ($sort == 'id' && $direction == 'DESC') {
+        } elseif ($sort == 'id' && $direction == 'DESC') {
             $msg = 'ID Descending';
-        } else if ($sort == 'random') {
+        } elseif ($sort == 'random') {
             $msg = 'Randomized';
         } else {
             $msg = false;

--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -87,7 +87,7 @@ class GradingSection extends AbstractModel {
             return array_map(function (User $user) {
                 return new Submitter($this->core, $user);
             }, $this->users);
-        } else if ($this->teams !== null) {
+        } elseif ($this->teams !== null) {
             return array_map(function (Team $team) {
                 return new Submitter($this->core, $team);
             }, $this->teams);

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -163,13 +163,13 @@ class Notification extends AbstractModel {
         $actual_time = $this->getCreatedAt();
         if($elapsed_time < 60){
             return "Less than a minute ago";
-        } else if($elapsed_time < 3600){
+        } elseif($elapsed_time < 3600){
             $minutes = floor($elapsed_time / 60);
             if($minutes == 1)
                 return "1 minute ago";
             else
                 return "{$minutes} minutes ago";
-        } else if($elapsed_time < 3600 * 24){
+        } elseif($elapsed_time < 3600 * 24){
             $hours = floor($elapsed_time / 3600);
             if($hours == 1)
                 return "1 hour ago";

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -64,7 +64,7 @@ class Team extends AbstractModel {
                     $this->member_users[] = $user;
                 }
             }
-            else if ($user_details['state'] === 0) {
+            elseif ($user_details['state'] === 0) {
                 $this->invited_user_ids[] = $user_details['user_id'];
                 if ($user !== null) {
                     $this->invited_users[] = $user;

--- a/site/app/models/forum/Forum.php
+++ b/site/app/models/forum/Forum.php
@@ -122,7 +122,7 @@ class Forum extends AbstractModel {
         //Validate the post data prior to thread data
         $goodPost = $this->validatePostData($data, false, true);
 
-        if( !$goodPost[0] ||
+        if(!$goodPost[0] ||
             empty($data['title']) || empty($data['status']) ||
             empty($data['announcement']) || empty($data['categories']) ||
             empty($data['email_announcement']) || $data['parent_id'] !== -1 ||
@@ -136,7 +136,7 @@ class Forum extends AbstractModel {
 
     private function validatePostData(array $data, bool $createObject, bool $isThread): array {
 
-        if( empty($data['content']) || empty($data['anon']) ||
+        if(empty($data['content']) || empty($data['anon']) ||
             empty($data['thread_id']) || empty($data['parent_id']) ||
             (!$isThread && !$this->core->getQueries()->existsThread($data['thread_id'])) ||
             (!$isThread && !$this->core->getQueries()->existsPost($data['thread_id'], $data['parent_id'])) || (strlen($data['content']) > 5000) ) {

--- a/site/app/models/gradeable/AutoGradedTestcase.php
+++ b/site/app/models/gradeable/AutoGradedTestcase.php
@@ -61,7 +61,7 @@ class AutoGradedTestcase extends AbstractModel {
             /*
             $this->points = min(max(0, $this->points), $testcase->getPoints());
             */
-        } else if ($testcase->getPoints() < 0) {
+        } elseif ($testcase->getPoints() < 0) {
             // PENALTY TESTCASE
             // TODO: ADD ERROR <--(what does this mean)?
             $this->points = min(max($testcase->getPoints(), $this->points), 0);

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -383,7 +383,7 @@ class AutoGradedVersion extends AbstractModel {
 
         if ($clamp === true && $result > 1.0) {
             return 1.0;
-        } else if ($result < 0) {
+        } elseif ($result < 0) {
             return 0.0;
         }
         return $result;
@@ -424,7 +424,7 @@ class AutoGradedVersion extends AbstractModel {
 
         if ($clamp === true && $result > 1.0) {
             return 1.0;
-        } else if ($result < 0) {
+        } elseif ($result < 0) {
             return 0.0;
         }
         return $result;

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -91,7 +91,7 @@ class AutogradingConfig extends AbstractModel {
         $this->max_submissions = intval($details['max_submissions'] ?? 0);
         if (isset($details['assignment_message'])) {
             $this->gradeable_message = $details['assignment_message'] ?? '';
-        } else if (isset($details['gradeable_message'])) {
+        } elseif (isset($details['gradeable_message'])) {
             $this->gradeable_message = $details['gradeable_message'] ?? '';
         }
 
@@ -233,7 +233,7 @@ class AutogradingConfig extends AbstractModel {
             return $cell['markdown_string'];
         }
         // Else if markdown_file is set then read the file and return its contents
-        else if(isset($cell['markdown_file']))
+        elseif(isset($cell['markdown_file']))
         {
             // TODO: Implement reading from markdown_file and passing that along
             throw new NotImplementedException("Reading from a markdown_file is not yet implemented.");

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -506,7 +506,7 @@ class Gradeable extends AbstractModel {
                 } else {
                     $result = self::date_properties_bare;
                 }
-            } else if ($this->isTaGrading()) {
+            } elseif ($this->isTaGrading()) {
                 $result = self::date_properties_elec_ta;
             } else {
                 $result = self::date_properties_elec_no_ta;
@@ -1636,12 +1636,12 @@ class Gradeable extends AbstractModel {
         // Inherit rotating/registration section from leader if not provided
         if ($registration_section === '') {
             $registration_section = $leader->getRegistrationSection();
-        } else if($registration_section === 'NULL') {
+        } elseif($registration_section === 'NULL') {
             $registration_section = null;
         }
         if ($rotating_section < 0) {
             $rotating_section = $leader->getRotatingSection();
-        } else if ($rotating_section === 0) {
+        } elseif ($rotating_section === 0) {
             $rotating_section = null;
         }
 
@@ -1734,7 +1734,7 @@ class Gradeable extends AbstractModel {
      */
     public function hasOverriddenGrades(Submitter $submitter) {
         $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->getId(), $submitter->getId());
-        if($userWithOverriddenGrades === null ){
+        if($userWithOverriddenGrades === null){
             return false;
         }
         return true;

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -81,7 +81,7 @@ class GradeableList extends AbstractModel {
             if ($gradeable->getGradeReleasedDate() <= $this->now) {
                 $this->graded_gradeables[$gradeable->getId()] = $gradeable;
             }
-            else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->hasDueDate()) {
+            elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->hasDueDate()) {
                 // Filter out gradeables with no due date
                 if ($gradeable->isStudentSubmit()) {
                     if ($gradeable->getGradeStartDate() < $this->core->getDateTimeNow() && $this->core->getUser()->accessGrading()) {
@@ -96,23 +96,23 @@ class GradeableList extends AbstractModel {
                     $this->grading_gradeables[$gradeable->getId()] = $gradeable;
                 }
             }
-            else if ((($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->isTaGrading()) ||
+            elseif ((($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->isTaGrading()) ||
                     $gradeable->getType() !== GradeableType::ELECTRONIC_FILE) &&
                     $gradeable->getGradeStartDate() <= $this->now) {
                 $this->grading_gradeables[$gradeable->getId()] = $gradeable;
             }
-            else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
+            elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
                 $gradeable->getSubmissionOpenDate() <= $this->now && $gradeable->getSubmissionDueDate() <= $this->now) {
                 $this->closed_gradeables[$gradeable->getId()] = $gradeable;
             }
-            else if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
+            elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
                 $gradeable->getSubmissionOpenDate() <= $this->now && $gradeable->getTaViewStartDate() <= $this->now) {
                 $this->open_gradeables[$gradeable->getId()] = $gradeable;
             }
-            else if ($this->core->getUser()->accessGrading() && $gradeable->getTaViewStartDate() <= $this->now) {
+            elseif ($this->core->getUser()->accessGrading() && $gradeable->getTaViewStartDate() <= $this->now) {
                 $this->beta_gradeables[$gradeable->getId()] = $gradeable;
             }
-            else if ($this->core->getUser()->accessAdmin()) {
+            elseif ($this->core->getUser()->accessAdmin()) {
                 $this->future_gradeables[$gradeable->getId()] = $gradeable;
             }
         }
@@ -161,7 +161,7 @@ class GradeableList extends AbstractModel {
             if ($type !== null && $gradeable->getType() === $type) {
                 return $gradeable;
             }
-            else if ($type === null) {
+            elseif ($type === null) {
                 return $gradeable;
             }
         }

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -325,7 +325,7 @@ class GradedComponentContainer extends AbstractModel {
             $verifier_id = $graded_component->getVerifierId();
             if($grader->accessFullGrading())
                 $visible_graders[$grader->getId()] = $grader;
-            else if($verifier_id != '')
+            elseif($verifier_id != '')
                 $visible_graders[$verifier_id] = $graded_component->getVerifier();
         }
         return $visible_graders;

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -298,7 +298,7 @@ class GradedGradeable extends AbstractModel {
             }
 
             // Handle if notebook cell type is multiple_choice
-            else if(isset($notebookVal['type']) &&
+            elseif(isset($notebookVal['type']) &&
                     $notebookVal['type'] == "multiple_choice")
             {
 

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -225,7 +225,7 @@ class LateDays extends AbstractModel {
                 // Due to the way getLateDaysCharged works, this subtraction should never make the
                 //  count go below zero (if it does, fix getLateDaysCharged)
                 $late_days_remaining -= $info->getLateDaysCharged();
-            } else if (isset($event['update'])) {
+            } elseif (isset($event['update'])) {
                 // Late days update event, so add the difference between the new and old
                 //  available count and add that to the late days remaining.
                 //  Clamp to 0 to ensure that subtractions don't make us go below zero

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -179,13 +179,13 @@ class TaGradedGradeable extends AbstractModel {
             $v = $container->getGradedVersion();
             if ($v !== false && $strict !== true) {
                 return $v;
-            } else if ($v === false) {
+            } elseif ($v === false) {
                 return false;
             }
 
             if ($version === false) {
                 $version = $v;
-            } else if ($version !== $v) {
+            } elseif ($version !== $v) {
                 return false;
             }
         }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -168,7 +168,7 @@ class AutoGradingView extends AbstractView {
                         "show_popup" => false,
                         "src" => $this->autoGetImageSrc($actual_image),
                     ];
-                } else if ($diff_viewer->hasDisplayActual()) {
+                } elseif ($diff_viewer->hasDisplayActual()) {
                     if($autocheck->isDisplayAsSequenceDiagram()){
                         $check["actual"] = [
                             "type" => "sequence_diagram",
@@ -196,7 +196,7 @@ class AutoGradingView extends AbstractView {
                         "show_popup" => false,
                         "src" => $this->autoGetImageSrc($expected_image)
                     ];
-                } else if ($diff_viewer->hasDisplayExpected()) {
+                } elseif ($diff_viewer->hasDisplayExpected()) {
                     $check["expected"] = [
                         "type" => "text",
                         "title" => $expected_title,
@@ -303,7 +303,7 @@ class AutoGradingView extends AbstractView {
         // Special messages for peer / mentor-only grades
         if ($gradeable->isPeerGrading()) {
             $grader_names = ['Graded by Peer(s)'];
-        } else if (count($grader_names) === 0) {
+        } elseif (count($grader_names) === 0) {
             // Non-peer assignment with only limited access graders
             $grader_names = ['Course Staff'];
         }
@@ -410,7 +410,7 @@ class AutoGradingView extends AbstractView {
         }
 
         // for bulk uploads only show PDFs
-        if ($gradeable->isScannedExam() ){
+        if ($gradeable->isScannedExam()){
             $files = $uploaded_pdfs;
         }else{
             $files = array_merge($files['submissions'], $files['checkout']);

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -29,7 +29,7 @@ class GlobalView extends AbstractView {
         $page_title = "Submitty";
         if ($this->core->getUser() === null) {
             $page_title = "Submitty Login";
-        } else if ($this->core->getConfig()->isCourseLoaded()) {
+        } elseif ($this->core->getConfig()->isCourseLoaded()) {
             $page_title = "Submitty " . $course_name . " " . $page_name;
         }
 

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -95,7 +95,7 @@ class NavigationView extends AbstractView {
                     $message_file_details = $message_json->special_message;
 
                     //If any fields are missing, treat this as though we just didn't have a message for this user.
-                    if(!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename') ){
+                    if(!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename')){
                         $display_custom_message = false;
                         $messsage_file_details = null;
                     }
@@ -476,13 +476,13 @@ class NavigationView extends AbstractView {
                 $title = "BULK UPLOAD";
                 $class = "btn-primary";
                 $display_date = "";
-            } else if ($gradeable->isStudentSubmit() && !$gradeable->hasDueDate() && $list_section != GradeableList::OPEN) {
+            } elseif ($gradeable->isStudentSubmit() && !$gradeable->hasDueDate() && $list_section != GradeableList::OPEN) {
                 $title = "SUBMIT";
                 $class = "btn-default";
-            } else if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::OPEN) {
+            } elseif ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::OPEN) {
                 //if the user submitted something on time
                 $title = "RESUBMIT";
-            } else if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::CLOSED) {
+            } elseif ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::CLOSED) {
                 //if the user submitted something past time
                 if ($gradeable->isLateSubmissionAllowed()) {
                     $title = "LATE RESUBMIT";
@@ -491,11 +491,11 @@ class NavigationView extends AbstractView {
                     $class = 'btn-default';
                     $display_date = "";
                 }
-            } else if (!$graded_gradeable->getAutoGradedGradeable()->hasSubmission() && !$gradeable->isLateSubmissionAllowed() && $list_section == GradeableList::CLOSED) {
+            } elseif (!$graded_gradeable->getAutoGradedGradeable()->hasSubmission() && !$gradeable->isLateSubmissionAllowed() && $list_section == GradeableList::CLOSED) {
                 $title = "NO SUBMISSION";
                 $class = "btn-danger";
                 $display_date = "";
-            } else if (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
+            } elseif (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
                 //to change the text to overdue submission if nothing was submitted on time
                 if ($gradeable->isStudentSubmit()) {
                     $title = "OVERDUE SUBMISSION";
@@ -503,7 +503,7 @@ class NavigationView extends AbstractView {
                     $title = "NO SUBMISSION";
                     $display_date = "";
                 }
-            } else if ($gradeable->isTaGrading() && !$graded_gradeable->isTaGradingComplete() && $list_section == GradeableList::GRADED) {
+            } elseif ($gradeable->isTaGrading() && !$graded_gradeable->isTaGradingComplete() && $list_section == GradeableList::GRADED) {
                 //when there is no TA grade and due date passed
                 $title = "TA GRADE NOT AVAILABLE";
             }
@@ -554,7 +554,7 @@ class NavigationView extends AbstractView {
         }
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'status']);
-        } else if ($gradeable->getType() === GradeableType::CHECKPOINTS || $gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        } elseif ($gradeable->getType() === GradeableType::CHECKPOINTS || $gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading']) . '?view=' . $view;
         }
         else {
@@ -595,10 +595,10 @@ class NavigationView extends AbstractView {
             $date = $this->core->getDateTimeNow();
             $grades_due = $gradeable->getGradeDueDate();
             $grades_released = $gradeable->getGradeReleasedDate();
-            if ($list_section === GradeableList::GRADING && $date < $grades_due ) {
+            if ($list_section === GradeableList::GRADING && $date < $grades_due) {
                 $title = 'GRADE';
                 $date_text = '(grades due ' . $gradeable->getGradeDueDate()->format(self::DATE_FORMAT) . ')';
-            } else if($list_section === GradeableList::GRADING && $date < $grades_released){
+            } elseif($list_section === GradeableList::GRADING && $date < $grades_released){
                 $title = 'GRADE';
                 $date_text = '(grades will be released ' . $grades_released->format(self::DATE_FORMAT) . ')';
             }
@@ -619,7 +619,7 @@ class NavigationView extends AbstractView {
                             //You forgot somebody
                             $class = 'btn-danger';
                             $title = 'GRADE';
-                        } else if(!is_nan($TA_percent) && $list_section === GradeableList::GRADING && $grades_due < $date && $date < $grades_released){
+                        } elseif(!is_nan($TA_percent) && $list_section === GradeableList::GRADING && $grades_due < $date && $date < $grades_released){
                             $class = 'btn-danger';
                             $title = 'GRADE';
                         }
@@ -706,7 +706,7 @@ class NavigationView extends AbstractView {
                 "class" => "btn btn-primary btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);
-        } else if ($list_section === GradeableList::FUTURE) {
+        } elseif ($list_section === GradeableList::FUTURE) {
             $button = new Button($this->core, [
                 "subtitle" => "OPEN TO TAS NOW",
                 "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
@@ -714,7 +714,7 @@ class NavigationView extends AbstractView {
                 "class" => "btn btn-primary btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);
-        } else if ($list_section === GradeableList::BETA) {
+        } elseif ($list_section === GradeableList::BETA) {
             if ($gradeable->getType() == GradeableType::ELECTRONIC_FILE) {
                 $button = new Button($this->core, [
                     "subtitle" => "OPEN NOW",
@@ -732,7 +732,7 @@ class NavigationView extends AbstractView {
                     "name" => "quick-link-btn"
                 ]);
             }
-        } else if ($list_section === GradeableList::CLOSED) {
+        } elseif ($list_section === GradeableList::CLOSED) {
             $button = new Button($this->core, [
                 "subtitle" => "OPEN TO GRADING NOW",
                 "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
@@ -740,7 +740,7 @@ class NavigationView extends AbstractView {
                 "class" => "btn btn-primary btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);
-        } else if ($list_section === GradeableList::OPEN) {
+        } elseif ($list_section === GradeableList::OPEN) {
             $url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
                 . http_build_query(['action' => 'close_submissions']);
 

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -69,7 +69,7 @@ HTML;
             }
 
             #lichen job in processing stage for this gradeable but not completed
-            else if (file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $id . ".json")) {
+            elseif (file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $id . ".json")) {
                 $return .= <<<HTML
         <tr style="color:green;">
             <td>$title
@@ -515,7 +515,7 @@ HTML;
 HTML;
         }
 
-        else if($new_or_edit == "edit") {
+        elseif($new_or_edit == "edit") {
             $title = '';
             if (isset($saved_config['gradeable']) && $saved_config['gradeable'] !== null) {
                 $title = $this->core->getQueries()->getGradeableConfig($saved_config['gradeable'])->getTitle();
@@ -611,7 +611,7 @@ HTML;
                         <option value="">None</option>
 HTML;
                 foreach($prior_term_gradeables as $sem => $sem_courses) {
-                    if( $sem == $saved_prev_sem) {
+                    if($sem == $saved_prev_sem) {
                         $return .= <<<HTML
                         <option value="{$sem}" selected>$sem</option>
 HTML;
@@ -628,7 +628,7 @@ HTML;
 HTML;
 
                 foreach($prior_term_gradeables[$saved_prev_sem] as $sem_course => $course_gradeables) {
-                    if( $sem_course == $saved_prev_course) {
+                    if($sem_course == $saved_prev_course) {
                         $return .= <<<HTML
                         <option value="{$sem_course}" selected>$sem_course</option>
 HTML;
@@ -645,7 +645,7 @@ HTML;
                         <option value="">None</option>
 HTML;
                 foreach($prior_term_gradeables[$saved_prev_sem][$saved_prev_course] as $course_gradeable) {
-                    if( $course_gradeable == $saved_prev_gradeable) {
+                    if($course_gradeable == $saved_prev_gradeable) {
                         $return .= <<<HTML
                         <option value="{$course_gradeable}" selected>$course_gradeable</option>
 HTML;

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -40,16 +40,16 @@ class CourseMaterialsView extends AbstractView {
                 $releaseData = $now_date_time->format("Y-m-d H:i:sO");
                 $isShareToOther = '0';
                 if ($json == true){
-                    if ( isset( $json[$expected_file_path] ) )
+                    if (isset( $json[$expected_file_path] ))
                     {
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
 
-                        if ( isset( $json[$expected_file_path]['sections'] ) ){
+                        if (isset( $json[$expected_file_path]['sections'] )){
                             $file_sections[$expected_file_path] = $json[$expected_file_path]['sections'];
                         }
                         $release_date = DateUtils::parseDateTime($json[$expected_file_path]['release_datetime'], $core->getConfig()->getTimezone());
-                        if ( isset( $json[$expected_file_path]['hide_from_students'] ) ){
+                        if (isset( $json[$expected_file_path]['hide_from_students'] )){
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
 
@@ -63,11 +63,11 @@ class CourseMaterialsView extends AbstractView {
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
                         $release_date = $json['release_time'];
-                        if ( isset( $json[$expected_file_path]['hide_from_students'] ) ){
+                        if (isset( $json[$expected_file_path]['hide_from_students'] )){
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
                         $json[$expected_file_path]['release_datetime'] = $release_date;
-                        if ( isset( $json[$expected_file_path]['sections'] ) ){
+                        if (isset( $json[$expected_file_path]['sections'] )){
                             $file_sections[$expected_file_path] = $json[$expected_file_path]['sections'];
                         }
                         $releaseData = $json[$expected_file_path]['release_datetime'];
@@ -112,7 +112,7 @@ class CourseMaterialsView extends AbstractView {
 
                 $file_datas[$expected_file_path] = $isShareToOther;
 
-                if( $releaseData == $now_date_time->format("Y-m-d H:i:sO")){
+                if($releaseData == $now_date_time->format("Y-m-d H:i:sO")){
                     //for uploaded files that have had no manually set date to be set to never and maintained as never
                     //also permission set to yes
                     $releaseData = substr_replace($releaseData, "9999", 0, 4);

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -321,7 +321,7 @@ class ForumThreadView extends AbstractView {
             $generatePostContent = $this->generatePostList($currentThread, $posts, $unviewed_posts, $currentCourse, true, $threadExists, $display_option, $categories, $cookieSelectedCategories, $cookieSelectedThreadStatus, $cookieSelectedUnread, $currentCategoriesIds, $currentThreadFavorite, false);
         }
 
-        if ( !empty($activeThread['id']) ) {
+        if (!empty($activeThread['id'])) {
             $this->core->getQueries()->visitThread($user, $activeThread['id']);
         }
 
@@ -476,7 +476,7 @@ class ForumThreadView extends AbstractView {
 
         $form_action_link = $this->core->buildCourseUrl(['forum', 'posts', 'new']);
 
-        if(($isThreadLocked != 1 || $accessFullGrading ) && $includeReply  ) {
+        if(($isThreadLocked != 1 || $accessFullGrading ) && $includeReply) {
 
             $GLOBALS['post_box_id'] = $post_box_id = isset($GLOBALS['post_box_id']) ? $GLOBALS['post_box_id'] + 1 : 1;
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -89,7 +89,7 @@ class ElectronicGraderView extends AbstractView {
         }
         if ($total === 0 && $no_team_total === 0){
             $graded_percentage = -1;
-        } else if ($total === 0 && $no_team_total > 0){
+        } elseif ($total === 0 && $no_team_total > 0){
             $graded_percentage = 0;
         } else{
             $graded_percentage = number_format(($graded / $total) * 100, 1);
@@ -449,7 +449,7 @@ HTML;
 
             if ($peer) {
                 $section_title = "PEER STUDENT GRADER";
-            } else if ($gradeable->isGradeByRegistration()) {
+            } elseif ($gradeable->isGradeByRegistration()) {
                 $section_title = $row->getSubmitter()->getRegistrationSection();
             } else {
                 $section_title = $row->getSubmitter()->getRotatingSection();
@@ -497,12 +497,12 @@ HTML;
                 if ($graded_component === null) {
                     //not graded
                     $info["graded_groups"][] = "NULL";
-                } else if ($grade_inquiry !== null && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE && $gradeable->isGradeInquiryPerComponentAllowed()) {
+                } elseif ($grade_inquiry !== null && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE && $gradeable->isGradeInquiryPerComponentAllowed()) {
                     $info["graded_groups"][] = "grade-inquiry";
-                } else if(!$graded_component->getVerifier()){
+                } elseif(!$graded_component->getVerifier()){
                     //no verifier exists, show the grader group
                     $info["graded_groups"][] = $graded_component->getGrader()->getGroup();
-                } else if($graded_component->getGrader()->accessFullGrading()){
+                } elseif($graded_component->getGrader()->accessFullGrading()){
                     //verifier exists and original grader is full access, show verifier grader group
                     $info["graded_groups"][] = $graded_component->getVerifier()->getGroup();
                 } else{
@@ -540,7 +540,7 @@ HTML;
 
             if ($peer) {
                 $section_title = "PEER STUDENT GRADER";
-            } else if ($gradeable->isGradeByRegistration()) {
+            } elseif ($gradeable->isGradeByRegistration()) {
                 $section_title = $teamless_user->getRegistrationSection();
             } else {
                 $section_title = $teamless_user->getRotatingSection();
@@ -724,7 +724,7 @@ HTML;
                 "message" => "Overridden grades"
             ]);
         }
-        else if ($graded_gradeable->getAutoGradedGradeable()->getActiveVersion() === 0) {
+        elseif ($graded_gradeable->getAutoGradedGradeable()->getActiveVersion() === 0) {
             if ($graded_gradeable->getAutoGradedGradeable()->hasSubmission()) {
                 $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
                     "color" => "var(--standard-creamsicle-orange)", // mango orange

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -53,7 +53,7 @@ class HomeworkView extends AbstractView {
         // showing submission if user is full grader or student can submit
         if ($this->core->getUser()->accessFullGrading()) {
             $return .= $this->renderSubmitBox($gradeable, $graded_gradeable, $version_instance, $late_days_use);
-        } else if ($gradeable->isStudentSubmit()) {
+        } elseif ($gradeable->isStudentSubmit()) {
             if ($gradeable->canStudentSubmit()) {
                 $return .= $this->renderSubmitBox($gradeable, $graded_gradeable, $version_instance, $late_days_use);
             } else {
@@ -151,7 +151,7 @@ class HomeworkView extends AbstractView {
                     'remaining' => $late_days_remaining
                 ]];
             } // BAD STATUS - AUTO ZERO BECAUSE TOO MANY LATE DAYS USED ON THIS ASSIGNMENT
-            else if ($active_days_charged > $late_days_allowed) {
+            elseif ($active_days_charged > $late_days_allowed) {
                 $error = true;
                 $messages[] = ['type' => 'too_many_used', 'info' => [
                     'late' => $active_days_late,
@@ -197,7 +197,7 @@ class HomeworkView extends AbstractView {
                     $error = true;
                     $messages[] = ['type' => 'would_get_zero'];
                 } // SUBMISSION NOW WOULD BE BAD STATUS -- EXCEEDS LIMIT FOR THIS ASSIGNMENT
-                else if ($new_late_charged > $late_days_allowed) {
+                elseif ($new_late_charged > $late_days_allowed) {
                     $messages[] = ['type' => 'would_too_many_used', 'info' => [
                         'allowed' => $late_days_allowed
                     ]];
@@ -492,7 +492,7 @@ class HomeworkView extends AbstractView {
         for ($i = 0; $i < count($files); $i++) {
             if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr'] && !array_key_exists($files[$i]['filename_full'], $bulk_upload_data)){
                 continue;
-            }else if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']){
+            }elseif(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']){
                 $data = $bulk_upload_data[ $files[$i]['filename_full'] ];
             }
 

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -52,7 +52,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
 
         $config->method('getTimezone')->willReturn(new \DateTimeZone("America/New_York"));
 
-        if (isset($config_values['use_mock_time']) && $config_values['use_mock_time'] === true ){
+        if (isset($config_values['use_mock_time']) && $config_values['use_mock_time'] === true){
             $core->method('getDateTimeNow')->willReturn(new \DateTime('2001-01-01', $config->getTimezone()));
         }else{
             $core->method('getDateTimeNow')->willReturnCallback(function () use ($config) {

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -416,10 +416,10 @@ class SubmissionControllerTester extends BaseUnitTest {
                 $iter->next();
                 continue;
             }
-            else if ($iter->isFile()) {
+            elseif ($iter->isFile()) {
                 $this->assertEquals(".submit.timestamp", $iter->getFilename());
             }
-            else if ($iter->isDir()) {
+            elseif ($iter->isDir()) {
                 $this->assertTrue(in_array($iter->getFilename(), array('part1', 'part2')));
                 $files[$iter->getFilename()] = array();
                 $iter2 = $iter->getChildren();
@@ -428,7 +428,7 @@ class SubmissionControllerTester extends BaseUnitTest {
                         $iter2->next();
                         continue;
                     }
-                    else if ($iter2->isFile()) {
+                    elseif ($iter2->isFile()) {
                         $files[$iter->getFilename()][$iter2->getFilename()] = file_get_contents($iter2->getPathname());
                     }
                     else {
@@ -486,10 +486,10 @@ class SubmissionControllerTester extends BaseUnitTest {
                 $iter->next();
                 continue;
             }
-            else if ($iter->isFile()) {
+            elseif ($iter->isFile()) {
                 $filenames[] = $iter->getFilename();
             }
-            else if ($iter->isDir()) {
+            elseif ($iter->isDir()) {
                 $this->assertEquals("testDir", $iter->getFilename());
                 $iter2 = $iter->getChildren();
                 while ($iter2 !== "" && $iter2->getFilename() !== "") {
@@ -497,7 +497,7 @@ class SubmissionControllerTester extends BaseUnitTest {
                         $iter2->next();
                         continue;
                     }
-                    else if ($iter2->isFile()) {
+                    elseif ($iter2->isFile()) {
                         $this->assertEquals("test1.txt", $iter2->getFilename());
                     }
                     else {
@@ -825,7 +825,7 @@ class SubmissionControllerTester extends BaseUnitTest {
                 $iter->next();
                 continue;
             }
-            else if ($iter->isFile()) {
+            elseif ($iter->isFile()) {
                 $files[] = $iter->getFilename();
             }
             else {
@@ -948,14 +948,14 @@ class SubmissionControllerTester extends BaseUnitTest {
                 $iter->next();
                 continue;
             }
-            else if ($iter->isDir()) {
+            elseif ($iter->isDir()) {
                 $this->assertEquals("folder with spaces", $iter->getFilename());
                 foreach (new \FilesystemIterator($iter->getPathname()) as $iter2) {
                     $this->assertTrue($iter2->isFile());
                     $this->assertEquals("filename with spaces2.txt", $iter2->getFilename());
                 }
             }
-            else if ($iter->isFile()) {
+            elseif ($iter->isFile()) {
                 $files[] = $iter->getFilename();
             }
             else {

--- a/site/tests/app/models/gradeable/LateDayInfoTester.php
+++ b/site/tests/app/models/gradeable/LateDayInfoTester.php
@@ -23,7 +23,7 @@ class LateDayInfoTester extends BaseUnitTest {
         $gradeable->method('getLateDays')->willReturn($late_days);
 
         $auto_graded_gradeable = $this->createMockModel(AutoGradedGradeable::class);
-        if ($submission_date !== '' ) {
+        if ($submission_date !== '') {
             $auto_graded_version = $this->createMockModel(AutoGradedVersion::class);
             $auto_graded_version->method('getSubmissionTime')->willReturn(new \DateTime($submission_date));
             $auto_graded_version->method('getDaysLate')->willReturn(DateUtils::calculateDayDiff($due_date, $submission_date));

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -26,9 +26,6 @@
 
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
 
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
-        <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
         <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket" />
         <exclude name="PSR2.Methods.FunctionCallSignature.Indent" />
         <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
@@ -97,5 +94,9 @@
 
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>../public/index.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed">
+        <type>error</type>
     </rule>
 </ruleset>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes all `PSR2.ControlStructures` style errors which is that spaces should not follow or precede opening/closing parenthesis of the control structure and that `elseif` is used instead of `else if`. The former is not a hard rule in PSR-12 (it is labelled just that it "should" be done, but marking it as required here to ensure consistency.