### PR TITLE
[Bugfix:TAGrading] View your section button on test/lab not working

### DIFF
--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -45,9 +45,9 @@
                 If nothing to grade, Instructor will see all sections
             #}
             {% if show_all_sections_button %}
-                <a 
+                <a
                     class="btn btn-default"
-                    href="{{ grading_url }}?view=all&sort={{ sort }}"
+                    href="{{ grading_url }}?view={{ view_all ? '' : 'all' }}&sort={{ sort }}"
                 >
                     {{ view_all ? "View Your Sections" : "View All Sections" }}
                 </a>
@@ -71,7 +71,7 @@
                 <input class="csvButtonUpload" type="file" id="csvUpload" accept=".csv, .txt">
             </label>
             <p>
-                The CSV file should be formatted as such: 
+                The CSV file should be formatted as such:
                 <br />
                 user id,first name,last name,grade1,grade2,...,total points earned,text1,text2,...
             </p>
@@ -87,17 +87,17 @@
                 <th width="20"></th>
                 <th width="70">Section</th>
                 <th width="90" style="text-align: left">
-                    <a href="{{ grading_url }}?view={{ view }}&sort=id">
+                    <a href="{{ grading_url }}?view={{ view_all ? 'all' : '' }}&sort=id">
                         <span class="tooltiptext" title="sort by ID" aria-hidden="true">User ID </span><i class="fas fa-sort"></i>
                     </a>
                 </th>
                 <th width="110" style="text-align: left">
-                    <a href="{{ grading_url }}?view={{ view }}&sort=first">
+                    <a href="{{ grading_url }}?view={{ view_all ? 'all' : '' }}&sort=first">
                         <span class="tooltiptext" title="sort by First Name" aria-hidden="true">First Name </span><i class="fas fa-sort"></i>
                     </a>
                 </th>
                 <th width="110" style="text-align: left">
-                    <a href="{{ grading_url }}?view={{ view }}&sort=last">
+                    <a href="{{ grading_url }}?view={{ view_all ? 'all' : '' }}&sort=last">
                         <span class="tooltiptext" title="sort by Last Name" aria-hidden="true">Last Name </span><i class="fas fa-sort"></i>
                     </a>
                 </th>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4633 

Hitting the "View Your Section" button would just reload the page for viewing all sections. Also fixes that clicking to sort a column when viewing all sections would sort, but take you back to viewing just your sections.

### What is the new behavior?

Hitting the "View Your Sections" button not takes you to view your sections. Column headers links now properly retains whether you're viewing all sections or your sections.

### Other information?
`{{ view }}` was not defined in thew View file, but boolean `{{ view_all }` is, so utilize ternary argument to set the right value for `view=` in the URL. I checked all usages of `{{ grading_url }}` to find where in the file might need fixing, which was just the button and the columns.
