### PR TITLE
[Bugfix:Autograding] Stop the Shipper from Claiming VCS Queue Files

### DIFF
--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -686,15 +686,16 @@ def get_job(my_name,which_machine,my_capabilities,which_untrusted,overall_lock):
     for full_path_file, file_time in files_and_times:
         # get the file name (without the path)
         just_file = full_path_file[len(folder)+1:]
+
         # skip items that are already being graded
         if (just_file[0:8]=="GRADING_"):
             continue
-
-        if (just_file[0:5]=="VCS__"):
-            continue
-
         grading_file = os.path.join(folder,"GRADING_"+just_file)
         if grading_file in files:
+            continue
+
+        # skip items (very recently added!) that are already waiting for a VCS checkout
+        if (just_file[0:5]=="VCS__"):
             continue
 
         # found something to do

--- a/sbin/submitty_autograding_shipper.py
+++ b/sbin/submitty_autograding_shipper.py
@@ -689,6 +689,10 @@ def get_job(my_name,which_machine,my_capabilities,which_untrusted,overall_lock):
         # skip items that are already being graded
         if (just_file[0:8]=="GRADING_"):
             continue
+
+        if (just_file[0:5]=="VCS__"):
+            continue
+
         grading_file = os.path.join(folder,"GRADING_"+just_file)
         if grading_file in files:
             continue


### PR DESCRIPTION
This PR adds a mitigation to a race condition which was causing the shipper to errantly claim ```VCS_``` queue files in place of autograding queue files.

When claiming a job, a single locked shipper process checks out every repo corresponding with a ```VCS_``` queue file it can find, and then deletes those queue files.

This opens the door for a race condition, where, if a student submits a VCS gradable after all existing repos have started to be checked out, but before the thread gets an updated list of all files in the directory, it might accidentally claim a ```VCS_``` instead of an autograding queue file. When checking out many potentially large repos, there is a larger than expected window of time for such submissions to occur. This would also lead to the job being claimed twice, once as a VCS_ queue file, and again as a normal queue file which can be successfully graded.

The fix to this issue is a check in the ```get_job``` function which has the shipper ignore ```VCS_``` files in the same way that it ignores ```GRADING_``` files.