### PR TITLE
[Bugfix:TAGrading] properly calculate median for grades

### DIFF
--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -262,39 +262,34 @@
                     var modeCount = 0;
                     var rangeT = 0;
 
-                    var xValueT = [];
+                    var xValueT = [{{ bTA | join(',') }}];
+                    xValueT.sort((a, b) => a - b);
                     var yValue = [];
                     var yValue2 = [];
-                    var xValueSorted = [];
+                    var xValueSorted = Array.from(new Set(xValueT));
                     var xBuckets = [];
 
-                    {% for b in bTA %}
-                        xValueT.push({{ b }});
-                        if(!xValueSorted.includes({{ b }})){
-                            xValueSorted.push({{ b }});
-                        }
-                        if(xValueT[xValueT.length-1]>maxT){
-                            maxT = {{ b }};
-                        }
-                        if(xValueT[xValueT.length-1]<minT){
-                            minT = {{ b }};
-                        }
-                    {% endfor %}
-
-                    if(maxT!=0&&minT!=50){
-                        rangeT = maxT-minT;
+                    if (xValueSorted.length > 0) {
+                        minT = xValueSorted[0];
+                        maxT = xValueSorted[xValueSorted.length-1];
+                        rangeT = maxT - minT;
                     }
+
                     var bucketSize = Math.floor(rangeT/10);
                     mode=fillBuckets(rangeT,bucketSize,betterBuckets,xValueT,yValue,xBuckets,mode,modeCount,maxT,minT);
                     xValueSorted.sort((a,b)=>a-b);
-                    var len = xValueSorted.length;
 
-                    len = len/2;
-                    len = Math.ceil(len);
-                    if(xValueSorted.length>0){
-                        median = xValueSorted[xValueSorted.length-len];
+                    if (xValueT.length > 0) {
+                        let pivot = Math.floor((xValueT.length - 1) / 2);
+                        if (xValueT.length % 2 === 0) {
+                            median = (xValueT[pivot] + xValueT[pivot+1]) / 2;
+                        }
+                        else {
+                            median = xValueT[pivot];
+                        }
                     }
-                    if(maxT==0&&minT==50){
+
+                    if (maxT==0 && minT==50) {
                         minT=0;
                     }
 
@@ -642,7 +637,7 @@
                             {% if team_assignment %}
                                 <br/>
                                 <b>Number of teams where at least one member viewed their grade:</b> {{ viewed_grade }} / {{ viewed_total }} ({{ viewed_percent }}%)
-								<b>Number of students who have viewed their grade:</b> 
+								<b>Number of students who have viewed their grade:</b>
 									{{ individual_viewed_grade }} / {{ total_students_submitted }} ({{ individual_viewed_percent }}%)
                             {% else %}
                                 <br/>

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -282,7 +282,7 @@
                     }
 
                     var bucketSize = Math.floor(rangeT/10);
-                    mode= fillBuckets(rangeT, bucketSize, betterBuckets, xValueT, yValue, xBuckets, mode, modeCount, maxT, minT);
+                    mode = fillBuckets(rangeT, bucketSize, betterBuckets, xValueT, yValue, xBuckets, mode, modeCount, maxT, minT);
 
                     if (maxT==0 && minT==50) {
                         minT=0;
@@ -489,7 +489,7 @@
                         }
 
                         var bucketSize = Math.floor(rangeA/10);
-                        mode=fillBuckets(rangeA,bucketSize,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA);
+                        mode = fillBuckets(rangeA,bucketSize,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA);
 
                         if (minA==50 && maxA==0) {
                             minA=0;

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -266,20 +266,12 @@
                     xValueT.sort((a, b) => a - b);
                     var yValue = [];
                     var yValue2 = [];
-                    var xValueSorted = Array.from(new Set(xValueT));
                     var xBuckets = [];
 
-                    if (xValueSorted.length > 0) {
-                        minT = xValueSorted[0];
-                        maxT = xValueSorted[xValueSorted.length-1];
-                        rangeT = maxT - minT;
-                    }
-
-                    var bucketSize = Math.floor(rangeT/10);
-                    mode=fillBuckets(rangeT,bucketSize,betterBuckets,xValueT,yValue,xBuckets,mode,modeCount,maxT,minT);
-                    xValueSorted.sort((a,b)=>a-b);
-
                     if (xValueT.length > 0) {
+                        minT = xValueT[0];
+                        maxT = xValueT[xValueT.length-1];
+                        rangeT = maxT - minT;
                         let pivot = Math.floor((xValueT.length - 1) / 2);
                         if (xValueT.length % 2 === 0) {
                             median = (xValueT[pivot] + xValueT[pivot+1]) / 2;
@@ -288,6 +280,9 @@
                             median = xValueT[pivot];
                         }
                     }
+
+                    var bucketSize = Math.floor(rangeT/10);
+                    mode= fillBuckets(rangeT, bucketSize, betterBuckets, xValueT, yValue, xBuckets, mode, modeCount, maxT, minT);
 
                     if (maxT==0 && minT==50) {
                         minT=0;
@@ -474,39 +469,29 @@
                         var xValue = [];
                         var yValue = [];
                         var xBuckets = [];
-                        var xValueSorted = [];
 
-
-                        {% for b in bAuto %}
-
-                            xValue.push({{ b }});
-                            if(!xValueSorted.includes({{ b }})){
-                                xValueSorted.push({{ b }});
+                        xValue = [{{ bAuto | join(',') }}]
+                        xValue.sort((a, b) => a - b);
+                        if (xValue.length > 0) {
+                            minA = xValue[0];
+                            maxA = xValue[xValue.length - 1];
+                            let pivot = Math.floor((xValue.length - 1) / 2);
+                            if (xValue.length % 2 === 0) {
+                                median = (xValue[pivot] + xValue[pivot+1]) / 2;
                             }
-                            if(xValue[xValue.length-1]>maxA){
-                                maxA = {{ b }};
+                            else {
+                                median = xValue[pivot];
                             }
-                            if(xValue[xValue.length-1]<minA){
-                                minA = {{ b }};
-                            }
-                        {% endfor %}
+                        }
 
-                       if(maxA!=0&&minA!=50){
+                        if (maxA!=0 && minA!=50) {
                             rangeA = maxA-minA;
                         }
 
                         var bucketSize = Math.floor(rangeA/10);
                         mode=fillBuckets(rangeA,bucketSize,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA);
-                        xValueSorted.sort((a,b)=>a-b);
 
-                        var len = xValueSorted.length;
-
-                        len = len/2;
-                        len = Math.ceil(len);
-                        if(xValueSorted.length>0){
-                            median = xValueSorted[xValueSorted.length-len];
-                        }
-                        if(minA==50&&maxA==0){
+                        if (minA==50 && maxA==0) {
                             minA=0;
                         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #4801 

The median showed on the histogram page is the middle bucket value, not the middle grade value. It was also not calculating median properly for an even number of values.

### What is the new behavior?

Median is calculated for the median value of all grades. Also calculates properly for medians of even and odd number of values.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Using the sample course, I changed all 5 / 10 grades to 0 / 10 except for one. The value shown in master was `5`, but with this change was 3.75 (due to even number of values where pivot point lies at middle of 3.5 and 4). Removing one 0 / 10 grade, and value then changed to 4 as expected.

The big rewrite here is that instead of doing a for loop of twig and doing repeated calls to JS method `.push()`, we can just use the [join filter](https://twig.symfony.com/doc/2.x/filters/join.html) to inline the entire list creation. `xValueSorted` is removed as it looks like it was a sorted set of used values, which was only being used for the median, which is not useful so safe to throw it away. Also, given that `xValue` is sorted, we know if it's non-empty, the min/max will be at the beginning/end and can then calculate the median as well, handling even length lists special from odd length lists.