### PR TITLE
[Refactor:GradeSummary] Greatly reduce number of run queries for csv generation

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -3,12 +3,8 @@
 namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
-use app\exceptions\FileReadException;
-use app\libraries\Core;
-use app\libraries\DateUtils;
 use app\libraries\FileUtils;
 use app\libraries\GradeableType;
-use app\libraries\Output;
 use app\libraries\routers\AccessControl;
 use app\models\gradeable\AutoGradedGradeable;
 use app\models\gradeable\Gradeable;
@@ -19,7 +15,6 @@ use app\models\gradeable\Mark;
 use app\models\gradeable\Submitter;
 use app\models\User;
 use Symfony\Component\Routing\Annotation\Route;
-use app\models\GradeSummary;
 use app\models\RainbowCustomization;
 use app\exceptions\ValidationException;
 
@@ -32,6 +27,8 @@ class ReportController extends AbstractController {
 
     const MAX_AUTO_RG_WAIT_TIME = 45;       // Time in seconds a call to autoRainbowGradesStatus should
                                             // wait for the job to complete before timing out and returning failure
+
+    private $all_overrides = [];
 
     /**
      * @Route("/{_semester}/{_course}/reports")
@@ -134,7 +131,7 @@ class ReportController extends AbstractController {
         ];
 
         // Generate the reports
-        $rows = $this->generateReportInternal($g_sort_keys, $gg_sort_keys, function ($a, $b, $c) {
+        $rows = $this->generateReportInternal($g_sort_keys, $gg_sort_keys, function (User $a, array $b, LateDays $c) {
             return $this->generateCSVRow($a, $b, $c);
         });
 
@@ -148,6 +145,7 @@ class ReportController extends AbstractController {
                 $csv .= implode(',', $row) . PHP_EOL;
             }
         }
+
         //Send csv data to file download.  Filename: "{course}_csvreport_{date/time stamp}.csv"
         $this->core->getOutput()->renderFile($csv, $this->core->getConfig()->getCourse() . "_csvreport_" . date("ymdHis") . ".csv");
     }
@@ -214,11 +212,14 @@ class ReportController extends AbstractController {
             /** @var Gradeable $g */
             if ($g->isTeamAssignment()) {
                 // if the user doesn't have a team, MAKE THE USER A SUBMITTER
-                $ggs[] = $team_graded_gradeables[$g->getId()][$user->getId()] ?? $this->genDummyGradedGradeable($g, new Submitter($this->core, $user));
+                $graded_gradeable = $team_graded_gradeables[$g->getId()][$user->getId()] ?? $this->genDummyGradedGradeable($g, new Submitter($this->core, $user));
             }
             else {
-                $ggs[] = $user_graded_gradeables[$g->getId()];
+                $graded_gradeable = $user_graded_gradeables[$g->getId()];
             }
+
+            $graded_gradeable->setOverriddenGrades($this->all_overrides[$graded_gradeable->getSubmitter()->getId()][$graded_gradeable->getGradeableId()] ?? null);
+            $ggs[] = $graded_gradeable;
         }
         return $ggs;
     }
@@ -242,10 +243,18 @@ class ReportController extends AbstractController {
         //Gradeable iterator will append one gradeable score per loop pass.
         $user_graded_gradeables = [];
 
+        $mem = memory_get_usage();
+        $all_late_days = [];
+        foreach ($this->core->getQueries()->getLateDayUpdates(null) as $row) {
+            $all_late_days[$row['user_id']] = $row;
+        }
+
+        $this->all_overrides = $this->core->getQueries()->getAllOverriddenGrades();
+
         // Method to call the callback with the required parameters
-        $call_callback = function ($all_gradeables, User $current_user, $user_graded_gradeables, $team_graded_gradeables, $per_user_callback) {
+        $call_callback = function ($all_gradeables, User $current_user, $user_graded_gradeables, $team_graded_gradeables, $per_user_callback) use ($all_late_days) {
             $ggs = $this->mergeGradedGradeables($all_gradeables, $current_user, $user_graded_gradeables, $team_graded_gradeables);
-            $late_days = new LateDays($this->core, $current_user, $ggs);
+            $late_days = new LateDays($this->core, $current_user, $ggs, $all_late_days[$current_user->getId()] ?? []);
             return $per_user_callback($current_user, $ggs, $late_days);
         };
         foreach ($this->core->getQueries()->getGradedGradeables($user_gradeables, null, null, $graded_gradeable_sort_keys) as $gg) {
@@ -271,7 +280,7 @@ class ReportController extends AbstractController {
                 if (!isset($results[$u->getId()])) {
                     // This user had no results, so generate results
                     $ggs = $this->mergeGradedGradeables($all_gradeables, $u, [], $team_graded_gradeables);
-                    $late_days = new LateDays($this->core, $u, $ggs);
+                    $late_days = new LateDays($this->core, $u, $ggs, $all_late_days[$u->getId()] ?? []);
                     $results[$current_user->getId()] = $per_user_callback($u, $ggs, $late_days);
                 }
             }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -243,10 +243,12 @@ class ReportController extends AbstractController {
         //Gradeable iterator will append one gradeable score per loop pass.
         $user_graded_gradeables = [];
 
-        $mem = memory_get_usage();
         $all_late_days = [];
         foreach ($this->core->getQueries()->getLateDayUpdates(null) as $row) {
-            $all_late_days[$row['user_id']] = $row;
+            if (!isset($all_late_days[$row['user_id']])) {
+                $all_late_days[$row['user_id']] = [];
+            }
+            $all_late_days[$row['user_id']][] = $row;
         }
 
         $this->all_overrides = $this->core->getQueries()->getAllOverriddenGrades();

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -39,6 +39,9 @@ class GradedGradeable extends AbstractModel {
     /** @property @var array The late day exceptions indexed by user id */
     protected $late_day_exceptions = [];
 
+    /** @property @var bool|null|SimpleGradeOverriddenUser Does this graded gradeable have overridden grades */
+    protected $overridden_grades = false;
+
 
     /**
      * GradedGradeable constructor.
@@ -238,8 +241,7 @@ class GradedGradeable extends AbstractModel {
      */
     public function getTotalScore() {
         if ($this->hasOverriddenGrades()) {
-            $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(), $this->submitter->getId());
-            return floatval(max(0.0, $userWithOverriddenGrades->getMarks()));
+            return floatval(max(0.0, $this->overridden_grades->getMarks()));
         }
         else {
             return floatval(max(0.0, $this->getTaGradingScore() + $this->getAutoGradingScore()));
@@ -248,9 +250,8 @@ class GradedGradeable extends AbstractModel {
 
     public function getOverriddenComment() {
         $overridden_comment = "";
-        $userWithOverriddenGrades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable->getId(), $this->submitter->getId());
-        if ($userWithOverriddenGrades !== null) {
-            $overridden_comment = $userWithOverriddenGrades->getComment();
+        if ($this->hasOverriddenGrades()) {
+            $overridden_comment = $this->overridden_grades->getComment();
         }
         return $overridden_comment;
     }
@@ -375,7 +376,10 @@ class GradedGradeable extends AbstractModel {
     }
 
     public function hasOverriddenGrades() {
-        return $this->gradeable->hasOverriddenGrades($this->submitter);
+        if ($this->overridden_grades === false) {
+            $this->overridden_grades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->getId(), $this->submitter->getId());
+        }
+        return $this->overridden_grades !== null;
     }
     /* Intentionally Unimplemented accessor methods */
 

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -42,7 +42,6 @@ class GradedGradeable extends AbstractModel {
     /** @property @var bool|null|SimpleGradeOverriddenUser Does this graded gradeable have overridden grades */
     protected $overridden_grades = false;
 
-
     /**
      * GradedGradeable constructor.
      * @param Core $core
@@ -377,7 +376,7 @@ class GradedGradeable extends AbstractModel {
 
     public function hasOverriddenGrades() {
         if ($this->overridden_grades === false) {
-            $this->overridden_grades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->getId(), $this->submitter->getId());
+            $this->overridden_grades = $this->core->getQueries()->getAUserWithOverriddenGrades($this->gradeable_id, $this->submitter->getId());
         }
         return $this->overridden_grades !== null;
     }

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -32,7 +32,7 @@ class LateDays extends AbstractModel {
      * @param User $user
      * @param GradedGradeable[] $graded_gradeables An array of only GradedGradeables
      */
-    public function __construct(Core $core, User $user, array $graded_gradeables) {
+    public function __construct(Core $core, User $user, array $graded_gradeables, $late_day_updates = null) {
         parent::__construct($core);
         $this->user = $user;
 
@@ -51,7 +51,7 @@ class LateDays extends AbstractModel {
         });
 
         // Get the late day updates that the instructor will enter
-        $this->late_days_updates = $this->core->getQueries()->getLateDayUpdates($user->getId());
+        $this->late_days_updates = $late_day_updates ?? $this->core->getQueries()->getLateDayUpdates($user->getId());
 
         // Construct late days info for each gradeable
         foreach ($graded_gradeables as $graded_gradeable) {

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -31,6 +31,7 @@ class LateDays extends AbstractModel {
      * @param Core $core
      * @param User $user
      * @param GradedGradeable[] $graded_gradeables An array of only GradedGradeables
+     * @param array|null $late_day_updates
      */
     public function __construct(Core $core, User $user, array $graded_gradeables, $late_day_updates = null) {
         parent::__construct($core);

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1463,6 +1463,11 @@ parameters:
 			path: app/models/SimpleLateUser.php
 
 		-
+			message: "#^PHPDoc tag @property has invalid value \\(@var bool is this a component\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var string Title of gradeable or component\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/SimpleStat.php
@@ -1499,11 +1504,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var bool Does this component use peer grading\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
-			count: 1
-			path: app/models/SimpleStat.php
-
-		-
-			message: "#^PHPDoc tag @property has invalid value \\(@var bool is this a component\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/SimpleStat.php
 
@@ -2448,17 +2448,12 @@ parameters:
 			path: app/models/gradeable/GradedGradeable.php
 
 		-
+			message: "#^PHPDoc tag @property has invalid value \\(@var bool\\|null\\|SimpleGradeOverriddenUser Does this graded gradeable have overridden grades\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
 			message: "#^PHPDoc tag @param has invalid value \\(\\$gc_id int Gradeable Component id\\)\\: Unexpected token \"\\$gc_id\", expected TOKEN_IDENTIFIER at offset 95$#"
-			count: 1
-			path: app/models/gradeable/GradedGradeable.php
-
-		-
-			message: "#^Cannot call method getMarks\\(\\) on array\\<app\\\\models\\\\SimpleGradeOverriddenUser\\>\\.$#"
-			count: 1
-			path: app/models/gradeable/GradedGradeable.php
-
-		-
-			message: "#^Cannot call method getComment\\(\\) on array\\<app\\\\models\\\\SimpleGradeOverriddenUser\\>\\.$#"
 			count: 1
 			path: app/models/gradeable/GradedGradeable.php
 
@@ -2661,3 +2656,5 @@ parameters:
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$can_inquirye$#"
 			count: 1
 			path: app/views/submission/HomeworkView.php
+
+


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4755 

Generating the CSV grade report is very inefficiently, currently running over 7,000 queries for the sample course in Vagrant. For real courses at RPI, this count is most likely going over 30,000 queries, which causes the page to take a very long time and generally just time out (with its 700+ students).

### What is the new behavior?

Fixes the slowdown, reducing the above query count to a constant 6 (or so) queries for the basic use-case. This is achieved by getting the following information in one batch instead of one at a time per user per gradeable.
1. Get all late day updates for all students
2. Get if a grade override exists for all gradeables for all students

This saved information is then used throughout as needed without requiring any subsequent queries for more information. The downside is that this does require additional memory throughout the entire process, however the upside is that this only requires a set number of queries used to run this page.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is marked as a draft pull request until I am able to complete my assessment of memory overread through this method, as well as perform additional testing around grade overrides with team assignments.