### PR TITLE
[Bugfix:TAGrading] popup error when writing a custom message

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1837,8 +1837,8 @@ function onCancelComponent(me) {
   const anon_id = getAnonId();
   ajaxGetGradedComponent(gradeable_id, component_id, anon_id).then((component)=>{
     // If there is any changes made in comment of a component , prompt the TA
-    if ( component.comment !== $('#component-' + component_id).find('.mark-note-custom').val().trim()) {
-      if(confirm("Note: Changes made to the Student Message will be lost! Do you want to continue ? ")){
+    if ( component.comment !== $('#component-' + component_id).find('.mark-note-custom').val()) {
+      if(confirm( "Are you sure you want to discard all changes to the student message?")){
         toggleComponent(component_id, false)
           .catch(function (err) {
             console.error(err);
@@ -1889,7 +1889,7 @@ function onCancelOverallComment(me) {
   // if the overall Comment is changed then prompt the TA for loss in comment
   ajaxGetOverallComment(getGradeableId(), getAnonId()).then((lastSavedOverallComment) => {
     if (getOverallCommentFromDOM() !== lastSavedOverallComment) {
-      if(confirm("Note: Changes made to the Student Message will be lost! Do you want to continue ? ")){
+      if(confirm( "Are you sure you want to discard all changes to the student message?")){
         toggleOverallComment(false)
           .catch(function (err) {
             console.error(err);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Closes #4729 
If we make any changes made in custom message for some mark or overall message and hit *cancel* there is prompt for the TA which lead to accidental loss of that message.  
### What is the new behavior?
Now if there is any changes made in the custom message of any mark or the overall component and you press *cancel* submitty will ask you for a confirmation.  

![confirm](https://user-images.githubusercontent.com/48342617/70769357-2ebeb380-1d8f-11ea-9c0c-240f82abae27.jpg)
