### PR TITLE
[Refactor:PHP] Remove usage of core from HomePageView

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -2,6 +2,7 @@
 
 namespace app\controllers;
 
+use app\authentication\DatabaseAuthentication;
 use app\libraries\response\RedirectResponse;
 use app\models\Course;
 use app\models\User;
@@ -93,40 +94,26 @@ class HomePageController extends AbstractController {
             $user_id = $user->getId();
         }
 
-        $unarchived_courses = $this->core->getQueries()->getUnarchivedCoursesById($user_id);
-        $archived_courses = $this->core->getQueries()->getArchivedCoursesById($user_id);
+        $unarchived_courses = $this->core->getQueries()->getCourseForUserId($user_id);
+        $archived_courses = $this->core->getQueries()->getCourseForUserId($user_id, true);
 
         // Filter out any courses a student has dropped so they do not appear on the homepage.
         // Do not filter courses for non-students.
+        foreach (['archived_courses', 'unarchived_courses'] as $var) {
+            $$var = array_filter($$var, function (Course $course) use ($user_id, $as_instructor) {
+                $query = $as_instructor ? 'checkIsInstructorInCourse' : 'checkStudentActiveInCourse';
+                return $this->core->getQueries()->$query($user_id, $course->getTitle(), $course->getSemester());
+            });
+        }
 
-        $unarchived_courses = array_filter($unarchived_courses, function (Course $course) use ($user_id, $as_instructor) {
-            return $as_instructor ?
-                $this->core->getQueries()->checkIsInstructorInCourse($user_id, $course->getTitle(), $course->getSemester())
-                :
-                $this->core->getQueries()->checkStudentActiveInCourse($user_id, $course->getTitle(), $course->getSemester());
-        });
-
-        $archived_courses = array_filter($archived_courses, function (Course $course) use ($user_id, $as_instructor) {
-            return $as_instructor ?
-                $this->core->getQueries()->checkIsInstructorInCourse($user_id, $course->getTitle(), $course->getSemester())
-                :
-                $this->core->getQueries()->checkStudentActiveInCourse($user_id, $course->getTitle(), $course->getSemester());
-        });
+        $callback = function (Course $course) {
+            return $course->getCourseInfo();
+        };
 
         return Response::JsonOnlyResponse(
             JsonResponse::getSuccessResponse([
-                "unarchived_courses" => array_map(
-                    function (Course $course) {
-                        return $course->getCourseInfo();
-                    },
-                    $unarchived_courses
-                ),
-                "archived_courses" => array_map(
-                    function (Course $course) {
-                        return $course->getCourseInfo();
-                    },
-                    $archived_courses
-                )
+                "unarchived_courses" => array_map($callback, $unarchived_courses),
+                "archived_courses" => array_map($callback, $archived_courses)
             ])
         );
     }
@@ -145,10 +132,12 @@ class HomePageController extends AbstractController {
             new WebResponse(
                 ['HomePage'],
                 'showHomePage',
-                $user = $this->core->getUser(),
+                $this->core->getUser(),
                 $courses["data"]["unarchived_courses"],
                 $courses["data"]["archived_courses"],
-                $this->core->getConfig()->getUsernameChangeText()
+                $this->core->getConfig()->getUsernameChangeText(),
+                $this->core->getAuthentication() instanceof DatabaseAuthentication,
+                $this->core->getCsrfToken()
             )
         );
     }
@@ -300,7 +289,9 @@ class HomePageController extends AbstractController {
                 'showCourseCreationPage',
                 $faculty ?? null,
                 $this->core->getUser()->getId(),
-                $this->core->getQueries()->getAllUnarchivedSemester()
+                $this->core->getQueries()->getAllUnarchivedSemester(),
+                $this->core->getUser()->getAccessLevel() === User::LEVEL_SUPERUSER,
+                $this->core->getCsrfToken()
             )
         );
     }

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -554,11 +554,19 @@ HTML;
         return (microtime(true) - $this->start_time);
     }
 
-    public function buildUrl(string ...$parts): string {
+    /**
+     * Builds a URL
+     * @param string[] $parts
+     */
+    public function buildUrl(array $parts): string {
         return $this->core->buildUrl($parts);
     }
 
-    public function buildCourseUrl(string ...$parts): string {
+    /**
+     * Builds a course URL (starts with /<semester>/<course>)
+     * @param string[] $parts
+     */
+    public function buildCourseUrl(array $parts): string {
         return $this->core->buildCourseUrl($parts);
     }
 }

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -11,15 +11,18 @@ use app\libraries\FileUtils;
  * @method string getSemester()
  * @method string getTitle()
  * @method string getDisplayName()
+ * @method int getUserGroup()
   */
 class Course extends AbstractModel {
-     
+
     /** @property @var string the semester in which the course is taking place." */
     protected $semester;
-    /** @property @var the proper title of the course. */
+    /** @property @var string the proper title of the course. */
     protected $title;
-    /** @property @var the display name of the course */
+    /** @property @var string the display name of the course */
     protected $display_name;
+    /** @property @var int */
+    protected $user_group;
 
     /**
      * Course constructor.
@@ -32,6 +35,7 @@ class Course extends AbstractModel {
         $this->semester = $details['semester'];
         $this->title = $details['course'];
         $this->display_name = "";
+        $this->user_group = $details['user_group'] ?? 3;
     }
 
     public function loadDisplayName() {
@@ -77,7 +81,8 @@ class Course extends AbstractModel {
             "semester" => $this->semester,
             "title" => $this->title,
             "display_name" => $this->display_name,
-            "display_semester" => $this->getLongSemester()
+            "display_semester" => $this->getLongSemester(),
+            "user_group" => $this->user_group
         ];
     }
 }

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -2,7 +2,6 @@
 
 namespace app\views;
 
-use app\authentication\DatabaseAuthentication;
 use app\models\User;
 
 class HomePageView extends AbstractView {
@@ -12,7 +11,14 @@ class HomePageView extends AbstractView {
      * @param array $archived_courses
      * @param string $change_name_text
      */
-    public function showHomePage(User $user, $unarchived_courses, $archived_courses, $change_name_text) {
+    public function showHomePage(
+        User $user,
+        array $unarchived_courses,
+        array $archived_courses,
+        string $change_name_text,
+        bool $database_authentication,
+        string $csrf_token
+    ) {
         $statuses = array();
         $course_types = [$unarchived_courses, $archived_courses];
         $rank_titles = [
@@ -34,8 +40,7 @@ class HomePageView extends AbstractView {
 
             //Assemble courses into rank lists
             foreach ($course_type as $course) {
-                $rank = $this->core->getQueries()->getGroupForUserInClass($course['semester'], $course['title'], $user->getId());
-                array_push($ranks[$rank]["courses"], $course);
+                array_push($ranks[$course['user_group']]["courses"], $course);
             }
 
             //Filter any ranks with no courses
@@ -46,7 +51,7 @@ class HomePageView extends AbstractView {
         }
 
 
-        $autofill_preferred_name = [$user->getLegalFirstName(),$user->getLegalLastName()];
+        $autofill_preferred_name = [$user->getLegalFirstName(), $user->getLegalLastName()];
         if ($user->getPreferredFirstName() != "") {
             $autofill_preferred_name[0] = $user->getPreferredFirstName();
         }
@@ -59,32 +64,32 @@ class HomePageView extends AbstractView {
             User::LEVEL_FACULTY     => "faculty",
             User::LEVEL_SUPERUSER   => "superuser"
         ];
-        $this->core->getOutput()->addInternalJs('homepage.js');
-        $this->core->getOutput()->addInternalCss('homepage.css');
-        return $this->core->getOutput()->renderTwigTemplate('HomePage.twig', [
+        $this->output->addInternalJs('homepage.js');
+        $this->output->addInternalCss('homepage.css');
+        return $this->output->renderTwigTemplate('HomePage.twig', [
             "user" => $user,
             "user_first" => $autofill_preferred_name[0],
             "user_last" => $autofill_preferred_name[1],
             "statuses" => $statuses,
             "change_name_text" => $change_name_text,
-            "show_change_password" => $this->core->getAuthentication() instanceof DatabaseAuthentication,
-            "csrf_token" => $this->core->getCsrfToken(),
+            "show_change_password" => $database_authentication,
+            "csrf_token" => $csrf_token,
             "access_level" => $access_levels[$user->getAccessLevel()],
             "display_access_level" => $user->accessFaculty(),
-            "change_password_url" => $this->core->buildUrl(['current_user', 'change_password']),
-            "change_username_url" => $this->core->buildUrl(['current_user', 'change_username'])
+            "change_password_url" => $this->output->buildUrl(['current_user', 'change_password']),
+            "change_username_url" => $this->output->buildUrl(['current_user', 'change_username'])
         ]);
     }
 
-    public function showCourseCreationPage($faculty, $head_instructor, $semesters) {
-        $this->core->getOutput()->addBreadcrumb("New Course");
-        return $this->core->getOutput()->renderTwigTemplate('CreateCourseForm.twig', [
-            "csrf_token" => $this->core->getCsrfToken(),
+    public function showCourseCreationPage($faculty, $head_instructor, $semesters, bool $is_superuser, string $csrf_token) {
+        $this->output->addBreadcrumb("New Course");
+        return $this->output->renderTwigTemplate('CreateCourseForm.twig', [
+            "csrf_token" => $csrf_token,
             "head_instructor" => $head_instructor,
             "faculty" => $faculty,
-            "is_superuser" => $this->core->getUser()->getAccessLevel() === User::LEVEL_SUPERUSER,
+            "is_superuser" => $is_superuser,
             "semesters" => $semesters,
-            "course_creation_url" => $this->core->buildUrl(['home', 'courses', 'new']),
+            "course_creation_url" => $this->output->buildUrl(['home', 'courses', 'new']),
             "course_code_requirements" => $this->core->getConfig()->getCourseCodeRequirements()
         ]);
     }

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -833,12 +833,17 @@ parameters:
 			path: app/models/Course.php
 
 		-
-			message: "#^PHPDoc tag @property has invalid value \\(@var the proper title of the course\\.\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			message: "#^PHPDoc tag @property has invalid value \\(@var string the proper title of the course\\.\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/Course.php
 
 		-
-			message: "#^PHPDoc tag @property has invalid value \\(@var the display name of the course\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			message: "#^PHPDoc tag @property has invalid value \\(@var string the display name of the course\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(@var int\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/Course.php
 
@@ -2178,13 +2183,11 @@ parameters:
 			path: app/models/gradeable/GradedGradeable.php
 
 		-
-
 			message: "#^PHPDoc tag @param has invalid value \\(\\$gc_id int Gradeable Component id\\)\\: Unexpected token \"\\$gc_id\", expected TOKEN_IDENTIFIER at offset 95$#"
 			count: 1
 			path: app/models/gradeable/GradedGradeable.php
 
 		-
-
 			message: "#^PHPDoc tag @param has invalid value \\(\\$filename Name of the file to collect the data out of\\)\\: Unexpected token \"\\$filename\", expected TOKEN_IDENTIFIER at offset 87$#"
 			count: 1
 			path: app/models/gradeable/GradedGradeable.php

--- a/site/tests/app/models/CourseTester.php
+++ b/site/tests/app/models/CourseTester.php
@@ -11,7 +11,8 @@ class CourseTester extends BaseUnitTest {
     public function testCourse() {
         $details = [
             'semester' => 's18',
-            'course' => 'csci1000'
+            'course' => 'csci1000',
+            'user_group' => 1
         ];
         $course = new Course($this->createMockCore(), $details);
         $this->assertEquals('s18', $course->getSemester());
@@ -24,6 +25,7 @@ class CourseTester extends BaseUnitTest {
             'semester' => 's18',
             'title' => 'csci1000',
             'display_name' => '',
+            'user_group' => 1,
             'modified' => false
         ];
         $this->assertEquals($array, $course->toArray());
@@ -79,6 +81,7 @@ class CourseTester extends BaseUnitTest {
                 'semester' => 's18',
                 'title' => 'csci1000',
                 'display_name' => 'Test Course',
+                'user_group' => 3,
                 'modified' => false
             ];
             $this->assertEquals($array, $course->toArray());


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The HomePageView runs a number of SQL queries and made a number of calls to `$this->core`.

### What is the new behavior?

The query logic is moved to the controller and all calls to `$this->core` rewritten to use `$this->output` where possible and then passed in new variables where not able.

This cherry picks the idea of commit 7a2b920a0ed19bd23ae6e2311176ed544760f2a7 from #4576, but rewritten incorporating my comments as well as some other substantial changes to further clean-up the code there.

### Other Information

Make sure that the squash + merge message has `Co-authored-by: Matthew Ma <alphaintec@gmail.com>` in it after two blank lines from the previous text to ensure proper attribution in the commit log on master.