### PR TITLE
[Refactor:PHP] Fix Squiz.WhiteSpace.ScopeClosingBrace style errors

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -743,10 +743,18 @@ class AdminGradeableController extends AbstractController {
 
             // Find which radio button is pressed and what host type to use
             $host_type = -1;
-            if      ($host_button === 'submitty-hosted')     { $host_type = 0; }
-            elseif ($host_button === 'submitty-hosted-url') { $host_type = 1; }
-            elseif ($host_button === 'public-github')       { $host_type = 2; }
-            elseif ($host_button === 'private-github')      { $host_type = 3; }
+            if ($host_button === 'submitty-hosted') {
+                $host_type = 0;
+            }
+            elseif ($host_button === 'submitty-hosted-url') {
+                $host_type = 1;
+            }
+            elseif ($host_button === 'public-github') {
+                $host_type = 2;
+            }
+            elseif ($host_button === 'private-github') {
+                $host_type = 3;
+            }
 
             $subdir = '';
             // Submitty hosted -> this gradeable subdirectory

--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -31,8 +31,10 @@ class ExceptionHandler {
     /**
      * This is a static class so it should never be instaniated or copied anywhere
      */
-    private function __construct() { }
-    private function __clone() { }
+    private function __construct() {
+    }
+    private function __clone() {
+    }
 
     /**
      * @param bool $boolean True/False to control whether we log/not log exceptions

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -28,8 +28,10 @@ class Logger {
     /**
      * Don't allow usage of this class outside a static context
      */
-    private function __construct() { }
-    private function __clone() { }
+    private function __construct() {
+    }
+    private function __clone() {
+    }
 
 
     /**

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -43,8 +43,6 @@
         <exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
         <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
         <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
-        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore" />
-        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent" />
 
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall" />
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant" />

--- a/site/tests/utils/NullOutput.php
+++ b/site/tests/utils/NullOutput.php
@@ -37,9 +37,11 @@ class NullOutput extends Output {
         $this->renderTwigTemplate($filename, $context);
     }
 
-    protected function renderHeader() {}
+    protected function renderHeader() {
+    }
 
-    protected function renderFooter() {}
+    protected function renderFooter() {
+    }
 
     public function bufferOutput() {
         return $this->buffer_output;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes the `Squiz.WhiteSpace.ScopeClosingBrace` which covers the following bit from PSR-12:
* The structure body MUST be indented once
* The body MUST be on the next line after the opening brace
* The closing brace MUST be on the next line after the body