### PR TITLE
[Bugfix:Autograding] Added site_log_path to Workers

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -352,8 +352,8 @@ else:
     config['institution_homepage'] = INSTITUTION_HOMEPAGE
     config['debugging_enabled'] = DEBUGGING_ENABLED
 
-    config['site_log_path'] = TAGRADING_LOG_PATH
-
+# site_log_path is a holdover name. This could more accurately be called the "log_path"
+config['site_log_path'] = TAGRADING_LOG_PATH
 config['autograding_log_path'] = AUTOGRADING_LOG_PATH
 
 if args.worker:
@@ -470,9 +470,10 @@ config['submitty_install_dir'] = SUBMITTY_INSTALL_DIR
 config['submitty_repository'] = SUBMITTY_REPOSITORY
 config['submitty_data_dir'] = SUBMITTY_DATA_DIR
 config['autograding_log_path'] = AUTOGRADING_LOG_PATH
+# site_log_path is a holdover name. This could more accurately be called the "log_path"
+config['site_log_path'] = TAGRADING_LOG_PATH
 
 if not args.worker:
-    config['site_log_path'] = TAGRADING_LOG_PATH
     config['submission_url'] = SUBMISSION_URL
     config['vcs_url'] = VCS_URL
     config['cgi_url'] = CGI_URL


### PR DESCRIPTION
The ```site_log_path```, which could more accurately be called the ```submitty_log_path```, was missing from worker machines, causing an error when autograding. This PR adds the ```site_log_path``` to workers.