### PR TITLE
[Refactor:PHP] Fix PSR2.Methods.FunctionCallSignature style errors

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -187,7 +187,7 @@ class MiscController extends AbstractController {
 
         if ($dir == 'submissions') {
             //cannot download scanned images for bulk uploads
-            if (strpos(basename($path), "upload_page_" ) !== false &&
+            if (strpos(basename($path), "upload_page_") !== false &&
                 FileUtils::getContentType($path) !== "application/pdf") {
 
                 $this->core->getOutput()->showError("You do not have access to this file");
@@ -356,8 +356,11 @@ class MiscController extends AbstractController {
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
         foreach ($paths as $path) {
-            $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $path,
-                $gradeable->getId());
+            $gradeable_path = FileUtils::joinPaths(
+                $this->core->getConfig()->getCoursePath(),
+                $path,
+                $gradeable->getId()
+            );
             if($type === "all") {
                 $zip->addEmptyDir($path);
                 if (file_exists($gradeable_path)) {
@@ -399,8 +402,10 @@ class MiscController extends AbstractController {
                 }
                 else {
                     $section_key = "rotating_section";
-                    $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable->getId(),
-                        $this->core->getUser()->getId());
+                    $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser(
+                        $gradeable->getId(),
+                        $this->core->getUser()->getId()
+                    );
                     $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
                 }
                 $students_array = array();

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -974,10 +974,13 @@ class AdminGradeableController extends AbstractController {
             // Try to set the property
             try {
                 //convert the property name to a setter name
-                $setter_name = 'set' . implode('',
-                        array_map(function ($val) {
+                $setter_name = 'set' . implode(
+                    '',
+                    array_map(function ($val) {
                             return ucfirst($val);
-                        }, explode('_', $prop)));
+                    },
+                    explode('_', $prop))
+                );
                 $gradeable->$setter_name($post_val);
             } catch (\Exception $e) {
                 // If something goes wrong, record it so we can tell the user

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -977,7 +977,7 @@ class AdminGradeableController extends AbstractController {
                 $setter_name = 'set' . implode(
                     '',
                     array_map(function ($val) {
-                            return ucfirst($val);
+                        return ucfirst($val);
                     },
                     explode('_', $prop))
                 );

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -220,8 +220,10 @@ class LateController extends AbstractController {
                         $team_members[$team_member_ids[$i]] = $this->core->getQueries()->getUserById($team_member_ids[$i])->getDisplayedFirstName() . " " .
                             $this->core->getQueries()->getUserById($team_member_ids[$i])->getDisplayedLastName();
                     }
-                    $popup_html = $this->core->getOutput()->renderTwigTemplate("admin/users/MoreExtensions.twig",
-                        ['g_id' => $_POST['g_id'], 'member_list' => $team_members]);
+                    $popup_html = $this->core->getOutput()->renderTwigTemplate(
+                        "admin/users/MoreExtensions.twig",
+                        ['g_id' => $_POST['g_id'], 'member_list' => $team_members]
+                    );
                     return Response::JsonOnlyResponse(
                         JsonResponse::getSuccessResponse(['is_team' => true, 'popup' => $popup_html])
                     );

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -690,7 +690,7 @@ class PlagiarismController extends AbstractController {
             foreach($content as $match) {
                 if($match["type"] == "match") {
                     foreach ($match["others"] as $match_info) {
-                        if(!in_array(array($match_info["username"],$match_info["version"]), $return )) {
+                        if(!in_array(array($match_info["username"],$match_info["version"]), $return)) {
                             array_push($return, array($match_info["username"],$match_info["version"]));
                         }
                     }

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -379,8 +379,15 @@ class UsersController extends AbstractController {
 
         $null_counts = $this->core->getQueries()->getCountNullUsersRotatingSections();
         $max_section = $this->core->getQueries()->getMaxRotatingSection();
-        $this->core->getOutput()->renderOutput(array('admin', 'Users'), 'sectionsForm', $students, $reg_sections,
-            $non_null_counts, $null_counts, $max_section);
+        $this->core->getOutput()->renderOutput(
+            array('admin', 'Users'),
+            'sectionsForm',
+            $students,
+            $reg_sections,
+            $non_null_counts,
+            $null_counts,
+            $max_section
+        );
     }
 
     /**
@@ -890,7 +897,7 @@ class UsersController extends AbstractController {
                     // Preferred first and last name must be alpha characters, white-space, or certain punctuation.
                     // Automatically validate if not set (this field is optional).
                 case !isset($vals[$pref_firstname_idx]) || User::validateUserData('user_preferred_firstname', $vals[$pref_firstname_idx]):
-                case !isset($vals[$pref_lastname_idx]) || User::validateUserData('user_preferred_lastname', $vals[$pref_lastname_idx] ):
+                case !isset($vals[$pref_lastname_idx]) || User::validateUserData('user_preferred_lastname', $vals[$pref_lastname_idx]):
                     // Validation failed somewhere.  Record which row failed.
                     // $row_num is zero based.  ($row_num+1) will better match spreadsheet labeling.
                     $bad_rows[] = ($row_num + 1);

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -222,7 +222,7 @@ class CourseMaterialsController extends AbstractController {
 
         $new_data_time = htmlspecialchars($newdatatime);
         //Check if the datetime is correct
-        if(\DateTime::createFromFormat ( 'Y-m-d H:i:s', $new_data_time ) === false){
+        if(\DateTime::createFromFormat('Y-m-d H:i:s', $new_data_time) === false){
             return $this->core->getOutput()->renderResultMessage("ERROR: Improperly formatted date", false);
         }
 
@@ -309,7 +309,7 @@ class CourseMaterialsController extends AbstractController {
         }
 
         //Check if the datetime is correct
-        if(\DateTime::createFromFormat ( 'Y-m-d H:i:s', $release_time ) === false){
+        if(\DateTime::createFromFormat('Y-m-d H:i:s', $release_time) === false){
             return $this->core->getOutput()->renderResultMessage("ERROR: Improperly formatted date", false);
         }
 
@@ -419,7 +419,7 @@ class CourseMaterialsController extends AbstractController {
                         $zip->extractTo($upload_path, $entries);
 
                         foreach ($zfiles as $zfile) {
-                            $path = FileUtils::joinPaths( $upload_path, $zfile );
+                            $path = FileUtils::joinPaths($upload_path, $zfile);
                             if(!(is_null($sections))){
                                 $sections_exploded = @explode(",", $sections);
                                 if($sections_exploded == null){

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -733,15 +733,17 @@ class ForumController2 extends AbstractController {
             $categories_ids[] = (int)$category_id;
         }
 
-        $result = $this->core->getForum()->publish( [   'title'              => $title,
-                                                        'content'            => $thread_post_content,
-                                                        'anon'               => $anon,
-                                                        'status'             => $thread_status,
-                                                        'announcement'       => $announcement,
-                                                        'email_announcement' => $email_announcement,
-                                                        'categories'         => $categories_ids,
-                                                        'parent_id'          => -1,
-                                                        'thread_id'          => -1 ], true );
+        $result = $this->core->getForum()->publish([
+            'title'              => $title,
+            'content'            => $thread_post_content,
+            'anon'               => $anon,
+            'status'             => $thread_status,
+            'announcement'       => $announcement,
+            'email_announcement' => $email_announcement,
+            'categories'         => $categories_ids,
+            'parent_id'          => -1,
+            'thread_id'          => -1
+        ], true);
 
         if($result) {
             //We published with success!
@@ -759,10 +761,12 @@ class ForumController2 extends AbstractController {
         $anon = !empty($_POST['Anon']) ? true : false;
 
 
-        return $this->core->getForum()->publish( [ 'content'   => $post_content,
-                                                   'anon'      => $anon,
-                                                   'thread_id' => $thread_id,
-                                                   'parent_id' => $parent_id ], false );
+        return $this->core->getForum()->publish([
+            'content'   => $post_content,
+            'anon'      => $anon,
+            'thread_id' => $thread_id,
+            'parent_id' => $parent_id
+        ], false);
     }
 
 

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -398,10 +398,25 @@ class ElectronicGraderController extends AbstractController {
             $total_students_submitted = 0;
         }
 
-        $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'statusPage', $gradeable, $sections,
-            $component_averages, $autograded_average, $overall_scores, $overall_average, $total_submissions, $individual_viewed_grade ?? 0,
-            $total_students_submitted, $registered_but_not_rotating, $rotating_but_not_registered, $viewed_grade,
-            $section_key, $regrade_requests, $show_warnings);
+        $this->core->getOutput()->renderOutput(
+            array('grading', 'ElectronicGrader'),
+            'statusPage',
+            $gradeable,
+            $sections,
+            $component_averages,
+            $autograded_average,
+            $overall_scores,
+            $overall_average,
+            $total_submissions,
+            $individual_viewed_grade ?? 0,
+            $total_students_submitted,
+            $registered_but_not_rotating,
+            $rotating_but_not_registered,
+            $viewed_grade,
+            $section_key,
+            $regrade_requests,
+            $show_warnings
+        );
     }
 
     /**
@@ -1298,8 +1313,16 @@ class ElectronicGraderController extends AbstractController {
 
         try {
             // Once we've parsed the inputs and checked permissions, perform the operation
-            $this->saveGradedComponent($ta_graded_gradeable, $graded_component, $grader, $custom_points,
-                $custom_message, $marks, $component_version, !$silent_edit);
+            $this->saveGradedComponent(
+                $ta_graded_gradeable,
+                $graded_component,
+                $grader,
+                $custom_points,
+                $custom_message,
+                $marks,
+                $component_version,
+                !$silent_edit
+            );
             $this->core->getOutput()->renderJsonSuccess();
         } catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
@@ -1589,8 +1612,18 @@ class ElectronicGraderController extends AbstractController {
             $page = $gradeable->isPdfUpload() ? ($gradeable->isStudentPdfUpload() ? Component::PDF_PAGE_STUDENT : 1) : Component::PDF_PAGE_NONE;
 
             // Once we've parsed the inputs and checked permissions, perform the operation
-            $component = $gradeable->addComponent('Problem ' . strval(count($gradeable->getComponents()) + 1), '', '', 0, 0,
-                0, 0, false, false, $page);
+            $component = $gradeable->addComponent(
+                'Problem ' . strval(count($gradeable->getComponents()) + 1),
+                '',
+                '',
+                0,
+                0,
+                0,
+                0,
+                false,
+                false,
+                $page
+            );
             $component->addMark('No Credit', 0.0, false);
             $this->core->getQueries()->updateGradeable($gradeable);
             $this->core->getOutput()->renderJsonSuccess(['component_id' => $component->getId()]);
@@ -1814,8 +1847,16 @@ class ElectronicGraderController extends AbstractController {
             $can_view_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable]);
             $popup_css = "diff-viewer.css";
             $this->core->getOutput()->renderJsonSuccess(
-                $this->core->getOutput()->renderTemplate('AutoGrading', 'loadAutoChecks',
-                    $graded_gradeable, $version_instance, $testcase, $popup_css, $who_id, $can_view_hidden)
+                $this->core->getOutput()->renderTemplate(
+                    'AutoGrading',
+                    'loadAutoChecks',
+                    $graded_gradeable,
+                    $version_instance,
+                    $testcase,
+                    $popup_css,
+                    $who_id,
+                    $can_view_hidden
+                )
             );
         } catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -99,8 +99,11 @@ class SubmissionController extends AbstractController {
             $url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]);
             $this->core->getOutput()->addBreadcrumb($gradeable->getTitle(), $url);
             if (!$gradeable->hasAutogradingConfig()) {
-                $this->core->getOutput()->renderOutput('Error',
-                                                       'unbuiltGradeable', $gradeable->getTitle());
+                $this->core->getOutput()->renderOutput(
+                    'Error',
+                    'unbuiltGradeable',
+                    $gradeable->getTitle()
+                );
                 $error = true;
             }
             else {
@@ -127,8 +130,15 @@ class SubmissionController extends AbstractController {
                 $this->core->getOutput()->addInternalJs('forum.js');
                 $this->core->getOutput()->addInternalCss('grade-inquiry.css');
                 $this->core->getOutput()->addInternalJs('grade-inquiry.js');
-                $this->core->getOutput()->renderOutput(array('submission', 'Homework'),
-                                                       'showGradeable', $gradeable, $graded_gradeable, $version, $can_inquiry ?? false, $show_hidden);
+                $this->core->getOutput()->renderOutput(
+                    array('submission', 'Homework'),
+                    'showGradeable',
+                    $gradeable,
+                    $graded_gradeable,
+                    $version,
+                    $can_inquiry ?? false,
+                    $show_hidden
+                );
             }
         }
         return array('id' => $gradeable_id, 'error' => $error);
@@ -436,8 +446,11 @@ class SubmissionController extends AbstractController {
 
         $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $user_id, null);
 
-        $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
-            $gradeable->getId());
+        $gradeable_path = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "submissions",
+            $gradeable->getId()
+        );
 
         /*
          * Perform checks on the following folders (and whether or not they exist):
@@ -519,7 +532,7 @@ class SubmissionController extends AbstractController {
         //images are order <original>_<split-number>_<page-number>, so grab everuthing with the same suffixes
         preg_match("/\d*$/", pathinfo($path, PATHINFO_FILENAME), $matches);
         $split_number = count($matches) >= 1 ? reset($matches) : "-1";
-        $image_files = glob(FileUtils::joinPaths(  dirname($uploaded_file), "*.*"));
+        $image_files = glob(FileUtils::joinPaths(dirname($uploaded_file), "*.*"));
 
         $regex = "/.*_{$split_number}_\d*\.\w*$/";
         $image_files = preg_grep($regex, $image_files);
@@ -569,7 +582,7 @@ class SubmissionController extends AbstractController {
             $i = 1;
             foreach ($image_files as $image) {
                 // copy over the uploaded image
-                if (!@copy($image, FileUtils::joinPaths($version_path, "upload_page_" . $i . "." . $image_extension ))) {
+                if (!@copy($image, FileUtils::joinPaths($version_path, "upload_page_" . $i . "." . $image_extension))) {
                     return $this->uploadResult("Failed to copy uploaded image {$image} to current submission.", false);
                 }
                 if (!@unlink($image)) {
@@ -582,8 +595,13 @@ class SubmissionController extends AbstractController {
 
         // if split_pdf/gradeable_id/timestamp directory is now empty, delete that directory
         $timestamp = substr($path, 0, strpos($path, DIRECTORY_SEPARATOR));
-        $timestamp_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
-            $gradeable->getId(), $timestamp);
+        $timestamp_path = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "uploads",
+            "split_pdf",
+            $gradeable->getId(),
+            $timestamp
+        );
         $files = FileUtils::getAllFiles($timestamp_path);
         if (count($files) == 0) {
             if (!FileUtils::recursiveRmdir($timestamp_path)) {
@@ -634,8 +652,11 @@ class SubmissionController extends AbstractController {
 
         $queue_file = array($this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse(),
             $gradeable->getId(), $who_id, $new_version);
-        $queue_file = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "to_be_graded_queue",
-            implode("__", $queue_file));
+        $queue_file = FileUtils::joinPaths(
+            $this->core->getConfig()->getSubmittyPath(),
+            "to_be_graded_queue",
+            implode("__", $queue_file)
+        );
 
         $vcs_checkout = isset($_REQUEST['vcs_checkout']) ? $_REQUEST['vcs_checkout'] === "true" : false;
 
@@ -690,8 +711,13 @@ class SubmissionController extends AbstractController {
 
         $path = rawurldecode(htmlspecialchars_decode($_POST['path']));
 
-        $uploaded_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
-            $gradeable->getId(), $path);
+        $uploaded_file = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "uploads",
+            "split_pdf",
+            $gradeable->getId(),
+            $path
+        );
 
         $uploaded_file = rawurldecode(htmlspecialchars_decode($uploaded_file));
 
@@ -705,8 +731,13 @@ class SubmissionController extends AbstractController {
 
         // delete timestamp folder if empty
         $timestamp = substr($path, 0, strpos($path, DIRECTORY_SEPARATOR));
-        $timestamp_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "split_pdf",
-            $gradeable->getId(), $timestamp);
+        $timestamp_path = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "uploads",
+            "split_pdf",
+            $gradeable->getId(),
+            $timestamp
+        );
         $files = FileUtils::getAllFiles($timestamp_path);
         if(count($files) === 0){
             if (!FileUtils::recursiveRmdir($timestamp_path)) {
@@ -778,8 +809,11 @@ class SubmissionController extends AbstractController {
         }
 
         $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $user_id, null);
-        $gradeable_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
-            $gradeable->getId());
+        $gradeable_path = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "submissions",
+            $gradeable->getId()
+        );
 
         /*
          * Perform checks on the following folders (and whether or not they exist):
@@ -1187,8 +1221,11 @@ class SubmissionController extends AbstractController {
         $queue_file_helper = array($this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse(),
                                    $gradeable->getId(), $who_id, $new_version);
         $queue_file_helper = implode("__", $queue_file_helper);
-        $queue_file = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "to_be_graded_queue",
-                                           $queue_file_helper);
+        $queue_file = FileUtils::joinPaths(
+            $this->core->getConfig()->getSubmittyPath(),
+            "to_be_graded_queue",
+            $queue_file_helper
+        );
         // SPECIAL NAME FOR QUEUE FILE OF VCS GRADEABLES
         $vcs_queue_file = "";
         if ($vcs_checkout === true) {
@@ -1354,8 +1391,13 @@ class SubmissionController extends AbstractController {
         $original_user_id = $this->core->getUser()->getId();
         $submitter_id = $graded_gradeable->getSubmitter()->getId();
 
-        $settings_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions",
-            $gradeable->getId(), $submitter_id, "user_assignment_settings.json");
+        $settings_file = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "submissions",
+            $gradeable->getId(),
+            $submitter_id,
+            "user_assignment_settings.json"
+        );
         $json = FileUtils::readJsonFile($settings_file);
         if ($json === false) {
             $msg = "Failed to open settings file.";
@@ -1432,14 +1474,24 @@ class SubmissionController extends AbstractController {
             }
         }
 
-        $filepath = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "results", $gradeable_id,
-            $submitter_id, $gradeable_version, "results.json");
+        $filepath = FileUtils::joinPaths(
+            $this->core->getConfig()->getCoursePath(),
+            "results",
+            $gradeable_id,
+            $submitter_id,
+            $gradeable_version,
+            "results.json"
+        );
 
         $results_json_exists = file_exists($filepath);
 
         // if the results json exists, check the database to make sure that the autograding results are there.
         $has_results = $results_json_exists && $this->core->getQueries()->getGradeableVersionHasAutogradingResults(
-            $gradeable_id, $gradeable_version, $user_id, $team_id);
+            $gradeable_id,
+            $gradeable_version,
+            $user_id,
+            $team_id
+        );
 
         if ($has_results) {
             $refresh_string = "REFRESH_ME";

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -126,7 +126,7 @@ class Core {
         if (!empty($semester) && !empty($course)) {
             $course_path = FileUtils::joinPaths($this->config->getSubmittyPath(), "courses", $semester, $course);
             $course_json_path = FileUtils::joinPaths($course_path, "config", "config.json");
-            if (file_exists($course_json_path) && is_readable ($course_json_path)) {
+            if (file_exists($course_json_path) && is_readable($course_json_path)) {
                 $this->config->loadCourseJson($semester, $course, $course_json_path);
             }
             else{
@@ -211,8 +211,11 @@ class Core {
             throw new \Exception("Need to load the config before we can initialize the grading queue");
         }
 
-        $this->grading_queue = new GradingQueue($this->config->getSemester(),
-            $this->config->getCourse(), $this->config->getSubmittyPath());
+        $this->grading_queue = new GradingQueue(
+            $this->config->getSemester(),
+            $this->config->getCourse(),
+            $this->config->getSubmittyPath()
+        );
     }
 
     /**

--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -72,12 +72,14 @@ class ExceptionHandler {
         
         $trace_string = array();
         foreach ($exception->getTrace() as $elem => $frame) {
-            $trace_string[] = sprintf( "#%s %s(%s): %s(%s)",
-                             $elem,
-                             isset($frame['file']) ? $frame['file'] : 'unknown file',
-                             isset($frame['line']) ? $frame['line'] : 'unknown line',
-                             (isset($frame['class']))  ? $frame['class'] . $frame['type'] . $frame['function'] : $frame['function'],
-                             static::parseArgs(is_a($exception, '\app\exceptions\AuthenticationException') ? array() : $frame['args']));
+            $trace_string[] = sprintf(
+                "#%s %s(%s): %s(%s)",
+                $elem,
+                isset($frame['file']) ? $frame['file'] : 'unknown file',
+                isset($frame['line']) ? $frame['line'] : 'unknown line',
+                (isset($frame['class']))  ? $frame['class'] . $frame['type'] . $frame['function'] : $frame['function'],
+                static::parseArgs(is_a($exception, '\app\exceptions\AuthenticationException') ? array() : $frame['args'])
+            );
         }
         $trace_string = implode("\n", $trace_string);
 

--- a/site/app/libraries/SessionManager.php
+++ b/site/app/libraries/SessionManager.php
@@ -57,8 +57,11 @@ class SessionManager {
             $this->session['session_id'] = Utils::generateRandomString();
             $this->session['user_id'] = $user_id;
             $this->session['csrf_token'] = Utils::generateRandomString();
-            $this->core->getQueries()->newSession($this->session['session_id'], $this->session['user_id'],
-                                                  $this->session['csrf_token']);
+            $this->core->getQueries()->newSession(
+                $this->session['session_id'],
+                $this->session['user_id'],
+                $this->session['csrf_token']
+            );
         }
         return $this->session['session_id'];
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2047,8 +2047,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      */
     public function getUsersSeekingTeamByGradeableId($g_id) {
         $this->course_db->query(
-            "
-          SELECT user_id
+            "SELECT user_id
           FROM seeking_team
           WHERE g_id=?
           ORDER BY user_id",

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1412,7 +1412,8 @@ ORDER BY rotating_section");
 
     public function getGradersByUserType() {
         $this->course_db->query(
-            "SELECT user_firstname, user_lastname, user_id, user_group FROM users WHERE user_group < 4 ORDER BY user_group, user_id ASC");
+            "SELECT user_firstname, user_lastname, user_id, user_group FROM users WHERE user_group < 4 ORDER BY user_group, user_id ASC"
+        );
         $users = [];
 
         foreach ($this->course_db->rows() as $row) {
@@ -1601,12 +1602,16 @@ autograding_hidden_non_extra_credit, autograding_hidden_extra_credit, submission
 
 VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $timestamp));
         if ($user_id === null) {
-            $this->course_db->query("SELECT * FROM electronic_gradeable_version WHERE g_id=? AND team_id=?",
-                array($g_id, $team_id));
+            $this->course_db->query(
+                "SELECT * FROM electronic_gradeable_version WHERE g_id=? AND team_id=?",
+                array($g_id, $team_id)
+            );
         }
         else {
-            $this->course_db->query("SELECT * FROM electronic_gradeable_version WHERE g_id=? AND user_id=?",
-                array($g_id, $user_id));
+            $this->course_db->query(
+                "SELECT * FROM electronic_gradeable_version WHERE g_id=? AND user_id=?",
+                array($g_id, $user_id)
+            );
         }
         $row = $this->course_db->row();
         if (!empty($row)) {
@@ -1632,12 +1637,16 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      */
     public function updateActiveVersion($g_id, $user_id, $team_id, $version) {
         if ($user_id === null) {
-            $this->course_db->query("UPDATE electronic_gradeable_version SET active_version=? WHERE g_id=? AND team_id=?",
-                array($version, $g_id, $team_id));
+            $this->course_db->query(
+                "UPDATE electronic_gradeable_version SET active_version=? WHERE g_id=? AND team_id=?",
+                array($version, $g_id, $team_id)
+            );
         }
         else {
-            $this->course_db->query("UPDATE electronic_gradeable_version SET active_version=? WHERE g_id=? AND user_id=?",
-                array($version, $g_id, $user_id));
+            $this->course_db->query(
+                "UPDATE electronic_gradeable_version SET active_version=? WHERE g_id=? AND user_id=?",
+                array($version, $g_id, $user_id)
+            );
         }
     }
 
@@ -1650,14 +1659,12 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
                 SELECT * FROM sections_registration
                 ORDER BY SUBSTRING(sections_registration_id, '^[^0-9]*'),
                 COALESCE(SUBSTRING(sections_registration_id, '[0-9]+')::INT, -1),
-                SUBSTRING(sections_registration_id, '[^0-9]*$')"
-            );
+                SUBSTRING(sections_registration_id, '[^0-9]*$')");
         }
         else {
             $this->course_db->query("
                 SELECT * FROM sections_rotating
-                ORDER BY sections_rotating_id"
-            );
+                ORDER BY sections_rotating_id");
         }
 
         $sections = $this->course_db->rows();
@@ -1740,8 +1747,10 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @param $user_id
      */
     public function updateTeamViewedTime($team_id, $user_id) {
-        $this->course_db->query("UPDATE teams SET last_viewed_time = NOW() WHERE team_id=? and user_id=?",
-                array($team_id,$user_id));
+        $this->course_db->query(
+            "UPDATE teams SET last_viewed_time = NOW() WHERE team_id=? and user_id=?",
+            array($team_id,$user_id)
+        );
     }
 
     /**
@@ -1750,8 +1759,10 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @param $team_id
      */
     public function clearTeamViewedTime($team_id) {
-        $this->course_db->query("UPDATE teams SET last_viewed_time = NULL WHERE team_id=?",
-            array($team_id));
+        $this->course_db->query(
+            "UPDATE teams SET last_viewed_time = NULL WHERE team_id=?",
+            array($team_id)
+        );
     }
 
     /**
@@ -1801,9 +1812,11 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @return string
      */
     public function newSession($session_id, $user_id, $csrf_token) {
-        $this->submitty_db->query("INSERT INTO sessions (session_id, user_id, csrf_token, session_expires)
+        $this->submitty_db->query(
+            "INSERT INTO sessions (session_id, user_id, csrf_token, session_expires)
                                    VALUES(?,?,?,current_timestamp + interval '336 hours')",
-            array($session_id, $user_id, $csrf_token));
+            array($session_id, $user_id, $csrf_token)
+        );
 
     }
 
@@ -1993,7 +2006,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
     public function getTeamsWithMembersFromGradeableID($g_id) {
         $team_map = $this->core->getQueries()->getTeamIdsAllGradeables();
 
-        if (!array_key_exists( $g_id, $team_map)) {
+        if (!array_key_exists($g_id, $team_map)) {
             return array();
         }
 
@@ -2033,12 +2046,14 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
      * @return array $users_seeking_team
      */
     public function getUsersSeekingTeamByGradeableId($g_id) {
-        $this->course_db->query("
+        $this->course_db->query(
+            "
           SELECT user_id
           FROM seeking_team
           WHERE g_id=?
           ORDER BY user_id",
-            array($g_id));
+            array($g_id)
+        );
 
         $users_seeking_team = array();
         foreach($this->course_db->rows() as $row) {
@@ -3088,7 +3103,7 @@ AND gc_id IN (
         foreach ($params as $id) {
             $result[$id] = array_filter($this->course_db->rows(), function ($v) use ($id) {
                 return $v['regrade_id'] == $id;
-            } );
+            });
         }
         return $result;
     }
@@ -3716,10 +3731,12 @@ AND gc_id IN (
             $graded_component->getGraderId(),
         ], $mark_ids);
         $place_holders = $this->createParamaterList(count($mark_ids));
-        $this->course_db->query("
+        $this->course_db->query(
+            "
             DELETE FROM gradeable_component_mark_data
             WHERE gd_id=? AND gc_id=? AND gcd_grader_id=? AND gcm_id IN {$place_holders}",
-            $param);
+            $param
+        );
     }
 
     /**
@@ -3966,8 +3983,10 @@ AND gc_id IN (
      * @param int $submitter_id User or Team id
      */
     public function deleteTaGradedGradeableByIds($gradeable_id, $submitter_id) {
-        $this->course_db->query('DELETE FROM gradeable_data WHERE g_id=? AND (gd_user_id=? OR gd_team_id=?)',
-            [$gradeable_id, $submitter_id, $submitter_id]);
+        $this->course_db->query(
+            'DELETE FROM gradeable_data WHERE g_id=? AND (gd_user_id=? OR gd_team_id=?)',
+            [$gradeable_id, $submitter_id, $submitter_id]
+        );
     }
 
     /**
@@ -3977,8 +3996,10 @@ AND gc_id IN (
      * @return bool
      */
     public function getHasSubmission(Gradeable $gradeable, Submitter $submitter) {
-        $this->course_db->query('SELECT EXISTS (SELECT g_id FROM electronic_gradeable_data WHERE g_id=? AND (user_id=? OR team_id=?))',
-            [$gradeable->getId(), $submitter->getId(), $submitter->getId()]);
+        $this->course_db->query(
+            'SELECT EXISTS (SELECT g_id FROM electronic_gradeable_data WHERE g_id=? AND (user_id=? OR team_id=?))',
+            [$gradeable->getId(), $submitter->getId(), $submitter->getId()]
+        );
         return $this->course_db->row()['exists'] ?? false;
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3732,8 +3732,7 @@ AND gc_id IN (
         ], $mark_ids);
         $place_holders = $this->createParamaterList(count($mark_ids));
         $this->course_db->query(
-            "
-            DELETE FROM gradeable_component_mark_data
+            "DELETE FROM gradeable_component_mark_data
             WHERE gd_id=? AND gc_id=? AND gcd_grader_id=? AND gcm_id IN {$place_holders}",
             $param
         );

--- a/site/app/libraries/database/ForumQueries.php
+++ b/site/app/libraries/database/ForumQueries.php
@@ -14,13 +14,13 @@ class ForumQueries {
         $parent_id = $p->getParentId();
 
         if(!$isFirst && $parent_id == 0){
-            $this->course_db->query("SELECT MIN(id) as id FROM posts where thread_id = ?", [ $p->getThreadId() ] );
+            $this->course_db->query("SELECT MIN(id) as id FROM posts where thread_id = ?", [ $p->getThreadId() ]);
             $parent_id = $this->course_db->rows()[0]["id"];
         }
 
         try {
             $this->course_db->query("INSERT INTO posts (thread_id, parent_id, author_user_id, content, timestamp, anonymous, deleted, endorsed_by, type, has_attachment) VALUES (?, ?, ?, ?, current_timestamp, ?, ?, ?, ?, ?)", array($p->getThreadId(), $p->getParentId(), $p->getAuthor(), $p->getContent(), $anonymous, 0, null, $type, $hasAttachment));
-            $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", [ $p->getThreadId(), $p->getUser() ] );
+            $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", [ $p->getThreadId(), $p->getUser() ]);
         } catch (DatabaseException $dbException){
             if($this->course_db->inTransaction()){
                 $this->course_db->rollback();

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -472,8 +472,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
               grading_rotating
             GROUP BY g_id, user_id
             ) AS gr ON gu.user_id=gr.user_id AND gu.g_id=gr.g_id
-            ORDER BY user_group, user_id, g_grade_start_date", $params
-        );
+            ORDER BY user_group, user_id, g_grade_start_date", $params);
         $rows = $this->course_db->rows();
         $modified_rows = [];
         foreach($rows as $row) {
@@ -531,7 +530,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @return \app\models\Team|null
      */
     public function getTeamById($team_id) {
-        $this->course_db->query("
+        $this->course_db->query(
+            "
             SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
             FROM gradeable_teams gt
               JOIN
@@ -541,7 +541,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
               ) AS u ON gt.team_id = u.team_id
             WHERE gt.team_id = ?
             GROUP BY gt.team_id",
-            array($team_id));
+            array($team_id)
+        );
         if (count($this->course_db->rows()) === 0) {
             return null;
         }
@@ -557,7 +558,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @return \app\models\Team|null
      */
     public function getTeamByGradeableAndUser($g_id, $user_id) {
-        $this->course_db->query("
+        $this->course_db->query(
+            "
             SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
             FROM gradeable_teams gt
               JOIN
@@ -570,7 +572,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
               FROM teams
               WHERE user_id=? AND state=1)
             GROUP BY gt.team_id",
-            array($g_id, $user_id));
+            array($g_id, $user_id)
+        );
         if (count($this->course_db->rows()) === 0) {
             return null;
         }
@@ -585,7 +588,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @return \app\models\Team[]
      */
     public function getTeamsByGradeableId($g_id) {
-        $this->course_db->query("
+        $this->course_db->query(
+            "
             SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
             FROM gradeable_teams gt
               JOIN
@@ -596,7 +600,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
             WHERE g_id=?
             GROUP BY gt.team_id
             ORDER BY team_id",
-            array($g_id));
+            array($g_id)
+        );
 
         $teams = array();
         foreach($this->course_db->rows() as $row) {
@@ -829,7 +834,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
                 }, $sort_keys),
                 function ($a) {
                     return $a !== '';
-                }));
+                }
+            ));
         }
         return '';
     }
@@ -1297,10 +1303,14 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
                 'autograding_complete'
             ];
             $db_row_split = [];
-            foreach (array_merge($version_array_properties, $comp_array_properties,
+            foreach (array_merge(
+                $version_array_properties,
+                $comp_array_properties,
                 array_map(function ($elem) {
                     return 'grader_' . $elem;
-                }, $user_properties)) as $property) {
+                },
+                $user_properties)
+            ) as $property) {
                 $db_row_split[$property] = json_decode($row['array_' . $property]);
             }
 
@@ -1325,11 +1335,13 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
                         $grader = new User($this->core, $user_array);
 
                         // Create the component
-                        $graded_component = new GradedComponent($this->core,
+                        $graded_component = new GradedComponent(
+                            $this->core,
                             $ta_graded_gradeable,
                             $gradeable->getComponent($db_row_split['comp_id'][$i]),
                             $grader,
-                            $comp_array);
+                            $comp_array
+                        );
                         $graded_component->setMarkIdsFromDb($db_row_split['mark_id'][$i] ?? []);
                         $graded_components_by_id[$graded_component->getComponentId()][] = $graded_component;
                     }
@@ -1583,9 +1595,11 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
             return $gradeable;
         };
 
-        return $this->course_db->queryIterator($query,
+        return $this->course_db->queryIterator(
+            $query,
             $ids,
-            $gradeable_constructor);
+            $gradeable_constructor
+        );
     }
 
     public function getActiveVersions(Gradeable $gradeable, array $submitter_ids) {

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -531,8 +531,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      */
     public function getTeamById($team_id) {
         $this->course_db->query(
-            "
-            SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
+            "SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
             FROM gradeable_teams gt
               JOIN
               (SELECT t.team_id, t.state, u.*
@@ -559,8 +558,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      */
     public function getTeamByGradeableAndUser($g_id, $user_id) {
         $this->course_db->query(
-            "
-            SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
+            "SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
             FROM gradeable_teams gt
               JOIN
               (SELECT t.team_id, t.state, u.*
@@ -589,8 +587,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      */
     public function getTeamsByGradeableId($g_id) {
         $this->course_db->query(
-            "
-            SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
+            "SELECT gt.team_id, gt.registration_section, gt.rotating_section, json_agg(u) AS users
             FROM gradeable_teams gt
               JOIN
                 (SELECT t.team_id, t.state, u.*

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -441,7 +441,12 @@ class Config extends AbstractModel {
         // grab the name of the submitty_admin user (only if 'verified',
         // that is, password successfully used to grab an API token.
         $users_file = FileUtils::joinPaths(
-            '/', 'usr', 'local', 'submitty', 'config', 'submitty_users.json'
+            '/',
+            'usr',
+            'local',
+            'submitty',
+            'config',
+            'submitty_users.json'
         );
         if(!is_file($users_file)) {
             throw new FileNotFoundException('Unable to locate the submity_users.json file');
@@ -465,8 +470,11 @@ class Config extends AbstractModel {
         }
         $course = $this->getCourse();
         $semester = $this->getSemester();
-        return $this->core->getQueries()->checkIsInstructorInCourse
-          ($submitty_admin_user, $course, $semester);
+        return $this->core->getQueries()->checkIsInstructorInCourse(
+            $submitty_admin_user,
+            $course,
+            $semester
+        );
     }
 
 

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -82,7 +82,7 @@ class CourseMaterial extends AbstractModel {
         else
         {
             $current_user_group = $current_user->getGroup();
-            if (!isset( $meta_data->$path_to_file->sections )){
+            if (!isset($meta_data->$path_to_file->sections)){
                 $retVal = true;
                 return $retVal;
             }

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -435,8 +435,12 @@ class GradingOrder extends AbstractModel {
      * @return GradedGradeable[] All graded gradeables for students, in the correct order
      */
     public function getSortedGradedGradeables() {
-        $iter = $this->core->getQueries()->getGradedGradeables([$this->gradeable],
-            $this->all_user_ids, $this->all_team_ids, [$this->getSectionKey(), 'team_id', 'user_id']);
+        $iter = $this->core->getQueries()->getGradedGradeables(
+            [$this->gradeable],
+            $this->all_user_ids,
+            $this->all_team_ids,
+            [$this->getSectionKey(), 'team_id', 'user_id']
+        );
 
         $gg_idx = [];
         $unsorted = [];

--- a/site/app/models/gradeable/AutoGradedTestcase.php
+++ b/site/app/models/gradeable/AutoGradedTestcase.php
@@ -46,9 +46,12 @@ class AutoGradedTestcase extends AbstractModel {
             foreach ($details['autochecks'] as $idx => $autocheck) {
                 $index = "id_{$testcase->getIndex()}_{$idx}";
                 $this->autochecks[$idx] = new GradeableAutocheck(
-                    $this->core, $autocheck,
+                    $this->core,
+                    $autocheck,
                     $this->core->getConfig()->getCoursePath(),
-                    $results_path, $results_public_path, $index
+                    $results_path,
+                    $results_public_path,
+                    $index
                 );
             }
         }

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -236,8 +236,13 @@ class AutoGradedVersion extends AbstractModel {
             if ($result_details != null &&
                 count($result_details['testcases']) > $testcase->getIndex() &&
                 $result_details['testcases'][$testcase->getIndex()] != null) {
-                $graded_testcase = new AutoGradedTestcase
-                ($this->core, $testcase, $results_path, $results_public_path, $result_details['testcases'][$testcase->getIndex()]);
+                $graded_testcase = new AutoGradedTestcase(
+                    $this->core,
+                    $testcase,
+                    $results_path,
+                    $results_public_path,
+                    $result_details['testcases'][$testcase->getIndex()]
+                );
                 $this->graded_testcases[$testcase->getIndex()] = $graded_testcase;
                 if (in_array($testcase, $config->getEarlySubmissionTestCases())) {
                     $this->early_incentive_points += $graded_testcase->getPoints();
@@ -436,7 +441,9 @@ class AutoGradedVersion extends AbstractModel {
      */
     public function getDaysLate() {
         return $this->getGradedGradeable()->getGradeable()->hasDueDate() ? max(0, DateUtils::calculateDayDiff(
-            $this->getGradedGradeable()->getGradeable()->getSubmissionDueDate(), $this->submission_time)) : 0;
+            $this->getGradedGradeable()->getGradeable()->getSubmissionDueDate(),
+            $this->submission_time
+        )) : 0;
     }
 
     /**
@@ -445,7 +452,9 @@ class AutoGradedVersion extends AbstractModel {
      */
     public function getDaysEarly() {
         return $this->getGradedGradeable()->getGradeable()->hasDueDate() ? max(0, -DateUtils::calculateDayDiff(
-            $this->getGradedGradeable()->getGradeable()->getSubmissionDueDate(), $this->submission_time)) : 0;
+            $this->getGradedGradeable()->getGradeable()->getSubmissionDueDate(),
+            $this->submission_time
+        )) : 0;
     }
 
     /**

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -320,10 +320,12 @@ class AutogradingConfig extends AbstractModel {
      * @return bool
      */
     public function anyPoints() {
-        return max($this->total_hidden_non_extra_credit,
-                $this->total_non_hidden_non_extra_credit,
-                $this->total_hidden_extra_credit,
-                $this->total_non_hidden_extra_credit) > 0;
+        return max(
+            $this->total_hidden_non_extra_credit,
+            $this->total_non_hidden_non_extra_credit,
+            $this->total_hidden_extra_credit,
+            $this->total_non_hidden_extra_credit
+        ) > 0;
     }
 
     /**

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -417,8 +417,12 @@ class Gradeable extends AbstractModel {
         $course_path = $this->core->getConfig()->getCoursePath();
 
         try {
-            $details = FileUtils::readJsonFile(FileUtils::joinPaths($course_path, 'config', 'build',
-                "build_{$this->id}.json"));
+            $details = FileUtils::readJsonFile(FileUtils::joinPaths(
+                $course_path,
+                'config',
+                'build',
+                "build_{$this->id}.json"
+            ));
 
             // If the file could not be found, the result will be false, so don't
             //  create the config if the file can't be found
@@ -590,11 +594,17 @@ class Gradeable extends AbstractModel {
         $black_list = $this->getDateValidationSet();
 
         // First coerce in the forward direction, then in the reverse direction
-        return $coerce_dates(array_reverse(self::date_validated_properties), $black_list,
-            $coerce_dates(self::date_validated_properties, $black_list, $dates,
+        return $coerce_dates(
+            array_reverse(self::date_validated_properties),
+            $black_list,
+            $coerce_dates(
+                self::date_validated_properties,
+                $black_list,
+                $dates,
                 function (\DateTime $val, \DateTime $cmp) {
                     return $val < $cmp;
-                }),
+                }
+            ),
             function (\DateTime $val, \DateTime $cmp) {
                 return $val > $cmp;
             }
@@ -1193,7 +1203,8 @@ class Gradeable extends AbstractModel {
                     $this->core->getConfig()->getSemester(),
                     $this->core->getConfig()->getCourse(),
                     'submissions',
-                    $this->getId());
+                    $this->getId()
+                );
                 if (is_dir($submission_path)) {
                     $this->any_submissions = true;
                 }
@@ -1405,7 +1416,8 @@ class Gradeable extends AbstractModel {
         if ($this->split_pdf_files === null) {
             $upload_path = FileUtils::joinPaths(
                 $this->core->getConfig()->getCoursePath(),
-                'uploads', 'split_pdf',
+                'uploads',
+                'split_pdf',
                 $this->id
             );
             $this->split_pdf_files = FileUtils::getAllFiles($upload_path);
@@ -1530,8 +1542,14 @@ class Gradeable extends AbstractModel {
 
             $sections = [];
             foreach ($section_names as $section_name) {
-                $sections[] = new GradingSection($this->core, $this->isGradeByRegistration(), $section_name,
-                    $graders[$section_name] ?? [], $users[$section_name] ?? null, $teams[$section_name] ?? null);
+                $sections[] = new GradingSection(
+                    $this->core,
+                    $this->isGradeByRegistration(),
+                    $section_name,
+                    $graders[$section_name] ?? [],
+                    $users[$section_name] ?? null,
+                    $teams[$section_name] ?? null
+                );
             }
 
             return $sections;

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -355,7 +355,8 @@ class GradedGradeable extends AbstractModel {
             $gradable_dir,
             $student_id,
             $version,
-            $filename);
+            $filename
+        );
 
         // Check if the user has permission to access this submission
         $isAuthorized = $this->core->getAccess()->canI('path.read', ["dir" => "submissions", "path" => $complete_file_path]);

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -55,8 +55,12 @@ class LateDays extends AbstractModel {
 
         // Construct late days info for each gradeable
         foreach ($graded_gradeables as $graded_gradeable) {
-            $info = new LateDayInfo($core, $user, $graded_gradeable,
-                $this->getLateDaysRemainingByContext($graded_gradeable->getGradeable()->getSubmissionDueDate()));
+            $info = new LateDayInfo(
+                $core,
+                $user,
+                $graded_gradeable,
+                $this->getLateDaysRemainingByContext($graded_gradeable->getGradeable()->getSubmissionDueDate())
+            );
             $this->late_day_info[$graded_gradeable->getGradeableId()] = $info;
         }
     }
@@ -202,7 +206,9 @@ class LateDays extends AbstractModel {
                     'timestamp' => $update['since_timestamp'],
                     'update' => $update
                 ];
-            }, $this->late_days_updates));
+            },
+            $this->late_days_updates)
+        );
 
         // Sort by 'timestamp'
         usort($late_day_events, function ($e1, $e2) {

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -237,8 +237,11 @@ class TaGradedGradeable extends AbstractModel {
      * @return float percentage (0 to 1), or NAN if no grading started
      */
     public function getTotalScorePercent($clamp = false) {
-        return Utils::safeCalcPercent($this->getTotalScore(),
-            $this->getGradedGradeable()->getGradeable()->getTaPoints(), $clamp);
+        return Utils::safeCalcPercent(
+            $this->getTotalScore(),
+            $this->getGradedGradeable()->getGradeable()->getTaPoints(),
+            $clamp
+        );
     }
 
     /**
@@ -335,8 +338,10 @@ class TaGradedGradeable extends AbstractModel {
 
         if ($grader === null || !$component->getGradeable()->isPeerGrading()) {
             // If the grader is null or we aren't peer grading, then delete all component grades for this component
-            $this->deleted_graded_components = array_merge($this->deleted_graded_components,
-                $container->getGradedComponents());
+            $this->deleted_graded_components = array_merge(
+                $this->deleted_graded_components,
+                $container->getGradedComponents()
+            );
 
             // Clear the container for this component
             $container->setGradedComponents([]);

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -137,8 +137,14 @@ class NavigationView extends AbstractView {
 
                 // if the user seating details have both a building and a room property
                 if(property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
-                    $seating_config_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'uploads', 'seating',
-                        $gradeable_id, $user_seating_details->building, $user_seating_details->room . '.json');
+                    $seating_config_path = FileUtils::joinPaths(
+                        $this->core->getConfig()->getCoursePath(),
+                        'uploads',
+                        'seating',
+                        $gradeable_id,
+                        $user_seating_details->building,
+                        $user_seating_details->room . '.json'
+                    );
                     // if the report the instructor generated corresponds to a valid room config and a valid room template
                     if (is_file($seating_config_path) && is_file(FileUtils::joinPaths(dirname(dirname(__DIR__)), 'room_templates', $user_seating_details->building, $user_seating_details->room . '.twig'))) {
                         $seating_config = file_get_contents($seating_config_path);

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -40,16 +40,16 @@ class CourseMaterialsView extends AbstractView {
                 $releaseData = $now_date_time->format("Y-m-d H:i:sO");
                 $isShareToOther = '0';
                 if ($json == true){
-                    if (isset( $json[$expected_file_path] ))
+                    if (isset($json[$expected_file_path]))
                     {
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
 
-                        if (isset( $json[$expected_file_path]['sections'] )){
+                        if (isset($json[$expected_file_path]['sections'])){
                             $file_sections[$expected_file_path] = $json[$expected_file_path]['sections'];
                         }
                         $release_date = DateUtils::parseDateTime($json[$expected_file_path]['release_datetime'], $core->getConfig()->getTimezone());
-                        if (isset( $json[$expected_file_path]['hide_from_students'] )){
+                        if (isset($json[$expected_file_path]['hide_from_students'])){
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
 
@@ -63,11 +63,11 @@ class CourseMaterialsView extends AbstractView {
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
                         $release_date = $json['release_time'];
-                        if (isset( $json[$expected_file_path]['hide_from_students'] )){
+                        if (isset($json[$expected_file_path]['hide_from_students'])){
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
                         $json[$expected_file_path]['release_datetime'] = $release_date;
-                        if (isset( $json[$expected_file_path]['sections'] )){
+                        if (isset($json[$expected_file_path]['sections'])){
                             $file_sections[$expected_file_path] = $json[$expected_file_path]['sections'];
                         }
                         $releaseData = $json[$expected_file_path]['release_datetime'];
@@ -159,7 +159,7 @@ class CourseMaterialsView extends AbstractView {
         }
 
         $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
-        $max_size_string = Utils::formatBytes("MB", $max_size ) . " (" . Utils::formatBytes("KB", $max_size) . ")";
+        $max_size_string = Utils::formatBytes("MB", $max_size) . " (" . Utils::formatBytes("KB", $max_size) . ")";
         $reg_sections = $this->core->getQueries()->getRegistrationSections();
         $server_time = DateUtils::getServerTimeJson($this->core);
 

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -56,7 +56,7 @@ class ImagesView extends AbstractView {
         }
 
         $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
-        $max_size_string = Utils::formatBytes("MB", $max_size ) . " (" . Utils::formatBytes("KB", $max_size) . ")";
+        $max_size_string = Utils::formatBytes("MB", $max_size) . " (" . Utils::formatBytes("KB", $max_size) . ")";
 
         $this->core->getOutput()->disableBuffer();
         return $this->core->getOutput()->renderTwigTemplate("grading/Images.twig", [

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -702,8 +702,13 @@ class HomeworkView extends AbstractView {
         $been_ta_graded = false;
         if ($graded_gradeable->isTaGradingComplete()) {
             $been_ta_graded = true;
-            $rendered_ta_results = $this->core->getOutput()->renderTemplate('AutoGrading', 'showTAResults',
-                $graded_gradeable->getTaGradedGradeable(), $regrade_available, $graded_gradeable->getAutoGradedGradeable()->getActiveVersionInstance()->getFiles());
+            $rendered_ta_results = $this->core->getOutput()->renderTemplate(
+                'AutoGrading',
+                'showTAResults',
+                $graded_gradeable->getTaGradedGradeable(),
+                $regrade_available,
+                $graded_gradeable->getAutoGradedGradeable()->getActiveVersionInstance()->getFiles()
+            );
         }
 
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/TAResultsBox.twig', [

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
  * to set it from inside of php to make sure the group read & execute
  * permissions aren't lost for newly created files & directories.
 */
-umask (0027);
+umask(0027);
 
 session_start();
 /*

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -59,7 +59,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
                 for($j = 0; $j < $num_files; $j++){
                     $fname = "test" . $j . ".txt";
                     $tmpfile = fopen($this->config['course_path'] . $lev . "/" . $fname, "w");
-                    $zip->addFile( $this->config['course_path'] . $lev . "/" . $fname  );
+                    $zip->addFile($this->config['course_path'] . $lev . "/" . $fname);
                     $files[] = $this->config['course_path'] . $lev . "/" . $fname;
                 }
                 $lev .= "/lev" . $i . "";
@@ -98,7 +98,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
         $json = FileUtils::readJsonFile($this->json_path);
         //we need to check that the file exists in the correct folder and also the JSON file
-        $filename_full = FileUtils::joinPaths( $this->upload_path, $name );
+        $filename_full = FileUtils::joinPaths($this->upload_path, $name);
         $expected_json = [
             $filename_full => [
                 "checked" => '1',
@@ -151,7 +151,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
             'hide_from_students' => null
         ];
 
-        $this->assertEquals($expected_json1, $json[$keys[1]] );
+        $this->assertEquals($expected_json1, $json[$keys[1]]);
         $expected_files1 = [
             'name' => 'test0.txt',
             'path' => $this->upload_path . $this->config['course_path'] . '/lev0/test0.txt',
@@ -197,9 +197,9 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
         $new_date = new \DateTime('2005-01-01');
         $new_date = $new_date->format('Y-m-d H:i:s');
 
-        $ret = $controller->modifyCourseMaterialsFileTimeStamp($_POST['fn'][0], $new_date );
+        $ret = $controller->modifyCourseMaterialsFileTimeStamp($_POST['fn'][0], $new_date);
 
-        $this->assertEquals( ['status' => 'success', 'data' => 'Time successfully set.'], $ret);
+        $this->assertEquals(['status' => 'success', 'data' => 'Time successfully set.'], $ret);
         $json = FileUtils::readJsonFile($this->json_path);
 
         //check the date has been updated to the new time
@@ -224,7 +224,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
         $ret = $controller->ajaxUploadCourseMaterialsFiles();
 
         $_POST['fn'][] = FileUtils::joinPaths($this->upload_path, $name);
-        $ret = $controller->modifyCourseMaterialsFileTimeStamp($_POST['fn'], $new_date );
+        $ret = $controller->modifyCourseMaterialsFileTimeStamp($_POST['fn'], $new_date);
 
         $json = FileUtils::readJsonFile($this->json_path);
         $this->assertEquals(2, count($json));   //2 files
@@ -264,7 +264,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
         //check that the file no longer exists in the path and json file
         $json = FileUtils::readJsonFile($this->json_path);
-        $this->assertEquals([], $json );
+        $this->assertEquals([], $json);
 
         $files = FileUtils::getAllFiles($this->upload_path);
         $this->assertEquals(0, count($files));
@@ -317,7 +317,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
         $ret = $controller->ajaxUploadCourseMaterialsFiles();
         $json = FileUtils::readJsonFile($this->json_path);
 
-        $filename_full = FileUtils::joinPaths( $this->upload_path, "foo/foo2", $name );
+        $filename_full = FileUtils::joinPaths($this->upload_path, "foo/foo2", $name);
         $expected_json = [
             $filename_full => [
                 "checked" => '1',

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -1213,8 +1213,10 @@ class SubmissionControllerTester extends BaseUnitTest {
         $return = $controller->ajaxUploadSubmission('test');
 
         $this->assertTrue($return['status'] == 'fail', "An error should have happened");
-        $this->assertEquals("File(s) uploaded too large.  Maximum size is 1000 kb. Uploaded file(s) was 10240 kb.",
-            $return['message']);
+        $this->assertEquals(
+            "File(s) uploaded too large.  Maximum size is 1000 kb. Uploaded file(s) was 10240 kb.",
+            $return['message']
+        );
         $this->assertFalse($return['status'] == 'success');
         $tmp = FileUtils::joinPaths($this->config['course_path'], "submissions", "test", "testUser", "1");
         $this->assertFalse(is_dir($tmp));

--- a/site/tests/app/libraries/DiffViewerTester.php
+++ b/site/tests/app/libraries/DiffViewerTester.php
@@ -50,16 +50,23 @@ class DiffViewerTester extends \PHPUnit\Framework\TestCase {
     }
 
     public function testExpectedException() {
-        $diff = new DiffViewer(__TEST_DATA__ . "/diffs/diff_test_01/input_actual.txt",
-                               "file_that_doesnt_exist", "", "");
+        $diff = new DiffViewer(
+            __TEST_DATA__ . "/diffs/diff_test_01/input_actual.txt",
+            "file_that_doesnt_exist",
+            "",
+            ""
+        );
         $this->expectException(\Exception::class);
         $diff->buildViewer();
     }
 
     public function testDifferencesException() {
-        $diff = new DiffViewer(__TEST_DATA__ . "/diffs/diff_test_01/input_actual.txt",
-                               __TEST_DATA__ . "/diffs/diff_test_01/input_expected.txt",
-                               "file_that_doesnt_exist", "");
+        $diff = new DiffViewer(
+            __TEST_DATA__ . "/diffs/diff_test_01/input_actual.txt",
+            __TEST_DATA__ . "/diffs/diff_test_01/input_expected.txt",
+            "file_that_doesnt_exist",
+            ""
+        );
         $this->expectException(\Exception::class);
         $diff->buildViewer();
     }

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -469,22 +469,26 @@ STRING;
 
         $stat = FileUtils::validateUploadedFiles($_FILES["files1"]);
 
-        $this->assertCount(2, $stat );
-        $this->assertEquals($stat[0],
+        $this->assertCount(2, $stat);
+        $this->assertEquals(
+            $stat[0],
             ['name' => 'foo.txt',
              'type' => 'text/plain',
              'error' => 'No error.',
              'size' => 100,
              'success' => true
-            ]);
+            ]
+        );
 
-          $this->assertEquals($stat[1],
-            ['name' => 'foo2.txt',
-             'type' => 'text/plain',
-             'error' => 'No error.',
-             'size' => 100,
-             'success' => true
-            ]);
+          $this->assertEquals(
+              $stat[1],
+              ['name' => 'foo2.txt',
+              'type' => 'text/plain',
+              'error' => 'No error.',
+              'size' => 100,
+              'success' => true
+              ]
+          );
     }
 
     public function testvalidateUploadedFilesBad() {
@@ -493,7 +497,8 @@ STRING;
         $stat = FileUtils::validateUploadedFiles($_FILES["files2"]);
 
         $this->assertCount(1, $stat);
-        $this->assertEquals($stat[0],
+        $this->assertEquals(
+            $stat[0],
             ['name' => 'bad.txt',
              'type' => 'text/plain',
              'error' => 'The file was only partially uploaded',
@@ -506,7 +511,8 @@ STRING;
         $stat = FileUtils::validateUploadedFiles($_FILES["files2"]);
 
         $this->assertCount(2, $stat);
-        $this->assertEquals($stat[1],
+        $this->assertEquals(
+            $stat[1],
             ['name' => 'bad2.txt',
              'type' => 'text/plain',
              'error' => 'No file was uploaded.',
@@ -523,7 +529,8 @@ STRING;
         $stat = FileUtils::validateUploadedFiles($_FILES["files2"]);
 
         $this->assertCount(6, $stat);
-        $this->assertEquals($stat[1],
+        $this->assertEquals(
+            $stat[1],
             ['name' => 'bad2.txt',
              'type' => 'text/plain',
              'error' => 'No file was uploaded.',
@@ -532,7 +539,8 @@ STRING;
              ]
         );
 
-        $this->assertEquals($stat[2],
+        $this->assertEquals(
+            $stat[2],
             ['name' => 'bad3.txt',
              'type' => 'text/plain',
              'error' => 'Unknown error code.',
@@ -545,7 +553,8 @@ STRING;
         $stat = FileUtils::validateUploadedFiles($_FILES["files2"]);
 
         $this->assertCount(7, $stat);
-        $this->assertEquals($stat[6],
+        $this->assertEquals(
+            $stat[6],
             ['name' => '\?<>.txt',
              'type' => 'text/plain',
              'error' => 'Invalid filename',
@@ -561,7 +570,8 @@ STRING;
         $stat = FileUtils::validateUploadedFiles($_FILES["files3"]);
 
         $this->assertCount(1, $stat);
-        $this->assertEquals($stat[0],
+        $this->assertEquals(
+            $stat[0],
             ['name' => 'big.txt',
              'type' => 'text/plain',
              'error' => 'File "big.txt" too large got (2.0000953674316MB)',
@@ -574,7 +584,8 @@ STRING;
         $stat = FileUtils::validateUploadedFiles($_FILES["files3"]);
 
         $this->assertCount(2, $stat);
-        $this->assertEquals($stat[1],
+        $this->assertEquals(
+            $stat[1],
             ['name' => 'just_big_enough.txt',
              'type' => 'text/plain',
              'error' => 'No error.',
@@ -587,11 +598,11 @@ STRING;
     public function testvalidateUploadedFilesFail() {
         $stat = FileUtils::validateUploadedFiles(null);
         $this->assertArrayHasKey("failed", $stat);
-        $this->assertEquals($stat["failed"], "No files sent to validate" );
+        $this->assertEquals($stat["failed"], "No files sent to validate");
 
         $stat = FileUtils::validateUploadedFiles([]);
         $this->assertArrayHasKey("failed", $stat);
-        $this->assertEquals($stat["failed"], "No files sent to validate" );
+        $this->assertEquals($stat["failed"], "No files sent to validate");
     }
 
     private function getAllFilesSetup(): void {

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -202,8 +202,10 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $this->assertFalse($config->displayCustomMessage());
         $this->assertFalse($config->keepPreviousFiles());
         $this->assertFalse($config->displayRainbowGradesSummary());
-        $this->assertEquals(FileUtils::joinPaths($this->temp_dir, "courses", "s17", "csci0000", "config", "config.json"),
-            $config->getCourseJsonPath());
+        $this->assertEquals(
+            FileUtils::joinPaths($this->temp_dir, "courses", "s17", "csci0000", "config", "config.json"),
+            $config->getCourseJsonPath()
+        );
         $this->assertEquals('', $config->getRoomSeatingGradeableId());
         $this->assertFalse($config->displayRoomSeating());
         $this->assertEquals('LIW0RT5XAxOn2xjVY6rrLTcb6iacl4IDNRyPw58M0Kn0haQbHtNvPfK18xpvpD93', $config->getSecretSession());

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -15,50 +15,148 @@ class GradeableListTester extends BaseUnitTest {
     public function testFullList() {
         $core = $this->getCore();
         $gradeables = array();
-        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable($core, "01_future_homework_no_ta",
-            GradeableType::ELECTRONIC_FILE, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['02_future_homework'] = $this->mockGradeable($core, "02_future_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['03_open_homework'] = $this->mockGradeable($core, "03_open_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['04_closed_homework'] = $this->mockGradeable($core, "04_closed_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['05_grading_homework'] = $this->mockGradeable($core, "05_grading_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '9999-01-01');
-        $gradeables['06_graded_homework'] = $this->mockGradeable($core, "06_graded_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-01-01');
+        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable(
+            $core,
+            "01_future_homework_no_ta",
+            GradeableType::ELECTRONIC_FILE,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['02_future_homework'] = $this->mockGradeable(
+            $core,
+            "02_future_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['03_open_homework'] = $this->mockGradeable(
+            $core,
+            "03_open_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['04_closed_homework'] = $this->mockGradeable(
+            $core,
+            "04_closed_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['05_grading_homework'] = $this->mockGradeable(
+            $core,
+            "05_grading_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '9999-01-01'
+        );
+        $gradeables['06_graded_homework'] = $this->mockGradeable(
+            $core,
+            "06_graded_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-01-01'
+        );
 
-        $gradeables['11_future_numeric_no_ta'] = $this->mockGradeable($core, "11_future_numeric_no_ta",
-            GradeableType::NUMERIC_TEXT, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['12_future_numeric'] = $this->mockGradeable($core, "12_future_numeric",
-            GradeableType::NUMERIC_TEXT, '1000-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['13_grading_numeric'] = $this->mockGradeable($core, "13_grading_numeric",
-            GradeableType::NUMERIC_TEXT, '1000-01-01', '1001-01-01', '9997-01-01', '1003-01-01',
-            '9999-01-01');
-        $gradeables['14_graded_numeric'] = $this->mockGradeable($core, "14_graded_numeric",
-            GradeableType::NUMERIC_TEXT, '1000-01-01', '1001-01-01', '1002-01-01', '1003-03-01',
-            '1004-02-01');
+        $gradeables['11_future_numeric_no_ta'] = $this->mockGradeable(
+            $core,
+            "11_future_numeric_no_ta",
+            GradeableType::NUMERIC_TEXT,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['12_future_numeric'] = $this->mockGradeable(
+            $core,
+            "12_future_numeric",
+            GradeableType::NUMERIC_TEXT,
+            '1000-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['13_grading_numeric'] = $this->mockGradeable(
+            $core,
+            "13_grading_numeric",
+            GradeableType::NUMERIC_TEXT,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-01-01',
+            '9999-01-01'
+        );
+        $gradeables['14_graded_numeric'] = $this->mockGradeable(
+            $core,
+            "14_graded_numeric",
+            GradeableType::NUMERIC_TEXT,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-03-01',
+            '1004-02-01'
+        );
 
-        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable($core, "07_future_checkpoint_no_ta",
-            GradeableType::CHECKPOINTS, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['08_future_checkpoint'] = $this->mockGradeable($core, "08_future_checkpoint",
-            GradeableType::CHECKPOINTS, '1000-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['09_grading_lab'] = $this->mockGradeable($core, "09_grading_lab",
-            GradeableType::CHECKPOINTS, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
-            '9999-01-01');
-        $gradeables['10_graded_lab'] = $this->mockGradeable($core, "10_graded_lab",
-            GradeableType::CHECKPOINTS, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-03-01');
+        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable(
+            $core,
+            "07_future_checkpoint_no_ta",
+            GradeableType::CHECKPOINTS,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['08_future_checkpoint'] = $this->mockGradeable(
+            $core,
+            "08_future_checkpoint",
+            GradeableType::CHECKPOINTS,
+            '1000-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['09_grading_lab'] = $this->mockGradeable(
+            $core,
+            "09_grading_lab",
+            GradeableType::CHECKPOINTS,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-02-01',
+            '9999-01-01'
+        );
+        $gradeables['10_graded_lab'] = $this->mockGradeable(
+            $core,
+            "10_graded_lab",
+            GradeableType::CHECKPOINTS,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-03-01'
+        );
 
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(true);
@@ -116,27 +214,76 @@ class GradeableListTester extends BaseUnitTest {
     public function testSubmittableHasDueAdmin() {
         $gradeables = array();
         $core = $this->getCore();
-        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable($core, "01_future_homework_no_ta",
-            GradeableType::ELECTRONIC_FILE, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['02_future_homework'] = $this->mockGradeable($core, "02_future_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['03_open_homework'] = $this->mockGradeable($core, "03_open_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['04_closed_homework'] = $this->mockGradeable($core, "04_closed_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['05_grading_homework'] = $this->mockGradeable($core, "05_grading_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '9999-01-01');
-        $gradeables['06_graded_homework'] = $this->mockGradeable($core, "06_graded_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-01-01');
-        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable($core, "07_future_checkpoint_no_ta",
-            GradeableType::CHECKPOINTS, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
+        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable(
+            $core,
+            "01_future_homework_no_ta",
+            GradeableType::ELECTRONIC_FILE,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['02_future_homework'] = $this->mockGradeable(
+            $core,
+            "02_future_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['03_open_homework'] = $this->mockGradeable(
+            $core,
+            "03_open_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['04_closed_homework'] = $this->mockGradeable(
+            $core,
+            "04_closed_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['05_grading_homework'] = $this->mockGradeable(
+            $core,
+            "05_grading_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '9999-01-01'
+        );
+        $gradeables['06_graded_homework'] = $this->mockGradeable(
+            $core,
+            "06_graded_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-01-01'
+        );
+        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable(
+            $core,
+            "07_future_checkpoint_no_ta",
+            GradeableType::CHECKPOINTS,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(true);
 
@@ -147,27 +294,76 @@ class GradeableListTester extends BaseUnitTest {
     public function testSubmittableHasDueGrader() {
         $gradeables = array();
         $core = $this->getCore(false);
-        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable($core, "01_future_homework_no_ta",
-            GradeableType::ELECTRONIC_FILE, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['02_future_homework'] = $this->mockGradeable($core, "02_future_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['03_open_homework'] = $this->mockGradeable($core, "03_open_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['04_closed_homework'] = $this->mockGradeable($core, "04_closed_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['05_grading_homework'] = $this->mockGradeable($core, "05_grading_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '9999-01-01');
-        $gradeables['06_graded_homework'] = $this->mockGradeable($core, "06_graded_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-01-01');
-        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable($core, "07_future_checkpoint_no_ta",
-            GradeableType::CHECKPOINTS, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
+        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable(
+            $core,
+            "01_future_homework_no_ta",
+            GradeableType::ELECTRONIC_FILE,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['02_future_homework'] = $this->mockGradeable(
+            $core,
+            "02_future_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['03_open_homework'] = $this->mockGradeable(
+            $core,
+            "03_open_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['04_closed_homework'] = $this->mockGradeable(
+            $core,
+            "04_closed_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['05_grading_homework'] = $this->mockGradeable(
+            $core,
+            "05_grading_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '9999-01-01'
+        );
+        $gradeables['06_graded_homework'] = $this->mockGradeable(
+            $core,
+            "06_graded_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-01-01'
+        );
+        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable(
+            $core,
+            "07_future_checkpoint_no_ta",
+            GradeableType::CHECKPOINTS,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
 
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(true);
@@ -179,27 +375,76 @@ class GradeableListTester extends BaseUnitTest {
     public function testSubmittableHasDueStudent() {
         $gradeables = array();
         $core = $this->getCore(false, false);
-        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable($core, "01_future_homework_no_ta",
-            GradeableType::ELECTRONIC_FILE, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['02_future_homework'] = $this->mockGradeable($core, "02_future_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['03_open_homework'] = $this->mockGradeable($core, "03_open_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['04_closed_homework'] = $this->mockGradeable($core, "04_closed_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['05_grading_homework'] = $this->mockGradeable($core, "05_grading_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '9999-01-01');
-        $gradeables['06_graded_homework'] = $this->mockGradeable($core, "06_graded_homework",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-01-01');
-        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable($core, "07_future_checkpoint_no_ta",
-            GradeableType::CHECKPOINTS, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
+        $gradeables['01_future_homework_no_ta'] = $this->mockGradeable(
+            $core,
+            "01_future_homework_no_ta",
+            GradeableType::ELECTRONIC_FILE,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['02_future_homework'] = $this->mockGradeable(
+            $core,
+            "02_future_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['03_open_homework'] = $this->mockGradeable(
+            $core,
+            "03_open_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['04_closed_homework'] = $this->mockGradeable(
+            $core,
+            "04_closed_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['05_grading_homework'] = $this->mockGradeable(
+            $core,
+            "05_grading_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '9999-01-01'
+        );
+        $gradeables['06_graded_homework'] = $this->mockGradeable(
+            $core,
+            "06_graded_homework",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-01-01'
+        );
+        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable(
+            $core,
+            "07_future_checkpoint_no_ta",
+            GradeableType::CHECKPOINTS,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
 
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(true);
@@ -211,15 +456,45 @@ class GradeableListTester extends BaseUnitTest {
     public function testSubmittableNoDueGrader() {
         $gradeables = array();
         $core = $this->getCore(false);
-        $gradeables['01_future_no_due'] = $this->mockGradeable($core, "01_future_no_due",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01', true, true, false);
-        $gradeables['02_grading_no_due'] = $this->mockGradeable($core, "02_grading_no_due",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
-            '9999-01-01', true, true, false);
-        $gradeables['03_ta_submit_no_due'] = $this->mockGradeable($core, "03_ta_submit_no_due",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
-            '9999-01-01', true, false, false);
+        $gradeables['01_future_no_due'] = $this->mockGradeable(
+            $core,
+            "01_future_no_due",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01',
+            true,
+            true,
+            false
+        );
+        $gradeables['02_grading_no_due'] = $this->mockGradeable(
+            $core,
+            "02_grading_no_due",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-02-01',
+            '9999-01-01',
+            true,
+            true,
+            false
+        );
+        $gradeables['03_ta_submit_no_due'] = $this->mockGradeable(
+            $core,
+            "03_ta_submit_no_due",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-02-01',
+            '9999-01-01',
+            true,
+            false,
+            false
+        );
 
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(false);
@@ -257,21 +532,71 @@ class GradeableListTester extends BaseUnitTest {
         $core = $this->GetCore(false, false);
 
         $gradeables = array();
-        $gradeables['01_no_submit_no_due'] = $this->mockGradeable($core, "01_no_submit_no_due",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
-            '9999-01-01', true, true, false);
-        $gradeables['02_submitted_no_due'] = $this->mockGradeable($core, "02_submitted_no_due",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
-            '9999-01-01', true, true, false);
-        $gradeables['03_ta_submit_no_due'] = $this->mockGradeable($core, "03_ta_submit_no_due",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '9997-01-01', '1003-02-01',
-            '9999-01-01', true, false, false);
-        $gradeables['04_no_submit_grades_released'] = $this->mockGradeable($core, "04_no_submit_grades_released",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-01-01', true, true, false);
-        $gradeables['05_submitted_grades_released'] = $this->mockGradeable($core, "05_submitted_grades_released",
-            GradeableType::ELECTRONIC_FILE, '1000-01-01', '1001-01-01', '1002-01-01', '1003-01-01',
-            '1004-01-01', true, true, false);
+        $gradeables['01_no_submit_no_due'] = $this->mockGradeable(
+            $core,
+            "01_no_submit_no_due",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-02-01',
+            '9999-01-01',
+            true,
+            true,
+            false
+        );
+        $gradeables['02_submitted_no_due'] = $this->mockGradeable(
+            $core,
+            "02_submitted_no_due",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-02-01',
+            '9999-01-01',
+            true,
+            true,
+            false
+        );
+        $gradeables['03_ta_submit_no_due'] = $this->mockGradeable(
+            $core,
+            "03_ta_submit_no_due",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '9997-01-01',
+            '1003-02-01',
+            '9999-01-01',
+            true,
+            false,
+            false
+        );
+        $gradeables['04_no_submit_grades_released'] = $this->mockGradeable(
+            $core,
+            "04_no_submit_grades_released",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-01-01',
+            true,
+            true,
+            false
+        );
+        $gradeables['05_submitted_grades_released'] = $this->mockGradeable(
+            $core,
+            "05_submitted_grades_released",
+            GradeableType::ELECTRONIC_FILE,
+            '1000-01-01',
+            '1001-01-01',
+            '1002-01-01',
+            '1003-01-01',
+            '1004-01-01',
+            true,
+            true,
+            false
+        );
 
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->will($this->onConsecutiveCalls(false, true, false, false, true));
@@ -311,9 +636,16 @@ class GradeableListTester extends BaseUnitTest {
     public function testNoSubmittableGradeables() {
         $core = $this->getCore();
         $gradeables = array();
-        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable($core, "07_future_checkpoint_no_ta",
-            GradeableType::CHECKPOINTS, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
+        $gradeables['07_future_checkpoint_no_ta'] = $this->mockGradeable(
+            $core,
+            "07_future_checkpoint_no_ta",
+            GradeableType::CHECKPOINTS,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(true);
 
@@ -325,12 +657,26 @@ class GradeableListTester extends BaseUnitTest {
         $core = $this->getCore();
 
         $gradeables = array();
-        $gradeables['01_electronic'] = $this->mockGradeable($core, "01_electronic",
-            GradeableType::ELECTRONIC_FILE, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
-        $gradeables['02_checkpoint'] = $this->mockGradeable($core, "02_checkpoint",
-            GradeableType::CHECKPOINTS, '9995-01-01', '9996-01-01', '9997-01-01', '9998-01-01',
-            '9999-01-01');
+        $gradeables['01_electronic'] = $this->mockGradeable(
+            $core,
+            "01_electronic",
+            GradeableType::ELECTRONIC_FILE,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
+        $gradeables['02_checkpoint'] = $this->mockGradeable(
+            $core,
+            "02_checkpoint",
+            GradeableType::CHECKPOINTS,
+            '9995-01-01',
+            '9996-01-01',
+            '9997-01-01',
+            '9998-01-01',
+            '9999-01-01'
+        );
 
         $this->mockGetGradeables($core, $gradeables);
         $core->getQueries()->method('getHasSubmission')->willReturn(true);

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -26,14 +26,7 @@
 
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
 
-        <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket" />
-        <exclude name="PSR2.Methods.FunctionCallSignature.Indent" />
         <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
-        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket" />
-        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeOpenBracket" />
-        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket" />
-        <exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine" />
-        <exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments" />
 
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent" />
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes `PSR2.Methods.FunctionCallSignature` style errors, which is largely that there should not be a space around the beginning or end of parameters, parameters should not be split between multiple lines unless its one argument per line.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This makes some of the queries in DatabaseQueries (and other Query files) look a bit funny, but I will address fixing them up after more style errors are fixed as else it's going to cause some amount of repeat effort in styling them that I would like to avoid.
