### PR TITLE
[Bugfix: Autograding] Move Stack Trace Logs

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -213,7 +213,7 @@ fi
 # Create the logs directories that exist on both primary & worker machines
 mkdir -p ${SUBMITTY_DATA_DIR}/logs
 mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding
-mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding/stack_traces
+mkdir -p ${SUBMITTY_DATA_DIR}/logs/stack_traces
 # Create the logs directories that only exist on the primary machine
 if [ "${WORKER}" == 0 ]; then
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/access
@@ -246,6 +246,7 @@ fi
 chown root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs
 # Set owner/group for logs directories that exist on both primary & work machines
 chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/autograding
+chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/stack_traces
 # Set owner/group for logs directories that exist only on the primary machine
 if [ "${WORKER}" == 0 ]; then
     chown  -R ${PHP_USER}:${COURSE_BUILDERS_GROUP}    ${SUBMITTY_DATA_DIR}/logs/access

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -213,7 +213,7 @@ fi
 # Create the logs directories that exist on both primary & worker machines
 mkdir -p ${SUBMITTY_DATA_DIR}/logs
 mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding
-mkdir -p ${SUBMITTY_DATA_DIR}/logs/stack_traces
+mkdir -p ${SUBMITTY_DATA_DIR}/logs/autograding_stack_traces
 # Create the logs directories that only exist on the primary machine
 if [ "${WORKER}" == 0 ]; then
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/access
@@ -246,7 +246,7 @@ fi
 chown root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs
 # Set owner/group for logs directories that exist on both primary & work machines
 chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/autograding
-chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/stack_traces
+chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/autograding_stack_traces
 # Set owner/group for logs directories that exist only on the primary machine
 if [ "${WORKER}" == 0 ]; then
     chown  -R ${PHP_USER}:${COURSE_BUILDERS_GROUP}    ${SUBMITTY_DATA_DIR}/logs/access

--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -100,7 +100,7 @@ def log_stack_trace(log_path, job_id="UNKNOWN", is_batch=False, which_untrusted=
     """ Given a log directory, create or append a stack trace to a dated log file in that directory. """
 
     now = dateutils.get_current_time()
-    datefile = "stack_traces_{0}.txt".format(datetime.strftime(now, "%Y%m%d"))
+    datefile = "{0}.txt".format(datetime.strftime(now, "%Y%m%d"))
     autograding_log_file = os.path.join(log_path, datefile)
     easy_to_read_date = dateutils.write_submitty_date(now, True)
     batch_string = "BATCH" if is_batch else ""

--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -12,7 +12,7 @@ from .execution_environments import jailed_sandbox
 with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
     OPEN_JSON = json.load(open_file)
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
-AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['autograding_log_path'], 'stack_traces')
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'stack_traces')
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 

--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -12,7 +12,7 @@ from .execution_environments import jailed_sandbox
 with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
     OPEN_JSON = json.load(open_file)
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
-AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'stack_traces')
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'autograding_stack_traces')
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 

--- a/migration/migrator/migrations/system/20191113082100_move_stack_trace_logs.py
+++ b/migration/migrator/migrations/system/20191113082100_move_stack_trace_logs.py
@@ -1,0 +1,35 @@
+"""Migration for the Submitty system."""
+import os
+import json
+from pathlib import Path
+import shutil
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    old_stack_trace_path = os.path.join(config.submitty['autograding_log_path'], 'stack_traces')
+    new_stack_trace_path = os.path.join(config.submitty['site_log_path'], 'autograding_stack_traces')
+
+    # If the old path exists and the new one does not, move old to new
+    if os.path.exists(old_stack_trace_path) and not os.path.exists(new_stack_trace_path):
+        shutil.move(old_stack_trace_path, new_stack_trace_path)
+    # If neither the new nor old path exists, make the new stack trace directory
+    elif not os.path.exists(new_stack_trace_path):
+        os.mkdir(new_stack_trace_path)
+
+
+
+def down(config):
+    old_stack_trace_path = os.path.join(config.submitty['autograding_log_path'], 'stack_traces')
+    new_stack_trace_path = os.path.join(config.submitty['site_log_path'], 'autograding_stack_traces')
+
+    # If the new path exists and the old one does not, move new to old
+    if os.path.exists(new_stack_trace_path) and not os.path.exists(old_stack_trace_path):
+        shutil.move(new_stack_trace_path, old_stack_trace_path)
+    # If neither the new nor old path exists, make the new stack trace directory
+    elif not os.path.exists(old_stack_trace_path):
+        os.mkdir(old_stack_trace_path)

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -27,7 +27,7 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
-AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'stack_traces')
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'autograding_stack_traces')
 
 with open(os.path.join(CONFIG_PATH, 'submitty_users.json')) as open_file:
     OPEN_JSON = json.load(open_file)
@@ -392,7 +392,7 @@ def grade_queue_file(my_name, which_machine,which_untrusted,queue_file):
 
         #prep_job_success = prepare_job(my_name,which_machine, which_untrusted, my_dir, queue_file)
         while not prepare_job(my_name,which_machine, which_untrusted, my_dir, queue_file):
-            time.sleep(5)
+            autograding_utils.log_message(AUTOGRADING_LOG_PATH, JOB_ID, message=str(my_name)+" ERROR going to re-try prepare_job: " + queue_file)
 
         prep_job_success = True
         

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -27,7 +27,7 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
-AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['autograding_log_path'], 'stack_traces')
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'stack_traces')
 
 with open(os.path.join(CONFIG_PATH, 'submitty_users.json')) as open_file:
     OPEN_JSON = json.load(open_file)
@@ -392,7 +392,7 @@ def grade_queue_file(my_name, which_machine,which_untrusted,queue_file):
 
         #prep_job_success = prepare_job(my_name,which_machine, which_untrusted, my_dir, queue_file)
         while not prepare_job(my_name,which_machine, which_untrusted, my_dir, queue_file):
-            autograding_utils.log_message(AUTOGRADING_LOG_PATH, JOB_ID, message=str(my_name)+" ERROR going to re-try prepare_job: " + queue_file)
+            time.sleep(5)
 
         prep_job_success = True
         

--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -28,7 +28,7 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
-AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'stack_traces')
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'autograding_stack_traces')
 
 JOB_ID = '~WORK~'
 

--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -28,7 +28,7 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 AUTOGRADING_LOG_PATH = OPEN_JSON['autograding_log_path']
-AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['autograding_log_path'], 'stack_traces')
+AUTOGRADING_STACKTRACE_PATH = os.path.join(OPEN_JSON['site_log_path'], 'stack_traces')
 
 JOB_ID = '~WORK~'
 


### PR DESCRIPTION
1. Adds a migration which moves the stack trace logs from ```var/local/submitty/logs/autograding/stack_traces``` to ```var/local/submitty/logs/stack_traces```.
2. Appropriate down migration also added.
3. New stack trace log names are no longer prepended with ```stack_trace_```. 
4.  ~~On failure to prepare a job, the autograding shipper now waits 5 seconds before trying again instead of instantly retrying. This should help to slow down log build-up in cases of failed grading. Future revisions should be made to further fix this error.~~  ___Moving to another PR___