### PR TITLE
[Refactor:PHP] Fix Generic.Formatting.SpaceAfterCast style errors

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -504,7 +504,7 @@ class PlagiarismController extends AbstractController {
         }
 
         $return = "";
-        $active_version_user_1 =  (string)$graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
+        $active_version_user_1 =  (string) $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $file_path = $course_path . "/lichen/ranking/" . $gradeable_id . ".txt";
         if(!file_exists($file_path)) {
             $return = array('error' => 'Ranking file not exists.');

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -533,7 +533,7 @@ class ReportController extends AbstractController {
                 "available_buckets" => $customization->getAvailableBuckets(),
                 "used_buckets" => $customization->getUsedBuckets(),
                 'display_benchmarks' => $customization->getDisplayBenchmarks(),
-                'sections_and_labels' => (array)$customization->getSectionsAndLabels(),
+                'sections_and_labels' => (array) $customization->getSectionsAndLabels(),
                 'bucket_percentages' => $customization->getBucketPercentages(),
                 'messages' => $customization->getMessages(),
                 'limited_functionality_mode' => !$this->core->getConfig()->isSubmittyAdminUserInCourse()

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -787,7 +787,7 @@ class UsersController extends AbstractController {
                 case "classlist":
                     return $user->getRegistrationSection();
                 case "graderlist":
-                    return (string)$user->getGroup();
+                    return (string) $user->getGroup();
                 default:
                     throw new ValidationException("Unknown classlist", array($list_type, '$get_user_registration_or_group_function'));
             }

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -124,7 +124,7 @@ class ForumController extends AbstractController {
         // Check if not the last category which exists
         $rows = $this->core->getQueries()->getCategories();
         foreach($rows as $index => $values){
-            if(((int)$values["category_id"]) !== $category_id) {
+            if(((int) $values["category_id"]) !== $category_id) {
                 return true;
             }
         }
@@ -171,7 +171,7 @@ class ForumController extends AbstractController {
      */
     public function deleteCategory() {
         if(!empty($_POST["deleteCategory"])) {
-            $category = (int)$_POST["deleteCategory"];
+            $category = (int) $_POST["deleteCategory"];
             if(!$this->isValidCategories(array($category))) {
                 return $this->core->getOutput()->renderJsonFail("That category doesn't exists.");
             } elseif(!$this->isCategoryDeletionGood($category)) {
@@ -226,11 +226,11 @@ class ForumController extends AbstractController {
 
         $current_order = array();
         foreach ($rows as $row) {
-            $current_order[] = (int)$row['category_id'];
+            $current_order[] = (int) $row['category_id'];
         }
         $new_order = array();
         foreach ($_POST['categorylistitem'] as $item) {
-            $new_order[] = (int)$item;
+            $new_order[] = (int) $item;
         }
 
         if(count(array_diff(array_merge($current_order, $new_order), array_intersect($current_order, $new_order))) === 0) {
@@ -273,7 +273,7 @@ class ForumController extends AbstractController {
 
         $categories_ids  = array();
         foreach ($_POST["cat"] as $category_id) {
-            $categories_ids[] = (int)$category_id;
+            $categories_ids[] = (int) $category_id;
         }
         if(empty($thread_title) || empty($thread_post_content)){
             $this->core->addErrorMessage("One of the fields was empty or bad. Please re-submit your thread.");
@@ -490,7 +490,7 @@ class ForumController extends AbstractController {
                 // We want to reload same thread again, in both case (thread/post undelete)
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
-                $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string)$post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
+                $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string) $post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
                 $subject = "Undeleted: " . Notification::textShortner($post["content"]);
                 $content = "In " . $full_course_name . "\n\nThe following post was undeleted.\n\nThread: " . $thread_title . "\n\n" . $post["content"];
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post_author_id, 'preference' => 'all_modifications_forum'];
@@ -541,7 +541,7 @@ class ForumController extends AbstractController {
             if($any_changes) {
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
-                $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string)$post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
+                $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string) $post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
                 if ($type == "Post") {
                     $post_content = $_POST["thread_post_content"];
                     $subject = "Post Edited: " . Notification::textShortner($post_content);
@@ -597,7 +597,7 @@ class ForumController extends AbstractController {
                 $child_thread_author = $child_thread['created_by'];
                 $child_thread_title = $child_thread['title'];
                 $parent_thread_title = $this->core->getQueries()->getThreadTitle($parent_thread_id)['title'];
-                $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $parent_thread_id]) . '#' . (string)$child_root_post, 'thread_id' => $parent_thread_id, 'post_id' => $child_root_post));
+                $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $parent_thread_id]) . '#' . (string) $child_root_post, 'thread_id' => $parent_thread_id, 'post_id' => $child_root_post));
                 $subject = "Thread Merge: " . Notification::textShortner($child_thread_title);
                 $content = "Two threads were merged in:\n" . $full_course_name . "\n\nAll messages posted in Merged Thread:\n" . $child_thread_title . "\n\nAre now contained within Parent Thread:\n" . $parent_thread_title;
                 $event = [ 'component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $child_thread_author, 'preference' => 'merge_threads'];
@@ -626,7 +626,7 @@ class ForumController extends AbstractController {
             $categories_ids  = array();
             if(!empty($_POST["cat"])) {
                 foreach ($_POST["cat"] as $category_id) {
-                    $categories_ids[] = (int)$category_id;
+                    $categories_ids[] = (int) $category_id;
                 }
             }
             if(!$this->isValidCategories($categories_ids)) {
@@ -679,7 +679,7 @@ class ForumController extends AbstractController {
         foreach ($ordered_threads as &$thread) {
             $list = array();
             foreach(explode("|", $thread['categories_ids']) as $id) {
-                $list[] = (int)$id;
+                $list[] = (int) $id;
             }
             $thread['categories_ids'] = $list;
             $thread['categories_desc'] = explode("|", $thread['categories_desc']);
@@ -692,7 +692,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/threads", methods={"POST"})
      */
     public function getThreads($page_number = null) {
-        $pageNumber = !empty($page_number) && is_numeric($page_number) ? (int)$page_number : 1;
+        $pageNumber = !empty($page_number) && is_numeric($page_number) ? (int) $page_number : 1;
         $show_deleted = $this->showDeleted();
         $currentCourse = $this->core->getConfig()->getCourse();
         $show_merged_thread = $this->showMergedThreads($currentCourse);
@@ -706,15 +706,15 @@ class ForumController extends AbstractController {
             $thread_status = explode("|", $_COOKIE['forum_thread_status']);
         }
         foreach ($categories_ids as &$id) {
-            $id = (int)$id;
+            $id = (int) $id;
         }
         foreach ($thread_status as &$status) {
-            $status = (int)$status;
+            $status = (int) $status;
         }
         $max_thread = 0;
         $threads = $this->getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, $pageNumber, -1);
         $currentCategoriesIds = (!empty($_POST['currentCategoriesId'])) ? explode("|", $_POST["currentCategoriesId"]) : array();
-        $currentThreadId = array_key_exists('currentThreadId', $_POST) && !empty($_POST["currentThreadId"]) && is_numeric($_POST["currentThreadId"]) ? (int)$_POST["currentThreadId"] : -1;
+        $currentThreadId = array_key_exists('currentThreadId', $_POST) && !empty($_POST["currentThreadId"]) && is_numeric($_POST["currentThreadId"]) ? (int) $_POST["currentThreadId"] : -1;
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'showAlteredDisplayList', $threads, true, $currentThreadId, $currentCategoriesIds);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
@@ -748,10 +748,10 @@ class ForumController extends AbstractController {
             $unread_threads = ($_COOKIE['unread_select_value'] === 'true');
         }
         foreach ($category_id as &$id) {
-            $id = (int)$id;
+            $id = (int) $id;
         }
         foreach ($thread_status as &$status) {
-            $status = (int)$status;
+            $status = (int) $status;
         }
 
         $max_thread = 0;
@@ -768,9 +768,9 @@ class ForumController extends AbstractController {
         }
         $option = ($this->core->getUser()->accessGrading() || $option != 'alpha') ? $option : 'tree';
         if(!empty($thread_id)){
-            $thread_id = (int)$thread_id;
+            $thread_id = (int) $thread_id;
             $thread_resolve_state = $this->core->getQueries()->getResolveState($thread_id)[0]['status'];
-            $this->core->getQueries()->markNotificationAsSeen($user, -2, (string)$thread_id);
+            $this->core->getQueries()->markNotificationAsSeen($user, -2, (string) $thread_id);
             $unread_p = $this->core->getQueries()->getUnviewedPosts($thread_id, $current_user);
             foreach ($unread_p as $up) {
                 $new_posts[] = $up["id"];

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -139,7 +139,7 @@ class ForumController2 extends AbstractController {
         // Check if not the last category which exists
         $rows = $this->core->getQueries()->getCategories();
         foreach($rows as $index => $values){
-            if(((int)$values["category_id"]) !== $category_id) {
+            if(((int) $values["category_id"]) !== $category_id) {
                 return true;
             }
         }
@@ -171,7 +171,7 @@ class ForumController2 extends AbstractController {
         $result = array();
         if($this->core->getUser()->accessGrading()){
             if(!empty($_REQUEST["deleteCategory"])) {
-                $category = (int)$_REQUEST["deleteCategory"];
+                $category = (int) $_REQUEST["deleteCategory"];
                 if(!$this->isValidCategories(array($category))) {
                     $result["error"] = "That category doesn't exists.";
                 } elseif(!$this->isCategoryDeletionGood($category)) {
@@ -235,11 +235,11 @@ class ForumController2 extends AbstractController {
 
             $current_order = array();
             foreach ($rows as $row) {
-                $current_order[] = (int)$row['category_id'];
+                $current_order[] = (int) $row['category_id'];
             }
             $new_order = array();
             foreach ($_POST['categorylistitem'] as $item) {
-                $new_order[] = (int)$item;
+                $new_order[] = (int) $item;
             }
 
             if(count(array_diff(array_merge($current_order, $new_order), array_intersect($current_order, $new_order))) === 0) {
@@ -409,7 +409,7 @@ class ForumController2 extends AbstractController {
             $categories_ids  = array();
             if(!empty($_POST["cat"])) {
                 foreach ($_POST["cat"] as $category_id) {
-                    $categories_ids[] = (int)$category_id;
+                    $categories_ids[] = (int) $category_id;
                 }
             }
             if(!$this->isValidCategories($categories_ids)) {
@@ -459,7 +459,7 @@ class ForumController2 extends AbstractController {
         foreach ($ordered_threads as &$thread) {
             $list = array();
             foreach(explode("|", $thread['categories_ids']) as $id) {
-                $list[] = (int)$id;
+                $list[] = (int) $id;
             }
             $thread['categories_ids'] = $list;
             $thread['categories_desc'] = explode("|", $thread['categories_desc']);
@@ -469,7 +469,7 @@ class ForumController2 extends AbstractController {
     }
 
     public function getThreads() {
-        $pageNumber = !empty($_GET["page_number"]) && is_numeric($_GET["page_number"]) ? (int)$_GET["page_number"] : 1;
+        $pageNumber = !empty($_GET["page_number"]) && is_numeric($_GET["page_number"]) ? (int) $_GET["page_number"] : 1;
         $show_deleted = $this->showDeleted();
         $currentCourse = $this->core->getConfig()->getCourse();
         $show_merged_thread = $this->showMergedThreads($currentCourse);
@@ -483,15 +483,15 @@ class ForumController2 extends AbstractController {
             $thread_status = explode("|", $_COOKIE['forum_thread_status']);
         }
         foreach ($categories_ids as &$id) {
-            $id = (int)$id;
+            $id = (int) $id;
         }
         foreach ($thread_status as &$status) {
-            $status = (int)$status;
+            $status = (int) $status;
         }
         $max_thread = 0;
         $threads = $this->getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, $pageNumber, -1);
         $currentCategoriesIds = (!empty($_POST['currentCategoriesId'])) ? explode("|", $_POST["currentCategoriesId"]) : array();
-        $currentThreadId = array_key_exists('currentThreadId', $_POST) && !empty($_POST["currentThreadId"]) && is_numeric($_POST["currentThreadId"]) ? (int)$_POST["currentThreadId"] : -1;
+        $currentThreadId = array_key_exists('currentThreadId', $_POST) && !empty($_POST["currentThreadId"]) && is_numeric($_POST["currentThreadId"]) ? (int) $_POST["currentThreadId"] : -1;
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'showAlteredDisplayList', $threads, true, $currentThreadId, $currentCategoriesIds);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
@@ -520,10 +520,10 @@ class ForumController2 extends AbstractController {
             $unread_threads = ($_COOKIE['unread_select_value'] === 'true');
         }
         foreach ($category_id as &$id) {
-            $id = (int)$id;
+            $id = (int) $id;
         }
         foreach ($thread_status as &$status) {
-            $status = (int)$status;
+            $status = (int) $status;
         }
 
         $max_thread = 0;
@@ -540,8 +540,8 @@ class ForumController2 extends AbstractController {
         }
         $option = ($this->core->getUser()->accessGrading() || $option != 'alpha') ? $option : 'tree';
         if(!empty($_REQUEST["thread_id"])){
-            $thread_id = (int)$_REQUEST["thread_id"];
-            $this->core->getQueries()->markNotificationAsSeen($user, -2, (string)$thread_id);
+            $thread_id = (int) $_REQUEST["thread_id"];
+            $this->core->getQueries()->markNotificationAsSeen($user, -2, (string) $thread_id);
             $unread_p = $this->core->getQueries()->getUnviewedPosts($thread_id, $current_user);
             foreach ($unread_p as $up) {
                 $new_posts[] = $up["id"];
@@ -727,7 +727,7 @@ class ForumController2 extends AbstractController {
 
         $categories_ids  = array();
         foreach ($_POST["cat"] as $category_id) {
-            $categories_ids[] = (int)$category_id;
+            $categories_ids[] = (int) $category_id;
         }
 
         $result = $this->core->getForum()->publish([

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -765,13 +765,13 @@ class Access {
                     }
                     break;
                 case "version":
-                    $args["gradeable_version"] = (int)$value;
+                    $args["gradeable_version"] = (int) $value;
                     break;
                 case "thread":
-                    $args["thread"] = (int)$value;
+                    $args["thread"] = (int) $value;
                     break;
                 case "post":
-                    $args["post"] = (int)$value;
+                    $args["post"] = (int) $value;
                     break;
             }
         }

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -444,7 +444,7 @@ class DiffViewer {
          * Run through every line, starting a highlight around any group of mismatched lines that exist (whether
          * there's a difference on that line or that the line doesn't exist.
          */
-        $max_digits = strlen((string)count($lines));
+        $max_digits = strlen((string) count($lines));
         for ($i = 0; $i < count($lines); $i++) {
             $j = $i + 1;
             if ($start === null && isset($this->diff[$type][$i])) {
@@ -458,7 +458,7 @@ class DiffViewer {
                 $html .= "\t<div>";
             }
             $html .= "<span class='line_number'>";
-            $digits_at_line = strlen((string)$j);
+            $digits_at_line = strlen((string) $j);
             for ($counter = ($max_digits - $digits_at_line); $counter > 0; $counter--) {
                 $html .= "&nbsp;";
             }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -355,7 +355,7 @@ class DatabaseQueries {
         $this->course_db->query("SELECT category_id from thread_categories t where t.thread_id = ?", array($thread_id));
         $categories_list = array();
         foreach ($this->course_db->rows() as $row) {
-            $categories_list[] = (int)$row["category_id"];
+            $categories_list[] = (int) $row["category_id"];
         }
         return $categories_list;
     }

--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -42,7 +42,7 @@ class GradingSection extends AbstractModel {
     public function __construct(Core $core, bool $registration, $name, $graders, $users, $teams) {
         parent::__construct($core);
         $this->registration = $registration;
-        $this->name = $name !== null ? (string)$name : null;
+        $this->name = $name !== null ? (string) $name : null;
         $this->graders = $graders;
         $this->users = $users;
         $this->teams = $teams;

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -49,7 +49,7 @@ class RainbowCustomization extends AbstractModel {
         $this->has_error = "false";
         $this->error_messages = [];
 
-        $this->sections = (object)[];
+        $this->sections = (object) [];
 
         // Attempt to load json from customization file
         // If it fails then set to null, will be used to load defaults later
@@ -141,7 +141,7 @@ class RainbowCustomization extends AbstractModel {
             foreach ($json_gradeables as $json_gradeable)
             {
                 // Get percentage, cast back to whole number integer
-                $retArray[$json_gradeable->type] = (int)($json_gradeable->percent * 100);
+                $retArray[$json_gradeable->type] = (int) ($json_gradeable->percent * 100);
 
                 // Keep track of the sum
                 $sum += $retArray[$json_gradeable->type];
@@ -231,7 +231,7 @@ class RainbowCustomization extends AbstractModel {
         if(!is_null($this->RCJSON))
         {
             // Get sections from the file
-            $sectionsFromFile = (array)$this->RCJSON->getSection();
+            $sectionsFromFile = (array) $this->RCJSON->getSection();
 
             // If sections from database is larger than sections from file then there must be a new section in
             // in the database, add new fields into sections from file with defaults
@@ -242,17 +242,17 @@ class RainbowCustomization extends AbstractModel {
             {
                 for($i = $sectionsFromFileCount + 1; $i <= $sectionsCount; $i++)
                 {
-                    $sectionsFromFile[$i] = (string)$i;
+                    $sectionsFromFile[$i] = (string) $i;
                 }
             }
 
-            return (object)$sectionsFromFile;
+            return (object) $sectionsFromFile;
         }
         // RCJSON was null so return database sections as default
         else
         {
             // Collect sections out of the database
-            return (object)$sections;
+            return (object) $sections;
         }
     }
 
@@ -277,7 +277,7 @@ class RainbowCustomization extends AbstractModel {
         {
             foreach($form_json->section as $key => $value)
             {
-                $this->RCJSON->addSection((string)$key, $value);
+                $this->RCJSON->addSection((string) $key, $value);
             }
         }
 
@@ -301,7 +301,7 @@ class RainbowCustomization extends AbstractModel {
         $this->RCJSON->saveToJsonFile();
 
         // Configure json to go into jobs queue
-        $job_json = (object)[];
+        $job_json = (object) [];
         $job_json->job = 'RunAutoRainbowGrades';
         $job_json->semester = $this->core->getConfig()->getSemester();
         $job_json->course = $this->core->getConfig()->getCourse();

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -43,8 +43,8 @@ class RainbowCustomizationJSON extends AbstractModel {
 
         // Items that must be initialized as objects
         // This is done so json_encode will properly encode the item when converting to json
-        $this->section = (object)[];
-        $this->benchmark_percent = (object)[];
+        $this->section = (object) [];
+        $this->benchmark_percent = (object) [];
     }
 
     /**
@@ -212,7 +212,7 @@ class RainbowCustomizationJSON extends AbstractModel {
         // TODO: Validate gradeable data
         // Validation of this item will be better handled when schema validation is complete, until then just make
         // sure gradeable is not empty
-        $emptyObject = (object)[];
+        $emptyObject = (object) [];
         if($gradeable == $emptyObject)
         {
             throw new BadArgumentException('Gradeable may not be empty.');
@@ -261,7 +261,7 @@ class RainbowCustomizationJSON extends AbstractModel {
         }
 
         // Create object that will be written to file after collecting non-empty items
-        $json = (object)[];
+        $json = (object) [];
 
         // Copy each property from $this over to $json
         foreach($this as $key => $value)

--- a/site/app/models/forum/Post.php
+++ b/site/app/models/forum/Post.php
@@ -70,11 +70,11 @@ class Post extends AbstractModel {
         }
 
         //setPostId($details['post_id']);
-        $this->setThreadId((int)$details['thread_id']);
-        $this->setParentId((int)$details['parent_id']);
+        $this->setThreadId((int) $details['thread_id']);
+        $this->setParentId((int) $details['parent_id']);
         $this->setContent($details['content']);
         //setTimestamp($details['timestamp']);
-        $this->setIsAnonymous((bool)$details['anon']);
+        $this->setIsAnonymous((bool) $details['anon']);
         //setDeleted($details['deleted']);
         //setType($details['type']);
         //setAttachment($details['has_attachment']);

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -249,7 +249,7 @@ class Gradeable extends AbstractModel {
             $this->setPrecision($details['precision']);
             $this->setRegradeAllowedInternal($details['regrade_allowed']);
             $this->setGradeInquiryPerComponentAllowed($details['grade_inquiry_per_component_allowed']);
-            $this->setDiscussionBased((boolean)$details['discussion_based']);
+            $this->setDiscussionBased((boolean) $details['discussion_based']);
             $this->setDiscussionThreadId($details['discussion_thread_ids']);
         }
 
@@ -1149,7 +1149,7 @@ class Gradeable extends AbstractModel {
         }
 
         $points = floatval($points);
-        $q = (int)($points / $this->precision);
+        $q = (int) ($points / $this->precision);
         $r = fmod($points, $this->precision);
 
         // If the remainder is more than half the precision away from zero, then add one

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -142,7 +142,7 @@ class ForumThreadView extends AbstractView {
         }
 
         if($filteredThreadExists || $threadFiltering) {
-            $currentThread = isset($_GET["thread_id"]) && is_numeric($_GET["thread_id"]) && (int)$_GET["thread_id"] < $max_thread && (int)$_GET["thread_id"] > 0 ? (int)$_GET["thread_id"] : $posts[0]["thread_id"];
+            $currentThread = isset($_GET["thread_id"]) && is_numeric($_GET["thread_id"]) && (int) $_GET["thread_id"] < $max_thread && (int) $_GET["thread_id"] > 0 ? (int) $_GET["thread_id"] : $posts[0]["thread_id"];
             $currentCategoriesIds = $this->core->getQueries()->getCategoriesIdForThread($currentThread);
         }
 
@@ -185,7 +185,7 @@ class ForumThreadView extends AbstractView {
 
         if(!empty($_COOKIE[$currentCourse . '_forum_categories'])) {
             foreach(explode('|', $_COOKIE[$currentCourse . '_forum_categories']) as $selectedId) {
-                if(in_array((int)$selectedId, $category_ids_array)) {
+                if(in_array((int) $selectedId, $category_ids_array)) {
                     $cookieSelectedCategories[] = $selectedId;
                 }
             }
@@ -193,7 +193,7 @@ class ForumThreadView extends AbstractView {
 
         if(!empty($_COOKIE['forum_thread_status'])) {
             foreach(explode('|', $_COOKIE['forum_thread_status']) as $selectedStatus) {
-                if(in_array((int)$selectedStatus, array(-1,0,1))) {
+                if(in_array((int) $selectedStatus, array(-1,0,1))) {
                     $cookieSelectedThreadStatus[] = $selectedStatus;
                 }
             }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -19,7 +19,6 @@
         <exclude name="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed" />
         <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
         <exclude name="Generic.Files.LineLength.TooLong" />
-        <exclude name="Generic.Formatting.SpaceAfterCast.NoSpace" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />
         <exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes the `Generic.Formatting.SpaceAfterCast` style errors which is that there must be a single space between a cast the argument it acts on:
```
$a = (int) $value;
```