### PR TITLE
[Bugfix:Instructor UI] Exam Seating Dropdown Dropping An Option

### DIFF
--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -201,7 +201,9 @@ class ConfigurationController extends AbstractController {
             return is_dir(FileUtils::joinPaths($seating_dir, $seating_option['g_id']));
         });
 
-        $empty_option = [[
+        //This needs to be -1 or it will default to 0 and clobber g_id 0 if that is in $gradeable_seating_options
+        // during the concatenation in return (which is basically array_merge).
+        $empty_option = [-1 => [
             'g_id' => "",
             'g_title' => "--None--"
         ]];

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -201,7 +201,8 @@ class ConfigurationController extends AbstractController {
             return is_dir(FileUtils::joinPaths($seating_dir, $seating_option['g_id']));
         });
 
-        //This needs to be -1 or it will default to 0 and clobber g_id 0 if that is in $gradeable_seating_options
+        // This needs to be -1 or it will default to 0 and clobber g_id 0
+        // if that gradeable is in $gradeable_seating_options
         // during the concatenation in return (which is basically array_merge).
         $empty_option = [-1 => [
             'g_id' => "",


### PR DESCRIPTION
If a gradeable is set up to be used for exam seating (i.e. the `reports/seating/<g_id>` directory exists and `g_id` is a valid gradeable), but the gradeable TITLE is alphabetically first among all gradeable titles in the course, then it did not display. This was due to the "None" option always occupying position 0 in the resulting array.

This has been rectified by making the "None" option occupy position -1 which should never be occupied by the query/filtering of valid gradeable IDs.