### PR TITLE
[Refactor:PHP] Fix for UselessVariable and DuplicateAssignment

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -643,8 +643,7 @@ class PlagiarismController extends AbstractController {
     }
 
     public function getDisplayForCode($file_name, $color_info) {
-        $content = file_get_contents($file_name);
-        return $content;
+        return file_get_contents($file_name);
     }
 
     /**

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -642,7 +642,7 @@ class PlagiarismController extends AbstractController {
         return $color_info;
     }
 
-    public function getDisplayForCode($file_name, $color_info) {
+    public function getDisplayForCode(string $file_name, $color_info) {
         return file_get_contents($file_name);
     }
 

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -435,12 +435,11 @@ class Core {
         try {
             if ($this->authentication->authenticate()) {
                 $this->database_queries->refreshUserApiKey($user_id);
-                $token = (string) TokenManager::generateApiToken(
+                return (string) TokenManager::generateApiToken(
                     $this->database_queries->getSubmittyUserApiKey($user_id),
                     $this->getConfig()->getBaseUrl(),
                     $this->getConfig()->getSecretSession()
                 );
-                return $token;
             }
         }
         catch (\Exception $e) {
@@ -505,8 +504,7 @@ class Core {
      * @return string
      */
     public function buildUrl($parts = array()) {
-        $url = $this->getConfig()->getBaseUrl() . implode("/", $parts);
-        return $url;
+        return $this->getConfig()->getBaseUrl() . implode("/", $parts);
     }
 
     /**

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -540,8 +540,7 @@ class DiffViewer {
                 $html .= "\t</div>\n";
             }
         }
-        $html .= "</div></div>\n";
-        return $html;
+        return $html . "</div></div>\n";
     }
 
     public function getWhiteSpaces() {

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -145,10 +145,9 @@ class FileUtils {
      * off the string.
      */
     public static function getAllFilesTrimSearchPath(string $search_path, int $path_length): array {
-        $files = array_map(function ($entry) use ($path_length) {
+        return array_map(function ($entry) use ($path_length) {
             return substr($entry['path'], $path_length, strlen($entry['path']) - $path_length);
         }, array_values(FileUtils::getAllFiles($search_path, [], true)));
-        return $files;
     }
 
     /**

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2706,8 +2706,7 @@ AND gc_id IN (
         else {
             $this->course_db->query("SELECT posts.*, fph.edit_timestamp FROM posts {$history_query} WHERE thread_id=? AND {$query_delete} {$query_filter_on_user} ORDER BY timestamp ASC", array_reverse($param_list));
         }
-        $result_rows = $this->course_db->rows();
-        return $result_rows;
+        return $this->course_db->rows();
     }
 
     public function getRootPostOfNonMergedThread($thread_id, &$title, &$message) {
@@ -2719,8 +2718,7 @@ AND gc_id IN (
         }
         $title = $result_rows[0]['title'] . "\n";
         $this->course_db->query("SELECT id FROM posts where thread_id = ? and parent_id = -1", array($thread_id));
-        $root_post = $this->course_db->rows()[0]['id'];
-        return $root_post;
+        return $this->course_db->rows()[0]['id'];
     }
 
     public function mergeThread($parent_thread_id, $child_thread_id, &$message, &$child_root_post) {
@@ -3082,8 +3080,7 @@ AND gc_id IN (
 
     public function getRegradeRequestStatus($user_id, $gradeable_id) {
         $row = $this->course_db->query("SELECT * FROM regrade_requests WHERE user_id = ? AND g_id = ? ", array($user_id, $gradeable_id));
-        $result = ($this->course_db->row()) ? $row['status'] : 0;
-        return $result;
+        return ($this->course_db->row()) ? $row['status'] : 0;
     }
 
 
@@ -4148,8 +4145,7 @@ AND gc_id IN (
         $in_queue_sc = OfficeHoursQueueInstructor::STATUS_CODE_IN_QUEUE;
         $this->course_db->query("SELECT COUNT(*) FROM queue where status = ? and entry_id <= ?", array($in_queue_sc,$row['entry_id']));
         $position_in_queue = $this->course_db->rows()[0]['count'];
-        $oh_queue = new OfficeHoursQueueStudent($this->core, $row['entry_id'], $this->core->getUser()->getId(), $row['name'], $row['status'], $num_in_queue, $position_in_queue, $row['time_in'], $row['time_helped'], $row['time_out'], $row['removed_by']);
-        return $oh_queue;
+        return new OfficeHoursQueueStudent($this->core, $row['entry_id'], $this->core->getUser()->getId(), $row['name'], $row['status'], $num_in_queue, $position_in_queue, $row['time_in'], $row['time_helped'], $row['time_out'], $row['removed_by']);
     }
 
     public function removeUserFromQueue($entry_id, $remover) {
@@ -4179,8 +4175,7 @@ AND gc_id IN (
 
     public function isQueueOpen() {
         $this->course_db->query("SELECT open FROM queue_settings LIMIT 1");
-        $queue_open = $this->course_db->rows()[0]['open'];
-        return $queue_open;
+        return $this->course_db->rows()[0]['open'];
     }
 
     public function getQueueCode() {
@@ -4215,8 +4210,7 @@ AND gc_id IN (
             $index = $index + 1;
         }
 
-        $oh_queue_instr = new OfficeHoursQueueInstructor($this->core, $needs_help, $already_helped, $this->isQueueOpen(), $this->getQueueCode());
-        return $oh_queue_instr;
+        return new OfficeHoursQueueInstructor($this->core, $needs_help, $already_helped, $this->isQueueOpen(), $this->getQueueCode());
     }
 
     public function isValidCode($code) {

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -195,8 +195,7 @@ class PostgresqlDatabase extends AbstractDatabase {
                 $elements[] = "{$e}";
             }
         }
-        $text = "{" . implode(", ", $elements) . "}";
-        return $text;
+        return "{" . implode(", ", $elements) . "}";
     }
 
     public function convertBoolean($value) {

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -38,9 +38,7 @@ class CourseMaterial extends AbstractModel {
             $release_time = \DateTime::createFromFormat('Y-m-d H:i:s', $meta_data->$path_to_file->release_datetime);
 
             // If current time is greater than release time return true, else return false
-            $current_time > $release_time ? $retVal = true : $retVal = false;
-
-            return $retVal;
+            return $current_time > $release_time;
         }
     }
 
@@ -75,14 +73,11 @@ class CourseMaterial extends AbstractModel {
         else {
             $current_user_group = $current_user->getGroup();
             if (!isset($meta_data->$path_to_file->sections)) {
-                $retVal = true;
-                return $retVal;
+                return true;
             }
             $file_sections = $meta_data->$path_to_file->sections;
             $user_section = $current_user->getRegistrationSection();
-            ($current_user_group < 4 || in_array($user_section, $file_sections, true)) ? $retVal = true : $retVal = false;
-
-            return $retVal;
+            return ($current_user_group < 4 || in_array($user_section, $file_sections, true));
         }
     }
 }

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -129,8 +129,7 @@ class Notification extends AbstractModel {
         if (is_null($metadata)) {
             return null;
         }
-        $thread_id = $metadata['thread_id'] ?? -1;
-        return $thread_id;
+        return $metadata['thread_id'] ?? -1;
     }
 
     /**

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -161,9 +161,7 @@ class RainbowCustomization extends AbstractModel {
     }
 
     public function getMessages() {
-        $messages = !is_null($this->RCJSON) ? $this->RCJSON->getMessages() : [];
-
-        return $messages;
+        return !is_null($this->RCJSON) ? $this->RCJSON->getMessages() : [];
     }
 
     /**

--- a/site/app/models/forum/Forum.php
+++ b/site/app/models/forum/Forum.php
@@ -58,9 +58,7 @@ class Forum extends AbstractModel {
         }
 
         //Will use forum queries
-        $query_execute = $this->core->getQueries()->addPinnedThread($user, $thread_id, $toggle);
-
-        return $query_execute;
+        return $this->core->getQueries()->addPinnedThread($user, $thread_id, $toggle);
     }
 
     public function getEditContent($post_id) {

--- a/site/app/models/gradeable/AutoGradedGradeable.php
+++ b/site/app/models/gradeable/AutoGradedGradeable.php
@@ -40,18 +40,7 @@ class AutoGradedGradeable extends AbstractModel {
     }
 
     public function toArray() {
-        $details = parent::toArray();
-
-        // Uncomment this block if we want to serialize the scores
-//        $visible_percent = $this->getVisiblePercent();
-//        $visible_percent = is_nan($visible_percent) ? 0 : $visible_percent;
-//        $details['visible_score'] = $visible_percent;
-//
-//        $total_score = $this->getTotalPercent();
-//        $total_score = is_nan($total_score) ? 0 : $total_score;
-//        $details['total_score'] = $total_score;
-
-        return $details;
+        return parent::toArray();
     }
 
     /**

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -137,8 +137,7 @@ class GradedComponentContainer extends AbstractModel {
 
         // Grades exist for component, so get the only one
         if ($grades_exist) {
-            $graded_component = $this->graded_components[0];
-            return $graded_component;
+            return $this->graded_components[0];
         }
 
         // Grades don't exist, but generate one (at zero index of array)

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -173,13 +173,11 @@ class GradedGradeable extends AbstractModel {
     public function getActiveGradeInquiryCount() {
         if (!$this->gradeable->isGradeInquiryPerComponentAllowed()) {
             return array_reduce($this->regrade_requests, function ($carry, RegradeRequest $grade_inquiry) {
-                $carry += is_null($grade_inquiry->getGcId()) && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
-                return $carry;
+                return $carry + is_null($grade_inquiry->getGcId()) && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
             });
         }
         return array_reduce($this->regrade_requests, function ($carry, RegradeRequest $grade_inquiry) {
-            $carry += $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
-            return $carry;
+            return $carry + $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
         });
     }
 

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -173,11 +173,11 @@ class GradedGradeable extends AbstractModel {
     public function getActiveGradeInquiryCount() {
         if (!$this->gradeable->isGradeInquiryPerComponentAllowed()) {
             return array_reduce($this->regrade_requests, function ($carry, RegradeRequest $grade_inquiry) {
-                return $carry + is_null($grade_inquiry->getGcId()) && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
+                return $carry + (is_null($grade_inquiry->getGcId()) && $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0);
             });
         }
         return array_reduce($this->regrade_requests, function ($carry, RegradeRequest $grade_inquiry) {
-            return $carry + $grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0;
+            return $carry + ($grade_inquiry->getStatus() == RegradeRequest::STATUS_ACTIVE ? 1 : 0);
         });
     }
 

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -368,15 +368,13 @@ class NavigationView extends AbstractView {
             }
         }
 
-        $button = new Button($this->core, [
+        return new Button($this->core, [
             "title" => $team_button_text,
             "subtitle" => $team_display_date,
             "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'team']),
             "class" => "btn {$team_button_type} btn-nav",
             "name" => "team-btn"
         ]);
-
-        return $button;
     }
 
     /**
@@ -400,13 +398,11 @@ class NavigationView extends AbstractView {
 
         //Button types that override any other buttons
         if (!$gradeable->hasAutogradingConfig()) {
-            $button = new Button($this->core, [
+            return new Button($this->core, [
                 "title" => "Need to run BUILD_{$this->core->getConfig()->getCourse()}.sh",
                 "disabled" => true,
                 "class" => "btn btn-default btn-nav"
             ]);
-
-            return $button;
         }
 
         if ($graded_gradeable !== null) {
@@ -562,7 +558,7 @@ class NavigationView extends AbstractView {
             }
         }
 
-        $button = new Button($this->core, [
+        return new Button($this->core, [
             "title" => $title,
             "subtitle" => $display_date,
             "href" => $href,
@@ -571,8 +567,6 @@ class NavigationView extends AbstractView {
             "class" => "btn {$class} btn-nav btn-nav-submit",
             "name" => "submit-btn"
         ]);
-
-        return $button;
     }
 
     /**
@@ -607,24 +601,20 @@ class NavigationView extends AbstractView {
         //Button types that override any other buttons
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
             if (!$gradeable->hasAutogradingConfig()) {
-                $button = new Button($this->core, [
+                return new Button($this->core, [
                     "title" => "Need to run BUILD_{$this->core->getConfig()->getCourse()}.sh",
                     "disabled" => true,
                     "class" => "btn btn-default btn-nav"
                 ]);
-
-                return $button;
             }
 
             if ($gradeable->anyActiveRegradeRequests()) {
                 //Open grade inquiries
-                $button = new Button($this->core, [
+                return new Button($this->core, [
                     "title" => "REGRADE",
                     "class" => "btn btn-danger btn-nav btn-nav-grade",
                     "href" => $href
                 ]);
-
-                return $button;
             }
         }
 
@@ -691,7 +681,7 @@ class NavigationView extends AbstractView {
             }
         }
 
-        $button = new Button($this->core, [
+        return new Button($this->core, [
             "title" => $title,
             "subtitle" => $date_text,
             "href" => $href,
@@ -699,8 +689,6 @@ class NavigationView extends AbstractView {
             "class" => "btn btn-nav btn-nav-grade {$class}",
             "name" => "grade-btn"
         ]);
-
-        return $button;
     }
 
     /**
@@ -708,14 +696,13 @@ class NavigationView extends AbstractView {
      * @return Button|null
      */
     private function getEditButton(Gradeable $gradeable) {
-        $button = new Button($this->core, [
+        return new Button($this->core, [
             "title" => "Edit Gradeable Configuration",
             "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'update']),
             "class" => "fas fa-pencil-alt black-btn",
             "title_on_hover" => true,
             "aria_label" => "edit gradeable {$gradeable->getTitle()}"
         ]);
-        return $button;
     }
 
         /**
@@ -723,7 +710,7 @@ class NavigationView extends AbstractView {
      * @return Button|null
      */
     private function getDeleteButton(Gradeable $gradeable) {
-        $button = new Button($this->core, [
+        return new Button($this->core, [
             "title" => "Delete Gradeable",
             "href" => "javascript:newDeleteGradeableForm('" .
                 $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'delete'])
@@ -732,7 +719,6 @@ class NavigationView extends AbstractView {
             "title_on_hover" => true,
             "aria_label" => "Delete {$gradeable->getTitle()}"
         ]);
-        return $button;
     }
 
     /**

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -386,7 +386,7 @@ HTML;
     }
 
     public function deletePlagiarismResultAndConfigForm() {
-        $return = <<<HTML
+        return <<<HTML
     <div class="popup-form"  style="display: none;" id="delete-plagiarism-result-and-config-form">
         <form name="delete" method="post" action="">
             <div class="popup-box">
@@ -414,15 +414,13 @@ HTML;
         $(".popup-window").draggable();
     </script>
 HTML;
-        return $return;
     }
 
     public function plagiarismPopUpToShowMatches() {
-        $return = <<<HTML
+        return <<<HTML
     <ul id="popup_to_show_matches_id" tabindex="0" class="ui-menu ui-widget ui-widget-content ui-autocomplete ui-front" style="display: none;top:0px;left:0px;width:auto;" >
     </ul>
 HTML;
-        return $return;
     }
 
     public function configureGradeableForPlagiarismForm($new_or_edit, $gradeable_ids_titles, $prior_term_gradeables, $saved_config) {
@@ -705,7 +703,7 @@ HTML;
         }
 
 
-        $return .= <<<HTML
+        return $return . <<<HTML
                     <input type="text" name="ignore_submission_{$count}" />
                 </div><br />
                 <div style="width:70%;float:right">
@@ -738,7 +736,5 @@ HTML;
     });
 </script>
 HTML;
-
-        return $return;
     }
 }

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -94,14 +94,12 @@ class ForumThreadView extends AbstractView {
         }
 
 
-        $return = $this->core->getOutput()->renderTwigTemplate("forum/searchResults.twig", [
+        return $this->core->getOutput()->renderTwigTemplate("forum/searchResults.twig", [
             "buttons" => $buttons,
             "count_threads" => count($threads),
             "threads" => $thread_list,
             "search_url" => $this->core->buildCourseUrl(['forum', 'search'])
         ]);
-
-        return $return;
     }
 
     /** Shows Forums thread splash page, including all posts
@@ -934,7 +932,7 @@ class ForumThreadView extends AbstractView {
             $GLOBALS['post_box_id'] = $post_box_id = isset($GLOBALS['post_box_id']) ? $GLOBALS['post_box_id'] + 1 : 1;
         }
 
-        $return = [
+        return [
             "classes" => $classes,
             "post_id" => $post_id,
             "reply_level" => $reply_level,
@@ -962,8 +960,6 @@ class ForumThreadView extends AbstractView {
             "parent_id" => $post_id,
             "render_markdown" => $markdown
         ];
-
-        return $return;
     }
 
     public function createThread($category_colors) {
@@ -1006,7 +1002,7 @@ class ForumThreadView extends AbstractView {
         $thread_exists = $this->core->getQueries()->threadExists();
         $manage_categories_url = $this->core->buildCourseUrl(['forum', 'categories']);
 
-        $return = $this->core->getOutput()->renderTwigTemplate("forum/createThread.twig", [
+        return $this->core->getOutput()->renderTwigTemplate("forum/createThread.twig", [
             "categories" => $categories,
             "category_colors" => $category_colors,
             "buttons" => $buttons,
@@ -1017,8 +1013,6 @@ class ForumThreadView extends AbstractView {
             "email_enabled" => $this->core->getConfig()->isEmailEnabled(),
             "search_url" => $this->core->buildCourseUrl(['forum', 'search'])
         ]);
-
-        return $return;
     }
 
     public function showCategories($category_colors) {
@@ -1065,15 +1059,13 @@ class ForumThreadView extends AbstractView {
             "thread_exists" => $thread_exists
         ];
 
-        $return = $this->core->getOutput()->renderTwigTemplate("forum/ShowCategories.twig", [
+        return $this->core->getOutput()->renderTwigTemplate("forum/ShowCategories.twig", [
             "categories" => $categories,
             "category_colors" => $category_colors,
             "forumBarData" => $forumBarData,
             "csrf_token" => $this->core->getCsrfToken(),
             "search_url" => $this->core->buildCourseUrl(['forum', 'search'])
         ]);
-
-        return $return;
     }
 
     public function statPage($users) {
@@ -1141,12 +1133,10 @@ class ForumThreadView extends AbstractView {
             ];
         }
 
-        $return = $this->core->getOutput()->renderTwigTemplate("forum/StatPage.twig", [
+        return $this->core->getOutput()->renderTwigTemplate("forum/StatPage.twig", [
             "forumBarData" => $forumBarData,
             "userData" => $userData,
             "search_url" => $this->core->buildCourseUrl(['forum', 'search'])
         ]);
-
-        return $return;
     }
 }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1007,7 +1007,7 @@ HTML;
         $this->core->getOutput()->addInternalJs('ta-grading-rubric-conflict.js');
         $this->core->getOutput()->addInternalJs('ta-grading-rubric.js');
         $this->core->getOutput()->addInternalJs('gradeable.js');
-        $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/RubricPanel.twig", [
+        return $return . $this->core->getOutput()->renderTwigTemplate("grading/electronic/RubricPanel.twig", [
             "gradeable_id" => $gradeable->getId(),
             "is_ta_grading" => $gradeable->isTaGrading(),
             "anon_id" => $graded_gradeable->getSubmitter()->getAnonId(),
@@ -1022,7 +1022,6 @@ HTML;
             "grader_id" => $this->core->getUser()->getId(),
             "display_version" => $display_version,
         ]);
-        return $return;
     }
 
     /**

--- a/site/tests/app/controllers/AuthenticationControllerTester.php
+++ b/site/tests/app/controllers/AuthenticationControllerTester.php
@@ -232,7 +232,7 @@ class AuthenticationControllerTester extends BaseUnitTest {
         unset($_POST['user_id']);
         $_POST['no_redirect'] = true;
         $_POST['password'] = 'test';
-        $core = $core = $this->getAuthenticationCore();
+        $core = $this->getAuthenticationCore();
         $controller = new AuthenticationController($core);
         $response = $controller->checkLogin()->json_response->json;
         $this->assertEquals(['status' => 'fail', 'message' => 'Cannot leave user id or password blank'], $response);

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -57,8 +57,6 @@
         <exclude name="SlevomatCodingStandard.PHP.TypeCast.InvalidCastUsed" />
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceBeforeColon" />
         <exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable" />
-        <exclude name="SlevomatCodingStandard.Variables.UselessVariable.UselessVariable" />
-        <exclude name="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable.DuplicateAssignment" />
     </rule>
 
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes the remaining control structure sniff errors, which include:

 * SlevomatCodingStandard.Variables.UselessVariable.UselessVariable
 * SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable.DuplicateAssignment

This change removes variables that are created to be immediately returned in a return statement.