### PR TITLE
[BugFix:Emails] Added urls to forum and team gradeable emails

### DIFF
--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -56,7 +56,7 @@ class Email extends AbstractModel {
     //inject a "do not reply" note in the footer of the body
     //also adds a relevant url if one exists
     private function formatBody($body, $relevant_url = null) {
-        if (!is_null($relevant_url) ) {
+        if (!is_null($relevant_url)) {
             $body .= "\n\nClick here for more info: " . $relevant_url;
         }
         return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -39,7 +39,12 @@ class Email extends AbstractModel {
         }
         $this->setUserId($details["to_user_id"]);
         $this->setSubject($this->formatSubject($details["subject"]));
-        $this->setBody($this->formatBody($details["body"]));
+
+        $relevant_url = NULL;
+        if (array_key_exists("relevant_url", $details)){
+            $relevant_url = $details["relevant_url"];
+        }
+        $this->setBody($this->formatBody($details["body"], $relevant_url));
     }
 
     //inject course label into subject
@@ -49,7 +54,11 @@ class Email extends AbstractModel {
     }
 
     //inject a "do not reply" note in the footer of the body
-    private function formatBody($body) {
+    //also adds a relevant url if one exists
+    private function formatBody($body, $relevant_url=NULL) {
+        if(!is_null($relevant_url)){
+            $body .= "\n\nClick here for more info: " . $relevant_url;
+        }
         return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
     }
 }

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -40,8 +40,8 @@ class Email extends AbstractModel {
         $this->setUserId($details["to_user_id"]);
         $this->setSubject($this->formatSubject($details["subject"]));
 
-        $relevant_url = NULL;
-        if (array_key_exists("relevant_url", $details)){
+        $relevant_url = null;
+        if (array_key_exists("relevant_url", $details)) {
             $relevant_url = $details["relevant_url"];
         }
         $this->setBody($this->formatBody($details["body"], $relevant_url));
@@ -55,8 +55,8 @@ class Email extends AbstractModel {
 
     //inject a "do not reply" note in the footer of the body
     //also adds a relevant url if one exists
-    private function formatBody($body, $relevant_url=NULL) {
-        if(!is_null($relevant_url)){
+    private function formatBody($body, $relevant_url = null) {
+        if (!is_null($relevant_url) ) {
             $body .= "\n\nClick here for more info: " . $relevant_url;
         }
         return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";

--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -170,7 +170,8 @@ class NotificationFactory {
             $details = [
                 'to_user_id' => $recipient,
                 'subject' => $event['subject'],
-                'body' => $event['content']
+                'body' => $event['content'],
+                'relevant_url' => json_decode($event['metadata'], true)['url']
             ];
             $emails[] = new Email($this->core, $details);
         }

--- a/site/app/models/NotificationFactory.php
+++ b/site/app/models/NotificationFactory.php
@@ -167,11 +167,18 @@ class NotificationFactory {
     private function createEmailsArray($event, $recipients) {
         $emails = array();
         foreach ($recipients as $recipient) {
+            //Checks if a url is in metadata and sets $relevant_url null or that url
+            $metadata = json_decode($event['metadata'], true);
+            $relevant_url = null;
+            if (array_key_exists("url", $metadata)) {
+                $relevant_url = $metadata["url"];
+            }
+
             $details = [
                 'to_user_id' => $recipient,
                 'subject' => $event['subject'],
                 'body' => $event['content'],
-                'relevant_url' => json_decode($event['metadata'], true)['url']
+                'relevant_url' => $relevant_url
             ];
             $emails[] = new Email($this->core, $details);
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Emails for forum notifications dont contain a link to the post/comment. This is annoying because once you get an email you have to separately open submitty, click the forum, then find the post. By adding a directly link to the emails it makes it much easier for people to get to the post/comment.

### What is the new behavior?

Added a url at the bottom of emails
(This is what it looks like when I open one of the email logs in nano)
![image](https://user-images.githubusercontent.com/18558130/70682383-b52ea480-1c6c-11ea-9449-e1a7f59f2423.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->