### PR TITLE
[Bugfix:UI] Modal Scrolling & "Modal Footer" w/ Close & Submit buttons

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -15,17 +15,17 @@
                 {% block body_panel %}
                     <div class="form-body">
                         {% block body %}Be sure to override the body block.{% endblock %}
-                    </div>
-                {% endblock %}
-                {% block buttons_panel %}
-                    <div class="form-buttons">
-                        <div class="form-button-container">
-                            {% block buttons %}
-                                {% block close_button %}
-                                   <a href="javascript:closePopup('{{ block('popup_id') }}')" class="btn btn-default close-button">Close</a>
-                                {% endblock %}
-                            {% endblock %}
-                        </div>
+                        {% block buttons_panel %}
+                          <div class="form-buttons">
+                                <div class="form-button-container">
+                                    {% block buttons %}
+                                        {% block close_button %}
+                                            <a href="javascript:closePopup('{{ block('popup_id') }}')" class="btn btn-default close-button">Close</a>
+                                        {% endblock %}
+                                    {% endblock %}
+                                </div>
+                           </div>
+                       {% endblock %}
                     </div>
                 {% endblock %}
             </div>
@@ -37,6 +37,6 @@
     $(".popup-window").draggable();
 
     function closePopup(id) {
-        $('#' + id).hide(); 
+        $('#' + id).hide();
     }
 </script>

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -399,11 +399,11 @@ HTML;
                         <p>Note: Deleting plagiarism results will also delete the saved configuration for the gradeable.</p><br>
                         Are you sure to delete Plagiarism Results for
                         <b><div name="gradeable_title"></div></b>
-                    </div>
-                    <div class="form-buttons">
-                        <div class="form-button-container">
-                            <a onclick="$('#delete-plagiarism-result-and-config-form').css('display', 'none');" class="btn btn-default">Cancel</a>
-                            <input class="btn btn-danger" type="submit" value="Delete" />
+                        <div class="form-buttons">
+                            <div class="form-button-container">
+                                <a onclick="$('#delete-plagiarism-result-and-config-form').css('display', 'none');" class="btn btn-default">Cancel</a>
+                                <input class="btn btn-danger" type="submit" value="Delete" />
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1180,6 +1180,12 @@ div.full_height {
 
 .popup-form .form-button-container {
     text-align: right;
+    padding: 0.5rem;
+}
+
+.close-button {
+    margin-right: 5px;
+    border: 1px solid black !important;
 }
 
 .popup-form .form-button-container .btn {

--- a/site/public/js/directory.js
+++ b/site/public/js/directory.js
@@ -4,6 +4,7 @@ function newDownloadForm() {
     $('.popup-form').css('display', 'none');
     var form = $('#download-form');
     form.css('display', 'block');
+    form.find('.form-body').scrollTop(0);
     $("#download-form input:checkbox").each(function() {
         if ($(this).val() === 'NULL') {
             $(this).prop('checked', false);
@@ -19,6 +20,7 @@ function newClassListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#class-list-form");
     form.css("display", "block");
+    form.find('.form-body').scrollTop(0);
     $('[name="move_missing"]', form).prop('checked', false);
     $('[name="upload"]', form).val(null);
     $("#move_missing").focus();
@@ -28,6 +30,7 @@ function newGraderListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#grader-list-form");
     form.css("display", "block");
+    form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
     $("#grader-list-upload").focus();
 }
@@ -35,5 +38,6 @@ function newGraderListForm() {
 function editRegistrationSectionsForm() {
     var form = $("#registration-sections-form");
     form.css("display","block");
+    form.find('.form-body').scrollTop(0);
     $("#instructor_all").focus();
 }

--- a/site/public/js/homepage.js
+++ b/site/public/js/homepage.js
@@ -2,6 +2,7 @@ function userNameChange() {
     $('.popup-form').css('display', 'none');
     var form = $("#edit-username-form");
     form.css("display", "block");
+    form.find('.form-body').scrollTop(0);
     $('[name="user_name_change"]', form).val("");
     $("#user-firstname-change").focus();
 }
@@ -10,6 +11,7 @@ function passwordChange() {
     $('.popup-form').css('display', 'none');
     var form = $("#change-password-form");
     form.css("display", "block");
+    form.find('.form-body').scrollTop(0);
     $('[name="new_password"]', form).val("");
     $('[name="confirm_new_password"]', form).val("");
     $("#new_password").focus();

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -169,6 +169,7 @@ function displayCloseSubmissionsWarning(form_action,gradeable_name) {
     $('[name="close-submissions-confirmation"]', form).attr('action', form_action);
     form.css("display", "block");
     captureTabInModal("close-submissions-form");
+    form.find('.form-body').scrollTop(0);
 }
 
 function newDeleteCourseMaterialForm(path, file_name) {
@@ -195,6 +196,7 @@ function newDeleteCourseMaterialForm(path, file_name) {
     $('[name="delete-confirmation"]', form).attr('action', url);
     form.css("display", "block");
     captureTabInModal("delete-course-material-form");
+    form.find('.form-body').scrollTop(0);
 }
 
 function newUploadImagesForm() {
@@ -202,6 +204,7 @@ function newUploadImagesForm() {
     var form = $("#upload-images-form");
     form.css("display", "block");
     captureTabInModal("upload-images-form");
+    form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
 }
 
@@ -219,20 +222,22 @@ function newUploadCourseMaterialsForm() {
     }
 
     $('.popup-form').css('display', 'none');
+    var form = $("#upload-course-materials-form");
 
     $('[name="existing-file-list"]', form).html('');
     $('[name="existing-file-list"]', form).append('<b>'+JSON.stringify(files)+'</b>');
-    var form = $("#upload-course-materials-form");
+
     form.css("display", "block");
     captureTabInModal("upload-course-materials-form");
+    form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
 
 }
 
 function captureTabInModal(formName){
-    
+
     var form = $("#".concat(formName));
-    
+
     /*get all the elements to tab through*/
     var inputs = form.find(':focusable').filter(':visible');
     var firstInput = inputs.first();
@@ -252,14 +257,14 @@ function captureTabInModal(formName){
             e.preventDefault();
         }
     });
-    
+
     form.on('hidden.bs.modal', function () {
         releaseTabFromModal(formName);
     })
 }
 
 function releaseTabFromModal(formName){
-    
+
     var form = $("#".concat(formName));
     form.off('keydown');
 }
@@ -273,6 +278,7 @@ function setFolderRelease(changeActionVariable,releaseDates,id,inDir){
 
     captureTabInModal("set-folder-release-form");
 
+    form.find('.form-body').scrollTop(0);
     $('[id="release_title"]',form).attr('data-path',changeActionVariable);
     $('[name="release_date"]', form).val(releaseDates);
     $('[name="release_date"]',form).attr('data-fp',changeActionVariable);
@@ -290,6 +296,7 @@ function deletePlagiarismResultAndConfigForm(form_action, gradeable_title) {
     $('[name="gradeable_title"]', form).append(gradeable_title);
     $('[name="delete"]', form).attr('action', form_action);
     form.css("display", "block");
+    form.find('.form-body').scrollTop(0);
     captureTabInModal("delete-plagiarism-result-and-config-form");
 }
 
@@ -814,6 +821,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
     form.css("display", "block");
     captureTabInModal("admin-team-form");
 
+    form.find('.form-body').scrollTop(0);
     $("#admin-team-form-submit").prop('disabled',false);
     $('[name="new_team"]', form).val(new_team);
     $('[name="reg_section"] option[value="' + reg_section + '"]', form).prop('selected', true);
@@ -995,6 +1003,7 @@ function importTeamForm() {
     var form = $("#import-team-form");
     form.css("display", "block");
     captureTabInModal("import-team-form");
+    form.find('.form-body').scrollTop(0);
     $('[name="upload_team"]', form).val(null);
 }
 
@@ -1004,6 +1013,7 @@ function randomizeRotatingGroupsButton() {
     var form = $("#randomize-button-warning");
     form.css("display", "block");
     captureTabInModal("randomize-button-warning");
+    form.find('.form-body').scrollTop(0);
 }
 
 

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -48,6 +48,7 @@ function newUserForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#edit-user-form");
     form.css("display", "block");
+    form.find('.form-body').scrollTop(0);
     $("#edit-student-modal-title").css('display','none');
     $("#edit-grader-modal-title").css('display','none');
     $("#user-form-already-exists-error-message").css('display','none');
@@ -76,6 +77,7 @@ function editUserForm(user_id) {
             var json = JSON.parse(data)['data'];
             var form = $("#edit-user-form");
             form.css("display", "block");
+            form.find('.form-body').scrollTop(0);
             if (json['user_group'] == 4) {
                 $("#edit-student-modal-title").css('display','block');
                 $("#edit-grader-modal-title").css('display','none');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behaviour?
Currently, in small browser windows, a lot of `popup modals`  like user-form  requires scrolling. As the position of modal buttons are fixed , it creates a impression as if there are no more fields (or content like in `upload classlist` and `upload graderlist`)

### What is the new behaviour?
Closes #4203 
Now the modals are changed to have fluid footer and buttons i.e they are kept inside the scrolling section.
