### PR TITLE
[Autograding:Bufgix] Fixed Missing/Incorrect Graphics Action Specifications

### DIFF
--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -773,6 +773,26 @@
                     "enum" : ["origin"]
                   }
                 }
+              },
+              {
+                "description" : "Moves the mouse to the specified location.",
+                "type": "object",
+                "additionalProperties" : false,
+                "required" : ["action"],
+                "properties" : {
+                  "action" : {
+                    "type" : "string",
+                    "enum" : ["move mouse"]
+                  },
+                  "action" : {
+                    "type" : "integer",
+                    "enum" : ["end_x"]
+                  },
+                  "action" : {
+                    "type" : "integer",
+                    "enum" : ["end_y"]
+                  }
+                }
               }
             ]
           }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -568,8 +568,8 @@ void FormatGraphicsActions(nlohmann::json &whole_config) {
 
         validate_mouse_button(action);
 
-        validate_integer(action, "end_x",   true,  0, 0);
-        validate_integer(action, "end_y",   true,  0, 0);
+        validate_integer(action, "end_x",   true,  -100000, 0);
+        validate_integer(action, "end_y",   true,  -100000, 0);
 
         if(action["end_x"] == 0 && action["end_y"] == 0){
           std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;


### PR DESCRIPTION
Closes #3437

```move mouse``` was missing from the json schema.
```click and drag delta``` did not allow negative x or y values.