### PR TITLE
[Bugfix:PDFAnnotate] Update annotator and fix deprecation warnings

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,9 +14,9 @@
       "integrity": "sha512-XiUPoS79r1G7PcpnNtq85TJ7inJWe0v+b5oZJZKb0pGHNIV6+UiNeQWiFGmuQ0aj7GEhnD/v9iqxIsjuRKtEnQ=="
     },
     "@submitty/pdf-annotate.js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@submitty/pdf-annotate.js/-/pdf-annotate.js-2.1.0.tgz",
-      "integrity": "sha512-Kyhh7avGPcE+MPsCHm1OFT+pQrL+BrwyOvm2Ugpok6K1UJ6+yirQRKF25d59kkJbHpuVYKaIyYcvNKij97ZBaw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@submitty/pdf-annotate.js/-/pdf-annotate.js-2.2.0.tgz",
+      "integrity": "sha512-VVV3ShsPRWYmNbilPuUg6KrZ5iElbSyjipekBC9iPgRHk12QsA+p3ZjdDnUC0xo2M4zYhxgManaKgG4WbRJ+yA=="
     },
     "ajv": {
       "version": "6.10.1",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -19,9 +19,9 @@
       "integrity": "sha512-VVV3ShsPRWYmNbilPuUg6KrZ5iElbSyjipekBC9iPgRHk12QsA+p3ZjdDnUC0xo2M4zYhxgManaKgG4WbRJ+yA=="
     },
     "ajv": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -612,9 +612,9 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.1.266",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.1.266.tgz",
-      "integrity": "sha512-Jy7o1wE3NezPxozexSbq4ltuLT0Z21ew/qrEiAEeUZzHxMHGk4DUV1D7RuCXg5vJDvHmjX1YssN+we9QfRRgXQ==",
+      "version": "2.2.228",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.2.228.tgz",
+      "integrity": "sha512-W5LhYPMS2UKX0ELIa4u+CFCMoox5qQNQElt0bAK2mwz1V8jZL0rvLao+0tBujce84PK6PvWG36Nwr7agCCWFGQ==",
       "requires": {
         "node-ensure": "^0.0.0",
         "worker-loader": "^2.0.0"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,9 +14,9 @@
       "integrity": "sha512-XiUPoS79r1G7PcpnNtq85TJ7inJWe0v+b5oZJZKb0pGHNIV6+UiNeQWiFGmuQ0aj7GEhnD/v9iqxIsjuRKtEnQ=="
     },
     "@submitty/pdf-annotate.js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@submitty/pdf-annotate.js/-/pdf-annotate.js-2.2.0.tgz",
-      "integrity": "sha512-VVV3ShsPRWYmNbilPuUg6KrZ5iElbSyjipekBC9iPgRHk12QsA+p3ZjdDnUC0xo2M4zYhxgManaKgG4WbRJ+yA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@submitty/pdf-annotate.js/-/pdf-annotate.js-2.2.2.tgz",
+      "integrity": "sha512-wL3ZZX0750JkashK2afSIvtNKyx64TVTVsTAEMVpRP1ShDZJTJ4Fpq4Stp3vc7oVpyiiDL2a6EtOLs5/mixpeA=="
     },
     "ajv": {
       "version": "6.10.2",

--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,7 @@
     "jquery-ui-timepicker-addon": "1.6.3",
     "jquery.are-you-sure": "1.9.0",
     "mermaid": "8.4.0",
-    "pdfjs-dist": "2.1.266",
+    "pdfjs-dist": "2.2.228",
     "plotly.js-dist": "1.50.1",
     "shortcut-buttons-flatpickr": "0.3.0",
     "twig": "1.13.3"

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/Submitty/Submitty#readme",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.11.2",
-    "@submitty/pdf-annotate.js": "2.1.0",
+    "@submitty/pdf-annotate.js": "2.2.0",
     "bootstrap": "4.3.1",
     "chosen-js": "1.8.7",
     "codemirror": "5.49.2",

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/Submitty/Submitty#readme",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.11.2",
-    "@submitty/pdf-annotate.js": "2.2.0",
+    "@submitty/pdf-annotate.js": "2.2.2",
     "bootstrap": "4.3.1",
     "chosen-js": "1.8.7",
     "codemirror": "5.49.2",

--- a/site/public/js/pdf/PDFAnnotate.js
+++ b/site/public/js/pdf/PDFAnnotate.js
@@ -52,7 +52,7 @@ function render() {
             documentId = 'toy_eb'.pdf;
             let pdfData = JSON.parse(data);
             pdfData = atob(pdfData);
-            pdfjsLib.getDocument({data: pdfData}).then((pdf) => {
+            pdfjsLib.getDocument({data: pdfData}).promise.then((pdf) => {
                 RENDER_OPTIONS.pdfDocument = pdf;
 
                 let viewer = document.getElementById('viewer');

--- a/site/public/js/pdf/PDFAnnotate.js
+++ b/site/public/js/pdf/PDFAnnotate.js
@@ -64,7 +64,7 @@ function render() {
                 }
 
                 PDFAnnotate.UI.renderPage(1, RENDER_OPTIONS).then(([pdfPage, annotations]) => {
-                    let viewport = pdfPage.getViewport(RENDER_OPTIONS.scale, RENDER_OPTIONS.rotate);
+                    let viewport = pdfPage.getViewport({scale: RENDER_OPTIONS.scale, rotation: RENDER_OPTIONS.rotate});
                     PAGE_HEIGHT = viewport.height;
                 });
             });

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -67,7 +67,7 @@ function render(gradeable_id, user_id, grader_id, file_name, page_num, url = "")
                 data: pdfData,
                 cMapUrl: '../../vendor/pdfjs/cmaps/',
                 cMapPacked: true
-            }).then((pdf) => {
+            }).promise.then((pdf) => {
                 window.RENDER_OPTIONS.pdfDocument = pdf;
                 let viewer = document.getElementById('viewer');
                 $(viewer).on('touchstart touchmove', function(e){


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #4345 

When loading a PDF, would see a number of deprecation warnings.

### What is the new behavior?

Deprecation warnings are fixed, with `@submitty/pdf-annotate.js` and `pdfjs-dist` updated to take advantage of this.