### PR TITLE
[Refactor:PHP] Fix Squiz.Scope.MethodScope.Missing style errors

### DIFF
--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -96,7 +96,10 @@ class DiffViewer {
                                 "en dash" => ["\xE2\x80\x93", "–", "\\xE2\\x80\\x93"]
                                );
 
-    static function isValidSpecialCharsOption($option) {
+    const EXPECTED = 'expected';
+    const ACTUAL = 'actual';
+
+    public static function isValidSpecialCharsOption($option) {
         return in_array($option, [
             self::SPECIAL_CHARS_ORIGINAL,
             self::SPECIAL_CHARS_UNICODE,
@@ -104,10 +107,7 @@ class DiffViewer {
         ]);
     }
 
-    const EXPECTED = 'expected';
-    const ACTUAL = 'actual';
-
-    static function isValidType($type) {
+    public static function isValidType($type) {
         return in_array($type, [
             self::EXPECTED,
             self::ACTUAL

--- a/site/tests/app/libraries/database/SqliteDatabaseTester.php
+++ b/site/tests/app/libraries/database/SqliteDatabaseTester.php
@@ -5,7 +5,7 @@ namespace tests\app\libraries\database;
 use app\libraries\database\SqliteDatabase;
 
 class SqliteDatabaseTester extends \PHPUnit\Framework\TestCase {
-    function testMemorySqliteDSN() {
+    public function testMemorySqliteDSN() {
         $database = new SqliteDatabase(array('memory' => true));
         $this->assertEquals("sqlite::memory:", $database->getDSN());
     }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -48,7 +48,6 @@
         <exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
         <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
         <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
-        <exclude name="Squiz.Scope.MethodScope.Missing" />
         <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore" />
         <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes `Squiz.Scope.MethodScope.Missing` style errors, which is that all methods must have the visibility for it defined (instead of just relying on the default public).