### PR TITLE
[Refactor:PHP] Fix PSR12.Keywords.ShortFormTypeKeywords style errors

### DIFF
--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -234,10 +234,10 @@ abstract class AbstractDatabase {
             if (isset($columns[$col])) {
                 $column = $columns[$col];
                 if ($column['native_type'] === 'integer' && $column['pdo_type'] !== \PDO::PARAM_INT) {
-                    $value = (integer) $value;
+                    $value = (int) $value;
                 }
                 elseif ($column['native_type'] === 'boolean' && $column['pdo_type'] !== \PDO::PARAM_BOOL) {
-                    $value = (boolean) $value;
+                    $value = (bool) $value;
                 }
                 $result[$col] = $value;
             }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -249,7 +249,7 @@ class Gradeable extends AbstractModel {
             $this->setPrecision($details['precision']);
             $this->setRegradeAllowedInternal($details['regrade_allowed']);
             $this->setGradeInquiryPerComponentAllowed($details['grade_inquiry_per_component_allowed']);
-            $this->setDiscussionBased((boolean) $details['discussion_based']);
+            $this->setDiscussionBased((bool) $details['discussion_based']);
             $this->setDiscussionThreadId($details['discussion_thread_ids']);
         }
 

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -33,7 +33,6 @@
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
         <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
         <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMiddle"/>
-        <exclude name="PSR12.Keywords.ShortFormTypeKeywords.LongFound" />
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
 
         <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceAfterBracket" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes `PSR12.Keywords.ShortFormKeywords` style errors, which is that you should never use the long form of a keyword (e.g. `boolean` instead of `bool`).