### PR TITLE
[VPAT:Gradeable] Poor Contrast Ratio In New Gradeables View

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -75,7 +75,7 @@ a.nav-bar.normal-btn:hover {
 }
 
 a.nav-bar.disabled-btn {
-    color: var(--standard-medium-gray) ;
+    color: var(--standard-medium-dark-gray) ;
     cursor: default;
     border: none !important;
     pointer-events: none;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -57,7 +57,7 @@
     --standard-hover-light-gray: #e5e5e5;
     --standard-light-gray: #d3d3d3;
     --standard-light-medium-gray: #bbbbbb;
-    --standard-medium-gray: #696968;
+    --standard-medium-gray: #888888;
     --standard-medium-dark-gray: #666666;
     --standard-dark-gray: #5555555;
     --standard-deep-dark-gray: #2e2e2e;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -57,7 +57,7 @@
     --standard-hover-light-gray: #e5e5e5;
     --standard-light-gray: #d3d3d3;
     --standard-light-medium-gray: #bbbbbb;
-    --standard-medium-gray: #888888;
+    --standard-medium-gray: #696968;
     --standard-medium-dark-gray: #666666;
     --standard-dark-gray: #5555555;
     --standard-deep-dark-gray: #2e2e2e;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?

Closes #4836

Grey text (disabled tab labels near top) that is circled in blue is colored #888888 and has a contrast ratio of 3.54:1.

### What is the new behavior?
Contrast ratio is now 5.50: 1 .
