### PR TITLE
[BugFix:Bulk Upload] Fix last split PDF not getting saved

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -149,11 +149,11 @@ def main(args):
         # save whatever is left
         prepended_index = str(i).zfill(3)
         output_filename = '{}_{}.pdf'.format(filename[:-4], prepended_index)
-        output[output_filename]['id'] = data
-        output[output_filename]['page_count'] = page_count
+        output[prev_file]['id'] = data
+        output[prev_file]['page_count'] = page_count
         logger.write_to_json(json_file, output)
 
-        with open(output_filename, 'wb') as out:
+        with open(prev_file, 'wb') as out:
             pdf_writer.write(out)
         # write the buffer to the log file, so everything is on one line
         logger.write_to_log(log_file_path, buff)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The Bulk Upload QR splitter does not save the last split PDF it found and only saves the 
along with filename.

### What is the new behavior?
Fixes uses the wrong key to save the file, now correctly saves the split pdf and its page count & id
