### PR TITLE
[Refactor:PHP] Fix all remaining control structure style errors

### DIFF
--- a/site/app/authentication/PamAuthentication.php
+++ b/site/app/authentication/PamAuthentication.php
@@ -20,8 +20,11 @@ use app\exceptions\CurlException;
 class PamAuthentication extends AbstractAuthentication {
     public function authenticate() {
         // Check for $this->user_id and $this->>password to be non empty
-        if (empty($this->user_id) || empty($this->password) ||
-            $this->core->getQueries()->getSubmittyUser($this->user_id) === null) {
+        if (
+            empty($this->user_id)
+            || empty($this->password)
+            || $this->core->getQueries()->getSubmittyUser($this->user_id) === null
+        ) {
             return false;
         }
 

--- a/site/app/controllers/AbstractController.php
+++ b/site/app/controllers/AbstractController.php
@@ -199,7 +199,8 @@ abstract class AbstractController {
                 }
                 return false;
             }
-        } else {
+        }
+        else {
             $version_instance = $auto_graded_gradeable->getActiveVersionInstance();
             if ($version_instance === null) {
                 if ($render_json) {
@@ -250,14 +251,14 @@ abstract class AbstractController {
      * @return \app\models\GradeableAutocheck|bool false in the fail/error case
      */
     protected function tryGetAutocheck(AutoGradedTestcase $testcase, string $autocheck_index, bool $render_json = true) {
-        if($autocheck_index === '') {
-            if($render_json) {
+        if ($autocheck_index === '') {
+            if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('Must provide an autocheck index parameter');
             }
             return false;
         }
         if (!ctype_digit($autocheck_index)) {
-            if($render_json) {
+            if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('autocheck index parameter must be a non-negative integer');
             }
             return false;
@@ -265,8 +266,8 @@ abstract class AbstractController {
         $autocheck_index = intval($autocheck_index);
         try {
             return $testcase->getAutocheck($autocheck_index);
-        } catch (\InvalidArgumentException $e){
-            if($render_json) {
+        } catch (\InvalidArgumentException $e) {
+            if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('Invalid autocheck index parameter');
             }
             return false;

--- a/site/app/controllers/AbstractController.php
+++ b/site/app/controllers/AbstractController.php
@@ -46,11 +46,13 @@ abstract class AbstractController {
         // Get the gradeable
         try {
             return $this->core->getQueries()->getGradeableConfig($gradeable_id);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('Invalid gradeable_id parameter');
             }
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonError('Failed to load gradeable');
             }
@@ -81,7 +83,8 @@ abstract class AbstractController {
         $component_id = intval($component_id);
         try {
             return $gradeable->getComponent($component_id);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('Invalid component_id for this gradeable');
             }
@@ -112,7 +115,8 @@ abstract class AbstractController {
         $mark_id = intval($mark_id);
         try {
             return $component->getMark($mark_id);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('Invalid mark_id for this component');
             }
@@ -143,7 +147,8 @@ abstract class AbstractController {
                 return false;
             }
             return $submitter_id;
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonError('Error getting user id from anon_id parameter');
             }
@@ -174,7 +179,8 @@ abstract class AbstractController {
                 return false;
             }
             return $graded_gradeable;
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonError('Failed to load Gradeable grade');
             }
@@ -266,7 +272,8 @@ abstract class AbstractController {
         $autocheck_index = intval($autocheck_index);
         try {
             return $testcase->getAutocheck($autocheck_index);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             if ($render_json) {
                 $this->core->getOutput()->renderJsonFail('Invalid autocheck index parameter');
             }

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -51,7 +51,7 @@ class AuthenticationController extends AbstractController {
 
         Utils::setCookie('submitty_session', '', time() - 3600);
         // Remove all history for checkpoint gradeables
-        foreach(array_keys($_COOKIE) as $cookie) {
+        foreach (array_keys($_COOKIE) as $cookie) {
             if (strpos($cookie, "_history") == strlen($cookie) - 8) { // '_history' is len 8
                 Utils::setCookie($cookie, '', time() - 3600);
             }
@@ -190,8 +190,13 @@ class AuthenticationController extends AbstractController {
      * @return Response
      */
     public function vcsLogin() {
-        if (empty($_POST['user_id']) || empty($_POST['password']) || empty($_POST['gradeable_id'])
-            || empty($_POST['id']) || !$this->core->getConfig()->isCourseLoaded()) {
+        if (
+            empty($_POST['user_id'])
+            || empty($_POST['password'])
+            || empty($_POST['gradeable_id'])
+            || empty($_POST['id'])
+            || !$this->core->getConfig()->isCourseLoaded()
+        ) {
             $msg = 'Missing value for one of the fields';
             return Response::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
         }

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -214,7 +214,8 @@ class GlobalController extends AbstractController {
                         "id" => "nav-sidebar-photos",
                         "icon" => "fa-id-card"
                     ]);
-                } elseif (count($any_images_files) !== 0 && $this->core->getUser()->accessGrading()) {
+                }
+                elseif (count($any_images_files) !== 0 && $this->core->getUser()->accessGrading()) {
                     $sections = $this->core->getUser()->getGradingRegistrationSections();
                     if (!empty($sections) || $this->core->getUser()->getGroup() !== User::GROUP_LIMITED_ACCESS_GRADER) {
                         $at_least_one_grader_link = true;
@@ -345,7 +346,7 @@ class GlobalController extends AbstractController {
         $day = $now['mday'];
 
         $duck_img = 'moorthy_duck.png';
-        if($month === 10 && ($day >= 27 && $day <= 31)){
+        if ($month === 10 && ($day >= 27 && $day <= 31)) {
             //halloween
             $duck_img = 'moorthy_halloween.png';
         }

--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -33,8 +33,11 @@ class HomePageController extends AbstractController {
      */
     public function changePassword() {
         $user = $this->core->getUser();
-        if(!empty($_POST['new_password']) && !empty($_POST['confirm_new_password'])
-            && $_POST['new_password'] == $_POST['confirm_new_password']) {
+        if (
+            !empty($_POST['new_password'])
+            && !empty($_POST['confirm_new_password'])
+            && $_POST['new_password'] == $_POST['confirm_new_password']
+        ) {
             $user->setPassword($_POST['new_password']);
             $this->core->getQueries()->updateUser($user);
             $this->core->addSuccessMessage("Updated password");
@@ -53,7 +56,7 @@ class HomePageController extends AbstractController {
      */
     public function changeUserName() {
         $user = $this->core->getUser();
-        if(isset($_POST['user_firstname_change']) && isset($_POST['user_lastname_change'])) {
+        if (isset($_POST['user_firstname_change']) && isset($_POST['user_lastname_change'])) {
             $newFirstName = trim($_POST['user_firstname_change']);
             $newLastName = trim($_POST['user_lastname_change']);
             // validateUserData() checks both for length (not to exceed 30) and for valid characters.
@@ -163,9 +166,11 @@ class HomePageController extends AbstractController {
             );
         }
 
-        if (!isset($_POST['course_semester']) ||
-            !isset($_POST['course_title']) ||
-            !isset($_POST['head_instructor'])) {
+        if (
+            !isset($_POST['course_semester'])
+            || !isset($_POST['course_title'])
+            || !isset($_POST['head_instructor'])
+        ) {
             $error = "Semester, course title or head instructor not set.";
             $this->core->addErrorMessage($error);
             return new Response(

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -481,7 +481,8 @@ class MiscController extends AbstractController {
             }
             $result = ['found' => $found, 'job_data' => $result, 'count' => $complete_count];
             return $this->core->getOutput()->renderJsonSuccess($result);
-        }catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             return $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -79,7 +79,8 @@ class MiscController extends AbstractController {
                 $this->core->getOutput()->showError("You do not have access to this file");
                 return false;
             }
-        } else {
+        }
+        else {
             // Check access through Access library
             if (!$this->core->getAccess()->canI("path.read", ["dir" => $dir, "path" => $path])) {
                 $this->core->getOutput()->showError("You do not have access to this file");
@@ -87,17 +88,14 @@ class MiscController extends AbstractController {
             }
 
             // If attempting to obtain course materials
-            if($dir == 'course_materials')
-            {
+            if ($dir == 'course_materials') {
                 // If the user attempting to access the file is not at least a grader then ensure the file has been released
-                if(!$this->core->getUser()->accessGrading() && !CourseMaterial::isMaterialReleased($this->core, $path))
-                {
+                if (!$this->core->getUser()->accessGrading() && !CourseMaterial::isMaterialReleased($this->core, $path)) {
                     $this->core->getOutput()->showError("You may not access this file until it is released.");
                     return false;
                 }
 
-                if(!$this->core->getUser()->accessGrading() && !CourseMaterial::isSectionAllowed($this->core, $path, $this->core->getUser()))
-                {
+                if (!$this->core->getUser()->accessGrading() && !CourseMaterial::isSectionAllowed($this->core, $path, $this->core->getUser())) {
                     $this->core->getOutput()->showError("Your section may not access this file.");
                     return false;
                 }
@@ -185,8 +183,10 @@ class MiscController extends AbstractController {
 
         if ($dir == 'submissions') {
             //cannot download scanned images for bulk uploads
-            if (strpos(basename($path), "upload_page_") !== false &&
-                FileUtils::getContentType($path) !== "application/pdf") {
+            if (
+                strpos(basename($path), "upload_page_") !== false
+                && FileUtils::getContentType($path) !== "application/pdf"
+            ) {
                 $this->core->getOutput()->showError("You do not have access to this file");
                 return false;
             }
@@ -239,7 +239,7 @@ class MiscController extends AbstractController {
         // Context of these next two checks is important
         // If the request is coming from the submissions page, then the results and results_public folder
         // should not be included, otherwise include them
-        if($origin != 'submission') {
+        if ($origin != 'submission') {
             if ($this->core->getAccess()->canI("path.read.results", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
                 $folder_names[] = "results";
             }
@@ -279,20 +279,21 @@ class MiscController extends AbstractController {
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 );
                 $zip -> addEmptyDir($folder_names[$x]);
-                foreach ($files as $name => $file)
-                {
+                foreach ($files as $name => $file) {
                     // Skip directories (they would be added automatically)
-                    if (!$file->isDir())
-                    {
+                    if (!$file->isDir()) {
                         // Get real and relative path for current file
                         $filePath = $file->getRealPath();
                         $relativePath = substr($filePath, strlen($paths[$x]) + 1);
 
-                        if($this->core->getUser()->accessGrading()){
+                        if ($this->core->getUser()->accessGrading()) {
                             // Add current file to archive
                             $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
-                        }elseif ($gradeable->isScannedExam()
-                                  && FileUtils::getContentType($filePath) === "application/pdf"){
+                        }
+                        elseif (
+                            $gradeable->isScannedExam()
+                            && FileUtils::getContentType($filePath) === "application/pdf"
+                        ) {
                             //If the user is a student, only get PDFs if this is a bulk upload gradeable
                             // Add current file to archive
                             $zip->addFile($filePath, $folder_names[$x] . "/" . $relativePath);
@@ -320,7 +321,7 @@ class MiscController extends AbstractController {
         $zip_file_name = $gradeable_id . "_section_students_" . date("m-d-Y") . ".zip";
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
-        if($type === "all") {
+        if ($type === "all") {
             $zip_file_name = $gradeable_id . "_all_students_" . date("m-d-Y") . ".zip";
             if (!($this->core->getUser()->accessFullGrading())) {
                 $message = "You do not have access to that page.";
@@ -328,8 +329,7 @@ class MiscController extends AbstractController {
                 $this->core->redirect($this->core->buildCourseUrl());
             }
         }
-        else
-        {
+        else {
             $type = "";
         }
 
@@ -354,7 +354,7 @@ class MiscController extends AbstractController {
                 $path,
                 $gradeable->getId()
             );
-            if($type === "all") {
+            if ($type === "all") {
                 $zip->addEmptyDir($path);
                 if (file_exists($gradeable_path)) {
                     if (!is_dir($gradeable_path)) { //if dir is already present, but it's a file
@@ -362,16 +362,14 @@ class MiscController extends AbstractController {
                         $this->core->addErrorMessage($message);
                         $this->core->redirect($this->core->buildCourseUrl());
                     }
-                    else{
+                    else {
                         $files = new \RecursiveIteratorIterator(
                             new \RecursiveDirectoryIterator($gradeable_path),
                             \RecursiveIteratorIterator::LEAVES_ONLY
                         );
-                        foreach ($files as $name => $file)
-                        {
+                        foreach ($files as $name => $file) {
                             // Skip directories (they would be added automatically)
-                            if (!$file->isDir())
-                            {
+                            if (!$file->isDir()) {
                                 // Get real and relative path for current file
                                 $filePath = $file->getRealPath();
                                 $relativePath = substr($filePath, strlen($gradeable_path) + 1);
@@ -380,12 +378,14 @@ class MiscController extends AbstractController {
                             }
                         }
                     }
-                } else { //no dir exists with this name
+                }
+                else { //no dir exists with this name
                     $message = "Oops! That page is not available.";
                     $this->core->addErrorMessage($message);
                     $this->core->redirect($this->core->buildCourseUrl());
                 }
-            } else {
+            }
+            else {
                 //gets the students that are part of the sections
                 if ($gradeable->isGradeByRegistration()) {
                     $section_key = "registration_section";
@@ -401,12 +401,12 @@ class MiscController extends AbstractController {
                     $students = $this->core->getQueries()->getUsersByRotatingSections($sections);
                 }
                 $students_array = array();
-                foreach($students as $student) {
+                foreach ($students as $student) {
                     $students_array[] = $student->getId();
                 }
                 $files = scandir($gradeable_path);
                 $arr_length = count($students_array);
-                foreach($files as $file) {
+                foreach ($files as $file) {
                     for ($x = 0; $x < $arr_length; $x++) {
                         if ($students_array[$x] === $file) {
                             $temp_path = $gradeable_path . "/" . $file;
@@ -418,11 +418,9 @@ class MiscController extends AbstractController {
                             //makes a new directory in the zip to add the files in
                             $zip -> addEmptyDir($file);
 
-                            foreach ($files_in_folder as $name => $file_in_folder)
-                            {
+                            foreach ($files_in_folder as $name => $file_in_folder) {
                                 // Skip directories (they would be added automatically)
-                                if (!$file_in_folder->isDir())
-                                {
+                                if (!$file_in_folder->isDir()) {
                                     // Get real and relative path for current file
                                     $filePath = $file_in_folder->getRealPath();
                                     $relativePath = substr($filePath, strlen($temp_path) + 1);
@@ -456,11 +454,12 @@ class MiscController extends AbstractController {
         $found = false;
         $job_data = null;
         $complete_count = 0;
-        try{
-            foreach(scandir($job_path) as $job){
-                if(strpos($job, 'bulk_upload_') !== false) {
+        try {
+            foreach (scandir($job_path) as $job) {
+                if (strpos($job, 'bulk_upload_') !== false) {
                     $found = true;
-                } else {
+                }
+                else {
                     continue;
                 }
                 //remove 'bulk_upload_' and '.json' from job file name
@@ -471,18 +470,18 @@ class MiscController extends AbstractController {
             $sub_dirs = array_filter(glob($split_uploads . '/*'), 'is_dir');
             foreach ($sub_dirs as $dir) {
                 foreach (scandir($dir) as $file) {
-                    if(pathinfo($file)['extension'] !== "pdf") {
+                    if (pathinfo($file)['extension'] !== "pdf") {
                         continue;
                     }
 
-                    if(strpos($file, "_cover")) {
+                    if (strpos($file, "_cover")) {
                         $complete_count++;
                     }
                 }
             }
             $result = ['found' => $found, 'job_data' => $result, 'count' => $complete_count];
             return $this->core->getOutput()->renderJsonSuccess($result);
-        }catch(\Exception $e){
+        }catch (\Exception $e) {
             return $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }

--- a/site/app/controllers/NavigationController.php
+++ b/site/app/controllers/NavigationController.php
@@ -34,7 +34,7 @@ class NavigationController extends AbstractController {
         $closed_gradeables_list = $gradeables_list->getClosedGradeables();
         $grading_gradeables_list = $gradeables_list->getGradingGradeables();
         $graded_gradeables_list = $gradeables_list->getGradedGradeables();
-        
+
         $sections_to_lists = [];
 
         $user = $this->core->getUser();
@@ -65,8 +65,8 @@ class NavigationController extends AbstractController {
         // Get a single array of the visible gradeables
         $visible_gradeables = [];
         $submit_everyone = [];
-        foreach($sections_to_lists as $gradeables) {
-            foreach($gradeables as $gradeable) {
+        foreach ($sections_to_lists as $gradeables) {
+            foreach ($gradeables as $gradeable) {
                 $visible_gradeables[] = $gradeable;
                 $submit_everyone[$gradeable->getId()] =
                     $this->core->getAccess()->canI('gradeable.submit.everyone', ['gradeable' => $gradeable]);
@@ -95,8 +95,11 @@ class NavigationController extends AbstractController {
         $user = $this->core->getUser();
 
         //Remove incomplete gradeables for non-instructors
-        if (!$user->accessAdmin() && $gradeable->getType() == GradeableType::ELECTRONIC_FILE &&
-            !$gradeable->hasAutogradingConfig()) {
+        if (
+            !$user->accessAdmin()
+            && $gradeable->getType() == GradeableType::ELECTRONIC_FILE
+            && !$gradeable->hasAutogradingConfig()
+        ) {
             return false;
         }
 

--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -135,7 +135,7 @@ class NotificationController extends AbstractController {
 
         if ($this->validateNotificationSettings(array_keys($new_settings))) {
             $values_not_sent = array_diff($this->selections, array_keys($new_settings));
-            foreach(array_values($values_not_sent) as $value) {
+            foreach (array_values($values_not_sent) as $value) {
                 $new_settings[$value] = 'false';
             }
             $this->core->getQueries()->updateNotificationSettings($new_settings);

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -27,12 +27,12 @@ class OfficeHoursQueueController extends AbstractController {
     * @return Response
     */
     public function showQueue() {
-        if(!$this->core->getConfig()->isQueueEnabled()){
+        if (!$this->core->getConfig()->isQueueEnabled()) {
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['home']))
             );
         }
-        if(!$this->core->getUser()->accessGrading()){
+        if (!$this->core->getUser()->accessGrading()) {
             $oh_queue = $this->core->getQueries()->getQueueByUser($this->core->getUser()->getId());
             return Response::WebOnlyResponse(
                 new WebResponse(
@@ -42,7 +42,8 @@ class OfficeHoursQueueController extends AbstractController {
                     $this->core->getConfig()->getCourse()
                 )
             );
-        }else{
+        }
+        else {
             $oh_queue = $this->core->getQueries()->getInstructorQueue();
             return Response::WebOnlyResponse(
                 new WebResponse(
@@ -60,31 +61,36 @@ class OfficeHoursQueueController extends AbstractController {
     * @return Response
     */
     public function addPerson() {
-        if(!isset($_POST['code']) || !isset($_POST['name'])){
+        if (!isset($_POST['code']) || !isset($_POST['name'])) {
             $this->core->addErrorMessage("Missing name or code in request");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
             );
         }
         $section_id = $this->core->getQueries()->isValidCode($_POST['code']);
-        if($_POST['name'] !== "" && !is_null($section_id) && $this->core->getQueries()->isQueueOpen()){
+        if ($_POST['name'] !== "" && !is_null($section_id) && $this->core->getQueries()->isQueueOpen()) {
             //Add the user to the database
             $oh_queue = $this->core->getQueries()->getQueueByUser($this->core->getUser()->getId());
-            if(!$oh_queue->isInQueue()){
-                if($this->core->getQueries()->addUserToQueue($this->core->getUser()->getId(), $_POST['name'])){
+            if (!$oh_queue->isInQueue()) {
+                if ($this->core->getQueries()->addUserToQueue($this->core->getUser()->getId(), $_POST['name'])) {
                     $this->core->addSuccessMessage("Added to queue");
-                }else{
+                }
+                else {
                     $this->core->addErrorMessage("Unable to add to queue");
                 }
-            }else{
+            }
+            else {
                 $this->core->addErrorMessage("You are already in the queue");
             }
-        }else{
-            if($_POST['name'] == ""){
+        }
+        else {
+            if ($_POST['name'] == "") {
                 $this->core->addErrorMessage("Invalid Name");
-            }elseif(is_null($section_id)){
+            }
+            elseif (is_null($section_id)) {
                 $this->core->addErrorMessage("Invalid Code");
-            }elseif(!$this->core->getQueries()->isQueueOpen()){
+            }
+            elseif (!$this->core->getQueries()->isQueueOpen()) {
                 $this->core->addErrorMessage("Queue is closed");
             }
         }
@@ -100,7 +106,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @return Response
     */
     public function startHelpPerson() {
-        if(!isset($_POST['entry_id'])){
+        if (!isset($_POST['entry_id'])) {
             $this->core->addErrorMessage("Missing entry ID");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
@@ -119,7 +125,7 @@ class OfficeHoursQueueController extends AbstractController {
     * @return Response
     */
     public function finishHelpPerson() {
-        if(!isset($_POST['entry_id'])){
+        if (!isset($_POST['entry_id'])) {
             $this->core->addErrorMessage("Missing entry ID");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
@@ -138,15 +144,16 @@ class OfficeHoursQueueController extends AbstractController {
     * @return Response
     */
     public function toggleQueue() {
-        if(!isset($_POST['queue_open'])){
+        if (!isset($_POST['queue_open'])) {
             $this->core->addErrorMessage("Missing queue status");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
             );
         }
-        if($_POST['queue_open'] == "Open Queue"){
+        if ($_POST['queue_open'] == "Open Queue") {
             $this->core->getQueries()->openQueue();
-        } else{
+        }
+        else {
             $this->core->getQueries()->closeQueue();
         }
         return Response::RedirectOnlyResponse(
@@ -173,13 +180,13 @@ class OfficeHoursQueueController extends AbstractController {
     * @return Response
     */
     public function removePerson() {
-        if(!isset($_POST['entry_id'])){
+        if (!isset($_POST['entry_id'])) {
             $this->core->addErrorMessage("Missing entry ID");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
             );
         }
-        if(!$this->core->getUser()->accessGrading() && $this->core->getUser()->getId() != $this->core->getQueries()->getUserIdFromQueueSlot($_POST['entry_id'])){
+        if (!$this->core->getUser()->accessGrading() && $this->core->getUser()->getId() != $this->core->getQueries()->getUserIdFromQueueSlot($_POST['entry_id'])) {
             $this->core->addErrorMessage("Permission denied to remove that person");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -26,7 +26,8 @@ class AdminGradeableController extends AbstractController {
         try {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
             $this->editPage($gradeable, $this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse(), intval($nav_tab));
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             // If the gradeable can't be found, redirect to new page
             $this->newPage();
         }
@@ -360,9 +361,11 @@ class AdminGradeableController extends AbstractController {
         try {
             $this->updateRubric($gradeable, $_POST['values']);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -443,7 +446,8 @@ class AdminGradeableController extends AbstractController {
         }
         try {
             $file_iter = new \RecursiveDirectoryIterator($folder_path, \RecursiveDirectoryIterator::SKIP_DOTS);
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             return false;
         }
         while ($file_iter->valid()) {
@@ -488,7 +492,8 @@ class AdminGradeableController extends AbstractController {
 
             try {
                 $iter = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 $error_messages[] = "An error occured when parsing repository #" . $repo_id_number . " entered on the \"Course Settings\" page";
                 return array();
             }
@@ -645,9 +650,11 @@ class AdminGradeableController extends AbstractController {
             $this->updateGraders($gradeable, $_POST);
             // Finally, send the requester back the information
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail('Error setting graders' . $e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -676,7 +683,8 @@ class AdminGradeableController extends AbstractController {
                 $this->core->addErrorMessage($build_result);
             }
             $this->redirectToEdit($gradeable_id);
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->addErrorMessage($e->getMessage());
             $this->core->redirect($this->core->buildCourseUrl());
         }
@@ -903,9 +911,11 @@ class AdminGradeableController extends AbstractController {
             $response_props = $this->updateGradeable($gradeable, $_POST);
             // Finally, send the requester back the information
             $this->core->getOutput()->renderJsonSuccess($response_props);
-        } catch (ValidationException $e) {
+        }
+        catch (ValidationException $e) {
             $this->core->getOutput()->renderJsonFail('See "data" for details', $e->getDetails());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1004,7 +1014,8 @@ class AdminGradeableController extends AbstractController {
                     explode('_', $prop))
                 );
                 $gradeable->$setter_name($post_val);
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 // If something goes wrong, record it so we can tell the user
                 $errors[$prop] = $e->getMessage();
             }
@@ -1015,7 +1026,8 @@ class AdminGradeableController extends AbstractController {
             try {
                 $gradeable->setDates($dates);
                 $updated_properties = $gradeable->getDateStrings(false);
-            } catch (ValidationException $e) {
+            }
+            catch (ValidationException $e) {
                 $errors = array_merge($errors, $e->getDetails());
             }
         }
@@ -1319,7 +1331,8 @@ class AdminGradeableController extends AbstractController {
         try {
             $arrs = $gradeable->exportComponents();
             $this->core->getOutput()->renderFile(json_encode($arrs, JSON_PRETTY_PRINT), $gradeable->getId() . '_components.json');
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->addErrorMessage($e->getMessage());
             $this->core->redirect($url);
         }
@@ -1354,9 +1367,11 @@ class AdminGradeableController extends AbstractController {
             // Save to the database
             $this->core->getQueries()->updateGradeable($gradeable);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -26,7 +26,7 @@ class AdminGradeableController extends AbstractController {
         try {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
             $this->editPage($gradeable, $this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse(), intval($nav_tab));
-        } catch(\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             // If the gradeable can't be found, redirect to new page
             $this->newPage();
         }
@@ -164,17 +164,21 @@ class AdminGradeableController extends AbstractController {
         });
 
         $type_string = 'UNKNOWN';
-        if($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
-            if($gradeable->isScannedExam()) {
+        if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
+            if ($gradeable->isScannedExam()) {
                 $type_string = self::gradeable_type_strings['electronic_exam'];
-            } elseif($gradeable->isVcs()) {
+            }
+            elseif ($gradeable->isVcs()) {
                 $type_string = self::gradeable_type_strings['electronic_hw_vcs'];
-            } else {
+            }
+            else {
                 $type_string = self::gradeable_type_strings['electronic_hw'];
             }
-        } elseif($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        }
+        elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             $type_string = self::gradeable_type_strings['numeric'];
-        } elseif($gradeable->getType() === GradeableType::CHECKPOINTS) {
+        }
+        elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
             $type_string = self::gradeable_type_strings['checkpoint'];
         }
 
@@ -267,7 +271,8 @@ class AdminGradeableController extends AbstractController {
                     // Need to remove non-student users, or users in the NULL section
                     if ($user->getRegistrationSection() == null) {
                         unset($users[$key]);
-                    } else {
+                    }
+                    else {
                         $user_ids[] = $user->getId();
                         $grading[$user->getId()] = array();
                     }
@@ -325,14 +330,17 @@ class AdminGradeableController extends AbstractController {
             $mark0 = $this->newMark($component);
             $mark0->setTitle('No Credit');
             $component->setMarks([$mark0]);
-        } elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
+        }
+        elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
             $component->setTitle('Checkpoint 1');
             $component->setPoints(['lower_clamp' => 0, 'default' => 0, 'max_value' => 1, 'upper_clamp' => 1]);
-        } elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        }
+        elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             // Add a new mark to the db if its electronic
             $mark = $this->newMark($component);
             $component->setMarks([$mark]);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Gradeable type invalid');
         }
 
@@ -438,7 +446,7 @@ class AdminGradeableController extends AbstractController {
         } catch (\Exception $e) {
             return false;
         }
-        while($file_iter->valid()) {
+        while ($file_iter->valid()) {
             if ($file_iter->current()->getFilename() == 'config.json') {
                 return true;
             }
@@ -463,7 +471,7 @@ class AdminGradeableController extends AbstractController {
         $count = 0;
         $return_array = array();
 
-        while(count($dir_queue) != 0) {
+        while (count($dir_queue) != 0) {
             if ($count >= 1000) {
                 $error_messages[] = "Repository #" . $repo_id_number . " entered on the \"Course Settings\" is too large to parse.";
                 return array();
@@ -480,7 +488,7 @@ class AdminGradeableController extends AbstractController {
 
             try {
                 $iter = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
-            } catch(\Exception $e) {
+            } catch (\Exception $e) {
                 $error_messages[] = "An error occured when parsing repository #" . $repo_id_number . " entered on the \"Course Settings\" page";
                 return array();
             }
@@ -489,7 +497,7 @@ class AdminGradeableController extends AbstractController {
                 $return_array[] = ["DIRECTORY " . $repo_id_number . ": " . substr($dir, strlen($repository_path)),$dir];
             }
             else {
-                while($iter->valid()) {
+                while ($iter->valid()) {
                     $file = $iter->current();
                     if ($file->isDir()) {
                         $dir_queue[] = $file->getPathname();
@@ -514,7 +522,8 @@ class AdminGradeableController extends AbstractController {
         //  with a unified interface with TA grading and share a separate "rubric" controller for it.
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             throw new \InvalidArgumentException('Attempt to update rubric using outdated method!');
-        } elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
+        }
+        elseif ($gradeable->getType() === GradeableType::CHECKPOINTS) {
             if (!isset($details['checkpoints'])) {
                 $details['checkpoints'] = [];
             }
@@ -540,7 +549,8 @@ class AdminGradeableController extends AbstractController {
                 $component->setOrder($x);
                 $new_components[] = $component;
             }
-        } elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        }
+        elseif ($gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             if (!isset($details['numeric'])) {
                 $details['numeric'] = [];
             }
@@ -563,7 +573,8 @@ class AdminGradeableController extends AbstractController {
                 if ($old_component->isText() === true) {
                     $old_texts[] = $old_component;
                     $num_old_texts++;
-                } else {
+                }
+                else {
                     $old_numerics[] = $old_component;
                     $num_old_numerics++;
                 }
@@ -609,7 +620,8 @@ class AdminGradeableController extends AbstractController {
                 $component->setOrder($y + $z);
                 $new_components[] = $component;
             }
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException("Invalid gradeable type");
         }
 
@@ -711,7 +723,8 @@ class AdminGradeableController extends AbstractController {
             foreach ($template_property_names as $name) {
                 $gradeable_create_data[$name] = $template_data[$name];
             }
-        } else {
+        }
+        else {
             $non_template_property_values = [
                 'min_grading_group' => 1,
                 'grader_assignment_method' => Gradeable::REGISTRATION_SECTION,
@@ -771,7 +784,8 @@ class AdminGradeableController extends AbstractController {
                 'vcs_host_type' => $host_type
             ];
             $gradeable_create_data = array_merge($gradeable_create_data, $vcs_property_values);
-        } else {
+        }
+        else {
             $non_vcs_property_values = [
                 'vcs' => false,
                 'vcs_subdirectory' => '',
@@ -786,10 +800,10 @@ class AdminGradeableController extends AbstractController {
             $discussion_clicked = isset($details['discussion_based']) && ($details['discussion_based'] === 'true');
 
             //Validate user input for discussion threads
-            if($discussion_clicked) {
+            if ($discussion_clicked) {
                 $jsonThreads = array_map('intval', explode(',', $details['discussion_thread_id']));
-                foreach($jsonThreads as $thread) {
-                    if(!$this->core->getQueries()->existsThread($thread)) {
+                foreach ($jsonThreads as $thread) {
+                    if (!$this->core->getQueries()->existsThread($thread)) {
                         throw new \InvalidArgumentException('Invalid thread id specified.');
                     }
                 }
@@ -816,7 +830,8 @@ class AdminGradeableController extends AbstractController {
                 'peer_grade_set' => 0,
                 'late_submission_allowed' => true
             ]);
-        } else {
+        }
+        else {
             // Values for these electronic-only properties
             $gradeable_create_data = array_merge($gradeable_create_data, [
                 'team_assignment' => false,
@@ -962,17 +977,18 @@ class AdminGradeableController extends AbstractController {
             }
 
             // Converts string array sep by ',' to json
-            if($prop === $discussion_ids) {
+            if ($prop === $discussion_ids) {
                 $post_val = array_map('intval', explode(',', $post_val));
-                foreach($post_val as $thread) {
-                    if(!$this->core->getQueries()->existsThread($thread)) {
+                foreach ($post_val as $thread) {
+                    if (!$this->core->getQueries()->existsThread($thread)) {
                         $errors[$prop] = 'Invalid thread id specified.';
                         break;
                     }
                 }
-                if(count($errors) == 0) {
+                if (count($errors) == 0) {
                     $post_val = json_encode($post_val);
-                } else {
+                }
+                else {
                     continue;
                 }
             }
@@ -1016,7 +1032,7 @@ class AdminGradeableController extends AbstractController {
         }
 
         // Be strict.  Only apply database changes if there were no errors
-        if(count($errors) !== 0) {
+        if (count($errors) !== 0) {
             throw new ValidationException('', $errors);
         }
         $this->core->getQueries()->updateGradeable($gradeable);
@@ -1071,8 +1087,10 @@ class AdminGradeableController extends AbstractController {
         ];
 
         $fp = $this->core->getConfig()->getCoursePath() . '/config/form/form_' . $gradeable->getId() . '.json';
-        if ((!is_writable($fp) && file_exists($fp))
-            || file_put_contents($fp, json_encode($jsonProperties, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) === false) {
+        if (
+            (!is_writable($fp) && file_exists($fp))
+            || file_put_contents($fp, json_encode($jsonProperties, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) === false
+        ) {
             return "Failed to write to file {$fp}";
         }
         return null;
@@ -1092,8 +1110,10 @@ class AdminGradeableController extends AbstractController {
             "gradeable" => $g_id
         ];
 
-        if ((!is_writable($config_build_file) && file_exists($config_build_file))
-            || file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false) {
+        if (
+            (!is_writable($config_build_file) && file_exists($config_build_file))
+            || file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false
+        ) {
             return "Failed to write to file {$config_build_file}";
         }
         return null;
@@ -1110,8 +1130,10 @@ class AdminGradeableController extends AbstractController {
             "gradeable" => $g_id
         ];
 
-        if ((!is_writable($config_build_file) && file_exists($config_build_file))
-            || file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false) {
+        if (
+            (!is_writable($config_build_file) && file_exists($config_build_file))
+            || file_put_contents($config_build_file, json_encode($config_build_data, JSON_PRETTY_PRINT)) === false
+        ) {
             return "Failed to write to file {$config_build_file}";
         }
         return null;
@@ -1204,43 +1226,52 @@ class AdminGradeableController extends AbstractController {
                 $this->shiftDates($dates, 'grade_released_date', $now);
                 $message .= "Released grades for ";
                 $success = true;
-            } else {
+            }
+            else {
                 $message .= "Grades already released for";
                 $success = false;
             }
-        } elseif ($action === "open_ta_now") {
+        }
+        elseif ($action === "open_ta_now") {
             if ($dates['ta_view_start_date'] > $now) {
                 $this->shiftDates($dates, 'ta_view_start_date', $now);
                 $message .= "Opened TA access to ";
                 $success = true;
-            } else {
+            }
+            else {
                 $message .= "TA access already open for ";
                 $success = false;
             }
-        } elseif ($action === "open_grading_now") {
+        }
+        elseif ($action === "open_grading_now") {
             if ($dates['grade_start_date'] > $now) {
                 $this->shiftDates($dates, 'grade_start_date', $now);
                 $message .= "Opened grading for ";
                 $success = true;
-            } else {
+            }
+            else {
                 $message .= "Grading already open for ";
                 $success = false;
             }
-        } elseif ($action === "open_students_now") {
+        }
+        elseif ($action === "open_students_now") {
             if ($dates['submission_open_date'] > $now) {
                 $this->shiftDates($dates, 'submission_open_date', $now);
                 $message .= "Opened student access to ";
                 $success = true;
-            } else {
+            }
+            else {
                 $message .= "Student access already open for ";
                 $success = false;
             }
-        } elseif ($action === "close_submissions") {
+        }
+        elseif ($action === "close_submissions") {
             if ($dates['submission_due_date'] > $now) {
                 $this->shiftDates($dates, 'submission_due_date', $now);
                 $message .= "Closed assignment ";
                 $success = true;
-            } else {
+            }
+            else {
                 $message .= "Grading already closed for ";
                 $success = false;
             }
@@ -1249,9 +1280,11 @@ class AdminGradeableController extends AbstractController {
         $this->core->getQueries()->updateGradeable($gradeable);
         if ($success === true) {
             $this->core->addSuccessMessage($message . $gradeable_id);
-        } elseif ($success === false) {
+        }
+        elseif ($success === false) {
             $this->core->addErrorMessage($message . $gradeable_id);
-        } else {
+        }
+        else {
             $this->core->addErrorMessage("Failed to update status of " . $gradeable_id);
         }
 

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -25,13 +25,13 @@ class AutogradingConfigController extends AbstractController {
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
         $all_files = FileUtils::getAllFiles($target_dir);
         $all_paths = array();
-        foreach($all_files as $file){
+        foreach ($all_files as $file) {
             $all_paths[] = $file['path'];
         }
         $inuse_config = array();
-        foreach($this->core->getQueries()->getGradeableConfigs(null) as $gradeable){
-            foreach($all_paths as $path){
-                if($gradeable->getAutogradingConfigPath() === $path){
+        foreach ($this->core->getQueries()->getGradeableConfigs(null) as $gradeable) {
+            foreach ($all_paths as $path) {
+                if ($gradeable->getAutogradingConfigPath() === $path) {
                     $inuse_config[] = $path;
                 }
             }
@@ -70,7 +70,7 @@ class AutogradingConfigController extends AbstractController {
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
         $counter = count(scandir($target_dir)) - 1;
         $try_dir = FileUtils::joinPaths($target_dir, $counter);
-        while(is_dir($try_dir)){
+        while (is_dir($try_dir)) {
             $counter++;
             $try_dir = FileUtils::joinPaths($target_dir, $counter);
         }
@@ -114,11 +114,13 @@ class AutogradingConfigController extends AbstractController {
      */
     public function renameConfig() {
         $config_file_path = $_POST['curr_config_name'] ?? null;
-        if($config_file_path == null){
+        if ($config_file_path == null) {
             $this->core->addErrorMessage("Unable to find file");
-        } elseif (strpos($config_file_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
+        }
+        elseif (strpos($config_file_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false) {
             $this->core->addErrorMessage("This action can't be completed.");
-        } else {
+        }
+        else {
             $new_name = $_POST['new_config_name'] ?? "";
             if ($new_name === "") {
                 $this->core->addErrorMessage("Could not rename upload because no name was entered.");
@@ -128,9 +130,10 @@ class AutogradingConfigController extends AbstractController {
             }
             else {
                 $new_dir = FileUtils::joinPaths(dirname($config_file_path, 1), $new_name);
-                if(rename($config_file_path, $new_dir)){
+                if (rename($config_file_path, $new_dir)) {
                     $this->core->addSuccessMessage("Successfully renamed file");
-                } else {
+                }
+                else {
                     $this->core->addErrorMessage("Directory already exist, please choose another name.");
                 }
             }
@@ -147,22 +150,26 @@ class AutogradingConfigController extends AbstractController {
     public function deleteConfig() {
         $config_path = $_POST['config_path'] ?? null;
         $in_use = false;
-        foreach($this->core->getQueries()->getGradeableConfigs(null) as $gradeable){
-            if($gradeable->getAutogradingConfigPath() === $config_path){
+        foreach ($this->core->getQueries()->getGradeableConfigs(null) as $gradeable) {
+            if ($gradeable->getAutogradingConfigPath() === $config_path) {
                 $in_use = true;
                 break;
             }
         }
         if ($config_path == null) {
             $this->core->addErrorMessage("Selecting config failed.");
-        } elseif (strpos($config_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false){
+        }
+        elseif (strpos($config_path, FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload")) === false) {
             $this->core->addErrorMessage("This action can't be completed.");
-        } elseif ($in_use){
+        }
+        elseif ($in_use) {
             $this->core->addErrorMessage("This config is currently in use.");
-        } else {
-            if(FileUtils::recursiveRmdir($config_path)){
+        }
+        else {
+            if (FileUtils::recursiveRmdir($config_path)) {
                 $this->core->addSuccessMessage("The config folder has been succesfully deleted");
-            } else {
+            }
+            else {
                 $this->core->addErrorMessage("Deleting config failed.");
             }
         }

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -77,65 +77,77 @@ class ConfigurationController extends AbstractController {
      * @return Response
      */
     public function updateConfiguration(): Response {
-        if(!isset($_POST['name'])) {
+        if (!isset($_POST['name'])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Name of config value not provided')
             );
         }
         $name = $_POST['name'];
 
-        if(!isset($_POST['entry'])) {
+        if (!isset($_POST['entry'])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Name of config entry not provided')
             );
         }
         $entry = $_POST['entry'];
 
-        if($name === "room_seating_gradeable_id") {
+        if ($name === "room_seating_gradeable_id") {
             $gradeable_seating_options = $this->getGradeableSeatingOptions();
             $gradeable_ids = array();
-            foreach($gradeable_seating_options as $option) {
+            foreach ($gradeable_seating_options as $option) {
                 $gradeable_ids[] = $option['g_id'];
             }
-            if(!in_array($entry, $gradeable_ids)) {
+            if (!in_array($entry, $gradeable_ids)) {
                 return Response::JsonOnlyResponse(
                     JsonResponse::getFailResponse('Invalid gradeable chosen for seating')
                 );
             }
         }
-        elseif(in_array($name, array('default_hw_late_days', 'default_student_late_days'))) {
-            if(!ctype_digit($entry)) {
+        elseif (in_array($name, array('default_hw_late_days', 'default_student_late_days'))) {
+            if (!ctype_digit($entry)) {
                 return Response::JsonOnlyResponse(
                     JsonResponse::getFailResponse('Must enter a number for this field')
                 );
             }
             $entry = intval($entry);
         }
-        elseif(in_array($name, array('zero_rubric_grades', 'keep_previous_files', 'display_rainbow_grades_summary',
-                                      'display_custom_message', 'forum_enabled', 'regrade_enabled', 'seating_only_for_instructor'))) {
+        elseif (
+            in_array(
+                $name,
+                [
+                    'zero_rubric_grades',
+                    'keep_previous_files',
+                    'display_rainbow_grades_summary',
+                    'display_custom_message',
+                    'forum_enabled',
+                    'regrade_enabled',
+                    'seating_only_for_instructor'
+                ]
+            )
+        ) {
             $entry = $entry === "true" ? true : false;
-        }elseif($name === 'queue_enabled'){
+        }
+        elseif ($name === 'queue_enabled') {
             $entry = $entry === "true" ? true : false;
             $this->core->getQueries()->genQueueSettings();
         }
-        elseif($name === 'upload_message') {
+        elseif ($name === 'upload_message') {
             $entry = nl2br($entry);
         }
-        elseif($name == "course_home_url") {
-            if(!filter_var($entry, FILTER_VALIDATE_URL) && !empty($entry)){
+        elseif ($name == "course_home_url") {
+            if (!filter_var($entry, FILTER_VALIDATE_URL) && !empty($entry)) {
                 return Response::JsonOnlyResponse(
                     JsonResponse::getFailResponse($entry . ' is not a valid URL')
                 );
             }
         }
-        // Special validation for auto_rainbow_grades checkbox
-        elseif($name === 'auto_rainbow_grades') {
+        elseif ($name === 'auto_rainbow_grades') {
+            // Special validation for auto_rainbow_grades checkbox
             // Get a new customization json object
             $customization_json = new RainbowCustomizationJSON($this->core);
 
             // If a custom_customization.json does not exist, then check for the presence of a regular one
-            if(!$customization_json->doesCustomCustomizationExist())
-            {
+            if (!$customization_json->doesCustomCustomizationExist()) {
                 // Attempt to populate it from the customization.json in the course rainbow_grades directory
                 try {
                     $customization_json->loadFromJsonFile();
@@ -151,9 +163,9 @@ class ConfigurationController extends AbstractController {
             $entry = $entry === "true" ? true : false;
         }
 
-        if($name === 'forum_enabled') {
-            if($entry == 1){
-                if($this->core->getAccess()->canI("forum.modify_category")) {
+        if ($name === 'forum_enabled') {
+            if ($entry == 1) {
+                if ($this->core->getAccess()->canI("forum.modify_category")) {
                     $categories = ["General Questions", "Homework Help", "Quizzes" , "Tests"];
                     $rows = $this->core->getQueries()->getCategories();
 
@@ -167,7 +179,7 @@ class ConfigurationController extends AbstractController {
         }
 
         $config_ini = $this->core->getConfig()->getCourseJson();
-        if(!isset($config_ini['course_details'][$name])) {
+        if (!isset($config_ini['course_details'][$name])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Not a valid config name')
             );

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -149,10 +149,10 @@ class ConfigurationController extends AbstractController {
             // If a custom_customization.json does not exist, then check for the presence of a regular one
             if (!$customization_json->doesCustomCustomizationExist()) {
                 // Attempt to populate it from the customization.json in the course rainbow_grades directory
+                // If no file exists do not allow user to enable this check mark until one is supplied
                 try {
                     $customization_json->loadFromJsonFile();
                 }
-                // If no file exists do not allow user to enable this check mark until one is supplied
                 catch (\Exception $e) {
                     return Response::JsonOnlyResponse(
                         JsonResponse::getFailResponse(ConfigurationController::FAIL_AUTO_RG_MSG)

--- a/site/app/controllers/admin/EmailRoomSeatingController.php
+++ b/site/app/controllers/admin/EmailRoomSeatingController.php
@@ -63,13 +63,13 @@ Please email your instructor with any questions or concerns.';
 
         $class_list = $this->core->getQueries()->getEmailListWithIds();
 
-        foreach($class_list as $user) {
+        foreach ($class_list as $user) {
             $user_id = $user['user_id'];
 
             $room_seating_file = FileUtils::joinPaths($seating_assignments_path, "$user_id.json");
             $room_seating_json = FileUtils::readJsonFile($room_seating_file);
 
-            if($room_seating_json === false){
+            if ($room_seating_json === false) {
                 continue;
             }
 
@@ -100,7 +100,7 @@ Please email your instructor with any questions or concerns.';
             'seat' => 'exam_seat',
         ];
 
-        foreach($replaces as $key => $variable) {
+        foreach ($replaces as $key => $variable) {
             $message = str_replace('{$' . $variable . '}', $data[$key] ?? 'SEE INSTRUCTOR', $message);
         }
 

--- a/site/app/controllers/admin/GradeOverrideController.php
+++ b/site/app/controllers/admin/GradeOverrideController.php
@@ -27,7 +27,7 @@ class GradeOverrideController extends AbstractController {
     public function getOverriddenGrades($gradeable_id) {
         $users = $this->core->getQueries()->getUsersWithOverriddenGrades($gradeable_id);
         $user_table = array();
-        foreach($users as $user){
+        foreach ($users as $user) {
             $user_table[] = array('user_id' => $user->getId(),'user_firstname' => $user->getDisplayedFirstName(), 'user_lastname' => $user->getDisplayedLastName(), 'marks' => $user->getMarks(), 'comment' => $user->getComment());
         }
         return $this->core->getOutput()->renderJsonSuccess(array(

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -61,7 +61,7 @@ class LateController extends AbstractController {
                 );
             }
             else {
-                for ($i = 0; $i < count($data); $i++){
+                for ($i = 0; $i < count($data); $i++) {
                     $this->core->getQueries()->updateLateDays($data[$i][0], $data[$i][1], $data[$i][2], $csv_option);
                 }
                 $this->core->addSuccessMessage("Late days have been updated");
@@ -141,7 +141,7 @@ class LateController extends AbstractController {
                 );
             }
             else {
-                for ($i = 0; $i < count($data); $i++){
+                for ($i = 0; $i < count($data); $i++) {
                     $this->core->getQueries()->updateExtensions($data[$i][0], $data[$i][1], $data[$i][2]);
                 }
                 return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
@@ -173,7 +173,8 @@ class LateController extends AbstractController {
                         JsonResponse::getFailResponse($error)
                     );
                 }
-            } else {
+            }
+            else {
                 $error = "You must specify a number of late days or a new due date for the student";
                 $this->core->addErrorMessage($error);
                 return Response::JsonOnlyResponse(
@@ -185,7 +186,7 @@ class LateController extends AbstractController {
             $simple_late_user = null;
             $no_change = false;
             if (!$no_change) {
-                foreach($users_with_exceptions as $user) {
+                foreach ($users_with_exceptions as $user) {
                     if ($user->getId() == $_POST['user_id']) {
                         $simple_late_user = $user;
                         $no_change = $simple_late_user->getLateDayExceptions() == $late_days;
@@ -201,22 +202,24 @@ class LateController extends AbstractController {
             $team = $this->core->getQueries()->getTeamByGradeableAndUser($_POST['g_id'], $_POST['user_id']);
             //0 is for single submission, 1 is for team submission
             $option = isset($_POST['option']) ? $_POST['option'] : -1;
-            if($team != null && $team->getSize() > 1){
-                if($option == 0){
+            if ($team != null && $team->getSize() > 1) {
+                if ($option == 0) {
                     $this->core->getQueries()->updateExtensions($_POST['user_id'], $_POST['g_id'], $late_days);
                     $this->core->addSuccessMessage("Extensions have been updated");
                     return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
-                } elseif($option == 1){
+                }
+                elseif ($option == 1) {
                     $team_member_ids = explode(", ", $team->getMemberList());
-                    for($i = 0; $i < count($team_member_ids); $i++) {
+                    for ($i = 0; $i < count($team_member_ids); $i++) {
                         $this->core->getQueries()->updateExtensions($team_member_ids[$i], $_POST['g_id'], $late_days);
                     }
                     $this->core->addSuccessMessage("Extensions have been updated");
                     return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
-                } else {
+                }
+                else {
                     $team_member_ids = explode(", ", $team->getMemberList());
                     $team_members = array();
-                    for($i = 0; $i < count($team_member_ids); $i++){
+                    for ($i = 0; $i < count($team_member_ids); $i++) {
                         $team_members[$team_member_ids[$i]] = $this->core->getQueries()->getUserById($team_member_ids[$i])->getDisplayedFirstName() . " " .
                             $this->core->getQueries()->getUserById($team_member_ids[$i])->getDisplayedLastName();
                     }
@@ -228,7 +231,8 @@ class LateController extends AbstractController {
                         JsonResponse::getSuccessResponse(['is_team' => true, 'popup' => $popup_html])
                     );
                 }
-            } else {
+            }
+            else {
                 $this->core->getQueries()->updateExtensions($_POST['user_id'], $_POST['g_id'], $late_days);
                 $this->core->addSuccessMessage("Extensions have been updated");
                 return Response::JsonOnlyResponse(JsonResponse::getSuccessResponse());
@@ -242,7 +246,7 @@ class LateController extends AbstractController {
     private function getLateDays() {
         $users = $this->core->getQueries()->getUsersWithLateDays();
         $user_table = array();
-        foreach($users as $user){
+        foreach ($users as $user) {
             $user_table[] = array('user_id' => $user->getId(),'user_firstname' => $user->getDisplayedFirstName(), 'user_lastname' => $user->getDisplayedLastName(), 'late_days' => $user->getAllowedLateDays(), 'datestamp' => $user->getSinceTimestamp(), 'late_day_exceptions' => $user->getLateDayExceptions());
         }
         return Response::JsonOnlyResponse(
@@ -272,7 +276,7 @@ class LateController extends AbstractController {
             $data = null;
             return false;
         }
-        foreach($rows as $row) {
+        foreach ($rows as $row) {
             $fields = explode(',', $row);
             //Remove any extraneous whitespace at beginning/end of all fields.
             $fields = array_map(function ($k) {
@@ -314,7 +318,7 @@ class LateController extends AbstractController {
 
     private function validateHomework($id) {
         $g_ids = $this->core->getQueries()->getAllElectronicGradeablesIds();
-        foreach($g_ids as $index => $value) {
+        foreach ($g_ids as $index => $value) {
             if ($id === $value['g_id']) {
                 return true;
             }

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -28,7 +28,7 @@ class PlagiarismController extends AbstractController {
                 exit("Unable to open file!");
             }
 
-            while(!feof($file)) {
+            while (!feof($file)) {
                 $line = fgets($file);
                 $line = trim($line, " ");
                 $line = explode("/", $line);
@@ -49,7 +49,7 @@ class PlagiarismController extends AbstractController {
             uksort($return, function ($semester_a, $semester_b) {
                 $year_a = (int) substr($semester_a, 1);
                 $year_b = (int) substr($semester_b, 1);
-                if($year_a > $year_b) {
+                if ($year_a > $year_b) {
                     return 0;
                 }
                 elseif ($year_a < $year_b) {
@@ -70,16 +70,16 @@ class PlagiarismController extends AbstractController {
         $course = $this->core->getConfig()->getCourse();
 
         $gradeables_with_plagiarism_result = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
-        foreach($gradeables_with_plagiarism_result as $i => $gradeable_id_title) {
-            if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id_title['g_id'] . ".txt") && !file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") && !file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
+        foreach ($gradeables_with_plagiarism_result as $i => $gradeable_id_title) {
+            if (!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id_title['g_id'] . ".txt") && !file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") && !file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
                 unset($gradeables_with_plagiarism_result[$i]);
             }
         }
 
         $nightly_rerun_info_file = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/nightly_rerun.json";
-        if(!file_exists($nightly_rerun_info_file)) {
+        if (!file_exists($nightly_rerun_info_file)) {
             $nightly_rerun_info = array();
-            foreach($gradeables_with_plagiarism_result as $gradeable_id_title) {
+            foreach ($gradeables_with_plagiarism_result as $gradeable_id_title) {
                 $nightly_rerun_info[$gradeable_id_title['g_id']] = false;
             }
             if (file_put_contents($nightly_rerun_info_file, json_encode($nightly_rerun_info, JSON_PRETTY_PRINT)) === false) {
@@ -102,8 +102,8 @@ class PlagiarismController extends AbstractController {
                 }
             }
 
-            foreach($gradeables_with_plagiarism_result as $gradeable_id_title) {
-                if(!array_key_exists($gradeable_id_title['g_id'], $nightly_rerun_info)) {
+            foreach ($gradeables_with_plagiarism_result as $gradeable_id_title) {
+                if (!array_key_exists($gradeable_id_title['g_id'], $nightly_rerun_info)) {
                     #implies plagiarism was run for this gradeable
                     $nightly_rerun_info[$gradeable_id_title['g_id']] = false;
                 }
@@ -129,11 +129,11 @@ class PlagiarismController extends AbstractController {
         $return_url = $this->core->buildCourseUrl(['plagiarism']);
 
         $file_path = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id . ".txt";
-        if(!file_exists($file_path)) {
+        if (!file_exists($file_path)) {
             $this->core->addErrorMessage("Plagiarism Detection job is running for this gradeable.");
             $this->core->redirect($return_url);
         }
-        if(file_get_contents($file_path) == "") {
+        if (file_get_contents($file_path) == "") {
             $this->core->addSuccessMessage("There are no matches(plagiarism) for the gradeable with current configuration");
             $this->core->redirect($return_url);
         }
@@ -141,7 +141,7 @@ class PlagiarismController extends AbstractController {
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
         $rankings = array_chunk($rankings, 3);
-        foreach($rankings as $i => $ranking) {
+        foreach ($rankings as $i => $ranking) {
             array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedFirstName());
             array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedLastName());
         }
@@ -158,8 +158,8 @@ class PlagiarismController extends AbstractController {
         $course = $this->core->getConfig()->getCourse();
         $gradeable_with_submission = array_diff(scandir("/var/local/submitty/courses/$semester/$course/submissions/"), array('.', '..'));
         $gradeable_ids_titles = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
-        foreach($gradeable_ids_titles as $i => $gradeable_id_title) {
-            if(!in_array($gradeable_id_title['g_id'], $gradeable_with_submission) || file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id_title['g_id'] . ".json")) {
+        foreach ($gradeable_ids_titles as $i => $gradeable_id_title) {
+            if (!in_array($gradeable_id_title['g_id'], $gradeable_with_submission) || file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id_title['g_id'] . ".json")) {
                 unset($gradeable_ids_titles[$i]);
             }
         }
@@ -178,7 +178,7 @@ class PlagiarismController extends AbstractController {
         $course = $this->core->getConfig()->getCourse();
 
         $return_url = $this->core->buildCourseUrl(['plagiarism', 'configuration', 'new']);
-        if($new_or_edit == "new") {
+        if ($new_or_edit == "new") {
             $gradeable_id = $_POST['gradeable_id'];
         }
 
@@ -186,7 +186,7 @@ class PlagiarismController extends AbstractController {
             $return_url = $this->core->buildCourseUrl(['plagiarism', 'configuration', 'edit']) . '?' . http_build_query(['gradeable_id' => $gradeable_id]);
         }
 
-        if(file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json")) {
+        if (file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json")) {
                 $this->core->addErrorMessage("A job is already running for the gradeable. Try again after a while.");
                 $this->core->redirect($return_url);
         }
@@ -208,8 +208,8 @@ class PlagiarismController extends AbstractController {
         else {
             $file_option = "all";
         }
-        if($file_option == "matching_regex") {
-            if(isset($_POST['regex_to_select_files']) && $_POST['regex_to_select_files'] !== '') {
+        if ($file_option == "matching_regex") {
+            if (isset($_POST['regex_to_select_files']) && $_POST['regex_to_select_files'] !== '') {
                 $regex_for_selecting_files = $_POST['regex_to_select_files'];
             }
             else {
@@ -219,14 +219,14 @@ class PlagiarismController extends AbstractController {
         }
 
         $language = $_POST['language'];
-        if(isset($_POST['threshold']) && $_POST['threshold'] !== '') {
+        if (isset($_POST['threshold']) && $_POST['threshold'] !== '') {
             $threshold = $_POST['threshold'];
         }
         else {
             $this->core->addErrorMessage("No input provided for threshold");
             $this->core->redirect($return_url);
         }
-        if(isset($_POST['sequence_length']) && $_POST['sequence_length'] !== '') {
+        if (isset($_POST['sequence_length']) && $_POST['sequence_length'] !== '') {
             $sequence_length = $_POST['sequence_length'];
         }
         else {
@@ -235,8 +235,8 @@ class PlagiarismController extends AbstractController {
         }
 
         $prev_term_gradeables = array();
-        for($i = 0; $i < $prev_gradeable_number; $i++) {
-            if($_POST['prev_sem_' . $i] != "" && $_POST['prev_course_' . $i] != "" && $_POST['prev_gradeable_' . $i] != "") {
+        for ($i = 0; $i < $prev_gradeable_number; $i++) {
+            if ($_POST['prev_sem_' . $i] != "" && $_POST['prev_course_' . $i] != "" && $_POST['prev_gradeable_' . $i] != "") {
                 array_push($prev_term_gradeables, "/var/local/submitty/course/" . $_POST['prev_sem_' . $i] . "/" . $_POST['prev_course_' . $i] . "/submissions/" . $_POST['prev_gradeable_' . $i]);
             }
         }
@@ -244,8 +244,8 @@ class PlagiarismController extends AbstractController {
         $ignore_submissions = array();
         $ignore_submission_option = $_POST['ignore_submission_option'];
         if ($ignore_submission_option == "ignore") {
-            for($i = 0; $i < $ignore_submission_number; $i++) {
-                if(isset($_POST['ignore_submission_' . $i]) && $_POST['ignore_submission_' . $i] !== '') {
+            for ($i = 0; $i < $ignore_submission_number; $i++) {
+                if (isset($_POST['ignore_submission_' . $i]) && $_POST['ignore_submission_' . $i] !== '') {
                     array_push($ignore_submissions, $_POST['ignore_submission_' . $i]);
                 }
             }
@@ -253,26 +253,26 @@ class PlagiarismController extends AbstractController {
 
         $gradeable_path =  FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "submissions", $gradeable_id);
         $provided_code_option = $_POST['provided_code_option'];
-        if($provided_code_option == "code_provided") {
+        if ($provided_code_option == "code_provided") {
             $instructor_provided_code = true;
         }
         else {
-            if(is_dir(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen/provided_code", $gradeable_id))) {
+            if (is_dir(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen/provided_code", $gradeable_id))) {
                 FileUtils::emptyDir(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen/provided_code", $gradeable_id));
             }
             $instructor_provided_code = false;
         }
 
-        if($instructor_provided_code == true) {
+        if ($instructor_provided_code == true) {
             if (empty($_FILES) || !isset($_FILES['provided_code_file'])) {
                 $this->core->addErrorMessage("Upload failed: Instructor code not provided");
                 $this->core->redirect($return_url);
             }
+
             if (!isset($_FILES['provided_code_file']['tmp_name']) || $_FILES['provided_code_file']['tmp_name'] == "") {
                 $this->core->addErrorMessage("Upload failed: Instructor code not provided");
                 $this->core->redirect($return_url);
             }
-
             else {
                 $upload = $_FILES['provided_code_file'];
                 $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen/provided_code", $gradeable_id);
@@ -322,10 +322,10 @@ class PlagiarismController extends AbstractController {
                             "instructor_provided_code" =>   $instructor_provided_code,
                                         );
 
-        if($file_option == "matching_regex") {
+        if ($file_option == "matching_regex") {
             $json_data["regex"] = $regex_for_selecting_files;
         }
-        if($instructor_provided_code == true) {
+        if ($instructor_provided_code == true) {
             $json_data["instructor_provided_code_path"] = $instructor_provided_code_path;
         }
 
@@ -348,7 +348,7 @@ class PlagiarismController extends AbstractController {
         // if fails at following step, still provided code, cnfiguration, timestamp file get saved
 
         $ret = $this->enqueueLichenJob("RunLichen", $gradeable_id);
-        if($ret !== null) {
+        if ($ret !== null) {
             $this->core->addErrorMessage("Failed to create configuration. Create the configuration again.");
             $this->core->redirect($return_url);
         }
@@ -369,11 +369,11 @@ class PlagiarismController extends AbstractController {
         ];
         $lichen_job_file = "/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json";
 
-        if(file_exists($lichen_job_file) && !is_writable($lichen_job_file)) {
+        if (file_exists($lichen_job_file) && !is_writable($lichen_job_file)) {
             return "Failed to create lichen job. Try again";
         }
 
-        if(file_put_contents($lichen_job_file, json_encode($lichen_job_data, JSON_PRETTY_PRINT)) === false) {
+        if (file_put_contents($lichen_job_file, json_encode($lichen_job_data, JSON_PRETTY_PRINT)) === false) {
             return "Failed to write lichen job file. Try again";
         }
         return null;
@@ -388,12 +388,12 @@ class PlagiarismController extends AbstractController {
         $return_url = $this->core->buildCourseUrl(['plagiarism']);
 
         # Re run only if following checks are passed.
-        if(file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json")) {
+        if (file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json")) {
                 $this->core->addErrorMessage("A job is already running for the gradeable. Try again after a while.");
                 $this->core->redirect($return_url);
         }
 
-        if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
+        if (!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
             $this->core->addErrorMessage("Plagiarism results have been deleted. Add new configuration for the gradeable.");
             $this->core->redirect($return_url);
         }
@@ -407,7 +407,7 @@ class PlagiarismController extends AbstractController {
         }
 
         $ret = $this->enqueueLichenJob("RunLichen", $gradeable_id);
-        if($ret !== null) {
+        if ($ret !== null) {
             $this->core->addErrorMessage($ret);
             $this->core->redirect($return_url);
         }
@@ -426,7 +426,7 @@ class PlagiarismController extends AbstractController {
 
         $prior_term_gradeables = $this->getGradeablesFromPriorTerm();
 
-        if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
+        if (!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
             $this->core->addErrorMessage("Saved configuration not found.");
             $this->core->redirect($return_url);
         }
@@ -444,18 +444,18 @@ class PlagiarismController extends AbstractController {
         $course = $this->core->getConfig()->getCourse();
         $return_url = $this->core->buildCourseUrl(['plagiarism']);
 
-        if(file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json")) {
+        if (file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id . ".json")) {
                 $this->core->addErrorMessage("A job is already running for the gradeable. Try again after a while.");
                 $this->core->redirect($return_url);
         }
 
-        if(!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
+        if (!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id . ".json")) {
             $this->core->addErrorMessage("Plagiarism results for the gradeable are already deleted. Refresh the page.");
             $this->core->redirect($return_url);
         }
 
         $ret = $this->enqueueLichenJob("DeleteLichenResult", $gradeable_id);
-        if($ret !== null) {
+        if ($ret !== null) {
             $this->core->addErrorMessage($ret);
             $this->core->redirect($return_url);
         }
@@ -493,7 +493,7 @@ class PlagiarismController extends AbstractController {
         $this->core->getOutput()->useFooter(false);
 
         $gradeable = $this->tryGetGradeable($gradeable_id);
-        if($gradeable === false) {
+        if ($gradeable === false) {
             return;
         }
         $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $user_id_1);
@@ -504,7 +504,7 @@ class PlagiarismController extends AbstractController {
         $return = "";
         $active_version_user_1 =  (string) $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $file_path = $course_path . "/lichen/ranking/" . $gradeable_id . ".txt";
-        if(!file_exists($file_path)) {
+        if (!file_exists($file_path)) {
             $return = array('error' => 'Ranking file not exists.');
             $return = json_encode($return);
             echo($return);
@@ -514,20 +514,20 @@ class PlagiarismController extends AbstractController {
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
         $rankings = array_chunk($rankings, 3);
-        foreach($rankings as $ranking) {
-            if($ranking[1] == $user_id_1) {
+        foreach ($rankings as $ranking) {
+            if ($ranking[1] == $user_id_1) {
                 $max_matching_version = $ranking[2];
             }
         }
-        if($version_user_1 == "max_matching") {
+        if ($version_user_1 == "max_matching") {
             $version_user_1 = $max_matching_version;
         }
         $all_versions_user_1 = array_diff(scandir($course_path . "/submissions/" . $gradeable_id . "/" . $user_id_1), array(".", "..", "user_assignment_settings.json"));
 
         $file_name = $course_path . "/lichen/concatenated/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/submission.concatenated";
         $data = "";
-        if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
-            if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
+        if (($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
+            if (isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
                 $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, '1');
             }
             else {
@@ -541,10 +541,10 @@ class PlagiarismController extends AbstractController {
             echo($return);
             return;
         }
-        if(isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
+        if (isset($user_id_2) && !empty($user_id_2) && isset($version_user_2) && !empty($version_user_2)) {
             $file_name = $course_path . "/lichen/concatenated/" . $gradeable_id . "/" . $user_id_2 . "/" . $version_user_2 . "/submission.concatenated";
 
-            if(($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
+            if (($this->core->getUser()->accessAdmin()) && (file_exists($file_name))) {
                 $color_info = $this->getColorInfo($course_path, $gradeable_id, $user_id_1, $version_user_1, $user_id_2, $version_user_2, '2');
                 $data['display_code2'] = $this->getDisplayForCode($file_name, $color_info);
             }
@@ -575,11 +575,11 @@ class PlagiarismController extends AbstractController {
             $matches = json_decode(file_get_contents($file_path), true);
             $file_path = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $user_id_1 . "/" . $version_user_1 . "/tokens.json";
             $tokens_user_1 = json_decode(file_get_contents($file_path), true);
-            if($user_id_2 != "") {
+            if ($user_id_2 != "") {
                 $file_path = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $user_id_2 . "/" . $version_user_2 . "/tokens.json";
                 $tokens_user_2 = json_decode(file_get_contents($file_path), true);
             }
-            foreach($matches as $match) {
+            foreach ($matches as $match) {
                 $start_pos = $tokens_user_1[$match["start"] - 1]["char"] - 1;
                 $start_line = $tokens_user_1[$match["start"] - 1]["line"] - 1;
                 $end_pos = $tokens_user_1[$match["end"] - 1]["char"] - 1; //!!!!!
@@ -588,28 +588,28 @@ class PlagiarismController extends AbstractController {
                 $end_value = $tokens_user_1[$match["end"] - 1]["value"];
                 $userMatchesStarts = array();
                 $userMatchesEnds = array();
-                if($match["type"] == "match") {
+                if ($match["type"] == "match") {
                     $orange_color = false;
-                    if($user_id_2 != "") {
-                        foreach($match['others'] as $i => $other) {
-                            if($other["username"] == $user_id_2) {
+                    if ($user_id_2 != "") {
+                        foreach ($match['others'] as $i => $other) {
+                            if ($other["username"] == $user_id_2) {
                                 $orange_color = true;
                                 $user_2_index_in_others = $i;
                             }
                         }
                     }
 
-                    if($orange_color) {
+                    if ($orange_color) {
                         //Color is orange -- general match from selected match
                         $color = '#ffa500';
                     }
-                    elseif(!$orange_color) {
+                    elseif (!$orange_color) {
                         //Color is yellow -- matches other students...
                         $color = '#ffff00';
                     }
 
-                    if($codebox == "2" && $user_id_2 != "" && $orange_color) {
-                        foreach($match['others'][$user_2_index_in_others]['matchingpositions'] as $user_2_matchingposition) {
+                    if ($codebox == "2" && $user_id_2 != "" && $orange_color) {
+                        foreach ($match['others'][$user_2_index_in_others]['matchingpositions'] as $user_2_matchingposition) {
                             $start_pos_2 = $tokens_user_2[$user_2_matchingposition["start"] - 1]["char"] - 1;
                             $start_line_2 = $tokens_user_2[$user_2_matchingposition["start"] - 1]["line"] - 1;
                             $end_pos_2 = $tokens_user_2[$user_2_matchingposition["end"] - 1]["char"] - 1; //!!!!
@@ -623,11 +623,11 @@ class PlagiarismController extends AbstractController {
                         }
                     }
                 }
-                elseif($match["type"] == "common") {
+                elseif ($match["type"] == "common") {
                     //Color is grey -- common matches among all students
                     $color = '#cccccc';
                 }
-                elseif($match["type"] == "provided") {
+                elseif ($match["type"] == "provided") {
                     //Color is green -- instructor provided code #b5e3b5
                     $color = '#b5e3b5';
                 }
@@ -658,7 +658,7 @@ class PlagiarismController extends AbstractController {
         $return = array();
         $error = "";
         $file_path = $course_path . "/lichen/ranking/" . $gradeable_id . ".txt";
-        if(!file_exists($file_path)) {
+        if (!file_exists($file_path)) {
             $return = array('error' => 'Ranking file not exists.');
             $return = json_encode($return);
             echo($return);
@@ -668,13 +668,13 @@ class PlagiarismController extends AbstractController {
         $content = trim(str_replace(array("\r", "\n"), '', $content));
         $rankings = preg_split('/ +/', $content);
         $rankings = array_chunk($rankings, 3);
-        foreach($rankings as $ranking) {
-            if($ranking[1] == $user_id_1) {
+        foreach ($rankings as $ranking) {
+            if ($ranking[1] == $user_id_1) {
                 $max_matching_version = $ranking[2];
             }
         }
         $version = $version_user_1;
-        if($version_user_1 == "max_matching") {
+        if ($version_user_1 == "max_matching") {
             $version = $max_matching_version;
         }
         $file_path = $course_path . "/lichen/matches/" . $gradeable_id . "/" . $user_id_1 . "/" . $version . "/matches.json";
@@ -683,16 +683,16 @@ class PlagiarismController extends AbstractController {
         }
         else {
             $content = json_decode(file_get_contents($file_path), true);
-            foreach($content as $match) {
-                if($match["type"] == "match") {
+            foreach ($content as $match) {
+                if ($match["type"] == "match") {
                     foreach ($match["others"] as $match_info) {
-                        if(!in_array(array($match_info["username"],$match_info["version"]), $return)) {
+                        if (!in_array(array($match_info["username"],$match_info["version"]), $return)) {
                             array_push($return, array($match_info["username"],$match_info["version"]));
                         }
                     }
                 }
             }
-            foreach($return as $i => $match_user) {
+            foreach ($return as $i => $match_user) {
                 array_push($return[$i], $this->core->getQueries()->getUserById($match_user[0])->getDisplayedFirstName());
                 array_push($return[$i], $this->core->getQueries()->getUserById($match_user[0])->getDisplayedLastName());
             }
@@ -721,13 +721,13 @@ class PlagiarismController extends AbstractController {
         }
         else {
             $content = json_decode(file_get_contents($file_path), true);
-            foreach($content as $match) {
-                if($tokens_user_1[$match["start"] - 1]["line"] - 1 == $start && $tokens_user_1[$match["end"] - 1]["line"] - 1 == $end) { //also do char place
+            foreach ($content as $match) {
+                if ($tokens_user_1[$match["start"] - 1]["line"] - 1 == $start && $tokens_user_1[$match["end"] - 1]["line"] - 1 == $end) { //also do char place
                     foreach ($match["others"] as $match_info) {
                         $matchingpositions = array();
                         $token_path_2 = $course_path . "/lichen/tokenized/" . $gradeable_id . "/" . $match_info['username'] . "/" . $match_info['version'] . "/tokens.json";
                         $tokens_user_2 = json_decode(file_get_contents($token_path_2), true);
-                        foreach($match_info['matchingpositions'] as $matchingpos) {
+                        foreach ($match_info['matchingpositions'] as $matchingpos) {
                             array_push($matchingpositions, array("start_line" => $tokens_user_2[$matchingpos["start"] - 1]["line"] - 1 , "start_ch" => $tokens_user_2[$matchingpos["start"] - 1]["char"] - 1,
                                  "end_line" => $tokens_user_2[$matchingpos["end"] - 1]["line"] - 1, "end_ch" => $tokens_user_2[$matchingpos["end"] - 1]["char"] - 1 ));
                         }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -518,10 +518,12 @@ class ReportController extends AbstractController {
 
                 // Finally, send the requester back the information
                 $this->core->getOutput()->renderJsonSuccess("Successfully wrote customization.json file");
-            } catch (ValidationException $e) {
+            }
+            catch (ValidationException $e) {
                 //Use this to handle any invalid/inconsistent input exceptions thrown during processForm()
                 $this->core->getOutput()->renderJsonFail('See "data" for details', $e->getDetails());
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 //Catches any other exceptions, should be "unexpected" issues
                 $this->core->getOutput()->renderJsonError($e->getMessage());
             }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -60,7 +60,7 @@ class ReportController extends AbstractController {
         $base_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'reports', 'all_grades');
 
         // Check that the directory is writable, fail if not
-        if(!is_writable($base_path)) {
+        if (!is_writable($base_path)) {
             $this->core->addErrorMessage('Unable to write to the grade summaries directory');
             $this->core->redirect($this->core->buildCourseUrl(['reports']));
         }
@@ -98,13 +98,11 @@ class ReportController extends AbstractController {
         $file_count = count($files) - 2;
 
         // If folder is empty return never
-        if($file_count == 0)
-        {
+        if ($file_count == 0) {
             return 'Never';
         }
-        // Else folder has contents return the time stamp off the first file
-        else
-        {
+        else {
+            // Else folder has contents return the time stamp off the first file
             // Get file modification time of first student json
             $time_stamp = filemtime($summaries_dir . '/' . $files[2]);
 
@@ -187,7 +185,8 @@ class ReportController extends AbstractController {
             $all_gradeables[] = $g;
             if ($g->isTeamAssignment()) {
                 $team_gradeables[] = $g;
-            } else {
+            }
+            else {
                 $user_gradeables[] = $g;
             }
         }
@@ -216,7 +215,8 @@ class ReportController extends AbstractController {
             if ($g->isTeamAssignment()) {
                 // if the user doesn't have a team, MAKE THE USER A SUBMITTER
                 $ggs[] = $team_graded_gradeables[$g->getId()][$user->getId()] ?? $this->genDummyGradedGradeable($g, new Submitter($this->core, $user));
-            } else {
+            }
+            else {
                 $ggs[] = $user_graded_gradeables[$g->getId()];
             }
         }
@@ -304,13 +304,14 @@ class ReportController extends AbstractController {
             //Append one gradeable score to row.  Scores are indexed by gradeable's ID.
             $row[$gg->getGradeableId()] = $gg->getTotalScore();
 
-            if (!$gg->hasOverriddenGrades()){
+            if (!$gg->hasOverriddenGrades()) {
                 // Check if the score should be a zero
                 if ($gg->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE) {
                     if ($gg->getGradeable()->isTaGrading() && ($gg->getOrCreateTaGradedGradeable()->hasVersionConflict() || !$gg->isTaGradingComplete())) {
                         // Version conflict or incomplete grading, so zero score
                         $row[$gg->getGradeableId()] = 0;
-                    } elseif ($late_days->getLateDayInfoByGradeable($gg->getGradeable())->getStatus() === LateDayInfo::STATUS_BAD) {
+                    }
+                    elseif ($late_days->getLateDayInfoByGradeable($gg->getGradeable())->getStatus() === LateDayInfo::STATUS_BAD) {
                         // BAD submission, so zero score
                         $row[$gg->getGradeableId()] = 0;
                     }
@@ -372,7 +373,7 @@ class ReportController extends AbstractController {
 
         $ldi = $ld->getLateDayInfoByGradeable($g);
 
-        if ($gg->hasOverriddenGrades()){
+        if ($gg->hasOverriddenGrades()) {
             $entry['status'] = 'Overridden';
             $entry['comment'] = $gg->getOverriddenComment();
         }
@@ -416,9 +417,11 @@ class ReportController extends AbstractController {
                         //  but to keep the rest of the report generation sane, they can be users if the
                         //  user is not on a team
                         $entry['note'] = 'User is not on a team';
-                    } elseif (!$ta_gg->isComplete()) {
+                    }
+                    elseif (!$ta_gg->isComplete()) {
                         $entry['note'] = 'This has not been graded yet.';
-                    } else {
+                    }
+                    else {
                         $entry['note'] = 'Score is set to 0 because there are version conflicts.';
                     }
                 }
@@ -445,7 +448,8 @@ class ReportController extends AbstractController {
                 ];
                 if ($component->isText()) {
                     $inner['comment'] = $gc !== null ? $gc->getComment() : '';
-                } else {
+                }
+                else {
                     $inner['score'] = $gc !== null ? $gc->getTotalScore() : 0.0;
                     $inner['default_score'] = $component->getDefault();
                     $inner['upper_clamp'] = $component->getUpperClamp();
@@ -490,7 +494,8 @@ class ReportController extends AbstractController {
             case LateDayInfo::STATUS_NO_ACTIVE_VERSION:
                 if ($ldi->getGradedGradeable()->getAutoGradedGradeable()->hasSubmission()) {
                     return 'Cancelled';
-                } else {
+                }
+                else {
                     return 'Unsubmitted';
                 }
             default:
@@ -506,7 +511,7 @@ class ReportController extends AbstractController {
         $customization = new RainbowCustomization($this->core);
         $customization->buildCustomization();
 
-        if(isset($_POST["json_string"])){
+        if (isset($_POST["json_string"])) {
             //Handle user input (the form) being submitted
             try {
                 $customization->processForm();
@@ -521,7 +526,7 @@ class ReportController extends AbstractController {
                 $this->core->getOutput()->renderJsonError($e->getMessage());
             }
         }
-        else{
+        else {
             $this->core->getOutput()->addInternalJs('rainbow-customization.js');
             $this->core->getOutput()->addInternalCss('rainbow-customization.css');
 
@@ -563,8 +568,7 @@ class ReportController extends AbstractController {
         $max_wait_time = self::MAX_AUTO_RG_WAIT_TIME;
 
         // Check the jobs queue every second to see if the job has finished yet
-        while(file_exists($jobs_file) && $max_wait_time)
-        {
+        while (file_exists($jobs_file) && $max_wait_time) {
             sleep(1);
             $max_wait_time--;
             clearstatcache();
@@ -573,8 +577,7 @@ class ReportController extends AbstractController {
         // Jobs queue daemon actually changes the name of the job by prepending PROCESSING onto the filename
         // We must also wait for that file to be removed
         // Check the jobs queue every second to see if the job has finished yet
-        while(file_exists($processing_jobs_file) && $max_wait_time)
-        {
+        while (file_exists($processing_jobs_file) && $max_wait_time) {
             sleep(1);
             $max_wait_time--;
             clearstatcache();
@@ -587,12 +590,10 @@ class ReportController extends AbstractController {
             '/rainbow_grades/auto_debug_output.txt';
 
         // Look over the output file to see if any part of the process failed
-        try
-        {
+        try {
             $failure_detected = FileUtils::areWordsInFile($debug_output_path, ['Exception', 'Aborted', 'failed']);
         }
-        catch (\Exception $e)
-        {
+        catch (\Exception $e) {
             $failure_detected = true;
         }
 
@@ -600,13 +601,11 @@ class ReportController extends AbstractController {
 
         // If we finished the previous loops before max_wait_time hit 0 then the file successfully left the jobs queue
         // implying that it finished
-        if ($max_wait_time && $failure_detected == false)
-        {
+        if ($max_wait_time && $failure_detected == false) {
             $this->core->getOutput()->renderJsonSuccess($debug_contents);
         }
-        // Else we timed out or something else went wrong
-        else
-        {
+        else {
+            // Else we timed out or something else went wrong
             $this->core->getOutput()->renderJsonFail($debug_contents);
         }
     }

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -155,7 +155,7 @@ class UsersController extends AbstractController {
             }
         }
 
-        foreach($this->core->getQueries()->getAllGraders() as $grader) {
+        foreach ($this->core->getQueries()->getAllGraders() as $grader) {
             $grader_id = $grader->getId();
             if (array_key_exists($grader_id, $new_registration_information)) {
                 $grader->setGradingRegistrationSections($new_registration_information[$grader_id]);
@@ -419,8 +419,8 @@ class UsersController extends AbstractController {
                 $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
                 $json = file_get_contents($fp);
                 $jsonArray = json_decode($json, true);
-                foreach ($jsonArray as $key => $value){
-                    if(isset($value['sections'])){
+                foreach ($jsonArray as $key => $value) {
+                    if (isset($value['sections'])) {
                         $sections = $value['sections'];
                         if ($key = array_search($_POST['delete_reg_section'], $sections) !== false) {
                             $this->core->addErrorMessage("Section {$_POST['delete_reg_section']} not removed.  This section is referenced in course materials");
@@ -679,22 +679,27 @@ class UsersController extends AbstractController {
                 if ($output === null) {
                     $this->core->addErrorMessage("Error parsing JSON response: " . json_last_error_msg());
                     $this->core->redirect($return_url);
-                } elseif ($output['error'] === true) {
+                }
+                elseif ($output['error'] === true) {
                     $this->core->addErrorMessage("Error parsing xlsx to csv: " . $output['error_message']);
                     $this->core->redirect($return_url);
-                } elseif ($output['success'] !== true) {
+                }
+                elseif ($output['success'] !== true) {
                     $this->core->addErrorMessage("Error on response on parsing xlsx: " . curl_error($ch));
                     $this->core->redirect($return_url);
                 }
 
                 curl_close($ch);
-            } else {
+            }
+            else {
                 $this->core->addErrorMessage("Did not properly recieve spreadsheet. Contact your sysadmin.");
                 $this->core->redirect($return_url);
             }
-        } elseif ($content_type === 'text/csv' && $mime_type === 'text/plain') {
+        }
+        elseif ($content_type === 'text/csv' && $mime_type === 'text/plain') {
             $csv_file = $tmp_name;
-        } else {
+        }
+        else {
             $this->core->addErrorMessage("Must upload xlsx or csv");
             $this->core->redirect($return_url);
         }
@@ -757,7 +762,7 @@ class UsersController extends AbstractController {
          */
         $row4_validation_function = function () use ($list_type, &$vals) {
             //$row[4] is different based on classlist vs graderlist
-            switch($list_type) {
+            switch ($list_type) {
                 case "classlist":
                     //student
                     if (isset($vals[4]) && strtolower($vals[4]) === "null") {
@@ -783,7 +788,7 @@ class UsersController extends AbstractController {
          * @return string
          */
         $get_user_registration_or_group_function = function ($user) use ($list_type) {
-            switch($list_type) {
+            switch ($list_type) {
                 case "classlist":
                     return $user->getRegistrationSection();
                 case "graderlist":
@@ -797,7 +802,7 @@ class UsersController extends AbstractController {
          * Closure to set a user's registration_section or group_id based on $list_type)
          */
         $set_user_registration_or_group_function = function (&$user) use ($list_type, &$row) {
-            switch($list_type) {
+            switch ($list_type) {
                 case "classlist":
                     // Registration section has to exist, or a DB exception gets thrown on INSERT or UPDATE.
                     // ON CONFLICT clause in DB query prevents thrown exceptions when registration section already exists.
@@ -820,7 +825,7 @@ class UsersController extends AbstractController {
          */
         $insert_or_update_user_function = function ($action, $user) use (&$semester, &$course, &$uploaded_data, &$return_url) {
             try {
-                switch($action) {
+                switch ($action) {
                     case 'insert':
                         //User must first exist in Submitty before being enrolled to a course.
                         //$uploaded_data[0] = authentication ID.
@@ -849,7 +854,7 @@ class UsersController extends AbstractController {
          * @return string
          */
         $set_return_url_action_function = function () use ($list_type) {
-            switch($list_type) {
+            switch ($list_type) {
                 case "classlist":
                     return "users";
                 case "graderlist":
@@ -873,9 +878,9 @@ class UsersController extends AbstractController {
         $pref_firstname_idx = $use_database ? 6 : 5;
         $pref_lastname_idx = $pref_firstname_idx + 1;
         $bad_rows = array();
-        foreach($uploaded_data as $row_num => $vals) {
+        foreach ($uploaded_data as $row_num => $vals) {
             // Blacklist validation.  Validation fails if any test resolves as false.
-            switch(false) {
+            switch (false) {
                 // Bounds check to ensure minimum required number of rows is present.
                 case count($vals) >= 5:
                     // Username must contain only lowercase alpha, numbers, underscores, hyphens
@@ -916,9 +921,9 @@ class UsersController extends AbstractController {
         $existing_users = $this->core->getQueries()->getAllUsers();
         $users_to_add = array();
         $users_to_update = array();
-        foreach($uploaded_data as $row) {
+        foreach ($uploaded_data as $row) {
             $exists = false;
-            foreach($existing_users as $i => $existing_user) {
+            foreach ($existing_users as $i => $existing_user) {
                 if ($row[0] === $existing_user->getId()) {
                     // Validate if this user has any data to update.
                     // Did student registration section or grader group change?
@@ -940,7 +945,7 @@ class UsersController extends AbstractController {
         // Insert new students to database
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
-        foreach($users_to_add as $uploaded_data) {
+        foreach ($users_to_add as $uploaded_data) {
             $user = new User($this->core);
             $user->setId($uploaded_data[0]);
             $user->setLegalFirstName($uploaded_data[1]);
@@ -960,7 +965,7 @@ class UsersController extends AbstractController {
         }
 
         // Existing users update
-        foreach($users_to_update as $row) {
+        foreach ($users_to_update as $row) {
             $user = $this->core->getQueries()->getUserById($row[0]);
             //Update registration section (student) or group (grader)
             $set_user_registration_or_group_function($user);
@@ -971,7 +976,7 @@ class UsersController extends AbstractController {
 
         //Special case to move students to the NULL section with a classlist upload.
         if ($list_type === "classlist" && isset($_POST['move_missing'])) {
-            foreach($existing_users as $existing_user) {
+            foreach ($existing_users as $existing_user) {
                 if (!is_null($existing_user->getRegistrationSection())) {
                     $existing_user->setRegistrationSection(null);
                     $insert_or_update_user_function('update', $existing_user);

--- a/site/app/controllers/admin/WrapperController.php
+++ b/site/app/controllers/admin/WrapperController.php
@@ -62,7 +62,7 @@ class WrapperController extends AbstractController {
         }
         $upload = $_FILES['wrapper_upload'];
 
-        if(!isset($_POST['location']) || !in_array($_POST['location'], WrapperController::WRAPPER_FILES)) {
+        if (!isset($_POST['location']) || !in_array($_POST['location'], WrapperController::WRAPPER_FILES)) {
             $this->core->addErrorMessage("Upload failed: Invalid location");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['theme']))
@@ -96,13 +96,13 @@ class WrapperController extends AbstractController {
             );
         }
 
-        if(!isset($_POST['location']) || !in_array($_POST['location'], WrapperController::WRAPPER_FILES)) {
+        if (!isset($_POST['location']) || !in_array($_POST['location'], WrapperController::WRAPPER_FILES)) {
             $this->core->addErrorMessage("Delete failed: Invalid filename");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['theme']))
             );
         }
-        if(!@unlink($location)) {
+        if (!@unlink($location)) {
             $this->core->addErrorMessage("Deletion failed: Could not unlink file");
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['theme']))

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -29,7 +29,7 @@ class CourseMaterialsController extends AbstractController {
             return;
         }
         else {
-            if(array_key_exists('files', $file)) {
+            if (array_key_exists('files', $file)) {
                 $this->deleteHelper($file['files'], $json);
             }
             else {
@@ -60,11 +60,11 @@ class CourseMaterialsController extends AbstractController {
 
         if ($json != false) {
             $all_files = is_dir($path) ? FileUtils::getAllFiles($path) : [$path];
-            foreach($all_files as $file) {
-                if(is_array($file)){
+            foreach ($all_files as $file) {
+                if (is_array($file)) {
                     $this->deleteHelper($file, $json);
                 }
-                else{
+                else {
                     unset($json[$file]);
                 }
             }
@@ -110,14 +110,13 @@ class CourseMaterialsController extends AbstractController {
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
 
-        if(!$this->core->getUser()->accessGrading()) {
+        if (!$this->core->getUser()->accessGrading()) {
             // if the user is not the instructor
             // download all accessible files according to course_materials_file_data.json
             $file_data = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
             $json = FileUtils::readJsonFile($file_data);
             foreach ($json as $path => $file) {
-                if(!CourseMaterial::isSectionAllowed($this->core, $path, $this->core->getUser()))
-                {
+                if (!CourseMaterial::isSectionAllowed($this->core, $path, $this->core->getUser())) {
                     $this->core->getOutput()->showError("Your section may not access this file.");
                     return false;
                 }
@@ -166,13 +165,15 @@ class CourseMaterialsController extends AbstractController {
      */
     public function modifyCourseMaterialsFilePermission($checked) {
         $data = $_POST['fn'];
-        if(is_string($data)){
+        if (is_string($data)) {
             $data = [$data];
         }
 
-        foreach ($data as $filename){
-            if (!isset($filename) ||
-                !isset($checked)) {
+        foreach ($data as $filename) {
+            if (
+                !isset($filename)
+                || !isset($checked)
+            ) {
                 $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
             }
 
@@ -188,16 +189,16 @@ class CourseMaterialsController extends AbstractController {
             $hide_from_students = "off";
             if ($json != false) {
                 $release_datetime  = $json[$file_name]['release_datetime'];
-                if(isset($json[$file_name]['sections'])){
+                if (isset($json[$file_name]['sections'])) {
                     $sections = $json[$file_name]['sections'];
                 }
                 $hide_from_students = $json[$file_name]['hide_from_students'];
             }
 
-            if(!is_null($sections)){
+            if (!is_null($sections)) {
                 $json[$file_name] = array('checked' => $checked, 'release_datetime' => $release_datetime, 'sections' => $sections, 'hide_from_students' => $hide_from_students);
             }
-            else{
+            else {
                 $json[$file_name] = array('checked' => $checked, 'release_datetime' => $release_datetime, 'hide_from_students' => $hide_from_students);
             }
             if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
@@ -214,22 +215,22 @@ class CourseMaterialsController extends AbstractController {
         $data = $_POST['fn'];
         $hide_from_students = null;
 
-        if(!isset($newdatatime)) {
+        if (!isset($newdatatime)) {
             $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
         }
 
         $new_data_time = htmlspecialchars($newdatatime);
         //Check if the datetime is correct
-        if(\DateTime::createFromFormat('Y-m-d H:i:s', $new_data_time) === false){
+        if (\DateTime::createFromFormat('Y-m-d H:i:s', $new_data_time) === false) {
             return $this->core->getOutput()->renderResultMessage("ERROR: Improperly formatted date", false);
         }
 
         //only one will not iterate correctly
-        if(is_string($data)){
+        if (is_string($data)) {
             $data = [$data];
         }
 
-        foreach ($data as $filename){
+        foreach ($data as $filename) {
             if (!isset($filename)) {
                 $this->core->redirect($this->core->buildCourseUrl(['course_materials']));
             }
@@ -242,17 +243,17 @@ class CourseMaterialsController extends AbstractController {
             $json = FileUtils::readJsonFile($fp);
             if ($json != false) {
                 $checked  = $json[$file_name]['checked'];
-                if(isset($json[$file_name]['sections'])){
+                if (isset($json[$file_name]['sections'])) {
                     $sections  = $json[$file_name]['sections'];
                 }
-                if(isset($json[$file_name]['hide_from_students'])){
+                if (isset($json[$file_name]['hide_from_students'])) {
                     $hide_from_students  = $json[$file_name]['hide_from_students'];
                 }
             }
-            if(!is_null($sections)){
+            if (!is_null($sections)) {
                 $json[$file_name] = array('checked' => $checked, 'release_datetime' => $new_data_time, 'sections' => $sections, 'hide_from_students' => $hide_from_students);
             }
-            else{
+            else {
                 $json[$file_name] = array('checked' => $checked, 'release_datetime' => $new_data_time, 'hide_from_students' => $hide_from_students);
             }
             if (file_put_contents($fp, FileUtils::encodeJson($json)) === false) {
@@ -288,26 +289,26 @@ class CourseMaterialsController extends AbstractController {
         }
 
         $release_time = "";
-        if(isset($_POST['release_time'])){
+        if (isset($_POST['release_time'])) {
             $release_time = $_POST['release_time'];
         }
 
         $sections = null;
-        if(isset($_POST['sections'])){
+        if (isset($_POST['sections'])) {
             $sections = $_POST['sections'];
         }
 
         $hide_from_students = null;
-        if(isset($_POST['hide_from_students'])){
+        if (isset($_POST['hide_from_students'])) {
             $hide_from_students = $_POST['hide_from_students'];
         }
 
-        if(empty($sections) && !is_null($sections)){
+        if (empty($sections) && !is_null($sections)) {
             $sections = [];
         }
 
         //Check if the datetime is correct
-        if(\DateTime::createFromFormat('Y-m-d H:i:s', $release_time) === false){
+        if (\DateTime::createFromFormat('Y-m-d H:i:s', $release_time) === false) {
             return $this->core->getOutput()->renderResultMessage("ERROR: Improperly formatted date", false);
         }
 
@@ -330,14 +331,14 @@ class CourseMaterialsController extends AbstractController {
         }
 
         $status = FileUtils::validateUploadedFiles($_FILES["files1"]);
-        if(array_key_exists("failed", $status)){
+        if (array_key_exists("failed", $status)) {
             return $this->core->getOutput()->renderResultMessage("Failed to validate uploads " . $status["failed"], false);
         }
 
         $file_size = 0;
         foreach ($status as $stat) {
             $file_size += $stat['size'];
-            if($stat['success'] === false){
+            if ($stat['success'] === false) {
                 return $this->core->getOutput()->renderResultMessage("Error " . $stat['error'], false);
             }
         }
@@ -371,7 +372,7 @@ class CourseMaterialsController extends AbstractController {
                     $is_zip_file = false;
 
                     if (mime_content_type($uploaded_files[1]["tmp_name"][$j]) == "application/zip") {
-                        if(FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
+                        if (FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
                             return $this->core->getOutput()->renderResultMessage("ERROR: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[1]["name"][$j] . ".", false);
                         }
                         $is_zip_file = true;
@@ -384,7 +385,7 @@ class CourseMaterialsController extends AbstractController {
                         $zip = new \ZipArchive();
                         $res = $zip->open($uploaded_files[1]["tmp_name"][$j]);
 
-                        if(!$res){
+                        if (!$res) {
                             return $this->core->getOutput()->renderResultMessage("ERROR: Failed to open zip archive", false);
                         }
 
@@ -418,9 +419,9 @@ class CourseMaterialsController extends AbstractController {
 
                         foreach ($zfiles as $zfile) {
                             $path = FileUtils::joinPaths($upload_path, $zfile);
-                            if(!(is_null($sections))){
+                            if (!(is_null($sections))) {
                                 $sections_exploded = @explode(",", $sections);
-                                if($sections_exploded == null){
+                                if ($sections_exploded == null) {
                                     $sections_exploded = [];
                                 }
                                 $json[$path] = [
@@ -430,7 +431,7 @@ class CourseMaterialsController extends AbstractController {
                                     'hide_from_students' => $hide_from_students
                                 ];
                             }
-                            else{
+                            else {
                                 $json[$path] = [
                                     'checked' => '1',
                                     'release_datetime' => $release_time,
@@ -439,19 +440,19 @@ class CourseMaterialsController extends AbstractController {
                             }
                         }
                     }
-                    else
-                    {
+                    else {
                         if (!@copy($uploaded_files[1]["tmp_name"][$j], $dst)) {
                             return $this->core->getOutput()->renderResultMessage("ERROR: Failed to copy uploaded file {$uploaded_files[1]["name"][$j]} to current location.", false);
-                        }else{
-                            if(!(is_null($sections))){
+                        }
+                        else {
+                            if (!(is_null($sections))) {
                                 $sections_exploded = @explode(",", $sections);
-                                if($sections_exploded == null){
+                                if ($sections_exploded == null) {
                                     $sections_exploded = [];
                                 }
                                 $json[$dst] = array('checked' => '1', 'release_datetime' => $release_time, 'sections' => $sections_exploded, 'hide_from_students' => $hide_from_students);
                             }
-                            else{
+                            else {
                                 $json[$dst] = array('checked' => '1', 'release_datetime' => $release_time, 'hide_from_students' => $hide_from_students);
                             }
                         }

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -40,7 +40,7 @@ class ForumController extends AbstractController {
         //Notify User
         $this->core->addErrorMessage($error);
 
-        if($isThread){
+        if ($isThread) {
             $url = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
         }
         else {
@@ -56,26 +56,28 @@ class ForumController extends AbstractController {
         if (is_null($thread_id)) {
             $thread_id = $_POST['thread_id'];
         }
-        if($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
-            if($this->core->getQueries()->updateResolveState($thread_id, $status)) {
+        if ($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
+            if ($this->core->getQueries()->updateResolveState($thread_id, $status)) {
                 return $this->core->getOutput()->renderJsonSuccess();
-            } else {
+            }
+            else {
                 return $this->core->getOutput()->renderJsonFail('The thread resolve state could not be updated. Please try again.');
             }
-        } else {
+        }
+        else {
             return $this->core->getOutput()->renderJsonFail("You do not have permissions to do that.");
         }
     }
 
     private function checkGoodAttachment($isThread, $thread_id, $file_post) {
-        if((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE){
+        if ((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE) {
             return array(0);
         }
-        if(count($_FILES[$file_post]['tmp_name']) > 5) {
+        if (count($_FILES[$file_post]['tmp_name']) > 5) {
             return $this->returnUserContentToPage("Max file upload size is 5. Please try again.", $isThread, $thread_id);
         }
         $imageCheck = Utils::checkUploadedImageFile($file_post) ? 1 : 0;
-        if($imageCheck == 0 && !empty($_FILES[$file_post]['tmp_name'])){
+        if ($imageCheck == 0 && !empty($_FILES[$file_post]['tmp_name'])) {
             return $this->returnUserContentToPage("Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)", $isThread, $thread_id);
         }
         return array($imageCheck);
@@ -83,36 +85,36 @@ class ForumController extends AbstractController {
 
     private function isValidCategories($inputCategoriesIds = -1, $inputCategoriesName = -1) {
         $rows = $this->core->getQueries()->getCategories();
-        if(is_array($inputCategoriesIds)) {
-            if(count($inputCategoriesIds) < 1) {
+        if (is_array($inputCategoriesIds)) {
+            if (count($inputCategoriesIds) < 1) {
                 return false;
             }
             foreach ($inputCategoriesIds as $category_id) {
                 $match_found = false;
-                foreach($rows as $index => $values){
-                    if($values["category_id"] === $category_id) {
+                foreach ($rows as $index => $values) {
+                    if ($values["category_id"] === $category_id) {
                         $match_found = true;
                         break;
                     }
                 }
-                if(!$match_found) {
+                if (!$match_found) {
                     return false;
                 }
             }
         }
-        if(is_array($inputCategoriesName)) {
-            if(count($inputCategoriesName) < 1) {
+        if (is_array($inputCategoriesName)) {
+            if (count($inputCategoriesName) < 1) {
                 return false;
             }
             foreach ($inputCategoriesName as $category_name) {
                 $match_found = false;
-                foreach($rows as $index => $values){
-                    if($values["category_desc"] === $category_name) {
+                foreach ($rows as $index => $values) {
+                    if ($values["category_desc"] === $category_name) {
                         $match_found = true;
                         break;
                     }
                 }
-                if(!$match_found) {
+                if (!$match_found) {
                     return false;
                 }
             }
@@ -123,8 +125,8 @@ class ForumController extends AbstractController {
     private function isCategoryDeletionGood($category_id) {
         // Check if not the last category which exists
         $rows = $this->core->getQueries()->getCategories();
-        foreach($rows as $index => $values){
-            if(((int) $values["category_id"]) !== $category_id) {
+        foreach ($rows as $index => $values) {
+            if (((int) $values["category_id"]) !== $category_id) {
                 return true;
             }
         }
@@ -137,12 +139,13 @@ class ForumController extends AbstractController {
      */
     public function addNewCategory($category = []) {
         $result = array();
-        if(!empty($_POST["newCategory"])) {
+        if (!empty($_POST["newCategory"])) {
             $category = trim($_POST["newCategory"]);
-            if($this->isValidCategories(-1, array($category))) {
+            if ($this->isValidCategories(-1, array($category))) {
                 return $this->core->getOutput()->renderJsonFail("That category already exists.");
-            } else {
-                if(strlen($category) > 50){
+            }
+            else {
+                if (strlen($category) > 50) {
                     return $this->core->getOutput()->renderJsonFail("Category name is more than 50 characters.");
                 }
                 else {
@@ -150,10 +153,11 @@ class ForumController extends AbstractController {
                     $result["new_id"] = $newCategoryId["category_id"];
                 }
             }
-        } elseif (count($category) > 0){
+        }
+        elseif (count($category) > 0) {
             $result["new_ids"] = [];
-            foreach ($category as $categoryName){
-                if(!$this->isValidCategories(-1, array($categoryName))) {
+            foreach ($category as $categoryName) {
+                if (!$this->isValidCategories(-1, array($categoryName))) {
                     $newCategoryId = $this->core->getQueries()->addNewCategory($categoryName);
                     $result["new_ids"][] = $newCategoryId;
                 }
@@ -170,20 +174,24 @@ class ForumController extends AbstractController {
      * @AccessControl(permission="forum.modify_category")
      */
     public function deleteCategory() {
-        if(!empty($_POST["deleteCategory"])) {
+        if (!empty($_POST["deleteCategory"])) {
             $category = (int) $_POST["deleteCategory"];
-            if(!$this->isValidCategories(array($category))) {
+            if (!$this->isValidCategories(array($category))) {
                 return $this->core->getOutput()->renderJsonFail("That category doesn't exists.");
-            } elseif(!$this->isCategoryDeletionGood($category)) {
+            }
+            elseif (!$this->isCategoryDeletionGood($category)) {
                 return $this->core->getOutput()->renderJsonFail("Last category can't be deleted.");
-            } else {
-                if($this->core->getQueries()->deleteCategory($category)) {
+            }
+            else {
+                if ($this->core->getQueries()->deleteCategory($category)) {
                     return $this->core->getOutput()->renderJsonSuccess();
-                } else {
+                }
+                else {
                     return $this->core->getOutput()->renderJsonFail("Category is in use.");
                 }
             }
-        } else {
+        }
+        else {
             return $this->core->getOutput()->renderJsonFail("No category data submitted. Please try again.");
         }
     }
@@ -197,18 +205,18 @@ class ForumController extends AbstractController {
         $category_desc = null;
         $category_color = null;
 
-        if(!empty($_POST["category_desc"])) {
+        if (!empty($_POST["category_desc"])) {
             $category_desc = trim($_POST["category_desc"]);
-            if($this->isValidCategories(-1, array($category_desc))) {
+            if ($this->isValidCategories(-1, array($category_desc))) {
                 return $this->core->getOutput()->renderJsonFail("That category already exists.");
             }
-            elseif(strlen($category_desc) > 50){
+            elseif (strlen($category_desc) > 50) {
                 return $this->core->getOutput()->renderJsonFail("Category name is more than 50 characters.");
             }
         }
-        if(!empty($_POST["category_color"])) {
+        if (!empty($_POST["category_color"])) {
             $category_color = $_POST["category_color"];
-            if(!in_array(strtoupper($category_color), $this->getAllowedCategoryColor())) {
+            if (!in_array(strtoupper($category_color), $this->getAllowedCategoryColor())) {
                 return $this->core->getOutput()->renderJsonFail("Given category color is not allowed.");
             }
         }
@@ -233,10 +241,11 @@ class ForumController extends AbstractController {
             $new_order[] = (int) $item;
         }
 
-        if(count(array_diff(array_merge($current_order, $new_order), array_intersect($current_order, $new_order))) === 0) {
+        if (count(array_diff(array_merge($current_order, $new_order), array_intersect($current_order, $new_order))) === 0) {
             $this->core->getQueries()->reorderCategories($new_order);
             return $this->core->getOutput()->renderJsonSuccess();
-        } else {
+        }
+        else {
             return $this->core->getOutput()->renderJsonFail("Different Categories IDs given");
         }
     }
@@ -255,14 +264,15 @@ class ForumController extends AbstractController {
         $thread_post_content = str_replace("\r", "", $_POST["thread_post_content"]);
         $anon = (isset($_POST["Anon"]) && $_POST["Anon"] == "Anon") ? 1 : 0;
 
-        if(strlen($thread_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
+        if (strlen($thread_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT) {
             $result['next_page'] = $this->core->buildUrl(['forum', 'threads', 'new']);
             return $this->core->getOutput()->renderJsonFail("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long", $result);
         }
 
-        if(!empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()){
+        if (!empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()) {
             $lock_thread_date = $_POST['lock_thread_date'];
-        } else {
+        }
+        else {
             $lock_thread_date = null;
         }
 
@@ -275,46 +285,49 @@ class ForumController extends AbstractController {
         foreach ($_POST["cat"] as $category_id) {
             $categories_ids[] = (int) $category_id;
         }
-        if(empty($thread_title) || empty($thread_post_content)){
+        if (empty($thread_title) || empty($thread_post_content)) {
             $this->core->addErrorMessage("One of the fields was empty or bad. Please re-submit your thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
-        } elseif(!$this->isValidCategories($categories_ids)){
+        }
+        elseif (!$this->isValidCategories($categories_ids)) {
             $this->core->addErrorMessage("You must select valid categories. Please re-submit your thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', 'new']);
-        } else {
+        }
+        else {
             $hasGoodAttachment = $this->checkGoodAttachment(true, -1, 'file_input');
-            if($hasGoodAttachment[0] == -1){
+            if ($hasGoodAttachment[0] == -1) {
                 $result['next_page'] = $hasGoodAttachment[1];
-            } else {
+            }
+            else {
                 // Good Attachment
                 $result = $this->core->getQueries()->createThread($markdown, $current_user_id, $thread_title, $thread_post_content, $anon, $announcement, $thread_status, $hasGoodAttachment[0], $categories_ids, $lock_thread_date);
 
                 $thread_id = $result["thread_id"];
                 $post_id = $result["post_id"];
 
-                if($hasGoodAttachment[0] == 1) {
+                if ($hasGoodAttachment[0] == 1) {
                     $thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $thread_id);
                     FileUtils::createDir($thread_dir);
 
                     $post_dir = FileUtils::joinPaths($thread_dir, $post_id);
                     FileUtils::createDir($post_dir);
 
-                    for($i = 0; $i < count($_FILES["file_input"]["name"]); $i++){
+                    for ($i = 0; $i < count($_FILES["file_input"]["name"]); $i++) {
                         $target_file = $post_dir . "/" . basename($_FILES["file_input"]["name"][$i]);
                         move_uploaded_file($_FILES["file_input"]["tmp_name"][$i], $target_file);
                     }
                 }
                 $full_course_name = $this->core->getFullCourseName();
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]), 'thread_id' => $thread_id));
-                // notify on a new announcement
                 if ($announcement) {
+                    // notify on a new announcement
                     $subject = "New Announcement: " . Notification::textShortner($thread_title);
                     $content = "An Instructor or Teaching Assistant made an announcement in:\n" . $full_course_name . "\n\n" . $thread_title . "\n\n" . $thread_post_content;
                     $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject];
                     $this->core->getNotificationFactory()->onNewAnnouncement($event);
                 }
-                // notify on a new thread
                 else {
+                    // notify on a new thread
                     $subject = "New Thread: " . Notification::textShortner($thread_title);
                     $content = "A new discussion thread was created in:\n" . $full_course_name . "\n\n" . $thread_title . "\n\n" . $thread_post_content;
                     $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject];
@@ -348,12 +361,12 @@ class ForumController extends AbstractController {
         $post_content = str_replace("\r", "", $_POST[$post_content_tag]);
         $thread_id = htmlentities($_POST["thread_id"], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
-        if(strlen($post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
+        if (strlen($post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT) {
             $result['next_page'] = $this->core->buildUrl(['forum', 'threads']);
             return $this->core->getOutput()->renderJsonFail("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long", $result);
         }
 
-        if(isset($_POST['thread_status'])){
+        if (isset($_POST['thread_status'])) {
             $this->changeThreadStatus($_POST['thread_status'], $thread_id);
         }
 
@@ -363,34 +376,39 @@ class ForumController extends AbstractController {
 
         $display_option = (!empty($_POST["display_option"])) ? htmlentities($_POST["display_option"], ENT_QUOTES | ENT_HTML5, 'UTF-8') : "tree";
         $anon = (isset($_POST["Anon"]) && $_POST["Anon"] == "Anon") ? 1 : 0;
-        if(empty($post_content) || empty($thread_id)){
+        if (empty($post_content) || empty($thread_id)) {
             $this->core->addErrorMessage("There was an error submitting your post. Please re-submit your post.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } elseif(!$this->core->getQueries()->existsThread($thread_id)) {
+        }
+        elseif (!$this->core->getQueries()->existsThread($thread_id)) {
             $this->core->addErrorMessage("There was an error submitting your post. Thread doesn't exist.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } elseif(!$this->core->getQueries()->existsPost($thread_id, $parent_id)) {
+        }
+        elseif (!$this->core->getQueries()->existsPost($thread_id, $parent_id)) {
             $this->core->addErrorMessage("There was an error submitting your post. Parent post doesn't exist in given thread.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads']);
-        } elseif($this->core->getQueries()->isThreadLocked($thread_id) && !$this->core->getUser()->accessAdmin()) {
+        }
+        elseif ($this->core->getQueries()->isThreadLocked($thread_id) && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Thread is locked.");
             $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
-        } else {
+        }
+        else {
             $hasGoodAttachment = $this->checkGoodAttachment(false, $thread_id, $file_post);
-            if($hasGoodAttachment[0] == -1){
+            if ($hasGoodAttachment[0] == -1) {
                 $result['next_page'] = $hasGoodAttachment[1];
-            } else {
+            }
+            else {
                 $post_id = $this->core->getQueries()->createPost($current_user_id, $post_content, $thread_id, $anon, 0, false, $hasGoodAttachment[0], $markdown, $parent_id);
                 $thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $thread_id);
 
-                if(!is_dir($thread_dir)) {
+                if (!is_dir($thread_dir)) {
                     FileUtils::createDir($thread_dir);
                 }
 
-                if($hasGoodAttachment[0] == 1) {
+                if ($hasGoodAttachment[0] == 1) {
                     $post_dir = FileUtils::joinPaths($thread_dir, $post_id);
                     FileUtils::createDir($post_dir);
-                    for($i = 0; $i < count($_FILES[$file_post]["name"]); $i++){
+                    for ($i = 0; $i < count($_FILES[$file_post]["name"]); $i++) {
                         $target_file = $post_dir . "/" . basename($_FILES[$file_post]["name"][$i]);
                         move_uploaded_file($_FILES[$file_post]["tmp_name"][$i], $target_file);
                     }
@@ -453,21 +471,23 @@ class ForumController extends AbstractController {
 
         $markdown = !empty($_POST['markdown_status']);
 
-        if(!$this->core->getAccess()->canI("forum.modify_post", ['post_author' => $post['author_user_id']])) {
+        if (!$this->core->getAccess()->canI("forum.modify_post", ['post_author' => $post['author_user_id']])) {
                 return $this->core->getOutput()->renderJsonFail('You do not have permissions to do that.');
         }
-        if(!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) && !$this->core->getUser()->accessAdmin()){
+        if (!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Thread is locked.");
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $_POST['edit_thread_id']]));
-        } elseif($this->core->getQueries()->isThreadLocked($_POST['thread_id']) && !$this->core->getUser()->accessAdmin()){
+        }
+        elseif ($this->core->getQueries()->isThreadLocked($_POST['thread_id']) && !$this->core->getUser()->accessAdmin()) {
             return $this->core->getOutput()->renderJsonFail('Thread is locked');
         }
-        elseif($modify_type == 0) { //delete post or thread
+        elseif ($modify_type == 0) { //delete post or thread
             $thread_id = $_POST["thread_id"];
             $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
-            if($this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 1)){
+            if ($this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 1)) {
                 $type = "thread";
-            } else {
+            }
+            else {
                 $type = "post";
             }
 
@@ -480,13 +500,15 @@ class ForumController extends AbstractController {
 
             $this->core->getQueries()->removeNotificationsPost($post_id);
             return $this->core->getOutput()->renderJsonSuccess(array('type' => $type));
-        } elseif($modify_type == 2) { //undelete post or thread
+        }
+        elseif ($modify_type == 2) { //undelete post or thread
             $thread_id = $_POST["thread_id"];
             $result = $this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 0);
-            if(is_null($result)) {
+            if (is_null($result)) {
                 $error = "Parent post must be undeleted first.";
                 return $this->core->getOutput()->renderJsonFail($error);
-            } else {
+            }
+            else {
                 // We want to reload same thread again, in both case (thread/post undelete)
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
@@ -498,7 +520,8 @@ class ForumController extends AbstractController {
                 $type = "post";
                 return $this->core->getOutput()->renderJsonSuccess(array('type' => $type));
             }
-        } elseif($modify_type == 1) { //edit post or thread
+        }
+        elseif ($modify_type == 1) { //edit post or thread
             $thread_id = $_POST["edit_thread_id"];
             $status_edit_thread = $this->editThread();
             $status_edit_post   = $this->editPost();
@@ -508,37 +531,42 @@ class ForumController extends AbstractController {
             $isError = false;
             $messageString = '';
              // Author of first post and thread must be same
-            if(is_null($status_edit_thread) && is_null($status_edit_post)) {
+            if (is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
-            } elseif(is_null($status_edit_thread) || is_null($status_edit_post)) {
+            }
+            elseif (is_null($status_edit_thread) || is_null($status_edit_post)) {
                 $type = is_null($status_edit_thread) ? "Post" : "Thread";
-                if($status_edit_thread || $status_edit_post) {
+                if ($status_edit_thread || $status_edit_post) {
                     //$type is true
                     $messageString = "{$type} updated successfully.";
                     $any_changes = true;
-                } else {
+                }
+                else {
                     $isError = true;
                     $messageString = "{$type} update failed. Please try again.";
                 }
-            } else {
-                if($status_edit_thread && $status_edit_post) {
+            }
+            else {
+                if ($status_edit_thread && $status_edit_post) {
                     $type = "Thread and Post";
                     $messageString = "Thread and post updated successfully.";
                     $any_changes = true;
-                } else {
+                }
+                else {
                     $type = ($status_edit_thread) ? "Thread" : "Post";
                     $type_opposite = (!$status_edit_thread) ? "Thread" : "Post";
                     $isError = true;
-                    if($status_edit_thread || $status_edit_post) {
+                    if ($status_edit_thread || $status_edit_post) {
                         //$type is true
                         $messageString = "{$type} updated successfully. {$type_opposite} update failed. Please try again.";
                         $any_changes = true;
-                    } else {
+                    }
+                    else {
                         $messageString = "Thread and Post update failed. Please try again.";
                     }
                 }
             }
-            if($any_changes) {
+            if ($any_changes) {
                 $thread_title = $this->core->getQueries()->getThread($thread_id)[0]['title'];
                 $post_author_id = $post['author_user_id'];
                 $metadata = json_encode(array('url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string) $post_id, 'thread_id' => $thread_id, 'post_id' => $post_id));
@@ -556,7 +584,7 @@ class ForumController extends AbstractController {
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post_author_id, 'preference' => 'all_modifications_forum'];
                 $this->core->getNotificationFactory()->onPostModified($event);
             }
-            if($isError) {
+            if ($isError) {
                 return $this->core->getOutput()->renderJsonFail($messageString);
             }
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $thread_id]));
@@ -574,14 +602,14 @@ class ForumController extends AbstractController {
         preg_match('/\((.*?)\)/', $parent_thread_id, $result);
         $parent_thread_id = $result[1];
         $thread_id = $child_thread_id;
-        if(is_numeric($parent_thread_id) && is_numeric($child_thread_id)) {
+        if (is_numeric($parent_thread_id) && is_numeric($child_thread_id)) {
             $message = "";
             $child_root_post = -1;
-            if($this->core->getQueries()->mergeThread($parent_thread_id, $child_thread_id, $message, $child_root_post)) {
+            if ($this->core->getQueries()->mergeThread($parent_thread_id, $child_thread_id, $message, $child_root_post)) {
                 $child_thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $child_thread_id);
-                if(is_dir($child_thread_dir)) {
+                if (is_dir($child_thread_dir)) {
                     $parent_thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $parent_thread_id);
-                    if(!is_dir($parent_thread_dir)) {
+                    if (!is_dir($parent_thread_dir)) {
                         FileUtils::createDir($parent_thread_dir);
                     }
                     $child_posts_dirs = FileUtils::getAllDirs($child_thread_dir);
@@ -604,7 +632,8 @@ class ForumController extends AbstractController {
                 $this->core->getNotificationFactory()->onPostModified($event);
                 $this->core->addSuccessMessage("Threads merged!");
                 $thread_id = $parent_thread_id;
-            } else {
+            }
+            else {
                 $this->core->addErrorMessage("Merging Failed! " . $message);
             }
         }
@@ -613,23 +642,23 @@ class ForumController extends AbstractController {
 
     private function editThread() {
         // Ensure authentication before call
-        if(!empty($_POST["title"])) {
+        if (!empty($_POST["title"])) {
             $thread_id = $_POST["edit_thread_id"];
-            if(!empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()){
+            if (!empty($_POST['lock_thread_date']) && $this->core->getUser()->accessAdmin()) {
                 $lock_thread_date = $_POST['lock_thread_date'];
             }
-            else{
+            else {
                 $lock_thread_date = null;
             }
             $thread_title = $_POST["title"];
             $status = $_POST["thread_status"];
             $categories_ids  = array();
-            if(!empty($_POST["cat"])) {
+            if (!empty($_POST["cat"])) {
                 foreach ($_POST["cat"] as $category_id) {
                     $categories_ids[] = (int) $category_id;
                 }
             }
-            if(!$this->isValidCategories($categories_ids)) {
+            if (!$this->isValidCategories($categories_ids)) {
                 return false;
             }
             return $this->core->getQueries()->editThread($thread_id, $thread_title, $categories_ids, $status, $lock_thread_date);
@@ -640,20 +669,20 @@ class ForumController extends AbstractController {
     private function editPost() {
         // Ensure authentication before call
         $new_post_content = $_POST["thread_post_content"];
-        if(!empty($new_post_content)) {
-            if(strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
+        if (!empty($new_post_content)) {
+            if (strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT) {
                 $this->core->addErrorMessage("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long");
                 return null;
             }
 
             $post_id = $_POST["edit_post_id"];
             $original_post = $this->core->getQueries()->getPost($post_id);
-            if(!empty($original_post)) {
+            if (!empty($original_post)) {
                 $original_creator = $original_post['author_user_id'];
             }
             $anon = (!empty($_POST["Anon"]) && $_POST["Anon"] == "Anon") ? 1 : 0;
             $current_user = $this->core->getUser()->getId();
-            if(!$this->modifyAnonymous($original_creator)) {
+            if (!$this->modifyAnonymous($original_creator)) {
                 $anon = $original_post["anonymous"] ? 1 : 0;
             }
 
@@ -666,7 +695,7 @@ class ForumController extends AbstractController {
 
     private function getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, &$blockNumber, $thread_id = -1) {
         $current_user = $this->core->getUser()->getId();
-        if(!$this->isValidCategories($categories_ids)) {
+        if (!$this->isValidCategories($categories_ids)) {
             // No filter for category
             $categories_ids = array();
         }
@@ -678,7 +707,7 @@ class ForumController extends AbstractController {
 
         foreach ($ordered_threads as &$thread) {
             $list = array();
-            foreach(explode("|", $thread['categories_ids']) as $id) {
+            foreach (explode("|", $thread['categories_ids']) as $id) {
                 $list[] = (int) $id;
             }
             $thread['categories_ids'] = $list;
@@ -699,10 +728,10 @@ class ForumController extends AbstractController {
         $categories_ids = array_key_exists('thread_categories', $_POST) && !empty($_POST["thread_categories"]) ? explode("|", $_POST['thread_categories']) : array();
         $thread_status = array_key_exists('thread_status', $_POST) && ($_POST["thread_status"] === "0" || !empty($_POST["thread_status"])) ? explode("|", $_POST['thread_status']) : array();
         $unread_threads = ($_POST["unread_select"] === 'true');
-        if(empty($categories_ids) && !empty($_COOKIE[$currentCourse . '_forum_categories'])){
+        if (empty($categories_ids) && !empty($_COOKIE[$currentCourse . '_forum_categories'])) {
             $categories_ids = explode("|", $_COOKIE[$currentCourse . '_forum_categories']);
         }
-        if(empty($thread_status) && !empty($_COOKIE['forum_thread_status'])){
+        if (empty($thread_status) && !empty($_COOKIE['forum_thread_status'])) {
             $thread_status = explode("|", $_COOKIE['forum_thread_status']);
         }
         foreach ($categories_ids as &$id) {
@@ -738,13 +767,13 @@ class ForumController extends AbstractController {
         $thread_status = array();
         $new_posts = array();
         $unread_threads = false;
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1) {
+        if (!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1) {
             $category_id = explode('|', $_COOKIE[$currentCourse . '_forum_categories']);
         }
-        if(!empty($_COOKIE['forum_thread_status'])){
+        if (!empty($_COOKIE['forum_thread_status'])) {
             $thread_status = explode("|", $_COOKIE['forum_thread_status']);
         }
-        if(!empty($_COOKIE['unread_select_value'])){
+        if (!empty($_COOKIE['unread_select_value'])) {
             $unread_threads = ($_COOKIE['unread_select_value'] === 'true');
         }
         foreach ($category_id as &$id) {
@@ -763,11 +792,11 @@ class ForumController extends AbstractController {
 
         $posts = null;
         $option = 'tree';
-        if(!empty($_COOKIE['forum_display_option'])) {
+        if (!empty($_COOKIE['forum_display_option'])) {
             $option = $_COOKIE['forum_display_option'];
         }
         $option = ($this->core->getUser()->accessGrading() || $option != 'alpha') ? $option : 'tree';
-        if(!empty($thread_id)){
+        if (!empty($thread_id)) {
             $thread_id = (int) $thread_id;
             $thread_resolve_state = $this->core->getQueries()->getResolveState($thread_id)[0]['status'];
             $this->core->getQueries()->markNotificationAsSeen($user, -2, (string) $thread_id);
@@ -776,43 +805,45 @@ class ForumController extends AbstractController {
                 $new_posts[] = $up["id"];
             }
             $thread = $this->core->getQueries()->getThread($thread_id);
-            if(!empty($thread)) {
+            if (!empty($thread)) {
                 $thread = $thread[0];
-                if($thread['merged_thread_id'] != -1){
+                if ($thread['merged_thread_id'] != -1) {
                     // Redirect merged thread to parent
                     $this->core->addSuccessMessage("Requested thread is merged into current thread.");
                     $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads', $thread['merged_thread_id']]));
                     return;
                 }
-                if($option == "alpha"){
+                if ($option == "alpha") {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'alpha');
-                } elseif($option == "reverse-time") {
+                }
+                elseif ($option == "reverse-time") {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'reverse-time');
-                }else {
+                }
+                else {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'tree');
                 }
-                if(empty($posts)){
+                if (empty($posts)) {
                     $this->core->addErrorMessage("No posts found for selected thread.");
                 }
             }
         }
-        if(empty($thread_id) || empty($posts)) {
+        if (empty($thread_id) || empty($posts)) {
             $new_posts = $this->core->getQueries()->getUnviewedPosts(-1, $current_user);
             $posts = $this->core->getQueries()->getPostsForThread($current_user, -1, $show_deleted);
         }
         $thread_id = -1;
-        if(!empty($posts)){
+        if (!empty($posts)) {
             $thread_id = $posts[0]["thread_id"];
         }
-        foreach($posts as &$post) {
+        foreach ($posts as &$post) {
             do {
                 $post['content'] = preg_replace('/(?:!\[(.*?)\]\((.*?)\))/', '$2', $post['content'], -1, $count);
-            } while($count > 0);
+            } while ($count > 0);
         }
         $pageNumber = 0;
         $threads = $this->getSortedThreads($category_id, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, $pageNumber, $thread_id);
 
-        if(!empty($_REQUEST["ajax"])){
+        if (!empty($_REQUEST["ajax"])) {
             $this->core->getOutput()->renderTemplate('forum\ForumThread', 'showForumThreads', $user, $posts, $new_posts, $threads, $show_deleted, $show_merged_thread, $option, $max_thread, $pageNumber, $thread_resolve_state, ForumUtils::FORUM_CHAR_POST_LIMIT, true);
         }
         else {
@@ -837,7 +868,7 @@ class ForumController extends AbstractController {
      * @Route("/{_semester}/{_course}/forum/threads/new", methods={"GET"})
      */
     public function showCreateThread() {
-        if(empty($this->core->getQueries()->getCategories())){
+        if (empty($this->core->getQueries()->getCategories())) {
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads']));
             return;
         }
@@ -871,7 +902,7 @@ class ForumController extends AbstractController {
             $_post['post_time'] = DateUtils::parseDateTime($post['edit_timestamp'], $this->core->getConfig()->getTimezone())->format("n/j g:i A");
             $output[] = $_post;
         }
-        if(count($output) == 0) {
+        if (count($output) == 0) {
             // Current post
             $_post['user'] = !$this->modifyAnonymous($oc) && $anon ? '' : $oc;
             $_post['content'] = $return = $this->core->getOutput()->renderTwigTemplate("forum/RenderPost.twig", [
@@ -898,9 +929,9 @@ class ForumController extends AbstractController {
      */
     public function getEditPostContent() {
         $post_id = $_POST["post_id"];
-        if(!empty($post_id)) {
+        if (!empty($post_id)) {
             $result = $this->core->getQueries()->getPost($post_id);
-            if($this->core->getAccess()->canI("forum.modify_post", ['post_author' => $result['author_user_id']])) {
+            if ($this->core->getAccess()->canI("forum.modify_post", ['post_author' => $result['author_user_id']])) {
                 $output = array();
                 $output['post'] = $result["content"];
                 $output['post_time'] = $result['timestamp'];
@@ -908,11 +939,12 @@ class ForumController extends AbstractController {
                 $output['change_anon'] = $this->modifyAnonymous($result["author_user_id"]);
                 $output['user'] = $output['anon'] ? 'Anonymous' : $result["author_user_id"];
                 $output['markdown'] = $result['render_markdown'];
-                if(isset($_POST["thread_id"])) {
+                if (isset($_POST["thread_id"])) {
                     $this->getThreadContent($_POST["thread_id"], $output);
                 }
                 return $this->core->getOutput()->renderJsonSuccess($output);
-            } else {
+            }
+            else {
                 return $this->core->getOutput()->renderJsonFail("You do not have permissions to do that.");
             }
         }
@@ -934,10 +966,10 @@ class ForumController extends AbstractController {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
         $users = array();
-        for($i = 0; $i < $num_posts; $i++){
+        for ($i = 0; $i < $num_posts; $i++) {
             $user = $posts[$i]["author_user_id"];
             $content = $posts[$i]["content"];
-            if(!isset($users[$user])){
+            if (!isset($users[$user])) {
                 $users[$user] = array();
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["first_name"] = htmlspecialchars($u -> getDisplayedFirstName());
@@ -948,7 +980,7 @@ class ForumController extends AbstractController {
                 $users[$user]["total_threads"] = 0;
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
             }
-            if($posts[$i]["parent_id"] == -1){
+            if ($posts[$i]["parent_id"] == -1) {
                 $users[$user]["total_threads"]++;
             }
             $users[$user]["posts"][] = $content;

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -113,7 +113,8 @@ class ForumController2 extends AbstractController {
         $this->core->addErrorMessage($error);
         if ($isThread) {
             $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'create_thread'));
-        } else {
+        }
+        else {
             $url = $this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id));
         }
         return array(-1, $url);
@@ -122,13 +123,15 @@ class ForumController2 extends AbstractController {
     private function changeThreadStatus($status) {
         $thread_id = $_POST['thread_id'];
         $result = array();
-        if($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
-            if($this->core->getQueries()->updateResolveState($thread_id, $status)) {
+        if ($this->core->getQueries()->getAuthorOfThread($thread_id) === $this->core->getUser()->getId() || $this->core->getUser()->accessGrading()) {
+            if ($this->core->getQueries()->updateResolveState($thread_id, $status)) {
                 $result['success'] = 'Thread resolve state has been changed.';
-            } else {
+            }
+            else {
                 $result['error'] = 'The thread resolve state could not be updated. Please try again.';
             }
-        } else {
+        }
+        else {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
@@ -138,8 +141,8 @@ class ForumController2 extends AbstractController {
     private function isCategoryDeletionGood($category_id) {
         // Check if not the last category which exists
         $rows = $this->core->getQueries()->getCategories();
-        foreach($rows as $index => $values){
-            if(((int) $values["category_id"]) !== $category_id) {
+        foreach ($rows as $index => $values) {
+            if (((int) $values["category_id"]) !== $category_id) {
                 return true;
             }
         }
@@ -148,19 +151,22 @@ class ForumController2 extends AbstractController {
 
     public function addNewCategory() {
         $result = array();
-        if($this->core->getUser()->accessGrading()){
-            if(!empty($_REQUEST["newCategory"])) {
+        if ($this->core->getUser()->accessGrading()) {
+            if (!empty($_REQUEST["newCategory"])) {
                 $category = $_REQUEST["newCategory"];
-                if($this->isValidCategories(-1, array($category))) {
+                if ($this->isValidCategories(-1, array($category))) {
                     $result["error"] = "That category already exists.";
-                } else {
+                }
+                else {
                     $newCategoryId = $this->core->getQueries()->addNewCategory($category);
                     $result["new_id"] = $newCategoryId["category_id"];
                 }
-            } else {
+            }
+            else {
                 $result["error"] = "No category data submitted. Please try again.";
             }
-        } else {
+        }
+        else {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
@@ -169,24 +175,29 @@ class ForumController2 extends AbstractController {
 
     public function deleteCategory() {
         $result = array();
-        if($this->core->getUser()->accessGrading()){
-            if(!empty($_REQUEST["deleteCategory"])) {
+        if ($this->core->getUser()->accessGrading()) {
+            if (!empty($_REQUEST["deleteCategory"])) {
                 $category = (int) $_REQUEST["deleteCategory"];
-                if(!$this->isValidCategories(array($category))) {
+                if (!$this->isValidCategories(array($category))) {
                     $result["error"] = "That category doesn't exists.";
-                } elseif(!$this->isCategoryDeletionGood($category)) {
+                }
+                elseif (!$this->isCategoryDeletionGood($category)) {
                     $result["error"] = "Last category can't be deleted.";
-                } else {
-                    if($this->core->getQueries()->deleteCategory($category)) {
+                }
+                else {
+                    if ($this->core->getQueries()->deleteCategory($category)) {
                         $result["success"] = "OK";
-                    } else {
+                    }
+                    else {
                         $result["error"] = "Category is in use.";
                     }
                 }
-            } else {
+            }
+            else {
                 $result["error"] = "No category data submitted. Please try again.";
             }
-        } else {
+        }
+        else {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
@@ -195,33 +206,35 @@ class ForumController2 extends AbstractController {
 
     public function editCategory() {
         $result = array();
-        if($this->core->getUser()->accessGrading()){
+        if ($this->core->getUser()->accessGrading()) {
             $category_id = $_REQUEST["category_id"];
             $category_desc = null;
             $category_color = null;
             $should_update = true;
 
-            if(!empty($_REQUEST["category_desc"])) {
+            if (!empty($_REQUEST["category_desc"])) {
                 $category_desc = $_REQUEST["category_desc"];
-                if($this->isValidCategories(-1, array($category_desc))) {
+                if ($this->isValidCategories(-1, array($category_desc))) {
                     $result["error"] = "That category already exists.";
                     $should_update = false;
                 }
             }
-            if(!empty($_REQUEST["category_color"])) {
+            if (!empty($_REQUEST["category_color"])) {
                 $category_color = $_REQUEST["category_color"];
-                if(!in_array(strtoupper($category_color), $this->getAllowedCategoryColor())) {
+                if (!in_array(strtoupper($category_color), $this->getAllowedCategoryColor())) {
                     $result["error"] = "Given category color is not allowed.";
                     $should_update = false;
                 }
             }
-            if($should_update) {
+            if ($should_update) {
                 $this->core->getQueries()->editCategory($category_id, $category_desc, $category_color);
                 $result["success"] = "OK";
-            } elseif(!isset($result["error"])) {
+            }
+            elseif (!isset($result["error"])) {
                 $result["error"] = "No category data updated. Please try again.";
             }
-        } else {
+        }
+        else {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
@@ -230,7 +243,7 @@ class ForumController2 extends AbstractController {
 
     public function reorderCategories() {
         $result = array();
-        if($this->core->getUser()->accessGrading()){
+        if ($this->core->getUser()->accessGrading()) {
             $rows = $this->core->getQueries()->getCategories();
 
             $current_order = array();
@@ -242,13 +255,15 @@ class ForumController2 extends AbstractController {
                 $new_order[] = (int) $item;
             }
 
-            if(count(array_diff(array_merge($current_order, $new_order), array_intersect($current_order, $new_order))) === 0) {
+            if (count(array_diff(array_merge($current_order, $new_order), array_intersect($current_order, $new_order))) === 0) {
                 $this->core->getQueries()->reorderCategories($new_order);
                 $results["success"] = "ok";
-            } else {
+            }
+            else {
                 $result["error"] = "Different Categories IDs given";
             }
-        } else {
+        }
+        else {
             $result["error"] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($result);
@@ -262,25 +277,27 @@ class ForumController2 extends AbstractController {
 
 
     public function alterAnnouncement($type) {
-        if($this->core->getUser()->getGroup() <= 2){
+        if ($this->core->getUser()->getGroup() <= 2) {
             $thread_id = $_POST["thread_id"];
             $this->core->getQueries()->setAnnouncement($thread_id, $type);
-            if($type) {
+            if ($type) {
                 $notification = new Notification($this->core, array('component' => 'forum', 'type' => 'updated_announcement', 'thread_id' => $thread_id, 'thread_title' => $this->core->getQueries()->getThreadTitle($thread_id)['title']));
                 $this->core->getQueries()->pushNotification($notification);
             }
-        } else {
+        }
+        else {
             $this->core->addErrorMessage("You do not have permissions to do that.");
         }
     }
 
     private function checkPostEditAccess($post_id) {
-        if($this->core->getUser()->accessGrading()){
+        if ($this->core->getUser()->accessGrading()) {
                 // Instructor/full access ta/mentor
                 return true;
-        } else {
+        }
+        else {
             $post = $this->core->getQueries()->getPost($post_id);
-            if($post['author_user_id'] === $this->core->getUser()->getId()) {
+            if ($post['author_user_id'] === $this->core->getUser()->getId()) {
                 // Original Author
                 return true;
             }
@@ -289,12 +306,13 @@ class ForumController2 extends AbstractController {
     }
 
     private function checkThreadEditAccess($thread_id) {
-        if($this->core->getUser()->accessGrading()){
+        if ($this->core->getUser()->accessGrading()) {
                 // Instructor/full access ta/mentor
                 return true;
-        } else {
+        }
+        else {
             $post = $this->core->getQueries()->getThread($thread_id)[0];
-            if($post['created_by'] === $this->core->getUser()->getId()) {
+            if ($post['created_by'] === $this->core->getUser()->getId()) {
                 // Original Author
                 return true;
             }
@@ -311,15 +329,16 @@ class ForumController2 extends AbstractController {
      */
     public function alterPost($modifyType) {
         $post_id = $_POST["post_id"] ?? $_POST["edit_post_id"];
-        if(!($this->checkPostEditAccess($post_id))) {
+        if (!($this->checkPostEditAccess($post_id))) {
                 $this->core->addErrorMessage("You do not have permissions to do that.");
                 return;
         }
-        if($modifyType == 0) { //delete post or thread
+        if ($modifyType == 0) { //delete post or thread
             $thread_id = $_POST["thread_id"];
-            if($this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 1)){
+            if ($this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 1)) {
                 $type = "thread";
-            } else {
+            }
+            else {
                 $type = "post";
             }
             $post = $this->core->getQueries()->getPost($post_id);
@@ -329,13 +348,15 @@ class ForumController2 extends AbstractController {
             $this->core->getQueries()->removeNotificationsPost($post_id);
             $this->core->getOutput()->renderJson($response = array('type' => $type));
             return $this->core->getOutput()->getOutput();
-        } elseif($modifyType == 2) { //undelete post or thread
+        }
+        elseif ($modifyType == 2) { //undelete post or thread
             $thread_id = $_POST["thread_id"];
             $result = $this->core->getQueries()->setDeletePostStatus($post_id, $thread_id, 0);
-            if(is_null($result)) {
+            if (is_null($result)) {
                 $error = "Parent post must be undeleted first.";
                 $this->core->getOutput()->renderJson($response = array('error' => $error));
-            } else {
+            }
+            else {
                 /// We want to reload same thread again, in both case (thread/post undelete)
                 $type = "post";
                 $post = $this->core->getQueries()->getPost($post_id);
@@ -345,7 +366,8 @@ class ForumController2 extends AbstractController {
                 $this->core->getOutput()->renderJson($response = array('type' => $type));
             }
             return $this->core->getOutput()->getOutput();
-        } elseif($modifyType == 1) { //edit post or thread
+        }
+        elseif ($modifyType == 1) { //edit post or thread
             $thread_id = $_POST["edit_thread_id"];
             $status_edit_thread = $this->editThread();
             $status_edit_post   = $this->editPost();
@@ -353,45 +375,51 @@ class ForumController2 extends AbstractController {
             $isError = false;
             $messageString = '';
              // Author of first post and thread must be same
-            if(is_null($status_edit_thread) && is_null($status_edit_post)) {
+            if (is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
-            } elseif(is_null($status_edit_thread) || is_null($status_edit_post)) {
+            }
+            elseif (is_null($status_edit_thread) || is_null($status_edit_post)) {
                 $type = is_null($status_edit_thread) ? "Post" : "Thread";
-                if($status_edit_thread || $status_edit_post) {
+                if ($status_edit_thread || $status_edit_post) {
                     //$type is true
                     $messageString = "{$type} updated successfully.";
                     $any_changes = true;
-                } else {
+                }
+                else {
                     $isError = true;
                     $messageString = "{$type} update failed. Please try again.";
                 }
-            } else {
-                if($status_edit_thread && $status_edit_post) {
+            }
+            else {
+                if ($status_edit_thread && $status_edit_post) {
                     $messageString = "Thread and post updated successfully.";
                     $any_changes = true;
-                } else {
+                }
+                else {
                     $type = ($status_edit_thread) ? "Thread" : "Post";
                     $type_opposite = (!$status_edit_thread) ? "Thread" : "Post";
                     $isError = true;
-                    if($status_edit_thread || $status_edit_post) {
+                    if ($status_edit_thread || $status_edit_post) {
                         //$type is true
                         $messageString = "{$type} updated successfully. {$type_opposite} update failed. Please try again.";
                         $any_changes = true;
-                    } else {
+                    }
+                    else {
                         $messageString = "Thread and Post update failed. Please try again.";
                     }
                 }
             }
-            if($any_changes) {
+            if ($any_changes) {
                 $post = $this->core->getQueries()->getPost($post_id);
                 $post_author = $post['author_user_id'];
                 $notification = new Notification($this->core, array('component' => 'forum', 'type' => 'edited', 'thread_id' => $thread_id, 'post_id' => $post_id, 'post_content' => $post['content'], 'reply_to' => $post_author));
                 $this->core->getQueries()->pushNotification($notification);
             }
-            if($isError) {
+            if ($isError) {
                 $this->core->addErrorMessage($messageString);
-            } else {
-                $this->core->addSuccessMessage($messageString);
+            }
+            else {
+                        $this->core->addSuccessMessage($messageString);
             }
             $this->core->redirect($this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id)));
         }
@@ -399,20 +427,20 @@ class ForumController2 extends AbstractController {
 
     private function editThread() {
         // Ensure authentication before call
-        if(!empty($_POST["title"])) {
+        if (!empty($_POST["title"])) {
             $thread_id = $_POST["edit_thread_id"];
-            if(!$this->checkThreadEditAccess($thread_id)) {
+            if (!$this->checkThreadEditAccess($thread_id)) {
                 return false;
             }
             $thread_title = $_POST["title"];
             $status = $_POST["thread_status"];
             $categories_ids  = array();
-            if(!empty($_POST["cat"])) {
+            if (!empty($_POST["cat"])) {
                 foreach ($_POST["cat"] as $category_id) {
                     $categories_ids[] = (int) $category_id;
                 }
             }
-            if(!$this->isValidCategories($categories_ids)) {
+            if (!$this->isValidCategories($categories_ids)) {
                 return false;
             }
             return $this->core->getQueries()->editThread($thread_id, $thread_title, $categories_ids, $status);
@@ -423,20 +451,20 @@ class ForumController2 extends AbstractController {
     private function editPost() {
         // Ensure authentication before call
         $new_post_content = $_POST["thread_post_content"];
-        if(!empty($new_post_content)) {
-            if(strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT){
+        if (!empty($new_post_content)) {
+            if (strlen($new_post_content) > ForumUtils::FORUM_CHAR_POST_LIMIT) {
                 $this->core->addErrorMessage("Posts cannot be over " . ForumUtils::FORUM_CHAR_POST_LIMIT . " characters long");
                 return null;
             }
 
             $post_id = $_POST["edit_post_id"];
             $original_post = $this->core->getQueries()->getPost($post_id);
-            if(!empty($original_post)) {
+            if (!empty($original_post)) {
                 $original_creator = $original_post['author_user_id'];
             }
             $anon = ($_POST["Anon"] == "Anon") ? 1 : 0;
             $current_user = $this->core->getUser()->getId();
-            if(!$this->modifyAnonymous($original_creator)) {
+            if (!$this->modifyAnonymous($original_creator)) {
                 $anon = $original_post["anonymous"] ? 1 : 0;
             }
             return $this->core->getQueries()->editPost($original_creator, $current_user, $post_id, $new_post_content, $anon);
@@ -446,7 +474,7 @@ class ForumController2 extends AbstractController {
 
     private function getSortedThreads($categories_ids, $max_thread, $show_deleted, $show_merged_thread, $thread_status, $unread_threads, &$blockNumber, $thread_id = -1) {
         $current_user = $this->core->getUser()->getId();
-        if(!ForumUtils::isValidCategories($this->core->getQueries()->getCategories(), $categories_ids)) {
+        if (!ForumUtils::isValidCategories($this->core->getQueries()->getCategories(), $categories_ids)) {
             // No filter for category
             $categories_ids = array();
         }
@@ -458,7 +486,7 @@ class ForumController2 extends AbstractController {
 
         foreach ($ordered_threads as &$thread) {
             $list = array();
-            foreach(explode("|", $thread['categories_ids']) as $id) {
+            foreach (explode("|", $thread['categories_ids']) as $id) {
                 $list[] = (int) $id;
             }
             $thread['categories_ids'] = $list;
@@ -476,10 +504,10 @@ class ForumController2 extends AbstractController {
         $categories_ids = array_key_exists('thread_categories', $_POST) && !empty($_POST["thread_categories"]) ? explode("|", $_POST['thread_categories']) : array();
         $thread_status = array_key_exists('thread_status', $_POST) && ($_POST["thread_status"] === "0" || !empty($_POST["thread_status"])) ? explode("|", $_POST['thread_status']) : array();
         $unread_threads = ($_POST["unread_select"] === 'true');
-        if(empty($categories_ids) && !empty($_COOKIE[$currentCourse . '_forum_categories'])){
+        if (empty($categories_ids) && !empty($_COOKIE[$currentCourse . '_forum_categories'])) {
             $categories_ids = explode("|", $_COOKIE[$currentCourse . '_forum_categories']);
         }
-        if(empty($thread_status) && !empty($_COOKIE['forum_thread_status'])){
+        if (empty($thread_status) && !empty($_COOKIE['forum_thread_status'])) {
             $thread_status = explode("|", $_COOKIE['forum_thread_status']);
         }
         foreach ($categories_ids as &$id) {
@@ -510,13 +538,13 @@ class ForumController2 extends AbstractController {
         $thread_status = array();
         $new_posts = array();
         $unread_threads = false;
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1) {
+        if (!empty($_COOKIE[$currentCourse . '_forum_categories']) && $category_id[0] == -1) {
             $category_id = explode('|', $_COOKIE[$currentCourse . '_forum_categories']);
         }
-        if(!empty($_COOKIE['forum_thread_status'])){
+        if (!empty($_COOKIE['forum_thread_status'])) {
             $thread_status = explode("|", $_COOKIE['forum_thread_status']);
         }
-        if(!empty($_COOKIE['unread_select_value'])){
+        if (!empty($_COOKIE['unread_select_value'])) {
             $unread_threads = ($_COOKIE['unread_select_value'] === 'true');
         }
         foreach ($category_id as &$id) {
@@ -533,13 +561,14 @@ class ForumController2 extends AbstractController {
 
         $posts = null;
         $option = 'tree';
-        if(!empty($_REQUEST['option'])) {
+        if (!empty($_REQUEST['option'])) {
             $option = $_REQUEST['option'];
-        } elseif(!empty($_COOKIE['forum_display_option'])) {
+        }
+        elseif (!empty($_COOKIE['forum_display_option'])) {
             $option = $_COOKIE['forum_display_option'];
         }
         $option = ($this->core->getUser()->accessGrading() || $option != 'alpha') ? $option : 'tree';
-        if(!empty($_REQUEST["thread_id"])){
+        if (!empty($_REQUEST["thread_id"])) {
             $thread_id = (int) $_REQUEST["thread_id"];
             $this->core->getQueries()->markNotificationAsSeen($user, -2, (string) $thread_id);
             $unread_p = $this->core->getQueries()->getUnviewedPosts($thread_id, $current_user);
@@ -547,30 +576,31 @@ class ForumController2 extends AbstractController {
                 $new_posts[] = $up["id"];
             }
             $thread = $this->core->getQueries()->getThread($thread_id);
-            if(!empty($thread)) {
+            if (!empty($thread)) {
                 $thread = $thread[0];
-                if($thread['merged_thread_id'] != -1){
+                if ($thread['merged_thread_id'] != -1) {
                     // Redirect merged thread to parent
                     $this->core->addSuccessMessage("Requested thread is merged into current thread.");
                     $this->core->redirect($this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread['merged_thread_id'])));
                     return;
                 }
-                if($option == "alpha"){
+                if ($option == "alpha") {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'alpha');
-                } else {
+                }
+                else {
                     $posts = $this->core->getQueries()->getPostsForThread($current_user, $thread_id, $show_deleted, 'tree');
                 }
-                if(empty($posts)){
+                if (empty($posts)) {
                     $this->core->addErrorMessage("No posts found for selected thread.");
                 }
             }
         }
-        if(empty($_REQUEST["thread_id"]) || empty($posts)) {
+        if (empty($_REQUEST["thread_id"]) || empty($posts)) {
             $new_posts = $this->core->getQueries()->getUnviewedPosts(-1, $current_user);
             $posts = $this->core->getQueries()->getPostsForThread($current_user, -1, $show_deleted);
         }
         $thread_id = -1;
-        if(!empty($posts)){
+        if (!empty($posts)) {
             $thread_id = $posts[0]["thread_id"];
         }
         $pageNumber = 0;
@@ -599,7 +629,7 @@ class ForumController2 extends AbstractController {
     public function getHistory() {
         $post_id = $_POST["post_id"];
         $output = array();
-        if($this->core->getUser()->accessGrading()){
+        if ($this->core->getUser()->accessGrading()) {
             $_post = array();
             $older_posts = $this->core->getQueries()->getPostHistory($post_id);
             $current_post = $this->core->getQueries()->getPost($post_id);
@@ -611,7 +641,7 @@ class ForumController2 extends AbstractController {
                 $_post['post_time'] = DateUtils::parseDateTime($post['edit_timestamp'], $this->core->getConfig()->getTimezone())->format("n/j g:i A");
                 $output[] = $_post;
             }
-            if(count($output) == 0) {
+            if (count($output) == 0) {
                 // Current post
                 $_post['user'] = !$this->modifyAnonymous($oc) && $anon ? '' : $oc;
                 $_post['content'] = $this->core->getOutput()->renderTemplate('forum\ForumThread', 'filter_post_content', $current_post["content"]);
@@ -624,7 +654,8 @@ class ForumController2 extends AbstractController {
                 $_post['user_info'] = $emptyUser ? array('first_name' => 'Anonymous', 'last_name' => '', 'email' => '') : $this->core->getQueries()->getDisplayUserInfoFromUserId($_post['user']);
                 $_post['is_staff_post'] = $emptyUser ? false : $this->core->getQueries()->isStaffPost($_post['user']);
             }
-        } else {
+        }
+        else {
             $output['error'] = "You do not have permissions to do that.";
         }
         $this->core->getOutput()->renderJson($output);
@@ -639,10 +670,10 @@ class ForumController2 extends AbstractController {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
         $users = array();
-        for($i = 0; $i < $num_posts; $i++){
+        for ($i = 0; $i < $num_posts; $i++) {
             $user = $posts[$i]["author_user_id"];
             $content = $posts[$i]["content"];
-            if(!isset($users[$user])){
+            if (!isset($users[$user])) {
                 $users[$user] = array();
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["first_name"] = htmlspecialchars($u -> getDisplayedFirstName());
@@ -653,7 +684,7 @@ class ForumController2 extends AbstractController {
                 $users[$user]["total_threads"] = 0;
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
             }
-            if($posts[$i]["parent_id"] == -1){
+            if ($posts[$i]["parent_id"] == -1) {
                 $users[$user]["total_threads"]++;
             }
             $users[$user]["posts"][] = $content;
@@ -672,15 +703,15 @@ class ForumController2 extends AbstractController {
         preg_match('/\((.*?)\)/', $parent_thread_id, $result);
         $parent_thread_id = $result[1];
         $thread_id = $child_thread_id;
-        if($this->core->getUser()->accessGrading()){
-            if(is_numeric($parent_thread_id) && is_numeric($child_thread_id)) {
+        if ($this->core->getUser()->accessGrading()) {
+            if (is_numeric($parent_thread_id) && is_numeric($child_thread_id)) {
                 $message = "";
                 $child_root_post = -1;
-                if($this->core->getQueries()->mergeThread($parent_thread_id, $child_thread_id, $message, $child_root_post)) {
+                if ($this->core->getQueries()->mergeThread($parent_thread_id, $child_thread_id, $message, $child_root_post)) {
                     $child_thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $child_thread_id);
-                    if(is_dir($child_thread_dir)) {
+                    if (is_dir($child_thread_dir)) {
                         $parent_thread_dir = FileUtils::joinPaths(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "forum_attachments"), $parent_thread_id);
-                        if(!is_dir($parent_thread_dir)) {
+                        if (!is_dir($parent_thread_dir)) {
                             FileUtils::createDir($parent_thread_dir);
                         }
                         $child_posts_dirs = FileUtils::getAllDirs($child_thread_dir);
@@ -699,11 +730,13 @@ class ForumController2 extends AbstractController {
                     $this->core->getQueries()->pushNotification($notification);
                     $this->core->addSuccessMessage("Threads merged!");
                     $thread_id = $parent_thread_id;
-                } else {
+                }
+                else {
                     $this->core->addErrorMessage("Merging Failed! " . $message);
                 }
             }
-        } else {
+        }
+        else {
             $this->core->addErrorMessage("You do not have permissions to do that.");
         }
         $this->core->redirect($this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread', 'thread_id' => $thread_id)));
@@ -742,11 +775,12 @@ class ForumController2 extends AbstractController {
             'thread_id'          => -1
         ], true);
 
-        if($result) {
+        if ($result) {
             //We published with success!
             $this->core->addSuccessMessage('Thread created successfully.');
             $this->core->redirect($this->core->buildUrl(array('component' => 'forum', 'page' => 'view_thread')));
-        } else {
+        }
+        else {
             return $this->core->getOutput()->renderJson(['error' => 'The post data is malformed. Please try submitting your post again.']);
         }
     }
@@ -773,10 +807,11 @@ class ForumController2 extends AbstractController {
 
         $result = $this->core->getForum()->pinThread($thread_id, $type);
 
-        if($result) {
+        if ($result) {
             //Should review specs on submitty.org
             $response = ['success' => 'Thread pinned successfully.'];
-        } else {
+        }
+        else {
             $response = ['failure' => 'Thread id does not exist.'];
         }
 

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -265,8 +265,8 @@ class ElectronicGraderController extends AbstractController {
             }
             $num_components = count($gradeable->getNonPeerComponents());
         }
-        //grading by rotating section
         else {
+            //grading by rotating section
             if (!$this->core->getAccess()->canI("grading.electronic.status.full")) {
                 $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id, $this->core->getUser()->getId());
             }
@@ -281,6 +281,7 @@ class ElectronicGraderController extends AbstractController {
                 $graders = $this->core->getQueries()->getGradersForRotatingSections($gradeable_id, $sections);
             }
         }
+
         //Check if this is a team project or a single-user project
         if ($gradeable->isTeamAssignment()) {
             $num_submitted = $this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'registration_section');
@@ -288,6 +289,7 @@ class ElectronicGraderController extends AbstractController {
         else {
             $num_submitted = $this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($gradeable_id, $sections, $section_key);
         }
+
         if (count($sections) > 0) {
             if ($gradeable->isTeamAssignment()) {
                 $total_users = $this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, $section_key);

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -104,7 +104,8 @@ class ElectronicGraderController extends AbstractController {
         try {
             $results = $this->removeEmpty($autocheck, $option, $which);
             $this->core->getOutput()->renderJsonSuccess($results);
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -184,9 +185,11 @@ class ElectronicGraderController extends AbstractController {
             }
             $this->core->getQueries()->saveTaGradedGradeable($ta_graded_gradeable);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -637,7 +640,8 @@ class ElectronicGraderController extends AbstractController {
             $members = $this->core->getQueries()->getUsersById(array_slice($members, 1));
             try {
                 $gradeable->createTeam($leader, $members);
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 $this->core->addErrorMessage("Team may not have been properly initialized ($leader_id): {$e->getMessage()}");
             }
         }
@@ -781,7 +785,8 @@ class ElectronicGraderController extends AbstractController {
             try {
                 $gradeable->createTeam($leader, $users, $reg_section, $rot_section);
                 $this->core->addSuccessMessage("Created New Team {$team_id}");
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 $this->core->addErrorMessage("Team may not have been properly initialized: {$e->getMessage()}");
                 $this->core->redirect($return_url);
             }
@@ -1081,9 +1086,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $results = $this->getGradeableRubric($gradeable, $grader);
             $this->core->getOutput()->renderJsonSuccess($results);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1131,9 +1138,11 @@ class ElectronicGraderController extends AbstractController {
         try {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->core->getOutput()->renderJsonSuccess($component->toArray());
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1179,9 +1188,11 @@ class ElectronicGraderController extends AbstractController {
                 $response_data = $this->getGradedGradeable($ta_graded_gradeable, $grader);
             }
             $this->core->getOutput()->renderJsonSuccess($response_data);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1333,9 +1344,11 @@ class ElectronicGraderController extends AbstractController {
                 !$silent_edit
             );
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1477,9 +1490,11 @@ class ElectronicGraderController extends AbstractController {
             $component->setPeer($peer);
             $this->core->getQueries()->saveComponent($component);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1514,9 +1529,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->saveComponentOrder($gradeable, $order);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1576,9 +1593,11 @@ class ElectronicGraderController extends AbstractController {
             }
             $this->core->getQueries()->updateGradeable($gradeable);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1638,9 +1657,11 @@ class ElectronicGraderController extends AbstractController {
             $component->addMark('No Credit', 0.0, false);
             $this->core->getQueries()->updateGradeable($gradeable);
             $this->core->getOutput()->renderJsonSuccess(['component_id' => $component->getId()]);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1676,9 +1697,11 @@ class ElectronicGraderController extends AbstractController {
             $gradeable->deleteComponent($component);
             $this->core->getQueries()->updateGradeable($gradeable);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1739,9 +1762,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->saveMark($mark, $points, $title, $publish);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1796,9 +1821,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->saveMarkOrder($component, $order);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1869,7 +1896,8 @@ class ElectronicGraderController extends AbstractController {
                     $can_view_hidden
                 )
             );
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1921,9 +1949,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $mark = $this->addNewMark($component, $title, $points, $publish);
             $this->core->getOutput()->renderJsonSuccess(['mark_id' => $mark->getId()]);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -1971,9 +2001,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->deleteMark($mark);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -2022,9 +2054,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $this->saveOverallComment($ta_graded_gradeable, $comment);
             $this->core->getOutput()->renderJsonSuccess();
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -2106,9 +2140,11 @@ class ElectronicGraderController extends AbstractController {
                 $response_data = $graded_component->toArray();
             }
             $this->core->getOutput()->renderJsonSuccess($response_data);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }
@@ -2187,9 +2223,11 @@ class ElectronicGraderController extends AbstractController {
             // Once we've parsed the inputs and checked permissions, perform the operation
             $results = $this->getMarkStats($mark, $grader);
             $this->core->getOutput()->renderJsonSuccess($results);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             $this->core->getOutput()->renderJsonFail($e->getMessage());
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -115,7 +115,8 @@ class ElectronicGraderController extends AbstractController {
         //There are currently two views, the view of student's code and the expected view.
         if ($type === DiffViewer::ACTUAL) {
             $html = $diff_viewer->getDisplayActual($option);
-        } else {
+        }
+        else {
             $html = $diff_viewer->getDisplayExpected($option);
         }
         $white_spaces = $diff_viewer->getWhiteSpaces();
@@ -150,7 +151,7 @@ class ElectronicGraderController extends AbstractController {
         }
         // Get / create the TA grade
         $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
-        if(!$verify_all){
+        if (!$verify_all) {
             $component_id = $_POST['component_id'] ?? '';
             // get the component
             $component = $this->tryGetComponent($gradeable, $component_id);
@@ -168,15 +169,16 @@ class ElectronicGraderController extends AbstractController {
             }
         }
         try {
-            if($verify_all === 'true'){
+            if ($verify_all === 'true') {
                 foreach ($gradeable->getComponents() as $comp) {
                     $graded_component = $ta_graded_gradeable->getGradedComponent($comp);
-                    if ($graded_component !== null && $graded_component->getGraderId() != $grader->getId()){
+                    if ($graded_component !== null && $graded_component->getGraderId() != $grader->getId()) {
                         $graded_component->setVerifier($grader);
                         $graded_component->setVerifyTime($this->core->getDateTimeNow());
                     }
                 }
-            }else{
+            }
+            else {
                 $graded_component->setVerifier($grader);
                 $graded_component->setVerifyTime($this->core->getDateTimeNow());
             }
@@ -248,7 +250,7 @@ class ElectronicGraderController extends AbstractController {
             $section_key = 'registration_section';
         }
         elseif ($gradeable->isGradeByRegistration()) {
-            if(!$this->core->getAccess()->canI("grading.electronic.status.full")) {
+            if (!$this->core->getAccess()->canI("grading.electronic.status.full")) {
                 $sections = $this->core->getUser()->getGradingRegistrationSections();
             }
             else {
@@ -265,7 +267,7 @@ class ElectronicGraderController extends AbstractController {
         }
         //grading by rotating section
         else {
-            if(!$this->core->getAccess()->canI("grading.electronic.status.full")) {
+            if (!$this->core->getAccess()->canI("grading.electronic.status.full")) {
                 $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable_id, $this->core->getUser()->getId());
             }
             else {
@@ -280,10 +282,10 @@ class ElectronicGraderController extends AbstractController {
             }
         }
         //Check if this is a team project or a single-user project
-        if($gradeable->isTeamAssignment()){
+        if ($gradeable->isTeamAssignment()) {
             $num_submitted = $this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'registration_section');
         }
-        else{
+        else {
             $num_submitted = $this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($gradeable_id, $sections, $section_key);
         }
         if (count($sections) > 0) {
@@ -331,8 +333,8 @@ class ElectronicGraderController extends AbstractController {
                     'graded_components' => 0,
                     'graders' => array()
                 );
-                foreach($total_users as $key => $value) {
-                    if($key == 'NULL') {
+                foreach ($total_users as $key => $value) {
+                    if ($key == 'NULL') {
                         continue;
                     }
                     $sections['all']['total_components'] += $value * $num_components * $peer_grade_set;
@@ -343,13 +345,14 @@ class ElectronicGraderController extends AbstractController {
             }
             else {
                 foreach ($total_users as $key => $value) {
-                    if(array_key_exists($key, $num_submitted)){
+                    if (array_key_exists($key, $num_submitted)) {
                         $sections[$key] = array(
                             'total_components' => $num_submitted[$key] * $num_components,
                             'graded_components' => 0,
                             'graders' => array()
                         );
-                    } else{
+                    }
+                    else {
                         $sections[$key] = array(
                             'total_components' => 0,
                             'graded_components' => 0,
@@ -475,7 +478,7 @@ class ElectronicGraderController extends AbstractController {
         if ($gradeable->isTeamAssignment()) {
             // Only give getGradeables one User ID per team
             $all_teams = $this->core->getQueries()->getTeamsByGradeableId($gradeable_id);
-            foreach($all_teams as $team) {
+            foreach ($all_teams as $team) {
                 $student_ids = array_diff($student_ids, $team->getMembers());
                 $team_section = $gradeable->isGradeByRegistration() ? $team->getRegistrationSection() : $team->getRotatingSection();
                 if ($team->getSize() > 0 && (in_array($team_section, $sections) || $show_all)) {
@@ -492,7 +495,7 @@ class ElectronicGraderController extends AbstractController {
         /** @var GradedGradeable $g */
         foreach ($order->getSortedGradedGradeables() as $g) {
             $graded_gradeables[] = $g;
-            if($gradeable->isTeamAssignment()) {
+            if ($gradeable->isTeamAssignment()) {
                 $user_ids = array_merge($user_ids, $g->getSubmitter()->getTeam()->getMemberUserIds());
             }
         }
@@ -501,10 +504,12 @@ class ElectronicGraderController extends AbstractController {
             //Find teamless users
             if ($show_all) {
                 $students = $this->core->getQueries()->getAllUsers();
-            } else {
+            }
+            else {
                 if ($gradeable->isGradeByRegistration()) {
                     $students = $this->core->getQueries()->getUsersByRegistrationSections($order->getSectionNames());
-                } else {
+                }
+                else {
                     $students = $this->core->getQueries()->getUsersByRotatingSections($order->getSectionNames());
                 }
             }
@@ -725,7 +730,8 @@ class ElectronicGraderController extends AbstractController {
 
         if ($rot_section === 'NULL') {
             $rot_section = 0;
-        } else {
+        }
+        else {
             $rot_section = intval($rot_section);
         }
 
@@ -777,7 +783,8 @@ class ElectronicGraderController extends AbstractController {
                 $this->core->addErrorMessage("Team may not have been properly initialized: {$e->getMessage()}");
                 $this->core->redirect($return_url);
             }
-        } else {
+        }
+        else {
             $team = $this->core->getQueries()->getTeamById($team_id);
             if ($team === null) {
                 $this->core->addErrorMessage("ERROR: {$team_id} is not a valid Team ID");
@@ -857,20 +864,20 @@ class ElectronicGraderController extends AbstractController {
 
         // If $who_id is empty string then this request came from the TA grading interface navigation buttons
         // We must decide who to display prev/next and assign them to $who_id
-        if($who_id === '') {
+        if ($who_id === '') {
             $order_grading_sections = new GradingOrder($this->core, $gradeable, $this->core->getUser());
             $order_grading_sections->sort($sort, $direction);
 
             // Only need to instantiate this order if the user is a full access grader
             // Limited access graders should never need the order that includes all sections
-            if($this->core->getUser()->accessFullGrading()) {
+            if ($this->core->getUser()->accessFullGrading()) {
                 $order_all_sections = new GradingOrder($this->core, $gradeable, $this->core->getUser(), true);
                 $order_all_sections->sort($sort, $direction);
             }
 
             // Get the graded gradeable for the $from user
             $from_graded_gradeable = $this->tryGetGradedGradeable($gradeable, $from, false);
-            if($from_graded_gradeable === false) {
+            if ($from_graded_gradeable === false) {
                 $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']));
             }
 
@@ -881,34 +888,39 @@ class ElectronicGraderController extends AbstractController {
             // For full access graders, pressing the single arrow should navigate to the next submission, regardless
             // of if that submission is in their assigned section
             // Limited access graders should only be able to navigate to submissions in their assigned sections
-            if($to === 'prev' && $to_ungraded === 'false' && $this->core->getUser()->accessFullGrading()) {
+            if ($to === 'prev' && $to_ungraded === 'false' && $this->core->getUser()->accessFullGrading()) {
                 $goToStudent = $order_all_sections->getPrevSubmitter($from_id);
-            } elseif($to === 'prev' && $to_ungraded === 'false') {
+            }
+            elseif ($to === 'prev' && $to_ungraded === 'false') {
                 $goToStudent = $order_grading_sections->getPrevSubmitter($from_id);
-            } elseif($to === 'next' && $to_ungraded === 'false' && $this->core->getUser()->accessFullGrading()) {
+            }
+            elseif ($to === 'next' && $to_ungraded === 'false' && $this->core->getUser()->accessFullGrading()) {
                 $goToStudent = $order_all_sections->getNextSubmitter($from_id);
-            } elseif($to === 'next' && $to_ungraded === 'false') {
+            }
+            elseif ($to === 'next' && $to_ungraded === 'false') {
                 $goToStudent = $order_grading_sections->getNextSubmitter($from_id);
-            } elseif($to === 'prev' && $to_ungraded === 'true') {
+            }
+            elseif ($to === 'prev' && $to_ungraded === 'true') {
                 $goToStudent = $order_grading_sections->getPrevUngradedSubmitter($from_id, $component_id);
-            } elseif($to === 'next' && $to_ungraded === 'true') {
+            }
+            elseif ($to === 'next' && $to_ungraded === 'true') {
                 $goToStudent = $order_grading_sections->getNextUngradedSubmitter($from_id, $component_id);
             }
 
             // Reassign who_id
-            if(!is_null($goToStudent)) {
+            if (!is_null($goToStudent)) {
                 $who_id = $goToStudent->getId();
             }
         }
 
         // Get the graded gradeable for the submitter we are requesting
         $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $who_id, false);
-        if($graded_gradeable === false) {
+        if ($graded_gradeable === false) {
             $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])  . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => 'all']));
         }
 
         $peer = false;
-        if($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
+        if ($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
             $peer = true;
         }
 
@@ -920,7 +932,7 @@ class ElectronicGraderController extends AbstractController {
         $graded = 0;
         $total = 0;
         $team = $gradeable->isTeamAssignment();
-        if($peer) {
+        if ($peer) {
             $section_key = 'registration_section';
             $total = $gradeable->getPeerGradeSet();
             $graded = $this->core->getQueries()->getNumGradedPeerComponents($gradeable->getId(), $this->core->getUser()->getId()) / count($gradeable->getPeerComponents());
@@ -934,7 +946,7 @@ class ElectronicGraderController extends AbstractController {
                     $sections[$i] = $sections[$i]['sections_registration_id'];
                 }
             }
-            if($team){
+            if ($team) {
                 $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'registration_section', $team));
                 $total = array_sum($this->core->getQueries()->getTotalTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
                 $total_submitted = array_sum($this->core->getQueries()->getSubmittedTeamCountByGradingSections($gradeable_id, $sections, 'registration_section'));
@@ -963,13 +975,13 @@ class ElectronicGraderController extends AbstractController {
             $graded = array_sum($this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, 'rotating_section', $team));
         }
         //multiplies users and the number of components a gradeable has together
-        if($team) {
+        if ($team) {
             $total_submitted = $total_submitted * count($gradeable->getComponents());
         }
         else {
             $total_submitted = $total_submitted * count($gradeable->getComponents());
         }
-        if($total_submitted == 0) {
+        if ($total_submitted == 0) {
             $progress = 100;
         }
         else {
@@ -1001,7 +1013,7 @@ class ElectronicGraderController extends AbstractController {
         $show_silent_edit = $this->core->getAccess()->canI("grading.electronic.silent_edit");
 
         $display_version = intval($gradeable_version ?? '0');
-        if($display_version <= 0) {
+        if ($display_version <= 0) {
             $display_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         }
 
@@ -1009,14 +1021,16 @@ class ElectronicGraderController extends AbstractController {
         if ($gradeable->isTeamAssignment()) {
             // If its a team assignment, use the leader for late days...
             $late_days_user = $this->core->getQueries()->getUserById($graded_gradeable->getSubmitter()->getTeam()->getLeaderId());
-        } else {
+        }
+        else {
             $late_days_user = $graded_gradeable->getSubmitter()->getUser();
         }
 
         $ldi = LateDays::fromUser($this->core, $late_days_user)->getLateDayInfoByGradeable($gradeable);
         if ($ldi === null) {
             $late_status = LateDayInfo::STATUS_GOOD;  // Assume its good
-        } else {
+        }
+        else {
             $late_status = $ldi->getStatus();
         }
 
@@ -1235,7 +1249,7 @@ class ElectronicGraderController extends AbstractController {
         // Convert the mark ids to integers
         $numeric_mark_ids = [];
         foreach ($marks as $mark) {
-            if(!ctype_digit($mark)) {
+            if (!ctype_digit($mark)) {
                 $this->core->getOutput()->renderJsonFail('One of provided mark ids was invalid');
                 return;
             }
@@ -1341,15 +1355,17 @@ class ElectronicGraderController extends AbstractController {
         $graded_component->setMarkIds($mark_ids);
 
         // Check if this graded component should be deleted
-        if (count($graded_component->getMarkIds()) === 0
+        if (
+            count($graded_component->getMarkIds()) === 0
             && $graded_component->getScore() === 0.0
-            && $graded_component->getComment() === '') {
+            && $graded_component->getComment() === ''
+        ) {
             $ta_graded_gradeable->deleteGradedComponent($graded_component->getComponent(), $graded_component->getGrader());
             $graded_component = null;
         }
-        else{
+        else {
             //change the component to be unverified after changing a mark
-            if($graded_component->isMarksModified()){
+            if ($graded_component->isMarksModified()) {
                 $graded_component->setVerifier();
                 $graded_component->setVerifyTime(null);
             }
@@ -1548,11 +1564,12 @@ class ElectronicGraderController extends AbstractController {
 
         try {
             // Once we've parsed the inputs and checked permissions, perform the operation
-            if(isset($pages['page']) && count($pages) === 1) {
+            if (isset($pages['page']) && count($pages) === 1) {
                 // if one page is sent, set all to that page.  This is useful
                 //  for setting the page settings to 'none' or 'student-assign'
                 $this->saveComponentsPage($gradeable, $pages['page']);
-            } else {
+            }
+            else {
                 $this->saveComponentPages($gradeable, $pages);
             }
             $this->core->getQueries()->updateGradeable($gradeable);
@@ -2215,9 +2232,11 @@ class ElectronicGraderController extends AbstractController {
         $sections = array();
         if ($full_stats) {
             $sections = $this->core->getQueries()->getAllSectionsForGradeable($gradeable);
-        } elseif ($gradeable->isGradeByRegistration()) {
+        }
+        elseif ($gradeable->isGradeByRegistration()) {
             $sections = $grader->getGradingRegistrationSections();
-        } else {
+        }
+        else {
             $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable->getId(), $grader->getId());
         }
 

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -32,7 +32,8 @@ class ImagesController extends AbstractController {
 
         if ($user_group !== USER::GROUP_LIMITED_ACCESS_GRADER) {
             $grader_sections = array();  //reset grader section to nothing so permission for every image
-        } else {
+        }
+        else {
             if (empty($grader_sections)) {
                 return;
             }
@@ -46,7 +47,7 @@ class ImagesController extends AbstractController {
      * @Route("/{_semester}/{_course}/student_photos/upload")
      */
     public function ajaxUploadImagesFiles() {
-        if(!$this->core->getUser()->accessAdmin()) {
+        if (!$this->core->getUser()->accessAdmin()) {
             return $this->core->getOutput()->renderResultMessage("You have no permission to access this page", false);
         }
 
@@ -65,12 +66,12 @@ class ImagesController extends AbstractController {
 
         $status = Fileutils::validateUploadedFiles($_FILES["files1"]);
         //check if we couldn't validate the uploaded files
-        if(array_key_exists("failed", $status)){
+        if (array_key_exists("failed", $status)) {
             return $this->core->getOutput()->renderResultMessage("Failed to validate uploads " . $status["failed"], false);
         }
 
         foreach ($status as $stat) {
-            if($stat['success'] === false){
+            if ($stat['success'] === false) {
                 return $this->core->getOutput()->renderResultMessage("Error " . $stat['error'], false);
             }
         }
@@ -87,7 +88,7 @@ class ImagesController extends AbstractController {
             $uploaded_files[1]["is_zip"] = array();
             for ($j = 0; $j < $count_item; $j++) {
                 if (mime_content_type($uploaded_files[1]["tmp_name"][$j]) == "application/zip") {
-                    if(FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
+                    if (FileUtils::checkFileInZipName($uploaded_files[1]["tmp_name"][$j]) === false) {
                         return $this->core->getOutput()->renderResultMessage("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[1]["name"][$j] . ".", false);
                     }
                     $uploaded_files[1]["is_zip"][$j] = true;

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -102,7 +102,8 @@ class SimpleGraderController extends AbstractController {
     public function gradePage($gradeable_id, $view = null, $sort = null) {
         try {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             return Response::WebOnlyResponse(
                 new WebResponse('Error', 'noGradeable')
             );

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -32,7 +32,7 @@ class SimpleGraderController extends AbstractController {
         if ($sort === "id") {
             $sort_by = "u.user_id";
         }
-        elseif($sort === "first"){
+        elseif ($sort === "first") {
             $sort_by = "coalesce(NULLIF(u.user_preferred_firstname, ''), u.user_firstname)";
         }
         else {
@@ -102,7 +102,7 @@ class SimpleGraderController extends AbstractController {
     public function gradePage($gradeable_id, $view = null, $sort = null) {
         try {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
-        } catch(\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             return Response::WebOnlyResponse(
                 new WebResponse('Error', 'noGradeable')
             );
@@ -129,7 +129,8 @@ class SimpleGraderController extends AbstractController {
 
         if ($gradeable->isGradeByRegistration()) {
             $grading_count = count($this->core->getUser()->getGradingRegistrationSections());
-        } else {
+        }
+        else {
             $grading_count = count($this->core->getQueries()->getRotatingSectionsForGradeableAndUser($gradeable->getId(), $this->core->getUser()->getId()));
         }
         //Can you show all
@@ -141,9 +142,10 @@ class SimpleGraderController extends AbstractController {
 
         //Checks to see if the Grader has access to all users in the course,
         //Will only show the sections that they are graders for if not TA or Instructor
-        if($show_all) {
+        if ($show_all) {
             $sections = $gradeable->getAllGradingSections();
-        } else {
+        }
+        else {
             $sections = $gradeable->getGradingSectionsForUser($this->core->getUser());
         }
 
@@ -159,7 +161,8 @@ class SimpleGraderController extends AbstractController {
 
         if ($gradeable->isGradeByRegistration()) {
             $section_key = "registration_section";
-        } else {
+        }
+        else {
             $section_key = "rotating_section";
         }
 
@@ -205,11 +208,13 @@ class SimpleGraderController extends AbstractController {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Invalid gradeable ID")
             );
-        } elseif ($user === null) {
+        }
+        elseif ($user === null) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Invalid user ID")
             );
-        } elseif (!isset($_POST['scores']) || empty($_POST['scores'])) {
+        }
+        elseif (!isset($_POST['scores']) || empty($_POST['scores'])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Didn't submit any scores")
             );
@@ -236,9 +241,12 @@ class SimpleGraderController extends AbstractController {
 
                 if ($component->isText()) {
                     $component_grade->setComment($data);
-                } else {
-                    if ($component->getUpperClamp() < $data ||
-                        !is_numeric($data)) {
+                }
+                else {
+                    if (
+                        $component->getUpperClamp() < $data
+                        || !is_numeric($data)
+                    ) {
                         return Response::JsonOnlyResponse(
                             JsonResponse::getFailResponse("Save error: score must be a number less than the upper clamp")
                         );
@@ -293,10 +301,10 @@ class SimpleGraderController extends AbstractController {
         }
 
         /** @var GradedGradeable $graded_gradeable */
-        foreach($this->core->getQueries()->getGradedGradeables([$gradeable], $users, null) as $graded_gradeable) {
+        foreach ($this->core->getQueries()->getGradedGradeables([$gradeable], $users, null) as $graded_gradeable) {
             for ($j = 0; $j < $arr_length; $j++) {
                 $username = $graded_gradeable->getSubmitter()->getId();
-                if($username !== $data_array[$j][0]) {
+                if ($username !== $data_array[$j][0]) {
                     continue;
                 }
 
@@ -318,17 +326,18 @@ class SimpleGraderController extends AbstractController {
                     $value_temp_str = $value_str . $index1;
                     $status_temp_str = $status_str . $index1;
                     if (isset($data_array[$j][$index2])) {
-                        if ($component->isText()){
+                        if ($component->isText()) {
                             $component_grade->setComment($data_array[$j][$index2]);
                             $component_grade->setGradeTime($this->core->getDateTimeNow());
                             $temp_array[$value_temp_str] = $data_array[$j][$index2];
                             $temp_array[$status_temp_str] = "OK";
                         }
-                        else{
-                            if($component->getUpperClamp() < $data_array[$j][$index2]){
+                        else {
+                            if ($component->getUpperClamp() < $data_array[$j][$index2]) {
                                 $temp_array[$value_temp_str] = $data_array[$j][$index2];
                                 $temp_array[$status_temp_str] = "ERROR";
-                            } else {
+                            }
+                            else {
                                 $component_grade->setScore($data_array[$j][$index2]);
                                 $component_grade->setGradeTime($this->core->getDateTimeNow());
                                 $temp_array[$value_temp_str] = $data_array[$j][$index2];
@@ -340,7 +349,7 @@ class SimpleGraderController extends AbstractController {
                     $index2++;
 
                     //skips the index of the total points in the csv file
-                    if($index1 == $num_numeric) {
+                    if ($index1 == $num_numeric) {
                         $index2++;
                     }
                 }

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -23,7 +23,7 @@ class PDFController extends AbstractController {
         $filename = html_entity_decode($filename);
         $id = $this->core->getUser()->getId();
         $gradeable = $this->tryGetGradeable($gradeable_id);
-        if($gradeable->isTeamAssignment()){
+        if ($gradeable->isTeamAssignment()) {
             $id = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable_id, $id)->getId();
         }
         $submitter = $this->core->getQueries()->getSubmitterById($id);
@@ -31,10 +31,10 @@ class PDFController extends AbstractController {
         $active_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $annotation_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotations', $gradeable_id, $id, $active_version);
         $annotation_jsons = [];
-        if(is_dir($annotation_path) && count(scandir($annotation_path)) > 2){
+        if (is_dir($annotation_path) && count(scandir($annotation_path)) > 2) {
             $first_file = scandir($annotation_path)[2];
             $annotation_path = FileUtils::joinPaths($annotation_path, $first_file);
-            if(is_file($annotation_path)) {
+            if (is_file($annotation_path)) {
                 $dir_iter = new \DirectoryIterator(dirname($annotation_path . '/'));
                 foreach ($dir_iter as $fileinfo) {
                     if (!$fileinfo->isDot()) {
@@ -42,7 +42,7 @@ class PDFController extends AbstractController {
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = $pdf_info[0];
                         $grader_id = $pdf_info[1];
-                        if($pdf_id . '.pdf' === $filename){
+                        if ($pdf_id . '.pdf' === $filename) {
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }
                     }
@@ -87,15 +87,15 @@ class PDFController extends AbstractController {
         $active_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
 
         $annotation_gradeable_path = FileUtils::joinPaths($course_path, 'annotations', $annotation_info['gradeable_id']);
-        if(!is_dir($annotation_gradeable_path) && !FileUtils::createDir($annotation_gradeable_path)){
+        if (!is_dir($annotation_gradeable_path) && !FileUtils::createDir($annotation_gradeable_path)) {
             return $this->core->getOutput()->renderJsonFail('Creating annotation gradeable folder failed');
         }
         $annotation_user_path = FileUtils::joinPaths($annotation_gradeable_path, $user_id);
-        if(!is_dir($annotation_user_path) && !FileUtils::createDir($annotation_user_path)){
+        if (!is_dir($annotation_user_path) && !FileUtils::createDir($annotation_user_path)) {
             return $this->core->getOutput()->renderJsonFail('Creating annotation user folder failed');
         }
         $annotation_version_path = FileUtils::joinPaths($annotation_user_path, $active_version);
-        if(!is_dir($annotation_version_path) && !FileUtils::createDir($annotation_version_path)){
+        if (!is_dir($annotation_version_path) && !FileUtils::createDir($annotation_version_path)) {
             return $this->core->getOutput()->renderJsonFail('Creating annotation version folder failed.');
         }
 
@@ -122,19 +122,20 @@ class PDFController extends AbstractController {
         $page_num = $_POST['page_num'] ?? null;
         $filename = html_entity_decode($filename);
         $gradeable = $this->tryGetGradeable($gradeable_id);
-        if($gradeable->isTeamAssignment()){
+        if ($gradeable->isTeamAssignment()) {
             $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, null, $id);
-        } else {
+        }
+        else {
             $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $id);
         }
         $active_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $annotation_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotations', $gradeable_id, $id, $active_version);
         $annotation_jsons = [];
         //Dir iterator needs the first file.
-        if(is_dir($annotation_path) && count(scandir($annotation_path)) > 2){
+        if (is_dir($annotation_path) && count(scandir($annotation_path)) > 2) {
             $first_file = scandir($annotation_path)[2];
             $annotation_path = FileUtils::joinPaths($annotation_path, $first_file);
-            if(is_file($annotation_path)) {
+            if (is_file($annotation_path)) {
                 $dir_iter = new \DirectoryIterator(dirname($annotation_path . '/'));
                 foreach ($dir_iter as $fileinfo) {
                     if (!$fileinfo->isDot()) {
@@ -142,7 +143,7 @@ class PDFController extends AbstractController {
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = $pdf_info[0];
                         $grader_id = $pdf_info[1];
-                        if($pdf_id . '.pdf' === $filename){
+                        if ($pdf_id . '.pdf' === $filename) {
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }
                     }

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -52,11 +52,13 @@ class GradeInquiryController extends AbstractController {
             return Response::JsonOnlyResponse(
                 JsonResponse::getSuccessResponse()
             );
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse($e->getMessage())
             );
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getErrorResponse($e->getMessage())
             );
@@ -112,11 +114,13 @@ class GradeInquiryController extends AbstractController {
             return Response::JsonOnlyResponse(
                 JsonResponse::getSuccessResponse()
             );
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse($e->getMessage())
             );
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getErrorResponse($e->getMessage())
             );
@@ -185,11 +189,13 @@ class GradeInquiryController extends AbstractController {
             return Response::JsonOnlyResponse(
                 JsonResponse::getSuccessResponse()
             );
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse($e->getMessage())
             );
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getErrorResponse($e->getMessage())
             );

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -28,7 +28,7 @@ class GradeInquiryController extends AbstractController {
             return null;
         }
 
-        if(!$gradeable->isRegradeOpen()) {
+        if (!$gradeable->isRegradeOpen()) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Grade inquiries are not enabled for this gradeable')
             );
@@ -99,7 +99,7 @@ class GradeInquiryController extends AbstractController {
         }
 
         $grade_inquiry = $graded_gradeable->getGradeInquiryByGcId($gc_id);
-        if (is_null($grade_inquiry)){
+        if (is_null($grade_inquiry)) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Cannot find grade inquiry')
             );
@@ -159,7 +159,7 @@ class GradeInquiryController extends AbstractController {
         }
 
         $grade_inquiry = $graded_gradeable->getGradeInquiryByGcId($gc_id);
-        if (is_null($grade_inquiry)){
+        if (is_null($grade_inquiry)) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Cannot find grade inquiry')
             );
@@ -169,7 +169,8 @@ class GradeInquiryController extends AbstractController {
         if ($status == -1) {
             $status = 0;
             $type = 'resolve';
-        } else {
+        }
+        else {
             $status = -1;
             $type = 'reopen';
         }
@@ -232,34 +233,41 @@ class GradeInquiryController extends AbstractController {
                 if ($this->core->getUser()->accessGrading()) {
                     $subject = "New Grade Inquiry: $gradeable_title - $user_id";
                     $body = "An Instructor/TA/Mentor submitted a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
-                } else {
+                }
+                else {
                     $subject = "New Grade Inquiry: $gradeable_title - $user_id";
                     $body = "A student has submitted a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
                 }
-            } elseif ($type == 'reply') {
+            }
+            elseif ($type == 'reply') {
                 if ($this->core->getUser()->accessGrading()) {
                     $subject = "New Grade Inquiry Reply: $gradeable_title - $user_id";
                     $body = "An Instructor/TA/Mentor made a post in a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
-                } else {
+                }
+                else {
                     $subject = "New Grade Inquiry Reply: $gradeable_title - $user_id";
                     $body = "A student has made a post in a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$user_id writes:\n$content";
                 }
-            } elseif ($type == 'resolve') {
+            }
+            elseif ($type == 'resolve') {
                 if ($this->core->getUser()->accessGrading()) {
                     $included_post_content = !empty($content) ? "$user_id writes:\n$content" : "";
                     $subject = "Grade Inquiry Resolved: $gradeable_title - $user_id";
                     $body = "An Instructor/TA/Mentor has resolved your grade inquiry for gradeable, $gradeable_title$component_string.\n\n$included_post_content";
-                } else {
+                }
+                else {
                     $included_post_content = !empty($content) ? "$user_id writes:\n$content" : "";
                     $subject = "Grade Inquiry Resolved: $gradeable_title - $user_id";
                     $body = "A student has cancelled a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$included_post_content";
                 }
-            } elseif ($type == 'reopen') {
+            }
+            elseif ($type == 'reopen') {
                 if ($this->core->getUser()->accessGrading()) {
                     $included_post_content = !empty($content) ? "$user_id writes:\n$content" : "";
                     $subject = "Grade Inquiry Reopened: $gradeable_title - $user_id";
                     $body = "An Instructor/TA/Mentor has reopened your grade inquiry for gradeable, $gradeable_title$component_string.\n\n$included_post_content";
-                } else {
+                }
+                else {
                     $included_post_content = !empty($content) ? "$user_id writes:\n$content" : "";
                     $subject = "Grade Inquiry Reopened: $gradeable_title - $user_id";
                     $body = "A student has reopened a grade inquiry for gradeable, $gradeable_title$component_string.\n\n$included_post_content";
@@ -281,14 +289,15 @@ class GradeInquiryController extends AbstractController {
 
             // make students' notifications and emails
             $metadata = json_encode(['url' => $this->core->buildCourseUrl(['gradeable', $gradeable_id])]);
-            if($submitter->isTeam()){
+            if ($submitter->isTeam()) {
                 $submitting_team = $submitter->getTeam()->getMemberUsers();
                 foreach ($submitting_team as $submitting_user) {
                     $details = ['component' => 'student', 'metadata' => $metadata, 'content' => $body, 'body' => $body, 'subject' => $subject, 'sender_id' => $user_id, 'to_user_id' => $submitting_user->getId()];
                     $notifications[] = Notification::createNotification($this->core, $details);
                     $emails[] = new Email($this->core, $details);
                 }
-            } else {
+            }
+            else {
                 $details = ['component' => 'student', 'metadata' => $metadata, 'content' => $body, 'body' => $body, 'subject' => $subject, 'sender_id' => $user_id, 'to_user_id' => $submitter->getId()];
                 $notifications[] = Notification::createNotification($this->core, $details);
                 $emails[] = new Email($this->core, $details);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -52,7 +52,8 @@ class SubmissionController extends AbstractController {
                 return $gradeable;
             }
             return null;
-        } catch (\InvalidArgumentException $e) {
+        }
+        catch (\InvalidArgumentException $e) {
             return null;
         }
     }
@@ -504,7 +505,8 @@ class SubmissionController extends AbstractController {
                 $leader_user = $this->core->getQueries()->getUserById($leader);
                 try {
                     $gradeable->createTeam($leader_user, $members);
-                } catch (\Exception $e) {
+                }
+                catch (\Exception $e) {
                     $this->core->addErrorMessage('Team may not have been properly initialized: ' . $e->getMessage());
                     return $this->uploadResult("Failed to form a team from members: " . implode(",", $members) . ", " . $leader_user, false);
                 }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -40,11 +40,15 @@ class SubmissionController extends AbstractController {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
             $now = $this->core->getDateTimeNow();
 
-            if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE
-                && ($this->core->getUser()->accessAdmin()
+            if (
+                $gradeable->getType() === GradeableType::ELECTRONIC_FILE
+                && (
+                    $this->core->getUser()->accessAdmin()
                     || $gradeable->getTaViewStartDate() <= $now
                     && $this->core->getUser()->accessGrading()
-                    || $gradeable->getSubmissionOpenDate() <= $now)) {
+                    || $gradeable->getSubmissionOpenDate() <= $now
+                )
+            ) {
                 return $gradeable;
             }
             return null;
@@ -60,7 +64,7 @@ class SubmissionController extends AbstractController {
      */
     public function showHomeworkPage($gradeable_id, $gradeable_version = null) {
         $gradeable = $this->tryGetElectronicGradeable($gradeable_id);
-        if($gradeable === null) {
+        if ($gradeable === null) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
             return array('error' => true, 'message' => 'No gradeable with that id.');
         }
@@ -83,10 +87,15 @@ class SubmissionController extends AbstractController {
         // ORIGINAL
         //if (!$gradeable->isSubmissionOpen() && !$this->core->getUser()->accessAdmin()) {
         // TEMPORARY - ALLOW LIMITED & FULL ACCESS GRADERS TO PRACTICE ALL FUTURE HOMEWORKS
-        if (!$this->core->getUser()->accessGrading() && (
+        if (
+            !$this->core->getUser()->accessGrading()
+            && (
                 !$gradeable->isSubmissionOpen()
-                || $gradeable->isStudentView() && $gradeable->isStudentViewAfterGrades() && !$gradeable->isTaGradeReleased()
-            )) {
+                || $gradeable->isStudentView()
+                && $gradeable->isStudentViewAfterGrades()
+                && !$gradeable->isTaGradeReleased()
+            )
+        ) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
             return array('error' => true, 'message' => 'No gradeable with that id.');
         }
@@ -107,10 +116,12 @@ class SubmissionController extends AbstractController {
                 $error = true;
             }
             else {
-                if ($graded_gradeable !== null
+                if (
+                    $graded_gradeable !== null
                     && $gradeable->isTaGradeReleased()
                     && $gradeable->isTaGrading()
-                    && $graded_gradeable->isTaGradingComplete()) {
+                    && $graded_gradeable->isTaGradingComplete()
+                ) {
                     $graded_gradeable->getOrCreateTaGradedGradeable()->setUserViewedDate($now);
                     $this->core->getQueries()->saveTaGradedGradeable($graded_gradeable->getTaGradedGradeable());
                     if ($graded_gradeable->getSubmitter()->isTeam()) {
@@ -169,9 +180,10 @@ class SubmissionController extends AbstractController {
 
         //filter out empty, null strings
         $tmp_ids = $_POST['user_id'];
-        if(is_array($tmp_ids)){
+        if (is_array($tmp_ids)) {
             $user_ids = array_filter($_POST['user_id']);
-        } else{
+        }
+        else {
             $user_ids = array($tmp_ids);
             $user_ids = array_filter($user_ids);
         }
@@ -183,7 +195,7 @@ class SubmissionController extends AbstractController {
         }
 
         //For every userid, we have to check that its real.
-        foreach($user_ids as $id){
+        foreach ($user_ids as $id) {
             $user = $this->core->getQueries()->getUserById($id);
             if ($user === null) {
                 $msg = "Invalid user id '{$id}'";
@@ -202,13 +214,14 @@ class SubmissionController extends AbstractController {
 
         $null_team_count = 0;
         $inconsistent_teams = false;
-        if($gradeable->isTeamAssignment()){
+        if ($gradeable->isTeamAssignment()) {
             $teams = [];
             foreach ($user_ids as $user) {
                 $tmp = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable->getId(), $user);
-                if($tmp === null){
+                if ($tmp === null) {
                     $null_team_count++;
-                }else{
+                }
+                else {
                     $teams[] = $tmp->getId();
                 }
             }
@@ -223,14 +236,14 @@ class SubmissionController extends AbstractController {
             return $this->core->getOutput()->renderJsonFail($msg);
         }
         //If a user not assigned to any team is matched with a user already on a team
-        if($gradeable->isTeamAssignment() && $null_team_count != 0 && count($teams) != 0){
+        if ($gradeable->isTeamAssignment() && $null_team_count != 0 && count($teams) != 0) {
             $msg = "One or more users with no team are being submitted with another user already on a team";
             return $this->core->getOutput()->renderJsonFail($msg);
         }
 
         $highest_version = -1;
 
-        if(count($graded_gradeables) > 0){
+        if (count($graded_gradeables) > 0) {
             $graded_gradeable = $graded_gradeables[0];
             $highest_version = $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
         }
@@ -280,17 +293,17 @@ class SubmissionController extends AbstractController {
         $status = FileUtils::validateUploadedFiles($uploaded_file);
         $count = count($uploaded_file["name"]);
 
-        if(array_key_exists("failed", $status)){
+        if (array_key_exists("failed", $status)) {
             return $this->core->getOutput()->renderResultMessage("Failed to validate uploads " . $status["failed"], false);
         }
 
         $file_size = 0;
         foreach ($status as $stat) {
-            if($stat['success'] === false){
+            if ($stat['success'] === false) {
                 return $this->core->getOutput()->renderResultMessage("Error " . $stat['error'], false);
             }
 
-            if($stat['type'] !== 'application/pdf'){
+            if ($stat['type'] !== 'application/pdf') {
                 return $this->core->getOutput()->renderResultMessage("Error " . $stat['name'] . " is not a PDF", false);
             }
 
@@ -346,13 +359,13 @@ class SubmissionController extends AbstractController {
 
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
-        if($is_qr){
+        if ($is_qr) {
             $qr_prefix = rawurlencode($_POST['qr_prefix']);
             $qr_suffix = rawurlencode($_POST['qr_suffix']);
 
             $config_data = json_decode(file_get_contents("/usr/local/submitty/config/submitty.json"));
             //create a new job to split but uploads via QR
-            for($i = 0; $i < $count; $i++){
+            for ($i = 0; $i < $count; $i++) {
                 $qr_upload_data = [
                     "job"       => "BulkUpload",
                     "semester"  => $semester,
@@ -368,13 +381,14 @@ class SubmissionController extends AbstractController {
                 $bulk_upload_job  = "/var/local/submitty/daemon_job_queue/bulk_upload_" . $uploaded_file["name"][$i] . ".json";
 
                 //add new job to queue
-                if(!file_put_contents($bulk_upload_job, json_encode($qr_upload_data, JSON_PRETTY_PRINT))){
+                if (!file_put_contents($bulk_upload_job, json_encode($qr_upload_data, JSON_PRETTY_PRINT))) {
                     $this->core->getOutput()->renderJsonFail("Failed to write BulkQRSplit job");
                     return $this->uploadResult("Failed to write BulkQRSplit job", false);
                 }
             }
-        }else{
-            for($i = 0; $i < $count; $i++){
+        }
+        else {
+            for ($i = 0; $i < $count; $i++) {
                 $job_data = [
                     "job"       => "BulkUpload",
                     "semester"  => $semester,
@@ -389,7 +403,7 @@ class SubmissionController extends AbstractController {
                 $bulk_upload_job  = "/var/local/submitty/daemon_job_queue/bulk_upload_" . $uploaded_file["name"][$i] . ".json";
 
                 //add new job to queue
-                if(!file_put_contents($bulk_upload_job, json_encode($job_data, JSON_PRETTY_PRINT))){
+                if (!file_put_contents($bulk_upload_job, json_encode($job_data, JSON_PRETTY_PRINT))) {
                     $this->core->getOutput()->renderJsonFail("Failed to write Bulk upload job");
                     return $this->uploadResult("Failed to write Bulk upload job", false);
                 }
@@ -432,9 +446,10 @@ class SubmissionController extends AbstractController {
         $original_user_id = $this->core->getUser()->getId();
 
         $tmp_ids = $_POST['user_id'];
-        if(is_array($tmp_ids)){
+        if (is_array($tmp_ids)) {
             $user_ids = array_filter($_POST['user_id']);
-        } else{
+        }
+        else {
             $user_ids = array($tmp_ids);
             $user_ids = array_filter($user_ids);
         }
@@ -473,14 +488,14 @@ class SubmissionController extends AbstractController {
                 $who_id = $team_id;
                 $user_id = "";
             }
-            //if the student isn't on a team, build the team.
-            else{
+            else {
+                //if the student isn't on a team, build the team.
                 //If the team doesn't exist yet, we need to build a new one. (Note, we have already checked in ajaxvalidgradeable
                 //that all users are either on the same team or no team).
 
                 $leaderless = array();
-                foreach($user_ids as $i => $member){
-                    if($member !== $leader){
+                foreach ($user_ids as $i => $member) {
+                    if ($member !== $leader) {
                         $leaderless[] = $member;
                     }
                 }
@@ -541,14 +556,14 @@ class SubmissionController extends AbstractController {
 
         if (isset($uploaded_file)) {
             // if we are merging in the previous submission (TODO check folder support)
-            if($merge_previous && $new_version !== 1) {
+            if ($merge_previous && $new_version !== 1) {
                 $old_version = $new_version - 1;
                 $old_version_path = FileUtils::joinPaths($user_path, $old_version);
                 $to_search = FileUtils::joinPaths($old_version_path, "*.*");
                 $files = glob($to_search);
-                foreach($files as $file) {
+                foreach ($files as $file) {
                     $file_base_name = basename($file);
-                    if(!$clobber && $file_base_name === $uploaded_file_base_name) {
+                    if (!$clobber && $file_base_name === $uploaded_file_base_name) {
                         $parts = explode(".", $file_base_name);
                         $parts[0] .= "_version_" . $old_version;
                         $file_base_name = implode(".", $parts);
@@ -558,12 +573,12 @@ class SubmissionController extends AbstractController {
                     preg_match("/\d*$/", $image_name, $matches);
                     $image_num = count($matches) > 0 ? intval(reset($matches)) : -1;
 
-                    if(!$clobber && strpos($image_name, "_page_") !== false && $image_num >= 0){
+                    if (!$clobber && strpos($image_name, "_page_") !== false && $image_num >= 0) {
                         $file_base_name = "upload_version_"  . $old_version . "_page_" . $image_num . "." . $image_extension;
                     }
 
                     $move_here = FileUtils::joinPaths($version_path, $file_base_name);
-                    if (!@copy($file, $move_here)){
+                    if (!@copy($file, $move_here)) {
                         return $this->uploadResult("Failed to merge previous version on file {$file_base_name}", false);
                     }
                 }
@@ -678,7 +693,7 @@ class SubmissionController extends AbstractController {
         }
 
         // FIXME: Add this as part of the graded gradeable saving query
-        if($gradeable->isTeamAssignment()) {
+        if ($gradeable->isTeamAssignment()) {
             $this->core->getQueries()->insertVersionDetails($gradeable->getId(), null, $team_id, $new_version, $current_time);
         }
         else {
@@ -738,7 +753,7 @@ class SubmissionController extends AbstractController {
             $timestamp
         );
         $files = FileUtils::getAllFiles($timestamp_path);
-        if(count($files) === 0){
+        if (count($files) === 0) {
             if (!FileUtils::recursiveRmdir($timestamp_path)) {
                 return $this->uploadResult("Failed to remove the empty timestamp directory {$timestamp} from the split_pdf directory.", false);
             }
@@ -879,7 +894,7 @@ class SubmissionController extends AbstractController {
 
         if ($vcs_checkout === false) {
             $uploaded_files = array();
-            for ($i = 1; $i <= $num_parts; $i++){
+            for ($i = 1; $i <= $num_parts; $i++) {
                 if (isset($_FILES["files{$i}"])) {
                     $uploaded_files[$i] = $_FILES["files{$i}"];
                 }
@@ -922,7 +937,7 @@ class SubmissionController extends AbstractController {
 
             $this_config_inputs = $gradeable->getAutogradingConfig()->getInputs() ?? array();
 
-            foreach($this_config_inputs as $this_input) {
+            foreach ($this_config_inputs as $this_input) {
                 if ($this_input instanceof SubmissionTextBox) {
                     $answers = $short_answer_objects["short_answer_" .  $num_short_answers] ?? array();
                     $num_short_answers += 1;
@@ -998,19 +1013,19 @@ class SubmissionController extends AbstractController {
 
                 // if merging is being done, get all the old filenames and put them into $previous_files_dst
                 // while checking for name conflicts and preventing them if clobbering is not enabled.
-                if($merge_previous) {
-                    for($i = 1; $i <= $num_parts; $i++) {
-                        if(isset($uploaded_files[$i])) {
+                if ($merge_previous) {
+                    for ($i = 1; $i <= $num_parts; $i++) {
+                        if (isset($uploaded_files[$i])) {
                             $current_files_set = array_flip($uploaded_files[$i]["name"]);
                             $previous_files_src[$i] = array();
                             $previous_files_dst[$i] = array();
                             $to_search = FileUtils::joinPaths($previous_part_path[$i], "*");
                             $filenames = glob($to_search);
                             $j = 0;
-                            foreach($filenames as $filename) {
+                            foreach ($filenames as $filename) {
                                 $file_base_name = basename($filename);
                                 $previous_files_src[$i][$j] = $file_base_name;
-                                if(!$clobber && isset($current_files_set[$file_base_name])) {
+                                if (!$clobber && isset($current_files_set[$file_base_name])) {
                                     $parts = explode(".", $file_base_name);
                                     $parts[0] .= "_version_" . $highest_version;
                                     $file_base_name = implode(".", $parts);
@@ -1045,14 +1060,14 @@ class SubmissionController extends AbstractController {
                     $uploaded_files[$i]["is_zip"] = array();
                     for ($j = 0; $j < $count[$i]; $j++) {
                         if (mime_content_type($uploaded_files[$i]["tmp_name"][$j]) == "application/zip") {
-                            if(FileUtils::checkFileInZipName($uploaded_files[$i]["tmp_name"][$j]) === false) {
+                            if (FileUtils::checkFileInZipName($uploaded_files[$i]["tmp_name"][$j]) === false) {
                                 return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[$i]["name"][$j] . ".", false);
                             }
                             $uploaded_files[$i]["is_zip"][$j] = true;
                             $file_size += FileUtils::getZipSize($uploaded_files[$i]["tmp_name"][$j]);
                         }
                         else {
-                            if(FileUtils::isValidFileName($uploaded_files[$i]["name"][$j]) === false) {
+                            if (FileUtils::isValidFileName($uploaded_files[$i]["name"][$j]) === false) {
                                 return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your file name " . $uploaded_files[$i]["name"][$j] . ".", false);
                             }
                             $uploaded_files[$i]["is_zip"][$j] = false;
@@ -1060,7 +1075,7 @@ class SubmissionController extends AbstractController {
                         }
                     }
                 }
-                if(isset($previous_part_path[$i]) && isset($previous_files_src[$i])) {
+                if (isset($previous_part_path[$i]) && isset($previous_files_src[$i])) {
                     foreach ($previous_files_src[$i] as $prev_file) {
                         $file_size += filesize(FileUtils::joinPaths($previous_part_path[$i], $prev_file));
                     }
@@ -1073,8 +1088,8 @@ class SubmissionController extends AbstractController {
 
             for ($i = 1; $i <= $num_parts; $i++) {
                 // copy selected previous submitted files
-                if (isset($previous_files_src[$i])){
-                    for ($j = 0; $j < count($previous_files_src[$i]); $j++){
+                if (isset($previous_files_src[$i])) {
+                    for ($j = 0; $j < count($previous_files_src[$i]); $j++) {
                         $src = FileUtils::joinPaths($previous_part_path[$i], $previous_files_src[$i][$j]);
                         $dst = FileUtils::joinPaths($part_path[$i], $previous_files_dst[$i][$j]);
                         if (!@copy($src, $dst)) {
@@ -1140,8 +1155,8 @@ class SubmissionController extends AbstractController {
                 }
                 $vcs_full_path = $repo_id;
             }
-            // use base url + path with variable string replacements
             else {
+                // use base url + path with variable string replacements
                 if (strpos($vcs_path, "\$repo_id") !== false && $repo_id == "") {
                     return $this->uploadResult("repository id input cannot be blank.", false);
                 }
@@ -1276,7 +1291,7 @@ class SubmissionController extends AbstractController {
             "{$this->core->getConfig()->getSemester()}:{$this->core->getConfig()->getCourse()}:submission:{$gradeable->getId()}"
         );
 
-        if($gradeable->isTeamAssignment()) {
+        if ($gradeable->isTeamAssignment()) {
             $this->core->getQueries()->insertVersionDetails($gradeable->getId(), null, $team_id, $new_version, $current_time);
             $team_members = $graded_gradeable->getSubmitter()->getTeam()->getMembers();
 
@@ -1304,13 +1319,15 @@ class SubmissionController extends AbstractController {
     private function uploadResult($message, $success = true) {
         if (!$success) {
             // we don't want to throw an exception here as that'll mess up our return json payload
-            if ($this->upload_details['version_path'] !== null
-                && !FileUtils::recursiveRmdir($this->upload_details['version_path'])) {
+            if (
+                $this->upload_details['version_path'] !== null
+                && !FileUtils::recursiveRmdir($this->upload_details['version_path'])
+            ) {
                 // @codeCoverageIgnoreStart
                 // Without the filesystem messing up here, we should not be able to hit this error
                 Logger::error("Could not clean up folder {$this->upload_details['version_path']}");
+                // @codeCoverageIgnoreEnd
             }
-            // @codeCoverageIgnoreEnd
             elseif ($this->upload_details['assignment_settings'] === true) {
                 $settings_file = FileUtils::joinPaths($this->upload_details['user_path'], "user_assignment_settings.json");
                 $settings = json_decode(file_get_contents($settings_file), true);
@@ -1420,7 +1437,7 @@ class SubmissionController extends AbstractController {
         $version = ($new_version > 0) ? $new_version : null;
 
         // FIXME: Add this kind of operation to the graded gradeable saving query
-        if($gradeable->isTeamAssignment()) {
+        if ($gradeable->isTeamAssignment()) {
             $this->core->getQueries()->updateActiveVersion($gradeable->getId(), null, $submitter_id, $version);
         }
         else {
@@ -1436,7 +1453,7 @@ class SubmissionController extends AbstractController {
             $msg = "Updated version of gradeable to version #{$new_version}.";
             $this->core->addSuccessMessage($msg);
         }
-        if($ta) {
+        if ($ta) {
             $this->core->redirect($this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'grade']) . '?'
                 . http_build_query(['who_id' => $who, 'gradeable_version' => $new_version]));
         }
@@ -1512,19 +1529,19 @@ class SubmissionController extends AbstractController {
         $base_path = $course_path . "/submissions/" . $gradeable_id . "/";
         $users = array();
         $user_id_arr = is_dir($base_path) ? array_slice(scandir($base_path), 2) : [];
-        for($i = 0; $i < count($user_id_arr); $i++) {
+        for ($i = 0; $i < count($user_id_arr); $i++) {
             $user_path = $base_path . $user_id_arr[$i];
-            if(!is_dir($user_path)) {
+            if (!is_dir($user_path)) {
                 continue;
             }
             $files = scandir($user_path);
             $num_files = count($files) - 3;
             $json_path = $user_path . "/" . $num_files . "/bulk_upload_data.json";
-            if(!file_exists($json_path)) {
+            if (!file_exists($json_path)) {
                 continue;
             }
             $user = $this->core->getQueries()->getUserById($user_id_arr[$i]);
-            if($user === null) {
+            if ($user === null) {
                 continue;
             }
             $file_contents = FileUtils::readJsonFile($json_path);

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -172,7 +172,7 @@ class TeamController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
-        if($this->core->getQueries()->getUserByID($invite_id)->getRegistrationSection() === null){
+        if ($this->core->getQueries()->getUserByID($invite_id)->getRegistrationSection() === null) {
             // If a student with this id is in the null section...
             // (make this look the same as a non-existant student so as not to
             // reveal information about dropped students)

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -524,12 +524,12 @@ class Access {
                 if ($course_status === 2 && $group !== User::GROUP_INSTRUCTOR) {
                     return false;
                 }
-                // only students with a non-null registration section should be able to view courses (and only active==1 courses)
                 elseif ($group === User::GROUP_STUDENT && ($course_status !== 1 || $user->getRegistrationSection() === null)) {
+                    // only students with a non-null registration section should be able to view courses (and only active==1 courses)
                     return false;
                 }
-                // no one can view courses with status greater than 2
                 elseif ($course_status > 2) {
+                    // no one can view courses with status greater than 2
                     return false;
                 }
             }

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -345,18 +345,22 @@ class Access {
                 return false;
             }
             $group = User::GROUP_NONE;
-        } else {
+        }
+        else {
             $group = $user->getGroup();
         }
 
         //Check user group first
         if ($group === User::GROUP_STUDENT && !self::checkBits($checks, self::ALLOW_STUDENT)) {
             return false;
-        } elseif ($group === User::GROUP_LIMITED_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_LIMITED_ACCESS_GRADER)) {
+        }
+        elseif ($group === User::GROUP_LIMITED_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_LIMITED_ACCESS_GRADER)) {
             return false;
-        } elseif ($group === User::GROUP_FULL_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_FULL_ACCESS_GRADER)) {
+        }
+        elseif ($group === User::GROUP_FULL_ACCESS_GRADER && !self::checkBits($checks, self::ALLOW_FULL_ACCESS_GRADER)) {
             return false;
-        } elseif ($group === User::GROUP_INSTRUCTOR && !self::checkBits($checks, self::ALLOW_INSTRUCTOR)) {
+        }
+        elseif ($group === User::GROUP_INSTRUCTOR && !self::checkBits($checks, self::ALLOW_INSTRUCTOR)) {
             return false;
         }
 
@@ -380,7 +384,8 @@ class Access {
             if (array_key_exists("graded_gradeable", $args)) {
                 $graded_gradeable = $args["graded_gradeable"];
                 $gradeable = $graded_gradeable->getGradeable();
-            } else {
+            }
+            else {
                 $gradeable = $this->requireArg($args, "gradeable");
                 if ($gradeable === null) {
                     return false;
@@ -400,7 +405,7 @@ class Access {
                         &&
                         //Students are allowed to see this if its a peer graded assignment
                         !($group === User::GROUP_STUDENT && $gradeable->isPeerGrading())
-                       ) {
+                    ) {
                         //Otherwise, you're not allowed
                         $grading_checks = false;
                     }
@@ -419,7 +424,8 @@ class Access {
                     if (!$this->isSectionInGradingSections($gradeable, $args["section"], $user)) {
                         $grading_checks = false;
                     }
-                } else {
+                }
+                else {
                     //If graded gradeable is null then we're asking if we can grade anything in this gradeable, which we can.
                     // If a graded gradeable is passed then we need to make sure we can grade that specific graded gradeable.
                     if ($graded_gradeable !== null) {
@@ -515,11 +521,11 @@ class Access {
             if (self::checkBits($checks, self::CHECK_COURSE_STATUS)) {
                 $course_status = $this->core->getQueries()->getCourseStatus($semester, $course);
                 // only instructors should be able to access courses with status archived==2
-                if($course_status === 2 && $group !== User::GROUP_INSTRUCTOR) {
+                if ($course_status === 2 && $group !== User::GROUP_INSTRUCTOR) {
                     return false;
                 }
                 // only students with a non-null registration section should be able to view courses (and only active==1 courses)
-                elseif($group === User::GROUP_STUDENT && ($course_status !== 1 || $user->getRegistrationSection() === null)) {
+                elseif ($group === User::GROUP_STUDENT && ($course_status !== 1 || $user->getRegistrationSection() === null)) {
                     return false;
                 }
                 // no one can view courses with status greater than 2
@@ -578,7 +584,8 @@ class Access {
                     if ($section->containsTeam($graded_gradeable->getSubmitter()->getTeam())) {
                         return true;
                     }
-                } else {
+                }
+                else {
                     if ($section->containsUser($graded_gradeable->getSubmitter()->getUser())) {
                         return true;
                     }
@@ -621,7 +628,8 @@ class Access {
 
         if (!$gradeable->isPeerGrading()) {
             return false;
-        } else {
+        }
+        else {
             $user_ids_to_grade = $this->core->getQueries()->getPeerAssignment($gradeable->getId(), $user->getId());
             return in_array($graded_gradeable->getSubmitter()->getId(), $user_ids_to_grade);
         }
@@ -666,7 +674,8 @@ class Access {
             if ($graded_gradeable->getSubmitter()->isTeam()) {
                 if ($submitter->isTeam()) {
                     return $graded_gradeable->getSubmitter()->getId() === $submitter->getId();
-                } else {
+                }
+                else {
                     return $graded_gradeable->getSubmitter()->getTeam()->hasMember($submitter->getId());
                 }
             }
@@ -734,7 +743,8 @@ class Access {
                                 return false;
                             }
                         }
-                    } else {
+                    }
+                    else {
                         $args["gradeable"] = $this->core->getQueries()->getGradeableConfig($value);
                     }
                     break;
@@ -746,11 +756,13 @@ class Access {
                             //If we already have a graded gradeable in the args, make sure this file
                             // actually belongs to it
                             $graded_gradeable = $args["graded_gradeable"];
-                        } elseif (array_key_exists("gradeable", $args)) {
+                        }
+                        elseif (array_key_exists("gradeable", $args)) {
                             $gradeable = $args["gradeable"];
                             $graded_gradeable = $this->core->getQueries()->getGradedGradeableForSubmitter($gradeable, $submitter);
                             $args["graded_gradeable"] = $graded_gradeable;
-                        } else {
+                        }
+                        else {
                             return false;
                         }
                         if ($graded_gradeable === null || !($graded_gradeable instanceof GradedGradeable)) {

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -82,13 +82,13 @@ class Core {
         $this->access = new Access($this);
 
         // initialize our alert queue if it doesn't exist
-        if(!isset($_SESSION['messages'])) {
+        if (!isset($_SESSION['messages'])) {
             $_SESSION['messages'] = array();
         }
 
         // initialize our alert types if one of them doesn't exist
         foreach (array('error', 'notice', 'success') as $key) {
-            if(!isset($_SESSION['messages'][$key])) {
+            if (!isset($_SESSION['messages'][$key])) {
                 $_SESSION['messages'][$key] = array();
             }
         }
@@ -129,7 +129,7 @@ class Core {
             if (file_exists($course_json_path) && is_readable($course_json_path)) {
                 $this->config->loadCourseJson($semester, $course, $course_json_path);
             }
-            else{
+            else {
                 $message = "Unable to access configuration file " . $course_json_path . " for " .
                   $semester . " " . $course . " please contact your system administrator.\n" .
                   "If this is a new course, the error might be solved by restarting php-fpm:\n" .
@@ -571,20 +571,20 @@ class Core {
         if ($this->getConfig()->getCourseName() !== "") {
             return htmlentities($this->getConfig()->getCourseName());
         }
-        else{
+        else {
             return $this->getConfig()->getCourse();
         }
     }
 
     public function getFullSemester() {
         $semester = $this->getConfig()->getSemester();
-        if ($this->getConfig()->getSemester() !== ""){
+        if ($this->getConfig()->getSemester() !== "") {
             $arr1 = str_split($semester);
             $semester = "";
-            if($arr1[0] == "f") {
+            if ($arr1[0] == "f") {
                 $semester .= "Fall ";
             }
-            elseif($arr1[0] == "s") {
+            elseif ($arr1[0] == "s") {
                 $semester .= "Spring ";
             }
             elseif ($arr1[0] == "u") {

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -97,7 +97,8 @@ class DateUtils {
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
-        } elseif (!($date instanceof \DateTime)) {
+        }
+        elseif (!($date instanceof \DateTime)) {
             throw new \InvalidArgumentException('Passed object was not a DateTime object or a date string');
         }
 

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -94,7 +94,8 @@ class DateUtils {
         if (gettype($date) === 'string') {
             try {
                 $date = new \DateTime($date, $time_zone);
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid DateTime Format');
             }
         }

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -180,14 +180,14 @@ class DiffViewer {
                 $this->actual_file_image = $actual_file;
             }
             else {
-                if(filesize($actual_file) < $size_limit){
+                if (filesize($actual_file) < $size_limit) {
                     $this->actual_file_name = $actual_file;
                     $this->actual = file_get_contents($actual_file);
                     $this->has_actual = trim($this->actual) !== "" ? true : false;
                     $this->actual = explode("\n", $this->actual);
                     $this->display_actual = true;
                 }
-                else{
+                else {
                     $this->actual_file_name = $actual_file;
                     $can_diff = false;
                     //load in the first sizelimit characters of the file (TEMP VALUE)
@@ -206,14 +206,14 @@ class DiffViewer {
             if (Utils::isImage($expected_file)) {
                 $this->expected_file_image = $expected_file;
             }
-            else{
-                if(filesize($expected_file) < $size_limit){
+            else {
+                if (filesize($expected_file) < $size_limit) {
                     $this->expected = file_get_contents($expected_file);
                     $this->has_expected = trim($this->expected) !== "" ? true : false;
                     $this->expected = explode("\n", $this->expected);
                     $this->display_expected = true;
                 }
-                else{
+                else {
                     $can_diff = false;
                     //load in the first sizelimit characters of the file (TEMP VALUE)
                     $this->expected = file_get_contents($expected_file, null, null, 0, $size_limit);
@@ -262,7 +262,8 @@ class DiffViewer {
                         $line_num = $line['line_number'];
                         if (isset($line['char_number'])) {
                             $this->diff[self::ACTUAL][$line_num] = $this->compressRange($line['char_number']);
-                        } else {
+                        }
+                        else {
                             $this->diff[self::ACTUAL][$line_num] = array();
                         }
                         $act_final = $line_num;
@@ -277,7 +278,8 @@ class DiffViewer {
                         $line_num = $line['line_number'];
                         if (isset($line['char_number'])) {
                             $this->diff[self::EXPECTED][$line_num] = $this->compressRange($line['char_number']);
-                        } else {
+                        }
+                        else {
                             $this->diff[self::EXPECTED][$line_num] = array();
                         }
                         $exp_final = $line_num;
@@ -472,15 +474,17 @@ class DiffViewer {
                     $test = str_replace("\0", "null", $html_orig);
                     $html_orig_error = htmlentities(substr($lines[$i], $diff[0], ($diff[1] - $diff[0] + 1)));
                     $test2 = str_replace("\0", "null", $html_orig_error);
-                    if($option == self::SPECIAL_CHARS_ORIGINAL){
+                    if ($option == self::SPECIAL_CHARS_ORIGINAL) {
                         $html .= $html_orig;
                         $html .= "<span class='highlight-char'>" . $html_orig_error . "</span>";
-                    } elseif($option == self::SPECIAL_CHARS_UNICODE) {
+                    }
+                    elseif ($option == self::SPECIAL_CHARS_UNICODE) {
                         $html_no_empty = $this->replaceEmptyChar($html_orig, false);
                         $html_no_empty_error = $this->replaceEmptyChar($html_orig_error, false);
                         $html .= $html_no_empty;
                         $html .= "<span class='highlight-char'>" . $html_no_empty_error . "</span>";
-                    } elseif($option == self::SPECIAL_CHARS_ESCAPE) {
+                    }
+                    elseif ($option == self::SPECIAL_CHARS_ESCAPE) {
                         $html_no_empty = $this->replaceEmptyChar($html_orig, true);
                         $html_no_empty_error = $this->replaceEmptyChar($html_orig_error, true);
                         $html .= $html_no_empty;
@@ -500,18 +504,21 @@ class DiffViewer {
             }
             else {
                 if (isset($lines[$i])) {
-                    if($option == self::SPECIAL_CHARS_ORIGINAL){
+                    if ($option == self::SPECIAL_CHARS_ORIGINAL) {
                         $html .= htmlentities($lines[$i]);
-                    } elseif($option == self::SPECIAL_CHARS_UNICODE){
+                    }
+                    elseif ($option == self::SPECIAL_CHARS_UNICODE) {
                         $html .= $this->replaceEmptyChar(htmlentities($lines[$i]), false);
-                    } elseif($option == self::SPECIAL_CHARS_ESCAPE){
+                    }
+                    elseif ($option == self::SPECIAL_CHARS_ESCAPE) {
                         $html .= $this->replaceEmptyChar(htmlentities($lines[$i]), true);
                     }
                 }
             }
-            if($option == self::SPECIAL_CHARS_UNICODE) {
+            if ($option == self::SPECIAL_CHARS_UNICODE) {
                 $html .= '<span class="whitespace">&#9166;</span>';
-            } elseif($option == self::SPECIAL_CHARS_ESCAPE) {
+            }
+            elseif ($option == self::SPECIAL_CHARS_ESCAPE) {
                 $html .= '<span class="whitespace">\\n</span>';
             }
             $html .= "</span></div>\n";
@@ -539,7 +546,7 @@ class DiffViewer {
 
     public function getWhiteSpaces() {
         $return = "";
-        foreach($this->white_spaces as $key => $value){
+        foreach ($this->white_spaces as $key => $value) {
             $return .= "$value" . " = " . "$key" . " ";
         }
         return $this->white_spaces;
@@ -555,12 +562,13 @@ class DiffViewer {
      */
     private function replaceEmptyChar($html, $with_escape) {
         $return = $html;
-        if($with_escape){
-            foreach(self::SPECIAL_CHARS_LIST as $name => $representations){
+        if ($with_escape) {
+            foreach (self::SPECIAL_CHARS_LIST as $name => $representations) {
                 $this->replaceUTF($representations[0], $representations[2], $return, $name);
             }
-        } else {
-            foreach(self::SPECIAL_CHARS_LIST as $name => $representations){
+        }
+        else {
+            foreach (self::SPECIAL_CHARS_LIST as $name => $representations) {
                 $this->replaceUTF($representations[0], $representations[1], $return, $name);
             }
         }
@@ -580,7 +588,7 @@ class DiffViewer {
         $count = 0;
         $what = '<span class="whitespace">' . $what . '</span>';
         $which = str_replace($text, $what, $which, $count);
-        if($count > 0) {
+        if ($count > 0) {
             $this->white_spaces[$description] = strip_tags($what);
         }
         return $what;
@@ -627,8 +635,8 @@ class DiffViewer {
     public function existsDifference() {
         $this->buildViewer();
         $return = false;
-        foreach(array(self::EXPECTED, self::ACTUAL) as $key) {
-            if(count($this->diff[$key]) > 0 || count($this->add[$key]) > 0) {
+        foreach (array(self::EXPECTED, self::ACTUAL) as $key) {
+            if (count($this->diff[$key]) > 0 || count($this->add[$key]) > 0) {
                 $return = true;
             }
         }

--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -71,7 +71,7 @@ class ExceptionHandler {
             $display_message = $exception->displayMessage();
             $log_exception = $exception->logException();
         }
-        
+
         $trace_string = array();
         foreach ($exception->getTrace() as $elem => $frame) {
             $trace_string[] = sprintf(
@@ -106,16 +106,17 @@ class ExceptionHandler {
         if ($is_base_exception) {
             /** @type BaseException $exception */
             $extra = $exception->getDetails();
-            if(count($extra) > 0) {
+            if (count($extra) > 0) {
                 $message .= "Extra Details:\n";
                 foreach ($extra as $key => $value) {
                     $message .= "\t" . $key . ":";
-                    if(is_array($value)) {
+                    if (is_array($value)) {
                         $message .= "\n";
                         foreach ($value as $kk => $vv) {
                             $message .= "\t\t" . $vv . "\n";
                         }
-                    } else {
+                    }
+                    else {
                         $message .= " " . $value . "\n";
                     }
                 }
@@ -139,7 +140,7 @@ An exception was thrown. Please contact an administrator about what you were doi
 HTML;
         }
     }
-    
+
     /**
      * Parse the arguments from the stack trace into type appropriate representation for the stack trace. We
      * may want to look into expanding the $args when they're an Array, but for now, this is probably fine.

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -244,7 +244,7 @@ class FileUtils {
             if ($handle = opendir($path)) {
                 while (false !== ($entry = readdir($handle))) {
                     $file = "{$path}/{$entry}";
-                    if(is_dir($file) && !in_array(strtolower($entry), $disallowed_folders)) {
+                    if (is_dir($file) && !in_array(strtolower($entry), $disallowed_folders)) {
                         $return[] = $entry;
                     }
                 }
@@ -312,10 +312,10 @@ class FileUtils {
      */
     public static function checkFileInZipName($zipname) {
         $zip = zip_open($zipname);
-        if(is_resource(($zip))) {
+        if (is_resource(($zip))) {
             while ($inner_file = zip_read($zip)) {
                 $fname = zip_entry_name($inner_file);
-                if(FileUtils::isValidFileName($fname) === false) {
+                if (FileUtils::isValidFileName($fname) === false) {
                     return false;
                 }
             }
@@ -336,11 +336,13 @@ class FileUtils {
         }
         else {
             foreach (str_split($filename) as $char) {
-                if ($char == "'" ||
-                    $char == '"' ||
-                    $char == "\\" ||
-                    $char == "<" ||
-                    $char == ">") {
+                if (
+                    $char == "'"
+                    || $char == '"'
+                    || $char == "\\"
+                    || $char == "<"
+                    || $char == ">"
+                ) {
                     return false;
                 }
             }
@@ -461,7 +463,7 @@ class FileUtils {
         $file_contents = @file_get_contents($file);
 
         // Check for failure
-        if($file_contents == false) {
+        if ($file_contents == false) {
             throw new FileReadException('Unable to either locate or read the file contents');
         }
 
@@ -471,7 +473,7 @@ class FileUtils {
         foreach ($words as $word) {
             $word_was_found = strpos($file_contents, $word);
 
-            if($word_was_found) {
+            if ($word_was_found) {
                 $words_detected = true;
                 break;
             }
@@ -510,7 +512,7 @@ class FileUtils {
 
             //manually check against set size limit
             //incase the max POST size is greater than max file size
-            if($size > $max_size){
+            if ($size > $max_size) {
                 $err_msg = "File \"" . $name . "\" too large got (" . Utils::formatBytes("mb", $size) . ")";
             }
 

--- a/site/app/libraries/ForumUtils.php
+++ b/site/app/libraries/ForumUtils.php
@@ -17,50 +17,50 @@ class ForumUtils {
     const FORUM_CHAR_POST_LIMIT = 5000;
 
     public static function checkGoodAttachment($isThread, $thread_id, $file_post) {
-        if((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE){
+        if ((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE) {
             return array(0);
         }
-        if(count($_FILES[$file_post]['tmp_name']) > 5) {
+        if (count($_FILES[$file_post]['tmp_name']) > 5) {
             //return $this->returnUserContentToPage("Max file upload size is 5. Please try again.", $isThread, $thread_id);
         }
         $imageCheck = Utils::checkUploadedImageFile($file_post) ? 1 : 0;
-        if($imageCheck == 0 && !empty($_FILES[$file_post]['tmp_name'])){
+        if ($imageCheck == 0 && !empty($_FILES[$file_post]['tmp_name'])) {
             //return $this->returnUserContentToPage("Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)", $isThread, $thread_id);
         }
         return array($imageCheck);
     }
 
     public static function isValidCategories($rows, $inputCategoriesIds = -1, $inputCategoriesName = -1) {
-        if(is_array($inputCategoriesIds)) {
-            if(count($inputCategoriesIds) < 1) {
+        if (is_array($inputCategoriesIds)) {
+            if (count($inputCategoriesIds) < 1) {
                 return false;
             }
             foreach ($inputCategoriesIds as $category_id) {
                 $match_found = false;
-                foreach($rows as $index => $values){
-                    if($values["category_id"] === $category_id) {
+                foreach ($rows as $index => $values) {
+                    if ($values["category_id"] === $category_id) {
                         $match_found = true;
                         break;
                     }
                 }
-                if(!$match_found) {
+                if (!$match_found) {
                     return false;
                 }
             }
         }
-        if(is_array($inputCategoriesName)) {
-            if(count($inputCategoriesName) < 1) {
+        if (is_array($inputCategoriesName)) {
+            if (count($inputCategoriesName) < 1) {
                 return false;
             }
             foreach ($inputCategoriesName as $category_name) {
                 $match_found = false;
-                foreach($rows as $index => $values){
-                    if($values["category_desc"] === $category_name) {
+                foreach ($rows as $index => $values) {
+                    if ($values["category_desc"] === $category_name) {
                         $match_found = true;
                         break;
                     }
                 }
-                if(!$match_found) {
+                if (!$match_found) {
                     return false;
                 }
             }
@@ -69,7 +69,7 @@ class ForumUtils {
     }
 
     public static function getDisplayName($anonymous, $real_name) {
-        if($anonymous) {
+        if ($anonymous) {
             return "Anonymous";
         }
         return $real_name['first_name'] . substr($real_name['last_name'], 0, 2) . '.';

--- a/site/app/libraries/GradeableType.php
+++ b/site/app/libraries/GradeableType.php
@@ -13,7 +13,7 @@ abstract class GradeableType {
      * @return string
      */
     public static function typeToString(int $type): string {
-        switch($type) {
+        switch ($type) {
             case static::ELECTRONIC_FILE:
                 return "Electronic File";
             case static::CHECKPOINTS:
@@ -31,7 +31,7 @@ abstract class GradeableType {
      * @return int
      */
     public static function stringToType(string $string): int {
-        switch($string) {
+        switch ($string) {
             case "Electronic File":
                 return static::ELECTRONIC_FILE;
             case "Checkpoints":

--- a/site/app/libraries/GradingQueue.php
+++ b/site/app/libraries/GradingQueue.php
@@ -52,7 +52,8 @@ class GradingQueue {
             if (is_file($fqp)) {
                 if (strpos($file, self::GRADING_FILE_PREFIX) !== false) {
                     $grading_files[] = $file;
-                } else {
+                }
+                else {
                     $queue_files[] = $file;
 
                     // Also, record the last modified of each item
@@ -73,7 +74,7 @@ class GradingQueue {
      * Loads the queue if it hasn't already been loaded yet
      */
     private function ensureLoadedQueue() {
-        if($this->queue_files === null) {
+        if ($this->queue_files === null) {
             $this->reloadQueue();
         }
     }
@@ -101,18 +102,18 @@ class GradingQueue {
 
         // First, check if its being graded
         $grading_status = array_search($grading_queue_file, $this->grading_files, true);
-        if($grading_status !== false) {
+        if ($grading_status !== false) {
             return self::GRADING;
         }
 
         // Then, check its position in the queue
         $queue_status = array_search($queue_file, $this->queue_files, true);
-        if($queue_status === false) {
+        if ($queue_status === false) {
             // Also check for the vcs queue file, which will soon be converted into a regular queue file
             $queue_status = array_search($vcs_queue_file, $this->queue_files, true);
         }
 
-        if($queue_status !== false) {
+        if ($queue_status !== false) {
             // Convert from 0-indexed array since 0 is self::GRADING
             return $queue_status + 1;
         }

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -121,7 +121,7 @@ class Logger {
         $filename = static::getFilename();
         $log_message = static::getTimestamp();
         $log_message .= " - ";
-        switch($level) {
+        switch ($level) {
             case 0:
                 $log_message .= "DEBUG";
                 break;

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -88,7 +88,7 @@ class Output {
             'debug' => $debug
         ]);
 
-        if($debug){
+        if ($debug) {
             $this->twig->addExtension(new \Twig\Extension\DebugExtension());
         }
 
@@ -114,7 +114,7 @@ HTML;
         if ($full_load) {
             $this->twig->getExtension(\Twig\Extension\CoreExtension::class)
                 ->setTimezone($this->core->getConfig()->getTimezone());
-            if($this->core->getConfig()->wrapperEnabled()) {
+            if ($this->core->getConfig()->wrapperEnabled()) {
                 $this->twig_loader->addPath(
                     FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'site'),
                     $namespace = 'site_uploads'
@@ -303,7 +303,8 @@ HTML;
 
         if ($success === true) {
             return $this->renderJsonSuccess($message);
-        } else {
+        }
+        else {
             return $this->renderJsonFail($message);
         }
     }
@@ -345,7 +346,8 @@ HTML;
     public function renderTwigOutput(string $filename, array $context = []): void {
         if ($this->buffer_output) {
             $this->output_buffer .= $this->renderTwigTemplate($filename, $context);
-        } else {
+        }
+        else {
             echo $this->renderTwigTemplate($filename, $context);
         }
     }
@@ -363,7 +365,7 @@ HTML;
         if (!Utils::startsWith($class, "app\\views")) {
             $class = "app\\views\\{$class}View";
         }
-        if(!isset($this->loaded_views[$class])) {
+        if (!isset($this->loaded_views[$class])) {
             /** @noinspection PhpUndefinedMethodInspection */
             $this->loaded_views[$class] = new $class($this->core, $this);
         }
@@ -391,7 +393,8 @@ HTML;
     protected function renderFooter() {
         if ($this->use_footer) {
             return $this->controller->footer();
-        } else {
+        }
+        else {
             return '';
         }
     }

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -331,7 +331,8 @@ HTML;
     public function renderTwigTemplate(string $filename, array $context = []): string {
         try {
             return $this->twig->render($filename, $context);
-        } catch (\Twig_Error $e) {
+        }
+        catch (\Twig_Error $e) {
             throw new OutputException("{$e->getMessage()} in {$e->getFile()}:{$e->getLine()}");
         }
     }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -21,7 +21,7 @@ class Utils {
         if (!is_array($haystack) || !is_string($needle)) {
             return null;
         }
-        foreach($haystack as $key => $value) {
+        foreach ($haystack as $key => $value) {
             if (is_array($value)) {
                 $haystack[$key] = Utils::stripStringFromArray($needle, $value);
             }
@@ -116,7 +116,7 @@ class Utils {
      * @return mixed|null
      */
     public static function getFirstArrayElement(array $array) {
-        foreach($array as $value) {
+        foreach ($array as $value) {
             return $value;
         }
         return null;
@@ -225,7 +225,8 @@ class Utils {
 
         if ($result > 1.0 && $clamp === true) {
             return 1.0;
-        } elseif ($result < 0.0 && $clamp === true) {
+        }
+        elseif ($result < 0.0 && $clamp === true) {
             return 0.0;
         }
         return $result;
@@ -262,7 +263,7 @@ class Utils {
             ];
 
             if ($students_version !== null) {
-                if($student->getRegistrationSection() !== null && array_key_exists($student->getId(), $students_version)) {
+                if ($student->getRegistrationSection() !== null && array_key_exists($student->getId(), $students_version)) {
                     if ($students_version[$student->getId()] !== 0) {
                         $student_entry['label'] .= ' (' . $students_version[$student->getId()] . ' Prev Submission)';
                     }

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -149,8 +149,11 @@ abstract class AbstractDatabase {
             $lower = trim(strtolower($query));
 
             $this->row_count = null;
-            if (Utils::startsWith($lower, 'update') || Utils::startsWith($lower, 'delete')
-                || Utils::startsWith($lower, 'insert')) {
+            if (
+                Utils::startsWith($lower, 'update')
+                || Utils::startsWith($lower, 'delete')
+                || Utils::startsWith($lower, 'insert')
+            ) {
                 $this->row_count = $statement->rowCount();
             }
             elseif (Utils::startsWith($lower, 'select')) {
@@ -279,7 +282,7 @@ abstract class AbstractDatabase {
      * @return array
      */
     public function row() {
-        if($this->results != null && count($this->results) > 0) {
+        if ($this->results != null && count($this->results) > 0) {
             return array_shift($this->results);
         }
         else {
@@ -294,7 +297,7 @@ abstract class AbstractDatabase {
      * @return array
      */
     public function rows() {
-        if($this->results !== null && count($this->results) > 0) {
+        if ($this->results !== null && count($this->results) > 0) {
             return $this->results;
         }
         else {
@@ -335,8 +338,8 @@ abstract class AbstractDatabase {
      */
     public function getPrintQueries() {
         $print = [];
-        foreach($this->all_queries as $query) {
-            foreach($query[1] as $parameter) {
+        foreach ($this->all_queries as $query) {
+            foreach ($query[1] as $parameter) {
                 $query[0] = preg_replace('/\?/', "'{$parameter}'", $query[0], 1);
             }
             $print[] = $query[0];

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -208,19 +208,21 @@ class DatabaseQueries {
         $query_parameters = array();
 
         // Query Generation
-        if(count($categories_ids) == 0) {
+        if (count($categories_ids) == 0) {
             $query_multiple_qmarks = "NULL";
-        } else {
+        }
+        else {
             $query_multiple_qmarks = "?" . str_repeat(",?", count($categories_ids) - 1);
         }
-        if(count($thread_status) == 0) {
+        if (count($thread_status) == 0) {
             $query_status = "true";
-        } else {
+        }
+        else {
             $query_status = "status in (?" . str_repeat(",?", count($thread_status) - 1) . ")";
         }
         $query_favorite = "case when sf.user_id is NULL then false else true end";
 
-        if($want_order){
+        if ($want_order) {
             $query_raw_select[]     = "row_number() over(ORDER BY pinned DESC, ({$query_favorite}) DESC, t.id DESC) AS row_number";
         }
         $query_raw_select[]     = "t.*";
@@ -235,10 +237,10 @@ class DatabaseQueries {
         $query_raw_join[]       = "LEFT JOIN student_favorites sf ON sf.thread_id = t.id and sf.user_id = ?";
         $query_parameters[]     = $current_user;
 
-        if(!$show_deleted) {
+        if (!$show_deleted) {
             $query_raw_where[]  = "deleted = false";
         }
-        if(!$show_merged_thread) {
+        if (!$show_merged_thread) {
             $query_raw_where[]  = "merged_thread_id = -1";
         }
 
@@ -248,7 +250,7 @@ class DatabaseQueries {
         $query_raw_where[]  = "{$query_status}";
         $query_parameters   = array_merge($query_parameters, $thread_status);
 
-        if($want_order){
+        if ($want_order) {
             $query_raw_order[]  = "row_number";
         }
         else {
@@ -256,7 +258,7 @@ class DatabaseQueries {
         }
 
         // Categories
-        if($want_categories) {
+        if ($want_categories) {
             $query_select_categories = "SELECT thread_id, array_to_string(array_agg(cl.category_id order by cl.rank nulls last, cl.category_id),'|')  as categories_ids, array_to_string(array_agg(cl.category_desc order by cl.rank nulls last, cl.category_id),'|') as categories_desc, array_to_string(array_agg(cl.color order by cl.rank nulls last, cl.category_id),'|') as categories_color FROM categories_list cl JOIN thread_categories e ON e.category_id = cl.category_id GROUP BY thread_id";
 
             $query_raw_select[] = "categories_ids";
@@ -266,7 +268,7 @@ class DatabaseQueries {
             $query_raw_join[] = "JOIN ({$query_select_categories}) AS QSC ON QSC.thread_id = t.id";
         }
         // Unread Threads
-        if($unread_threads) {
+        if ($unread_threads) {
             $query_raw_where[] =
 
             "EXISTS(
@@ -313,7 +315,7 @@ class DatabaseQueries {
         $query_raw_order  = null;
         $query_parameters = null;
         // $blockNumber is 1 based index
-        if($blockNumber <= -1) {
+        if ($blockNumber <= -1) {
             // Find the last block
             $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, false, false);
             $query = "SELECT count(*) FROM (SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where})";
@@ -321,18 +323,18 @@ class DatabaseQueries {
             $results = $this->course_db->rows();
             $row_count = $results[0]['count'];
             $blockNumber = 1 + floor(($row_count - 1) / $blockSize);
-        } elseif($blockNumber == 0) {
+        }
+        elseif ($blockNumber == 0) {
             // Load first block as default
             $blockNumber = 1;
-            if($thread_id >= 1)
-            {
+            if ($thread_id >= 1) {
                 // Find $blockNumber
                 $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, false, true);
                 $query = "SELECT SUBQUERY.row_number as row_number FROM (SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where} ORDER BY {$query_order}) AS SUBQUERY WHERE SUBQUERY.id = ?";
                 $query_parameters[] = $thread_id;
                 $this->course_db->query($query, $query_parameters);
                 $results = $this->course_db->rows();
-                if(count($results) > 0) {
+                if (count($results) > 0) {
                     $row_number = $results[0]['row_number'];
                     $blockNumber = 1 + floor(($row_number - 1) / $blockSize);
                 }
@@ -361,12 +363,12 @@ class DatabaseQueries {
     }
 
     public function createPost($user, $content, $thread_id, $anonymous, $type, $first, $hasAttachment, $markdown, $parent_post = -1) {
-        if(!$first && $parent_post == 0){
+        if (!$first && $parent_post == 0) {
             $this->course_db->query("SELECT MIN(id) as id FROM posts where thread_id = ?", array($thread_id));
             $parent_post = $this->course_db->rows()[0]["id"];
         }
 
-        if(!$markdown){
+        if (!$markdown) {
             $markdown = 0;
         }
 
@@ -374,8 +376,8 @@ class DatabaseQueries {
             $this->course_db->query("INSERT INTO posts (thread_id, parent_id, author_user_id, content, timestamp, anonymous, deleted, endorsed_by, type, has_attachment, render_markdown) VALUES (?, ?, ?, ?, current_timestamp, ?, ?, ?, ?, ?, ?)", array($thread_id, $parent_post, $user, $content, $anonymous, 0, null, $type, $hasAttachment, $markdown));
             $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", array($thread_id, $user));
             $this->visitThread($user, $thread_id);
-        } catch (DatabaseException $dbException){
-            if($this->course_db->inTransaction()){
+        } catch (DatabaseException $dbException) {
+            if ($this->course_db->inTransaction()) {
                 $this->course_db->rollback();
             }
         }
@@ -389,7 +391,7 @@ class DatabaseQueries {
     }
 
     public function updateResolveState($thread_id, $state) {
-        if(in_array($state, array(-1, 0, 1))) {
+        if (in_array($state, array(-1, 0, 1))) {
             $this->course_db->query("UPDATE threads set status = ? where id = ?", array($state, $thread_id));
             return true;
         }
@@ -401,8 +403,8 @@ class DatabaseQueries {
         $keys = implode(', ', array_keys($results));
         $updates = '';
 
-        foreach($results as $key => $value) {
-            if($value != 'false') {
+        foreach ($results as $key => $value) {
+            if ($value != 'false') {
                 $results[$key] = 'true';
             }
             $this->core->getUser()->updateUserNotificationSettings($key, $results[$key] == 'true' ? true : false);
@@ -445,9 +447,10 @@ class DatabaseQueries {
     public function getFirstPostForThread($thread_id) {
         $this->course_db->query("SELECT * FROM posts WHERE parent_id = -1 AND thread_id = ?", array($thread_id));
         $rows = $this->course_db->rows();
-        if(count($rows) > 0) {
+        if (count($rows) > 0) {
             return $rows[0];
-        } else {
+        }
+        else {
             return null;
         }
     }
@@ -471,19 +474,20 @@ class DatabaseQueries {
 
 
     public function getUnviewedPosts($thread_id, $user_id) {
-        if($thread_id == -1) {
+        if ($thread_id == -1) {
             $this->course_db->query("SELECT MAX(id) as max from threads WHERE deleted = false and merged_thread_id = -1 GROUP BY pinned ORDER BY pinned DESC");
             $rows = $this->course_db->rows();
-            if(!empty($rows)) {
+            if (!empty($rows)) {
                 $thread_id = $rows[0]["max"];
-            } else {
+            }
+            else {
                 // No thread found, hence no posts found
                 return array();
             }
         }
         $this->course_db->query("SELECT DISTINCT id FROM (posts LEFT JOIN forum_posts_history ON posts.id = forum_posts_history.post_id) AS pfph WHERE pfph.thread_id = ? AND NOT EXISTS(SELECT * FROM viewed_responses v WHERE v.thread_id = ? AND v.user_id = ? AND (v.timestamp >= pfph.timestamp AND (pfph.edit_timestamp IS NULL OR (pfph.edit_timestamp IS NOT NULL AND v.timestamp >= pfph.edit_timestamp))))", array($thread_id, $thread_id, $user_id));
         $rows = $this->course_db->rows();
-        if(empty($rows)){
+        if (empty($rows)) {
             $rows = array();
         }
         return $rows;
@@ -499,7 +503,7 @@ class DatabaseQueries {
 
             //retrieve generated thread_id
             $this->course_db->query("SELECT MAX(id) as max_id from threads where title=? and created_by=?", array($title, $user));
-        } catch(DatabaseException $dbException) {
+        } catch (DatabaseException $dbException) {
             $this->course_db->rollback();
         }
 
@@ -539,9 +543,10 @@ class DatabaseQueries {
     }
 
     public function addPinnedThread($user_id, $thread_id, $added) {
-        if($added) {
+        if ($added) {
             $this->course_db->query("INSERT INTO student_favorites(user_id, thread_id) VALUES (?,?)", array($user_id, $thread_id));
-        } else {
+        }
+        else {
             $this->course_db->query("DELETE FROM student_favorites where user_id=? and thread_id=?", array($user_id, $thread_id));
         }
     }
@@ -560,7 +565,7 @@ class DatabaseQueries {
         $query_delete = $get_deleted ? "true" : "deleted = false";
         $this->course_db->query("SELECT id from posts where {$query_delete} and parent_id=?", array($post_id));
         $row = $this->course_db->rows();
-        for($i = 0; $i < count($row); $i++){
+        for ($i = 0; $i < count($row); $i++) {
             $child_id = $row[$i]["id"];
             array_push($children, $child_id);
             $this->findChildren($child_id, $thread_id, $children, $get_deleted);
@@ -597,20 +602,21 @@ class DatabaseQueries {
         $get_deleted = ($newStatus ? false : true);
         $this->findChildren($post_id, $thread_id, $children, $get_deleted);
 
-        if(!$newStatus) {
+        if (!$newStatus) {
             // On undelete, parent post must have deleted = false
-            if($parent_id != -1) {
-                if($this->getPost($parent_id)['deleted']) {
+            if ($parent_id != -1) {
+                if ($this->getPost($parent_id)['deleted']) {
                     return null;
                 }
             }
         }
-        if($parent_id == -1){
+        if ($parent_id == -1) {
             $this->course_db->query("UPDATE threads SET deleted = ? WHERE id = ?", array($newStatus, $thread_id));
             $this->course_db->query("UPDATE posts SET deleted = ? WHERE thread_id = ?", array($newStatus, $thread_id));
             return true;
-        } else {
-            foreach($children as $post_id){
+        }
+        else {
+            foreach ($children as $post_id) {
                 $this->course_db->query("UPDATE posts SET deleted = ? WHERE id = ?", array($newStatus, $post_id));
             }
         } return false;
@@ -635,7 +641,7 @@ class DatabaseQueries {
             $this->course_db->query("INSERT INTO forum_posts_history(post_id, edit_author, content, edit_timestamp) SELECT id, ?, content, current_timestamp FROM posts WHERE id = ?", array($user, $post_id));
             $this->course_db->query("UPDATE notifications SET content = substring(content from '.+?(?=from)') || 'from ' || ? where metadata::json->>'thread_id' = ? and metadata::json->>'post_id' = ?", array(ForumUtils::getDisplayName($anon, $this->getDisplayUserInfoFromUserId($original_creator)), $this->getParentPostId($post_id), $post_id));
             $this->course_db->commit();
-        } catch(DatabaseException $dbException) {
+        } catch (DatabaseException $dbException) {
             $this->course_db->rollback();
             return false;
         } return true;
@@ -650,7 +656,7 @@ class DatabaseQueries {
                 $this->course_db->query("INSERT INTO thread_categories (thread_id, category_id) VALUES (?, ?)", array($thread_id, $category_id));
             }
             $this->course_db->commit();
-        } catch(DatabaseException $dbException) {
+        } catch (DatabaseException $dbException) {
             $this->course_db->rollback();
             return false;
         } return true;
@@ -719,7 +725,7 @@ class DatabaseQueries {
 
     public function getGradeableVersionHasAutogradingResults($g_id, $version, $user_id, $team_id) {
         $query = "SELECT * FROM electronic_gradeable_data WHERE g_id=? AND g_version=? AND ";
-        if($user_id === null) {
+        if ($user_id === null) {
             $query .= "team_id=?";
             $params = [$g_id, $version, $team_id];
         }
@@ -738,7 +744,7 @@ class DatabaseQueries {
 
     // Moved from class LateDaysCalculation on port from TAGrading server.  May want to incorporate late day information into gradeable object rather than having a separate query
     public function getLateDayUpdates($user_id) {
-        if($user_id != null) {
+        if ($user_id != null) {
             $query = "SELECT * FROM late_days WHERE user_id";
             if (is_array($user_id)) {
                 $query .= ' IN ' . $this->createParamaterList(count($user_id));
@@ -925,7 +931,7 @@ ORDER BY {$orderby}", $params);
          $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team){
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -963,7 +969,7 @@ ORDER BY {$u_or_t}.{$section_key}", $params);
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team){
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -1016,7 +1022,7 @@ ORDER BY gc_order
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team){
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -1039,7 +1045,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
    )g
 ) as individual;
           ", array($g_id));
-        if(count($this->course_db->rows()) == 0){
+        if (count($this->course_db->rows()) == 0) {
             return;
         }
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
@@ -1048,7 +1054,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team){
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -1095,7 +1101,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team){
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -1138,7 +1144,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
   )g WHERE count=?
 )AS individual
           ", array($g_id, $count));
-        if(count($this->course_db->rows()) == 0){
+        if (count($this->course_db->rows()) == 0) {
             return;
         }
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
@@ -1548,8 +1554,8 @@ ORDER BY user_id ASC");
 
     public function setupRotatingSections($graders, $gradeable_id) {
         $this->course_db->query("DELETE FROM grading_rotating WHERE g_id=?", array($gradeable_id));
-        foreach ($graders as $grader => $sections){
-            foreach($sections as $i => $section){
+        foreach ($graders as $grader => $sections) {
+            foreach ($sections as $i => $section) {
                 $this->course_db->query("INSERT INTO grading_rotating(g_id, user_id, sections_rotating_id) VALUES(?,?,?)", array($gradeable_id ,$grader, $section));
             }
         }
@@ -1573,7 +1579,7 @@ ORDER BY user_id ASC");
                 team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)", $params);
 
         $users = [];
-        foreach ($this->course_db->rows() as $row){
+        foreach ($this->course_db->rows() as $row) {
             $users[] = $row['user_id'];
         }
         return $users;
@@ -1777,7 +1783,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
                 team_id = ANY(SELECT team_id FROM gradeable_teams WHERE g_id = ?)", $params);
 
         $user_viewed_info = [];
-        foreach ($this->course_db->rows() as $row){
+        foreach ($this->course_db->rows() as $row) {
             $team = $row['team_id'];
             $user = $row['user_id'];
             $time = $row['last_viewed_time'];
@@ -1924,7 +1930,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
         $this->course_db->query("DELETE FROM teams AS t
           WHERE team_id=? AND user_id=? AND state=1", array($team_id, $user_id));
         $this->course_db->query("SELECT * FROM teams WHERE team_id=? AND state=1", array($team_id));
-        if(count($this->course_db->rows()) == 0){
+        if (count($this->course_db->rows()) == 0) {
            //If this happens, then remove all invitations
             $this->course_db->query("DELETE FROM teams AS t
               WHERE team_id=?", array($team_id));
@@ -2055,7 +2061,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)", array($g_id, $user_id, $team_id, $version, $
         );
 
         $users_seeking_team = array();
-        foreach($this->course_db->rows() as $row) {
+        foreach ($this->course_db->rows() as $row) {
             array_push($users_seeking_team, $row['user_id']);
         }
         return $users_seeking_team;
@@ -2137,7 +2143,7 @@ ORDER BY {$section_key}", $params);
             $params = array_merge($sections, $params);
         }
         $orderBy = "";
-        if($section_key == "registration_section") {
+        if ($section_key == "registration_section") {
             $orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
         }
         else {
@@ -2174,7 +2180,7 @@ ORDER BY {$orderBy}", $params);
             $params = array_merge($sections, $params);
         }
         $orderBy = "";
-        if($section_key == "registration_section") {
+        if ($section_key == "registration_section") {
             $orderBy = "SUBSTRING(registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(registration_section, '[0-9]+')::INT, -1), SUBSTRING(registration_section, '[^0-9]*$')";
         }
         else {
@@ -2253,7 +2259,7 @@ ORDER BY gt.{$section_key}", $params);
         ORDER BY user_email ASC;", array($gradeable_id));
 
         $return = array();
-        foreach($this->course_db->rows() as $row){
+        foreach ($this->course_db->rows() as $row) {
             $return[] = new SimpleLateUser($this->core, $row);
         }
         return $return;
@@ -2276,7 +2282,7 @@ ORDER BY gt.{$section_key}", $params);
         ORDER BY user_email ASC;", array($gradeable_id));
 
         $return = array();
-        foreach($this->course_db->rows() as $row){
+        foreach ($this->course_db->rows() as $row) {
             $return[] = new SimpleGradeOverriddenUser($this->core, $row);
         }
         return $return;
@@ -2484,7 +2490,7 @@ ORDER BY u.user_group ASC,
     public function getPeerAssignment($gradeable_id, $grader) {
         $this->course_db->query("SELECT user_id FROM peer_assign WHERE g_id=? AND grader_id=?", array($gradeable_id, $grader));
         $return = array();
-        foreach($this->course_db->rows() as $id) {
+        foreach ($this->course_db->rows() as $id) {
             $return[] = $id['user_id'];
         }
         return $return;
@@ -2524,7 +2530,7 @@ AND gc_id IN (
     public function getGradedPeerComponentsByRegistrationSection($gradeable_id, $sections = array()) {
         $where = "";
         $params = array();
-        if(count($sections) > 0) {
+        if (count($sections) > 0) {
             $where = "WHERE registration_section IN " . $this->createParamaterList(count($sections));
             $params = $sections;
         }
@@ -2547,7 +2553,7 @@ AND gc_id IN (
         ORDER BY SUBSTRING(u.registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(u.registration_section, '[0-9]+')::INT, -1), SUBSTRING(u.registration_section, '[^0-9]*$')", $params);
 
         $return = array();
-        foreach($this->course_db->rows() as $row) {
+        foreach ($this->course_db->rows() as $row) {
             $return[$row['registration_section']] = intval($row['count']);
         }
         return $return;
@@ -2556,7 +2562,7 @@ AND gc_id IN (
     public function getGradedPeerComponentsByRotatingSection($gradeable_id, $sections = array()) {
         $where = "";
         $params = array();
-        if(count($sections) > 0) {
+        if (count($sections) > 0) {
             $where = "WHERE rotating_section IN " . $this->createParamaterList(count($sections));
             $params = $sections;
         }
@@ -2579,7 +2585,7 @@ AND gc_id IN (
         ORDER BY u.rotating_section", $params);
 
         $return = array();
-        foreach($this->course_db->rows() as $row) {
+        foreach ($this->course_db->rows() as $row) {
             $return[$row['rotating_section']] = intval($row['count']);
         }
         return $return;
@@ -2633,20 +2639,21 @@ AND gc_id IN (
     public function deleteCategory($category_id) {
         // TODO, check if no thread is using current category
         $this->course_db->query("SELECT 1 FROM thread_categories WHERE category_id = ?", array($category_id));
-        if(count($this->course_db->rows()) == 0) {
+        if (count($this->course_db->rows()) == 0) {
             $this->course_db->query("DELETE FROM categories_list WHERE category_id = ?", array($category_id));
             return true;
-        } else {
+        }
+        else {
             return false;
         }
     }
 
     public function editCategory($category_id, $category_desc, $category_color) {
         $this->course_db->beginTransaction();
-        if(!is_null($category_desc)) {
+        if (!is_null($category_desc)) {
             $this->course_db->query("UPDATE categories_list SET category_desc = ? WHERE category_id = ?", array($category_desc, $category_id));
         }
-        if(!is_null($category_color)) {
+        if (!is_null($category_color)) {
             $this->course_db->query("UPDATE categories_list SET color = ? WHERE category_id = ?", array($category_color, $category_id));
         }
         $this->course_db->commit();
@@ -2676,7 +2683,7 @@ AND gc_id IN (
         if ($thread_id == -1) {
             $this->course_db->query("SELECT MAX(id) as max from threads WHERE deleted = false and merged_thread_id = -1 GROUP BY pinned ORDER BY pinned DESC");
             $rows = $this->course_db->rows();
-            if(!empty($rows)) {
+            if (!empty($rows)) {
                 $thread_id = $rows[0]["max"];
             }
             else {
@@ -2686,7 +2693,7 @@ AND gc_id IN (
         }
         $param_list[] = $thread_id;
         $history_query = "LEFT JOIN forum_posts_history fph ON (fph.post_id is NULL OR (fph.post_id = posts.id and NOT EXISTS (SELECT 1 from forum_posts_history WHERE post_id = fph.post_id and edit_timestamp > fph.edit_timestamp )))";
-        if($option == 'alpha') {
+        if ($option == 'alpha') {
             $this->course_db->query("SELECT posts.*, fph.edit_timestamp, users.user_lastname FROM posts INNER JOIN users ON posts.author_user_id=users.user_id {$history_query} WHERE thread_id=? AND {$query_delete} ORDER BY user_lastname, posts.timestamp;", array($thread_id));
         }
         elseif ($option == 'reverse-time') {
@@ -2702,7 +2709,7 @@ AND gc_id IN (
     public function getRootPostOfNonMergedThread($thread_id, &$title, &$message) {
         $this->course_db->query("SELECT title FROM threads WHERE id = ? and merged_thread_id = -1 and merged_post_id = -1", array($thread_id));
         $result_rows = $this->course_db->rows();
-        if(count($result_rows) == 0) {
+        if (count($result_rows) == 0) {
             $message = "Can't find thread";
             return false;
         }
@@ -2713,22 +2720,22 @@ AND gc_id IN (
     }
 
     public function mergeThread($parent_thread_id, $child_thread_id, &$message, &$child_root_post) {
-        try{
+        try {
             $this->course_db->beginTransaction();
             $parent_thread_title = null;
             $child_thread_title = null;
-            if(!($parent_root_post = $this->getRootPostOfNonMergedThread($parent_thread_id, $parent_thread_title, $message))) {
+            if (!($parent_root_post = $this->getRootPostOfNonMergedThread($parent_thread_id, $parent_thread_title, $message))) {
                 $this->course_db->rollback();
                 return false;
             }
-            if(!($child_root_post = $this->getRootPostOfNonMergedThread($child_thread_id, $child_thread_title, $message))) {
+            if (!($child_root_post = $this->getRootPostOfNonMergedThread($child_thread_id, $child_thread_title, $message))) {
                 $this->course_db->rollback();
                 return false;
             }
 
             $child_thread_title = "Merged Thread Title: " . $child_thread_title . "\n";
 
-            if($child_root_post <= $parent_root_post) {
+            if ($child_root_post <= $parent_root_post) {
                 $message = "Child thread must be newer than parent thread";
                 $this->course_db->rollback();
                 return false;
@@ -2739,14 +2746,14 @@ AND gc_id IN (
 
             // $merged_post_id is PK of linking node and $merged_thread_id is immediate parent thread_id
             $this->course_db->query("UPDATE threads SET merged_thread_id = ?, merged_post_id = ? WHERE id = ?", array($parent_thread_id, $child_root_post, $child_thread_id));
-            foreach($children as $post_id){
+            foreach ($children as $post_id) {
                 $this->course_db->query("UPDATE posts SET thread_id = ? WHERE id = ?", array($parent_thread_id,$post_id));
             }
             $this->course_db->query("UPDATE posts SET parent_id = ?, content = ? || content WHERE id = ?", array($parent_root_post, $child_thread_title, $child_root_post));
 
             $this->course_db->commit();
             return true;
-        } catch (DatabaseException $dbException){
+        } catch (DatabaseException $dbException) {
              $this->course_db->rollback();
         }
         return false;
@@ -2758,7 +2765,7 @@ AND gc_id IN (
         $question_marks = $this->createParamaterList(count($params));
         $this->course_db->query("SELECT user_id, anon_id FROM users WHERE user_id IN {$question_marks}", $params);
         $return = array();
-        foreach($this->course_db->rows() as $id_map) {
+        foreach ($this->course_db->rows() as $id_map) {
             $return[$id_map['user_id']] = $id_map['anon_id'];
         }
         return $return;
@@ -2770,7 +2777,7 @@ AND gc_id IN (
         $question_marks = $this->createParamaterList(count($params));
         $this->course_db->query("SELECT anon_id, user_id FROM users WHERE anon_id IN {$question_marks}", $params);
         $return = array();
-        foreach($this->course_db->rows() as $id_map) {
+        foreach ($this->course_db->rows() as $id_map) {
             $return[$id_map['anon_id']] = $id_map['user_id'];
         }
         return $return;
@@ -2965,9 +2972,10 @@ AND gc_id IN (
      * @return array(Notification)
      */
     public function getUserNotifications($user_id, $show_all) {
-        if($show_all){
+        if ($show_all) {
             $seen_status_query = "true";
-        } else {
+        }
+        else {
             $seen_status_query = "seen_at is NULL";
         }
         $this->course_db->query("SELECT id, component, metadata, content,
@@ -2997,9 +3005,10 @@ AND gc_id IN (
 
     public function getUnreadNotificationsCount($user_id, $component) {
         $parameters = array($user_id);
-        if(is_null($component)){
+        if (is_null($component)) {
             $component_query = "true";
-        } else {
+        }
+        else {
             $component_query = "component = ?";
             $parameters[] = $component;
         }
@@ -3016,12 +3025,14 @@ AND gc_id IN (
     public function markNotificationAsSeen($user_id, $notification_id, $thread_id = -1) {
         $parameters = array();
         $parameters[] = $user_id;
-        if($thread_id != -1) {
+        if ($thread_id != -1) {
             $id_query = "metadata::json->>'thread_id' = ?";
             $parameters[] = $thread_id;
-        } elseif($notification_id == -1) {
+        }
+        elseif ($notification_id == -1) {
             $id_query = "true";
-        } else {
+        }
+        else {
             $id_query = "id = ?";
             $parameters[] = $notification_id;
         }
@@ -3463,7 +3474,8 @@ AND gc_id IN (
         // New component, so add it
         if ($component->getId() < 1) {
             $this->createComponent($component);
-        } else {
+        }
+        else {
             $this->updateComponent($component);
         }
 
@@ -3804,7 +3816,7 @@ AND gc_id IN (
      */
     private function updateGradedComponent(GradedComponent $graded_component) {
         if ($graded_component->isModified()) {
-            if(!$graded_component->getComponent()->isPeer()) {
+            if (!$graded_component->getComponent()->isPeer()) {
                 $params = [
                     $graded_component->getScore(),
                     $graded_component->getComment(),
@@ -3876,7 +3888,8 @@ AND gc_id IN (
             foreach ($container->getGradedComponents() as $component_grade) {
                 if ($component_grade->isNew()) {
                     $this->createGradedComponent($component_grade);
-                } else {
+                }
+                else {
                     $this->updateGradedComponent($component_grade);
                 }
 
@@ -3960,9 +3973,10 @@ AND gc_id IN (
      */
     public function saveTaGradedGradeable(TaGradedGradeable $ta_graded_gradeable) {
         // Ta Grades are initialized to have an id of 0 if not loaded from the db, so use that to check
-        if($ta_graded_gradeable->getId() < 1) {
+        if ($ta_graded_gradeable->getId() < 1) {
             $this->createTaGradedGradeable($ta_graded_gradeable);
-        } else {
+        }
+        else {
             $this->updateTaGradedGradeable($ta_graded_gradeable);
         }
     }
@@ -4030,7 +4044,7 @@ AND gc_id IN (
     public function isThreadLocked($thread_id) {
 
         $this->course_db->query('SELECT lock_thread_date FROM threads WHERE id = ?', [$thread_id]);
-        if(empty($this->course_db->rows()[0]['lock_thread_date'])){
+        if (empty($this->course_db->rows()[0]['lock_thread_date'])) {
             return false;
         }
         return $this->course_db->rows()[0]['lock_thread_date'] < date("Y-m-d H:i:S");
@@ -4058,10 +4072,11 @@ AND gc_id IN (
         count($rotation_sections) ? $section_type = 'rotating_section' : $section_type = 'registration_section';
 
         // Configure variables related to user vs team submission
-        if($gradeable->isTeamAssignment()) {
+        if ($gradeable->isTeamAssignment()) {
             $id_string = 'team_id';
             $table = 'gradeable_teams';
-        } else {
+        }
+        else {
             $id_string = 'user_id';
             $table = 'users';
         }
@@ -4069,12 +4084,13 @@ AND gc_id IN (
         $main_query = "select $id_string from $table where $section_type is not null and $id_string not in";
 
         // Select which subquery to use
-        if($component_id != "-1") {
+        if ($component_id != "-1") {
             // Use this sub query to select users who do not have a specific component within this gradable graded
             $sub_query = "(select gd_$id_string
                 from gradeable_component_data left join gradeable_data on gradeable_component_data.gd_id = gradeable_data.gd_id
                 where g_id = '$gradeable_id' and gc_id = $component_id);";
-        } else {
+        }
+        else {
             // Use this sub query to select users who have at least one component not graded
             $sub_query = "(select gradeable_data.gd_$id_string
              from gradeable_component_data left join gradeable_data on gradeable_component_data.gd_id = gradeable_data.gd_id
@@ -4108,7 +4124,7 @@ AND gc_id IN (
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
         $being_helped_sc = OfficeHoursQueueInstructor::STATUS_CODE_BEING_HELPED;
         $this->course_db->query("SELECT * FROM queue where user_id = ? and (status = ? or status = ?) order by time_in DESC limit 1", array($user_id,$in_queue_sc,$being_helped_sc));
-        if(count($this->course_db->rows() == 0)){//checks that user is not already in the queue
+        if (count($this->course_db->rows() == 0)) {//checks that user is not already in the queue
             $this->course_db->query("INSERT INTO queue (user_id, name, time_in, time_helped, time_out, removed_by, status) VALUES(?, ?, current_timestamp, NULL, NULL, NULL, 0)", array($this->core->getUser()->getId(), $name));
             return true;
         }
@@ -4118,7 +4134,7 @@ AND gc_id IN (
     public function getQueueByUser($user_id) {
         $num_in_queue = $this->getNumInQueue();
         $this->course_db->query("SELECT * FROM queue where user_id = ? order by time_in DESC limit 1", array($user_id));
-        if(count($this->course_db->rows()) == 0){
+        if (count($this->course_db->rows()) == 0) {
             $name = $this->core->getUser()->getDisplayedFirstName() . " " . $this->core->getUser()->getDisplayedLastName();
             return new OfficeHoursQueueStudent($this->core, -1, $this->core->getUser()->getId(), $name, -1, $num_in_queue, -1, null, null, null, null);
         }
@@ -4133,7 +4149,7 @@ AND gc_id IN (
     public function removeUserFromQueue($entry_id, $remover) {
         //default to user was removed by an instructor/TA/mentor
         $status_code = OfficeHoursQueueInstructor::STATUS_CODE_REMOVED_BY_INSTRUCTOR;
-        if($remover == $this->getUserIdFromQueueSlot($entry_id)){
+        if ($remover == $this->getUserIdFromQueueSlot($entry_id)) {
             //switch to status code for when a user was removed by themselves
             $status_code = OfficeHoursQueueInstructor::STATUS_CODE_REMOVED_THEMSELVES;
         }
@@ -4176,7 +4192,7 @@ AND gc_id IN (
 
         $needs_help = array();
         $index = 1;
-        foreach($rows as $row){
+        foreach ($rows as $row) {
             $oh_queue_student = new OfficeHoursQueueStudent($this->core, $row['entry_id'], $row['user_id'], $row['name'], $row['status'], $this->getNumInQueue(), $index, $row['time_in'], $row['time_helped'], $row['time_out'], $row['removed_by']);
             array_push($needs_help, $oh_queue_student);
             $index = $index + 1;
@@ -4187,7 +4203,7 @@ AND gc_id IN (
 
         $already_helped = array();
         $index = 1;
-        foreach($rows as $row){
+        foreach ($rows as $row) {
             $oh_queue_student = new OfficeHoursQueueStudent($this->core, $row['entry_id'], $row['user_id'], $row['name'], $row['status'], $this->getNumInQueue(), $index, $row['time_in'], $row['time_helped'], $row['time_out'], $row['removed_by']);
             array_push($already_helped, $oh_queue_student);
             $index = $index + 1;
@@ -4200,9 +4216,10 @@ AND gc_id IN (
     public function isValidCode($code) {
         $code = strtoupper($code);
         $this->course_db->query("select * from queue_settings where code = ? limit 1", array($code));
-        if(count($this->course_db->rows()) != 0){
+        if (count($this->course_db->rows()) != 0) {
             return $this->course_db->rows()[0]['id'];
-        }else{
+        }
+        else {
             return null;
         }
     }
@@ -4236,7 +4253,7 @@ AND gc_id IN (
     public function getUserIdFromQueueSlot($entry_id) {
         $this->course_db->query("SELECT * FROM queue where entry_id = ? limit 1", array($entry_id));
         $rows = $this->course_db->rows();
-        if(count($rows) == 0){
+        if (count($rows) == 0) {
             return null;
         }
         return $rows[0]['user_id'];
@@ -4244,7 +4261,7 @@ AND gc_id IN (
 
     public function genQueueSettings() {
         $this->course_db->query("SELECT * FROM queue_settings");
-        if(count($this->course_db->rows()) == 0){
+        if (count($this->course_db->rows()) == 0) {
             $this->course_db->query("INSERT INTO queue_settings (open,code) VALUES (FALSE, '')");
         }
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -376,7 +376,8 @@ class DatabaseQueries {
             $this->course_db->query("INSERT INTO posts (thread_id, parent_id, author_user_id, content, timestamp, anonymous, deleted, endorsed_by, type, has_attachment, render_markdown) VALUES (?, ?, ?, ?, current_timestamp, ?, ?, ?, ?, ?, ?)", array($thread_id, $parent_post, $user, $content, $anonymous, 0, null, $type, $hasAttachment, $markdown));
             $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", array($thread_id, $user));
             $this->visitThread($user, $thread_id);
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             if ($this->course_db->inTransaction()) {
                 $this->course_db->rollback();
             }
@@ -503,7 +504,8 @@ class DatabaseQueries {
 
             //retrieve generated thread_id
             $this->course_db->query("SELECT MAX(id) as max_id from threads where title=? and created_by=?", array($title, $user));
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             $this->course_db->rollback();
         }
 
@@ -641,7 +643,8 @@ class DatabaseQueries {
             $this->course_db->query("INSERT INTO forum_posts_history(post_id, edit_author, content, edit_timestamp) SELECT id, ?, content, current_timestamp FROM posts WHERE id = ?", array($user, $post_id));
             $this->course_db->query("UPDATE notifications SET content = substring(content from '.+?(?=from)') || 'from ' || ? where metadata::json->>'thread_id' = ? and metadata::json->>'post_id' = ?", array(ForumUtils::getDisplayName($anon, $this->getDisplayUserInfoFromUserId($original_creator)), $this->getParentPostId($post_id), $post_id));
             $this->course_db->commit();
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             $this->course_db->rollback();
             return false;
         } return true;
@@ -656,7 +659,8 @@ class DatabaseQueries {
                 $this->course_db->query("INSERT INTO thread_categories (thread_id, category_id) VALUES (?, ?)", array($thread_id, $category_id));
             }
             $this->course_db->commit();
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             $this->course_db->rollback();
             return false;
         } return true;
@@ -2753,7 +2757,8 @@ AND gc_id IN (
 
             $this->course_db->commit();
             return true;
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
              $this->course_db->rollback();
         }
         return false;
@@ -3089,7 +3094,8 @@ AND gc_id IN (
             $this->course_db->query("INSERT INTO regrade_requests(g_id, timestamp, $submitter_col, status, gc_id) VALUES (?, current_timestamp, ?, ?, ?)", $params);
             $regrade_id = $this->course_db->getLastInsertId();
             $this->insertNewRegradePost($regrade_id, $sender->getId(), $initial_message);
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             if ($this->course_db->inTransaction()) {
                 $this->course_db->rollback();
             }

--- a/site/app/libraries/database/ForumQueries.php
+++ b/site/app/libraries/database/ForumQueries.php
@@ -21,7 +21,8 @@ class ForumQueries {
         try {
             $this->course_db->query("INSERT INTO posts (thread_id, parent_id, author_user_id, content, timestamp, anonymous, deleted, endorsed_by, type, has_attachment) VALUES (?, ?, ?, ?, current_timestamp, ?, ?, ?, ?, ?)", array($p->getThreadId(), $p->getParentId(), $p->getAuthor(), $p->getContent(), $anonymous, 0, null, $type, $hasAttachment));
             $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", [ $p->getThreadId(), $p->getUser() ]);
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             if ($this->course_db->inTransaction()) {
                 $this->course_db->rollback();
                 return [false, -1, -1];
@@ -38,7 +39,8 @@ class ForumQueries {
 
         try {
             $this->course_db->query("INSERT INTO threads (title, created_by, pinned, status, deleted, merged_thread_id, merged_post_id, is_visible) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", array($t->getTitle(), $t->getUser(), $t->isPinned(), $t->getStatus(), 0, -1, -1, true));
-        } catch (DatabaseException $dbException) {
+        }
+        catch (DatabaseException $dbException) {
             $this->course_db->rollback();
             return false;
         }
@@ -51,7 +53,8 @@ class ForumQueries {
         foreach ($categories_ids as $category_id) {
             try {
                 $this->course_db->query("INSERT INTO thread_categories (thread_id, category_id) VALUES (?, ?)", array($id, $category_id));
-            } catch (DatabaseException $dbException) {
+            }
+            catch (DatabaseException $dbException) {
                 $this->course_db->rollback();
                 return false;
             }

--- a/site/app/libraries/database/ForumQueries.php
+++ b/site/app/libraries/database/ForumQueries.php
@@ -13,7 +13,7 @@ class ForumQueries {
 
         $parent_id = $p->getParentId();
 
-        if(!$isFirst && $parent_id == 0){
+        if (!$isFirst && $parent_id == 0) {
             $this->course_db->query("SELECT MIN(id) as id FROM posts where thread_id = ?", [ $p->getThreadId() ]);
             $parent_id = $this->course_db->rows()[0]["id"];
         }
@@ -21,8 +21,8 @@ class ForumQueries {
         try {
             $this->course_db->query("INSERT INTO posts (thread_id, parent_id, author_user_id, content, timestamp, anonymous, deleted, endorsed_by, type, has_attachment) VALUES (?, ?, ?, ?, current_timestamp, ?, ?, ?, ?, ?)", array($p->getThreadId(), $p->getParentId(), $p->getAuthor(), $p->getContent(), $anonymous, 0, null, $type, $hasAttachment));
             $this->course_db->query("SELECT MAX(id) as max_id from posts where thread_id=? and author_user_id=?", [ $p->getThreadId(), $p->getUser() ]);
-        } catch (DatabaseException $dbException){
-            if($this->course_db->inTransaction()){
+        } catch (DatabaseException $dbException) {
+            if ($this->course_db->inTransaction()) {
                 $this->course_db->rollback();
                 return [false, -1, -1];
             }
@@ -38,7 +38,7 @@ class ForumQueries {
 
         try {
             $this->course_db->query("INSERT INTO threads (title, created_by, pinned, status, deleted, merged_thread_id, merged_post_id, is_visible) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", array($t->getTitle(), $t->getUser(), $t->isPinned(), $t->getStatus(), 0, -1, -1, true));
-        } catch(DatabaseException $dbException) {
+        } catch (DatabaseException $dbException) {
             $this->course_db->rollback();
             return false;
         }
@@ -51,7 +51,7 @@ class ForumQueries {
         foreach ($categories_ids as $category_id) {
             try {
                 $this->course_db->query("INSERT INTO thread_categories (thread_id, category_id) VALUES (?, ?)", array($id, $category_id));
-            } catch(DatabaseException $dbException) {
+            } catch (DatabaseException $dbException) {
                 $this->course_db->rollback();
                 return false;
             }
@@ -61,7 +61,7 @@ class ForumQueries {
 
         $post_result = $this->createPost($t->getFirst());
 
-        if(!$post_result) {
+        if (!$post_result) {
             $t->getFirst()->setThreadId(-1);
             return $post_result;
         }

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -63,9 +63,10 @@ class PostgresqlDatabase extends AbstractDatabase {
     public function fromDatabaseToPHPArray($text, $parse_bools = false, $start = 0, &$end = null) {
         $text = trim($text);
 
-        if(empty($text) || $text[0] != "{") {
+        if (empty($text) || $text[0] != "{") {
             return array();
-        } elseif(is_string($text)) {
+        }
+        elseif (is_string($text)) {
             $return = array();
             $element = "";
             $in_string = false;
@@ -93,10 +94,12 @@ class PostgresqlDatabase extends AbstractDatabase {
                     if ($text[$i + 1] === "\\") {
                         $element .= "\\";
                         $i++;
-                    } elseif ($text[$i + 1] === "\"") {
+                    }
+                    elseif ($text[$i + 1] === "\"") {
                         $element .= "\"";
                         $i++;
-                    } else {
+                    }
+                    else {
                         $element .= $text[$i];
                     }
                 }

--- a/site/app/libraries/database/PostgresqlDatabaseQueries.php
+++ b/site/app/libraries/database/PostgresqlDatabaseQueries.php
@@ -28,9 +28,10 @@ class PostgresqlDatabaseQueries extends DatabaseQueries {
     //if is_numeric is true, the numeric_id key will be used to lookup the user
     //this should be called through getUserById() or getUserByNumericId()
     private function getUser($user_id, $is_numeric = false) {
-        if(!$is_numeric){
+        if (!$is_numeric) {
             $this->submitty_db->query("SELECT * FROM users WHERE user_id=?", array($user_id));
-        }else{
+        }
+        else {
             $this->submitty_db->query("SELECT * FROM users WHERE user_numeric_id=?", array($user_id));
         }
 
@@ -86,7 +87,7 @@ class PostgresqlDatabaseQueries extends DatabaseQueries {
     //the numerical_id table
     public function getUserByIdOrNumericId($id) {
         $ret = $this->getUser($id);
-        if($ret === null){
+        if ($ret === null) {
             return $this->getUser($id, true);
         }
 
@@ -106,7 +107,7 @@ GROUP BY user_id", array($user_id));
         $keys = array("registration_section", "rotating_section");
         $section_key = (in_array($section_key, $keys)) ? $section_key : "registration_section";
         $orderBy = "";
-        if($section_key == "registration_section") {
+        if ($section_key == "registration_section") {
             $orderBy = "SUBSTRING(u.registration_section, '^[^0-9]*'), COALESCE(SUBSTRING(u.registration_section, '[0-9]+')::INT, -1), SUBSTRING(u.registration_section, '[^0-9]*$'), u.user_id";
         }
         else {
@@ -297,7 +298,7 @@ WHERE semester=? AND course=? AND user_id=?", $params);
                         late_day_exceptions AS lde
                       ON submissions.g_id = lde.g_id
                       AND submissions.user_id = lde.user_id";
-        if($user_id !== null) {
+        if ($user_id !== null) {
             if (is_array($user_id)) {
                 $query .= " WHERE submissions.user_id IN (" . implode(", ", array_fill(0, count($user_id), '?')) . ")";
                 $params = array_merge($params, $user_id);
@@ -315,7 +316,7 @@ WHERE semester=? AND course=? AND user_id=?", $params);
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team) {
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -375,7 +376,7 @@ ORDER BY gc_order
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
-        if($is_team){
+        if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
@@ -423,7 +424,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         // Split arrays into php arrays
         $rows = $this->course_db->rows();
         $sections_row = [];
-        foreach($rows as $row) {
+        foreach ($rows as $row) {
             $sections_row[$row['user_id']] = json_decode($row['sections']);
         }
         return $sections_row;
@@ -441,7 +442,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
           user_email ASC, since_timestamp DESC;");
 
         $return = array();
-        foreach($this->course_db->rows() as $row){
+        foreach ($this->course_db->rows() as $row) {
             $return[] = new SimpleLateUser($this->core, $row);
         }
         return $return;
@@ -475,7 +476,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
             ORDER BY user_group, user_id, g_grade_start_date", $params);
         $rows = $this->course_db->rows();
         $modified_rows = [];
-        foreach($rows as $row) {
+        foreach ($rows as $row) {
             $row['sections_rotating_id'] = json_decode($row['sections_rotating_id']);
             $modified_rows[] = $row;
         }
@@ -601,7 +602,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         );
 
         $teams = array();
-        foreach($this->course_db->rows() as $row) {
+        foreach ($this->course_db->rows() as $row) {
             $row['users'] = json_decode($row['users'], true);
             $teams[] = new Team($this->core, $row);
         }
@@ -854,7 +855,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         foreach ($gradeables as $gradeable) {
             if ($gradeable->isTeamAssignment()) {
                 $team_gradeables[] = $gradeable;
-            } else {
+            }
+            else {
                 $non_team_gradeables[] = $gradeable;
             }
         }
@@ -891,9 +893,14 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
         }
 
         // If one array is blank, and the other is null or also blank, don't get anything
-        if ($users === [] && $teams === null ||
-            $users === null && $teams === [] ||
-            $users === [] && $teams === []) {
+        if (
+            $users === []
+            && $teams === null
+            || $users === null
+            && $teams === []
+            || $users === []
+            && $teams === []
+        ) {
             return new \EmptyIterator();
         }
 
@@ -902,14 +909,16 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
             if (!is_array($users)) {
                 $users = [$users];
             }
-        } else {
+        }
+        else {
             $users = [];
         }
         if ($teams !== null) {
             if (!is_array($teams)) {
                 $teams = [$teams];
             }
-        } else {
+        }
+        else {
             $teams = [];
         }
 
@@ -940,7 +949,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
             $param = $users;
             if (!$team) {
                 $selector_union_list[] = "u.user_id IN ($user_placeholders)";
-            } else {
+            }
+            else {
                 // Select the users' teams as well
                 $selector_union_list[] = "team.team_id IN (SELECT team_id FROM teams WHERE state=1 AND user_id IN ($user_placeholders))";
             }
@@ -990,7 +1000,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
                 LEFT JOIN teams t ON e.user_id=t.user_id AND t.state=1
                 GROUP BY team_id, g_id
               ) AS ldet ON g.g_id=ldet.g_id AND ldet.team_id=team.team_id';
-        } else {
+        }
+        else {
             $submitter_data_inject = '
               u.user_id,
               u.anon_id,
@@ -1220,7 +1231,8 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
                         $late_day_exceptions[$user_id] = 0;
                     }
                 }
-            } else {
+            }
+            else {
                 if (isset($row['grading_registration_sections'])) {
                     $row['grading_registration_sections'] = json_decode($row['grading_registration_sections']);
                 }
@@ -1300,14 +1312,16 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
                 'autograding_complete'
             ];
             $db_row_split = [];
-            foreach (array_merge(
-                $version_array_properties,
-                $comp_array_properties,
-                array_map(function ($elem) {
-                    return 'grader_' . $elem;
-                },
-                $user_properties)
-            ) as $property) {
+            foreach (
+                array_merge(
+                    $version_array_properties,
+                    $comp_array_properties,
+                    array_map(function ($elem) {
+                        return 'grader_' . $elem;
+                    },
+                    $user_properties)
+                ) as $property
+            ) {
                 $db_row_split[$property] = json_decode($row['array_' . $property]);
             }
 
@@ -1391,16 +1405,16 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
      * @throws ValidationException If any Gradeable or Component fails to construct
      */
     public function getGradeableConfigs($ids, $sort_keys = ['id']) {
-        if($ids === []) {
+        if ($ids === []) {
             return new \EmptyIterator();
         }
-        if($ids === null) {
+        if ($ids === null) {
             $ids = [];
         }
 
         // Generate the selector statement
         $selector = '';
-        if(count($ids) > 0) {
+        if (count($ids) > 0) {
             $place_holders = implode(',', array_fill(0, count($ids), '?'));
             $selector = "WHERE g.g_id IN ($place_holders)";
         }

--- a/site/app/libraries/routers/AccessControl.php
+++ b/site/app/libraries/routers/AccessControl.php
@@ -94,15 +94,17 @@ class AccessControl {
      */
     public function setRole($role) {
         $role = strtoupper($role);
-        if (in_array(
-            $role,
-            [
-                "INSTRUCTOR",
-                "FULL_ACCESS_GRADER",
-                "LIMITED_ACCESS_GRADER",
-                "STUDENT"
-            ]
-        )) {
+        if (
+            in_array(
+                $role,
+                [
+                    "INSTRUCTOR",
+                    "FULL_ACCESS_GRADER",
+                    "LIMITED_ACCESS_GRADER",
+                    "STUDENT"
+                ]
+            )
+        ) {
             $this->role = $role;
         }
         else {

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -64,8 +64,10 @@ class WebRouter {
             $logged_in = $core->isApiLoggedIn($request);
 
             // prevent user that is not logged in from going anywhere except AuthenticationController
-            if (!$logged_in &&
-                !Utils::endsWith($router->parameters['_controller'], 'AuthenticationController')) {
+            if (
+                !$logged_in
+                && !Utils::endsWith($router->parameters['_controller'], 'AuthenticationController')
+            ) {
                 return new Response(JsonResponse::getFailResponse("Unauthenticated access. Please log in."));
             }
 
@@ -171,8 +173,10 @@ class WebRouter {
      * @throws \Exception
      */
     private function loadCourse() {
-        if (array_key_exists('_semester', $this->parameters) &&
-            array_key_exists('_course', $this->parameters)) {
+        if (
+            array_key_exists('_semester', $this->parameters)
+            && array_key_exists('_course', $this->parameters)
+        ) {
             $semester = $this->parameters['_semester'];
             $course = $this->parameters['_course'];
 
@@ -181,7 +185,7 @@ class WebRouter {
             /** @noinspection PhpUnhandledExceptionInspection */
             $this->core->loadGradingQueue();
 
-            if($this->core->getConfig()->isCourseLoaded()){
+            if ($this->core->getConfig()->isCourseLoaded()) {
                 $this->core->getOutput()->addBreadcrumb(
                     $this->core->getDisplayedCourseName(),
                     $this->core->buildCourseUrl(),
@@ -192,7 +196,7 @@ class WebRouter {
             /** @noinspection PhpUnhandledExceptionInspection */
             $this->core->loadCourseDatabase();
 
-            if($this->core->getConfig()->isCourseLoaded() && $this->core->getConfig()->isForumEnabled()) {
+            if ($this->core->getConfig()->isCourseLoaded() && $this->core->getConfig()->isForumEnabled()) {
                 /** @noinspection PhpUnhandledExceptionInspection */
                 $this->core->loadForum();
             }
@@ -213,19 +217,23 @@ class WebRouter {
                 )
             );
         }
-        elseif ($this->core->getConfig()->isCourseLoaded()
+        elseif (
+            $this->core->getConfig()->isCourseLoaded()
             && !$this->core->getAccess()->canI("course.view", ["semester" => $this->core->getConfig()->getSemester(), "course" => $this->core->getConfig()->getCourse()])
             && !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')
-            && $this->parameters['_method'] !== 'noAccess') {
+            && $this->parameters['_method'] !== 'noAccess'
+        ) {
             return Response::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['no_access']))
             );
         }
 
-        if(!$this->core->getConfig()->isCourseLoaded() && !Utils::endsWith($this->parameters['_controller'], 'MiscController')) {
-            if ($logged_in){
-                if ($this->parameters['_method'] !== 'logout' &&
-                    !Utils::endsWith($this->parameters['_controller'], 'HomePageController')) {
+        if (!$this->core->getConfig()->isCourseLoaded() && !Utils::endsWith($this->parameters['_controller'], 'MiscController')) {
+            if ($logged_in) {
+                if (
+                    $this->parameters['_method'] !== 'logout'
+                    && !Utils::endsWith($this->parameters['_controller'], 'HomePageController')
+                ) {
                     return Response::RedirectOnlyResponse(
                         new RedirectResponse($this->core->buildUrl(['home']))
                     );
@@ -246,9 +254,10 @@ class WebRouter {
      * @return Response|bool
      */
     private function csrfCheck() {
-        if ($this->request->isMethod('POST') &&
-            !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController') &&
-            !$this->core->checkCsrfToken()
+        if (
+            $this->request->isMethod('POST')
+            && !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')
+            && !$this->core->checkCsrfToken()
         ) {
             $msg = "Invalid CSRF token.";
             $this->core->addErrorMessage($msg);

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -288,7 +288,7 @@ class Config extends AbstractModel {
 
         $this->base_url = rtrim($this->base_url, "/") . "/";
 
-        if (!empty($submitty_json['cgi_url'])){
+        if (!empty($submitty_json['cgi_url'])) {
             $this->cgi_url = rtrim($submitty_json['cgi_url'], "/") . "/";
         }
         else {
@@ -305,14 +305,14 @@ class Config extends AbstractModel {
         $this->cgi_tmp_path = FileUtils::joinPaths($this->submitty_path, "tmp", "cgi");
 
         // Check that the paths from the config file are valid
-        foreach(array('submitty_path', 'submitty_log_path') as $path) {
+        foreach (array('submitty_path', 'submitty_log_path') as $path) {
             if (!is_dir($this->$path)) {
                 throw new ConfigException("Invalid path for setting {$path}: {$this->$path}");
             }
             $this->$path = rtrim($this->$path, "/");
         }
 
-        foreach(array('autograding', 'access', 'site_errors', 'ta_grading') as $path) {
+        foreach (array('autograding', 'access', 'site_errors', 'ta_grading') as $path) {
             if (!is_dir(FileUtils::joinPaths($this->submitty_log_path, $path))) {
                 throw new ConfigException("Missing log folder: {$path}");
             }
@@ -323,7 +323,7 @@ class Config extends AbstractModel {
             throw new ConfigException("Could not find secrets config: {$this->config_path}/secrets_submitty_php.json");
         }
 
-        foreach(['session'] as $key) {
+        foreach (['session'] as $key) {
             $var = "secret_{$key}";
             $secrets_json[$key] = trim($secrets_json[$key]) ?? '';
             if (empty($secrets_json[$key])) {
@@ -347,8 +347,10 @@ class Config extends AbstractModel {
         if (!$version_json) {
             throw new ConfigException("Could not find version file: {$this->config_path}/version.json");
         }
-        if (!isset($version_json['most_recent_git_tag']) ||
-            !isset($version_json['short_installed_commit'])) {
+        if (
+            !isset($version_json['most_recent_git_tag'])
+            || !isset($version_json['short_installed_commit'])
+        ) {
             throw new ConfigException("Error parsing version information: {$this->config_path}/version.json");
         }
         $this->latest_tag = $version_json['most_recent_git_tag'];
@@ -448,7 +450,7 @@ class Config extends AbstractModel {
             'config',
             'submitty_users.json'
         );
-        if(!is_file($users_file)) {
+        if (!is_file($users_file)) {
             throw new FileNotFoundException('Unable to locate the submity_users.json file');
         }
         $users_file_contents = json_decode(file_get_contents($users_file));

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -33,7 +33,6 @@ class CourseMaterial extends AbstractModel {
         if (!property_exists($meta_data, $path_to_file)) {
             return false;
         }
-        // Else key does exist
         else {
             $current_time = new \DateTime('now');
             $release_time = \DateTime::createFromFormat('Y-m-d H:i:s', $meta_data->$path_to_file->release_datetime);
@@ -44,7 +43,7 @@ class CourseMaterial extends AbstractModel {
             return $retVal;
         }
     }
-    
+
      /**
      * Determine if a course materials file can be viewed by the current user's section
      *
@@ -73,7 +72,6 @@ class CourseMaterial extends AbstractModel {
         if (!property_exists($meta_data, $path_to_file)) {
             return false;
         }
-        // Else key does exist
         else {
             $current_user_group = $current_user->getGroup();
             if (!isset($meta_data->$path_to_file->sections)) {

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -23,21 +23,18 @@ class CourseMaterial extends AbstractModel {
         // Get path to the meta data json
         $meta_data_json = $core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
 
-        if(!is_file($meta_data_json))
-        {
+        if (!is_file($meta_data_json)) {
             throw new FileNotFoundException('Unable to locate the course_materials_file_data.json file');
         }
 
         $meta_data = json_decode(file_get_contents($meta_data_json));
 
         // If file path does not exist as key in $meta_data then it has not been released
-        if(!property_exists($meta_data, $path_to_file))
-        {
+        if (!property_exists($meta_data, $path_to_file)) {
             return false;
         }
         // Else key does exist
-        else
-        {
+        else {
             $current_time = new \DateTime('now');
             $release_time = \DateTime::createFromFormat('Y-m-d H:i:s', $meta_data->$path_to_file->release_datetime);
 
@@ -66,23 +63,20 @@ class CourseMaterial extends AbstractModel {
         // Get path to the meta data json
         $meta_data_json = $core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
 
-        if(!is_file($meta_data_json))
-        {
+        if (!is_file($meta_data_json)) {
             throw new FileNotFoundException('Unable to locate the course_materials_file_data.json file');
         }
 
         $meta_data = json_decode(file_get_contents($meta_data_json));
 
         // If file path does not exist as key in $meta_data then it has not been released
-        if(!property_exists($meta_data, $path_to_file))
-        {
+        if (!property_exists($meta_data, $path_to_file)) {
             return false;
         }
         // Else key does exist
-        else
-        {
+        else {
             $current_user_group = $current_user->getGroup();
-            if (!isset($meta_data->$path_to_file->sections)){
+            if (!isset($meta_data->$path_to_file->sections)) {
                 $retVal = true;
                 return $retVal;
             }

--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -19,16 +19,16 @@ use app\libraries\Utils;
  * @method boolean getPublic()
  */
 class GradeableAutocheck extends AbstractModel {
-    
+
     /** @property @var string */
     protected $index;
-    
+
     /** @var DiffViewer DiffViewer instance to hold the student, instructor, and differences */
     protected $diff_viewer;
-    
+
     /** @property @var string Description to show for displaying the diff */
     protected $description = "";
-    
+
     /** @property @var array[] Message to show underneath the description for a diff */
     protected $messages = array();
 
@@ -55,23 +55,24 @@ class GradeableAutocheck extends AbstractModel {
         if (isset($details['description'])) {
             $this->description = Utils::prepareHtmlString($details['description']);
         }
-        
+
         if (isset($details['messages'])) {
             foreach ($details['messages'] as $message) {
                 $this->messages[] = array('message' => Utils::prepareHtmlString($message['message']),
                                             'type' => Utils::prepareHtmlString($message['type']));
             }
         }
-        
-        if(isset($details["display_as_sequence_diagram"])){
+
+        if (isset($details["display_as_sequence_diagram"])) {
             $this->display_as_sequence_diagram = $details["display_as_sequence_diagram"];
-        }else{
+        }
+        else {
             $this->display_as_sequence_diagram = false;
         }
 
         $actual_file = $expected_file = $difference_file = $image_difference = "";
 
-        if(isset($details["actual_file"])) {
+        if (isset($details["actual_file"])) {
             $this->public = (isset($details["results_public"]) && $details["results_public"]);
             $path = ($this->public ? $results_public_path : $results_path) . "/details/" . $details["actual_file"];
 
@@ -79,37 +80,43 @@ class GradeableAutocheck extends AbstractModel {
                 $actual_file = $path;
             }
         }
-    
-        
-    
-        if(isset($details["expected_file"])) {
-            if(substr($details["expected_file"], 0, 11) == "test_output"){
-                if(file_exists($course_path . "/" . $details["expected_file"])){
+
+
+
+        if (isset($details["expected_file"])) {
+            if (substr($details["expected_file"], 0, 11) == "test_output") {
+                if (file_exists($course_path . "/" . $details["expected_file"])) {
                     $expected_file = $course_path . "/" . $details["expected_file"];
-                } else {
+                }
+                else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }
-            } elseif(substr($details["expected_file"], 0, 13) == "random_output"){
-                if(file_exists($results_path . "/" . $details["expected_file"])){
+            }
+            elseif (substr($details["expected_file"], 0, 13) == "random_output") {
+                if (file_exists($results_path . "/" . $details["expected_file"])) {
                     $expected_file = $results_path . "/" . $details["expected_file"];
-                } else {
+                }
+                else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }
             // Try to find the file in the details directory. Do not print an error,
             // as the file is likely student generated.
-            } else {
-                if(file_exists($results_path . "/details/" . $details["expected_file"])){
+            }
+            else {
+                if (file_exists($results_path . "/details/" . $details["expected_file"])) {
                     $expected_file = $results_path . "/details/" . $details["expected_file"];
                 }
             }
         }
-        
-        if(isset($details["difference_file"]) && file_exists($results_path . "/details/" . $details["difference_file"])) {
+
+        if (isset($details["difference_file"]) && file_exists($results_path . "/details/" . $details["difference_file"])) {
             $difference_file = $results_path . "/details/" . $details["difference_file"];
         }
 
-        if(isset($details["image_difference_file"]) &&
-            file_exists($results_path . "/details/" . $details["image_difference_file"])) {
+        if (
+            isset($details["image_difference_file"])
+            && file_exists($results_path . "/details/" . $details["image_difference_file"])
+        ) {
             $this->index = $idx;
             $image_difference = $results_path . "/details/" . $details["image_difference_file"];
         }

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -71,7 +71,8 @@ class GradingOrder extends AbstractModel {
         //Get that user's grading sections
         if ($all) {
             $this->sections = $gradeable->getAllGradingSections();
-        } else {
+        }
+        else {
             $this->sections = $gradeable->getGradingSectionsForUser($user);
         }
 
@@ -89,7 +90,8 @@ class GradingOrder extends AbstractModel {
                 foreach ($submitters as $submitter) {
                     $this->all_team_ids[] = $submitter->getId();
                 }
-            } else {
+            }
+            else {
                 foreach ($submitters as $submitter) {
                     $this->all_user_ids[] = $submitter->getId();
                 }
@@ -123,7 +125,8 @@ class GradingOrder extends AbstractModel {
                 $keyFn = function (Submitter $a) {
                     if ($a->isTeam()) {
                         return $a->getId();
-                    } else {
+                    }
+                    else {
                         return $a->getUser()->getDisplayedFirstName();
                     }
                 };
@@ -132,7 +135,8 @@ class GradingOrder extends AbstractModel {
                 $keyFn = function (Submitter $a) {
                     if ($a->isTeam()) {
                         return $a->getId();
-                    } else {
+                    }
+                    else {
                         return $a->getUser()->getDisplayedLastName();
                     }
                 };
@@ -192,7 +196,7 @@ class GradingOrder extends AbstractModel {
      * @param $component_id
      */
     private function initUsersNotFullyGraded($component_id) {
-        if(is_null($this->not_fully_graded)) {
+        if (is_null($this->not_fully_graded)) {
             $this->not_fully_graded = $this->core->getQueries()->getUsersNotFullyGraded($this->gradeable, $component_id);
         }
     }
@@ -250,14 +254,15 @@ class GradingOrder extends AbstractModel {
     public function getPrevSubmitterMatching(Submitter $submitter, callable $fn) {
 
         // If $submitter is in one of our sections, then get the $submitters index in the GradingOrder
-        if($this->containsSubmitter($submitter)) {
+        if ($this->containsSubmitter($submitter)) {
             $index = $this->getSubmitterIndex($submitter);
             if ($index === false) {
                 return null;
             }
 
         // Else $submitter is not in one of our sections so set $index to number of submitters in our sections
-        } else {
+        }
+        else {
             $count = 0;
 
             foreach ($this->section_submitters as $section) {
@@ -289,14 +294,15 @@ class GradingOrder extends AbstractModel {
     public function getNextSubmitterMatching(Submitter $submitter, callable $fn) {
 
         // If $submitter is in one of our sections, then get the $submitters index in the GradingOrder
-        if($this->containsSubmitter($submitter)) {
+        if ($this->containsSubmitter($submitter)) {
             $index = $this->getSubmitterIndex($submitter);
             if ($index === false) {
                 return null;
             }
 
         // Else $submitter is not in one of our sections so set $index to -1
-        } else {
+        }
+        else {
             $index = -1;
         }
 
@@ -448,7 +454,8 @@ class GradingOrder extends AbstractModel {
             //Should never happen, but better to be safe
             if ($idx === false) {
                 $unsorted[] = $gg;
-            } else {
+            }
+            else {
                 $gg_idx[$idx] = $gg;
             }
         }
@@ -467,21 +474,28 @@ class GradingOrder extends AbstractModel {
      */
     public static function getGradingOrderMessage($sort, $direction) {
 
-        if($sort == 'first' && $direction == 'ASC') {
+        if ($sort == 'first' && $direction == 'ASC') {
             $msg = 'First Name Ascending';
-        } elseif ($sort == 'first' && $direction == 'DESC') {
+        }
+        elseif ($sort == 'first' && $direction == 'DESC') {
             $msg = 'First Name Descending';
-        } elseif ($sort == 'last' && $direction == 'ASC') {
+        }
+        elseif ($sort == 'last' && $direction == 'ASC') {
             $msg = 'Last Name Ascending';
-        } elseif ($sort == 'last' && $direction == 'DESC') {
+        }
+        elseif ($sort == 'last' && $direction == 'DESC') {
             $msg = 'Last Name Descending';
-        } elseif ($sort == 'id' && $direction == 'ASC') {
+        }
+        elseif ($sort == 'id' && $direction == 'ASC') {
             $msg = 'ID Ascending';
-        } elseif ($sort == 'id' && $direction == 'DESC') {
+        }
+        elseif ($sort == 'id' && $direction == 'DESC') {
             $msg = 'ID Descending';
-        } elseif ($sort == 'random') {
+        }
+        elseif ($sort == 'random') {
             $msg = 'Randomized';
-        } else {
+        }
+        else {
             $msg = false;
         }
 

--- a/site/app/models/GradingSection.php
+++ b/site/app/models/GradingSection.php
@@ -87,11 +87,13 @@ class GradingSection extends AbstractModel {
             return array_map(function (User $user) {
                 return new Submitter($this->core, $user);
             }, $this->users);
-        } elseif ($this->teams !== null) {
+        }
+        elseif ($this->teams !== null) {
             return array_map(function (Team $team) {
                 return new Submitter($this->core, $team);
             }, $this->teams);
-        } else {
+        }
+        else {
             //No users, no teams, this section is empty!
             return [];
         }

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -126,7 +126,7 @@ class Notification extends AbstractModel {
 
     public static function getThreadIdIfExists($metadata_json) {
         $metadata = json_decode($metadata_json, true);
-        if(is_null($metadata)) {
+        if (is_null($metadata)) {
             return null;
         }
         $thread_id = $metadata['thread_id'] ?? -1;
@@ -142,7 +142,7 @@ class Notification extends AbstractModel {
     public static function textShortner($message) {
         $max_length = 40;
         $message = str_replace("\n", " ", $message);
-        if(strlen($message) > $max_length) {
+        if (strlen($message) > $max_length) {
             $message = substr($message, 0, $max_length - 3) . "...";
         }
         return $message;
@@ -161,23 +161,28 @@ class Notification extends AbstractModel {
     public function getNotifyTime() {
         $elapsed_time = $this->getElapsedTime();
         $actual_time = $this->getCreatedAt();
-        if($elapsed_time < 60){
+        if ($elapsed_time < 60) {
             return "Less than a minute ago";
-        } elseif($elapsed_time < 3600){
+        }
+        elseif ($elapsed_time < 3600) {
             $minutes = floor($elapsed_time / 60);
-            if($minutes == 1) {
+            if ($minutes == 1) {
                 return "1 minute ago";
-            } else {
+            }
+            else {
                 return "{$minutes} minutes ago";
             }
-        } elseif($elapsed_time < 3600 * 24){
+        }
+        elseif ($elapsed_time < 3600 * 24) {
             $hours = floor($elapsed_time / 3600);
-            if($hours == 1) {
+            if ($hours == 1) {
                 return "1 hour ago";
-            } else {
+            }
+            else {
                 return "{$hours} hours ago";
             }
-        } else {
+        }
+        else {
             return date_format(DateUtils::parseDateTime($actual_time, $this->core->getConfig()->getTimezone()), "n/j g:i A");
         }
     }

--- a/site/app/models/OfficeHoursQueueStudent.php
+++ b/site/app/models/OfficeHoursQueueStudent.php
@@ -82,9 +82,10 @@ class OfficeHoursQueueStudent extends AbstractModel {
     }
 
     public function getTimeWaitingInQueue() {
-        if($this->status  == 2){
+        if ($this->status  == 2) {
             $diff = strtotime($this->time_helped_iso) - strtotime($this->time_in_iso);
-        }else{
+        }
+        else {
             $diff = strtotime($this->time_out_iso) - strtotime($this->time_in_iso);
         }
         $h = $diff / 3600 % 24;

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -55,12 +55,10 @@ class RainbowCustomization extends AbstractModel {
         // If it fails then set to null, will be used to load defaults later
         $this->RCJSON = new RainbowCustomizationJSON($this->core);
 
-        try
-        {
+        try {
             $this->RCJSON->loadFromJsonFile();
         }
-        catch(\Exception $e)
-        {
+        catch (\Exception $e) {
             $this->RCJSON = null;
         }
     }
@@ -68,12 +66,12 @@ class RainbowCustomization extends AbstractModel {
     public function buildCustomization() {
 
         //This function should examine the DB(?) / a file(?) and if customization settings already exist, use them. Otherwise, populate with defaults.
-        foreach (self::syllabus_buckets as $bucket){
+        foreach (self::syllabus_buckets as $bucket) {
             $this->customization_data[$bucket] = [];
         }
 
         $gradeables = $this->core->getQueries()->getGradeableConfigs(null);
-        foreach ($gradeables as $gradeable){
+        foreach ($gradeables as $gradeable) {
             //XXX: 'none (for practice only)' we want to truncate to just 'none', otherwise use full bucket name
             $bucket = $gradeable->getSyllabusBucket() == "none (for practice only)" ? "none" : $gradeable->getSyllabusBucket();
             /*if(!isset($this->customization_data[$bucket])){
@@ -88,7 +86,7 @@ class RainbowCustomization extends AbstractModel {
 
             $max_score = $gradeable->getTAPoints();
             //If the gradeable has autograding points, load the config and add the non-extra-credit autograder total
-            if ($gradeable->hasAutogradingConfig()){
+            if ($gradeable->hasAutogradingConfig()) {
                 $last_index = count($this->customization_data[$bucket]) - 1;
                 $max_score += $gradeable->getAutogradingConfig()->getTotalNonExtraCredit();
             }
@@ -101,13 +99,11 @@ class RainbowCustomization extends AbstractModel {
         }
 
         // Determine which 'buckets' exist in the customization.json
-        if(!is_null($this->RCJSON))
-        {
+        if (!is_null($this->RCJSON)) {
             $json_gradeables = $this->RCJSON->getGradeables();
 
             // Place those buckets in $this->used_buckets
-            foreach ($json_gradeables as $json_gradeable)
-            {
+            foreach ($json_gradeables as $json_gradeable) {
                 $this->used_buckets[] = $json_gradeable->type;
             }
         }
@@ -132,14 +128,12 @@ class RainbowCustomization extends AbstractModel {
     public function getBucketPercentages() {
         $retArray = [];
 
-        if(!is_null($this->RCJSON))
-        {
+        if (!is_null($this->RCJSON)) {
             $json_gradeables = $this->RCJSON->getGradeables();
 
             $sum = 0;
 
-            foreach ($json_gradeables as $json_gradeable)
-            {
+            foreach ($json_gradeables as $json_gradeable) {
                 // Get percentage, cast back to whole number integer
                 $retArray[$json_gradeable->type] = (int) ($json_gradeable->percent * 100);
 
@@ -191,8 +185,7 @@ class RainbowCustomization extends AbstractModel {
             $usedDisplayBenchmarks = [];
 
         // Add data into retArray
-        foreach ($displayBenchmarks as $displayBenchmark)
-        {
+        foreach ($displayBenchmarks as $displayBenchmark) {
             in_array($displayBenchmark, $usedDisplayBenchmarks) ? $isUsed = true : $isUsed = false;
 
             // Add benchmark to return array
@@ -220,16 +213,14 @@ class RainbowCustomization extends AbstractModel {
         $sections = [];
 
         // Configure sections
-        foreach($db_sections as $section)
-        {
+        foreach ($db_sections as $section) {
             $key = $section['sections_registration_id'];
 
             $sections[$key] = $key;
         }
 
         // If RCJSON is not null then load it
-        if(!is_null($this->RCJSON))
-        {
+        if (!is_null($this->RCJSON)) {
             // Get sections from the file
             $sectionsFromFile = (array) $this->RCJSON->getSection();
 
@@ -238,10 +229,8 @@ class RainbowCustomization extends AbstractModel {
             $sectionsFromFileCount = count($sectionsFromFile);
             $sectionsCount = count($sections);
 
-            if($sectionsFromFileCount != $sectionsCount)
-            {
-                for($i = $sectionsFromFileCount + 1; $i <= $sectionsCount; $i++)
-                {
+            if ($sectionsFromFileCount != $sectionsCount) {
+                for ($i = $sectionsFromFileCount + 1; $i <= $sectionsCount; $i++) {
                     $sectionsFromFile[$i] = (string) $i;
                 }
             }
@@ -249,8 +238,7 @@ class RainbowCustomization extends AbstractModel {
             return (object) $sectionsFromFile;
         }
         // RCJSON was null so return database sections as default
-        else
-        {
+        else {
             // Collect sections out of the database
             return (object) $sections;
         }
@@ -265,34 +253,26 @@ class RainbowCustomization extends AbstractModel {
         $form_json = $_POST['json_string'];
         $form_json = json_decode($form_json);
 
-        if(isset($form_json->display_benchmark))
-        {
-            foreach($form_json->display_benchmark as $benchmark)
-            {
+        if (isset($form_json->display_benchmark)) {
+            foreach ($form_json->display_benchmark as $benchmark) {
                 $this->RCJSON->addDisplayBenchmarks($benchmark);
             }
         }
 
-        if(isset($form_json->section))
-        {
-            foreach($form_json->section as $key => $value)
-            {
+        if (isset($form_json->section)) {
+            foreach ($form_json->section as $key => $value) {
                 $this->RCJSON->addSection((string) $key, $value);
             }
         }
 
-        if(isset($form_json->gradeables))
-        {
-            foreach ($form_json->gradeables as $gradeable)
-            {
+        if (isset($form_json->gradeables)) {
+            foreach ($form_json->gradeables as $gradeable) {
                 $this->RCJSON->addGradeable($gradeable);
             }
         }
 
-        if(isset($form_json->messages))
-        {
-            foreach ($form_json->messages as $message)
-            {
+        if (isset($form_json->messages)) {
+            foreach ($form_json->messages as $message) {
                 $this->RCJSON->addMessage($message);
             }
         }

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -237,8 +237,8 @@ class RainbowCustomization extends AbstractModel {
 
             return (object) $sectionsFromFile;
         }
-        // RCJSON was null so return database sections as default
         else {
+            // RCJSON was null so return database sections as default
             // Collect sections out of the database
             return (object) $sections;
         }

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -73,13 +73,11 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @throws BadArgumentException The passed in argument is not allowed
      */
     public function addDisplayBenchmarks(string $benchmark) {
-        if(!in_array($benchmark, self::allowed_display_benchmarks))
-        {
+        if (!in_array($benchmark, self::allowed_display_benchmarks)) {
             throw new BadArgumentException('Passed in benchmark not found in the list of allowed benchmarks');
         }
 
-        if(!in_array($benchmark, $this->display_benchmark))
-        {
+        if (!in_array($benchmark, $this->display_benchmark)) {
             array_push($this->display_benchmark, $benchmark);
         }
     }
@@ -108,54 +106,45 @@ class RainbowCustomizationJSON extends AbstractModel {
         $course_path = $this->core->getConfig()->getCoursePath();
         $course_path = FileUtils::joinPaths($course_path, 'rainbow_grades', 'customization.json');
 
-        if(!file_exists($course_path))
-        {
+        if (!file_exists($course_path)) {
             throw new FileReadException('Unable to locate the file to read');
         }
 
         $file_contents = file_get_contents($course_path);
 
         // Validate file read
-        if($file_contents === false)
-        {
+        if ($file_contents === false) {
             throw new FileReadException('An error occurred trying to read the contents of customization file.');
         }
 
         $json = json_decode($file_contents);
 
         // Validate decode
-        if($json === null)
-        {
+        if ($json === null) {
             throw new MalformedDataException('Unable to decode JSON string');
         }
 
-        if(isset($json->display_benchmark))
-        {
+        if (isset($json->display_benchmark)) {
             $this->display_benchmark = $json->display_benchmark;
         }
 
-        if(isset($json->section))
-        {
+        if (isset($json->section)) {
             $this->section = $json->section;
         }
 
-        if(isset($json->messages))
-        {
+        if (isset($json->messages)) {
             $this->messages = $json->messages;
         }
 
-        if(isset($json->display))
-        {
+        if (isset($json->display)) {
             $this->display = $json->display;
         }
 
-        if(isset($json->benchmark_percent))
-        {
+        if (isset($json->benchmark_percent)) {
             $this->benchmark_percent = $json->benchmark_percent;
         }
 
-        if(isset($json->gradeables))
-        {
+        if (isset($json->gradeables)) {
             $this->gradeables = $json->gradeables;
         }
     }
@@ -167,13 +156,11 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @throws BadArgumentException The passed in argument is not allowed.
      */
     public function addDisplay($display) {
-        if(!in_array($display, self::allowed_display))
-        {
+        if (!in_array($display, self::allowed_display)) {
             throw new BadArgumentException('Passed in display not found in the list of allowed display items');
         }
 
-        if(!in_array($display, $this->display))
-        {
+        if (!in_array($display, $this->display)) {
             $this->display[] = $display;
         }
     }
@@ -186,8 +173,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @throws BadArgumentException The passed in section label is empty
      */
     public function addSection($sectionID, $label) {
-        if(empty($label))
-        {
+        if (empty($label)) {
             throw new BadArgumentException('The section label may not be empty.');
         }
 
@@ -213,8 +199,7 @@ class RainbowCustomizationJSON extends AbstractModel {
         // Validation of this item will be better handled when schema validation is complete, until then just make
         // sure gradeable is not empty
         $emptyObject = (object) [];
-        if($gradeable == $emptyObject)
-        {
+        if ($gradeable == $emptyObject) {
             throw new BadArgumentException('Gradeable may not be empty.');
         }
 
@@ -237,8 +222,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      * @param string $message
      */
     public function addMessage(string $message) {
-        if(empty($message))
-        {
+        if (empty($message)) {
             throw new BadArgumentException('You may not add an empty message.');
         }
 
@@ -254,8 +238,7 @@ class RainbowCustomizationJSON extends AbstractModel {
         $course_path = FileUtils::joinPaths($course_path, 'rainbow_grades', 'customization.json');
 
         // If display was empty then just add defaults
-        if(empty($this->display))
-        {
+        if (empty($this->display)) {
             $this->addDisplay('grade_summary');
             $this->addDisplay('grade_details');
         }
@@ -264,8 +247,7 @@ class RainbowCustomizationJSON extends AbstractModel {
         $json = (object) [];
 
         // Copy each property from $this over to $json
-        foreach($this as $key => $value)
-        {
+        foreach ($this as $key => $value) {
             // Dont include $core or $modified
             if ($key != 'core' && $key != 'modified') {
                 $json->$key = $value;

--- a/site/app/models/SimpleGradeOverriddenUser.php
+++ b/site/app/models/SimpleGradeOverriddenUser.php
@@ -45,7 +45,7 @@ class SimpleGradeOverriddenUser extends AbstractModel {
             $this->preferred_first_name = $details['user_preferred_firstname'];
             $this->displayed_first_name = $details['user_preferred_firstname'];
         }
-        else{
+        else {
             $this->displayed_first_name = $details['user_firstname'];
         }
 
@@ -54,15 +54,15 @@ class SimpleGradeOverriddenUser extends AbstractModel {
             $this->preferred_last_name = $details['user_preferred_lastname'];
             $this->displayed_last_name = $details['user_preferred_lastname'];
         }
-        else{
+        else {
             $this->displayed_last_name = $details['user_lastname'];
         }
 
-        if(isset($details['marks'])){
+        if (isset($details['marks'])) {
             $this->marks = $details['marks'];
         }
 
-        if(isset($details['comment'])){
+        if (isset($details['comment'])) {
             $this->comment = $details['comment'];
         }
     }

--- a/site/app/models/SimpleLateUser.php
+++ b/site/app/models/SimpleLateUser.php
@@ -48,7 +48,7 @@ class SimpleLateUser extends AbstractModel {
             $this->preferred_first_name = $details['user_preferred_firstname'];
             $this->displayed_first_name = $details['user_preferred_firstname'];
         }
-        else{
+        else {
             $this->displayed_first_name = $details['user_firstname'];
         }
 
@@ -57,15 +57,15 @@ class SimpleLateUser extends AbstractModel {
             $this->preferred_last_name = $details['user_preferred_lastname'];
             $this->displayed_last_name = $details['user_preferred_lastname'];
         }
-        else{
+        else {
             $this->displayed_last_name = $details['user_lastname'];
         }
 
-        if(isset($details['allowed_late_days']) && isset($details['since_timestamp'])){
+        if (isset($details['allowed_late_days']) && isset($details['since_timestamp'])) {
             $this->allowed_late_days = $details['allowed_late_days'];
             $this->since_timestamp = DateUtils::parseDateTime($details['since_timestamp'], $this->core->getConfig()->getTimezone());
         }
-        if(isset($details['late_day_exceptions'])){
+        if (isset($details['late_day_exceptions'])) {
             $this->late_day_exceptions = $details['late_day_exceptions'];
         }
     }

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -39,7 +39,7 @@ class SimpleStat extends AbstractModel {
 
     public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
-        if(isset($details['gc_id'])) {
+        if (isset($details['gc_id'])) {
             $this->component = true;
             $this->title = $details['gc_title'];
             $this->max_value = $details['gc_max_value'];

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -16,7 +16,7 @@ use app\models\gradeable\Gradeable;
  * @method User[] getInvitedUsers()
  */
 class Team extends AbstractModel {
-     
+
     /** @property @var string The id of this team of form "<unique number>_<creator user id>" */
     protected $id;
     /** @property @var integer rotating section (registration or rotating) of team creator */
@@ -51,11 +51,12 @@ class Team extends AbstractModel {
         $this->invited_user_ids = array();
         $this->member_users = array();
         $this->invited_users = array();
-        foreach($details['users'] as $user_details) {
+        foreach ($details['users'] as $user_details) {
             //If we have user details, get user objects
             if (array_key_exists('anon_id', $user_details)) {
                 $user = new User($core, $user_details);
-            } else {
+            }
+            else {
                 $user = null;
             }
             if ($user_details['state'] === 1) {
@@ -150,7 +151,7 @@ class Team extends AbstractModel {
     public function hasMember($user_id) {
         return in_array($user_id, $this->member_user_ids);
     }
-    
+
     /**
      * Get whether or not a given user invited to the team
      * @param string $user_id

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -293,7 +293,7 @@ class User extends AbstractModel {
     }
 
     public function getAnonId() {
-        if($this->anon_id === null) {
+        if ($this->anon_id === null) {
             $alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             $anon_ids = $this->core->getQueries()->getAllAnonIds();
             $alpha_length = strlen($alpha) - 1;
@@ -306,7 +306,7 @@ class User extends AbstractModel {
                     /** @noinspection PhpUnhandledExceptionInspection */
                     $random .= $alpha[random_int(0, $alpha_length)];
                 }
-            } while(in_array($random, $anon_ids));
+            } while (in_array($random, $anon_ids));
             $this->anon_id = $random;
             $this->core->getQueries()->updateUser($this, $this->core->getConfig()->getSemester(), $this->core->getConfig()->getCourse());
         }
@@ -322,7 +322,7 @@ class User extends AbstractModel {
      */
     public static function validateUserData($field, $data) {
 
-        switch($field) {
+        switch ($field) {
             case 'user_id':
                  //Username / user_id must contain only lowercase alpha, numbers, underscores, hyphens
                 return preg_match("~^[a-z0-9_\-]+$~", $data) === 1;

--- a/site/app/models/forum/Forum.php
+++ b/site/app/models/forum/Forum.php
@@ -25,21 +25,22 @@ class Forum extends AbstractModel {
 
         $pushFunction = null;
 
-        if($isThread) {
+        if ($isThread) {
             $verify = $this->validateThreadData($data, true);
             //$pushFunction = new $this->forum_db->pushThread;
-        } else {
+        }
+        else {
             $verify = $this->validatePostData($data, true, false);
             //$pushFunction = new $this->forum_db->pushPost;
         }
 
-        if(!$verify[0]) {
+        if (!$verify[0]) {
             return false;
         }
 
         $result = $verify[1];
 
-        if($isThread && $data['email_announcement']) {
+        if ($isThread && $data['email_announcement']) {
             $this->sendEmailAnnouncement($result);
         }
 
@@ -52,7 +53,7 @@ class Forum extends AbstractModel {
     public function pinThread($thread_id, $toggle) {
         $user = $this->core->getUser()->getId();
 
-        if(!$this->core->getQueries()->threadExists($thread_id)) {
+        if (!$this->core->getQueries()->threadExists($thread_id)) {
             return false;
         }
 
@@ -63,7 +64,7 @@ class Forum extends AbstractModel {
     }
 
     public function getEditContent($post_id) {
-        if($this->checkPostEditAccess($post_id) && !empty($post_id)) {
+        if ($this->checkPostEditAccess($post_id) && !empty($post_id)) {
             //This will return a Post obj also forum queries...
             $post = $this->core->getQueries()->getPost($post_id);
             $output = array();
@@ -74,7 +75,7 @@ class Forum extends AbstractModel {
             $output['anon'] = $post->getIsAnonymous();
             $output['change_anon'] = $this->modifyAnonymous($post->getAuthor());
             $output['user'] = $output['anon'] ? 'Anonymous' : $post->getAuthor();
-            if(isset($_POST["thread_id"])) {
+            if (isset($_POST["thread_id"])) {
                 $this->getThreadContent($post->getThreadId(), $output);
             }
             return $output;
@@ -88,7 +89,7 @@ class Forum extends AbstractModel {
         $class_list = $this->core->getQueries()->getEmailListWithIds();
         $formatted_body = "An Instructor/TA made an announcement in the Submitty discussion forum:\n\n" . $thread->getContent();
 
-        foreach($class_list as $user) {
+        foreach ($class_list as $user) {
             $user_id = $user['user_id'];
             $user_email = $user['user_email'];
             $user_group = $user['user_group'];
@@ -119,11 +120,17 @@ class Forum extends AbstractModel {
         //Validate the post data prior to thread data
         $goodPost = $this->validatePostData($data, false, true);
 
-        if(!$goodPost[0] ||
-            empty($data['title']) || empty($data['status']) ||
-            empty($data['announcement']) || empty($data['categories']) ||
-            empty($data['email_announcement']) || $data['parent_id'] !== -1 ||
-            !$this->isValidCategories($this->core->getQueries()->getCategories(), $data['categories']) || (strlen($data['content']) > 5000)  ){
+        if (
+            !$goodPost[0]
+            || empty($data['title'])
+            || empty($data['status'])
+            || empty($data['announcement'])
+            || empty($data['categories'])
+            || empty($data['email_announcement'])
+            || $data['parent_id'] !== -1
+            || !$this->isValidCategories($this->core->getQueries()->getCategories(), $data['categories'])
+            || (strlen($data['content']) > 5000)
+        ) {
             return [false, null];
         }
 
@@ -132,10 +139,15 @@ class Forum extends AbstractModel {
 
     private function validatePostData(array $data, bool $createObject, bool $isThread): array {
 
-        if(empty($data['content']) || empty($data['anon']) ||
-            empty($data['thread_id']) || empty($data['parent_id']) ||
-            (!$isThread && !$this->core->getQueries()->existsThread($data['thread_id'])) ||
-            (!$isThread && !$this->core->getQueries()->existsPost($data['thread_id'], $data['parent_id'])) || (strlen($data['content']) > 5000) ) {
+        if (
+            empty($data['content'])
+            || empty($data['anon'])
+            || empty($data['thread_id'])
+            || empty($data['parent_id'])
+            || (!$isThread && !$this->core->getQueries()->existsThread($data['thread_id']))
+            || (!$isThread && !$this->core->getQueries()->existsPost($data['thread_id'], $data['parent_id']))
+            || (strlen($data['content']) > 5000)
+        ) {
             return [false, null];
         }
 

--- a/site/app/models/forum/Post.php
+++ b/site/app/models/forum/Post.php
@@ -65,7 +65,7 @@ class Post extends AbstractModel {
     public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
 
-        if(empty($details)) {
+        if (empty($details)) {
             return;
         }
 

--- a/site/app/models/forum/Thread.php
+++ b/site/app/models/forum/Thread.php
@@ -34,7 +34,7 @@ class Thread extends AbstractModel {
 
     public function __construct(Core $core, $details = array()) {
         parent::__construct($core);
-        if(empty($details)) {
+        if (empty($details)) {
             return;
         }
 

--- a/site/app/models/gradeable/AbstractTextBox.php
+++ b/site/app/models/gradeable/AbstractTextBox.php
@@ -27,7 +27,8 @@ class AbstractTextBox extends AbstractGradeableInput {
         $this->row_count = $details['rows'];
         if ($details['type'] === "codebox") {
             $this->is_codebox = true;
-        } else {
+        }
+        else {
             $this->is_codebox = false;
         }
     }

--- a/site/app/models/gradeable/AutoGradedGradeable.php
+++ b/site/app/models/gradeable/AutoGradedGradeable.php
@@ -31,7 +31,7 @@ class AutoGradedGradeable extends AbstractModel {
     public function __construct(Core $core, GradedGradeable $graded_gradeable, array $details) {
         parent::__construct($core);
 
-        if($graded_gradeable === null) {
+        if ($graded_gradeable === null) {
             throw new \InvalidArgumentException('Graded gradeable cannot be null');
         }
         $this->setActiveVersion($details['active_version'] ?? 0);
@@ -90,7 +90,8 @@ class AutoGradedGradeable extends AbstractModel {
     public function setActiveVersion($version) {
         if ((is_int($version) || ctype_digit($version)) && intval($version) >= 0) {
             $this->active_version = intval($version);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Active version must be a non-negative integer');
         }
         $this->modified = true;
@@ -165,7 +166,7 @@ class AutoGradedGradeable extends AbstractModel {
         }
         return $highest_version;
     }
-    
+
     /**
      * Gets if the submitter has a version selected for grading
      * @return bool

--- a/site/app/models/gradeable/AutoGradedTestcase.php
+++ b/site/app/models/gradeable/AutoGradedTestcase.php
@@ -64,7 +64,8 @@ class AutoGradedTestcase extends AbstractModel {
             /*
             $this->points = min(max(0, $this->points), $testcase->getPoints());
             */
-        } elseif ($testcase->getPoints() < 0) {
+        }
+        elseif ($testcase->getPoints() < 0) {
             // PENALTY TESTCASE
             // TODO: ADD ERROR <--(what does this mean)?
             $this->points = min(max($testcase->getPoints(), $this->points), 0);

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -119,7 +119,7 @@ class AutoGradedVersion extends AbstractModel {
         $dirs = $gradeable->isVcs() ? ['submissions', 'checkout'] : ['submissions'];
 
 
-        foreach($dirs as $dir) {
+        foreach ($dirs as $dir) {
             $this->meta_files[$dir] = [];
             $this->files[$dir][0] = [];
 
@@ -130,13 +130,14 @@ class AutoGradedVersion extends AbstractModel {
             foreach ($submitted_files as $file => $details) {
                 if (substr(basename($file), 0, 1) === '.') {
                     $this->meta_files[$dir][$file] = $details;
-                } else {
+                }
+                else {
                     $this->files[$dir][0][$file] = $details;
                 }
             }
             // If there is only one part (no separation of upload files),
             //  be sure to set the "Part 1" files to the "all" files
-            if($config->getNumParts() === 1) {
+            if ($config->getNumParts() === 1) {
                 $this->files[$dir][1] = $this->files[$dir][0];
             }
 
@@ -159,23 +160,18 @@ class AutoGradedVersion extends AbstractModel {
 
         // If results were found then append message arrays to output array
         // where key is the testcase_label
-        if(!is_null($this->graded_testcases))
-        {
-            foreach ($this->graded_testcases as $graded_testcase)
-            {
+        if (!is_null($this->graded_testcases)) {
+            foreach ($this->graded_testcases as $graded_testcase) {
                 $testcase_label = $graded_testcase->getTestcase()->getTestcaseLabel();
 
                 // If a testcase_label exists then get the auto grading messages
-                if($testcase_label != "")
-                {
+                if ($testcase_label != "") {
                     $output[$testcase_label] = array();
 
                     $autochecks = $graded_testcase->getAutochecks();
 
-                    foreach ($autochecks as $autocheck)
-                    {
-                        foreach ($autocheck->getMessages() as $msg)
-                        {
+                    foreach ($autochecks as $autocheck) {
+                        foreach ($autocheck->getMessages() as $msg) {
                             array_push($output[$testcase_label], $msg); //autocheck->getMessages()[0]);
                         }
                     }
@@ -231,9 +227,11 @@ class AutoGradedVersion extends AbstractModel {
                 // TODO: Autograding results file was incomplete.  This is a big problem, but how should
                 // TODO:   we handle this error
             }
-            if ($result_details != null &&
-                count($result_details['testcases']) > $testcase->getIndex() &&
-                $result_details['testcases'][$testcase->getIndex()] != null) {
+            if (
+                $result_details != null
+                && count($result_details['testcases']) > $testcase->getIndex()
+                && $result_details['testcases'][$testcase->getIndex()] != null
+            ) {
                 $graded_testcase = new AutoGradedTestcase(
                     $this->core,
                     $testcase,
@@ -265,7 +263,7 @@ class AutoGradedVersion extends AbstractModel {
      * @return float
      */
     public function getEarlyIncentivePoints() {
-        if($this->graded_gradeable === null) {
+        if ($this->graded_gradeable === null) {
             $this->loadTestcases();
         }
         return $this->early_incentive_points;
@@ -285,7 +283,7 @@ class AutoGradedVersion extends AbstractModel {
      * @return array
      */
     public function getPartFiles($part = 0) {
-        if($this->files === null) {
+        if ($this->files === null) {
             $this->loadSubmissionFiles();
         }
         return array(
@@ -299,7 +297,7 @@ class AutoGradedVersion extends AbstractModel {
      * @return array
      */
     public function getMetaFiles() {
-        if($this->files === null) {
+        if ($this->files === null) {
             $this->loadSubmissionFiles();
         }
         return array('submissions' => $this->meta_files['submissions'], 'checkout' => ($this->graded_gradeable->getGradeable()->isVcs()) ? $this->meta_files['checkout'] : []);
@@ -310,7 +308,7 @@ class AutoGradedVersion extends AbstractModel {
      * @return array
      */
     public function getResultsFiles() {
-        if($this->results_files === null) {
+        if ($this->results_files === null) {
             $this->loadTestcases();
         }
         return $this->results_files;
@@ -321,7 +319,7 @@ class AutoGradedVersion extends AbstractModel {
      * @return array
      */
     public function getResultsPublicFiles() {
-        if($this->results_public_files === null) {
+        if ($this->results_public_files === null) {
             $this->loadTestcases();
         }
         return $this->results_public_files;
@@ -355,7 +353,7 @@ class AutoGradedVersion extends AbstractModel {
      *              otherwise the queue count
      */
     public function getQueuePosition() {
-        if($this->queue_position === null) {
+        if ($this->queue_position === null) {
             return $this->loadQueueStatus();
         }
         return $this->queue_position;
@@ -379,14 +377,15 @@ class AutoGradedVersion extends AbstractModel {
         $dividend = $this->getNonHiddenNonExtraCredit() + $this->getNonHiddenExtraCredit();
 
         // Avoid divide-by-zero (== not a typo)
-        if($divisor == 0) {
+        if ($divisor == 0) {
             return NAN;
         }
         $result = floatval($dividend) / $divisor;
 
         if ($clamp === true && $result > 1.0) {
             return 1.0;
-        } elseif ($result < 0) {
+        }
+        elseif ($result < 0) {
             return 0.0;
         }
         return $result;
@@ -420,14 +419,15 @@ class AutoGradedVersion extends AbstractModel {
             $this->getHiddenNonExtraCredit() + $this->getHiddenExtraCredit();
 
         // avoid divide-by-zero (== not a typo)
-        if($divisor == 0) {
+        if ($divisor == 0) {
             return NAN;
         }
         $result = floatval($dividend) / $divisor;
 
         if ($clamp === true && $result > 1.0) {
             return 1.0;
-        } elseif ($result < 0) {
+        }
+        elseif ($result < 0) {
             return 0.0;
         }
         return $result;
@@ -460,7 +460,7 @@ class AutoGradedVersion extends AbstractModel {
      * @return AutoGradedVersionHistory[]
      */
     public function getHistory() {
-        if($this->graded_testcases === null) {
+        if ($this->graded_testcases === null) {
             $this->loadTestcases();
         }
         return $this->history;
@@ -472,7 +472,7 @@ class AutoGradedVersion extends AbstractModel {
      */
     public function getLatestHistory() {
         $history = $this->getHistory();
-        if(count($history) === 0) {
+        if (count($history) === 0) {
             return null;
         }
         return $history[count($history) - 1];
@@ -511,7 +511,8 @@ class AutoGradedVersion extends AbstractModel {
     private function setVersionInternal($version) {
         if ((is_int($version) || ctype_digit($version)) && intval($version) >= 0) {
             $this->version = intval($version);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Version number must be a non-negative integer');
         }
     }
@@ -531,7 +532,8 @@ class AutoGradedVersion extends AbstractModel {
         foreach (self::point_properties as $property) {
             if (is_numeric($points[$property])) {
                 $this->$property = floatval($points[$property]);
-            } else {
+            }
+            else {
                 throw new \InvalidArgumentException('Graded version point values must be numeric');
             }
         }
@@ -545,7 +547,8 @@ class AutoGradedVersion extends AbstractModel {
     private function setSubmissionTimeInternal($submission_time) {
         if ($submission_time !== null) {
             $this->submission_time = DateUtils::parseDateTime($submission_time, $this->core->getConfig()->getTimezone());
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Graded version submission time must not be null');
         }
     }

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -91,7 +91,8 @@ class AutogradingConfig extends AbstractModel {
         $this->max_submissions = intval($details['max_submissions'] ?? 0);
         if (isset($details['assignment_message'])) {
             $this->gradeable_message = $details['assignment_message'] ?? '';
-        } elseif (isset($details['gradeable_message'])) {
+        }
+        elseif (isset($details['gradeable_message'])) {
             $this->gradeable_message = $details['gradeable_message'] ?? '';
         }
 
@@ -108,17 +109,20 @@ class AutogradingConfig extends AbstractModel {
 
                 // Accumulate only the positive points
                 $points = $testcase->getPoints();
-                if($points >= 0.0) {
+                if ($points >= 0.0) {
                     if ($testcase->isHidden()) {
                         if ($testcase->isExtraCredit()) {
                             $this->total_hidden_extra_credit += $points;
-                        } else {
+                        }
+                        else {
                             $this->total_hidden_non_extra_credit += $points;
                         }
-                    } else {
+                    }
+                    else {
                         if ($testcase->isExtraCredit()) {
                             $this->total_non_hidden_extra_credit += $points;
-                        } else {
+                        }
+                        else {
                             $this->total_non_hidden_non_extra_credit += $points;
                         }
                     }
@@ -149,9 +153,10 @@ class AutogradingConfig extends AbstractModel {
 
                 // If cell is of markdown type then figure out if it is markdown_string or markdown_file and pass this
                 // markdown forward as 'data' as opposed to 'string' or 'file'
-                if(isset($notebook_cell['type']) &&
-                   $notebook_cell['type'] == 'markdown')
-                {
+                if (
+                    isset($notebook_cell['type'])
+                    && $notebook_cell['type'] === 'markdown'
+                ) {
                     $markdown = $this->getMarkdownData($notebook_cell);
 
                     // Remove string or file from $notebook_cell
@@ -162,12 +167,12 @@ class AutogradingConfig extends AbstractModel {
                     $notebook_cell['markdown_data'] = $markdown;
 
                     // If next entry is an input type, we assign this as a label - otherwise it is plain markdown
-                    if ($i < count($details['notebook']) - 1)
-                    {
+                    if ($i < count($details['notebook']) - 1) {
                         $next_cell = &$details['notebook'][$i + 1];
-                        if (isset($next_cell['type']) &&
-                            ($next_cell['type'] == 'short_answer' || $next_cell['type'] == 'multiple_choice'))
-                        {
+                        if (
+                            isset($next_cell['type'])
+                            && ($next_cell['type'] == 'short_answer' || $next_cell['type'] == 'multiple_choice')
+                        ) {
                             $next_cell['label'] = $markdown;
                             // Do not add current cell to notebook, since it is embedded in the label
                             $do_add = false;
@@ -181,9 +186,10 @@ class AutogradingConfig extends AbstractModel {
                 }
 
                 // If cell is a type of input add it to the $actual_inputs array
-                if(isset($notebook_cell['type']) &&
-                   ($notebook_cell['type'] === 'short_answer' || $notebook_cell['type'] === 'multiple_choice'))
-                {
+                if (
+                    isset($notebook_cell['type'])
+                    && ($notebook_cell['type'] === 'short_answer' || $notebook_cell['type'] === 'multiple_choice')
+                ) {
                     array_push($actual_input, $notebook_cell);
                 }
             }
@@ -193,16 +199,15 @@ class AutogradingConfig extends AbstractModel {
         for ($i = 0; $i < count($actual_input); $i++) {
             if ($actual_input[$i]['type'] == 'short_answer') {
                 // If programming language is set then this is a codebox
-                if(isset($actual_input[$i]['programming_language']))
-                {
+                if (isset($actual_input[$i]['programming_language'])) {
                     $this->inputs[$i] = new SubmissionCodeBox($this->core, $actual_input[$i]);
                 }
                 // Else regular textbox
-                else
-                {
+                else {
                     $this->inputs[$i] = new SubmissionTextBox($this->core, $actual_input[$i]);
                 }
-            } elseif ($actual_input[$i]['type'] == 'multiple_choice') {
+            }
+            elseif ($actual_input[$i]['type'] == 'multiple_choice') {
                 $this->inputs[$i] = new SubmissionMultipleChoice($this->core, $actual_input[$i]);
             }
         }
@@ -213,10 +218,14 @@ class AutogradingConfig extends AbstractModel {
         // Get all of the part names
         for ($i = 1; $i <= $num_parts; $i++) {
             $j = $i - 1;
-            if (isset($details['part_names']) && isset($details['part_names'][$j]) &&
-                trim($details['part_names'][$j]) !== "") {
+            if (
+                isset($details['part_names'])
+                && isset($details['part_names'][$j])
+                && trim($details['part_names'][$j]) !== ""
+            ) {
                 $this->part_names[$i] = $details['part_names'][$j];
-            } else {
+            }
+            else {
                 $this->part_names[$i] = "Part " . $i;
             }
         }
@@ -224,19 +233,16 @@ class AutogradingConfig extends AbstractModel {
 
     private function getMarkdownData($cell) {
         // If markdown_string is set then just return that
-        if(isset($cell['markdown_string']))
-        {
+        if (isset($cell['markdown_string'])) {
             return $cell['markdown_string'];
         }
         // Else if markdown_file is set then read the file and return its contents
-        elseif(isset($cell['markdown_file']))
-        {
+        elseif (isset($cell['markdown_file'])) {
             // TODO: Implement reading from markdown_file and passing that along
             throw new NotImplementedException("Reading from a markdown_file is not yet implemented.");
         }
         // Else something unexpected happened
-        else
-        {
+        else {
             throw new \InvalidArgumentException("An error occured parsing notebook data.\n" .
                 "Markdown configuration may only specify one of 'markdown_string' or 'markdown_file'");
         }
@@ -330,8 +336,8 @@ class AutogradingConfig extends AbstractModel {
      */
     public function anyVisibleTestcases() {
         /** @var AutogradingTestcase $testcase */
-        foreach($this->testcases as $testcase) {
-            if(!$testcase->isHidden()) {
+        foreach ($this->testcases as $testcase) {
+            if (!$testcase->isHidden()) {
                 return true;
             }
         }

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -198,11 +198,10 @@ class AutogradingConfig extends AbstractModel {
         // Setup $this->inputs
         for ($i = 0; $i < count($actual_input); $i++) {
             if ($actual_input[$i]['type'] == 'short_answer') {
-                // If programming language is set then this is a codebox
+                // If programming language is set then this is a codebox, else regular textbox
                 if (isset($actual_input[$i]['programming_language'])) {
                     $this->inputs[$i] = new SubmissionCodeBox($this->core, $actual_input[$i]);
                 }
-                // Else regular textbox
                 else {
                     $this->inputs[$i] = new SubmissionTextBox($this->core, $actual_input[$i]);
                 }
@@ -236,13 +235,13 @@ class AutogradingConfig extends AbstractModel {
         if (isset($cell['markdown_string'])) {
             return $cell['markdown_string'];
         }
-        // Else if markdown_file is set then read the file and return its contents
         elseif (isset($cell['markdown_file'])) {
+            // Else if markdown_file is set then read the file and return its contents
             // TODO: Implement reading from markdown_file and passing that along
             throw new NotImplementedException("Reading from a markdown_file is not yet implemented.");
         }
-        // Else something unexpected happened
         else {
+            // Else something unexpected happened
             throw new \InvalidArgumentException("An error occured parsing notebook data.\n" .
                 "Markdown configuration may only specify one of 'markdown_string' or 'markdown_file'");
         }

--- a/site/app/models/gradeable/Component.php
+++ b/site/app/models/gradeable/Component.php
@@ -154,8 +154,8 @@ class Component extends AbstractModel {
      * @throws \InvalidArgumentException If the provided mark id isn't part of this component
      */
     public function getMark($mark_id) {
-        foreach($this->marks as $mark) {
-            if($mark->getId() === $mark_id) {
+        foreach ($this->marks as $mark) {
+            if ($mark->getId() === $mark_id) {
                 return $mark;
             }
         }
@@ -226,7 +226,8 @@ class Component extends AbstractModel {
         foreach (self::point_properties as $property) {
             if (is_numeric($points[$property])) {
                 $parsedPoints[$property] = floatval($points[$property]);
-            } else {
+            }
+            else {
                 $parsedPoints[$property] = null;
             }
         }
@@ -315,9 +316,17 @@ class Component extends AbstractModel {
         // Get the implied deleted marks from this operation and make sure that we aren't
         //  deleting any marks that are in use.
         $deleted_marks = array_udiff($this->marks, $marks, Utils::getCompareByReference());
-        if (in_array(true, array_map(function (Mark $mark) {
-                return $mark->anyReceivers();
-        }, $deleted_marks))) {
+        if (
+            in_array(
+                true,
+                array_map(
+                    function (Mark $mark) {
+                        return $mark->anyReceivers();
+                    },
+                    $deleted_marks
+                )
+            )
+        ) {
             throw new \InvalidArgumentException('Call to setMarks implied deletion of marks with receivers');
         }
 
@@ -371,7 +380,7 @@ class Component extends AbstractModel {
      */
     private function deleteMarkInner(Mark $mark, bool $force = false) {
         // Don't delete if the mark has receivers (and we aren't forcing)
-        if($mark->anyReceivers() && !$force) {
+        if ($mark->anyReceivers() && !$force) {
             throw new \InvalidArgumentException('Attempt to delete a mark with receivers!');
         }
 
@@ -422,7 +431,8 @@ class Component extends AbstractModel {
     private function setIdInternal($id) {
         if ((is_int($id) || ctype_digit($id)) && intval($id) >= 0) {
             $this->id = intval($id);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Component Id must be a non-negative integer');
         }
     }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -451,7 +451,8 @@ class Gradeable extends AbstractModel {
                 } catch (\Exception $e) {
                     $parsedDates[$date] = null;
                 }
-            } else {
+            }
+            else {
                 $parsedDates[$date] = null;
             }
         }
@@ -507,12 +508,15 @@ class Gradeable extends AbstractModel {
             if (!$this->isStudentSubmit()) {
                 if ($this->isTaGrading()) {
                     $result = self::date_properties_elec_exam;
-                } else {
+                }
+                else {
                     $result = self::date_properties_bare;
                 }
-            } elseif ($this->isTaGrading()) {
+            }
+            elseif ($this->isTaGrading()) {
                 $result = self::date_properties_elec_ta;
-            } else {
+            }
+            else {
                 $result = self::date_properties_elec_no_ta;
             }
 
@@ -526,7 +530,8 @@ class Gradeable extends AbstractModel {
             if ($this->isTaGrading() && $this->core->getConfig()->isRegradeEnabled() && $this->isRegradeAllowed()) {
                 $result[] = 'regrade_request_date';
             }
-        } else {
+        }
+        else {
             $result = self::date_properties_simple;
         }
         return $result;
@@ -572,7 +577,7 @@ class Gradeable extends AbstractModel {
                 }
 
                 // Don't coerce a date on the black list
-                if(in_array($property, $black_list)) {
+                if (in_array($property, $black_list)) {
                     continue;
                 }
 
@@ -692,7 +697,7 @@ class Gradeable extends AbstractModel {
      * @return array An array (indexed by user id) of arrays of section ids
      */
     public function getRotatingGraderSections() {
-        if($this->rotating_grader_sections === null) {
+        if ($this->rotating_grader_sections === null) {
             $this->setRotatingGraderSections($this->core->getQueries()->getRotatingSectionsByGrader($this->id));
             $this->rotating_grader_sections_modified = false;
         }
@@ -704,7 +709,7 @@ class Gradeable extends AbstractModel {
      * @return AutogradingConfig|null returns null if loading from the disk fails
      */
     public function getAutogradingConfig() {
-        if($this->autograding_config === null) {
+        if ($this->autograding_config === null) {
             $this->autograding_config = $this->loadAutogradingConfig();
         }
         return $this->autograding_config;
@@ -834,7 +839,8 @@ class Gradeable extends AbstractModel {
         // Disallow the 0 group (this may catch some potential bugs with instructors not being able to edit gradeables)
         if ($group > 0 && $group <= 4) {
             $this->min_grading_group = $group;
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Grading group must be an integer larger than 0');
         }
         $this->modified = true;
@@ -847,7 +853,8 @@ class Gradeable extends AbstractModel {
     public function setTeamSizeMax(int $max_team_size) {
         if ($max_team_size >= 0) {
             $this->team_size_max = intval($max_team_size);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Max team size must be a non-negative integer!');
         }
         $this->modified = true;
@@ -869,7 +876,8 @@ class Gradeable extends AbstractModel {
     public function setPeerGradingSet(int $peer_grading_set) {
         if ($peer_grading_set >= 0) {
             $this->peer_grade_set = intval($peer_grading_set);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Peer grade set must be a non-negative integer!');
         }
         $this->modified = true;
@@ -890,9 +898,17 @@ class Gradeable extends AbstractModel {
         // Get the implied deleted components from this operation and ensure we aren't deleting any
         //  components that have grades already
         $deleted_components = array_udiff($this->components, $components, Utils::getCompareByReference());
-        if (in_array(true, array_map(function (Component $component) {
-            return $component->anyGrades();
-        }, $deleted_components))) {
+        if (
+            in_array(
+                true,
+                array_map(
+                    function (Component $component) {
+                        return $component->anyGrades();
+                    },
+                    $deleted_components
+                )
+            )
+        ) {
             throw new \InvalidArgumentException('Call to setComponents implied deletion of component with grades');
         }
 
@@ -971,7 +987,7 @@ class Gradeable extends AbstractModel {
      */
     private function deleteComponentInner(Component $component, bool $force = false) {
         // Don't delete if the component has grades (and we aren't forcing)
-        if($component->anyGrades() && !$force) {
+        if ($component->anyGrades() && !$force) {
             throw new \InvalidArgumentException('Attempt to delete a component with grades!');
         }
 
@@ -1050,17 +1066,18 @@ class Gradeable extends AbstractModel {
         $num_sections = $this->core->getQueries()->getNumberRotatingSections();
 
         $parsed_graders_sections = [];
-        foreach($rotating_grader_sections as $user => $grader_sections) {
-            if($grader_sections !== null) {
-                if(!is_array($grader_sections)) {
+        foreach ($rotating_grader_sections as $user => $grader_sections) {
+            if ($grader_sections !== null) {
+                if (!is_array($grader_sections)) {
                     throw new \InvalidArgumentException('Rotating grader section for grader was not array');
                 }
                 // Parse each section array into strings
                 $parsed_sections = [];
-                foreach($grader_sections as $section) {
+                foreach ($grader_sections as $section) {
                     if ((is_int($section) || ctype_digit($section)) && intval($section) > 0 && intval($section) <= $num_sections) {
                         $parsed_sections[] = intval($section);
-                    } else {
+                    }
+                    else {
                         throw new \InvalidArgumentException('Grading section must be a positive integer no more than the number of rotating sections!');
                     }
                 }
@@ -1163,7 +1180,7 @@ class Gradeable extends AbstractModel {
      * @return Team[]
      */
     public function getTeams() {
-        if($this->teams === null) {
+        if ($this->teams === null) {
             $this->teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
         }
         return $this->teams;
@@ -1182,7 +1199,7 @@ class Gradeable extends AbstractModel {
      * @return bool True if any manual grades exist
      */
     public function anyManualGrades() {
-        if($this->any_manual_grades === null) {
+        if ($this->any_manual_grades === null) {
             $this->any_manual_grades = $this->core->getQueries()->getGradeableHasGrades($this->getId());
         }
         return $this->any_manual_grades;
@@ -1193,7 +1210,7 @@ class Gradeable extends AbstractModel {
      * @return bool
      */
     public function anySubmissions() {
-        if($this->any_submissions === null) {
+        if ($this->any_submissions === null) {
             // Until we find a submission, assume there are none
             $this->any_submissions = false;
             if ($this->type === GradeableType::ELECTRONIC_FILE) {
@@ -1347,17 +1364,20 @@ class Gradeable extends AbstractModel {
         if ($this->isGradeByRegistration()) {
             if (!$grader->accessFullGrading()) {
                 $sections = $grader->getGradingRegistrationSections();
-            } else {
+            }
+            else {
                 $sections = $this->core->getQueries()->getRegistrationSections();
                 foreach ($sections as $i => $section) {
                     $sections[$i] = $section['sections_registration_id'];
                 }
             }
             $section_key = 'registration_section';
-        } else {
+        }
+        else {
             if (!$grader->accessFullGrading()) {
                 $sections = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($this->getId(), $grader->getId());
-            } else {
+            }
+            else {
                 $sections = $this->core->getQueries()->getRotatingSections();
                 foreach ($sections as $i => $section) {
                     $sections[$i] = $section['sections_rotating_id'];
@@ -1371,7 +1391,8 @@ class Gradeable extends AbstractModel {
                 $total_users = $this->core->getQueries()->getTotalTeamCountByGradingSections($this->getId(), $sections, $section_key);
                 $graded_components = $this->core->getQueries()->getGradedComponentsCountByTeamGradingSections($this->getId(), $sections, $section_key);
                 $num_submitted = $this->core->getQueries()->getTotalSubmittedTeamCountByGradingSections($this->getId(), $sections, $section_key);
-            } else {
+            }
+            else {
                 $total_users = $this->core->getQueries()->getTotalUserCountByGradingSections($sections, $section_key);
                 $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($this->getId(), $sections, $section_key, $this->isTeamAssignment());
                 $num_submitted = $this->core->getQueries()->getTotalSubmittedUserCountByGradingSections($this->getId(), $sections, $section_key);
@@ -1472,7 +1493,7 @@ class Gradeable extends AbstractModel {
      */
     public function getTaPoints() {
         $total = 0.0;
-        foreach($this->getComponents() as $component) {
+        foreach ($this->getComponents() as $component) {
             $total += $component->getMaxValue();
         }
         return $total;
@@ -1488,7 +1509,8 @@ class Gradeable extends AbstractModel {
             $users = $this->core->getQueries()->getPeerAssignment($this->getId(), $user->getId());
             //TODO: Peer grading team assignments
             return [new GradingSection($this->core, false, "Peer", [$user], $users, [])];
-        } else {
+        }
+        else {
             $users = [];
             $teams = [];
 
@@ -1504,7 +1526,8 @@ class Gradeable extends AbstractModel {
                         /** @var Team $team */
                         $teams[$team->getRegistrationSection()][] = $team;
                     }
-                } else {
+                }
+                else {
                     foreach ($section_names as $section) {
                         $users[$section] = [];
                     }
@@ -1515,7 +1538,8 @@ class Gradeable extends AbstractModel {
                     }
                 }
                 $graders = $this->core->getQueries()->getGradersForRegistrationSections($section_names);
-            } else {
+            }
+            else {
                 $section_names = $this->core->getQueries()->getRotatingSectionsForGradeableAndUser($this->getId(), $user->getId());
 
                 if ($this->isTeamAssignment()) {
@@ -1527,7 +1551,8 @@ class Gradeable extends AbstractModel {
                         /** @var Team $team */
                         $teams[$team->getRotatingSection()][] = $team;
                     }
-                } else {
+                }
+                else {
                     foreach ($section_names as $section) {
                         $users[$section] = [];
                     }
@@ -1575,7 +1600,8 @@ class Gradeable extends AbstractModel {
                     /** @var Team $team */
                     $teams[$team->getRegistrationSection()][] = $team;
                 }
-            } else {
+            }
+            else {
                 $all_users = $this->core->getQueries()->getAllUsers();
                 foreach ($all_users as $user) {
                     /** @var User $user */
@@ -1587,14 +1613,16 @@ class Gradeable extends AbstractModel {
                 $section_names[$i] = $section['sections_registration_id'];
             }
             $graders = $this->core->getQueries()->getGradersForRegistrationSections($section_names);
-        } else {
+        }
+        else {
             if ($this->isTeamAssignment()) {
                 $all_teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
                 foreach ($all_teams as $team) {
                     /** @var Team $team */
                     $teams[$team->getRotatingSection()][] = $team;
                 }
-            } else {
+            }
+            else {
                 $all_users = $this->core->getQueries()->getAllUsers();
                 foreach ($all_users as $user) {
                     /** @var User $user */
@@ -1654,12 +1682,14 @@ class Gradeable extends AbstractModel {
         // Inherit rotating/registration section from leader if not provided
         if ($registration_section === '') {
             $registration_section = $leader->getRegistrationSection();
-        } elseif($registration_section === 'NULL') {
+        }
+        elseif ($registration_section === 'NULL') {
             $registration_section = null;
         }
         if ($rotating_section < 0) {
             $rotating_section = $leader->getRotatingSection();
-        } elseif ($rotating_section === 0) {
+        }
+        elseif ($rotating_section === 0) {
             $rotating_section = null;
         }
 
@@ -1708,10 +1738,12 @@ class Gradeable extends AbstractModel {
     public function getRepositoryPath(User $user, Team $team = null) {
         if (strpos($this->getVcsSubdirectory(), '://') !== false || substr($this->getVcsSubdirectory(), 0, 1) === '/') {
             $vcs_path = $this->getVcsSubdirectory();
-        } else {
+        }
+        else {
             if (strpos($this->core->getConfig()->getVcsBaseUrl(), '://')) {
                 $vcs_path = rtrim($this->core->getConfig()->getVcsBaseUrl(), '/') . '/' . $this->getVcsSubdirectory();
-            } else {
+            }
+            else {
                 $vcs_path = FileUtils::joinPaths($this->core->getConfig()->getVcsBaseUrl(), $this->getVcsSubdirectory());
             }
         }
@@ -1752,7 +1784,7 @@ class Gradeable extends AbstractModel {
      */
     public function hasOverriddenGrades(Submitter $submitter) {
         $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->getId(), $submitter->getId());
-        if($userWithOverriddenGrades === null){
+        if ($userWithOverriddenGrades === null) {
             return false;
         }
         return true;

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -430,7 +430,8 @@ class Gradeable extends AbstractModel {
                 return new AutogradingConfig($this->core, $details);
             }
             return null;
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             // Don't throw an error, just don't make any data
             return null;
         }
@@ -448,7 +449,8 @@ class Gradeable extends AbstractModel {
             if (isset($dates[$date]) && $dates[$date] !== null) {
                 try {
                     $parsedDates[$date] = DateUtils::parseDateTime($dates[$date], $this->core->getConfig()->getTimezone());
-                } catch (\Exception $e) {
+                }
+                catch (\Exception $e) {
                     $parsedDates[$date] = null;
                 }
             }
@@ -1100,7 +1102,8 @@ class Gradeable extends AbstractModel {
         try {
             // Asserts that this date information is valid after changing this property
             $this->setDates($this->getDates());
-        } catch (ValidationException $e) {
+        }
+        catch (ValidationException $e) {
             // Reset to the old value if validation fails
             $this->regrade_allowed = $old;
 
@@ -1133,7 +1136,8 @@ class Gradeable extends AbstractModel {
         try {
             // Asserts that this date information is valid after changing this property
             $this->setDates($this->getDates());
-        } catch (ValidationException $e) {
+        }
+        catch (ValidationException $e) {
             // Reset to the old value if validation fails
             $this->ta_grading = $old;
 

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -87,26 +87,38 @@ class GradeableList extends AbstractModel {
                     if ($gradeable->getGradeStartDate() < $this->core->getDateTimeNow() && $this->core->getUser()->accessGrading()) {
                         // Put in 'grading' category only if user is a grader
                         $this->grading_gradeables[$gradeable->getId()] = $gradeable;
-                    } else {
+                    }
+                    else {
                         $this->open_gradeables[$gradeable->getId()] = $gradeable;
                     }
-                } else {
+                }
+                else {
                     // If there is no due date and no student submission, it should
                     //  automatically show up in the 'Grading' category
                     $this->grading_gradeables[$gradeable->getId()] = $gradeable;
                 }
             }
-            elseif ((($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->isTaGrading()) ||
-                    $gradeable->getType() !== GradeableType::ELECTRONIC_FILE) &&
-                    $gradeable->getGradeStartDate() <= $this->now) {
+            elseif (
+                (
+                    ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->isTaGrading())
+                    || $gradeable->getType() !== GradeableType::ELECTRONIC_FILE
+                )
+                && $gradeable->getGradeStartDate() <= $this->now
+            ) {
                 $this->grading_gradeables[$gradeable->getId()] = $gradeable;
             }
-            elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
-                $gradeable->getSubmissionOpenDate() <= $this->now && $gradeable->getSubmissionDueDate() <= $this->now) {
+            elseif (
+                $gradeable->getType() === GradeableType::ELECTRONIC_FILE
+                && $gradeable->getSubmissionOpenDate() <= $this->now
+                && $gradeable->getSubmissionDueDate() <= $this->now
+            ) {
                 $this->closed_gradeables[$gradeable->getId()] = $gradeable;
             }
-            elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE &&
-                $gradeable->getSubmissionOpenDate() <= $this->now && $gradeable->getTaViewStartDate() <= $this->now) {
+            elseif (
+                $gradeable->getType() === GradeableType::ELECTRONIC_FILE
+                && $gradeable->getSubmissionOpenDate() <= $this->now
+                && $gradeable->getTaViewStartDate() <= $this->now
+            ) {
                 $this->open_gradeables[$gradeable->getId()] = $gradeable;
             }
             elseif ($this->core->getUser()->accessGrading() && $gradeable->getTaViewStartDate() <= $this->now) {
@@ -201,9 +213,11 @@ class GradeableList extends AbstractModel {
             if ($gradeable->getType() !== GradeableType::ELECTRONIC_FILE) {
                 continue;
             }
-            if ($this->core->getUser()->accessAdmin() ||
-                ($gradeable->getTaViewStartDate() <= $this->now && $this->core->getUser()->accessGrading()) ||
-                $gradeable->getSubmissionOpenDate() <= $this->now) {
+            if (
+                $this->core->getUser()->accessAdmin()
+                || ($gradeable->getTaViewStartDate() <= $this->now && $this->core->getUser()->accessGrading())
+                || $gradeable->getSubmissionOpenDate() <= $this->now
+            ) {
                 $return[$gradeable->getId()] = $gradeable;
             }
         }

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -277,7 +277,8 @@ class GradedComponent extends AbstractModel {
         else {
             try {
                 $this->grade_time = DateUtils::parseDateTime($grade_time, $this->core->getConfig()->getTimezone());
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid date string format');
             }
         }
@@ -344,7 +345,8 @@ class GradedComponent extends AbstractModel {
         else {
             try {
                 $this->verify_time = DateUtils::parseDateTime($verify_time, $this->core->getConfig()->getTimezone());
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid date string format');
             }
         }

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -74,7 +74,7 @@ class GradedComponent extends AbstractModel {
     public function __construct(Core $core, TaGradedGradeable $ta_graded_gradeable, Component $component, User $grader, array $details) {
         parent::__construct($core);
 
-        if($ta_graded_gradeable === null) {
+        if ($ta_graded_gradeable === null) {
             throw new \InvalidArgumentException('Cannot create GradedComponent with null TaGradedGradeable');
         }
         $this->ta_graded_gradeable = $ta_graded_gradeable;
@@ -86,14 +86,15 @@ class GradedComponent extends AbstractModel {
         $this->setGradedVersion($details['graded_version'] ?? 0);
         $this->setGradeTime($details['grade_time'] ?? $this->core->getDateTimeNow());
         $this->verifier_id = $details['verifier_id'] ?? '';
-        if($this->verifier_id !== '') {
+        if ($this->verifier_id !== '') {
             $this->verifier = $this->core->getQueries()->getUserById($this->verifier_id);
         }
         $this->setVerifyTime($details['verify_time'] ?? '');
         // assign the default score if its not electronic (or rather not a custom mark)
         if ($component->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE) {
             $score = $details['score'] ?? 0;
-        } else {
+        }
+        else {
             $score = $details['score'] ?? $component->getDefault();
         }
         $this->setScore($score);
@@ -194,7 +195,7 @@ class GradedComponent extends AbstractModel {
         }
         // Be sure to add the default so count-down gradeables don't become negative
         $score = $this->component->getDefault();
-        foreach($this->marks as $mark) {
+        foreach ($this->marks as $mark) {
             $score += $mark->getPoints();
         }
         $score += $this->getScore();
@@ -272,7 +273,8 @@ class GradedComponent extends AbstractModel {
     public function setGradeTime($grade_time) {
         if ($grade_time === null) {
             $this->grade_time = null;
-        } else {
+        }
+        else {
             try {
                 $this->grade_time = DateUtils::parseDateTime($grade_time, $this->core->getConfig()->getTimezone());
             } catch (\Exception $e) {
@@ -299,7 +301,8 @@ class GradedComponent extends AbstractModel {
     public function setScore(float $score) {
         if ($this->component->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE) {
             $this->score = $score;
-        } else {
+        }
+        else {
             // clamp the score (no error if not in bounds)
             //  min(max(a,b),c) will clamp the value 'b' in the range [a,c]
             $this->score = min(max($this->component->getLowerClamp(), $score), $this->component->getUpperClamp());
@@ -337,7 +340,8 @@ class GradedComponent extends AbstractModel {
     public function setVerifyTime($verify_time) {
         if ($verify_time === null) {
             $this->verify_time = null;
-        } else {
+        }
+        else {
             try {
                 $this->verify_time = DateUtils::parseDateTime($verify_time, $this->core->getConfig()->getTimezone());
             } catch (\Exception $e) {

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -231,7 +231,8 @@ class GradedComponentContainer extends AbstractModel {
         $graders = count($this->graded_components);
         if ($graders === $required_graders) {
             return true;
-        } else {
+        }
+        else {
             /** @var GradedComponent $graded_component */
             foreach ($this->graded_components as $graded_component) {
                 // TODO: should this be full access?
@@ -323,9 +324,10 @@ class GradedComponentContainer extends AbstractModel {
         foreach ($this->graded_components as $graded_component) {
             $grader = $graded_component->getGrader();
             $verifier_id = $graded_component->getVerifierId();
-            if($grader->accessFullGrading()) {
+            if ($grader->accessFullGrading()) {
                 $visible_graders[$grader->getId()] = $grader;
-            } elseif($verifier_id != '') {
+            }
+            elseif ($verifier_id != '') {
                 $visible_graders[$verifier_id] = $graded_component->getVerifier();
             }
         }

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -269,52 +269,44 @@ class GradedGradeable extends AbstractModel {
         $newNotebook = $this->getGradeable()->getAutogradingConfig()->getNotebook();
 
         foreach ($newNotebook as $notebookKey => $notebookVal) {
-            // Handle if the notebook cell type is short_answer
-            if (
-                isset($notebookVal['type'])
-                && $notebookVal['type'] == "short_answer"
-            ) {
-                // If no previous submissions set string to default initial_value
-                if ($this->getAutoGradedGradeable()->getHighestVersion() == 0) {
-                    $recentSubmission = $notebookVal['initial_value'];
-                }
-                // Else there has been a previous submission try to get it
-                else {
-                    try {
-                        // Try to get the most recent submission
-                        $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename']);
-                    }
-                    catch (AuthorizationException $e) {
-                        // If the user lacked permission then just set to default instructor provided string
+            if (isset($notebookVal['type'])) {
+                if ($notebookVal['type'] == "short_answer") {
+                    // If no previous submissions set string to default initial_value
+                    if ($this->getAutoGradedGradeable()->getHighestVersion() == 0) {
                         $recentSubmission = $notebookVal['initial_value'];
                     }
-                }
-
-                // Add field to the array
-                $newNotebook[$notebookKey]['recent_submission'] = $recentSubmission;
-            }
-
-            // Handle if notebook cell type is multiple_choice
-            elseif (
-                isset($notebookVal['type'])
-                && $notebookVal['type'] == "multiple_choice"
-            ) {
-                // If no previous submissions do nothing
-                if ($this->getAutoGradedGradeable()->getHighestVersion() == 0) {
-                    continue;
-                }
-                // Else there has been a previous submission try to get it
-                else {
-                    try {
-                        // Try to get the most recent submission
-                        $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename']);
-
-                        // Add field to the array
-                        $newNotebook[$notebookKey]['recent_submission'] = $recentSubmission;
+                    else {
+                        // Else there has been a previous submission try to get it
+                        try {
+                            // Try to get the most recent submission
+                            $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename']);
+                        }
+                        catch (AuthorizationException $e) {
+                            // If the user lacked permission then just set to default instructor provided string
+                            $recentSubmission = $notebookVal['initial_value'];
+                        }
                     }
-                    catch (AuthorizationException $e) {
-                        // If failed to get the most recent submission then skip
+
+                    // Add field to the array
+                    $newNotebook[$notebookKey]['recent_submission'] = $recentSubmission;
+                }
+                elseif ($notebookVal['type'] == "multiple_choice") {
+                    // If no previous submissions do nothing, else there has been, so try and get it
+                    if ($this->getAutoGradedGradeable()->getHighestVersion() == 0) {
                         continue;
+                    }
+                    else {
+                        try {
+                            // Try to get the most recent submission
+                            $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename']);
+
+                            // Add field to the array
+                            $newNotebook[$notebookKey]['recent_submission'] = $recentSubmission;
+                        }
+                        catch (AuthorizationException $e) {
+                            // If failed to get the most recent submission then skip
+                            continue;
+                        }
                     }
                 }
             }

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -197,8 +197,8 @@ class GradedGradeable extends AbstractModel {
      * @return int The number of late days the user has for this gradeable
      */
     public function getLateDayException($user = null) {
-        if($user === null) {
-            if($this->gradeable->isTeamAssignment()) {
+        if ($user === null) {
+            if ($this->gradeable->isTeamAssignment()) {
                 throw new \InvalidArgumentException('Must provide user if team assignment');
             }
             return $this->late_day_exceptions[$this->submitter->getId()] ?? 0;
@@ -237,10 +237,11 @@ class GradedGradeable extends AbstractModel {
      * @return float max(0.0, auto_score + ta_score)
      */
     public function getTotalScore() {
-        if ($this->hasOverriddenGrades()){
+        if ($this->hasOverriddenGrades()) {
             $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(), $this->submitter->getId());
             return floatval(max(0.0, $userWithOverriddenGrades->getMarks()));
-        } else {
+        }
+        else {
             return floatval(max(0.0, $this->getTaGradingScore() + $this->getAutoGradingScore()));
         }
     }
@@ -248,7 +249,7 @@ class GradedGradeable extends AbstractModel {
     public function getOverriddenComment() {
         $overridden_comment = "";
         $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(), $this->submitter->getId());
-        if ($userWithOverriddenGrades !== null){
+        if ($userWithOverriddenGrades !== null) {
             $overridden_comment = $userWithOverriddenGrades->getComment();
         }
         return $overridden_comment;
@@ -269,23 +270,21 @@ class GradedGradeable extends AbstractModel {
 
         foreach ($newNotebook as $notebookKey => $notebookVal) {
             // Handle if the notebook cell type is short_answer
-            if(isset($notebookVal['type']) &&
-               $notebookVal['type'] == "short_answer") {
+            if (
+                isset($notebookVal['type'])
+                && $notebookVal['type'] == "short_answer"
+            ) {
                 // If no previous submissions set string to default initial_value
-                if($this->getAutoGradedGradeable()->getHighestVersion() == 0)
-                {
+                if ($this->getAutoGradedGradeable()->getHighestVersion() == 0) {
                     $recentSubmission = $notebookVal['initial_value'];
                 }
                 // Else there has been a previous submission try to get it
-                else
-                {
-                    try
-                    {
+                else {
+                    try {
                         // Try to get the most recent submission
                         $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename']);
                     }
-                    catch (AuthorizationException $e)
-                    {
+                    catch (AuthorizationException $e) {
                         // If the user lacked permission then just set to default instructor provided string
                         $recentSubmission = $notebookVal['initial_value'];
                     }
@@ -296,27 +295,24 @@ class GradedGradeable extends AbstractModel {
             }
 
             // Handle if notebook cell type is multiple_choice
-            elseif(isset($notebookVal['type']) &&
-                    $notebookVal['type'] == "multiple_choice")
-            {
+            elseif (
+                isset($notebookVal['type'])
+                && $notebookVal['type'] == "multiple_choice"
+            ) {
                 // If no previous submissions do nothing
-                if($this->getAutoGradedGradeable()->getHighestVersion() == 0)
-                {
+                if ($this->getAutoGradedGradeable()->getHighestVersion() == 0) {
                     continue;
                 }
                 // Else there has been a previous submission try to get it
-                else
-                {
-                    try
-                    {
+                else {
+                    try {
                         // Try to get the most recent submission
                         $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename']);
 
                         // Add field to the array
                         $newNotebook[$notebookKey]['recent_submission'] = $recentSubmission;
                     }
-                    catch (AuthorizationException $e)
-                    {
+                    catch (AuthorizationException $e) {
                         // If failed to get the most recent submission then skip
                         continue;
                     }
@@ -359,14 +355,12 @@ class GradedGradeable extends AbstractModel {
         $isAuthorized = $this->core->getAccess()->canI('path.read', ["dir" => "submissions", "path" => $complete_file_path]);
 
         // If user lacks permission to get the submission contents throw Auth exception
-        if(!$isAuthorized)
-        {
+        if (!$isAuthorized) {
             throw new AuthorizationException("The user lacks permissions to access this data.");
         }
 
         // If desired file does not exist in the most recent submission directory throw exception
-        if(!file_exists($complete_file_path))
-        {
+        if (!file_exists($complete_file_path)) {
             throw new FileNotFoundException("Unable to locate submission file.");
         }
 
@@ -374,8 +368,7 @@ class GradedGradeable extends AbstractModel {
         $file_contents = file_get_contents($complete_file_path);
 
         // If file_contents is False an error has occured
-        if($file_contents === false)
-        {
+        if ($file_contents === false) {
             throw new IOException("An error occurred retrieving submission contents.");
         }
 

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -136,7 +136,8 @@ class LateDayInfo extends AbstractModel {
             case self::STATUS_NO_ACTIVE_VERSION:
                 if ($this->graded_gradeable->getAutoGradedGradeable()->hasSubmission()) {
                     return 'Cancelled Submission';
-                } else {
+                }
+                else {
                     return 'No Submission';
                 }
             case self::STATUS_GOOD:
@@ -147,7 +148,8 @@ class LateDayInfo extends AbstractModel {
                 $days_late = $this->getDaysLate();
                 if ($days_late > $this->late_days_remaining) {
                     return 'Bad (too many late days used this term)';
-                } else {
+                }
+                else {
                     return 'Bad (too many late days used on this assignment)';
                 }
             default:

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -231,7 +231,8 @@ class LateDays extends AbstractModel {
                 // Due to the way getLateDaysCharged works, this subtraction should never make the
                 //  count go below zero (if it does, fix getLateDaysCharged)
                 $late_days_remaining -= $info->getLateDaysCharged();
-            } elseif (isset($event['update'])) {
+            }
+            elseif (isset($event['update'])) {
                 // Late days update event, so add the difference between the new and old
                 //  available count and add that to the late days remaining.
                 //  Clamp to 0 to ensure that subtractions don't make us go below zero

--- a/site/app/models/gradeable/Mark.php
+++ b/site/app/models/gradeable/Mark.php
@@ -90,7 +90,8 @@ class Mark extends AbstractModel {
     private function setIdInternal($id) {
         if ((is_int($id) || ctype_digit($id)) && intval($id) >= 0) {
             $this->id = intval($id);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Mark Id must be a non-negative integer');
         }
     }
@@ -118,7 +119,8 @@ class Mark extends AbstractModel {
     public function setPoints($points) {
         if (is_numeric($points)) {
             $this->points = $this->getComponent()->getGradeable()->roundPointValue($points);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Mark points must be a number!');
         }
         $this->modified = true;

--- a/site/app/models/gradeable/SubmissionMultipleChoice.php
+++ b/site/app/models/gradeable/SubmissionMultipleChoice.php
@@ -26,7 +26,8 @@ class SubmissionMultipleChoice extends AbstractGradeableInput {
 
         if ($details["allow_multiple"] == true) {
             $this->allow_multiple = true;
-        } else {
+        }
+        else {
             $this->allow_multiple = false;
         }
 

--- a/site/app/models/gradeable/Submitter.php
+++ b/site/app/models/gradeable/Submitter.php
@@ -27,13 +27,14 @@ class Submitter extends AbstractModel {
     public function __construct(Core $core, $team_or_user) {
         parent::__construct($core);
 
-        if($team_or_user === null) {
+        if ($team_or_user === null) {
             throw new \InvalidArgumentException('Team or user must not be null');
         }
 
-        if($team_or_user instanceof Team || $team_or_user instanceof User) {
+        if ($team_or_user instanceof Team || $team_or_user instanceof User) {
             $this->team_or_user = $team_or_user;
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Team or user must be a Team or a User');
         }
     }
@@ -92,7 +93,7 @@ class Submitter extends AbstractModel {
             ? $this->getTeam()->hasMember($user->getId())
             : $this->getUser()->getId() === $user->getId();
     }
-    
+
     /**
      * Gets the anonymous id of the user/team
      * @return string The anonymous id of the submitter

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -379,7 +379,8 @@ class TaGradedGradeable extends AbstractModel {
         else {
             try {
                 $this->user_viewed_date = DateUtils::parseDateTime($user_viewed_date, $this->core->getConfig()->getTimezone());
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 throw new \InvalidArgumentException('Invalid date string format');
             }
         }

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -87,7 +87,8 @@ class TaGradedGradeable extends AbstractModel {
                     $graders[$graded_component->getGrader()->getId()] = $graded_component->getGrader();
                 }
             }
-        } else {
+        }
+        else {
             /** @var GradedComponentContainer $container */
             foreach ($this->graded_component_containers as $container) {
                 $details['graded_components'][$container->getComponent()->getId()] = $container->toArray();
@@ -179,13 +180,15 @@ class TaGradedGradeable extends AbstractModel {
             $v = $container->getGradedVersion();
             if ($v !== false && $strict !== true) {
                 return $v;
-            } elseif ($v === false) {
+            }
+            elseif ($v === false) {
                 return false;
             }
 
             if ($version === false) {
                 $version = $v;
-            } elseif ($version !== $v) {
+            }
+            elseif ($version !== $v) {
                 return false;
             }
         }
@@ -251,7 +254,7 @@ class TaGradedGradeable extends AbstractModel {
     public function getPercentGraded() {
         $running_percent = 0.0;
         /** @var GradedComponentContainer $container */
-        foreach($this->graded_component_containers as $container) {
+        foreach ($this->graded_component_containers as $container) {
             $running_percent += $container->getPercentGraded();
         }
         return Utils::safeCalcPercent($running_percent, count($this->graded_component_containers), false);
@@ -293,7 +296,8 @@ class TaGradedGradeable extends AbstractModel {
     public function setIdFromDatabase($id) {
         if ((is_int($id) || ctype_digit($id)) && intval($id) >= 0) {
             $this->id = intval($id);
-        } else {
+        }
+        else {
             throw new \InvalidArgumentException('Id must be a non-negative integer');
         }
         // Reset the modified flag since this gets called once saved to db or constructor
@@ -345,7 +349,8 @@ class TaGradedGradeable extends AbstractModel {
 
             // Clear the container for this component
             $container->setGradedComponents([]);
-        } else {
+        }
+        else {
             // Otherwise, only delete the component with the provided grader
             $deleted_component = $container->removeGradedComponent($grader);
             if ($deleted_component !== null) {
@@ -370,7 +375,8 @@ class TaGradedGradeable extends AbstractModel {
     public function setUserViewedDate($user_viewed_date) {
         if ($user_viewed_date === null) {
             $this->user_viewed_date = null;
-        } else {
+        }
+        else {
             try {
                 $this->user_viewed_date = DateUtils::parseDateTime($user_viewed_date, $this->core->getConfig()->getTimezone());
             } catch (\Exception $e) {
@@ -395,7 +401,7 @@ class TaGradedGradeable extends AbstractModel {
     public function getGraders() {
         $graders = [];
         /** @var GradedComponentContainer $container */
-        foreach($this->graded_component_containers as $container) {
+        foreach ($this->graded_component_containers as $container) {
             $graders = array_merge($graders, $container->getGraders());
         }
         return $graders;
@@ -408,7 +414,7 @@ class TaGradedGradeable extends AbstractModel {
     public function getVisibleGraders() {
         $graders = [];
         /** @var GradedComponentContainer $container */
-        foreach($this->graded_component_containers as $container) {
+        foreach ($this->graded_component_containers as $container) {
             $graders = array_merge($graders, $container->getVisibleGraders());
         }
         return $graders;

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -10,7 +10,7 @@
     {% endfor %}
 
     {# TODO, eventually remove these form individual twig files and enable this one
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" /> 
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     #}
 
     {% for js_ref in js %}
@@ -32,12 +32,13 @@
                     duck.style.right = -280 + 'px';
 
                     resetDriver();
-                } else {
+                }
+else {
                   pos++;
                   duck.style.right = pos + 'px';
                 }
             }
-        } 
+        }
 
         function resetDriver(){
             var duck = document.getElementById("duckdiv");
@@ -50,7 +51,8 @@
                 if (duck.style.right === '0px'){
                     clearInterval(id);
                     document.getElementById('moorthy-duck').onclick = function(){ducky();}
-                }else{
+                }
+else{
                     pos ++;
                     duck.style.right = pos + 'px';
                 }
@@ -118,24 +120,24 @@
                         {% endfor %}
                     </div>
                 </div>
-                <div id="duckdiv" 
+                <div id="duckdiv"
                     {% if enable_banner %}
                         style="position:relative;top:-30px; right:12px;"
                 >
                     {% else %}
                 >
-                        <a target="_blank" aria-label="Learn more about Moorthy" 
-                        href="http://submitty.org/developer/rcos_moorthy" 
-                        style="padding-right:15px;" 
+                        <a target="_blank" aria-label="Learn more about Moorthy"
+                        href="http://submitty.org/developer/rcos_moorthy"
+                        style="padding-right:15px;"
                         >
                     {% endif %}
-                    <img id="moorthy-duck" 
-                         src="{{ base_url }}/img/{{ duck_img }}" 
-                         alt="Duck Moorthy!" 
-                         height = "50" 
+                    <img id="moorthy-duck"
+                         src="{{ base_url }}/img/{{ duck_img }}"
+                         alt="Duck Moorthy!"
+                         height = "50"
                          {% if enable_banner %}
-                            style="position:absolute; right: 10px;" 
-                            onclick="ducky();" 
+                            style="position:absolute; right: 10px;"
+                            onclick="ducky();"
                             tabindex="0"
                          {% endif %}
                     />
@@ -144,11 +146,11 @@
                     {% endif %}
 
                     {% if enable_banner %}
-                    <img id="submitty-banner" 
+                    <img id="submitty-banner"
                          src="{{ base_url }}/img/submitty-banner.png"
-                         alt="Happy Submitty Week!" 
-                         height="80" 
-                         style="position:absolute;right: -420px; top:-5px;display:none;" 
+                         alt="Happy Submitty Week!"
+                         height="80"
+                         style="position:absolute;right: -420px; top:-5px;display:none;"
                     />
                     {% endif %}
                 </div>

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -33,7 +33,7 @@
 
                     resetDriver();
                 }
-else {
+                else {
                   pos++;
                   duck.style.right = pos + 'px';
                 }
@@ -52,7 +52,7 @@ else {
                     clearInterval(id);
                     document.getElementById('moorthy-duck').onclick = function(){ducky();}
                 }
-else{
+                else {
                     pos ++;
                     duck.style.right = pos + 'px';
                 }

--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -323,7 +323,7 @@
                         if(json['status'] == 'fail') {
                             var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
                         }
-else {
+                        else {
                             var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['data'] + '</div>';
                         }
                     } catch(err) {

--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -322,7 +322,8 @@
                         var json = JSON.parse(data);
                         if(json['status'] == 'fail') {
                             var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                        }else {
+                        }
+else {
                             var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['data'] + '</div>';
                         }
                     } catch(err) {

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -178,7 +178,8 @@
         let no_due_date = $('#has_due_date_no');
         if($('#yes_student_submit').is(':checked')) {
             cont.show();
-        } else {
+        }
+else {
             no_due_date.prop('checked', true);
             cont.hide();
         }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -179,7 +179,7 @@
         if($('#yes_student_submit').is(':checked')) {
             cont.show();
         }
-else {
+        else {
             no_due_date.prop('checked', true);
             cont.hide();
         }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -438,7 +438,7 @@
             disableElementChildren('#vcs_submitty_set_url_content', false);
             $('#vcs_submitty_url').prop('required', true);
         }
-else {
+        else {
             $('#vcs_submitty_url').prop('required', false);
         }
     }
@@ -463,7 +463,7 @@ else {
         if($('#yes_late_submission').is(':checked')) {
             lateSubmissionParts.show();
         }
-else {
+        else {
             lateSubmissionParts.hide();
         }
         updateDateDisplay();
@@ -531,13 +531,13 @@ else {
             if ($(this).val() === 'scanned_exam') {
                 scannedExam.val('true');
             }
-else {
+            else {
                 scannedExam.val('false');
                 if ($(this).val() === 'vcs') {
                     vcs.val('true');
                     $('#repository').show();
                 }
-else {
+                else {
                 }
             }
             vcs.change();

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -437,7 +437,8 @@
         if($('#vcs_radio_submitty_hosted_set_url').is(':checked')) {
             disableElementChildren('#vcs_submitty_set_url_content', false);
             $('#vcs_submitty_url').prop('required', true);
-        } else {
+        }
+else {
             $('#vcs_submitty_url').prop('required', false);
         }
     }
@@ -461,7 +462,8 @@
         let lateSubmissionParts = $('.yes-late-submission');
         if($('#yes_late_submission').is(':checked')) {
             lateSubmissionParts.show();
-        } else {
+        }
+else {
             lateSubmissionParts.hide();
         }
         updateDateDisplay();
@@ -528,12 +530,14 @@
             $('#repository').hide();
             if ($(this).val() === 'scanned_exam') {
                 scannedExam.val('true');
-            } else {
+            }
+else {
                 scannedExam.val('false');
                 if ($(this).val() === 'vcs') {
                     vcs.val('true');
                     $('#repository').show();
-                } else {
+                }
+else {
                 }
             }
             vcs.change();

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -121,7 +121,7 @@
                 cont.hide();
                 cont1.hide();
             }
-else {
+            else {
                 cont.show();
                 cont1.show();
             }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -120,7 +120,8 @@
             if($('#has_due_date_no').is(':checked')) {
                 cont.hide();
                 cont1.hide();
-            } else {
+            }
+else {
                 cont.show();
                 cont1.show();
             }

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -3,7 +3,7 @@
 {% if show_more %}
 	<script>
 
-		$(document).ready(function() { 
+		$(document).ready(function() {
 
 			$('#{{ more_data[0]["filter_option"] }}').parent().removeClass("active");
 			$('#{{ more_data[0]["filter_option"] }}').addClass("active");
@@ -16,7 +16,8 @@
 
 			if('{{ more_data[0]["filter_option"] }}' === 'tree' && !deleteActive && !deleteMerge) {
 				$('#dropdownLabel').removeClass("active");
-			} else {
+			}
+else {
 				$('#dropdownLabel').addClass("active");
 			}
 
@@ -72,7 +73,7 @@
 		{% endif %}
 
 		</div>
-		
+
 	<div class="col-4">
 
 		{% for button in forum_bar_buttons_right %}

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -17,7 +17,7 @@
 			if('{{ more_data[0]["filter_option"] }}' === 'tree' && !deleteActive && !deleteMerge) {
 				$('#dropdownLabel').removeClass("active");
 			}
-else {
+			else {
 				$('#dropdownLabel').addClass("active");
 			}
 

--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -53,7 +53,8 @@
 
         if ($(this).html().indexOf(' ↓') > -1) {
             sortTable(table_id, true);
-        } else {
+        }
+else {
             sortTable(table_id, false);
         }
     });

--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -54,7 +54,7 @@
         if ($(this).html().indexOf(' ↓') > -1) {
             sortTable(table_id, true);
         }
-else {
+        else {
             sortTable(table_id, false);
         }
     });

--- a/site/app/templates/grading/electronic/PDFAnnotationBar.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationBar.twig
@@ -62,7 +62,7 @@
         colorEvent = document.createEvent("HTMLEvents");
         colorEvent.initEvent('colorchange', true, true);
     }
-else {
+    else {
         colorEvent = document.createEventObject();
         colorEvent.eventType = "colorchange";
     }

--- a/site/app/templates/grading/electronic/PDFAnnotationBar.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationBar.twig
@@ -61,7 +61,8 @@
     if(document.createEvent){
         colorEvent = document.createEvent("HTMLEvents");
         colorEvent.initEvent('colorchange', true, true);
-    } else {
+    }
+else {
         colorEvent = document.createEventObject();
         colorEvent.eventType = "colorchange";
     }

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -177,7 +177,8 @@
                     $('#file_content').append(data);
                 }
             });
-        } else {
+        }
+else {
             $('#save_status').hide();
             $('#file_content').append("<div id=\"file_viewer_full_panel\" class=\"full_panel\" data-file_name=\"\" data-file_url=\"\"></div>");
             $("#file_viewer_full_panel").empty();

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -178,7 +178,7 @@
                 }
             });
         }
-else {
+        else {
             $('#save_status').hide();
             $('#file_content').append("<div id=\"file_viewer_full_panel\" class=\"full_panel\" data-file_name=\"\" data-file_url=\"\"></div>");
             $("#file_viewer_full_panel").empty();

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -198,7 +198,7 @@
                     user_id.push(tmp_user);
             }
         }
-else{
+        else {
             var user_id = user_id_textarea.value;
         }
 
@@ -208,11 +208,11 @@ else{
         //verify user id is valid, then assign
         validateUserId(CSRF, g_id, user_id)
         .then(function(response){
-            if(response['data']['previous_submission'] === false){
+            if(response['data']['previous_submission'] === false) {
                 //no previous submission, submit split item normally
                 uploadSplitHelper(user_id,path, index);
             }
-else{
+            else {
                 //user_id has previous submission give options to user first
                 let has_been_called = false;
                 var option = displayPreviousSubmissionOptions(getSubmissionOption);
@@ -232,7 +232,7 @@ else{
                         if(is_team_assignment){
                             document.getElementById("bulk_user_id_" + String(index) + "[" + String(max_team_size-1) + "]").focus();
                         }
-else{
+                        else{
                             user_id_textarea.focus();
                         }
                         return;
@@ -244,7 +244,7 @@ else{
                     if(option == 2){
                         merge_previous = true;
                     }
-else if(option == 3){
+                    else if(option == 3){
                         merge_previous = true;
                         clobber = true;
                     }
@@ -297,7 +297,7 @@ else if(option == 3){
                 toggleButtons(index, false);
             });
         }
-else{
+        else{
             //enable submit options if we don't delete
             toggleButtons(index, false);
         }
@@ -315,11 +315,11 @@ else{
             if(text_area.disabled === false){
                 user_id = text_area.value;
             }
-else{
+            else{
                 return submitAll(index + 1);
             }
         }
-else{
+        else{
             return submitAll(index + 1);
         }
         //if the expected page count doesn't match skip and let the user decide
@@ -346,7 +346,7 @@ else{
                 uploadSplitHelper(user_id,path,index);
                 return submitAll(index + 1);
             }
-else{
+            else{
                 return submitAll(index + 1);
             }
         })
@@ -375,7 +375,7 @@ else{
         if(submit_btn === null){
             return deleteAll(index + 1);
         }
-else if(submit_btn.disabled === true){
+        else if(submit_btn.disabled === true){
             return deleteAll(index + 1);
         }
         var path = decodeURIComponent(path_list[index]);

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -47,10 +47,10 @@
                     <td id="input_area">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                         <div id="users_{{ loop.index }}">
-                            <input type="text" id="bulk_user_id_{{ loop.index }}" aria-label = "Enter User ID to assign" 
+                            <input type="text" id="bulk_user_id_{{ loop.index }}" aria-label = "Enter User ID to assign"
                                 value ="{{ file["id"] }}"
                                 {# we should only submit on enter for normal bulk uploads or on the last team upload box #}
-                                {% if not team_assignment %} 
+                                {% if not team_assignment %}
                                     onkeydown="uploadOnEnter( {{ loop.index }}, event );"
                                 {% else %}
                                     onkeydown="focusNextOnEnter({{ loop.index }}, 0)"
@@ -60,12 +60,12 @@
                                 {# (size - 1) because twig loops are range inclusive #}
                                 {% set outer_loop = loop %}
                                 {% for i in 1..(max_team_size - 1) %}
-                                    <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value ="" 
+                                    <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value =""
                                         {# if this is the last input box submit on enter, otherwise move to next box#}
                                         {% if i == (max_team_size - 1) %}
-                                            onkeydown="uploadOnEnter({{ outer_loop.index }}, event);" 
+                                            onkeydown="uploadOnEnter({{ outer_loop.index }}, event);"
                                         {% else %}
-                                            onkeydown="focusNextOnEnter({{ outer_loop.index}}, {{ i }} )" 
+                                            onkeydown="focusNextOnEnter({{ outer_loop.index}}, {{ i }} )"
                                         {% endif %}
                                     />
                                 {% endfor %}
@@ -103,7 +103,7 @@
             document.getElementById("expected_pages_input").value = sessionStorage.getItem("expected_count");
 
         $("td > div :text").autocomplete({
-            source: students_full 
+            source: students_full
         });
         highlightPageCount();
     });
@@ -159,7 +159,7 @@
         let next = document.getElementById("bulk_user_id_" + String(index + 1));
         if( next ){
             document.getElementById("bulk_user_id_" + String(index + 1)).focus();
-        }    
+        }
     }
 
     //if the user presses 'enter' try and make a submission as if hitting the submit button
@@ -174,10 +174,10 @@
         var key = window.event ? window.event.keyCode : e.keyCode;
         if(key !== 13)
             return;
-        var input_box  = document.getElementById("bulk_user_id_" + String(table_row) + "[" + String(input_index + 1) + "]" ); 
+        var input_box  = document.getElementById("bulk_user_id_" + String(table_row) + "[" + String(input_index + 1) + "]" );
         if(!input_box)
             return;
-        
+
         input_box.focus();
     }
 
@@ -197,7 +197,8 @@
                 if(tmp_user != "")
                     user_id.push(tmp_user);
             }
-        }else{
+        }
+else{
             var user_id = user_id_textarea.value;
         }
 
@@ -210,11 +211,12 @@
             if(response['data']['previous_submission'] === false){
                 //no previous submission, submit split item normally
                 uploadSplitHelper(user_id,path, index);
-            }else{
+            }
+else{
                 //user_id has previous submission give options to user first
                 let has_been_called = false;
                 var option = displayPreviousSubmissionOptions(getSubmissionOption);
-                
+
                 return;
 
                 //callback function once user actually picks something
@@ -229,7 +231,8 @@
                         //if the user does nothing focus back on the first box or the last team box
                         if(is_team_assignment){
                             document.getElementById("bulk_user_id_" + String(index) + "[" + String(max_team_size-1) + "]").focus();
-                        }else{
+                        }
+else{
                             user_id_textarea.focus();
                         }
                         return;
@@ -240,7 +243,8 @@
 
                     if(option == 2){
                         merge_previous = true;
-                    } else if(option == 3){
+                    }
+else if(option == 3){
                         merge_previous = true;
                         clobber = true;
                     }
@@ -292,7 +296,8 @@
 
                 toggleButtons(index, false);
             });
-        }else{
+        }
+else{
             //enable submit options if we don't delete
             toggleButtons(index, false);
         }
@@ -309,10 +314,12 @@
         if(text_area !== null){
             if(text_area.disabled === false){
                 user_id = text_area.value;
-            }else{
+            }
+else{
                 return submitAll(index + 1);
             }
-        }else{
+        }
+else{
             return submitAll(index + 1);
         }
         //if the expected page count doesn't match skip and let the user decide
@@ -338,7 +345,8 @@
                 moveToNextSubmission(index);
                 uploadSplitHelper(user_id,path,index);
                 return submitAll(index + 1);
-            }else{
+            }
+else{
                 return submitAll(index + 1);
             }
         })
@@ -366,7 +374,8 @@
 
         if(submit_btn === null){
             return deleteAll(index + 1);
-        }else if(submit_btn.disabled === true){
+        }
+else if(submit_btn.disabled === true){
             return deleteAll(index + 1);
         }
         var path = decodeURIComponent(path_list[index]);

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -92,9 +92,11 @@
                 if(sessionStorage.getItem('radio-bulk')){
                     $('#radio-bulk').prop('checked', true);
                     $('#bulk_progress_box').prop('hidden', false);
-                }else if(sessionStorage.getItem('radio-student')){
+                }
+else if(sessionStorage.getItem('radio-student')){
                     $('#radio-student').prop('checked',true);
-                }else{
+                }
+else{
                     $('#radio-normal').prop('checked',true);
                 }
                 //load if bulkupload with qr codes selected or not
@@ -120,7 +122,8 @@
                 if ($("#radio-bulk").is(":checked")) {
                     $('#pdf-submit-button').show();
                     $('#bulk_progress_box').prop('hidden', false);
-                }else{
+                }
+else{
                      $('#bulk_progress_box').prop('hidden', true);
                 }
                 if($('#use-qr').is(':checked')){
@@ -333,7 +336,7 @@
                                                name="multiple_choice_{{ num_multiple_choice }}"
                                                id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                                value="{{ choice.value }}"
-                                               onclick="handle_input_keypress();" 
+                                               onclick="handle_input_keypress();"
                                         />
                                         {{ choice.description | markdown }}
                                     </label>
@@ -349,13 +352,13 @@
 
                                 {{ self.render_testcase_messages(cell, testcase_messages) }}
 
-                                {% for choice in cell.choices %}                                      
+                                {% for choice in cell.choices %}
                                     <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
                                         <input type="radio"
                                                name="multiple_choice_{{ num_multiple_choice }}"
                                                id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                                value="{{ choice.value }}"
-                                               onclick="handle_input_keypress();" 
+                                               onclick="handle_input_keypress();"
                                         />
                                         {{ choice.description | markdown }}
                                     </label>
@@ -511,7 +514,7 @@
 </div>
 
 {% if core.getUser().accessFullGrading() %}
-    {% include 'submission/homework/PreviousSubmissionForm.twig' %}            
+    {% include 'submission/homework/PreviousSubmissionForm.twig' %}
     {% include 'submission/homework/BulkUploadProgressBox.twig' %}
 {% endif %}
 
@@ -590,10 +593,10 @@
             }
             // bulk upload
             if ($("#radio-bulk").is(":checked")) {
-                handleBulk("{{ gradeable_id }}", 
-                            {{ max_post_size }}, 
+                handleBulk("{{ gradeable_id }}",
+                            {{ max_post_size }},
                             {{ max_file_size }},
-                            num_pages, use_qr, qr_prefix, qr_suffix 
+                            num_pages, use_qr, qr_prefix, qr_suffix
                           );
             }
             // no user id entered, upload for whoever is logged in
@@ -619,14 +622,16 @@
 
                             if(option == 2){
                                 merge_previous = true;
-                            } else if(option == 3){
+                            }
+else if(option == 3){
                                 merge_previous = true;
                                 clobber = true;
                             }
 
                             makeSubmission(user_id,response['data']['highest_version'], false, "", "", "", merge_previous,clobber);
                         }
-                    }else{
+                    }
+else{
                         makeSubmission(user_id, response['data']['highest_version'], false, "", "", "");
                     }
                 });

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -93,10 +93,10 @@
                     $('#radio-bulk').prop('checked', true);
                     $('#bulk_progress_box').prop('hidden', false);
                 }
-else if(sessionStorage.getItem('radio-student')){
+                else if(sessionStorage.getItem('radio-student')){
                     $('#radio-student').prop('checked',true);
                 }
-else{
+                else{
                     $('#radio-normal').prop('checked',true);
                 }
                 //load if bulkupload with qr codes selected or not
@@ -123,7 +123,7 @@ else{
                     $('#pdf-submit-button').show();
                     $('#bulk_progress_box').prop('hidden', false);
                 }
-else{
+                else{
                      $('#bulk_progress_box').prop('hidden', true);
                 }
                 if($('#use-qr').is(':checked')){
@@ -623,7 +623,7 @@ else{
                             if(option == 2){
                                 merge_previous = true;
                             }
-else if(option == 3){
+                            else if(option == 3){
                                 merge_previous = true;
                                 clobber = true;
                             }
@@ -631,7 +631,7 @@ else if(option == 3){
                             makeSubmission(user_id,response['data']['highest_version'], false, "", "", "", merge_previous,clobber);
                         }
                     }
-else{
+                    else{
                         makeSubmission(user_id, response['data']['highest_version'], false, "", "", "");
                     }
                 });

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -182,10 +182,10 @@ class AutoGradingView extends AbstractView {
                     }
                     else {
                         $check["actual"] = [
-                        "type" => "text",
-                        "title" => $actual_title,
-                        "show_popup" => $this->autoShouldDisplayPopup($actual_display),
-                        "src" => $actual_display,
+                            "type" => "text",
+                            "title" => $actual_title,
+                            "show_popup" => $this->autoShouldDisplayPopup($actual_display),
+                            "src" => $actual_display,
                         ];
                     }
                 }
@@ -203,10 +203,10 @@ class AutoGradingView extends AbstractView {
                 }
                 elseif ($diff_viewer->hasDisplayExpected()) {
                     $check["expected"] = [
-                    "type" => "text",
-                    "title" => $expected_title,
-                    "show_popup" => $this->autoShouldDisplayPopup($expected_display),
-                    "src" => $expected_display
+                        "type" => "text",
+                        "title" => $expected_title,
+                        "show_popup" => $this->autoShouldDisplayPopup($expected_display),
+                        "src" => $expected_display
                     ];
                 }
 
@@ -214,10 +214,10 @@ class AutoGradingView extends AbstractView {
                 $difference_title = "Difference {$description}";
                 if ($difference_image != "") {
                     $check["difference"] = [
-                    "type" => "image",
-                    "title" => $difference_title,
-                    "show_popup" => false,
-                    "src" => $this->autoGetImageSrc($difference_image)
+                        "type" => "image",
+                        "title" => $difference_title,
+                        "show_popup" => false,
+                        "src" => $this->autoGetImageSrc($difference_image)
                     ];
                 }
 

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -84,7 +84,7 @@ class AutoGradingView extends AbstractView {
                 ($version_instance->getNonHiddenNonExtraCredit() + $version_instance->getHiddenNonExtraCredit() > $autograding_config->getTotalNonHiddenNonExtraCredit());
         }
         // testcases should only be visible if autograding is complete
-        if(!$incomplete_autograding) {
+        if (!$incomplete_autograding) {
             foreach ($version_instance->getTestcases() as $testcase) {
                 if ($testcase->canView()) {
                     $num_visible_testcases++;
@@ -149,7 +149,8 @@ class AutoGradingView extends AbstractView {
                         "path" => $file_path
                     ])
                 ];
-            } else {
+            }
+            else {
                 $check = [
                     "messages" => $autocheck->getMessages(),
                     "description" => $description
@@ -169,20 +170,22 @@ class AutoGradingView extends AbstractView {
                         "show_popup" => false,
                         "src" => $this->autoGetImageSrc($actual_image),
                     ];
-                } elseif ($diff_viewer->hasDisplayActual()) {
-                    if($autocheck->isDisplayAsSequenceDiagram()){
+                }
+                elseif ($diff_viewer->hasDisplayActual()) {
+                    if ($autocheck->isDisplayAsSequenceDiagram()) {
                         $check["actual"] = [
                             "type" => "sequence_diagram",
                             "title" => $actual_title,
                             "show_popup" => $this->autoShouldDisplayPopup($actual_display),
                             "src" => file_get_contents($diff_viewer->getActualFilename())
                         ];
-                    }else{
+                    }
+                    else {
                         $check["actual"] = [
-                            "type" => "text",
-                            "title" => $actual_title,
-                            "show_popup" => $this->autoShouldDisplayPopup($actual_display),
-                            "src" => $actual_display,
+                        "type" => "text",
+                        "title" => $actual_title,
+                        "show_popup" => $this->autoShouldDisplayPopup($actual_display),
+                        "src" => $actual_display,
                         ];
                     }
                 }
@@ -197,12 +200,13 @@ class AutoGradingView extends AbstractView {
                         "show_popup" => false,
                         "src" => $this->autoGetImageSrc($expected_image)
                     ];
-                } elseif ($diff_viewer->hasDisplayExpected()) {
+                }
+                elseif ($diff_viewer->hasDisplayExpected()) {
                     $check["expected"] = [
-                        "type" => "text",
-                        "title" => $expected_title,
-                        "show_popup" => $this->autoShouldDisplayPopup($expected_display),
-                        "src" => $expected_display
+                    "type" => "text",
+                    "title" => $expected_title,
+                    "show_popup" => $this->autoShouldDisplayPopup($expected_display),
+                    "src" => $expected_display
                     ];
                 }
 
@@ -210,10 +214,10 @@ class AutoGradingView extends AbstractView {
                 $difference_title = "Difference {$description}";
                 if ($difference_image != "") {
                     $check["difference"] = [
-                        "type" => "image",
-                        "title" => $difference_title,
-                        "show_popup" => false,
-                        "src" => $this->autoGetImageSrc($difference_image)
+                    "type" => "image",
+                    "title" => $difference_title,
+                    "show_popup" => false,
+                    "src" => $this->autoGetImageSrc($difference_image)
                     ];
                 }
 
@@ -304,7 +308,8 @@ class AutoGradingView extends AbstractView {
         // Special messages for peer / mentor-only grades
         if ($gradeable->isPeerGrading()) {
             $grader_names = ['Graded by Peer(s)'];
-        } elseif (count($grader_names) === 0) {
+        }
+        elseif (count($grader_names) === 0) {
             // Non-peer assignment with only limited access graders
             $grader_names = ['Course Staff'];
         }
@@ -371,13 +376,13 @@ class AutoGradingView extends AbstractView {
         }, $gradeable->getComponents());
 
         $uploaded_pdfs = [];
-        foreach($uploaded_files['submissions'] as $file){
-            if(array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf"){
+        foreach ($uploaded_files['submissions'] as $file) {
+            if (array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf") {
                 $uploaded_pdfs[] = $file;
             }
         }
-        foreach($uploaded_files['checkout'] as $file){
-            if(array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf"){
+        foreach ($uploaded_files['checkout'] as $file) {
+            if (array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf") {
                 $uploaded_pdfs[] = $file;
             }
         }
@@ -386,22 +391,22 @@ class AutoGradingView extends AbstractView {
         //trying something
         $gradeable_id = $gradeable->getId();
         $id = $this->core->getUser()->getId();
-        if($gradeable->isTeamAssignment()){
+        if ($gradeable->isTeamAssignment()) {
             $id = $this->core->getQueries()->getTeamByGradeableAndUser($gradeable_id, $id)->getId();
         }
         $annotation_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotations', $gradeable_id, $id, $active_version);
         $annotated_file_names = [];
-        if(is_dir($annotation_path) && count(scandir($annotation_path)) > 2){
+        if (is_dir($annotation_path) && count(scandir($annotation_path)) > 2) {
             $first_file = scandir($annotation_path)[2];
             $annotation_path = FileUtils::joinPaths($annotation_path, $first_file);
-            if(is_file($annotation_path)) {
+            if (is_file($annotation_path)) {
                 $dir_iter = new \DirectoryIterator(dirname($annotation_path . '/'));
                 foreach ($dir_iter as $fileinfo) {
                     if (!$fileinfo->isDot()) {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = $pdf_info[0];
-                        if(file_get_contents($fileinfo->getPathname()) != ""){
+                        if (file_get_contents($fileinfo->getPathname()) != "") {
                             $pdf_id = $pdf_id . '.pdf';
                             $annotated_file_names[] = $pdf_id;
                         }
@@ -411,9 +416,10 @@ class AutoGradingView extends AbstractView {
         }
 
         // for bulk uploads only show PDFs
-        if ($gradeable->isScannedExam()){
+        if ($gradeable->isScannedExam()) {
             $files = $uploaded_pdfs;
-        }else{
+        }
+        else {
             $files = array_merge($files['submissions'], $files['checkout']);
         }
 

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -29,7 +29,8 @@ class GlobalView extends AbstractView {
         $page_title = "Submitty";
         if ($this->core->getUser() === null) {
             $page_title = "Submitty Login";
-        } elseif ($this->core->getConfig()->isCourseLoaded()) {
+        }
+        elseif ($this->core->getConfig()->isCourseLoaded()) {
             $page_title = "Submitty " . $course_name . " " . $page_name;
         }
 

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -22,11 +22,11 @@ class HomePageView extends AbstractView {
             User::GROUP_STUDENT                 => "Student:"
         ];
 
-        foreach($course_types as $course_type) {
+        foreach ($course_types as $course_type) {
             $ranks = array();
 
             //Create rank lists
-            for ($i = 1; $i < 5; $i++){
+            for ($i = 1; $i < 5; $i++) {
                 $ranks[$i] = [];
                 $ranks[$i]["title"] = $rank_titles[$i];
                 $ranks[$i]["courses"] = [];

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -85,17 +85,17 @@ class NavigationView extends AbstractView {
         $display_custom_message = $this->core->getConfig()->displayCustomMessage();
         $message_file_details = null;
         //Course settings have enabled displaying custom (banner) message
-        if($display_custom_message) {
+        if ($display_custom_message) {
             $message_file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "reports", "summary_html", $this->core->getUser()->getId() . ".json");
             $display_custom_message = is_file($message_file_path);
             //If statement seems redundant, but will help in case we ever decouple the is_file check from $display_custom_message
             if ($display_custom_message && is_file($message_file_path)) {
                 $message_json = json_decode(file_get_contents($message_file_path));
-                if(property_exists($message_json, 'special_message')){
+                if (property_exists($message_json, 'special_message')) {
                     $message_file_details = $message_json->special_message;
 
                     //If any fields are missing, treat this as though we just didn't have a message for this user.
-                    if(!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename')){
+                    if (!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename')) {
                         $display_custom_message = false;
                         $messsage_file_details = null;
                     }
@@ -118,13 +118,13 @@ class NavigationView extends AbstractView {
         $gradeable_title = null;
         $seating_config = null;
         // If the instructor has selected a gradeable for room seating
-        if($display_room_seating) {
+        if ($display_room_seating) {
             $this->core->getOutput()->addRoomTemplatesTwigPath();
             // use the room seating gradeable id to find the title to display.
             $gradeable_id = $this->core->getConfig()->getRoomSeatingGradeableId();
             $gradeable_ids_and_titles = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
-            foreach($gradeable_ids_and_titles as $gradeable_id_and_title) {
-                if($gradeable_id_and_title['g_id'] === $gradeable_id) {
+            foreach ($gradeable_ids_and_titles as $gradeable_id_and_title) {
+                if ($gradeable_id_and_title['g_id'] === $gradeable_id) {
                     $gradeable_title = $gradeable_id_and_title['g_title'];
                     break;
                 }
@@ -132,11 +132,11 @@ class NavigationView extends AbstractView {
 
             $seating_user_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'reports', 'seating', $gradeable_id, $this->core->getUser()->getId() . ".json");
             // if the instructor has generated a report for the student for this gradeable
-            if(is_file($seating_user_path)) {
+            if (is_file($seating_user_path)) {
                 $user_seating_details = json_decode(file_get_contents($seating_user_path));
 
                 // if the user seating details have both a building and a room property
-                if(property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
+                if (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
                     $seating_config_path = FileUtils::joinPaths(
                         $this->core->getConfig()->getCoursePath(),
                         'uploads',
@@ -336,14 +336,16 @@ class NavigationView extends AbstractView {
 
         if ($past_lock_date) {
             $team_display_date = "(teams lock {$gradeable->getTeamLockDate()->format(self::DATE_FORMAT)})";
-        } else {
+        }
+        else {
             $team_display_date = '';
         }
 
         if ($graded_gradeable === null || $graded_gradeable->getSubmitter()->getTeam() === null) {
             if ($past_lock_date) {
                 $team_button_type = 'btn-primary';
-            } else {
+            }
+            else {
                 $team_button_type = 'btn-danger';
             }
             $team_button_text = 'CREATE TEAM';
@@ -354,11 +356,13 @@ class NavigationView extends AbstractView {
                     break;
                 }
             }
-        } else {
+        }
+        else {
             if ($past_lock_date) {
                 $team_button_type = 'btn-primary';
                 $team_button_text = 'MANAGE TEAM';
-            } else {
+            }
+            else {
                 $team_button_type = 'btn-default';
                 $team_button_text = 'VIEW TEAM';
             }
@@ -405,37 +409,46 @@ class NavigationView extends AbstractView {
             return $button;
         }
 
-        if($graded_gradeable !== null) {
+        if ($graded_gradeable !== null) {
             /** @var TaGradedGradeable $ta_graded_gradeable */
             $ta_graded_gradeable = $graded_gradeable->getTaGradedGradeable();
             /** @var AutoGradedGradeable $auto_graded_gradeable */
             $auto_graded_gradeable = $graded_gradeable->getAutoGradedGradeable();
 
             //calculate the point percentage
-            if($auto_graded_gradeable !== null) {
+            if ($auto_graded_gradeable !== null) {
                 $points_percent = $auto_graded_gradeable->getNonHiddenPercent(true);
             }
 
 
             //If the button is autograded and has been submitted once, give a progress bar.
-            if (!is_nan($points_percent) && $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
-                ($list_section == GradeableList::CLOSED || $list_section == GradeableList::OPEN)) {
+            if (
+                !is_nan($points_percent)
+                && $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete()
+                && ($list_section == GradeableList::CLOSED || $list_section == GradeableList::OPEN)
+            ) {
                 $progress = $points_percent * 100;
             }
 
             // Not submitted or cancelled, after submission deadline
-            if (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
-                ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
+            if (
+                !$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete()
+                && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)
+            ) {
                 //You forgot to submit
                 $class = "btn-danger";
             }
 
             // TA grading enabled, the gradeable is fully graded, and the user hasn't viewed it
-            $grade_ready_for_view = $gradeable->isTaGrading() && $graded_gradeable->isTaGradingComplete() &&
-                $list_section === GradeableList::GRADED;
+            $grade_ready_for_view = $gradeable->isTaGrading()
+                && $graded_gradeable->isTaGradingComplete()
+                && $list_section === GradeableList::GRADED;
+
             if ($gradeable->isTeamAssignment()) {
-                if ($grade_ready_for_view &&
-                    $this->core->getQueries()->getTeamViewedTime($graded_gradeable->getSubmitter()->getId(), $this->core->getUser()->getId()) === null) {
+                if (
+                    $grade_ready_for_view
+                    && $this->core->getQueries()->getTeamViewedTime($graded_gradeable->getSubmitter()->getId(), $this->core->getUser()->getId()) === null
+                ) {
                     $class = "btn-success";
                 }
             }
@@ -447,31 +460,39 @@ class NavigationView extends AbstractView {
             }
 
             // Submitted, currently after grade released date
-            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
-                $list_section == GradeableList::GRADED) {
+            if (
+                $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete()
+                && $list_section == GradeableList::GRADED
+            ) {
                 if ($gradeable->isTaGrading()) {
                     if (!$graded_gradeable->isTaGradingComplete()) {
                         // Incomplete TA grading
                         $class = "btn-default";
                     }
-                } else {
+                }
+                else {
                     // No TA grading
                     $class = "btn-default";
                 }
             }
 
             // Due date passed with at least 50 percent points in autograding or gradable with no autograding points
-            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
-                (
-                    !$gradeable->getAutogradingConfig()->anyPoints() ||
-                    $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() != 0 && $points_percent >= 0.5
-                ) &&
-                $list_section == GradeableList::CLOSED) {
+            if (
+                $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete()
+                && (
+                    !$gradeable->getAutogradingConfig()->anyPoints()
+                    || $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() != 0
+                    && $points_percent >= 0.5
+                )
+                && $list_section == GradeableList::CLOSED
+            ) {
                 $class = "btn-default";
             }
 
-            if ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() &&
-                ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
+            if (
+                $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete()
+                && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)
+            ) {
                 $display_date = "";
             }
             if (!$gradeable->hasDueDate()) {
@@ -482,38 +503,47 @@ class NavigationView extends AbstractView {
                 $title = "BULK UPLOAD";
                 $class = "btn-primary";
                 $display_date = "";
-            } elseif ($gradeable->isStudentSubmit() && !$gradeable->hasDueDate() && $list_section != GradeableList::OPEN) {
+            }
+            elseif ($gradeable->isStudentSubmit() && !$gradeable->hasDueDate() && $list_section != GradeableList::OPEN) {
                 $title = "SUBMIT";
                 $class = "btn-default";
-            } elseif ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::OPEN) {
+            }
+            elseif ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::OPEN) {
                 //if the user submitted something on time
                 $title = "RESUBMIT";
-            } elseif ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::CLOSED) {
+            }
+            elseif ($graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && $list_section == GradeableList::CLOSED) {
                 //if the user submitted something past time
                 if ($gradeable->isLateSubmissionAllowed()) {
                     $title = "LATE RESUBMIT";
-                } else {
+                }
+                else {
                     $title = "VIEW SUBMISSION";
                     $class = 'btn-default';
                     $display_date = "";
                 }
-            } elseif (!$graded_gradeable->getAutoGradedGradeable()->hasSubmission() && !$gradeable->isLateSubmissionAllowed() && $list_section == GradeableList::CLOSED) {
+            }
+            elseif (!$graded_gradeable->getAutoGradedGradeable()->hasSubmission() && !$gradeable->isLateSubmissionAllowed() && $list_section == GradeableList::CLOSED) {
                 $title = "NO SUBMISSION";
                 $class = "btn-danger";
                 $display_date = "";
-            } elseif (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
+            }
+            elseif (!$graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete() && ($list_section == GradeableList::GRADED || $list_section == GradeableList::GRADING)) {
                 //to change the text to overdue submission if nothing was submitted on time
                 if ($gradeable->isStudentSubmit()) {
                     $title = "OVERDUE SUBMISSION";
-                } else {
+                }
+                else {
                     $title = "NO SUBMISSION";
                     $display_date = "";
                 }
-            } elseif ($gradeable->isTaGrading() && !$graded_gradeable->isTaGradingComplete() && $list_section == GradeableList::GRADED) {
+            }
+            elseif ($gradeable->isTaGrading() && !$graded_gradeable->isTaGradingComplete() && $list_section == GradeableList::GRADED) {
                 //when there is no TA grade and due date passed
                 $title = "TA GRADE NOT AVAILABLE";
             }
-        } else {
+        }
+        else {
             // This means either the user isn't on a team
             if ($gradeable->isTeamAssignment()) {
                 // team assignment, no team
@@ -552,15 +582,16 @@ class NavigationView extends AbstractView {
      */
     private function getGradeButton(Gradeable $gradeable, int $list_section) {
         //Location, location never changes
-        if($this->core->getUser()->accessAdmin()){
+        if ($this->core->getUser()->accessAdmin()) {
             $view = "all";
         }
-        else{
+        else {
             $view = null;
         }
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'status']);
-        } elseif ($gradeable->getType() === GradeableType::CHECKPOINTS || $gradeable->getType() === GradeableType::NUMERIC_TEXT) {
+        }
+        elseif ($gradeable->getType() === GradeableType::CHECKPOINTS || $gradeable->getType() === GradeableType::NUMERIC_TEXT) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading']) . '?view=' . $view;
         }
         else {
@@ -604,7 +635,8 @@ class NavigationView extends AbstractView {
             if ($list_section === GradeableList::GRADING && $date < $grades_due) {
                 $title = 'GRADE';
                 $date_text = '(grades due ' . $gradeable->getGradeDueDate()->format(self::DATE_FORMAT) . ')';
-            } elseif($list_section === GradeableList::GRADING && $date < $grades_released){
+            }
+            elseif ($list_section === GradeableList::GRADING && $date < $grades_released) {
                 $title = 'GRADE';
                 $date_text = '(grades will be released ' . $grades_released->format(self::DATE_FORMAT) . ')';
             }
@@ -620,12 +652,14 @@ class NavigationView extends AbstractView {
                         //If they're done, change the text to REGRADE
                         $class = 'btn-default';
                         $title = 'REGRADE';
-                    } else {
+                    }
+                    else {
                         if (!is_nan($TA_percent) && $list_section === GradeableList::GRADED) {
                             //You forgot somebody
                             $class = 'btn-danger';
                             $title = 'GRADE';
-                        } elseif(!is_nan($TA_percent) && $list_section === GradeableList::GRADING && $grades_due < $date && $date < $grades_released){
+                        }
+                        elseif (!is_nan($TA_percent) && $list_section === GradeableList::GRADING && $grades_due < $date && $date < $grades_released) {
                             $class = 'btn-danger';
                             $title = 'GRADE';
                         }
@@ -635,18 +669,22 @@ class NavigationView extends AbstractView {
                     if (!is_nan($TA_percent)) {
                         $progress = $TA_percent * 100;
                     }
-                } else {
+                }
+                else {
                     $title = "VIEW SUBMISSIONS";
                 }
-            } else {
+            }
+            else {
                 //Labs & Tests don't have exciting buttons
                 $class = 'btn-default';
             }
-        } else {
+        }
+        else {
             if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->isTaGrading()) {
                 $title = "VIEW SUBMISSIONS";
                 $date_text = "(no manual grading)";
-            } else {
+            }
+            else {
                 //Before grading has opened, only thing we can do is preview
                 $title = 'PREVIEW GRADING';
                 $date_text = '(grading starts ' . $gradeable->getGradeStartDate()->format(self::DATE_FORMAT) . ")";
@@ -712,7 +750,8 @@ class NavigationView extends AbstractView {
                 "class" => "btn btn-primary btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);
-        } elseif ($list_section === GradeableList::FUTURE) {
+        }
+        elseif ($list_section === GradeableList::FUTURE) {
             $button = new Button($this->core, [
                 "subtitle" => "OPEN TO TAS NOW",
                 "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
@@ -720,7 +759,8 @@ class NavigationView extends AbstractView {
                 "class" => "btn btn-primary btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);
-        } elseif ($list_section === GradeableList::BETA) {
+        }
+        elseif ($list_section === GradeableList::BETA) {
             if ($gradeable->getType() == GradeableType::ELECTRONIC_FILE) {
                 $button = new Button($this->core, [
                     "subtitle" => "OPEN NOW",
@@ -729,7 +769,8 @@ class NavigationView extends AbstractView {
                     "class" => "btn btn-primary btn-nav btn-nav-open",
                     "name" => "quick-link-btn"
                 ]);
-            } else {
+            }
+            else {
                 $button = new Button($this->core, [
                     "subtitle" => "OPEN TO GRADING NOW",
                     "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
@@ -738,7 +779,8 @@ class NavigationView extends AbstractView {
                     "name" => "quick-link-btn"
                 ]);
             }
-        } elseif ($list_section === GradeableList::CLOSED) {
+        }
+        elseif ($list_section === GradeableList::CLOSED) {
             $button = new Button($this->core, [
                 "subtitle" => "OPEN TO GRADING NOW",
                 "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
@@ -746,7 +788,8 @@ class NavigationView extends AbstractView {
                 "class" => "btn btn-primary btn-nav btn-nav-open",
                 "name" => "quick-link-btn"
             ]);
-        } elseif ($list_section === GradeableList::OPEN) {
+        }
+        elseif ($list_section === GradeableList::OPEN) {
             $url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
                 . http_build_query(['action' => 'close_submissions']);
 

--- a/site/app/views/admin/ExtensionsView.php
+++ b/site/app/views/admin/ExtensionsView.php
@@ -26,7 +26,7 @@ class ExtensionsView extends AbstractView {
 
         $users = $this->core->getQueries()->getUsersWithExtensions($current_gid);
         $current_exceptions = array();
-        foreach($users as $user) {
+        foreach ($users as $user) {
             $current_exceptions[] = array('user_id' => $user->getId(),
                                           'user_firstname' => $user->getDisplayedFirstName(),
                                           'user_lastname' => $user->getDisplayedLastName(),

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -28,11 +28,11 @@ HTML;
 
             $delete_form_action = $this->core->buildCourseUrl(['plagiarism', 'gradeable', $id, 'delete']);
 
-            if(file_exists($course_path . "/lichen/ranking/" . $id . ".txt")) {
+            if (file_exists($course_path . "/lichen/ranking/" . $id . ".txt")) {
                 $timestamp = date("F d Y H:i:s.", filemtime($course_path . "/lichen/ranking/" . $id . ".txt"));
                 $students = array_diff(scandir($course_path . "/lichen/concatenated/" . $id), array('.', '..'));
                 $submissions = 0;
-                foreach($students as $student) {
+                foreach ($students as $student) {
                     $submissions += count(array_diff(scandir($course_path . "/lichen/concatenated/" . $id . "/" . $student), array('.', '..')));
                 }
                 $students = count($students);
@@ -43,11 +43,11 @@ HTML;
                 $submissions = "N/A";
             }
             $night_rerun_status = "";
-            if($nightly_rerun_info[$id] == true) {
+            if ($nightly_rerun_info[$id] == true) {
                 $night_rerun_status = "checked";
             }
 
-            #lichen job in queue for this gradeable but processing not started
+            // lichen job in queue for this gradeable but processing not started
             if (file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $id . ".json")) {
                 $return .= <<<HTML
         <tr style="color:grey;">
@@ -67,9 +67,8 @@ HTML;
         </tr>
 HTML;
             }
-
-            #lichen job in processing stage for this gradeable but not completed
             elseif (file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $id . ".json")) {
+                // lichen job in processing stage for this gradeable but not completed
                 $return .= <<<HTML
         <tr style="color:green;">
             <td>$title
@@ -88,11 +87,10 @@ HTML;
         </tr>
 HTML;
             }
-
-            #no lichen job
             else {
+                // no lichen job
                 $ranking_file_path = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $id . ".txt";
-                if(file_get_contents($ranking_file_path) == "") {
+                if (file_get_contents($ranking_file_path) == "") {
                     $matches_and_topmatch = "0 students matched, N/A top match";
 
                     $return .= <<<HTML
@@ -151,7 +149,7 @@ HTML;
 </script>
 HTML;
         #refresh page ensures atleast one refresh of lichen mainpage when delete , rerun , edit or new configuration is saved.
-        if($refresh_page == "REFRESH_ME") {
+        if ($refresh_page == "REFRESH_ME") {
             $return .= <<<HTML
 <script type="text/javascript">
     var last_data= "REFRESH_ME";
@@ -454,20 +452,20 @@ HTML;
 
 
         #values which are in saved configuration
-        if($new_or_edit == "edit") {
+        if ($new_or_edit == "edit") {
             $gradeable_id = $saved_config['gradeable'];
             $all_version = ($saved_config['version'] == "all_version") ? "checked" : "";
             $active_version = ($saved_config['version'] == "active_version") ? "checked" : "";
-            if($saved_config['file_option'] == "matching_regex") {
+            if ($saved_config['file_option'] == "matching_regex") {
                 $all_files = "";
                 $regex_matching_files = "checked";
                 $regex = $saved_config['regex'];
             }
             $language[$saved_config['language']] = "selected";
 
-            if($saved_config["instructor_provided_code"] == true) {
+            if ($saved_config["instructor_provided_code"] == true) {
                 $provided_code_filename_array = (array_diff(scandir($saved_config["instructor_provided_code_path"]), array(".", "..")));
-                foreach($provided_code_filename_array as $filename) {
+                foreach ($provided_code_filename_array as $filename) {
                     $provided_code_filename = $filename;
                 }
                 $provided_code = "checked";
@@ -477,7 +475,7 @@ HTML;
             $threshold = $saved_config['threshold'];
             $sequence_length = $saved_config['sequence_length'];
 
-            if(count($saved_config['ignore_submissions']) > 0) {
+            if (count($saved_config['ignore_submissions']) > 0) {
                 $ignore = "checked";
                 $no_ignore = "";
             }
@@ -499,7 +497,7 @@ HTML;
                 <div style="width:20%;float:left">Select Gradeable:</div>
                 <div style="width:70%;float:right">
 HTML;
-        if($new_or_edit == "new") {
+        if ($new_or_edit == "new") {
             $return .= <<<HTML
                     <select name="gradeable_id">
 HTML;
@@ -514,8 +512,7 @@ HTML;
                     </select>
 HTML;
         }
-
-        elseif($new_or_edit == "edit") {
+        elseif ($new_or_edit == "edit") {
             $title = '';
             if (isset($saved_config['gradeable']) && $saved_config['gradeable'] !== null) {
                 $title = $this->core->getQueries()->getGradeableConfig($saved_config['gradeable'])->getTitle();
@@ -537,7 +534,7 @@ HTML;
                     <label for="code_provided_id">Yes</label><br />
                     <input type="file" name="provided_code_file">
 HTML;
-        if($new_or_edit == "edit" && $saved_config["instructor_provided_code"]) {
+        if ($new_or_edit == "edit" && $saved_config["instructor_provided_code"]) {
             $return .= <<<HTML
                     <br />
                     <font size="-1">Current Provided Code: $provided_code_filename</font>
@@ -600,7 +597,7 @@ HTML;
                 <div style="width:70%;float:right;overflow:auto;" name= "prev_gradeable_div">
 HTML;
         $count = 0;
-        if($new_or_edit == "edit") {
+        if ($new_or_edit == "edit") {
             foreach ($saved_config['prev_term_gradeables'] as $saved_prev_term_gradeable_path) {
                 $saved_prev_sem = strrev((explode("/", strrev($saved_prev_term_gradeable_path)))[3]);
                 $saved_prev_course = strrev((explode("/", strrev($saved_prev_term_gradeable_path)))[2]);
@@ -610,8 +607,8 @@ HTML;
                     <select name="prev_sem_{$count}">
                         <option value="">None</option>
 HTML;
-                foreach($prior_term_gradeables as $sem => $sem_courses) {
-                    if($sem == $saved_prev_sem) {
+                foreach ($prior_term_gradeables as $sem => $sem_courses) {
+                    if ($sem == $saved_prev_sem) {
                         $return .= <<<HTML
                         <option value="{$sem}" selected>$sem</option>
 HTML;
@@ -627,8 +624,8 @@ HTML;
                         <option value="">None</option>
 HTML;
 
-                foreach($prior_term_gradeables[$saved_prev_sem] as $sem_course => $course_gradeables) {
-                    if($sem_course == $saved_prev_course) {
+                foreach ($prior_term_gradeables[$saved_prev_sem] as $sem_course => $course_gradeables) {
+                    if ($sem_course == $saved_prev_course) {
                         $return .= <<<HTML
                         <option value="{$sem_course}" selected>$sem_course</option>
 HTML;
@@ -644,8 +641,8 @@ HTML;
                     <select name="prev_gradeable_{$count}">
                         <option value="">None</option>
 HTML;
-                foreach($prior_term_gradeables[$saved_prev_sem][$saved_prev_course] as $course_gradeable) {
-                    if($course_gradeable == $saved_prev_gradeable) {
+                foreach ($prior_term_gradeables[$saved_prev_sem][$saved_prev_course] as $course_gradeable) {
+                    if ($course_gradeable == $saved_prev_gradeable) {
                         $return .= <<<HTML
                         <option value="{$course_gradeable}" selected>$course_gradeable</option>
 HTML;
@@ -698,7 +695,7 @@ HTML;
 HTML;
 
         $count = 0;
-        if($new_or_edit == "edit") {
+        if ($new_or_edit == "edit") {
             foreach ($saved_config['ignore_submissions'] as $saved_ignore_submission) {
                 $return .= <<<HTML
                     <input type="text" name="ignore_submission_{$count}" value="{$saved_ignore_submission}"/><br />

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -28,7 +28,7 @@ class CourseMaterialsView extends AbstractView {
             $now_date_time = $core->getDateTimeNow();
             $no_json = array();
 
-            foreach($course_materials_array as $file) {
+            foreach ($course_materials_array as $file) {
                 $expected_file_path = FileUtils::joinPaths($expected_path, $file);
 
                 array_push($in_dir, $expected_file_path);
@@ -38,17 +38,16 @@ class CourseMaterialsView extends AbstractView {
 
                 $releaseData = $now_date_time->format("Y-m-d H:i:sO");
                 $isShareToOther = '0';
-                if ($json == true){
-                    if (isset($json[$expected_file_path]))
-                    {
+                if ($json == true) {
+                    if (isset($json[$expected_file_path])) {
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
 
-                        if (isset($json[$expected_file_path]['sections'])){
+                        if (isset($json[$expected_file_path]['sections'])) {
                             $file_sections[$expected_file_path] = $json[$expected_file_path]['sections'];
                         }
                         $release_date = DateUtils::parseDateTime($json[$expected_file_path]['release_datetime'], $core->getConfig()->getTimezone());
-                        if (isset($json[$expected_file_path]['hide_from_students'])){
+                        if (isset($json[$expected_file_path]['hide_from_students'])) {
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
 
@@ -58,22 +57,22 @@ class CourseMaterialsView extends AbstractView {
 
                         $releaseData  = $json[$expected_file_path]['release_datetime'];
                     }
-                    else{
+                    else {
                         //fill with upload time for new files add all files to json when uploaded
                         $json[$expected_file_path]['checked'] = '1';
                         $isShareToOther = $json[$expected_file_path]['checked'];
                         $release_date = $json['release_time'];
-                        if (isset($json[$expected_file_path]['hide_from_students'])){
+                        if (isset($json[$expected_file_path]['hide_from_students'])) {
                             $hide_from_students[$expected_file_path] = $json[$expected_file_path]['hide_from_students'];
                         }
                         $json[$expected_file_path]['release_datetime'] = $release_date;
-                        if (isset($json[$expected_file_path]['sections'])){
+                        if (isset($json[$expected_file_path]['sections'])) {
                             $file_sections[$expected_file_path] = $json[$expected_file_path]['sections'];
                         }
                         $releaseData = $json[$expected_file_path]['release_datetime'];
                     }
                 }
-                else{
+                else {
                     $ex_file_path = $expected_file_path;
                     $ex_file_path = array();
                     $ex_file_path['checked'] = '1';
@@ -94,7 +93,7 @@ class CourseMaterialsView extends AbstractView {
                 $working_dir = &$files[$start_dir_name];
                 $filename = array_pop($path);
 
-                foreach($path as $dir) {
+                foreach ($path as $dir) {
                     if (!isset($working_dir[$dir])) {
                         $working_dir[$dir] = array();
                     }
@@ -108,7 +107,7 @@ class CourseMaterialsView extends AbstractView {
 
                 $file_datas[$expected_file_path] = $isShareToOther;
 
-                if($releaseData == $now_date_time->format("Y-m-d H:i:sO")){
+                if ($releaseData == $now_date_time->format("Y-m-d H:i:sO")) {
                     //for uploaded files that have had no manually set date to be set to never and maintained as never
                     //also permission set to yes
                     $releaseData = substr_replace($releaseData, "9999", 0, 4);
@@ -118,11 +117,11 @@ class CourseMaterialsView extends AbstractView {
                 $file_release_dates[$expected_file_path] = $releaseData;
             }
 
-            if($json == false){
+            if ($json == false) {
                 FileUtils::writeJsonFile($fp, $no_json);
             }
             $can_write = is_writable($fp);
-            if(!$can_write){
+            if (!$can_write) {
                 $core->addErrorMessage("This json does not have write permissions, and therefore you cannot change the release date. Please change the permissions or contact someone who can.");
             }
         };

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -848,7 +848,7 @@ class ForumThreadView extends AbstractView {
         $post_button = [];
 
         if ($this->core->getUser()->getGroup() <= 3 || $post['author_user_id'] === $current_user) {
-            if (!($this->core->getQueries()->isThreadLocked($thread_id) != 1 || $this->core->getUser()->accessFullGrading() )) {
+            if (!($this->core->getQueries()->isThreadLocked($thread_id) != 1 || $this->core->getUser()->accessFullGrading())) {
             }
             else {
                 if ($deleted && $this->core->getUser()->getGroup() <= 3) {

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -40,8 +40,8 @@ class ForumThreadView extends AbstractView {
 
         $threadArray = array();
         $fromIdtoTitle = array();
-        foreach($threads as $thread){
-            if(!array_key_exists($thread["thread_id"], $threadArray)) {
+        foreach ($threads as $thread) {
+            if (!array_key_exists($thread["thread_id"], $threadArray)) {
                 $threadArray[$thread["thread_id"]] = array();
                 $fromIdtoTitle[$thread["thread_id"]] = $thread["thread_title"];
             }
@@ -51,21 +51,21 @@ class ForumThreadView extends AbstractView {
 
         $thread_list = [];
 
-        foreach($threadArray as $thread_id => $data){
+        foreach ($threadArray as $thread_id => $data) {
             $thread_title = $fromIdtoTitle[$thread_id];
 
             $thread_link = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
 
             $thread_list[$count - 1] = array("thread_title" => $thread_title, "thread_link" => $thread_link, "posts" => array());
 
-            foreach($data as $post) {
+            foreach ($data as $post) {
                 $author = $post['author'];
                 $user_info = $this->core->getQueries()->getDisplayUserInfoFromUserId($post["p_author"]);
                 $first_name = trim($user_info["first_name"]);
                 $last_name = trim($user_info["last_name"]);
                 $visible_username = $first_name . " " . substr($last_name, 0, 1) . ".";
 
-                if($post["anonymous"]){
+                if ($post["anonymous"]) {
                     $visible_username = 'Anonymous';
                 }
 
@@ -73,7 +73,7 @@ class ForumThreadView extends AbstractView {
                 $post_content = html_entity_decode($post["post_content"], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $pre_post = preg_replace('#(<a href=[\'"])(.*?)([\'"].*>)(.*?)(</a>)#', '[url=$2]$4[/url]', $post_content);
 
-                if(!empty($pre_post)){
+                if (!empty($pre_post)) {
                     $post_content = $pre_post;
                 }
 
@@ -112,7 +112,7 @@ class ForumThreadView extends AbstractView {
 
     public function showForumThreads($user, $posts, $unviewed_posts, $threadsHead, $show_deleted, $show_merged_thread, $display_option, $max_thread, $initialPageNumber, $thread_resolve_state, $post_content_limit, $ajax = false) {
 
-        if(!$this->forumAccess()){
+        if (!$this->forumAccess()) {
             $this->core->redirect($this->core->buildCourseUrl([]));
             return;
         }
@@ -124,7 +124,7 @@ class ForumThreadView extends AbstractView {
         $currentCourse = $this->core->getConfig()->getCourse();
         $threadFiltering = $threadExists && !$filteredThreadExists && !(empty($_COOKIE[$currentCourse . '_forum_categories']) && empty($_COOKIE['forum_thread_status']) && empty($_COOKIE['unread_select_value']) === 'false');
 
-        if(!$ajax) {
+        if (!$ajax) {
             $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
 
             //Body Style is necessary to make sure that the forum is still readable...
@@ -141,7 +141,7 @@ class ForumThreadView extends AbstractView {
             $this->core->getOutput()->addVendorJs('bootstrap/js/bootstrap.bundle.min.js');
         }
 
-        if($filteredThreadExists || $threadFiltering) {
+        if ($filteredThreadExists || $threadFiltering) {
             $currentThread = isset($_GET["thread_id"]) && is_numeric($_GET["thread_id"]) && (int) $_GET["thread_id"] < $max_thread && (int) $_GET["thread_id"] > 0 ? (int) $_GET["thread_id"] : $posts[0]["thread_id"];
             $currentCategoriesIds = $this->core->getQueries()->getCategoriesIdForThread($currentThread);
         }
@@ -150,11 +150,12 @@ class ForumThreadView extends AbstractView {
             return ($ar['id'] == $currentThread);
         });
 
-        if($show_merged_thread) {
+        if ($show_merged_thread) {
             $show_merged_thread_class = "active";
             $show_merged_thread_action = "alterShowMergeThreadStatus(0,'" . $currentCourse . "');";
             $show_merged_thread_title = "Hide Merged Threads";
-        } else {
+        }
+        else {
             $show_merged_thread_class = "";
             $show_merged_thread_action = "alterShowMergeThreadStatus(1,'" . $currentCourse . "');";
             $show_merged_thread_title = "Show Merged Threads";
@@ -164,12 +165,13 @@ class ForumThreadView extends AbstractView {
         $show_deleted_action = '';
         $show_deleted_thread_title = '';
 
-        if($this->core->getUser()->accessGrading()){
-            if($show_deleted) {
+        if ($this->core->getUser()->accessGrading()) {
+            if ($show_deleted) {
                 $show_deleted_class = "active";
                 $show_deleted_action = "alterShowDeletedStatus(0);";
                 $show_deleted_thread_title = "Hide Deleted Threads";
-            } else {
+            }
+            else {
                 $show_deleted_class = "";
                 $show_deleted_action = "alterShowDeletedStatus(1);";
                 $show_deleted_thread_title = "Show Deleted Threads";
@@ -183,23 +185,23 @@ class ForumThreadView extends AbstractView {
         $cookieSelectedUnread = false;
         $category_ids_array = array_column($categories, 'category_id');
 
-        if(!empty($_COOKIE[$currentCourse . '_forum_categories'])) {
-            foreach(explode('|', $_COOKIE[$currentCourse . '_forum_categories']) as $selectedId) {
-                if(in_array((int) $selectedId, $category_ids_array)) {
+        if (!empty($_COOKIE[$currentCourse . '_forum_categories'])) {
+            foreach (explode('|', $_COOKIE[$currentCourse . '_forum_categories']) as $selectedId) {
+                if (in_array((int) $selectedId, $category_ids_array)) {
                     $cookieSelectedCategories[] = $selectedId;
                 }
             }
         }
 
-        if(!empty($_COOKIE['forum_thread_status'])) {
-            foreach(explode('|', $_COOKIE['forum_thread_status']) as $selectedStatus) {
-                if(in_array((int) $selectedStatus, array(-1,0,1))) {
+        if (!empty($_COOKIE['forum_thread_status'])) {
+            foreach (explode('|', $_COOKIE['forum_thread_status']) as $selectedStatus) {
+                if (in_array((int) $selectedStatus, array(-1,0,1))) {
                     $cookieSelectedThreadStatus[] = $selectedStatus;
                 }
             }
         }
 
-        if(!empty($_COOKIE['unread_select_value'])){
+        if (!empty($_COOKIE['unread_select_value'])) {
             $cookieSelectedUnread = $_COOKIE['unread_select_value'];
         }
 
@@ -224,12 +226,13 @@ class ForumThreadView extends AbstractView {
             "show_more" => true
         ];
 
-        if($this->core->getUser()->accessGrading()){
-            if($show_deleted) {
+        if ($this->core->getUser()->accessGrading()) {
+            if ($show_deleted) {
                 $show_deleted_class = "active";
                 $show_deleted_action = "alterShowDeletedStatus(0);";
                 $show_deleted_thread_title = "Hide Deleted Threads";
-            } else {
+            }
+            else {
                 $show_deleted_class = "";
                 $show_deleted_action = "alterShowDeletedStatus(1);";
                 $show_deleted_thread_title = "Show Deleted Threads";
@@ -254,10 +257,11 @@ class ForumThreadView extends AbstractView {
         $displayThreadContent = "";
         $generatePostContent = "";
 
-        if(!$threadExists){
+        if (!$threadExists) {
             $button_params["show_threads"] = false;
             $button_params["thread_exists"] = false;
-        } else {
+        }
+        else {
             $more_data = array(
                 array(
                     "filter_option" => $display_option
@@ -312,7 +316,7 @@ class ForumThreadView extends AbstractView {
             $activeThread = array();
             $displayThreadContent = $this->displayThreadList($threadsHead, false, $activeThreadAnnouncement, $activeThreadTitle, $activeThread, $currentThread, $currentCategoriesIds, false);
 
-            if(count($activeThread) == 0) {
+            if (count($activeThread) == 0) {
                 $activeThread = $this->core->getQueries()->getThread($currentThread)[0];
             }
 
@@ -328,11 +332,11 @@ class ForumThreadView extends AbstractView {
         $return = "";
 
         $markdown_enabled = 0;
-        if(isset($_COOKIE['markdown_enabled'])){
+        if (isset($_COOKIE['markdown_enabled'])) {
             $markdown_enabled = $_COOKIE['markdown_enabled'];
         }
 
-        if(!$ajax) {
+        if (!$ajax) {
             $return = $this->core->getOutput()->renderTwigTemplate("forum/ShowForumThreads.twig", [
                 "categories" => $categories,
                 "filterFormData" => $filterFormData,
@@ -358,7 +362,7 @@ class ForumThreadView extends AbstractView {
                 "post_content_limit" => $post_content_limit
             ]);
         }
-        else{
+        else {
             $return = $this->core->getOutput()->renderTwigTemplate("forum/GeneratePostList.twig", [
                 "userGroup" => $generatePostContent["userGroup"],
                 "activeThread" => $generatePostContent["activeThread"],
@@ -406,27 +410,28 @@ class ForumThreadView extends AbstractView {
 
         $totalAttachments = 0;
 
-        if($display_option == "tree"){
+        if ($display_option == "tree") {
             $order_array = array();
             $reply_level_array = array();
-            foreach($posts as $post){
-                if($thread_id == -1) {
+            foreach ($posts as $post) {
+                if ($thread_id == -1) {
                     $thread_id = $post["thread_id"];
                 }
-                if($first){
+                if ($first) {
                     $first = false;
                     $first_post_id = $post["id"];
                 }
-                if($post["parent_id"] > $first_post_id){
+                if ($post["parent_id"] > $first_post_id) {
                     $place = array_search($post["parent_id"], $order_array);
                     $tmp_array = array($post["id"]);
                     $parent_reply_level = $reply_level_array[$place];
-                    while($place && $place + 1 < count($reply_level_array) && $reply_level_array[$place + 1] > $parent_reply_level){
+                    while ($place && $place + 1 < count($reply_level_array) && $reply_level_array[$place + 1] > $parent_reply_level) {
                         $place++;
                     }
                     array_splice($order_array, $place + 1, 0, $tmp_array);
                     array_splice($reply_level_array, $place + 1, 0, $parent_reply_level + 1);
-                } else {
+                }
+                else {
                     array_push($order_array, $post["id"]);
                     array_push($reply_level_array, 1);
                 }
@@ -434,12 +439,13 @@ class ForumThreadView extends AbstractView {
             $i = 0;
             $first = true;
 
-            foreach($order_array as $ordered_post){
-                foreach($posts as $post){
-                    if($post["id"] == $ordered_post){
-                        if($post["parent_id"] == $first_post_id) {
+            foreach ($order_array as $ordered_post) {
+                foreach ($posts as $post) {
+                    if ($post["id"] == $ordered_post) {
+                        if ($post["parent_id"] == $first_post_id) {
                             $reply_level = 1;
-                        } else {
+                        }
+                        else {
                             $reply_level = $reply_level_array[$i];
                         }
 
@@ -448,14 +454,15 @@ class ForumThreadView extends AbstractView {
                         break;
                     }
                 }
-                if($first){
+                if ($first) {
                     $first = false;
                 }
                 $i++;
             }
-        } else {
-            foreach($posts as $post){
-                if($thread_id == -1) {
+        }
+        else {
+            foreach ($posts as $post) {
+                if ($thread_id == -1) {
                     $thread_id = $post["thread_id"];
                 }
 
@@ -463,7 +470,7 @@ class ForumThreadView extends AbstractView {
 
                 $post_data[] = $this->createPost($thread_id, $post, $unviewed_posts, $function_date, $first, 1, $display_option, $includeReply, $totalAttachments);
 
-                if($first){
+                if ($first) {
                     $first = false;
                 }
             }
@@ -476,13 +483,13 @@ class ForumThreadView extends AbstractView {
 
         $form_action_link = $this->core->buildCourseUrl(['forum', 'posts', 'new']);
 
-        if(($isThreadLocked != 1 || $accessFullGrading ) && $includeReply) {
+        if (($isThreadLocked != 1 || $accessFullGrading ) && $includeReply) {
             $GLOBALS['post_box_id'] = $post_box_id = isset($GLOBALS['post_box_id']) ? $GLOBALS['post_box_id'] + 1 : 1;
         }
 
         $merge_thread_content = [];
 
-        if($this->core->getUser()->getGroup() <= 3){
+        if ($this->core->getUser()->getGroup() <= 3) {
             $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('chosen-js', 'chosen.min.css'));
             $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('chosen-js', 'chosen.jquery.min.js'));
             $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
@@ -504,7 +511,7 @@ class ForumThreadView extends AbstractView {
 
         $return = "";
 
-        if($render){
+        if ($render) {
             $return = $this->core->getOutput()->renderTwigTemplate("forum/GeneratePostList.twig", [
                 "userGroup" => $this->core->getUser()->getGroup(),
                 "activeThread" => $activeThread,
@@ -583,7 +590,8 @@ class ForumThreadView extends AbstractView {
                 // Thread without any posts(eg. Merged Thread)
                 $first_post = ['content' => ""];
                 $date = null;
-            } else {
+            }
+            else {
                 $date = DateUtils::parseDateTime($first_post['timestamp'], $this->core->getConfig()->getTimezone());
             }
             if ($thread['merged_thread_id'] != -1) {
@@ -623,7 +631,7 @@ class ForumThreadView extends AbstractView {
                 $first_post_content = $temp_first_post_content;
             }
 
-            if($first_post['render_markdown'] == 1) {
+            if ($first_post['render_markdown'] == 1) {
                 $first_post_content = $this->contentMarkdownToPlain($first_post_content);
             }
 
@@ -706,12 +714,12 @@ class ForumThreadView extends AbstractView {
 
         $return = "";
 
-        if($render) {
+        if ($render) {
             $return = $this->core->getOutput()->renderTwigTemplate("forum/displayThreadList.twig", [
                 "thread_content" => $thread_content,
             ]);
         }
-        else{
+        else {
             $return = [
                 "thread_content" => $thread_content,
             ];
@@ -724,23 +732,24 @@ class ForumThreadView extends AbstractView {
         $post_content = html_entity_decode($original_post_content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $pre_post = preg_replace('#(<a href=[\'"])(.*?)([\'"].*>)(.*?)(</a>)#', '[url=$2]$4[/url]', $post_content);
 
-        if(!empty($pre_post)){
+        if (!empty($pre_post)) {
             $post_content = $pre_post;
         }
 
         preg_match_all('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', $post_content, $result);
         $accepted_schemes = array("https", "http");
         $pos = 0;
-        if(count($result) > 0) {
-            foreach($result[1] as $url){
+        if (count($result) > 0) {
+            foreach ($result[1] as $url) {
                 $decoded_url = filter_var(trim(strip_tags(html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8'))), FILTER_SANITIZE_URL);
                 $parsed_url = parse_url($decoded_url, PHP_URL_SCHEME);
-                if(filter_var($decoded_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== false && in_array($parsed_url, $accepted_schemes, true)){
+                if (filter_var($decoded_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== false && in_array($parsed_url, $accepted_schemes, true)) {
                     $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', '<a href="' . htmlspecialchars($decoded_url, ENT_QUOTES) . '" target="_blank" rel="noopener nofollow">' . $result[2][$pos] . '</a>', $post_content, 1);
-                } else {
+                }
+                else {
                     $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', htmlentities(htmlspecialchars($decoded_url), ENT_QUOTES | ENT_HTML5, 'UTF-8'), $post_content, 1);
                 }
-                if(!empty($pre_post)){
+                if (!empty($pre_post)) {
                     $post_content = $pre_post;
                 }
 
@@ -748,7 +757,7 @@ class ForumThreadView extends AbstractView {
             }
         }
         //This code is for legacy posts that had an extra \r per newline
-        if(strpos($original_post_content, "\r") !== false){
+        if (strpos($original_post_content, "\r") !== false) {
             $post_content = str_replace("\r", "", $post_content);
         }
 
@@ -769,7 +778,8 @@ class ForumThreadView extends AbstractView {
         $date = DateUtils::parseDateTime($post["timestamp"], $this->core->getConfig()->getTimezone());
         if (!is_null($post["edit_timestamp"])) {
             $edit_date = $function_date(DateUtils::parseDateTime($post["edit_timestamp"], $this->core->getConfig()->getTimezone()), "n/j g:i A");
-        } else {
+        }
+        else {
             $edit_date = null;
         }
         $user_info = $this->core->getQueries()->getDisplayUserInfoFromUserId($post["author_user_id"]);
@@ -791,10 +801,11 @@ class ForumThreadView extends AbstractView {
             $classes[] = "first_post";
         }
         if (in_array($post_id, $unviewed_posts)) {
-            if($current_user != $post["author_user_id"]) {
+            if ($current_user != $post["author_user_id"]) {
                 $classes[] = "new_post";
             }
-        } else {
+        }
+        else {
             $classes[] = "viewed_post";
         }
         if ($this->core->getQueries()->isStaffPost($post["author_user_id"])) {
@@ -803,7 +814,8 @@ class ForumThreadView extends AbstractView {
         if ($post["deleted"]) {
             $classes[] = "deleted";
             $deleted = true;
-        } else {
+        }
+        else {
             $deleted = false;
         }
 
@@ -835,14 +847,16 @@ class ForumThreadView extends AbstractView {
 
         $post_button = [];
 
-        if($this->core->getUser()->getGroup() <= 3 || $post['author_user_id'] === $current_user) {
-            if(!($this->core->getQueries()->isThreadLocked($thread_id) != 1 || $this->core->getUser()->accessFullGrading() )){
-            } else {
-                if($deleted && $this->core->getUser()->getGroup() <= 3){
+        if ($this->core->getUser()->getGroup() <= 3 || $post['author_user_id'] === $current_user) {
+            if (!($this->core->getQueries()->isThreadLocked($thread_id) != 1 || $this->core->getUser()->accessFullGrading() )) {
+            }
+            else {
+                if ($deleted && $this->core->getUser()->getGroup() <= 3) {
                     $ud_toggle_status = "false";
                     $ud_button_title = "Undelete post";
                     $ud_button_icon = "fa-undo";
-                } else {
+                }
+                else {
                     $ud_toggle_status = "true";
                     $ud_button_title = "Remove post";
                     $ud_button_icon = "fa-trash";
@@ -857,10 +871,11 @@ class ForumThreadView extends AbstractView {
 
                 $shouldEditThread = null;
 
-                if($first) {
+                if ($first) {
                     $shouldEditThread = "true";
                     $edit_button_title = "Edit thread and post";
-                } else {
+                }
+                else {
                     $shouldEditThread = "false";
                     $edit_button_title = "Edit post";
                 }
@@ -952,7 +967,7 @@ class ForumThreadView extends AbstractView {
     }
 
     public function createThread($category_colors) {
-        if(!$this->forumAccess()){
+        if (!$this->forumAccess()) {
             $this->core->redirect($this->core->buildCourseUrl());
             return;
         }
@@ -1008,7 +1023,7 @@ class ForumThreadView extends AbstractView {
 
     public function showCategories($category_colors) {
 
-        if(!$this->forumAccess()){
+        if (!$this->forumAccess()) {
             $this->core->redirect($this->core->buildCourseUrl([]));
             return;
         }
@@ -1026,7 +1041,7 @@ class ForumThreadView extends AbstractView {
         $categories = "";
         $category_colors;
 
-        if($this->core->getUser()->accessGrading()){
+        if ($this->core->getUser()->accessGrading()) {
             $categories = $this->core->getQueries()->getCategories();
         }
 
@@ -1062,12 +1077,12 @@ class ForumThreadView extends AbstractView {
     }
 
     public function statPage($users) {
-        if(!$this->forumAccess()){
+        if (!$this->forumAccess()) {
             $this->core->redirect($this->core->buildCourseUrl());
             return;
         }
 
-        if(!$this->core->getUser()->accessFullGrading()){
+        if (!$this->core->getUser()->accessFullGrading()) {
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads']));
             return;
         }
@@ -1101,7 +1116,7 @@ class ForumThreadView extends AbstractView {
 
         $userData = [];
 
-        foreach($users as $user => $details){
+        foreach ($users as $user => $details) {
             $first_name = $details["first_name"];
             $last_name = $details["last_name"];
             $post_count = count($details["posts"]);

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -50,7 +50,7 @@ class ElectronicGraderView extends AbstractView {
     ) {
 
         $peer = false;
-        if($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
+        if ($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
             $peer = true;
         }
         $graded = 0;
@@ -87,43 +87,46 @@ class ElectronicGraderView extends AbstractView {
                 $team_total += $section['team'];
             }
         }
-        if ($total === 0 && $no_team_total === 0){
+        if ($total === 0 && $no_team_total === 0) {
             $graded_percentage = -1;
-        } elseif ($total === 0 && $no_team_total > 0){
+        }
+        elseif ($total === 0 && $no_team_total > 0) {
             $graded_percentage = 0;
-        } else{
+        }
+        else {
             $graded_percentage = number_format(($graded / $total) * 100, 1);
         }
 
-        if($graded_percentage !== -1){
+        if ($graded_percentage !== -1) {
             if ($gradeable->isTeamAssignment()) {
                 $total_students = $team_total + $no_team_total;
-            } else {
+            }
+            else {
                 $total_students = $total_submissions;
             }
             $num_components = count($gradeable->getNonPeerComponents());
             $submitted_total = $total / $num_components;
             $graded_total = round($graded / $num_components, 2);
-            if($peer) {
+            if ($peer) {
                 $num_components = count($gradeable->getPeerComponents()) * $gradeable->getPeerGradeSet();
                 $graded_total = $graded / $num_components;
                 $submitted_total = $total / $num_components;
             }
-            if($total_submissions != 0){
+            if ($total_submissions != 0) {
                 $submitted_percentage = round(($submitted_total / $total_submissions) * 100, 1);
             }
             //Add warnings to the warnings array to display them to the instructor.
             $warnings = array();
-            if($section_type === "rotating_section" && $show_warnings){
-                if ($registered_but_not_rotating > 0){
+            if ($section_type === "rotating_section" && $show_warnings) {
+                if ($registered_but_not_rotating > 0) {
                     array_push($warnings, "There are " . $registered_but_not_rotating . " registered students without a rotating section.");
                 }
-                if($rotating_but_not_registered > 0){
+                if ($rotating_but_not_registered > 0) {
                     array_push($warnings, "There are " . $rotating_but_not_registered . " unregistered students with a rotating section.");
                 }
             }
 
-            if($gradeable->isTeamAssignment()){
+            if ($gradeable->isTeamAssignment()) {
                 $team_percentage = $total_students != 0 ? round(($team_total / $total_students) * 100, 1) : 0;
             }
             if ($peer) {
@@ -131,11 +134,13 @@ class ElectronicGraderView extends AbstractView {
                 $peer_total = floor($sections['stu_grad']['total_components'] / $peer_count);
                 $peer_graded = floor($sections['stu_grad']['graded_components'] / $peer_count);
                 $peer_percentage = number_format(($sections['stu_grad']['graded_components'] / $sections['stu_grad']['total_components']) * 100, 1);
-            } else {
+            }
+            else {
                 foreach ($sections as $key => &$section) {
                     if ($section['total_components'] == 0) {
                         $section['percentage'] = 0;
-                    } else {
+                    }
+                    else {
                         $section['percentage'] = number_format(($section['graded_components'] / $section['total_components']) * 100, 1);
                     }
                     $section['graded'] = round($section['graded_components'] / $num_components, 1);
@@ -150,7 +155,7 @@ class ElectronicGraderView extends AbstractView {
                         number_format(($individual_viewed_grade / $total_students_submitted) * 100, 1);
                 }
             }
-            if(!$peer) {
+            if (!$peer) {
                 if ($overall_average !== null) {
                     $overall_total = $overall_average->getMaxValue() + $gradeable->getAutogradingConfig()->getTotalNonExtraCredit();
                     if ($overall_total != 0) {
@@ -269,7 +274,7 @@ HTML;
 					</tr>
 HTML;
 
-        foreach($users as $user => $details){
+        foreach ($users as $user => $details) {
             $first_name = htmlspecialchars($details["first_name"]);
             $last_name = htmlspecialchars($details["last_name"]);
             $upload_timestamp = $details["upload_time"];
@@ -376,7 +381,7 @@ HTML;
         // title => displayed title in the table header
         // function => maps to a macro in Details.twig:render_student
         $columns = [];
-        if($peer) {
+        if ($peer) {
             $columns[]         = ["width" => "5%",  "title" => "",                 "function" => "index"];
             $columns[]         = ["width" => "30%", "title" => "Student",          "function" => "user_id_anon"];
 
@@ -385,12 +390,14 @@ HTML;
                 $columns[]     = ["width" => "20%", "title" => "Grading",          "function" => "grading"];
                 $columns[]     = ["width" => "15%", "title" => "Total",            "function" => "total_peer"];
                 $columns[]     = ["width" => "15%", "title" => "Active Version",   "function" => "active_version"];
-            } else {
+            }
+            else {
                 $columns[]     = ["width" => "30%", "title" => "Grading",          "function" => "grading"];
                 $columns[]     = ["width" => "20%", "title" => "Total",            "function" => "total_peer"];
                 $columns[]     = ["width" => "15%", "title" => "Active Version",   "function" => "active_version"];
             }
-        } else {
+        }
+        else {
             if ($gradeable->isTeamAssignment()) {
                 if ($show_edit_teams) {
                     $columns[] = ["width" => "2%",  "title" => "",                 "function" => "index"];
@@ -398,12 +405,14 @@ HTML;
                     $columns[] = ["width" => "5%",  "title" => "Edit Teams",       "function" => "team_edit"];
                     $columns[] = ["width" => "10%", "title" => "Team Id",          "function" => "team_id", "sort_type" => "id"];
                     $columns[] = ["width" => "32%", "title" => "Team Members",     "function" => "team_members"];
-                } else {
+                }
+                else {
                     $columns[] = ["width" => "3%",  "title" => "",                 "function" => "index"];
                     $columns[] = ["width" => "5%",  "title" => "Section",          "function" => "section"];
                     $columns[] = ["width" => "50%", "title" => "Team Members",     "function" => "team_members"];
                 }
-            } else {
+            }
+            else {
                 $columns[]     = ["width" => "2%",  "title" => "",                 "function" => "index"];
                 $columns[]     = ["width" => "8%", "title" => "Section",          "function" => "section"];
                 $columns[]     = ["width" => "13%", "title" => "User ID",          "function" => "user_id", "sort_type" => "id"];
@@ -412,7 +421,7 @@ HTML;
             }
             if ($gradeable->getAutogradingConfig()->getTotalNonExtraCredit() !== 0) {
                 $columns[]     = ["width" => "9%",  "title" => "Autograding",      "function" => "autograding"];
-                if($gradeable->isTaGrading()) {
+                if ($gradeable->isTaGrading()) {
                     $columns[]     = ["width" => "8%",  "title" => "Graded Questions", "function" => "graded_questions"];
                 }
                 $columns[]     = ["width" => "8%",  "title" => "TA Grading",       "function" => "grading"];
@@ -421,8 +430,9 @@ HTML;
                 if ($gradeable->isTaGradeReleased()) {
                     $columns[] = ["width" => "8%",  "title" => "Viewed Grade",     "function" => "viewed_grade"];
                 }
-            } else {
-                if($gradeable->isTaGrading()) {
+            }
+            else {
+                if ($gradeable->isTaGrading()) {
                     $columns[]     = ["width" => "8%",  "title" => "Graded Questions", "function" => "graded_questions"];
                 }
                 $columns[]     = ["width" => "12%", "title" => "TA Grading",       "function" => "grading"];
@@ -446,9 +456,11 @@ HTML;
 
             if ($peer) {
                 $section_title = "PEER STUDENT GRADER";
-            } elseif ($gradeable->isGradeByRegistration()) {
+            }
+            elseif ($gradeable->isGradeByRegistration()) {
                 $section_title = $row->getSubmitter()->getRegistrationSection();
-            } else {
+            }
+            else {
                 $section_title = $row->getSubmitter()->getRotatingSection();
             }
             if ($section_title === null) {
@@ -464,7 +476,8 @@ HTML;
                 }
                 if (count($section_grader_ids) > 0) {
                     $section_graders = implode(", ", $section_grader_ids);
-                } else {
+                }
+                else {
                     $section_graders = "Nobody";
                 }
             }
@@ -494,15 +507,19 @@ HTML;
                 if ($graded_component === null) {
                     //not graded
                     $info["graded_groups"][] = "NULL";
-                } elseif ($grade_inquiry !== null && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE && $gradeable->isGradeInquiryPerComponentAllowed()) {
+                }
+                elseif ($grade_inquiry !== null && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE && $gradeable->isGradeInquiryPerComponentAllowed()) {
                     $info["graded_groups"][] = "grade-inquiry";
-                } elseif(!$graded_component->getVerifier()){
+                }
+                elseif (!$graded_component->getVerifier()) {
                     //no verifier exists, show the grader group
                     $info["graded_groups"][] = $graded_component->getGrader()->getGroup();
-                } elseif($graded_component->getGrader()->accessFullGrading()){
+                }
+                elseif ($graded_component->getGrader()->accessFullGrading()) {
                     //verifier exists and original grader is full access, show verifier grader group
                     $info["graded_groups"][] = $graded_component->getVerifier()->getGroup();
-                } else{
+                }
+                else {
                     //verifier exists and limited access grader, change the group to show semicircle on the details page
                     $info["graded_groups"][] = "verified";
                 }
@@ -529,7 +546,7 @@ HTML;
         }
 
         // TODO: this duplication is not ideal
-        foreach($teamless_users as $teamless_user) {
+        foreach ($teamless_users as $teamless_user) {
             //Extra info for the template
             $info = [
                 "user" => $teamless_user
@@ -537,9 +554,11 @@ HTML;
 
             if ($peer) {
                 $section_title = "PEER STUDENT GRADER";
-            } elseif ($gradeable->isGradeByRegistration()) {
+            }
+            elseif ($gradeable->isGradeByRegistration()) {
                 $section_title = $teamless_user->getRegistrationSection();
-            } else {
+            }
+            else {
                 $section_title = $teamless_user->getRotatingSection();
             }
             if ($section_title === null) {
@@ -550,7 +569,8 @@ HTML;
                 $section_graders = implode(", ", array_map(function (User $user) {
                     return $user->getId();
                 }, $graders[$section_title]));
-            } else {
+            }
+            else {
                 $section_graders = "Nobody";
             }
             if ($peer) {
@@ -686,7 +706,7 @@ HTML;
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
     public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $sort, $direction, $from) {
         $peer = false;
-        if($this->core->getUser()->getGroup() == User::GROUP_STUDENT && $gradeable->isPeerGrading()) {
+        if ($this->core->getUser()->getGroup() == User::GROUP_STUDENT && $gradeable->isPeerGrading()) {
             $peer = true;
         }
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('mermaid', 'mermaid.min.js'));
@@ -700,7 +720,7 @@ HTML;
         //If TA grading isn't enabled, the rubric won't actually show up, but the template should be rendered anyway to prevent errors, as the code references the rubric panel
         $return .= $this->core->getOutput()->renderTemplate(array('grading', 'ElectronicGrader'), 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit);
 
-        if($graded_gradeable->getGradeable()->isDiscussionBased()) {
+        if ($graded_gradeable->getGradeable()->isDiscussionBased()) {
             $return .= $this->core->getOutput()->renderTemplate(array('grading', 'ElectronicGrader'), 'renderDiscussionForum', json_decode($graded_gradeable->getGradeable()->getDiscussionThreadId(), true), $graded_gradeable->getSubmitter()->getId());
         }
 
@@ -708,7 +728,7 @@ HTML;
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'theme', 'eclipse.css'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('codemirror', 'codemirror.js'));
 
-        if(!$peer) {
+        if (!$peer) {
             $return .= $this->core->getOutput()->renderTemplate(array('grading', 'ElectronicGrader'), 'renderInformationPanel', $graded_gradeable, $display_version_instance);
         }
         if ($this->core->getConfig()->isRegradeEnabled()) {
@@ -727,13 +747,15 @@ HTML;
                     "color" => "var(--standard-creamsicle-orange)", // mango orange
                     "message" => "Cancelled Submission"
                 ]);
-            } else {
+            }
+            else {
                 $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
                     "color" => "var(--standard-light-pink)", // lipstick pink (purple)
                     "message" => "No Submission"
                 ]);
             }
-        } else {
+        }
+        else {
             if ($late_status != LateDayInfo::STATUS_GOOD && $late_status != LateDayInfo::STATUS_LATE) {
                 $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
                     "color" => "var(--standard-red-orange)", // fire engine red
@@ -801,15 +823,16 @@ HTML;
         $currentCourse = $this->core->getConfig()->getCourse();
 
         //Empty thread input
-        if($threadIds === "{}") {
+        if ($threadIds === "{}") {
             $threadIds = array();
         }
 
-        foreach($threadIds as $threadId) {
+        foreach ($threadIds as $threadId) {
             $posts = $this->core->getQueries()->getPostsForThread($this->core->getUser()->getId(), $threadId, false, 'time', $submitter_id);
-            if(count($posts) > 0) {
+            if (count($posts) > 0) {
                 $posts_view .= $this->core->getOutput()->renderTemplate('forum\ForumThread', 'generatePostList', $threadId, $posts, [], $currentCourse, false, true, $submitter_id);
-            } else {
+            }
+            else {
                 $posts_view .= <<<HTML
                     <h3 style="text-align: center;">No posts for thread id: {$threadId}</h3> <br/>
 HTML;
@@ -821,7 +844,7 @@ HTML;
 HTML;
         }
 
-        if(empty($threadIds)) {
+        if (empty($threadIds)) {
             $posts_view .= <<<HTML
                 <h3 style="text-align: center;">No thread id specified.</h3> <br/>
 HTML;
@@ -841,7 +864,7 @@ HTML;
     public function renderSubmissionPanel(GradedGradeable $graded_gradeable, int $display_version) {
         $add_files = function (&$files, $new_files, $start_dir_name) {
             $files[$start_dir_name] = array();
-            if($new_files) {
+            if ($new_files) {
                 foreach ($new_files as $file) {
                     $path = explode('/', $file['relative_name']);
                     array_pop($path);
@@ -912,14 +935,16 @@ HTML;
             foreach ($graded_gradeable->getSubmitter()->getTeam()->getMemberUsers() as $team_member) {
                 $tables[] = LateDaysTableController::renderLateTable($this->core, $team_member, $gradeable->getId());
             }
-        } else {
+        }
+        else {
             $tables[] = LateDaysTableController::renderLateTable($this->core, $graded_gradeable->getSubmitter()->getUser(), $gradeable->getId());
         }
 
         if ($display_version_instance === null) {
             $display_version = 0;
             $submission_time = null;
-        } else {
+        }
+        else {
             $display_version = $display_version_instance->getVersion();
             $submission_time = $display_version_instance->getSubmissionTime();
         }

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -33,7 +33,8 @@ class SimpleGraderView extends AbstractView {
         foreach ($gradeable->getComponents() as $component) {
             if ($component->isText()) {
                 $components_text[] = $component;
-            } else {
+            }
+            else {
                 $components_numeric[] = $component;
                 if ($action != 'lab') {
                     $comp_ids[] = $component->getId();
@@ -49,7 +50,8 @@ class SimpleGraderView extends AbstractView {
         foreach ($graded_gradeables as $graded_gradeable) {
             if ($gradeable->isGradeByRegistration()) {
                 $section = $graded_gradeable->getSubmitter()->getUser()->getRegistrationSection();
-            } else {
+            }
+            else {
                 $section = $graded_gradeable->getSubmitter()->getUser()->getRotatingSection();
             }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -53,10 +53,12 @@ class HomeworkView extends AbstractView {
         // showing submission if user is full grader or student can submit
         if ($this->core->getUser()->accessFullGrading()) {
             $return .= $this->renderSubmitBox($gradeable, $graded_gradeable, $version_instance, $late_days_use);
-        } elseif ($gradeable->isStudentSubmit()) {
+        }
+        elseif ($gradeable->isStudentSubmit()) {
             if ($gradeable->canStudentSubmit()) {
                 $return .= $this->renderSubmitBox($gradeable, $graded_gradeable, $version_instance, $late_days_use);
-            } else {
+            }
+            else {
                 $return .= $this->renderSubmitNotAllowedBox();
             }
         }
@@ -79,7 +81,8 @@ class HomeworkView extends AbstractView {
         $active_version = $auto_graded_gradeable !== null ? $auto_graded_gradeable->getActiveVersion() : 0;
         if ($submission_count === 0) {
             $return .= $this->renderNoSubmissionBox($graded_gradeable);
-        } else {
+        }
+        else {
             $return .= $this->renderVersionBox($graded_gradeable, $version_instance, $show_hidden_testcases);
         }
 
@@ -91,10 +94,12 @@ class HomeworkView extends AbstractView {
             && $gradeable->isRegradeOpen()
             && $submission_count !== 0;
 
-        if ($gradeable->isTaGradeReleased()
+        if (
+            $gradeable->isTaGradeReleased()
             && $gradeable->isTaGrading()
             && $submission_count !== 0
-            && $active_version !== 0) {
+            && $active_version !== 0
+        ) {
             $return .= $this->renderTAResultsBox($graded_gradeable, $regrade_available);
         }
         if ($regrade_available || $graded_gradeable !== null && $graded_gradeable->hasRegradeRequest()) {
@@ -179,9 +184,13 @@ class HomeworkView extends AbstractView {
             $new_late_charged = max(0, $would_be_days_late - $extensions);
 
             // if unsubmitted, or submitted but still in the late days allowed window
-            if ($active_version < 1 ||
-                ($new_late_charged <= $late_days_remaining &&
-                    $new_late_charged <= $late_days_allowed)) {
+            if (
+                $active_version < 1
+                || (
+                    $new_late_charged <= $late_days_remaining
+                    && $new_late_charged <= $late_days_allowed
+                )
+            ) {
                 // PRINT WOULD BE HOW MANY DAYS LATE
                 $messages[] = ['type' => 'would_late', 'info' => [
                     'late' => $would_be_days_late
@@ -275,8 +284,7 @@ class HomeworkView extends AbstractView {
         if (!$gradeable->isVcs()) {
             // Prepare notebook image data for displaying
             foreach ($notebook as $cell) {
-                if (isset($cell['type']) && $cell['type'] == "image")
-                {
+                if (isset($cell['type']) && $cell['type'] == "image") {
                     $image_name = $cell['image'];
                     $imgPath = FileUtils::joinPaths(
                         $this->core->getConfig()->getCoursePath(),
@@ -296,7 +304,7 @@ class HomeworkView extends AbstractView {
                 }
             }
 
-            if($version_instance !== null) {
+            if ($version_instance !== null) {
                 $display_version = $version_instance->getVersion();
                 for ($i = 1; $i <= $gradeable->getAutogradingConfig()->getNumParts(); $i++) {
                     foreach ($version_instance->getPartFiles($i)['submissions'] as $file) {
@@ -304,7 +312,8 @@ class HomeworkView extends AbstractView {
                         // $escape_quote_filename = str_replace('\'','\\\'',$file['name']);
                         if (substr($file['relative_name'], 0, strlen("part{$i}/")) === "part{$i}/") {
                             $escape_quote_filename = str_replace('\'', '\\\'', substr($file['relative_name'], strlen("part{$i}/")));
-                        } else {
+                        }
+                        else {
                             $escape_quote_filename = str_replace('\'', '\\\'', $file['relative_name']);
                         }
 
@@ -427,13 +436,13 @@ class HomeworkView extends AbstractView {
         foreach ($all_directories as $timestamp => $content) {
             $dir_files = $content['files'];
             foreach ($dir_files as $filename => $details) {
-                if($filename === 'decoded.json'){
+                if ($filename === 'decoded.json') {
                     $bulk_upload_data +=  FileUtils::readJsonFile($details['path']);
                 }
                 $clean_timestamp = str_replace('_', ' ', $timestamp);
                 $path = rawurlencode(htmlspecialchars($details['path']));
                 //get the cover image if it exists
-                if(strpos($filename, '_cover.jpg') && pathinfo($filename)['extension'] === 'jpg'){
+                if (strpos($filename, '_cover.jpg') && pathinfo($filename)['extension'] === 'jpg') {
                     $corrected_filename = rawurlencode(htmlspecialchars($filename));
                     $url = $this->core->buildCourseUrl(['display_file']) . '?' . http_build_query([
                         'dir' => 'split_pdf',
@@ -446,8 +455,11 @@ class HomeworkView extends AbstractView {
                         'url' => $url,
                     ];
                 }
-                if (strpos($filename, 'cover') === false || pathinfo($filename)['extension'] === 'json' ||
-                    pathinfo($filename)['extension'] === "jpg") {
+                if (
+                    strpos($filename, 'cover') === false
+                    || pathinfo($filename)['extension'] === 'json'
+                    || pathinfo($filename)['extension'] === "jpg"
+                ) {
                     continue;
                 }
                 // get the full filename for PDF popout
@@ -473,7 +485,7 @@ class HomeworkView extends AbstractView {
                 $cover_image_name = substr($filename, 0, -3) . "jpg";
                 $cover_image = [];
                 foreach ($cover_images as $img) {
-                    if($img['filename'] === $cover_image_name) {
+                    if ($img['filename'] === $cover_image_name) {
                         $cover_image = $img;
                     }
                 }
@@ -490,9 +502,10 @@ class HomeworkView extends AbstractView {
         }
 
         for ($i = 0; $i < count($files); $i++) {
-            if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr'] && !array_key_exists($files[$i]['filename_full'], $bulk_upload_data)){
+            if (array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr'] && !array_key_exists($files[$i]['filename_full'], $bulk_upload_data)) {
                 continue;
-            }elseif(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']){
+            }
+            elseif (array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']) {
                 $data = $bulk_upload_data[ $files[$i]['filename_full'] ];
             }
 
@@ -501,22 +514,24 @@ class HomeworkView extends AbstractView {
             $id = '';
 
             //decoded.json may be read before the assoicated data is written, check if key exists first
-            if(array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']){
-                if(array_key_exists('id', $data)){
+            if (array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']) {
+                if (array_key_exists('id', $data)) {
                     $id = $data['id'];
                     $is_valid = null !== $this->core->getQueries()->getUserByIdOrNumericId($id);
-                }else{
+                }
+                else {
                     //set the blank id as invalid for now, after a page refresh it will recorrect
                     $id = '';
                     $is_valid = false;
                 }
-                if(array_key_exists('page_count', $data)){
+                if (array_key_exists('page_count', $data)) {
                     $page_count = $data['page_count'];
                 }
-            }else{
+            }
+            else {
                 $is_valid = true;
                 $id = '';
-                if(array_key_exists('page_count', $bulk_upload_data)){
+                if (array_key_exists('page_count', $bulk_upload_data)) {
                     $page_count = $bulk_upload_data['page_count'];
                 }
             }
@@ -630,7 +645,7 @@ class HomeworkView extends AbstractView {
                 ]);
             }
 
-            if($version_instance->isQueued()) {
+            if ($version_instance->isQueued()) {
                 $param = array_merge($param, [
                     'queue_pos' => $version_instance->getQueuePosition(),
                     'queue_total' => $this->core->getGradingQueue()->getQueueCount()
@@ -801,7 +816,8 @@ class HomeworkView extends AbstractView {
                     ];
                     // add grade inquiry to grade inquiries array
                     $grade_inquiries_twig_array[$gc_id] = $grade_inquiry_twig_object;
-                } else {
+                }
+                else {
                     $grade_inquiries_twig_array[0]['id'] = $grade_inquiry->getId();
                     $grade_inquiries_twig_array[0]['gc_id'] = $gc_id;
                     $grade_inquiries_twig_array[0]['status'] = $grade_inquiry->getStatus();

--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -27,9 +27,10 @@ class TeamView extends AbstractView {
             foreach ($team->getMembers() as $teammate) {
                 $members[] = $this->core->getQueries()->getUserById($teammate);
             }
-        } else {
+        }
+        else {
             //Invites
-            foreach($teams as $t) {
+            foreach ($teams as $t) {
                 if ($t->sentInvite($user_id)) {
                     $invites_received[] = $t;
                 }

--- a/site/composer.json
+++ b/site/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "8.4.2",
-    "submitty/php-codesniffer": "2.2.1",
+    "submitty/php-codesniffer": "2.2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
     "php-mock/php-mock-phpunit": "2.5.0",
     "phpstan/phpstan": "0.11.19"

--- a/site/composer.json
+++ b/site/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "8.4.2",
-    "submitty/php-codesniffer": "2.2.2",
+    "submitty/php-codesniffer": "2.2.3",
     "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
     "php-mock/php-mock-phpunit": "2.5.0",
     "phpstan/phpstan": "0.11.19"

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5212c236c3fcd978e239e23f2f1729d",
+    "content-hash": "71bfc0abe5508dcd0c1563a24567b9f9",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1944,16 +1944,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.2.5",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "b76bbc3c51f22c570648de48e8c2d941ed5e2cf2"
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/b76bbc3c51f22c570648de48e8c2d941ed5e2cf2",
-                "reference": "b76bbc3c51f22c570648de48e8c2d941ed5e2cf2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
                 "shasum": ""
             },
             "require": {
@@ -1961,7 +1961,7 @@
                 "php": ">=7.0"
             },
             "require-dev": {
-                "ircmaxell/php-yacc": "0.0.4",
+                "ircmaxell/php-yacc": "0.0.5",
                 "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
             },
             "bin": [
@@ -1970,7 +1970,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1992,7 +1992,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-10-25T18:33:07+00:00"
+            "time": "2019-11-08T13:50:10+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -3788,16 +3788,16 @@
         },
         {
             "name": "submitty/php-codesniffer",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Submitty/submitty-php-codesniffer.git",
-                "reference": "b9aef1fe78e26b8c2890bd69960503d2ce29b419"
+                "reference": "bdca80b5cb059b1e72ee8fd43ccb7653e86023c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/b9aef1fe78e26b8c2890bd69960503d2ce29b419",
-                "reference": "b9aef1fe78e26b8c2890bd69960503d2ce29b419",
+                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/bdca80b5cb059b1e72ee8fd43ccb7653e86023c5",
+                "reference": "bdca80b5cb059b1e72ee8fd43ccb7653e86023c5",
                 "shasum": ""
             },
             "require": {
@@ -3830,7 +3830,7 @@
                 }
             ],
             "description": "Submitty PHP CodeSniffer Standard",
-            "time": "2019-11-08T10:36:55+00:00"
+            "time": "2019-11-08T13:08:44+00:00"
         },
         {
             "name": "symfony/console",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "944290c16a13ac3495aba8164ab1496f",
+    "content-hash": "a5212c236c3fcd978e239e23f2f1729d",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1152,24 +1152,24 @@
     "packages-dev": [
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.3",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f"
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/46867cbf8ca9fb8d60c506895449eb799db1184f",
-                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/cbe23383749496fe0f373345208b79568e4bc248",
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0",
+                "php": "^5.3.2 || ^7.0 || ^8.0",
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
             },
             "type": "library",
             "autoload": {
@@ -1187,12 +1187,12 @@
                     "email": "john-stevenson@blueyonder.co.uk"
                 }
             ],
-            "description": "Restarts a process without xdebug.",
+            "description": "Restarts a process without Xdebug.",
             "keywords": [
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-05-27T17:52:04+00:00"
+            "time": "2019-11-06T16:40:04+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -3788,16 +3788,16 @@
         },
         {
             "name": "submitty/php-codesniffer",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Submitty/submitty-php-codesniffer.git",
-                "reference": "c181432f47ef05103d0a41094f8b9daa740422a3"
+                "reference": "b9aef1fe78e26b8c2890bd69960503d2ce29b419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/c181432f47ef05103d0a41094f8b9daa740422a3",
-                "reference": "c181432f47ef05103d0a41094f8b9daa740422a3",
+                "url": "https://api.github.com/repos/Submitty/submitty-php-codesniffer/zipball/b9aef1fe78e26b8c2890bd69960503d2ce29b419",
+                "reference": "b9aef1fe78e26b8c2890bd69960503d2ce29b419",
                 "shasum": ""
             },
             "require": {
@@ -3830,7 +3830,7 @@
                 }
             ],
             "description": "Submitty PHP CodeSniffer Standard",
-            "time": "2019-11-01T19:49:08+00:00"
+            "time": "2019-11-08T10:36:55+00:00"
         },
         {
             "name": "symfony/console",

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -101,7 +101,7 @@ date_default_timezone_set($core->getConfig()->getTimezone()->getName());
 
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', 1);
-if($core->getConfig()->isDebug()) {
+if ($core->getConfig()->isDebug()) {
     error_reporting(E_ALL);
 }
 else {

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -266,9 +266,11 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
             setGradeableUpdateComplete();
             if (response.status === 'success') {
                 successCallback(response.data);
-            } else if (response.status === 'fail') {
+            }
+else if (response.status === 'fail') {
                 errorCallback(response.message, response.data);
-            } else {
+            }
+else {
                 alert('Internal server error');
                 console.error(response.message);
             }
@@ -421,7 +423,8 @@ function saveRubric(redirect = true) {
                 if (redirect) {
                     window.location.replace(buildCourseUrl(['gradeable', $('#g_id').val(), 'update']) + '?nav_tab=2');
                 }
-            } else {
+            }
+else {
                 errors['rubric'] = response.message;
                 updateErrorMessage();
                 alert('Error saving rubric, you may have tried to delete a component with grades.  Refresh the page');
@@ -484,7 +487,8 @@ function saveGraders() {
                 alert('Error saving graders!');
                 console.error(response.message);
                 errors['graders'] = '';
-            } else {
+            }
+else {
                 delete errors['graders'];
             }
             updateErrorMessage();

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -267,10 +267,10 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
             if (response.status === 'success') {
                 successCallback(response.data);
             }
-else if (response.status === 'fail') {
+            else if (response.status === 'fail') {
                 errorCallback(response.message, response.data);
             }
-else {
+            else {
                 alert('Internal server error');
                 console.error(response.message);
             }
@@ -424,7 +424,7 @@ function saveRubric(redirect = true) {
                     window.location.replace(buildCourseUrl(['gradeable', $('#g_id').val(), 'update']) + '?nav_tab=2');
                 }
             }
-else {
+            else {
                 errors['rubric'] = response.message;
                 updateErrorMessage();
                 alert('Error saving rubric, you may have tried to delete a component with grades.  Refresh the page');
@@ -488,7 +488,7 @@ function saveGraders() {
                 console.error(response.message);
                 errors['graders'] = '';
             }
-else {
+            else {
                 delete errors['graders'];
             }
             updateErrorMessage();

--- a/site/public/js/configuration.js
+++ b/site/public/js/configuration.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
         if ($("#room-seating-gradeable-id").val()) {
             showEmailSeatingOption();
         }
-else {
+        else {
             hideEmailSeatingOption();
         }
     }

--- a/site/public/js/configuration.js
+++ b/site/public/js/configuration.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-  
+
     $("input,textarea,select").on("change", function() {
         var elem = this;
         let formData = new FormData();
@@ -46,7 +46,7 @@ $(document).ready(function() {
             }
         });
     });
-  
+
     function updateForumMessage() {
         $("#forum-enabled-message").toggle();
         $("#forum-category-warning").toggle();
@@ -67,7 +67,8 @@ $(document).ready(function() {
     function updateEmailSeatingOption() {
         if ($("#room-seating-gradeable-id").val()) {
             showEmailSeatingOption();
-        } else {
+        }
+else {
             hideEmailSeatingOption();
         }
     }

--- a/site/public/js/directory.js
+++ b/site/public/js/directory.js
@@ -7,7 +7,8 @@ function newDownloadForm() {
     $("#download-form input:checkbox").each(function() {
         if ($(this).val() === 'NULL') {
             $(this).prop('checked', false);
-        } else {
+        }
+else {
             $(this).prop('checked', true);
         }
     });

--- a/site/public/js/directory.js
+++ b/site/public/js/directory.js
@@ -8,7 +8,7 @@ function newDownloadForm() {
         if ($(this).val() === 'NULL') {
             $(this).prop('checked', false);
         }
-else {
+        else {
             $(this).prop('checked', true);
         }
     });

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -260,7 +260,7 @@ function setButtonStatus() {
         if (empty_inputs) {
             $("#submit").prop("disabled", true);
         }
-else {
+        else {
             $("#submit").prop("disabled", false);
         }
     }
@@ -426,7 +426,7 @@ function validateUserId(csrf_token, gradeable_id, user_id){
                 if(response['status'] === 'success'){
                     resolve(response);
                 }
-else{
+                else {
                     reject(response);
                 }
             },
@@ -477,11 +477,11 @@ function displayPreviousSubmissionOptions(callback){
             localStorage.setItem("instructor-submit-option", "0");
             option = 1;
         }
-else if($("#instructor-submit-option-merge-1").is(":checked")) {
+        else if($("#instructor-submit-option-merge-1").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "1");
             option = 2;
         }
-else if($("#instructor-submit-option-merge-2").is(":checked")) {
+        else if($("#instructor-submit-option-merge-2").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "2");
             option = 3;
         }
@@ -494,10 +494,10 @@ else if($("#instructor-submit-option-merge-2").is(":checked")) {
         if($("#instructor-submit-option-new").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "0");
         }
-else if($("#instructor-submit-option-merge-1").is(":checked")) {
+        else if($("#instructor-submit-option-merge-1").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "1");
         }
-else if($("#instructor-submit-option-merge-2").is(":checked")) {
+        else if($("#instructor-submit-option-merge-2").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "2");
         }
         form.css("display", "none");
@@ -512,7 +512,7 @@ else if($("#instructor-submit-option-merge-2").is(":checked")) {
     if(localStorage.getItem("instructor-submit-option") === null) {
         radio_idx = 0;
     }
-else {
+    else {
         radio_idx = parseInt(localStorage.getItem("instructor-submit-option"));
     }
     form.find('input:radio')[radio_idx].checked = true;
@@ -533,46 +533,46 @@ else {
                     $("#instructor-submit-option-merge-1").focus();
                     $("#instructor-submit-option-merge-1").css({"outline" : "2px solid #C1E0FF"});
                 }
-else if(current_btn === 1){
+                else if(current_btn === 1){
                     $("#instructor-submit-option-merge-2").focus();
                     $("#instructor-submit-option-merge-2").css({"outline" : "2px solid #C1E0FF"});
                 }
-else if(current_btn === 2){
+                else if(current_btn === 2){
                     closer_btn.focus();
                 }
-else if(current_btn === 3){
+                else if(current_btn === 3){
                     submit_btn.focus();
                 }
-else if(current_btn === 4){
+                else if(current_btn === 4){
                     $("#instructor-submit-option-new").focus();
                     $("#instructor-submit-option-new").css({"outline" : "2px solid #C1E0FF"});
                 }
                 current_btn = (current_btn == 4) ? 0 : current_btn + 1;
             }
-else if(e.keyCode === 27){
+            else if(e.keyCode === 27){
                 //close the modal box on escape
                 closer_btn.click();
             }
-else if(e.keyCode === 13){
+            else if(e.keyCode === 13){
                 //on enter update whatever the user is focussing on
                 //uncheck everything and then recheck the desired button to make sure it actually updates
                 if(current_btn === 1){
                     $('input[name=instructor-submit]').prop('checked', false);
                     $("#instructor-submit-option-merge-1").prop('checked', true);
                 }
-else if(current_btn === 2){
+                else if(current_btn === 2){
                     $('input[name=instructor-submit]').prop('checked', false);
                     $("#instructor-submit-option-merge-2").prop('checked', true);
                 }
-else if(current_btn === 0){
+                else if(current_btn === 0){
                     $('input[name=instructor-submit]').prop('checked', false);
                     $("#instructor-submit-option-new").prop('checked', true);
                 }
-else if(current_btn === 3){
+                else if(current_btn === 3){
                     //close the modal if the close button is selected
                     closer_btn.click();
                 }
-else if(current_btn === 4){
+                else if(current_btn === 4){
                     submit_btn.click();
                 }
             }
@@ -642,7 +642,7 @@ function deleteSplitItem(csrf_token, gradeable_id, path) {
                 if (response['status'] === 'success') {
                     resolve(response);
                 }
-else {
+                else {
                     reject(response);
                 }
             },
@@ -793,7 +793,7 @@ function gatherInputAnswersByType(type){
             var editor = this_input_answer.querySelector(".CodeMirror").CodeMirror;
             value = editor.getValue();
         }
-else{
+        else{
             key = this_input_answer.name;
             value = this_input_answer.value;
         }

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -91,7 +91,7 @@ function dropWithMultipleZips(e){
     }
 }
 
-// show progressbar when uploading files 
+// show progressbar when uploading files
 function progress(e){
     var progressBar = document.getElementById("loading-bar");
 
@@ -104,7 +104,7 @@ function progress(e){
         progressBar.value = e.loaded;
         let perc = (e.loaded * 100)/e.total;
         $("#loading-bar-percentage").html(perc.toFixed(2) + " %");
-    }  
+    }
 }
 
 function get_part_number(e){
@@ -259,7 +259,8 @@ function setButtonStatus() {
         $("#startnew").prop("disabled", true);
         if (empty_inputs) {
             $("#submit").prop("disabled", true);
-        } else {
+        }
+else {
             $("#submit").prop("disabled", false);
         }
     }
@@ -424,7 +425,8 @@ function validateUserId(csrf_token, gradeable_id, user_id){
                 response = JSON.parse(response);
                 if(response['status'] === 'success'){
                     resolve(response);
-                }else{
+                }
+else{
                     reject(response);
                 }
             },
@@ -474,10 +476,12 @@ function displayPreviousSubmissionOptions(callback){
         if($("#instructor-submit-option-new").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "0");
             option = 1;
-        }else if($("#instructor-submit-option-merge-1").is(":checked")) {
+        }
+else if($("#instructor-submit-option-merge-1").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "1");
             option = 2;
-        }else if($("#instructor-submit-option-merge-2").is(":checked")) {
+        }
+else if($("#instructor-submit-option-merge-2").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "2");
             option = 3;
         }
@@ -489,9 +493,11 @@ function displayPreviousSubmissionOptions(callback){
     closer_btn.on('click', function() {
         if($("#instructor-submit-option-new").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "0");
-        }else if($("#instructor-submit-option-merge-1").is(":checked")) {
+        }
+else if($("#instructor-submit-option-merge-1").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "1");
-        }else if($("#instructor-submit-option-merge-2").is(":checked")) {
+        }
+else if($("#instructor-submit-option-merge-2").is(":checked")) {
             localStorage.setItem("instructor-submit-option", "2");
         }
         form.css("display", "none");
@@ -505,7 +511,8 @@ function displayPreviousSubmissionOptions(callback){
     var radio_idx;
     if(localStorage.getItem("instructor-submit-option") === null) {
         radio_idx = 0;
-    }else {
+    }
+else {
         radio_idx = parseInt(localStorage.getItem("instructor-submit-option"));
     }
     form.find('input:radio')[radio_idx].checked = true;
@@ -525,37 +532,47 @@ function displayPreviousSubmissionOptions(callback){
                 if(current_btn === 0){
                     $("#instructor-submit-option-merge-1").focus();
                     $("#instructor-submit-option-merge-1").css({"outline" : "2px solid #C1E0FF"});
-                }else if(current_btn === 1){
+                }
+else if(current_btn === 1){
                     $("#instructor-submit-option-merge-2").focus();
                     $("#instructor-submit-option-merge-2").css({"outline" : "2px solid #C1E0FF"});
-                }else if(current_btn === 2){
+                }
+else if(current_btn === 2){
                     closer_btn.focus();
-                }else if(current_btn === 3){
+                }
+else if(current_btn === 3){
                     submit_btn.focus();
-                }else if(current_btn === 4){
+                }
+else if(current_btn === 4){
                     $("#instructor-submit-option-new").focus();
                     $("#instructor-submit-option-new").css({"outline" : "2px solid #C1E0FF"});
                 }
                 current_btn = (current_btn == 4) ? 0 : current_btn + 1;
-            }else if(e.keyCode === 27){
+            }
+else if(e.keyCode === 27){
                 //close the modal box on escape
                 closer_btn.click();
-            }else if(e.keyCode === 13){
+            }
+else if(e.keyCode === 13){
                 //on enter update whatever the user is focussing on
                 //uncheck everything and then recheck the desired button to make sure it actually updates
                 if(current_btn === 1){
                     $('input[name=instructor-submit]').prop('checked', false);
                     $("#instructor-submit-option-merge-1").prop('checked', true);
-                }else if(current_btn === 2){
+                }
+else if(current_btn === 2){
                     $('input[name=instructor-submit]').prop('checked', false);
                     $("#instructor-submit-option-merge-2").prop('checked', true);
-                }else if(current_btn === 0){
+                }
+else if(current_btn === 0){
                     $('input[name=instructor-submit]').prop('checked', false);
                     $("#instructor-submit-option-new").prop('checked', true);
-                }else if(current_btn === 3){
+                }
+else if(current_btn === 3){
                     //close the modal if the close button is selected
                     closer_btn.click();
-                }else if(current_btn === 4){
+                }
+else if(current_btn === 4){
                     submit_btn.click();
                 }
             }
@@ -624,7 +641,8 @@ function deleteSplitItem(csrf_token, gradeable_id, path) {
                 response = JSON.parse(response);
                 if (response['status'] === 'success') {
                     resolve(response);
-                }else {
+                }
+else {
                     reject(response);
                 }
             },
@@ -691,14 +709,14 @@ function handleBulk(gradeable_id, max_file_size, max_post_size, num_pages, use_q
             total_size += file_array[i][j].size;
 
             if (total_size >= max_file_size){
-                alert("ERROR! Uploaded file(s) exceed max file size.\n" + 
+                alert("ERROR! Uploaded file(s) exceed max file size.\n" +
                       "Please visit https://submitty.org/sysadmin/system_customization for configuration instructions.");
                 $("#submit").prop("disabled", false);
                 return;
             }
 
              if (total_size >= max_post_size){
-                alert("ERROR! Uploaded file(s) exceed max PHP POST size.\n" + 
+                alert("ERROR! Uploaded file(s) exceed max PHP POST size.\n" +
                       "Please visit https://submitty.org/sysadmin/system_customization for configuration instructions.");
                 $("#submit").prop("disabled", false);
                 return;
@@ -774,7 +792,8 @@ function gatherInputAnswersByType(type){
             key = this_input_answer.id;
             var editor = this_input_answer.querySelector(".CodeMirror").CodeMirror;
             value = editor.getValue();
-        }else{
+        }
+else{
             key = this_input_answer.name;
             value = this_input_answer.value;
         }

--- a/site/public/js/extensions.js
+++ b/site/public/js/extensions.js
@@ -25,7 +25,8 @@ function updateHomeworkExtension() {
             }
             if (json['data'] && json['data']['is_team']) {
                 extensionPopup(json);
-            } else {
+            }
+else {
                 window.location=window.location; // pseudo post/redirect/get pattern
             }
         },

--- a/site/public/js/extensions.js
+++ b/site/public/js/extensions.js
@@ -26,7 +26,7 @@ function updateHomeworkExtension() {
             if (json['data'] && json['data']['is_team']) {
                 extensionPopup(json);
             }
-else {
+            else {
                 window.location=window.location; // pseudo post/redirect/get pattern
             }
         },

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -56,7 +56,7 @@ function checkNumFilesForumUpload(input, post_id){
         displayError('Max file upload size is 5. Please try again.');
         resetForumFileUploadAfterError(displayPostId);
     }
-else {
+    else {
         if(!checkForumFileExtensions(input.files)){
             displayError('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
             resetForumFileUploadAfterError(displayPostId);
@@ -94,12 +94,12 @@ function testAndGetAttachments(post_box_id, dynamic_check) {
         if(dynamic_check) {
             displayError('Max file upload size is 5. Please remove attachments accordingly.');
         }
-else {
+        else {
             displayError('Max file upload size is 5. Please try again.');
         }
         return false;
     }
-else {
+    else {
         if(!checkForumFileExtensions(files)){
             displayError('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
             return false;
@@ -270,7 +270,7 @@ function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_to
             if(change_anon) {
                 $('#thread_post_anon_edit').prop('checked', anon);
             }
-else {
+            else {
                 $('label[for=Anon]').remove();
                 $('#thread_post_anon_edit').remove();
             }
@@ -313,7 +313,7 @@ else {
                 $("#category-selection-container").show();
                 $("#thread_status").show();
             }
-else {
+            else {
                 $("#title").prop('disabled', true);
                 $(".edit_thread").hide();
                 $('#label_lock_thread').hide();
@@ -380,7 +380,7 @@ function dynamicScrollLoadPage(element, atEnd) {
                 // Stop further loads
                 $(element).attr("next_page", 0);
             }
-else {
+            else {
                 $(element).attr("next_page", parseInt(load_page) + 1);
                 arrow_down.show();
             }
@@ -400,7 +400,7 @@ else {
                 // Stop further loads
                 $(element).attr("prev_page", 0);
             }
-else {
+            else {
                 var prev_page = parseInt(load_page) - 1;
                 $(element).attr("prev_page", prev_page);
                 if(prev_page >= 1) {
@@ -480,7 +480,7 @@ function dynamicScrollContentOnDemand(jElement, urlPattern, currentThreadId, cur
             element.scrollTop = sensitivity;
             dynamicScrollLoadPage(element,false);
         }
-else if(isBottom) {
+        else if(isBottom) {
             dynamicScrollLoadPage(element,true);
         }
 
@@ -512,7 +512,7 @@ function checkAreYouSureForm() {
             elements.trigger('reinitialize.areYouSure');
             return true;
         }
-else {
+        else {
             return false;
         }
     }
@@ -571,7 +571,7 @@ function modifyThreadList(currentThreadId, currentCategoriesId, course, loadFirs
                 $("#thread_list .fa-caret-up").hide();
                 $("#thread_list .fa-caret-down").show();
             }
-else {
+            else {
                 $("#thread_list .fa-caret-up").show();
                 $("#thread_list .fa-caret-down").hide();
             }
@@ -596,7 +596,7 @@ function replyPost(post_id){
     if ( $('#'+ post_id + '-reply').css('display') == 'block' ){
         $('#'+ post_id + '-reply').css("display","none");
     }
-else {
+    else {
         hideReplies();
         $('#'+ post_id + '-reply').css('display', 'block');
     }
@@ -616,7 +616,7 @@ function generateCodeMirrorBlocks(container_element) {
         if (lineCount == 1) {
             editor0.setSize("100%", (editor0.defaultTextHeight() * 2) + "px");
         }
-else {
+        else {
             //Default height for CodeMirror is 300px... 500px looks good
             var h = (editor0.defaultTextHeight()) * lineCount + 15;
             editor0.setSize("100%", (h > 500 ? 500 : h) + "px");
@@ -873,7 +873,7 @@ function refreshCategories() {
             $(this).removeClass("btn-selected");
             $(this).find("input[type='checkbox']").prop("checked", false);
         }
-else {
+        else {
             $(this).addClass("btn-selected");
             $(this).find("input[type='checkbox']").prop("checked", true);
         }
@@ -891,7 +891,7 @@ function changeColorClass(){
     $(this).css("background-color",color);
     $(this).css("color","white");
   }
-else {
+    else {
     $(this).css("background-color","white");
     $(this).css("color", color);
   }
@@ -1034,7 +1034,7 @@ function addMarkdownCode(type, divTitle){
     if(type == 1) {
         insert = "[display text](url)";
     }
-else if(type == 0){
+    else if(type == 0){
         insert = "```" +
             "\ncode\n```";
     }
@@ -1064,7 +1064,7 @@ function sortTable(sort_element_index, reverse=false){
                     switching=true;
                 }
             }
-else {
+            else {
                 if(sort_element_index == 0 ? a.innerHTML>b.innerHTML : parseInt(a.innerHTML) < parseInt(b.innerHTML)){
                     rows[i].parentNode.insertBefore(rows[i+1],rows[i]);
                     switching=true;
@@ -1088,7 +1088,7 @@ else {
     if (reverse) {
         headers[sort_element_index].innerHTML = headers[sort_element_index].innerHTML + ' ↑';
     }
-else {
+    else {
         headers[sort_element_index].innerHTML = headers[sort_element_index].innerHTML + ' ↓';
     }
 }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -55,7 +55,8 @@ function checkNumFilesForumUpload(input, post_id){
     if(input.files.length > 5){
         displayError('Max file upload size is 5. Please try again.');
         resetForumFileUploadAfterError(displayPostId);
-    } else {
+    }
+else {
         if(!checkForumFileExtensions(input.files)){
             displayError('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
             resetForumFileUploadAfterError(displayPostId);
@@ -92,11 +93,13 @@ function testAndGetAttachments(post_box_id, dynamic_check) {
     if(files.length > 5){
         if(dynamic_check) {
             displayError('Max file upload size is 5. Please remove attachments accordingly.');
-        } else {
+        }
+else {
             displayError('Max file upload size is 5. Please try again.');
         }
         return false;
-    } else {
+    }
+else {
         if(!checkForumFileExtensions(files)){
             displayError('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
             return false;
@@ -266,7 +269,8 @@ function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_to
             document.getElementById('edit_thread_id').value = thread_id;
             if(change_anon) {
                 $('#thread_post_anon_edit').prop('checked', anon);
-            } else {
+            }
+else {
                 $('label[for=Anon]').remove();
                 $('#thread_post_anon_edit').remove();
             }
@@ -308,7 +312,8 @@ function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_to
                 $("#thread_form").prop("ignore-cat",false);
                 $("#category-selection-container").show();
                 $("#thread_status").show();
-            } else {
+            }
+else {
                 $("#title").prop('disabled', true);
                 $(".edit_thread").hide();
                 $('#label_lock_thread').hide();
@@ -374,7 +379,8 @@ function dynamicScrollLoadPage(element, atEnd) {
             if(count == 0) {
                 // Stop further loads
                 $(element).attr("next_page", 0);
-            } else {
+            }
+else {
                 $(element).attr("next_page", parseInt(load_page) + 1);
                 arrow_down.show();
             }
@@ -393,7 +399,8 @@ function dynamicScrollLoadPage(element, atEnd) {
             if(count == 0) {
                 // Stop further loads
                 $(element).attr("prev_page", 0);
-            } else {
+            }
+else {
                 var prev_page = parseInt(load_page) - 1;
                 $(element).attr("prev_page", prev_page);
                 if(prev_page >= 1) {
@@ -472,7 +479,8 @@ function dynamicScrollContentOnDemand(jElement, urlPattern, currentThreadId, cur
         if(isTop) {
             element.scrollTop = sensitivity;
             dynamicScrollLoadPage(element,false);
-        } else if(isBottom) {
+        }
+else if(isBottom) {
             dynamicScrollLoadPage(element,true);
         }
 
@@ -503,7 +511,8 @@ function checkAreYouSureForm() {
         if(confirm("You have unsaved changes! Do you want to continue?")) {
             elements.trigger('reinitialize.areYouSure');
             return true;
-        } else {
+        }
+else {
             return false;
         }
     }
@@ -561,7 +570,8 @@ function modifyThreadList(currentThreadId, currentCategoriesId, course, loadFirs
             if(loadFirstPage) {
                 $("#thread_list .fa-caret-up").hide();
                 $("#thread_list .fa-caret-down").show();
-            } else {
+            }
+else {
                 $("#thread_list .fa-caret-up").show();
                 $("#thread_list .fa-caret-down").hide();
             }
@@ -585,7 +595,8 @@ function modifyThreadList(currentThreadId, currentCategoriesId, course, loadFirs
 function replyPost(post_id){
     if ( $('#'+ post_id + '-reply').css('display') == 'block' ){
         $('#'+ post_id + '-reply').css("display","none");
-    } else {
+    }
+else {
         hideReplies();
         $('#'+ post_id + '-reply').css('display', 'block');
     }
@@ -604,7 +615,8 @@ function generateCodeMirrorBlocks(container_element) {
         var lineCount = editor0.lineCount();
         if (lineCount == 1) {
             editor0.setSize("100%", (editor0.defaultTextHeight() * 2) + "px");
-        } else {
+        }
+else {
             //Default height for CodeMirror is 300px... 500px looks good
             var h = (editor0.defaultTextHeight()) * lineCount + 15;
             editor0.setSize("100%", (h > 500 ? 500 : h) + "px");
@@ -860,7 +872,8 @@ function refreshCategories() {
         if($(this).hasClass("btn-selected")) {
             $(this).removeClass("btn-selected");
             $(this).find("input[type='checkbox']").prop("checked", false);
-        } else {
+        }
+else {
             $(this).addClass("btn-selected");
             $(this).find("input[type='checkbox']").prop("checked", true);
         }
@@ -877,7 +890,8 @@ function changeColorClass(){
   if($(this).hasClass("btn-selected")) {
     $(this).css("background-color",color);
     $(this).css("color","white");
-  } else {
+  }
+else {
     $(this).css("background-color","white");
     $(this).css("color", color);
   }
@@ -1019,7 +1033,8 @@ function addMarkdownCode(type, divTitle){
     var insert = "";
     if(type == 1) {
         insert = "[display text](url)";
-    } else if(type == 0){
+    }
+else if(type == 0){
         insert = "```" +
             "\ncode\n```";
     }
@@ -1048,7 +1063,8 @@ function sortTable(sort_element_index, reverse=false){
                     rows[i].parentNode.insertBefore(rows[i+1],rows[i]);
                     switching=true;
                 }
-            } else {
+            }
+else {
                 if(sort_element_index == 0 ? a.innerHTML>b.innerHTML : parseInt(a.innerHTML) < parseInt(b.innerHTML)){
                     rows[i].parentNode.insertBefore(rows[i+1],rows[i]);
                     switching=true;
@@ -1071,7 +1087,8 @@ function sortTable(sort_element_index, reverse=false){
     }
     if (reverse) {
         headers[sort_element_index].innerHTML = headers[sort_element_index].innerHTML + ' ↑';
-    } else {
+    }
+else {
         headers[sort_element_index].innerHTML = headers[sort_element_index].innerHTML + ' ↓';
     }
 }

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -23,7 +23,8 @@ function onComponentTabClicked(tab) {
   $(".grade-inquiry").each(function(){
     if ($(this).data("component_id") !== component_id) {
       $(this).hide();
-    } else {
+    }
+else {
       $(this).show();
     }
   });

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -24,7 +24,7 @@ function onComponentTabClicked(tab) {
     if ($(this).data("component_id") !== component_id) {
       $(this).hide();
     }
-else {
+    else {
       $(this).show();
     }
   });

--- a/site/public/js/pdf/PDFAnnotate.js
+++ b/site/public/js/pdf/PDFAnnotate.js
@@ -25,7 +25,8 @@ document.getElementById('content-wrapper').addEventListener('scroll', function (
     if (renderedPages.indexOf(visiblePageNum) == -1){
         okToRender = true;
         renderedPages.push(visiblePageNum);
-    } else {
+    }
+else {
         okToRender = false;
     }
 

--- a/site/public/js/pdf/PDFAnnotate.js
+++ b/site/public/js/pdf/PDFAnnotate.js
@@ -26,7 +26,7 @@ document.getElementById('content-wrapper').addEventListener('scroll', function (
         okToRender = true;
         renderedPages.push(visiblePageNum);
     }
-else {
+    else {
         okToRender = false;
     }
 

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -82,7 +82,7 @@ window.onbeforeunload = function() {
                     break;
             }
         }
-else {
+        else {
             //For color and size select
             switch(option){
                 case 'pen':
@@ -107,14 +107,14 @@ else {
         if(option == 'in'){
             zoom_level += 0.1;
         }
-else if(option == 'out'){
+        else if(option == 'out'){
             zoom_level -= 0.1;
         }
-else {
+        else {
             if(custom_val != null){
                 zoom_level = custom_val/100;
             }
-else {
+            else {
                 zoom_flag = false;
             }
             $('#zoom_selection').toggle();
@@ -159,7 +159,7 @@ else {
                     $('#save_status').text("Saved");
                     $('#save_status').css('color', 'black');
                 }
-else {
+                else {
                     alert(data.message);
                 }
             },

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -81,7 +81,8 @@ window.onbeforeunload = function() {
                     PDFAnnotate.UI.enableText();
                     break;
             }
-        } else {
+        }
+else {
             //For color and size select
             switch(option){
                 case 'pen':
@@ -105,12 +106,15 @@ window.onbeforeunload = function() {
         let zoom_level = window.RENDER_OPTIONS.scale;
         if(option == 'in'){
             zoom_level += 0.1;
-        } else if(option == 'out'){
+        }
+else if(option == 'out'){
             zoom_level -= 0.1;
-        } else {
+        }
+else {
             if(custom_val != null){
                 zoom_level = custom_val/100;
-            } else {
+            }
+else {
                 zoom_flag = false;
             }
             $('#zoom_selection').toggle();
@@ -154,7 +158,8 @@ window.onbeforeunload = function() {
                 if(response.status == "success"){
                     $('#save_status').text("Saved");
                     $('#save_status').css('color', 'black');
-                } else {
+                }
+else {
                     alert(data.message);
                 }
             },

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -221,13 +221,13 @@ function checkAutoRGStatus()
                 showLogButton(response.data);
 
             }
-else if (response.status === 'fail') {
+            else if (response.status === 'fail') {
 
                 $('#save_status').html('A failure occurred generating rainbow grades');
                 showLogButton(response.message);
 
             }
-else {
+            else {
 
                 $('#save_status').html('Internal Server Error');
                 console.log(response);
@@ -261,11 +261,11 @@ function ajaxUpdateJSON(successCallback, errorCallback) {
                     checkAutoRGStatus();
                     //successCallback(response.data);
                 }
-else if (response.status === 'fail') {
+                else if (response.status === 'fail') {
                     $('#save_status').html('A failure occurred saving customization data');
                     //errorCallback(response.message, response.data);
                 }
-else {
+                else {
                     $('#save_status').html('Internal Server Error');
                     console.error(response.message);
                 }

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -220,12 +220,14 @@ function checkAutoRGStatus()
                 $('#save_status').html('Rainbow grades successfully generated!');
                 showLogButton(response.data);
 
-            } else if (response.status === 'fail') {
+            }
+else if (response.status === 'fail') {
 
                 $('#save_status').html('A failure occurred generating rainbow grades');
                 showLogButton(response.message);
 
-            } else {
+            }
+else {
 
                 $('#save_status').html('Internal Server Error');
                 console.log(response);
@@ -258,10 +260,12 @@ function ajaxUpdateJSON(successCallback, errorCallback) {
                     // Call the server to see if auto_rainbow_grades has completed
                     checkAutoRGStatus();
                     //successCallback(response.data);
-                } else if (response.status === 'fail') {
+                }
+else if (response.status === 'fail') {
                     $('#save_status').html('A failure occurred saving customization data');
                     //errorCallback(response.message, response.data);
-                } else {
+                }
+else {
                     $('#save_status').html('Internal Server Error');
                     console.error(response.message);
                 }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -42,11 +42,13 @@ function changeDiffView(div_name, gradeable_id, who_id, version, index, autochec
         $("#show_char_"+index+"_"+autocheck_cnt).html("Display whitespace/non-printing characters as escape sequences");
         list_white_spaces['newline'] = '&#9166;';
         var option = 'unicode'
-    } else if($("#show_char_"+index+"_"+autocheck_cnt).text() == "Display whitespace/non-printing characters as escape sequences") {
+    }
+else if($("#show_char_"+index+"_"+autocheck_cnt).text() == "Display whitespace/non-printing characters as escape sequences") {
         $("#show_char_"+index+"_"+autocheck_cnt).html("Original View");
         list_white_spaces['newline'] = '\\n';
         var option = 'escape'
-    } else {
+    }
+else {
         $("#show_char_"+index+"_"+autocheck_cnt).removeClass('btn-primary');
         $("#show_char_"+index+"_"+autocheck_cnt).addClass('btn-default');
         $("#show_char_"+index+"_"+autocheck_cnt).html("Visualize whitespace characters");
@@ -60,7 +62,8 @@ function changeDiffView(div_name, gradeable_id, who_id, version, index, autochec
         if (data.status === 'fail') {
             alert("Error loading diff: " + data.message);
             return false;
-        } else if (data.status === 'error') {
+        }
+else if (data.status === 'error') {
             alert("Internal server error: " + data.message);
             return false;
         }
@@ -120,7 +123,8 @@ function loadTestcaseOutput(div_name, gradeable_id, who_id, index, version = '')
 
         loadingTools.find("span").hide();
         loadingTools.find(".loading-tools-show").show();
-    }else{
+    }
+else{
         $("#show_char_"+index).toggle();
         var url = buildCourseUrl(['gradeable', gradeable_id, 'grading', 'student_output']) + `?who_id=${who_id}&index=${index}&version=${version}`;
 
@@ -857,7 +861,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
             }
         }
     }
-    
+
     $(":text",form).change(function() {
         var found = false;
         for (var i = 0; i < student_full.length; i++) {
@@ -1037,7 +1041,8 @@ function check_server(url) {
         function(data) {
             if (data.indexOf("REFRESH_ME") > -1) {
                 location.reload(true);
-            } else {
+            }
+else {
                 checkRefreshPage(url);
             }
         }
@@ -1195,7 +1200,8 @@ function changeName(element, user, visible_username, anon){
         new_element.innerHTML = visible_username;
         icon.className = "fas fa-eye";
         icon.title = "Show full user information";
-    } else {
+    }
+else {
         if(anon) {
             new_element.style.color = "grey";
             new_element.style.fontStyle = "italic";
@@ -1347,7 +1353,8 @@ function enableTabsInTextArea(jQuerySelector) {
             var controls = $(":input").filter(":visible");
             controls.eq(controls.index(this) + 1).focus();
             return false;
-        } else if (!t.shiftKey && t.keyCode == 9) { //TAB was pressed without SHIFT, text indent
+        }
+else if (!t.shiftKey && t.keyCode == 9) { //TAB was pressed without SHIFT, text indent
             var text = this.value;
             var beforeCurse = this.selectionStart;
             var afterCurse = this.selectionEnd;
@@ -1428,7 +1435,8 @@ function refreshOnResponseOverriddenGrades(json) {
     $('#title').replaceWith(title);
     if(json['data']['users'].length === 0){
         $('#my_table').append('<tr><td colspan="5">There are no overridden grades for this homework</td></tr>');
-    } else {
+    }
+else {
         json['data']['users'].forEach(function(elem){
             var delete_button = "<a onclick=\"deleteOverriddenGrades('" + elem['user_id'] + "', '" + json['data']['gradeable_id'] + "');\"><i class='fas fa-trash'></i></a>"
             var bits = ['<tr><td>' + elem['user_id'], elem['user_firstname'], elem['user_lastname'], elem['marks'], elem['comment'], delete_button + '</td></tr>'];

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -43,12 +43,12 @@ function changeDiffView(div_name, gradeable_id, who_id, version, index, autochec
         list_white_spaces['newline'] = '&#9166;';
         var option = 'unicode'
     }
-else if($("#show_char_"+index+"_"+autocheck_cnt).text() == "Display whitespace/non-printing characters as escape sequences") {
+    else if($("#show_char_"+index+"_"+autocheck_cnt).text() == "Display whitespace/non-printing characters as escape sequences") {
         $("#show_char_"+index+"_"+autocheck_cnt).html("Original View");
         list_white_spaces['newline'] = '\\n';
         var option = 'escape'
     }
-else {
+    else {
         $("#show_char_"+index+"_"+autocheck_cnt).removeClass('btn-primary');
         $("#show_char_"+index+"_"+autocheck_cnt).addClass('btn-default');
         $("#show_char_"+index+"_"+autocheck_cnt).html("Visualize whitespace characters");
@@ -63,7 +63,7 @@ else {
             alert("Error loading diff: " + data.message);
             return false;
         }
-else if (data.status === 'error') {
+        else if (data.status === 'error') {
             alert("Internal server error: " + data.message);
             return false;
         }
@@ -124,7 +124,7 @@ function loadTestcaseOutput(div_name, gradeable_id, who_id, index, version = '')
         loadingTools.find("span").hide();
         loadingTools.find(".loading-tools-show").show();
     }
-else{
+    else{
         $("#show_char_"+index).toggle();
         var url = buildCourseUrl(['gradeable', gradeable_id, 'grading', 'student_output']) + `?who_id=${who_id}&index=${index}&version=${version}`;
 
@@ -1042,7 +1042,7 @@ function check_server(url) {
             if (data.indexOf("REFRESH_ME") > -1) {
                 location.reload(true);
             }
-else {
+        else {
                 checkRefreshPage(url);
             }
         }
@@ -1201,7 +1201,7 @@ function changeName(element, user, visible_username, anon){
         icon.className = "fas fa-eye";
         icon.title = "Show full user information";
     }
-else {
+    else {
         if(anon) {
             new_element.style.color = "grey";
             new_element.style.fontStyle = "italic";
@@ -1354,7 +1354,7 @@ function enableTabsInTextArea(jQuerySelector) {
             controls.eq(controls.index(this) + 1).focus();
             return false;
         }
-else if (!t.shiftKey && t.keyCode == 9) { //TAB was pressed without SHIFT, text indent
+        else if (!t.shiftKey && t.keyCode == 9) { //TAB was pressed without SHIFT, text indent
             var text = this.value;
             var beforeCurse = this.selectionStart;
             var afterCurse = this.selectionEnd;
@@ -1436,7 +1436,7 @@ function refreshOnResponseOverriddenGrades(json) {
     if(json['data']['users'].length === 0){
         $('#my_table').append('<tr><td colspan="5">There are no overridden grades for this homework</td></tr>');
     }
-else {
+    else {
         json['data']['users'].forEach(function(elem){
             var delete_button = "<a onclick=\"deleteOverriddenGrades('" + elem['user_id'] + "', '" + json['data']['gradeable_id'] + "');\"><i class='fas fa-trash'></i></a>"
             var bits = ['<tr><td>' + elem['user_id'], elem['user_firstname'], elem['user_lastname'], elem['marks'], elem['comment'], delete_button + '</td></tr>'];

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -282,7 +282,7 @@ function generateCheckpointCookie(user_id, g_id, old_scores, new_scores) {
     if (history.length > 11) {
         history.splice(1, 2);
     }
-else {
+    else {
         history[0] = history.length-1; // increment to latest new_scores
     }
 
@@ -531,14 +531,14 @@ function setupNumericTextCells() {
                                                 if (returned_data['data'][x][status_temp_str] === "OK") {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("background-color", "#ffffff");
                                                 }
-else {
+                                                else {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("background-color", "#ff7777");
                                                 }
 
                                                 if($('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).val() == 0) {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("color", "#bbbbbb");
                                                 }
-else {
+                                                else {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("color", "");
                                                 }
 
@@ -573,7 +573,7 @@ else {
                 }
             }
         }
-else {
+        else {
             var f = $('#csvUpload');
             f.replaceWith(f = f.clone(true));
         }

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -44,7 +44,7 @@ function calcSimpleGraderStats(action) {
             var reg_section;                        // the registration section of the current user
             elems.each(function() {
                 if(action == "lab") {
-                    reg_section = $(this).parent().find("td:nth-child(2)").text();              // second child of parent has registration section as text   
+                    reg_section = $(this).parent().find("td:nth-child(2)").text();              // second child of parent has registration section as text
                     section = $(this).parent().parent().attr("id").split("-")[1];               // grandparent id has section
                 }
                 else if(action == "numeric") {
@@ -99,7 +99,7 @@ function calcSimpleGraderStats(action) {
             component_averages.push(sum/num_users);
             component_stddevs.push(Math.sqrt(Math.max(0, (sum_sqrs - sum**2 / num_users) / num_users)));
         }
-        
+
         // get the elements for the next component
         elems = $(elem_type + "[id^=cell-][id$=" + (++c).toString() + "]");
     }
@@ -115,7 +115,7 @@ function calcSimpleGraderStats(action) {
     }
 
     stddev = Math.sqrt(stddev);                                 // take sqrt of sum of squared stddevs to get total stddev
-    stats_popup.find("#avg-total").text(average.toFixed(2));    // set the display text of the proper average element 
+    stats_popup.find("#avg-total").text(average.toFixed(2));    // set the display text of the proper average element
     stats_popup.find("#stddev-total").text(stddev.toFixed(2));  // set the display text of the proper stddev element
 
 
@@ -159,9 +159,9 @@ function updateCheckpointCells(elems, scores, no_cookie) {
     }
 
     // keep track of changes
-    var new_scores = {}; 
+    var new_scores = {};
     var old_scores = {};
-    
+
     elems = $(elems);
     elems.each(function(idx, el) {
         var elem = $(el);
@@ -178,33 +178,33 @@ function updateCheckpointCells(elems, scores, no_cookie) {
         else if (scores && elem.data("id") in scores) {
             elem.data("score", scores[elem.data("id")]);
             set_new = true;
-        } 
+        }
         // if no score set, toggle through options
         else if (!scores) {
             if (elem.data("score") === 1.0) elem.data("score", 0.5);
             else if (elem.data("score") === 0.5) elem.data("score", 0);
             else elem.data("score", 1);
             set_new = true;
-        } 
-        
+        }
+
         if (set_new) {
             new_scores[elem.data("id")] = elem.data("score");
-    
+
             // update css to reflect score
             if (elem.data("score") === 1.0) elem.css("background-color", "#149bdf");
             else if (elem.data("score") === 0.5) elem.css("background-color", "#88d0f4");
             else elem.css("background-color", "");
-    
+
             // create border we can animate to reflect ajax status
             elem.css("border-right", "60px solid #ddd");
         }
     });
-    
+
     var parent = $(elems[0]).parent();
     var user_id = parent.data("user");
     var g_id = parent.data('gradeable');
 
-    // update cookie for undo/redo 
+    // update cookie for undo/redo
     if (!no_cookie) {
         generateCheckpointCookie(user_id, g_id, old_scores, new_scores);
     }
@@ -262,12 +262,12 @@ function generateCheckpointCookie(user_id, g_id, old_scores, new_scores) {
     // pointer should be the index of the current state in history. new_scores should be true for all leading up to that state
     // the pointer is bound by 1, history.length-1
     var history = getCheckpointHistory(g_id);
-    
+
     // erase future snapshots on write
     if (history[0] < history.length-1) {
         history = history.slice(0, history[0]);
     }
-    
+
     // write new student entry
     history.push([user_id, old_scores]);
     history.push([user_id, new_scores]);
@@ -281,10 +281,11 @@ function generateCheckpointCookie(user_id, g_id, old_scores, new_scores) {
     // keep max history of 5 entries (1 buffer for pointer, 5x2 for old/new)
     if (history.length > 11) {
         history.splice(1, 2);
-    } else {
+    }
+else {
         history[0] = history.length-1; // increment to latest new_scores
     }
-    
+
     setCheckpointHistory(g_id, history);
 }
 
@@ -292,15 +293,15 @@ function generateCheckpointCookie(user_id, g_id, old_scores, new_scores) {
 function checkpointRollTo(g_id, diff) {
     // grab history from cookie
     var history = getCheckpointHistory(g_id);
-    
-    var update_queue = []; 
+
+    var update_queue = [];
     var direction = Math.sign(diff);
     var pointer = history[0];
 
     // clamp to bounds
     if (pointer + diff < 1) diff = 1 - pointer;
     if (pointer + diff >= history.length) diff = history.length - 1 - pointer;
-    
+
     // if redoing and pointer is on an old_score, move pointer to next new_score
     if (direction>0 && pointer%2) {
         pointer += 1;
@@ -330,7 +331,7 @@ function checkpointRollTo(g_id, diff) {
     if (pointer >= history.length-1) {
         $("#checkpoint-redo").prop("disabled", true);
     }
-    
+
     //write new cookie
     history[0] = pointer;
     setCheckpointHistory(g_id, history);
@@ -393,10 +394,10 @@ function setupNumericTextCells() {
         else{
             elem.css("color", "");
         }
-        
+
         var row_num = elem.attr("id").split("-")[1];
         var row_el = $("tr#row-" + row_num);
-        
+
         var scores = {};
         var old_scores = {};
         var total = 0;
@@ -413,7 +414,7 @@ function setupNumericTextCells() {
 
             // save old value so we can verify data is not stale
             elem.data('origval', elem.val());
-            elem.attr('data-origval', elem.val());  
+            elem.attr('data-origval', elem.val());
         });
 
         row_el.find(".cell-total").each(function() {
@@ -431,7 +432,7 @@ function setupNumericTextCells() {
             function() {
                 elem.css("background-color", "#ffffff");                                     // change the color
                 elem.attr("value", this.value);                                              // Stores the new input value
-                row_el.children("td.option-small-output").each(function() {  
+                row_el.children("td.option-small-output").each(function() {
                     $(this).children(".option-small-box").each(function() {
                         $(this).attr("value", this.value);                                      // Finds the element that stores the total and updates it to reflect increase
                     });
@@ -529,13 +530,15 @@ function setupNumericTextCells() {
                                                 $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).val(returned_data['data'][x][value_temp_str]);
                                                 if (returned_data['data'][x][status_temp_str] === "OK") {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("background-color", "#ffffff");
-                                                } else {
+                                                }
+else {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("background-color", "#ff7777");
                                                 }
 
                                                 if($('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).val() == 0) {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("color", "#bbbbbb");
-                                                } else {
+                                                }
+else {
                                                     $('#cell-'+$(this).parent().data("row")+'-'+(z-starting_index2)).css("color", "");
                                                 }
 
@@ -569,7 +572,8 @@ function setupNumericTextCells() {
                     }
                 }
             }
-        } else {
+        }
+else {
             var f = $('#csvUpload');
             f.replaceWith(f = f.clone(true));
         }
@@ -598,7 +602,7 @@ function setupSimpleGrading(action) {
     }
 
     var dont_hotkey_focus = true; // set to allow toggling of focus on input element so we can use enter as hotkey
-    
+
     // prevent hotkey focus while already focused, so we dont override search functionality
     $("#student-search-input").focus(function(event) {
         dont_hotkey_focus = true;
@@ -614,25 +618,25 @@ function setupSimpleGrading(action) {
     // moves the selection to an adjacent cell
     function movement(direction){
         var prev_cell = $(".cell-grade:focus");
-        if(prev_cell.length) {         
+        if(prev_cell.length) {
             // ids have the format cell-ROW#-COL#
             var new_selector_array = prev_cell.attr("id").split("-");
             new_selector_array[1] = parseInt(new_selector_array[1]);
             new_selector_array[2] = parseInt(new_selector_array[2]);
-            
+
             // update row and col to get new val
             if (direction == "up") new_selector_array[1] -= 1;
             else if (direction == "down") new_selector_array[1] += 1;
             else if (direction == "left") new_selector_array[2] -= 1;
             else if (direction == "right") new_selector_array[2] += 1;
-            
+
             // get new cell
             var new_cell = $("#" + new_selector_array.join("-"));
             if (new_cell.length) {
                 prev_cell.blur();
                 new_cell.focus();
                 new_cell.select(); // used to select text in input cells
-                
+
                 if((direction == "up" || direction == "down") && !new_cell.isInViewport()) {
                     $('html, body').animate( { scrollTop: new_cell.offset().top - $(window).height()/2}, 50);
                 }
@@ -640,14 +644,14 @@ function setupSimpleGrading(action) {
         }
     }
 
-    // default key movement 
+    // default key movement
     $(document).on("keydown", function(event) {
         // if input cell selected, use this to check if cursor is in the right place
         var input_cell = $("input.cell-grade:focus");
 
         // if there is no selection OR there is a selection to the far left with 0 length
         if(event.keyCode == 37 && (!input_cell.length || (
-                input_cell[0].selectionStart == 0 && 
+                input_cell[0].selectionStart == 0 &&
                 input_cell[0].selectionEnd - input_cell[0].selectionStart == 0))) {
             event.preventDefault();
             movement("left");
@@ -658,7 +662,7 @@ function setupSimpleGrading(action) {
         }
         // if there is no selection OR there is a selection to the far right with 0 length
         else if(event.keyCode == 39 && (!input_cell.length || (
-                input_cell[0].selectionEnd == input_cell[0].value.length && 
+                input_cell[0].selectionEnd == input_cell[0].value.length &&
                 input_cell[0].selectionEnd - input_cell[0].selectionStart == 0))) {
             event.preventDefault();
             movement("right");
@@ -667,8 +671,8 @@ function setupSimpleGrading(action) {
             event.preventDefault();
             movement("down");
         }
-    });  
-    
+    });
+
     // register empty function locked event handlers for "enter" so they show up in the hotkeys menu
     registerKeyHandler({name: "Search", code: "Enter", locked: true}, function() {});
     // make arrow keys in lab section changeable now
@@ -780,7 +784,7 @@ function setupSimpleGrading(action) {
     });
 
     // the offset of the search bar: used to lock the search bar on scroll
-    var sticky_offset = $("#checkpoint-sticky").offset(); 
+    var sticky_offset = $("#checkpoint-sticky").offset();
 
     // used to reposition the search field when the window scrolls
     $(window).on("scroll", function(event) {
@@ -802,7 +806,7 @@ function setupSimpleGrading(action) {
     // check if the search field needs to be repositioned when the page is resized
     $(window).on("resize", function(event) {
         var settings_btn_offset = $("#settings-btn").offset();
-        sticky_offset = {  
+        sticky_offset = {
             top : settings_btn_offset.top,
         };
         if(sticky_offset.top < $(window).scrollTop()) {

--- a/site/public/js/ta-grading-keymap.js
+++ b/site/public/js/ta-grading-keymap.js
@@ -203,7 +203,7 @@ function remapSetLS(mapName, code) {
     if (lsKeymap === null) {
         lsKeymap = {};
     }
-else {
+    else {
         try {
             lsKeymap = JSON.parse(lsKeymap);
         } catch (e) {

--- a/site/public/js/ta-grading-keymap.js
+++ b/site/public/js/ta-grading-keymap.js
@@ -202,7 +202,8 @@ function remapSetLS(mapName, code) {
     var lsKeymap = localStorage.getItem("keymap");
     if (lsKeymap === null) {
         lsKeymap = {};
-    } else {
+    }
+else {
         try {
             lsKeymap = JSON.parse(lsKeymap);
         } catch (e) {

--- a/site/public/js/ta-grading-rubric-conflict.js
+++ b/site/public/js/ta-grading-rubric-conflict.js
@@ -111,7 +111,8 @@ function openMarkConflictPopup(component_id, conflictMarks) {
                     if(!anyUnresolvedConflicts()) {
                         popup.hide();
                         resolve();
-                    } else {
+                    }
+else {
                         showNextConflict();
                     }
                 };
@@ -130,7 +131,8 @@ function openMarkConflictPopup(component_id, conflictMarks) {
                                         // Don't let this error hold up the whole operation
                                         alert('Could not delete mark: ' + err.message);
                                     });
-                            } else {
+                            }
+else {
                                 // If the mark was deleted from the server, but we want to keep our changes,
                                 //  we need to re-add the mark
                                 if (isMarkServerDeleted(id)) {
@@ -138,7 +140,8 @@ function openMarkConflictPopup(component_id, conflictMarks) {
                                         .then(function (data) {
                                             mark.id = data.mark_id;
                                         });
-                                } else {
+                                }
+else {
                                     return ajaxSaveMark(gradeable_id, component_id, id, mark.title, mark.points, mark.publish);
                                 }
                             }

--- a/site/public/js/ta-grading-rubric-conflict.js
+++ b/site/public/js/ta-grading-rubric-conflict.js
@@ -112,7 +112,7 @@ function openMarkConflictPopup(component_id, conflictMarks) {
                         popup.hide();
                         resolve();
                     }
-else {
+                    else {
                         showNextConflict();
                     }
                 };
@@ -132,7 +132,7 @@ else {
                                         alert('Could not delete mark: ' + err.message);
                                     });
                             }
-else {
+                            else {
                                 // If the mark was deleted from the server, but we want to keep our changes,
                                 //  we need to re-add the mark
                                 if (isMarkServerDeleted(id)) {
@@ -141,7 +141,7 @@ else {
                                             mark.id = data.mark_id;
                                         });
                                 }
-else {
+                                else {
                                     return ajaxSaveMark(gradeable_id, component_id, id, mark.title, mark.points, mark.publish);
                                 }
                             }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -98,7 +98,8 @@ function ajaxGetGradeableRubric(gradeable_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong fetching the gradeable rubric: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -147,7 +148,8 @@ function ajaxSaveComponent(gradeable_id, component_id, title, ta_comment, studen
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the component: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -175,7 +177,8 @@ function ajaxGetComponentRubric(gradeable_id, component_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong fetching the component rubric: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -203,7 +206,8 @@ function ajaxGetGradedGradeable(gradeable_id, anon_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong fetching the gradeable grade: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -232,7 +236,8 @@ function ajaxGetGradedComponent(gradeable_id, component_id, anon_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong fetching the component grade: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     // null is not the same as undefined, so we need to make that conversion before resolving
                     if(response.data === null) {
                         response.data = undefined;
@@ -280,7 +285,8 @@ function ajaxSaveGradedComponent(gradeable_id, component_id, anon_id, graded_ver
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the component grade: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -309,7 +315,8 @@ function ajaxGetOverallComment(gradeable_id, anon_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong fetching the gradeable comment: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -344,7 +351,8 @@ function ajaxSaveOverallComment(gradeable_id, anon_id, overall_comment) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the overall comment: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -382,7 +390,8 @@ function ajaxAddNewMark(gradeable_id, component_id, title, points, publish) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong adding a new mark: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -416,7 +425,8 @@ function ajaxDeleteMark(gradeable_id, component_id, mark_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong deleting the mark: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -456,7 +466,8 @@ function ajaxSaveMark(gradeable_id, component_id, mark_id, title, points, publis
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the mark: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -490,7 +501,8 @@ function ajaxGetMarkStats(gradeable_id, component_id, mark_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong getting mark stats: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -524,7 +536,8 @@ function ajaxSaveMarkOrder(gradeable_id, component_id, order) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the mark order: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -556,7 +569,8 @@ function ajaxSaveComponentPages(gradeable_id, pages) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the component pages: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -588,7 +602,8 @@ function ajaxSaveComponentOrder(gradeable_id, order) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong saving the component order: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -618,7 +633,8 @@ function ajaxAddComponent(gradeable_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong adding the component: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data)
                 }
             },
@@ -650,7 +666,8 @@ function ajaxDeleteComponent(gradeable_id, component_id) {
                 if (response.status !== 'success') {
                     console.error('Something went wrong deleting the component: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data);
                 }
             },
@@ -684,7 +701,8 @@ function ajaxVerifyComponent(gradeable_id, component_id, anon_id) {
                 if (response.status !== "success") {
                     console.error('Something went wrong verifying the component: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data);
                 }
             },
@@ -717,7 +735,8 @@ function ajaxVerifyAllComponents(gradeable_id, anon_id) {
                 if (response.status !== "success") {
                     console.error('Something went wrong verifying the all components: ' + response.message);
                     reject(new Error(response.message));
-                } else {
+                }
+else {
                     resolve(response.data);
                 }
             },
@@ -927,7 +946,8 @@ function setComponentInProgress(component_id, show = true) {
     domElement.find('.save-tools span').hide();
     if (show) {
         domElement.find('.save-tools-in-progress').show();
-    } else {
+    }
+else {
         domElement.find('.save-tools :not(.save-tools-in-progress)').show();
     }
 }
@@ -941,7 +961,8 @@ function setOverallCommentInProgress(show = true) {
     domElement.find('.save-tools span').hide();
     if (show) {
         domElement.find('.save-tools-in-progress').show();
-    } else {
+    }
+else {
         domElement.find('.save-tools :not(.save-tools-in-progress)').show();
     }
 }
@@ -1038,7 +1059,8 @@ function setRubricTotalBoxContents(contents) {
 function getCountDirection(component_id) {
     if (getComponentJQuery(component_id).find('input.count-up-selector').is(':checked')) {
         return COUNT_DIRECTION_UP;
-    } else {
+    }
+else {
         return COUNT_DIRECTION_DOWN;
     }
 }
@@ -1074,7 +1096,8 @@ function getComponentPageNumber(component_id) {
     let domElement = getComponentJQuery(component_id);
     if (isInstructorEditEnabled()) {
         return parseInt(domElement.find('input.page-number').val());
-    } else {
+    }
+else {
         return parseInt(domElement.attr('data-page'));
     }
 }
@@ -1158,7 +1181,8 @@ function getMarkFromDOM(mark_id) {
             deleted: domElement.hasClass('mark-deleted'),
             publish: domElement.find('.mark-publish-container input[type=checkbox]').is(':checked')
         };
-    } else {
+    }
+else {
         if (mark_id === 0) {
             return null;
         }
@@ -1196,7 +1220,8 @@ function getGradedComponentFromDOM(component_id) {
         let mark_id = parseInt($(this).attr('data-mark_id'));
         if (mark_id === CUSTOM_MARK_ID) {
             customMarkSelected = true;
-        } else {
+        }
+else {
             mark_ids.push(mark_id);
         }
     });
@@ -1208,7 +1233,8 @@ function getGradedComponentFromDOM(component_id) {
         score = parseFloat(customMarkDOMElement.attr('data-score'));
         comment = customMarkDOMElement.attr('data-comment');
         customMarkSelected = customMarkDOMElement.attr('data-selected') === 'true'
-    } else {
+    }
+else {
         score = parseFloat(customMarkContainer.find('input[type=number]').val());
         comment = customMarkContainer.find('textarea').val();
     }
@@ -1332,7 +1358,8 @@ function getOverallCommentFromDOM() {
 
     if (editComment.length > 0) {
         return editComment.val();
-    } else if (editComment.length > 0) {
+    }
+else if (editComment.length > 0) {
         return staticComment.html();
     }
     return '';
@@ -1594,7 +1621,8 @@ function anyUnverifiedComponents() {
 function updateVerifyAllButton() {
     if (!anyUnverifiedComponents()) {
         $('#verify-all').hide();
-    } else {
+    }
+else {
         $('#verify-all').show();
     }
 }
@@ -1619,7 +1647,8 @@ function setCustomMarkError(component_id, show_error) {
     if (show_error) {
         jquery.addClass(c);
         jquery.prop('title', 'Custom mark cannot be blank!');
-    } else {
+    }
+else {
         jquery.removeClass(c);
         jquery.prop('title', '');
     }
@@ -1741,7 +1770,8 @@ function importComponentsFromFile() {
             if (response.status !== 'success') {
                 console.error('Something went wrong importing components: ' + response.message);
                 reject(new Error(response.message));
-            } else {
+            }
+else {
                 location.reload();
             }
         },
@@ -1928,7 +1958,8 @@ function onToggleEditMode(me) {
 
     if (open_component_ids.length !== 0) {
         reopen_component_id = open_component_ids[0];
-    } else {
+    }
+else {
         updateEditModeEnabled();
         disableEditModeBox(false);
         return;
@@ -2016,7 +2047,8 @@ function onComponentPointsChange(me) {
                 console.error(err);
                 alert('Failed to refresh component! ' + err.message);
             });
-    } else {
+    }
+else {
 
         // Make box red to indicate error
         $(me).css("background-color", "#ff7777");
@@ -2299,7 +2331,8 @@ function toggleComponent(component_id, saveChanges) {
         action = action.then(function() {
             return closeComponent(component_id, saveChanges);
         });
-    } else {
+    }
+else {
         action = action.then(function () {
             return closeAllComponents(saveChanges)
                 .then(function () {
@@ -2358,7 +2391,8 @@ function addNewMark(component_id) {
         promise = promise.then(function () {
             return injectGradingComponent(component, graded_component, true, true);
         });
-    } else {
+    }
+else {
         promise = promise.then(function () {
             return injectInstructorEditComponent(component, true);
         });
@@ -2386,7 +2420,8 @@ function updateCustomMark(component_id) {
 
         // Uncheck the first mark just in case it's checked
         return unCheckFirstMark(component_id);
-    } else {
+    }
+else {
         // Automatically uncheck the custom mark if it's no longer relevant
         unCheckDOMCustomMark(component_id);
 
@@ -2404,7 +2439,8 @@ function toggleCustomMark(component_id) {
     if (isCustomMarkChecked(component_id)) {
         // Uncheck the first mark just in case it's checked
         return unCheckFirstMark(component_id);
-    } else {
+    }
+else {
         // Note: this is in the else block since `unCheckFirstMark` calls this function
         return refreshGradedComponent(component_id, true);
     }
@@ -2459,7 +2495,8 @@ function scrollToPage(page_num){
                 if(page.length) {
                     $('#file_content').animate({scrollTop: page[0].offsetTop}, 500);
                 }
-            } else {
+            }
+else {
                 expandFile("upload.pdf", files[i].getAttribute("file-url"), page_num-1);
             }
         }
@@ -2596,7 +2633,8 @@ function closeOverallComment(saveChanges = true) {
             .then(function () {
                 return refreshOverallComment(false);
             });
-    } else {
+    }
+else {
         return ajaxGetOverallComment(getGradeableId(), getAnonId())
             .then(function (comment) {
                 return injectOverallComment(comment, false);
@@ -2757,11 +2795,13 @@ function tryResolveMarkSave(gradeable_id, component_id, domMark, serverMark, old
             if ((marksEqual(domMark, serverMark) || marksEqual(domMark, oldServerMark)) && !markDeleted) {
                 // If the domMark is not unique, then we don't need to do anything
                 return Promise.resolve(true);
-            } else if (!marksEqual(serverMark, oldServerMark)) {
+            }
+else if (!marksEqual(serverMark, oldServerMark)) {
                 // The domMark is unique, and the serverMark is also unique,
                 // which means all 3 versions are different, which is a conflict state
                 return Promise.resolve(false);
-            } else if (markDeleted) {
+            }
+else if (markDeleted) {
                 // domMark was deleted and serverMark hasn't changed from oldServerMark,
                 //  so try to delete the mark
                 return ajaxDeleteMark(gradeable_id, component_id, domMark.id)
@@ -2773,7 +2813,8 @@ function tryResolveMarkSave(gradeable_id, component_id, domMark, serverMark, old
                         // Success, then resolve success
                         return Promise.resolve(true);
                     });
-            } else {
+            }
+else {
                 // The domMark is unique and the serverMark is the same as the oldServerMark
                 //  so we should save the domMark to the server
                 return ajaxSaveMark(gradeable_id, component_id, domMark.id, domMark.title, domMark.points, domMark.publish)
@@ -2782,22 +2823,26 @@ function tryResolveMarkSave(gradeable_id, component_id, domMark, serverMark, old
                         return Promise.resolve(true);
                     });
             }
-        } else {
+        }
+else {
             // This means it was deleted from the server.
             if (!marksEqual(domMark, oldServerMark) && !markDeleted) {
                 // And the mark changed and wasn't deleted, which is a conflict state
                 return Promise.resolve(false);
-            } else {
+            }
+else {
                 // And the mark didn't change or it was deleted, so don't do anything
                 return Promise.resolve(domMark.id);
             }
         }
-    } else {
+    }
+else {
         // This means it didn't exist when we started editing, so serverMark must also be null
         if (markDeleted) {
             // The mark was marked for deletion, but never existed... so do nothing
             return Promise.resolve(true);
-        } else {
+        }
+else {
             // The mark never existed and isn't deleted, so its new
             return ajaxAddNewMark(gradeable_id, component_id, domMark.title, domMark.points, domMark.publish)
                 .then(function (data) {
@@ -2848,7 +2893,8 @@ function gradedComponentsEqual(gcDOM, gcOLD) {
     // Since the custom mark can be unchecked with text / point value, treat unchecked as blank score / point values
     if (gcDOM.custom_mark_selected) {
         return gcDOM.score === gcOLD.score && gcDOM.comment === gcOLD.comment;
-    } else {
+    }
+else {
         return gcOLD.score === 0.0 && gcOLD.comment === '';
     }
 }
@@ -2858,7 +2904,8 @@ function saveComponent(component_id) {
     if (isEditModeEnabled()) {
         // We're in edit mode, so save the component and fetch the up-to-date grade / rubric data
         return saveMarkList(component_id);
-    } else {
+    }
+else {
         // The grader unchecked the custom mark, but didn't delete the text.  This shouldn't happen too often,
         //  so prompt the grader if this is what they really want since it will delete the text / score.
         let gradedComponent = getGradedComponentFromDOM(component_id);

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -99,7 +99,7 @@ function ajaxGetGradeableRubric(gradeable_id) {
                     console.error('Something went wrong fetching the gradeable rubric: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -149,7 +149,7 @@ function ajaxSaveComponent(gradeable_id, component_id, title, ta_comment, studen
                     console.error('Something went wrong saving the component: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -178,7 +178,7 @@ function ajaxGetComponentRubric(gradeable_id, component_id) {
                     console.error('Something went wrong fetching the component rubric: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -207,7 +207,7 @@ function ajaxGetGradedGradeable(gradeable_id, anon_id) {
                     console.error('Something went wrong fetching the gradeable grade: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -237,7 +237,7 @@ function ajaxGetGradedComponent(gradeable_id, component_id, anon_id) {
                     console.error('Something went wrong fetching the component grade: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     // null is not the same as undefined, so we need to make that conversion before resolving
                     if(response.data === null) {
                         response.data = undefined;
@@ -286,7 +286,7 @@ function ajaxSaveGradedComponent(gradeable_id, component_id, anon_id, graded_ver
                     console.error('Something went wrong saving the component grade: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -316,7 +316,7 @@ function ajaxGetOverallComment(gradeable_id, anon_id) {
                     console.error('Something went wrong fetching the gradeable comment: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -352,7 +352,7 @@ function ajaxSaveOverallComment(gradeable_id, anon_id, overall_comment) {
                     console.error('Something went wrong saving the overall comment: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -391,7 +391,7 @@ function ajaxAddNewMark(gradeable_id, component_id, title, points, publish) {
                     console.error('Something went wrong adding a new mark: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -426,7 +426,7 @@ function ajaxDeleteMark(gradeable_id, component_id, mark_id) {
                     console.error('Something went wrong deleting the mark: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -467,7 +467,7 @@ function ajaxSaveMark(gradeable_id, component_id, mark_id, title, points, publis
                     console.error('Something went wrong saving the mark: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -502,7 +502,7 @@ function ajaxGetMarkStats(gradeable_id, component_id, mark_id) {
                     console.error('Something went wrong getting mark stats: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -537,7 +537,7 @@ function ajaxSaveMarkOrder(gradeable_id, component_id, order) {
                     console.error('Something went wrong saving the mark order: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -570,7 +570,7 @@ function ajaxSaveComponentPages(gradeable_id, pages) {
                     console.error('Something went wrong saving the component pages: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -603,7 +603,7 @@ function ajaxSaveComponentOrder(gradeable_id, order) {
                     console.error('Something went wrong saving the component order: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -634,7 +634,7 @@ function ajaxAddComponent(gradeable_id) {
                     console.error('Something went wrong adding the component: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data)
                 }
             },
@@ -667,7 +667,7 @@ function ajaxDeleteComponent(gradeable_id, component_id) {
                     console.error('Something went wrong deleting the component: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data);
                 }
             },
@@ -702,7 +702,7 @@ function ajaxVerifyComponent(gradeable_id, component_id, anon_id) {
                     console.error('Something went wrong verifying the component: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data);
                 }
             },
@@ -736,7 +736,7 @@ function ajaxVerifyAllComponents(gradeable_id, anon_id) {
                     console.error('Something went wrong verifying the all components: ' + response.message);
                     reject(new Error(response.message));
                 }
-else {
+                else {
                     resolve(response.data);
                 }
             },
@@ -947,7 +947,7 @@ function setComponentInProgress(component_id, show = true) {
     if (show) {
         domElement.find('.save-tools-in-progress').show();
     }
-else {
+    else {
         domElement.find('.save-tools :not(.save-tools-in-progress)').show();
     }
 }
@@ -962,7 +962,7 @@ function setOverallCommentInProgress(show = true) {
     if (show) {
         domElement.find('.save-tools-in-progress').show();
     }
-else {
+    else {
         domElement.find('.save-tools :not(.save-tools-in-progress)').show();
     }
 }
@@ -1060,7 +1060,7 @@ function getCountDirection(component_id) {
     if (getComponentJQuery(component_id).find('input.count-up-selector').is(':checked')) {
         return COUNT_DIRECTION_UP;
     }
-else {
+    else {
         return COUNT_DIRECTION_DOWN;
     }
 }
@@ -1097,7 +1097,7 @@ function getComponentPageNumber(component_id) {
     if (isInstructorEditEnabled()) {
         return parseInt(domElement.find('input.page-number').val());
     }
-else {
+    else {
         return parseInt(domElement.attr('data-page'));
     }
 }
@@ -1182,7 +1182,7 @@ function getMarkFromDOM(mark_id) {
             publish: domElement.find('.mark-publish-container input[type=checkbox]').is(':checked')
         };
     }
-else {
+    else {
         if (mark_id === 0) {
             return null;
         }
@@ -1221,7 +1221,7 @@ function getGradedComponentFromDOM(component_id) {
         if (mark_id === CUSTOM_MARK_ID) {
             customMarkSelected = true;
         }
-else {
+        else {
             mark_ids.push(mark_id);
         }
     });
@@ -1234,7 +1234,7 @@ else {
         comment = customMarkDOMElement.attr('data-comment');
         customMarkSelected = customMarkDOMElement.attr('data-selected') === 'true'
     }
-else {
+    else {
         score = parseFloat(customMarkContainer.find('input[type=number]').val());
         comment = customMarkContainer.find('textarea').val();
     }
@@ -1359,7 +1359,7 @@ function getOverallCommentFromDOM() {
     if (editComment.length > 0) {
         return editComment.val();
     }
-else if (editComment.length > 0) {
+    else if (editComment.length > 0) {
         return staticComment.html();
     }
     return '';
@@ -1622,7 +1622,7 @@ function updateVerifyAllButton() {
     if (!anyUnverifiedComponents()) {
         $('#verify-all').hide();
     }
-else {
+    else {
         $('#verify-all').show();
     }
 }
@@ -1648,7 +1648,7 @@ function setCustomMarkError(component_id, show_error) {
         jquery.addClass(c);
         jquery.prop('title', 'Custom mark cannot be blank!');
     }
-else {
+    else {
         jquery.removeClass(c);
         jquery.prop('title', '');
     }
@@ -1771,7 +1771,7 @@ function importComponentsFromFile() {
                 console.error('Something went wrong importing components: ' + response.message);
                 reject(new Error(response.message));
             }
-else {
+            else {
                 location.reload();
             }
         },
@@ -1959,7 +1959,7 @@ function onToggleEditMode(me) {
     if (open_component_ids.length !== 0) {
         reopen_component_id = open_component_ids[0];
     }
-else {
+    else {
         updateEditModeEnabled();
         disableEditModeBox(false);
         return;
@@ -2048,7 +2048,7 @@ function onComponentPointsChange(me) {
                 alert('Failed to refresh component! ' + err.message);
             });
     }
-else {
+    else {
 
         // Make box red to indicate error
         $(me).css("background-color", "#ff7777");
@@ -2332,7 +2332,7 @@ function toggleComponent(component_id, saveChanges) {
             return closeComponent(component_id, saveChanges);
         });
     }
-else {
+    else {
         action = action.then(function () {
             return closeAllComponents(saveChanges)
                 .then(function () {
@@ -2392,7 +2392,7 @@ function addNewMark(component_id) {
             return injectGradingComponent(component, graded_component, true, true);
         });
     }
-else {
+    else {
         promise = promise.then(function () {
             return injectInstructorEditComponent(component, true);
         });
@@ -2421,7 +2421,7 @@ function updateCustomMark(component_id) {
         // Uncheck the first mark just in case it's checked
         return unCheckFirstMark(component_id);
     }
-else {
+    else {
         // Automatically uncheck the custom mark if it's no longer relevant
         unCheckDOMCustomMark(component_id);
 
@@ -2440,7 +2440,7 @@ function toggleCustomMark(component_id) {
         // Uncheck the first mark just in case it's checked
         return unCheckFirstMark(component_id);
     }
-else {
+    else {
         // Note: this is in the else block since `unCheckFirstMark` calls this function
         return refreshGradedComponent(component_id, true);
     }
@@ -2496,7 +2496,7 @@ function scrollToPage(page_num){
                     $('#file_content').animate({scrollTop: page[0].offsetTop}, 500);
                 }
             }
-else {
+            else {
                 expandFile("upload.pdf", files[i].getAttribute("file-url"), page_num-1);
             }
         }
@@ -2634,7 +2634,7 @@ function closeOverallComment(saveChanges = true) {
                 return refreshOverallComment(false);
             });
     }
-else {
+    else {
         return ajaxGetOverallComment(getGradeableId(), getAnonId())
             .then(function (comment) {
                 return injectOverallComment(comment, false);
@@ -2796,12 +2796,12 @@ function tryResolveMarkSave(gradeable_id, component_id, domMark, serverMark, old
                 // If the domMark is not unique, then we don't need to do anything
                 return Promise.resolve(true);
             }
-else if (!marksEqual(serverMark, oldServerMark)) {
+            else if (!marksEqual(serverMark, oldServerMark)) {
                 // The domMark is unique, and the serverMark is also unique,
                 // which means all 3 versions are different, which is a conflict state
                 return Promise.resolve(false);
             }
-else if (markDeleted) {
+            else if (markDeleted) {
                 // domMark was deleted and serverMark hasn't changed from oldServerMark,
                 //  so try to delete the mark
                 return ajaxDeleteMark(gradeable_id, component_id, domMark.id)
@@ -2814,7 +2814,7 @@ else if (markDeleted) {
                         return Promise.resolve(true);
                     });
             }
-else {
+            else {
                 // The domMark is unique and the serverMark is the same as the oldServerMark
                 //  so we should save the domMark to the server
                 return ajaxSaveMark(gradeable_id, component_id, domMark.id, domMark.title, domMark.points, domMark.publish)
@@ -2824,25 +2824,25 @@ else {
                     });
             }
         }
-else {
+        else {
             // This means it was deleted from the server.
             if (!marksEqual(domMark, oldServerMark) && !markDeleted) {
                 // And the mark changed and wasn't deleted, which is a conflict state
                 return Promise.resolve(false);
             }
-else {
+            else {
                 // And the mark didn't change or it was deleted, so don't do anything
                 return Promise.resolve(domMark.id);
             }
         }
     }
-else {
+    else {
         // This means it didn't exist when we started editing, so serverMark must also be null
         if (markDeleted) {
             // The mark was marked for deletion, but never existed... so do nothing
             return Promise.resolve(true);
         }
-else {
+        else {
             // The mark never existed and isn't deleted, so its new
             return ajaxAddNewMark(gradeable_id, component_id, domMark.title, domMark.points, domMark.publish)
                 .then(function (data) {
@@ -2894,7 +2894,7 @@ function gradedComponentsEqual(gcDOM, gcOLD) {
     if (gcDOM.custom_mark_selected) {
         return gcDOM.score === gcOLD.score && gcDOM.comment === gcOLD.comment;
     }
-else {
+    else {
         return gcOLD.score === 0.0 && gcOLD.comment === '';
     }
 }
@@ -2905,7 +2905,7 @@ function saveComponent(component_id) {
         // We're in edit mode, so save the component and fetch the up-to-date grade / rubric data
         return saveMarkList(component_id);
     }
-else {
+    else {
         // The grader unchecked the custom mark, but didn't delete the text.  This shouldn't happen too often,
         //  so prompt the grader if this is what they really want since it will delete the text / score.
         let gradedComponent = getGradedComponentFromDOM(component_id);

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -243,7 +243,7 @@ function readCookies(){
                             }
                         });
                     }
-else {
+                    else {
                         $(this).children('div[id^=div_viewer_]').each(function() {
                             if ($(this)[0].dataset.file_name == file_path[x]) {
                                 current = $(this);
@@ -317,7 +317,7 @@ function updateCookies(){
     if ($('#autoscroll_id').is(":checked")) {
         autoscroll = "on";
     }
-else {
+    else {
         autoscroll = "off";
     }
     document.cookie = "autoscroll=" + autoscroll + "; path=/;";
@@ -338,7 +338,7 @@ function changeEditorStyle(newStyle){
     if(newStyle === 'style_light'){
         localStorage.setItem("codeDisplayStyle", "light");
     }
-else {
+    else {
         localStorage.setItem("codeDisplayStyle", "dark");
     }
     window.location.reload();
@@ -359,7 +359,7 @@ function gotoPrevStudent(to_ungraded = false) {
         window_location += '&component_id=' + getFirstOpenComponentId();
 
     }
-else {
+    else {
         selector = "#prev-student";
         window_location = $(selector)[0].dataset.href
     }
@@ -390,7 +390,7 @@ function gotoNextStudent(to_ungraded = false) {
         // Append extra get param
         window_location += '&component_id=' + getFirstOpenComponentId();
     }
-else {
+    else {
         selector = "#next-student";
         window_location = $(selector)[0].dataset.href
     }
@@ -572,20 +572,20 @@ registerKeyHandler({name: "Open Next Component", code: 'ArrowDown'}, function(e)
         // Overall comment is open, so just close it
         closeOverallComment(true);
     }
-else if (openComponentId === NO_COMPONENT_ID) {
+    else if (openComponentId === NO_COMPONENT_ID) {
         // No component is open, so open the first one
         let componentId = getComponentIdByOrder(0);
         toggleComponent(componentId, true).then(function () {
             scrollToComponent(componentId);
         });
     }
-else if (openComponentId === getComponentIdByOrder(numComponents - 1)) {
+    else if (openComponentId === getComponentIdByOrder(numComponents - 1)) {
         // Last component is open, so open the general comment
         toggleOverallComment(true).then(function () {
             scrollToOverallComment();
         });
     }
-else {
+    else {
         // Any other case, open the next one
         let nextComponentId = getNextComponentId(openComponentId);
         toggleComponent(nextComponentId, true).then(function () {
@@ -614,11 +614,11 @@ registerKeyHandler({name: "Open Previous Component", code: 'ArrowUp'}, function(
             scrollToOverallComment();
         });
     }
-else if (openComponentId === getComponentIdByOrder(0)) {
+    else if (openComponentId === getComponentIdByOrder(0)) {
         // First component is open, so close it
         closeAllComponents(true);
     }
-else {
+    else {
         // Any other case, open the previous one
         let prevComponentId = getPrevComponentId(openComponentId);
         toggleComponent(prevComponentId, true).then(function () {
@@ -701,7 +701,7 @@ function updateValue(obj, option1, option2) {
         if(oldText.indexOf(option1) >= 0){
             newText = oldText.replace(option1, option2);
         }
-else{
+        else {
             newText = oldText.replace(option2, option1);
         }
         return newText;
@@ -826,7 +826,7 @@ function findAllOpenedFiles(elem, current_path, path, stored_paths, first) {
             return [];
         }
     }
-else {
+    else {
         current_path += "#$SPLIT#$" + path;
     }
 

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -242,7 +242,8 @@ function readCookies(){
                                 openDiv($(this).attr('id').split('_')[2]);
                             }
                         });
-                    } else {
+                    }
+else {
                         $(this).children('div[id^=div_viewer_]').each(function() {
                             if ($(this)[0].dataset.file_name == file_path[x]) {
                                 current = $(this);
@@ -315,7 +316,8 @@ function updateCookies(){
     var autoscroll = "on";
     if ($('#autoscroll_id').is(":checked")) {
         autoscroll = "on";
-    } else {
+    }
+else {
         autoscroll = "off";
     }
     document.cookie = "autoscroll=" + autoscroll + "; path=/;";
@@ -335,7 +337,8 @@ function updateCookies(){
 function changeEditorStyle(newStyle){
     if(newStyle === 'style_light'){
         localStorage.setItem("codeDisplayStyle", "light");
-    } else {
+    }
+else {
         localStorage.setItem("codeDisplayStyle", "dark");
     }
     window.location.reload();
@@ -355,7 +358,8 @@ function gotoPrevStudent(to_ungraded = false) {
         // Append extra get param
         window_location += '&component_id=' + getFirstOpenComponentId();
 
-    } else {
+    }
+else {
         selector = "#prev-student";
         window_location = $(selector)[0].dataset.href
     }
@@ -385,7 +389,8 @@ function gotoNextStudent(to_ungraded = false) {
 
         // Append extra get param
         window_location += '&component_id=' + getFirstOpenComponentId();
-    } else {
+    }
+else {
         selector = "#next-student";
         window_location = $(selector)[0].dataset.href
     }
@@ -566,18 +571,21 @@ registerKeyHandler({name: "Open Next Component", code: 'ArrowDown'}, function(e)
     if (isOverallCommentOpen()) {
         // Overall comment is open, so just close it
         closeOverallComment(true);
-    } else if (openComponentId === NO_COMPONENT_ID) {
+    }
+else if (openComponentId === NO_COMPONENT_ID) {
         // No component is open, so open the first one
         let componentId = getComponentIdByOrder(0);
         toggleComponent(componentId, true).then(function () {
             scrollToComponent(componentId);
         });
-    } else if (openComponentId === getComponentIdByOrder(numComponents - 1)) {
+    }
+else if (openComponentId === getComponentIdByOrder(numComponents - 1)) {
         // Last component is open, so open the general comment
         toggleOverallComment(true).then(function () {
             scrollToOverallComment();
         });
-    } else {
+    }
+else {
         // Any other case, open the next one
         let nextComponentId = getNextComponentId(openComponentId);
         toggleComponent(nextComponentId, true).then(function () {
@@ -605,10 +613,12 @@ registerKeyHandler({name: "Open Previous Component", code: 'ArrowUp'}, function(
         toggleOverallComment(true).then(function () {
             scrollToOverallComment();
         });
-    } else if (openComponentId === getComponentIdByOrder(0)) {
+    }
+else if (openComponentId === getComponentIdByOrder(0)) {
         // First component is open, so close it
         closeAllComponents(true);
-    } else {
+    }
+else {
         // Any other case, open the previous one
         let prevComponentId = getPrevComponentId(openComponentId);
         toggleComponent(prevComponentId, true).then(function () {
@@ -690,7 +700,8 @@ function updateValue(obj, option1, option2) {
     obj.text(function(i, oldText){
         if(oldText.indexOf(option1) >= 0){
             newText = oldText.replace(option1, option2);
-        } else{
+        }
+else{
             newText = oldText.replace(option2, option1);
         }
         return newText;
@@ -814,7 +825,8 @@ function findAllOpenedFiles(elem, current_path, path, stored_paths, first) {
         else {
             return [];
         }
-    } else {
+    }
+else {
         current_path += "#$SPLIT#$" + path;
     }
 

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -52,9 +52,10 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
 
         $config->method('getTimezone')->willReturn(new \DateTimeZone("America/New_York"));
 
-        if (isset($config_values['use_mock_time']) && $config_values['use_mock_time'] === true){
+        if (isset($config_values['use_mock_time']) && $config_values['use_mock_time'] === true) {
             $core->method('getDateTimeNow')->willReturn(new \DateTime('2001-01-01', $config->getTimezone()));
-        }else{
+        }
+        else {
             $core->method('getDateTimeNow')->willReturnCallback(function () use ($config) {
                 return new \DateTime('now', $config->getTimezone());
             });
@@ -98,23 +99,27 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
             $user->method('getId')->willReturn("testUser");
             if (isset($user_config['access_grading'])) {
                 $user->method('accessGrading')->willReturn($user_config['access_grading'] == true);
-            } else {
+            }
+            else {
                 $user->method('accessGrading')->willReturn(false);
             }
             if (isset($user_config['access_full_grading'])) {
                 $user->method('accessFullGrading')->willReturn($user_config['access_full_grading'] == true);
-            } else {
+            }
+            else {
                 $user->method('accessFullGrading')->willReturn(false);
             }
             if (isset($user_config['access_admin'])) {
                 $user->method('accessAdmin')->willReturn($user_config['access_admin'] == true);
-            } else {
+            }
+            else {
                 $user->method('accessAdmin')->willReturn(false);
             }
 
             if (isset($user_config['access_faculty'])) {
                 $user->method('accessFaculty')->willReturn($user_config['access_faculty'] == true);
-            } else {
+            }
+            else {
                 $user->method('accessFaculty')->willReturn(false);
             }
 

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -52,10 +52,10 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
         $filename_full = FileUtils::joinPaths($this->config['course_path'], $name);
         $files = array();
-        if ($zip->open($filename_full, ZipArchive::CREATE) === true){
+        if ($zip->open($filename_full, ZipArchive::CREATE) === true) {
             $lev = "";
-            for($i = 0; $i < $depth; $i++){
-                for($j = 0; $j < $num_files; $j++){
+            for ($i = 0; $i < $depth; $i++) {
+                for ($j = 0; $j < $num_files; $j++) {
                     $fname = "test" . $j . ".txt";
                     $tmpfile = fopen($this->config['course_path'] . $lev . "/" . $fname, "w");
                     $zip->addFile($this->config['course_path'] . $lev . "/" . $fname);

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -79,7 +79,7 @@ class TeamControllerTester extends BaseUnitTest {
         $gradeable = $this->createMockModel(Gradeable::class);
         $gradeable->method('getId')->willReturn("test");
         $gradeable->method('getTitle')->willReturn("Test Gradeable");
-        if($is_team){
+        if ($is_team) {
             $gradeable->method('isTeamAssignment')->willReturn(true);
         }
 

--- a/site/tests/app/libraries/DiffViewerTester.php
+++ b/site/tests/app/libraries/DiffViewerTester.php
@@ -20,7 +20,7 @@ class DiffViewerTester extends \PHPUnit\Framework\TestCase {
         $diffs = array();
         foreach ($files as $file) {
             if (is_dir($dir . "/" . $file) && strpos($file, '.') === false) {
-                foreach($needed_files as $needed_file) {
+                foreach ($needed_files as $needed_file) {
                     if (!file_exists($dir . "/" . $file . "/" . $needed_file)) {
                         continue 2;
                     }

--- a/site/tests/app/libraries/ExceptionHandlerTester.php
+++ b/site/tests/app/libraries/ExceptionHandlerTester.php
@@ -62,7 +62,7 @@ class ExceptionHandlerTester extends \PHPUnit\Framework\TestCase {
             $this->authenticate("test", "test");
             $this->fail("Should have thrown exception");
         }
-        catch(AuthenticationException $e) {
+        catch (AuthenticationException $e) {
             ExceptionHandler::setDisplayExceptions(true);
             $message = ExceptionHandler::handleException($e);
             $this->assertRegExp("/Stack Trace:\n#0 (.*)\/site\/tests\/app\/libraries\/ExceptionHandlerTester\.php\(62\): tests\\\app\\\libraries\\\ExceptionHandlerTester\-\>authenticate\(\)\n/", $message);

--- a/site/tests/app/models/gradeable/LateDayInfoTester.php
+++ b/site/tests/app/models/gradeable/LateDayInfoTester.php
@@ -29,7 +29,8 @@ class LateDayInfoTester extends BaseUnitTest {
             $auto_graded_version->method('getDaysLate')->willReturn(DateUtils::calculateDayDiff($due_date, $submission_date));
             $auto_graded_gradeable->method('getActiveVersionInstance')->willReturn($auto_graded_version);
             $auto_graded_gradeable->method('hasActiveVersion')->willReturn(true);
-        } else {
+        }
+        else {
             $auto_graded_gradeable->method('getActiveVersionInstance')->willReturn(null);
             $auto_graded_gradeable->method('hasActiveVersion')->willReturn(false);
         }

--- a/site/tests/app/models/gradeable/LateDaysTester.php
+++ b/site/tests/app/models/gradeable/LateDaysTester.php
@@ -32,7 +32,8 @@ class LateDaysTester extends BaseUnitTest {
             $auto_graded_version->method('getDaysLate')->willReturn(DateUtils::calculateDayDiff($due_date, $submission_date));
             $auto_graded_gradeable->method('getActiveVersionInstance')->willReturn($auto_graded_version);
             $auto_graded_gradeable->method('hasActiveVersion')->willReturn(true);
-        } else {
+        }
+        else {
             $auto_graded_gradeable->method('getActiveVersionInstance')->willReturn(null);
             $auto_graded_gradeable->method('hasActiveVersion')->willReturn(false);
         }

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -11,7 +11,6 @@
     <exclude-pattern>../app/models/Gradeable.php</exclude-pattern>
 
     <rule ref="SubmittyStandard">
-        <exclude name="SubmittyStandard.ControlStructures.StroustrupStructure.Found" />
         <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.NotSnakeCase" />
         <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 
@@ -24,12 +23,6 @@
 
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
 
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent" />
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.LineIndent" />
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine" />
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
 
         <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceAfterBracket" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the new behavior?

Fixes the remaining control structure sniff errors, which include:
* SubmittyStandard.ControlStructures.StroustrupStructure.Found
* PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisIndent
* PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace
* PSR12.ControlStructures.ControlStructureSpacing.LineIndent
* PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine
* PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine
* PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace
* PSR12.Properties.ConstantVisibility.NotFound
* Squiz.ControlStructures.ControlSignature
* Squiz.ControlStructures.ForEachLoopDeclaration
* Squiz.ControlStructures.ForLoopDeclaration
* Squiz.ControlStructures.LowercaseDeclaration

Which brings the style of control structures to follow our [Coding Standards/Control Structures](https://submitty.org/developer/coding_style_guide/php#control-structures) style guide, giving the general structure of:
```
if ($foo) {
    // code
}
elseif (
    $lot
    && $arguments
    && $in_this_if
    && $conditional
) {
    // code
}
else {
    // code
}
```

While I could have broken this up across a handful of more PRs, given that these are all touching more or less the same lines, I decided to do them all at once so that it was a bit less painful of doing merge conflict resolution (once instead of potentially many times).