### PR TITLE
[Refactor:PHP] Fix Generic.ControlStructures.InlineControlStructure style errors

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -458,10 +458,11 @@ class MiscController extends AbstractController {
         $complete_count = 0;
         try{
             foreach(scandir($job_path) as $job){
-                if(strpos($job, 'bulk_upload_') !== false)
+                if(strpos($job, 'bulk_upload_') !== false) {
                     $found = true;
-                else
+                } else {
                     continue;
+                }
                 //remove 'bulk_upload_' and '.json' from job file name
                 $result[] = substr($job, 11, -5);
             }
@@ -470,11 +471,13 @@ class MiscController extends AbstractController {
             $sub_dirs = array_filter(glob($split_uploads . '/*'), 'is_dir');
             foreach ($sub_dirs as $dir) {
                 foreach (scandir($dir) as $file) {
-                    if(pathinfo($file)['extension'] !== "pdf")
+                    if(pathinfo($file)['extension'] !== "pdf") {
                         continue;
+                    }
 
-                    if(strpos($file, "_cover"))
+                    if(strpos($file, "_cover")) {
                         $complete_count++;
+                    }
                 }
             }
             $result = ['found' => $found, 'job_data' => $result, 'count' => $complete_count];

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1047,8 +1047,9 @@ class AdminGradeableController extends AbstractController {
     }
 
     private function writeFormConfig(Gradeable $gradeable) {
-        if ($gradeable->getType() !== GradeableType::ELECTRONIC_FILE)
+        if ($gradeable->getType() !== GradeableType::ELECTRONIC_FILE) {
             return null;
+        }
 
         // Refresh the configuration file with updated information
         // See 'make_assignments_txt_file.py' and grade_item.py for where these properties are used

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -315,7 +315,9 @@ class ElectronicGraderController extends AbstractController {
         $total_submissions = 0;
         if (count($total_users) > 0) {
             foreach ($total_users as $key => $value) {
-                if ($key == 'NULL') continue;
+                if ($key == 'NULL') {
+                    continue;
+                }
                 $total_submissions += $value;
             }
             if ($peer) {
@@ -330,7 +332,9 @@ class ElectronicGraderController extends AbstractController {
                     'graders' => array()
                 );
                 foreach($total_users as $key => $value) {
-                    if($key == 'NULL') continue;
+                    if($key == 'NULL') {
+                        continue;
+                    }
                     $sections['all']['total_components'] += $value * $num_components * $peer_grade_set;
                     $sections['all']['graded_components'] += isset($graded_components[$key]) ? $graded_components[$key] : 0;
                 }
@@ -732,7 +736,9 @@ class ElectronicGraderController extends AbstractController {
         }
 
         $return_url = $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']);
-        if ($view !== '') $return_url .= "?view={$view}";
+        if ($view !== '') {
+            $return_url .= "?view={$view}";
+        }
 
         if (!$gradeable->isTeamAssignment()) {
             $this->core->addErrorMessage("{$gradeable->getTitle()} is not a team assignment");
@@ -2226,9 +2232,11 @@ class ElectronicGraderController extends AbstractController {
             $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable->getId(), $sections, $section_key, $gradeable->isTeamAssignment());
         }
 
-        foreach ($graded_components as $key => $value)
+        foreach ($graded_components as $key => $value) {
             $total_graded += intval($value);
-        foreach ($total_users as $key => $value)
+        }
+        foreach ($total_users as $key => $value) {
             $total_total += $value * $num_components;
+        }
     }
 }

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -30,9 +30,9 @@ class ImagesController extends AbstractController {
             return;
         }
 
-        if ($user_group !== USER::GROUP_LIMITED_ACCESS_GRADER)
+        if ($user_group !== USER::GROUP_LIMITED_ACCESS_GRADER) {
             $grader_sections = array();  //reset grader section to nothing so permission for every image
-        else {
+        } else {
             if (empty($grader_sections)) {
                 return;
             }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -943,7 +943,9 @@ class SubmissionController extends AbstractController {
                 $filename = $this_input->getFileName();
                 $dst = FileUtils::joinPaths($version_path, $filename);
 
-                if (count($answers) > 0)  $empty_inputs = false;
+                if (count($answers) > 0) {
+                    $empty_inputs = false;
+                }
 
                 // FIXME: add error checking
                 $file = fopen($dst, "w");
@@ -1512,16 +1514,19 @@ class SubmissionController extends AbstractController {
         $user_id_arr = is_dir($base_path) ? array_slice(scandir($base_path), 2) : [];
         for($i = 0; $i < count($user_id_arr); $i++) {
             $user_path = $base_path . $user_id_arr[$i];
-            if(!is_dir($user_path))
+            if(!is_dir($user_path)) {
                 continue;
+            }
             $files = scandir($user_path);
             $num_files = count($files) - 3;
             $json_path = $user_path . "/" . $num_files . "/bulk_upload_data.json";
-            if(!file_exists($json_path))
+            if(!file_exists($json_path)) {
                 continue;
+            }
             $user = $this->core->getQueries()->getUserById($user_id_arr[$i]);
-            if($user === null)
+            if($user === null) {
                 continue;
+            }
             $file_contents = FileUtils::readJsonFile($json_path);
             $users[$user_id_arr[$i]]["first_name"] = $user->getDisplayedFirstName();
             $users[$user_id_arr[$i]]["last_name"] = $user->getDisplayedLastName();

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -581,9 +581,15 @@ class Core {
         if ($this->getConfig()->getSemester() !== ""){
             $arr1 = str_split($semester);
             $semester = "";
-            if($arr1[0] == "f")  $semester .= "Fall ";
-            elseif($arr1[0] == "s")  $semester .= "Spring ";
-            elseif ($arr1[0] == "u") $semester .= "Summer ";
+            if($arr1[0] == "f") {
+                $semester .= "Fall ";
+            }
+            elseif($arr1[0] == "s") {
+                $semester .= "Spring ";
+            }
+            elseif ($arr1[0] == "u") {
+                $semester .= "Summer ";
+            }
 
             $semester .= "20" . $arr1[1] . $arr1[2];
         }

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -580,7 +580,9 @@ class DiffViewer {
         $count = 0;
         $what = '<span class="whitespace">' . $what . '</span>';
         $which = str_replace($text, $what, $which, $count);
-        if($count > 0) $this->white_spaces[$description] = strip_tags($what);
+        if($count > 0) {
+            $this->white_spaces[$description] = strip_tags($what);
+        }
         return $what;
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1891,7 +1891,9 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
     public function createTeam($g_id, $user_id, $registration_section, $rotating_section) {
         $this->course_db->query("SELECT COUNT(*) AS cnt FROM gradeable_teams");
         $team_id_prefix = strval($this->course_db->row()['cnt']);
-        if (strlen($team_id_prefix) < 5) $team_id_prefix = str_repeat("0", 5 - strlen($team_id_prefix)) . $team_id_prefix;
+        if (strlen($team_id_prefix) < 5) {
+            $team_id_prefix = str_repeat("0", 5 - strlen($team_id_prefix)) . $team_id_prefix;
+        }
         $team_id = "{$team_id_prefix}_{$user_id}";
 
         $params = array($team_id, $g_id, $registration_section, $rotating_section);
@@ -2088,7 +2090,9 @@ ORDER BY {$section_key}", $params);
             $return[$row[$section_key]] = intval($row['cnt']);
         }
         foreach ($sections as $section) {
-            if (!isset($return[$section])) $return[$section] = 0;
+            if (!isset($return[$section])) {
+                $return[$section] = 0;
+            }
         }
         ksort($return);
         return $return;
@@ -3075,7 +3079,9 @@ AND gc_id IN (
             $regrade_id = $this->course_db->getLastInsertId();
             $this->insertNewRegradePost($regrade_id, $sender->getId(), $initial_message);
         } catch (DatabaseException $dbException) {
-            if ($this->course_db->inTransaction()) $this->course_db->rollback();
+            if ($this->course_db->inTransaction()) {
+                $this->course_db->rollback();
+            }
             throw $dbException;
         }
     }

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -165,16 +165,18 @@ class Notification extends AbstractModel {
             return "Less than a minute ago";
         } elseif($elapsed_time < 3600){
             $minutes = floor($elapsed_time / 60);
-            if($minutes == 1)
+            if($minutes == 1) {
                 return "1 minute ago";
-            else
+            } else {
                 return "{$minutes} minutes ago";
+            }
         } elseif($elapsed_time < 3600 * 24){
             $hours = floor($elapsed_time / 3600);
-            if($hours == 1)
+            if($hours == 1) {
                 return "1 hour ago";
-            else
+            } else {
                 return "{$hours} hours ago";
+            }
         } else {
             return date_format(DateUtils::parseDateTime($actual_time, $this->core->getConfig()->getTimezone()), "n/j g:i A");
         }

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -336,7 +336,9 @@ class User extends AbstractModel {
                 return preg_match("~^[a-zA-Z'`\-\.\(\) ]{0,30}$~", $data) === 1;
             case 'user_email':
                 // emails are allowed to be the empty string...
-                if ($data === "") return true;
+                if ($data === "") {
+                    return true;
+                }
                 // -- or ---
                 // Check email address for appropriate format. e.g. "user@university.edu", "user@cs.university.edu", etc.
                 return preg_match("~^[^(),:;<>@\\\"\[\]]+@(?!\-)[a-zA-Z0-9\-]+(?<!\-)(\.[a-zA-Z0-9]+)+$~", $data) === 1;

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -86,8 +86,9 @@ class GradedComponent extends AbstractModel {
         $this->setGradedVersion($details['graded_version'] ?? 0);
         $this->setGradeTime($details['grade_time'] ?? $this->core->getDateTimeNow());
         $this->verifier_id = $details['verifier_id'] ?? '';
-        if($this->verifier_id !== '')
+        if($this->verifier_id !== '') {
             $this->verifier = $this->core->getQueries()->getUserById($this->verifier_id);
+        }
         $this->setVerifyTime($details['verify_time'] ?? '');
         // assign the default score if its not electronic (or rather not a custom mark)
         if ($component->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE) {

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -323,10 +323,11 @@ class GradedComponentContainer extends AbstractModel {
         foreach ($this->graded_components as $graded_component) {
             $grader = $graded_component->getGrader();
             $verifier_id = $graded_component->getVerifierId();
-            if($grader->accessFullGrading())
+            if($grader->accessFullGrading()) {
                 $visible_graders[$grader->getId()] = $grader;
-            elseif($verifier_id != '')
+            } elseif($verifier_id != '') {
                 $visible_graders[$verifier_id] = $graded_component->getVerifier();
+            }
         }
         return $visible_graders;
     }

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -159,8 +159,9 @@ class GradedGradeable extends AbstractModel {
      */
     public function getGradeInquiryByGcId($gc_id) {
         foreach ($this->regrade_requests as $grade_inquiry) {
-            if ($grade_inquiry->getGcId() == $gc_id)
+            if ($grade_inquiry->getGcId() == $gc_id) {
                 return $grade_inquiry;
+            }
         }
         return null;
     }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -70,7 +70,9 @@ class AutoGradingView extends AbstractView {
 
             if ($gradeable->isTaGradeReleased()) {
                 foreach ($version_instance->getTestcases() as $testcase) {
-                    if (!$testcase->canView()) continue;
+                    if (!$testcase->canView()) {
+                        continue;
+                    }
                     if ($testcase->getTestcase()->isHidden()) {
                         $any_visible_hidden = true;
                         break;

--- a/site/app/views/admin/ExtensionsView.php
+++ b/site/app/views/admin/ExtensionsView.php
@@ -32,7 +32,9 @@ class ExtensionsView extends AbstractView {
                                           'user_lastname' => $user->getDisplayedLastName(),
                                           'late_day_exceptions' => $user->getLateDayExceptions());
         }
-        if (empty($current_exceptions)) $current_exceptions = null;
+        if (empty($current_exceptions)) {
+            $current_exceptions = null;
+        }
 
         return $this->core->getOutput()->renderTwigTemplate("admin/Extensions.twig", [
             "gradeables" => $gradeables,

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -52,8 +52,9 @@ class CourseMaterialsView extends AbstractView {
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
 
-                        if ($isShareToOther == '1' && $release_date > $now_date_time)
+                        if ($isShareToOther == '1' && $release_date > $now_date_time) {
                             $isShareToOther = '0';
+                        }
 
                         $releaseData  = $json[$expected_file_path]['release_datetime'];
                     }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -599,10 +599,12 @@ class ForumThreadView extends AbstractView {
                 $used_active = true;
                 $activeThreadTitle = ($display_thread_ids ? "({$thread['id']}) " : '') . $thread["title"];
                 $activeThread = $thread;
-                if ($thread["pinned"])
+                if ($thread["pinned"]) {
                     $activeThreadAnnouncement = true;
-                if ($thread_id_p == -1)
+                }
+                if ($thread_id_p == -1) {
                     $thread_id_p = $thread["id"];
+                }
             }
             if (!$this->core->getQueries()->viewedThread($current_user, $thread["id"])) {
                 $class .= " new_thread";
@@ -636,8 +638,9 @@ class ForumThreadView extends AbstractView {
             }
             if (strlen($thread["title"]) > 40) {
                 //Fix ... appearing
-                if (empty($titleDisplay))
+                if (empty($titleDisplay)) {
                     $titleDisplay .= substr($thread['title'], 0, 30);
+                }
                 $titleDisplay .= "...";
             }
             $titleDisplay = ($display_thread_ids ? "({$thread['id']}) " : '') . $titleDisplay;

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -326,10 +326,12 @@ class HomeworkView extends AbstractView {
             if (file_exists($path)) {
                 $json = json_decode(file_get_contents($path), true);
                 if (!is_null($json)) {
-                    if (isset($json["git_user_id"]))
+                    if (isset($json["git_user_id"])) {
                         $github_user_id = $json["git_user_id"];
-                    if (isset($json["git_repo_id"]))
+                    }
+                    if (isset($json["git_repo_id"])) {
                         $github_repo_id = $json["git_repo_id"];
+                    }
                 }
             }
         }
@@ -471,8 +473,9 @@ class HomeworkView extends AbstractView {
                 $cover_image_name = substr($filename, 0, -3) . "jpg";
                 $cover_image = [];
                 foreach ($cover_images as $img) {
-                    if($img['filename'] === $cover_image_name)
+                    if($img['filename'] === $cover_image_name) {
                         $cover_image = $img;
+                    }
                 }
                 $files[] = [
                     'clean_timestamp' => $clean_timestamp,
@@ -771,7 +774,9 @@ class HomeworkView extends AbstractView {
                 // format posts
                 $posts = [];
                 foreach ($grade_inquiry_posts[$grade_inquiry->getId()] as $post) {
-                    if (empty($post)) break;
+                    if (empty($post)) {
+                        break;
+                    }
                     $is_staff = $this->core->getQueries()->isStaffPost($post['user_id']);
                     $name = $this->core->getQueries()->getUserById($post['user_id'])->getDisplayedFirstName();
                     $date = DateUtils::parseDateTime($post['timestamp'], $this->core->getConfig()->getTimezone());

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -17,7 +17,6 @@
 
         <exclude name="Generic.Arrays.DisallowLongArraySyntax.Found" />
         <exclude name="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed" />
-        <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
         <exclude name="Generic.Files.LineLength.TooLong" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
         <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes the `Generic.ControlStructures.InlineControlStructure` style errors which is that all control structures (if statements, for loops, etc.) must have braces around its body. This helps maintain the best readability and clarify of the code.