### PR TITLE
VPAT — Edit Gradeables Views

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -35,7 +35,8 @@
         <div class="option-desc col-md-6">
             <label for="g_title">
                 <div class="option-title">Title</div>
-                <div class="option-alt">What is the title of this gradable? <p style="color:red">(Required)</p></div>
+                <div class="option-alt">What is the title of this gradable?</div>
+                <p id="required_type">(Required)</p>
             </label>
         </div>
 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -1,5 +1,5 @@
 {% import _self as self %} {# Required to use macros in same template #}
-{# 
+{#
 Macros
 #}
 
@@ -29,7 +29,7 @@ Variables
 {% set section_numbers = range(1, num_rotating_sections) %}
 {% set grading_groups = {'1': 'Instructor', '2': 'Full Access Grader', '3': 'Limited Access Grader'} %}
 
-{# 
+{#
 Form
 #}
 
@@ -42,8 +42,8 @@ Form
 	</div>
 {% endif %}
 
-What is the lowest privileged user group that can grade this?
-    <a class="fa-question-circle" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-user-groups"></a>
+<label for="minimum_grading_group">What is the lowest privileged user group that can grade this?</label>
+    <a class="fa-question-circle" target=_blank aria-label="Help for grading user groups" href="http://submitty.org/instructor/create_edit_gradeable#grading-user-groups"></a>
 <select name="min_grading_group" id="minimum_grading_group" class="int_val" style="width:180px;">
     {% for num, role in grading_groups %}
         <option value="{{ num }}" {{ gradeable.getMinGradingGroup() == num ? 'selected' : '' }}>{{ role }}</option>
@@ -54,16 +54,16 @@ What is the lowest privileged user group that can grade this?
 <fieldset>
     <legend>
         How should graders be assigned to grade this item?
-        <a class="fa-question-circle" target=_blank href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section"></a>
+        <a class="fa-question-circle" target=_blank aria-label="Help for grading by registration or rotating section" href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section"></a>
     </legend>
-	<input type="radio" name="grader_assignment_method" value="2" id="all_access"
-        {{ (gradeable.getGraderAssignmentMethod() == 2) ? 'checked' : '' }}> All Access Grading
-	
+	<input type="radio" name="grader_assignment_method" id="grader_assignment_method" value="2" id="all_access"
+        {{ (gradeable.getGraderAssignmentMethod() == 2) ? 'checked' : '' }}> <label for="grader_assignment_method">All Access Grading</label>
+
     <input type="radio" name="grader_assignment_method" value="1" id="registration_section"
-        {{ (gradeable.getGraderAssignmentMethod() == 1 or action == "new") ? 'checked' : '' }}> Registration Section
+        {{ (gradeable.getGraderAssignmentMethod() == 1 or action == "new") ? 'checked' : '' }}> <label for="registration_section">Registration Section</label>
 
     <input type='radio' name="grader_assignment_method" value="0" id="rotating_section"
-        {{ (gradeable.getGraderAssignmentMethod() == 0) ? 'checked' : '' }}> Rotating Section
+        {{ (gradeable.getGraderAssignmentMethod() == 0) ? 'checked' : '' }}> <label for="rotating_section">Rotating Section</label>
 </fieldset>
 <div id="rotating_data">
     {% if rotating_gradeables|length != 0 and num_rotating_sections > 0 %}

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -9,10 +9,12 @@ Macros
         <tr class="{{ prefix }}">
             <th>{{ grader[1] ~ " " ~ grader[2] ~ "(" ~ grader[0] ~ ")" }}</th>
             <td><input type="checkbox" name="{{ prefix }}_all_{{ grader[0] }}" id="{{ prefix }}_all_{{ grader[0] }}"
+                       aria-label="all rotating sections"
                        onclick='updateCheckBoxes("{{ prefix }}", "{{ grader[0] }}", 0)'/></td>
             {% for rs in section_numbers %}
                 <td><input type="checkbox" name="grader_{{ prefix }}_{{ rs }}_{{ grader[0] }}"
                         id="grader_{{ prefix }}_{{ rs }}_{{ grader[0] }}"
+                        aria-label="rotating section {{ rs }}"
                         onclick='updateCheckBoxes("{{ prefix }}", "{{ grader[0] }}", {{ rs }});'
                         {{ (rs in history[grader[0]][g_id]) ? 'checked' : '' }}/></td>
             {% endfor %}

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableRubric.twig
@@ -6,10 +6,10 @@
 {% if gradeable.getType() == 0 %}
     {{ include('admin/admin_gradeable/rubric/ElectronicFileRubric.twig')   }}
 {% else %}
-    What overall instructions should be provided to the TA?:<br />
+    <label for="ta-instructions">What overall instructions should be provided to the TA?:</label><br />
     {# NOTE: "textarea" contents (space between <textarea> and </textarea>") should not have any extra characters
                     (that's why the '>' is on the next line) #}
-    <textarea rows="4" cols="200" name="ta_instructions" placeholder="(Optional)" style="width: 500px;"
+    <textarea rows="4" cols="200" name="ta_instructions" id="ta-instructions" placeholder="(Optional)" style="width: 500px;"
     >{{ gradeable.getTaInstructions() }}</textarea>
     <br /><br />
     {% if gradeable.getType() == 1 %}

--- a/site/app/templates/admin/admin_gradeable/rubric/CheckpointsRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/CheckpointsRubric.twig
@@ -10,10 +10,10 @@
         <!-- This is a bit of a hack, but it works (^_^) -->
         <tr class="rubric_layout_body multi-field" id="mult-field-0" style="display:none;">
             <td>
-                <input style="width: 200px" name="checkpoint_label_0" type="text" class="checkpoint_label" value="Checkpoint 0"/>
+                <input style="width: 200px" name="checkpoint_label_0" aria-label="checkpoint 0" type="text" class="checkpoint_label" value="Checkpoint 0"/>
             </td>
             <td>
-                <input type="checkbox" name="checkpoint_extra_0" class="checkpoint_extra extra" value="true" />
+                <input type="checkbox" name="checkpoint_extra_0" aria-label="is checkpoint 0 counted as extra credit?" class="checkpoint_extra extra" value="true" />
             </td>
         </tr>
     </table>
@@ -42,8 +42,8 @@
             var wrapper = $('.checkpoints-table');
             ++numCheckpoints;
             $('#mult-field-0', wrapper).clone(true).appendTo(wrapper).attr('id', 'mult-field-' + numCheckpoints).find('.checkpoint_label').val(label).focus();
-            $('#mult-field-' + numCheckpoints, wrapper).find('.checkpoint_label').attr('name', 'checkpoint_label_' + numCheckpoints).change(() => saveRubric(false));
-            $('#mult-field-' + numCheckpoints, wrapper).find('.checkpoint_extra').attr('name', 'checkpoint_extra_' + numCheckpoints).attr('checked', extra_credit).change(() => saveRubric(false));
+            $('#mult-field-' + numCheckpoints, wrapper).find('.checkpoint_label').attr('name', 'checkpoint_label_' + numCheckpoints).attr('aria-label', 'checkpoint ' + numCheckpoints).change(() => saveRubric(false));
+            $('#mult-field-' + numCheckpoints, wrapper).find('.checkpoint_extra').attr('name', 'checkpoint_extra_' + numCheckpoints).attr('checked', extra_credit).attr('aria-label', 'is checkpoint ' + numCheckpoints + ' counted as extra credit?').change(() => saveRubric(false));
             $('#remove-checkpoint_field').show();
             $('#mult-field-' + numCheckpoints, wrapper).show();
         }

--- a/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
@@ -1,4 +1,4 @@
-Point precision:
+<label for="point_precision_id">Point precision:</label>
 <input type="text" id="point_precision_id" name="precision" onchange="onPrecisionChange()" value="{{ gradeable.getPrecision() }}" class="ignore" />
 
 <div class="electronic_file ignore" id="gradeable_rubric">
@@ -8,16 +8,16 @@ Point precision:
             And do you expect each specific problem/item/component to appear on a specific page number of the PDF document?
         </legend>
         <input type="radio" id="yes_pdf_page" name="pdf_page" value="true" onchange="updatePdfPageSettings()"
-                {{ is_pdf_page ? 'checked' : '' }} /> Yes
+                {{ is_pdf_page ? 'checked' : '' }} /> <label for="yes_pdf_page">Yes</label>
         <input type="radio" id="no_pdf_page" name="pdf_page" value="false" onchange="updatePdfPageSettings()"
-                {{ not is_pdf_page ? 'checked' : '' }} /> No
+                {{ not is_pdf_page ? 'checked' : '' }} /> <label for="no_pdf_page">No</label>
     </fieldset>
     <fieldset id="pdf_page">
         Who will assign page numbers to problems/item/components?<br>
         <input type="radio" id="no_pdf_page_student" name="pdf_page_student" value="false" onchange="updatePdfPageSettings()"
-                {{ not is_pdf_page_student ? 'checked' : '' }} /> Instructor (specify the starting page number for each problem/item/component below)<br>
+                {{ not is_pdf_page_student ? 'checked' : '' }} /> <label for="no_pdf_page_student">Instructor (specify the starting page number for each problem/item/component below)</label><br>
         <input type="radio" id="yes_pdf_page_student" name="pdf_page_student" value="true" onchange="updatePdfPageSettings()"
-                {{ is_pdf_page_student ? 'checked' : '' }} /> Student (student will be asked for page numbers at submission time)
+                {{ is_pdf_page_student ? 'checked' : '' }} /> <label for="yes_pdf_page_student">Student (student will be asked for page numbers at submission time)</label>
     </fieldset>
     <div>
         <div id="rubric-total-container">

--- a/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
@@ -1,8 +1,8 @@
 <div id="gradeable_rubric">
-    How many numeric items? <input style="width: 50px" id="numeric_num-items" name="num_numeric_items" type="text" value="0" class="int_val ignore" onchange="calculateTotalScore();"/>
+    <label for="numeric_num-items">How many numeric items?</label> <input style="width: 50px" id="numeric_num-items" name="num_numeric_items" type="text" value="0" class="int_val ignore" onchange="calculateTotalScore();"/>
     &emsp;&emsp;
 
-    How many text items? <input style="width: 50px" id="numeric_num_text_items" name="num_text_items" type="text" value="0" class="int_val ignore"/>
+    <label for="numeric_num_text_items">How many text items?</label> <input style="width: 50px" id="numeric_num_text_items" name="num_text_items" type="text" value="0" class="int_val ignore"/>
     <br /> <br />
 
     <div class="multi-field-wrapper-numeric">
@@ -28,13 +28,13 @@
             <!-- This is a bit of a hack, but it works (^_^) -->
                 <tr class="multi-field" id="mult-field-0" style="display:none;">
                     <td>
-                        <input style="width: 200px" name="numeric_label_0" type="text" class="numeric_label" value="0" />
+                        <input style="width: 200px" name="numeric_label_0" type="text" aria-label="label for numeric item 0" class="numeric_label" value="0" />
                     </td>
                     <td>
-                        <input style="width: 60px" type="text" name="max_score_0" class="max_score" value="0" onchange="calculateTotalScore();"/>
+                        <input style="width: 60px" type="text" name="max_score_0" aria-label="max score for numeric item 0" class="max_score" value="0" onchange="calculateTotalScore();"/>
                     </td>
                     <td>
-                        <input type="checkbox" name="numeric_extra_0" class="numeric_extra extra" value="" onchange="calculateTotalScore();"/>
+                        <input type="checkbox" name="numeric_extra_0" aria-label="is numeric item 0 counted as extra credit?" class="numeric_extra extra" value="" onchange="calculateTotalScore();"/>
                     </td>
                 </tr>
             </tbody>
@@ -50,7 +50,7 @@
             <!-- This is a bit of a hack, but it works (^_^) -->
                 <tr class="multi-field" id="mult-field-0" style="display:none;">
                     <td>
-                        <input style="width: 200px" name="text_label_0" type="text" class="text_label" value="0"/>
+                        <input style="width: 200px" name="text_label_0" aria-label="label for text item 0" type="text" class="text_label" value="0"/>
                     </td>
                 </tr>
             </tbody>
@@ -88,9 +88,9 @@
             var wrapper = $('.numerics-table');
             numNumeric++;
             $('#mult-field-0', wrapper).clone(true).appendTo(wrapper).attr('id', 'mult-field-' + numNumeric).find('.numeric_label').val(label).focus();
-            $('#mult-field-' + numNumeric, wrapper).find('.numeric_extra').attr('name', 'numeric_extra_' + numNumeric).change(() => saveRubric(false));
-            $('#mult-field-' + numNumeric, wrapper).find('.numeric_label').attr('name', 'numeric_label_' + numNumeric).change(() => saveRubric(false));
-            $('#mult-field-' + numNumeric, wrapper).find('.max_score').attr('name', 'max_score_' + numNumeric).val(max_score).change(() => saveRubric(false));
+            $('#mult-field-' + numNumeric, wrapper).find('.numeric_extra').attr('name', 'numeric_extra_' + numNumeric).attr('aria-label', 'is numeric item ' + numNumeric + ' counted as extra credit?').change(() => saveRubric(false));
+            $('#mult-field-' + numNumeric, wrapper).find('.numeric_label').attr('name', 'numeric_label_' + numNumeric).attr('aria-label', 'label for numeric item ' + numNumeric).change(() => saveRubric(false));
+            $('#mult-field-' + numNumeric, wrapper).find('.max_score').attr('name', 'max_score_' + numNumeric).attr('aria-label', 'max score for numeric item' + numNumeric).val(max_score).change(() => saveRubric(false));
             if (extra_credit) {
                 $('#mult-field-' + numNumeric, wrapper).find('.numeric_extra').attr('checked', true);
             }
@@ -109,8 +109,7 @@
             var wrapper = $('.text-table');
             numText++;
             $('#mult-field-0', wrapper).clone(true).appendTo(wrapper).attr('id', 'mult-field-' + numText).find('.text_label').val(label).focus();
-            $('#mult-field-' + numText, wrapper).find('.text_label').attr('name', 'text_label_' + numText).change(() => saveRubric(false));
-
+            $('#mult-field-' + numText, wrapper).find('.text_label').attr('name', 'text_label_' + numText).attr('aria-label', 'label for text item ' + numText).change(() => saveRubric(false));
             $('#mult-field-' + numText, wrapper).show();
         }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1449,7 +1449,7 @@ end of styles used in the admin gradeable page
 .required:-ms-input-placeholder { var(--error-alert-dark-red); }
 
 #required_type{
-    var(--error-alert-dark-red);
+    color: var(--error-alert-dark-red);
     display: inline;
 }
 


### PR DESCRIPTION
Accessibility improvements in various views for Create/Edit Gradeables.

Fixes include
- Correcting contrast ratio — `#FF0000` changed to `#CC0000`.
    - HTML `style="color:red"` -> CSS `color: var(--error-alert-dark-red);`
- Adding `<label>` tags where needed.
- Adding `aria-label` properties where descriptive text does not exist.
