### PR TITLE
[Refactor:Submission] Update change version endpoint to use Response

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1485,18 +1485,18 @@ class SubmissionController extends AbstractController {
 
         $url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), $new_version]);
         if ($ta) {
-            $params = $this->core->buildCourseUrl([
+            $url = $this->core->buildCourseUrl([
                 'gradeable',
                 $graded_gradeable->getGradeableId(),
                 'grading',
-                'grade']
-            ) . '?' . http_build_query(['who_id' => $who, 'gradeable_version' => $new_version]);
+                'grade'
+            ]) . '?' . http_build_query(['who_id' => $who, 'gradeable_version' => $new_version]);
         }
 
         return new Response(
             JsonResponse::getSuccessResponse(['version' => $new_version, 'message' => $msg]),
             null,
-            new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]))
+            new RedirectResponse($url)
         );
     }
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -7,6 +7,9 @@ use app\libraries\ErrorMessages;
 use app\libraries\FileUtils;
 use app\libraries\GradeableType;
 use app\libraries\Logger;
+use app\libraries\response\JsonResponse;
+use app\libraries\response\RedirectResponse;
+use app\libraries\response\Response;
 use app\libraries\routers\AccessControl;
 use app\libraries\Utils;
 use app\models\gradeable\Gradeable;
@@ -1350,15 +1353,18 @@ class SubmissionController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/version/{new_version}", methods={"POST"})
      */
-    public function updateSubmissionVersion($gradeable_id, $new_version, $ta = null, $who = null) {
+    public function updateSubmissionVersion($gradeable_id, $new_version, $ta = null, $who = null): Response {
         $ta = $ta === "true" ?? false;
         if ($ta !== false) {
             // make sure is full grader
             if (!$this->core->getUser()->accessFullGrading()) {
                 $msg = "You do not have access to that page.";
                 $this->core->addErrorMessage($msg);
-                $this->core->redirect($this->core->buildCourseUrl());
-                return $this->core->getOutput()->renderJsonFail($msg);
+                return new Response(
+                    JsonResponse::getFailResponse($msg),
+                    null,
+                    new RedirectResponse($this->core->buildCourseUrl())
+                );
             }
             $ta = true;
         }
@@ -1367,8 +1373,11 @@ class SubmissionController extends AbstractController {
         if ($gradeable === null) {
             $msg = "Invalid gradeable id.";
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($this->core->buildCourseUrl());
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($this->core->buildCourseUrl())
+            );
         }
 
         $who = $who ?? $this->core->getUser()->getId();
@@ -1379,31 +1388,43 @@ class SubmissionController extends AbstractController {
         if ($gradeable->isTeamAssignment() && $graded_gradeable === null) {
             $msg = 'Must be on a team to access submission.';
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($this->core->buildCourseUrl());
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($url)
+            );
         }
 
         $new_version = intval($new_version);
         if ($new_version < 0) {
             $msg = "Cannot set the version below 0.";
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($url);
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($url)
+            );
         }
 
         $highest_version = $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
         if ($new_version > $highest_version) {
             $msg = "Cannot set the version past {$highest_version}.";
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($url);
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($url)
+            );
         }
 
         if (!$this->core->getUser()->accessGrading() && !$gradeable->isStudentSubmit()) {
             $msg = "Cannot submit for this assignment.";
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($url);
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($url)
+            );
         }
 
         $original_user_id = $this->core->getUser()->getId();
@@ -1420,8 +1441,11 @@ class SubmissionController extends AbstractController {
         if ($json === false) {
             $msg = "Failed to open settings file.";
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($url);
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($url)
+            );
         }
         $json["active_version"] = $new_version;
         $current_time = $this->core->getDateTimeNow()->format("Y-m-d H:i:sO");
@@ -1432,8 +1456,11 @@ class SubmissionController extends AbstractController {
         if (!@file_put_contents($settings_file, FileUtils::encodeJson($json))) {
             $msg = "Could not write to settings file.";
             $this->core->addErrorMessage($msg);
-            $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]));
-            return $this->core->getOutput()->renderJsonFail($msg);
+            return new Response(
+                JsonResponse::getFailResponse($msg),
+                null,
+                new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]))
+            );
         }
 
         $version = ($new_version > 0) ? $new_version : null;
@@ -1455,15 +1482,22 @@ class SubmissionController extends AbstractController {
             $msg = "Updated version of gradeable to version #{$new_version}.";
             $this->core->addSuccessMessage($msg);
         }
+
+        $url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), $new_version]);
         if ($ta) {
-            $this->core->redirect($this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'grade']) . '?'
-                . http_build_query(['who_id' => $who, 'gradeable_version' => $new_version]));
-        }
-        else {
-            $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable->getId(), $new_version]));
+            $params = $this->core->buildCourseUrl([
+                'gradeable',
+                $graded_gradeable->getGradeableId(),
+                'grading',
+                'grade']
+            ) . '?' . http_build_query(['who_id' => $who, 'gradeable_version' => $new_version]);
         }
 
-        return $this->core->getOutput()->renderJsonSuccess(['version' => $new_version, 'message' => $msg]);
+        return new Response(
+            JsonResponse::getSuccessResponse(['version' => $new_version, 'message' => $msg]),
+            null,
+            new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]))
+        );
     }
 
     /**

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -1636,7 +1636,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
         $this->assertNull($return->web_response);
         $this->assertNotNull($return->redirect_response);
-        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertEquals('test/test/gradeable/test/0', $return->redirect_response->url);
         $this->assertNotNull($return->json_response);
         $json_response = $return->json_response->json;
         $this->assertEquals('success', $json_response['status']);
@@ -1665,7 +1665,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
         $this->assertNull($return->web_response);
         $this->assertNotNull($return->redirect_response);
-        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertEquals('test/test/gradeable/test/4', $return->redirect_response->url);
         $this->assertNotNull($return->json_response);
         $json_response = $return->json_response->json;
         $this->assertEquals('success', $json_response['status']);

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -1543,12 +1543,30 @@ class SubmissionControllerTester extends BaseUnitTest {
         $this->assertEquals("No gradeable with that id.", $return['message']);
     }
 
+    public function testUpdateInvalidGradeable() {
+        $controller = new SubmissionController($this->core);
+        $return = $controller->updateSubmissionVersion('invalid_gradeable', -1);
+
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json = $return->json_response->json;
+        $this->assertEquals('fail', $json['status']);
+        $this->assertEquals("Invalid gradeable id.", $json['message']);
+    }
+
     public function testUpdateNegativeVersion() {
         $controller = new SubmissionController($this->core);
         $return = $controller->updateSubmissionVersion('test', -1);
 
-        $this->assertTrue($return['status'] == 'fail');
-        $this->assertEquals("Cannot set the version below 0.", $return['message']);
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json = $return->json_response->json;
+        $this->assertEquals('fail', $json['status']);
+        $this->assertEquals("Cannot set the version below 0.", $json['message']);
     }
 
     /**
@@ -1558,8 +1576,13 @@ class SubmissionControllerTester extends BaseUnitTest {
         $controller = new SubmissionController($this->core);
         $return = $controller->updateSubmissionVersion('test', 2);
 
-        $this->assertTrue($return['status'] == 'fail');
-        $this->assertEquals("Cannot set the version past 1.", $return['message']);
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json = $return->json_response->json;
+        $this->assertEquals('fail', $json['status']);
+        $this->assertEquals("Cannot set the version past 1.", $json['message']);
     }
 
     /**
@@ -1569,8 +1592,13 @@ class SubmissionControllerTester extends BaseUnitTest {
         $controller = new SubmissionController($this->core);
         $return = $controller->updateSubmissionVersion('test', 1);
 
-        $this->assertTrue($return['status'] == 'fail');
-        $this->assertEquals("Failed to open settings file.", $return['message']);
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json = $return->json_response->json;
+        $this->assertEquals('fail', $json['status']);
+        $this->assertEquals("Failed to open settings file.", $json['message']);
     }
 
     /**
@@ -1587,8 +1615,13 @@ class SubmissionControllerTester extends BaseUnitTest {
         $controller = new SubmissionController($this->core);
         $return = $controller->updateSubmissionVersion('test', 1);
 
-        $this->assertTrue($return['status'] == 'fail');
-        $this->assertEquals("Could not write to settings file.", $return['message']);
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json = $return->json_response->json;
+        $this->assertEquals('fail', $json['status']);
+        $this->assertEquals("Could not write to settings file.", $json['message']);
     }
 
     public function testUpdateCancelSubmission() {
@@ -1601,9 +1634,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $controller = new SubmissionController($this->core);
         $return = $controller->updateSubmissionVersion('test', 0);
 
-        $this->assertFalse($return['status'] == 'fail');
-        $this->assertEquals("Cancelled submission for gradeable.", $return['data']['message']);
-        $this->assertEquals(0, $return['data']['version']);
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json_response = $return->json_response->json;
+        $this->assertEquals('success', $json_response['status']);
+        $this->assertEquals("Cancelled submission for gradeable.", $json_response['data']['message']);
+        $this->assertEquals(0, $json_response['data']['version']);
         $json = json_decode(file_get_contents($settings), true);
         $this->assertEquals(0, $json['active_version']);
         $this->assertTrue(isset($json['history']));
@@ -1625,9 +1663,14 @@ class SubmissionControllerTester extends BaseUnitTest {
         $controller = new SubmissionController($this->core);
         $return = $controller->updateSubmissionVersion('test', 4);
 
-        $this->assertFalse($return['status'] == 'fail');
-        $this->assertEquals("Updated version of gradeable to version #4.", $return['data']['message']);
-        $this->assertEquals(4, $return['data']['version']);
+        $this->assertNull($return->web_response);
+        $this->assertNotNull($return->redirect_response);
+        $this->assertEquals('test/test/gradeable/test', $return->redirect_response->url);
+        $this->assertNotNull($return->json_response);
+        $json_response = $return->json_response->json;
+        $this->assertEquals('success', $json_response['status']);
+        $this->assertEquals("Updated version of gradeable to version #4.", $json_response['data']['message']);
+        $this->assertEquals(4, $json_response['data']['version']);
         $json = json_decode(file_get_contents($settings), true);
         $this->assertEquals(4, $json['active_version']);
         $this->assertTrue(isset($json['history']));


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The change version endpoint on submission controller used old method of doing redirect + json responses.

### What is the new behavior?

Updates it to use the new Response object, making it easier to test.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Requirement for #4840 to be merged.
