### PR TITLE
[VPAT] Adds higher contrast to error message popup 

### DIFF
--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -43,7 +43,7 @@
     --alert-success-green: #468847;
     --alert-background-success-green: #dff0d8;
     --alert-border-success-green: #d6e9c6;
-    --alert-danger-red: #b94a48;
+    --alert-danger-red: #8b0000;
     --alert-border-danger-red: #f2dede;
     --alert-background-danger-red: #eed3d7;
     --alert-info-blue: #3a87ad;

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -154,3 +154,7 @@ footer .footer-separator {
 #loading-bar-percentage{
     margin-left: 10px;
 }
+
+.inner-message.alert.alert-error{
+    color: darkred;
+}

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -154,7 +154,3 @@ footer .footer-separator {
 #loading-bar-percentage{
     margin-left: 10px;
 }
-
-.inner-message.alert.alert-error{
-    color: darkred;
-}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1636,7 +1636,7 @@ end of styles used in the admin gradeable page
 }
 
 .danger {
-    background: #f2dede;
+    background: var(--alert-background-danger-red);
     color: var(--alert-danger-red);
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
closes  #4457
* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The error message that sometimes shows up at the top of the page had a low contrast see  #4457
![image](https://user-images.githubusercontent.com/18558130/70685356-1fe4dd80-1c77-11ea-8502-31c65e683fe3.png)


### What is the new behavior?

I fixed the contrast to not be so low
It now looks like this
![image](https://user-images.githubusercontent.com/18558130/70685301-fb890100-1c76-11ea-9c74-d6510cbcfeeb.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I tested it with the wave plugin. The old version gave an error and my fix removed that error.
