### PR TITLE
[Bugfix:PDFAnnotator] PDFs with underscores fail to load annotations

### DIFF
--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -41,7 +41,7 @@ class PDFController extends AbstractController {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = implode('_', array_slice($pdf_info, 0, -1));
-                        $grader_id = $pdf_info[count($pdf_info)-1];
+                        $grader_id = $pdf_info[count($pdf_info) - 1];
                         if ($pdf_id . '.pdf' === $filename) {
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }
@@ -142,7 +142,7 @@ class PDFController extends AbstractController {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
                         $pdf_id = implode('_', array_slice($pdf_info, 0, -1));
-                        $grader_id = $pdf_info[count($pdf_info)-1];
+                        $grader_id = $pdf_info[count($pdf_info) - 1];
                         if ($pdf_id . '.pdf' === $filename) {
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -40,8 +40,8 @@ class PDFController extends AbstractController {
                     if (!$fileinfo->isDot()) {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
-                        $pdf_id = $pdf_info[0];
-                        $grader_id = $pdf_info[1];
+                        $pdf_id = implode('_', array_slice($pdf_info, 0, -1));
+                        $grader_id = $pdf_info[count($pdf_info)-1];
                         if ($pdf_id . '.pdf' === $filename) {
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }
@@ -141,8 +141,8 @@ class PDFController extends AbstractController {
                     if (!$fileinfo->isDot()) {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
-                        $pdf_id = $pdf_info[0];
-                        $grader_id = $pdf_info[1];
+                        $pdf_id = implode('_', array_slice($pdf_info, 0, -1));
+                        $grader_id = $pdf_info[count($pdf_info)-1];
                         if ($pdf_id . '.pdf' === $filename) {
                             $annotation_jsons[$grader_id] = file_get_contents($fileinfo->getPathname());
                         }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -405,7 +405,7 @@ class AutoGradingView extends AbstractView {
                     if (!$fileinfo->isDot()) {
                         $no_extension = preg_replace('/\\.[^.\\s]{3,4}$/', '', $fileinfo->getFilename());
                         $pdf_info = explode('_', $no_extension);
-                        $pdf_id = $pdf_info[0];
+                        $pdf_id = implode("_", array_slice($pdf_info, 0, -1));
                         if (file_get_contents($fileinfo->getPathname()) != "") {
                             $pdf_id = $pdf_id . '.pdf';
                             $annotated_file_names[] = $pdf_id;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

PDFs that have underscores in them failed to load properly as the code expected only one underscore in the name, where everything before it was the PDF name and everything after it is the user_id.

### What is the new behavior?

Allows the PDF to have as many underscores as it wants.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
There is still a bug that exists that if the user_id contains underscores, it will not properly attribute annotations to that user.