### PR TITLE
[Refactor:JS] Update error/success messages to match PHP generated ones

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -179,6 +179,7 @@
             </div>
             {% endif %}
             <div id='messages'>
+                <!-- If the below <div> definition changes, update the design in server.js in displayMessage function -->
                 {% for message in messages %}
                     <div id='{{ message.type }}-{{ message.key }}' class="inner-message alert alert-{{ message.type }}">
                         <span>

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -53,12 +53,12 @@ function resetForumFileUploadAfterError(displayPostId){
 function checkNumFilesForumUpload(input, post_id){
     var displayPostId = (typeof post_id !== "undefined") ? "_" + escapeSpecialChars(post_id) : "";
     if(input.files.length > 5){
-        displayError('Max file upload size is 5. Please try again.');
+        displayErrorMessage('Max file upload size is 5. Please try again.');
         resetForumFileUploadAfterError(displayPostId);
     }
     else {
         if(!checkForumFileExtensions(input.files)){
-            displayError('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
+            displayErrorMessage('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
             resetForumFileUploadAfterError(displayPostId);
             return;
         }
@@ -92,16 +92,16 @@ function testAndGetAttachments(post_box_id, dynamic_check) {
     }
     if(files.length > 5){
         if(dynamic_check) {
-            displayError('Max file upload size is 5. Please remove attachments accordingly.');
+            displayErrorMessage('Max file upload size is 5. Please remove attachments accordingly.');
         }
         else {
-            displayError('Max file upload size is 5. Please try again.');
+            displayErrorMessage('Max file upload size is 5. Please try again.');
         }
         return false;
     }
     else {
         if(!checkForumFileExtensions(files)){
-            displayError('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
+            displayErrorMessage('Invalid file type. Please upload only image files. (PNG, JPG, GIF, BMP...)');
             return false;
         }
     }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1303,9 +1303,11 @@ $(function() {
         }
     }
 
-    setTimeout(function() {
-        $('.alert-success').fadeOut();
-    }, 5000);
+    for (const elem of document.getElementsByClassName('alert-success')) {
+        setTimeout(() => {
+            $(elem).fadeOut();
+        }, 5000);
+    }
 });
 
 function getFileExtension(filename){
@@ -1322,10 +1324,35 @@ function openPopUp(css, title, count, testcase_num, side) {
     my_window.focus();
 }
 
-function displayError(message){
-    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + message + '</div>';
+let messages = 0;
+
+function displayErrorMessage(message){
+    displayMessage(message, 'error');
+}
+
+function displaySuccessMessage(message) {
+    displayMessage(message, 'success');
+}
+
+/**
+ * Display a toast message after an action.
+ *
+ * The styling here should match what's used in GlobalHeader.twig to define the messages coming from PHP
+ *
+ * @param {string} message
+ * @param {string} type
+ */
+function displayMessage(message, type) {
+    const id = `${type}-js-${messages}`;
+    message = `<div id="${id}" class="inner-message alert alert-${type}"><span><i class="fas fa-${type === 'error' ? 'times' : 'check'}-circle"></i>${message.replace(/(?:\r\n|\r|\n)/g, '<br />')}</span><a class="fas fa-times" onClick="removeMessagePopup('${type}-js-${messages}');"></a></div>`;
     $('#messages').append(message);
-    $('#messages').fadeIn("slow");
+    $('#messages').fadeIn('slow');
+    if (type === 'success') {
+        setTimeout(() => {
+            $(`#${id}`).fadeOut();
+        }, 5000);
+    }
+    messages++;
 }
 
 /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The method for JS for defining error messages differed from that of the PHP code and there was no function for success message.

### What is the new behavior?

Adds function for success messages and updates the error message function to match the styling for the messages generated via PHP. Also creates a comment in both places mentioning the link.
