### PR TITLE
[Bugfix:TAGrading] View all does not show the null section

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1597,21 +1597,24 @@ class Gradeable extends AbstractModel {
         $users = [];
         $teams = [];
 
+        $get_method = $this->isGradeByRegistration() ? 'getRegistrationSection' : 'getRotatingSection';
+
+        if ($this->isTeamAssignment()) {
+            $all_teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
+            foreach ($all_teams as $team) {
+                /** @var Team $team */
+                $teams[$team->$get_method() ?? 'NULL'][] = $team;
+            }
+        }
+        else {
+            $all_users = $this->core->getQueries()->getAllUsers();
+            foreach ($all_users as $user) {
+                /** @var User $user */
+                $users[$user->$get_method() ?? 'NULL'][] = $user;
+            }
+        }
+
         if ($this->isGradeByRegistration()) {
-            if ($this->isTeamAssignment()) {
-                $all_teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
-                foreach ($all_teams as $team) {
-                    /** @var Team $team */
-                    $teams[$team->getRegistrationSection()][] = $team;
-                }
-            }
-            else {
-                $all_users = $this->core->getQueries()->getAllUsers();
-                foreach ($all_users as $user) {
-                    /** @var User $user */
-                    $users[$user->getRegistrationSection()][] = $user;
-                }
-            }
             $section_names = $this->core->getQueries()->getRegistrationSections();
             foreach ($section_names as $i => $section) {
                 $section_names[$i] = $section['sections_registration_id'];
@@ -1619,26 +1622,13 @@ class Gradeable extends AbstractModel {
             $graders = $this->core->getQueries()->getGradersForRegistrationSections($section_names);
         }
         else {
-            if ($this->isTeamAssignment()) {
-                $all_teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
-                foreach ($all_teams as $team) {
-                    /** @var Team $team */
-                    $teams[$team->getRotatingSection()][] = $team;
-                }
-            }
-            else {
-                $all_users = $this->core->getQueries()->getAllUsers();
-                foreach ($all_users as $user) {
-                    /** @var User $user */
-                    $users[$user->getRotatingSection()][] = $user;
-                }
-            }
             $section_names = $this->core->getQueries()->getRotatingSections();
             foreach ($section_names as $i => $section) {
                 $section_names[$i] = $section['sections_rotating_id'];
             }
             $graders = $this->core->getQueries()->getGradersForRotatingSections($this->getId(), $section_names);
         }
+        $section_names[] = 'NULL';
 
         $sections = [];
         foreach ($section_names as $section_name) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4493 

Null section does not show up when viewing all sections.

### What is the new behavior?

Null sections show up when viewing all sections. The code was failing because doing `$a[null]` is silently recasted as doing `$a['']` which then did not correspond to any section names pull from `getRegistrationSections` or `getRotatingSections`. This fixes it so that instead, we write `$a['NULL']` as that's the section name we want to show. Code was also cleaned up so that it was a bit less repetitive.