### PR TITLE
[Bugfix:TAGrading] Fixed PDF viewer unintentionally opening

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -692,7 +692,11 @@ function checkOpenComponentMark(index) {
 // expand all files in Submissions and Results section
 function openAll(click_class, class_modifier) {
     $("."+click_class + class_modifier).each(function(){
-        $(this).click();
+        // Check that the file is not a PDF before clicking on it
+        let innerText = Object.values($(this))[0].innerText;
+        if (innerText.slice(-4) !== ".pdf") {
+            $(this).click();
+        }
     });
 }
 function updateValue(obj, option1, option2) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #4598

When grading an assignment that has a PDF in its submissions folder, clicking the "Open / Close Submissions" button will open the PDF file viewer. This is a bug as the PDF file viewer should only be opened when the user manually clicks on a PDF.

### What is the new behavior?
Clicking the "Open / Close Submissions" button will no longer cause the PDF file viewer to open in this case. Any PDF files in the submissions folder will now only be opened via manually clicking on the PDF, and the other files will open or close as expected. 


