### PR TITLE
[Bugfix:TAGrading] Fixed Simple Grader not validating backend saves

### DIFF
--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -232,6 +232,9 @@ class SimpleGraderController extends AbstractController {
 
         $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
 
+        // Return ids and scores of updated components in success response so frontend can validate
+        $return_data = array();
+
         foreach ($gradeable->getComponents() as $component) {
             $data = $_POST['scores'][$component->getId()] ?? '';
             $original_data = $_POST['old_scores'][$component->getId()] ?? '';
@@ -261,6 +264,7 @@ class SimpleGraderController extends AbstractController {
                     $component_grade->setScore($data);
                 }
                 $component_grade->setGradeTime($this->core->getDateTimeNow());
+                $return_data[$component->getId()] = $data;
             }
         }
 
@@ -268,7 +272,7 @@ class SimpleGraderController extends AbstractController {
         $this->core->getQueries()->saveTaGradedGradeable($ta_graded_gradeable);
 
         return Response::JsonOnlyResponse(
-            JsonResponse::getSuccessResponse()
+            JsonResponse::getSuccessResponse($return_data)
         );
     }
 

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -218,12 +218,24 @@ function updateCheckpointCells(elems, scores, no_cookie) {
           'old_scores': old_scores,
           'scores': new_scores
         },
-        function() {
-            elems.each(function(idx, elem) {
-                elem = $(elem);
-                elem.animate({"border-right-width": "0px"}, 400); // animate the box
-                elem.attr("data-score", elem.data("score"));      // update the score
-            });
+        function(returned_data) {
+            // Validate that the Simple Grader backend correctly saved components before updating
+            var expected_vals = JSON.stringify(Object.entries(new_scores).map(String));
+            var returned_vals = JSON.stringify(Object.entries(returned_data['data']).map(String));
+            if (expected_vals === returned_vals) {
+                elems.each(function(idx, elem) {
+                    elem = $(elem);
+                    elem.animate({"border-right-width": "0px"}, 400); // animate the box
+                    elem.attr("data-score", elem.data("score"));      // update the score
+                });
+            } else {
+                console.log("Save error: returned data:", returned_vals, "does not match expected new data:", expected_vals);
+                elems.each(function(idx, elem) {
+                    elem = $(elem);
+                    elem.stop(true, true);
+                    elem.css("border-right", "60px solid #DA4F49");
+                });
+            }
         },
         function() {
             elems.each(function(idx, elem) {

--- a/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
+++ b/site/tests/app/controllers/grading/SimpleGraderControllerTester.php
@@ -202,7 +202,9 @@ class SimpleGraderControllerTester extends BaseUnitTest {
         $this->assertEquals(
             [
                 'status' => 'success',
-                'data' => null
+                'data' => [
+                    '0' => 5
+                ]
             ],
             $response->json_response->json
         );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #4638 
Fixes #4716 

When a user modifies a checkpoint in the Simple Grader interface, the Simple Grader frontend does not, after receiving a success response, validate that the Simple Grader backend correctly saved the updated score. This means that it is possible for the frontend to report a successful save even when the backend did not actually save anything. 

### What is the new behavior?
The Simple Grader backend, upon a successful save, now returns a JSON response containing the ids and new scores of the components it updated. The Simple Grader frontend, during a checkpoint update, validates that this response matches with the expected new scores. If they do not match, then the Simple Grader interface reports a save error to the user via setting the checkpoint red, and also logs an error message to the console.

### Other information?
This change causes one of the PHP unit tests to fail due to the new behavior of `save` in SimpleGraderController. I have updated the respective test to reflect the new behavior and make it passing.