### PR TITLE
[BugFix:Notebooks] Adding multiple submit buttons to notebooks gradeables

### DIFF
--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -304,6 +304,11 @@ int main(int argc, char *argv[]) {
           out_notebook_cell["choices"] = choices;
           out_notebook_cell["allow_multiple"] = allow_multiple;
       }
+      
+      else if (type == "submit_button") {
+        
+      }
+      
 
       // Else unknown type was passed in throw exception
       else{

--- a/more_autograding_examples/paragraph_textboxes/config/config.json
+++ b/more_autograding_examples/paragraph_textboxes/config/config.json
@@ -38,6 +38,14 @@
         },
         {
             "type": "markdown",
+            "markdown_string": "Counts as one submission:"
+        },
+        {
+            "type": "submit_button"
+        },
+
+        {
+            "type": "markdown",
             "markdown_string": "Multiple choice select one:"
         },
         {
@@ -65,6 +73,15 @@
                 {"value": "5", "description": "five"}
             ],
             "allow_multiple": true
+    
+        },
+        {
+            "type": "markdown",
+            "markdown_string": "Counts as one submission:"
+        },
+
+        {
+            "type": "submit_button"
         },
         {
           "type": "markdown",

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -364,7 +364,9 @@
                                     </label>
                                 {% endfor %}
                             {% endif %}
-                        </fieldset>
+                        </fieldset>                    
+
+                        
 
                         {# Create reset to recent submission button #}
                         <button type="button" id="mc_{{ num_multiple_choice }}_clear_button" class="btn btn-primary mc-clear">Clear</button>
@@ -398,11 +400,16 @@
                         </script>
 
                         {% set num_multiple_choice = num_multiple_choice + 1 %}
+                    {# Handle if cell is submit button #}
+
+                    {% elseif cell.type == "submit_button" %}
+                        <button type="button" id="submit" class="btn btn-success">Submit</button>
+
 
                     {% endif %}
-
                 </div>
 
+                    
             {% endfor %}
 
         </div>


### PR DESCRIPTION
Closes #4596 
### Please check if the PR fulfills these requirements:

* [ #] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [# ] Tests for the changes have been added/updated (if possible)
* [# ] Documentation has been updated/added if relevant

### What is the current behavior?
A lengthy quiz gradeable (that can be re-submitted multiple times) currently only has a green "Submit" button at the bottom of the page. If it takes a while to fill out the form/quiz, the student may lose their work.

### What is the new behavior?
Added new duplicate submit buttons to encourage save/submit at specific points in the notebook. Also added text near the button to make it clear that it counts as one submission.

### Other information?
<!-- Is this a breaking change? --> no
<!-- How did you test --> tested on virtual submitty.
