### PR TITLE
[Bugfix:Forum] Corrected invalid typeof check for the forum

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1205,7 +1205,7 @@ if (!Array.prototype.toggleElement) {
     Object.defineProperty(Array.prototype, 'toggleElement', {
         value: function(element, comparer) {
             var index = this.inArray(comparer);
-            if ((typeof(index) == "boolean" && !index) || (typeof(index) == "int" && index === 0)) {
+            if ((typeof(index) == "boolean" && !index) || (typeof(index) == "number" && index === 0)) {
                 this.push(element);
             }
             else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

a typeof is checked to see if it equals "int"

### What is the new behavior?

typeof will never return the value "int" in javascript, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof for the list of types that can be returned. I changed "int" to "number" as that is the value that would be returned.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
