### PR TITLE
[Refactor:Forum] Move inline unresolved/resolved icon style to css

### DIFF
--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -12,7 +12,7 @@
             {% endif %}
 
             {% if thread.status != 0 %}
-                <i class="fa {{ thread.fa_icon }} thread-status" style="margin-right:{{ thread.fa_margin_right }}; color:{{ thread.fa_color }}; font-size:{{ thread.fa_font_size }};" title="{{ thread.tooltip }}" aria-hidden="true"></i>
+                <i class="fa {{ thread.fa_icon }} {{ thread.fa_class }} thread-status" title="{{ thread.tooltip }}" aria-hidden="true"></i>
             {% endif %}
 
             {% if thread.is_locked %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -656,9 +656,7 @@ class ForumThreadView extends AbstractView {
             $favorite = isset($thread['favorite']) && $thread['favorite'];
 
             $fa_icon = "fa-question";
-            $fa_color = "#ffcc00";
-            $fa_margin_right = "5px";
-            $fa_font_size = "1.8em";
+            $fa_class = "thread-unresolved";
             $tooltip = "Thread Unresolved";
 
             if (!isset($thread['status'])) {
@@ -667,9 +665,7 @@ class ForumThreadView extends AbstractView {
             if ($thread['status'] != 0) {
                 if ($thread['status'] == 1) {
                     $fa_icon = "fa-check";
-                    $fa_color = "#5cb85c";
-                    $fa_margin_right = "0px";
-                    $fa_font_size = "1.5em";
+                    $fa_class = "thread-resolved";
                     $tooltip = "Thread Resolved";
                 }
             }
@@ -700,9 +696,7 @@ class ForumThreadView extends AbstractView {
                 "merged_thread_id" => $thread['merged_thread_id'],
                 "status" => $thread["status"],
                 "fa_icon" => $fa_icon,
-                "fa_color" => $fa_color,
-                "fa_margin_right" => $fa_margin_right,
-                "fa_font_size" => $fa_font_size,
+                "fa_class" => $fa_class,
                 "tooltip" => $tooltip,
                 "is_locked" => $this->core->getQueries()->isThreadLocked($thread['id']),
                 "date" => $date_content,

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -107,6 +107,7 @@
     --standard-bronze: #856404;
     --standard-pastel-pink: #f2dede;
     --standard-light-pink: #ff9999;
+    --standard-tangerine-yellow: #ffcc00;
     --standard-pastel-yellow: #fcf8e3;
     --standard-pale-yellow: #ffff99;
     --standard-light-yellow: #ffff66;

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -528,3 +528,15 @@ body {min-width: 925px;}
     background: #fff;
     color: var(--actionable-blue);
 }
+
+.thread-resolved {
+    color: var(--good-green);
+    margin-right: 0px;
+    font-size: 1.5em;
+}
+
+.thread-unresolved {
+    color: var(--standard-tangerine-yellow);
+    margin-right: 5px;
+    font-size: 1.8em;
+}

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -220,7 +220,9 @@ function changeThreadStatus(thread_id) {
 }
 
 function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_token) {
-    if(!checkAreYouSureForm()) return;
+    if(!checkAreYouSureForm()) {
+        return;
+    }
     var form = $("#thread_form");
     var url = buildCourseUrl(['forum', 'posts', 'get']);
     $.ajax({


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The style for the unresolved/resolved icons were defined inline to the twig template.

### What is the new behavior?

The style definitions have been moved into two classes `.thread-resolved` and `.thread-unresolved` and the classes applied to the icons to get the appropriate color, size, and positioning. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is some prep work for a PR to simplify accomplishing #4720 without having to do a lot of inline style manipulation (versus just removing and applying classes).