### PR TITLE
[Bugfix:InstructorUI] Allow setting preferred name to empty string

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -282,12 +282,12 @@ class UsersController extends AbstractController {
         $user->setNumericId(trim($_POST['user_numeric_id']));
 
         $user->setLegalFirstName(trim($_POST['user_firstname']));
-        if (isset($_POST['user_preferred_firstname']) && trim($_POST['user_preferred_firstname']) != "") {
+        if (isset($_POST['user_preferred_firstname'])) {
             $user->setPreferredFirstName(trim($_POST['user_preferred_firstname']));
         }
 
         $user->setLegalLastName(trim($_POST['user_lastname']));
-        if (isset($_POST['user_preferred_lastname']) && trim($_POST['user_preferred_lastname']) != "") {
+        if (isset($_POST['user_preferred_lastname'])) {
             $user->setPreferredLastName(trim($_POST['user_preferred_lastname']));
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #4620

On the admin UI when viewing students / TAs, it is impossible to remove the preferred name (either first or last). If the preferred name is set to the empty string, nothing changes, and no error is displayed.

### What is the new behavior?

An instructor can set the preferred name to empty string (effectively removing it).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Looks like the bug was introduced 2 years ago with #1477 for preferred first name an then carried over into preferred last name when that was added.
