### PR TITLE
[Bugfix] PHP code incorrectly rounds valid numbers

### DIFF
--- a/site/app/libraries/NumberUtils.php
+++ b/site/app/libraries/NumberUtils.php
@@ -11,33 +11,42 @@ namespace app\libraries;
 class NumberUtils {
 
     /**
-     * @param $x float The number to round
-     * @param $y float The number $x to be rounded with respect to this variable $y
-     * @return float The rounded result to the nearest multiple of $y
+     * NumberUtils constructor.
+     * @param Core $core
      */
-    public static function roundPointValue($x, $y) {
-
-        // No $y, no rounding
-        if ($y === 0.0) {
-            return $x;
-        }
-
-        $x = floatval($x);
-        $q = (int) ($x / $y);
-        $r = self::fmod_round($x, $y);
-
-        // If the remainder is more than half the $y away from zero, then add one
-        //  times the direction from zero to the quotient.  Multiply by $y
-        return ($q + (abs($r) > $y / 2 ? ($r > 0 ? 1 : -1) : 0)) * $y;
+    public function __construct(Core $core) {
+        parent::__construct($core);
     }
 
     /**
-     * @param $x float
-     * @param $y float
-     * @return float|int
+     *  Gives the closest number to the `$value`  with respect to `$precision`
+     * @param $value float The number to round
+     * @param $precision float The precision with calculation to be made
+     * @return float The rounded result to the nearest multiple of $y
      */
-    public static function fmod_round($x, $y) {
-        $i = round($x / $y);
-        return $x - $i * $y;
+    public static function roundPointValue($value, $precision) {
+
+        // No $precision, no rounding
+        if ($precision === 0.0) return $value;
+
+        $value = floatval($value);
+        $qtnt_f = $value / $precision;
+        $qtnt_i = (int) ($value / $precision);
+
+        if ($qtnt_i == $qtnt_f) return $value;
+
+        $mod = $value - $qtnt_i * $precision;
+
+        $shift = null;
+        // difference is to little to be considered , No shifting needed
+        if(abs($mod) < $precision / 2 ) {
+            $shift = 0 ;
+        } else {
+            // shift to one unit in the direction from zero to the quotient
+            $shift = $mod > 0 ? 1 : -1;
+        }
+
+        return ($qtnt_i + $shift) * $precision;
     }
+
 }

--- a/site/app/libraries/NumberUtils.php
+++ b/site/app/libraries/NumberUtils.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace app\libraries;
+
+/**
+ * Class NumberUtils
+ *
+ * Utility functions for interacting with numbers
+ */
+
+class NumberUtils {
+
+    /**
+     * @param $x float The number to round
+     * @param $y float The number $x to be rounded with respect to this variable $y
+     * @return float The rounded result to the nearest multiple of $y
+     */
+    public static function roundPointValue($x, $y) {
+
+        // No $y, no rounding
+        if ($y === 0.0) {
+            return $x;
+        }
+
+        $x = floatval($x);
+        $q = (int) ($x / $y);
+        $r = self::fmod_round($x, $y);
+
+        // If the remainder is more than half the $y away from zero, then add one
+        //  times the direction from zero to the quotient.  Multiply by $y
+        return ($q + (abs($r) > $y / 2 ? ($r > 0 ? 1 : -1) : 0)) * $y;
+    }
+
+    /**
+     * @param $x float
+     * @param $y float
+     * @return float|int
+     */
+    public static function fmod_round($x, $y) {
+        $i = round($x / $y);
+        return $x - $i * $y;
+    }
+}

--- a/site/app/libraries/NumberUtils.php
+++ b/site/app/libraries/NumberUtils.php
@@ -1,29 +1,19 @@
 <?php
 
 namespace app\libraries;
-use app\models\AbstractModel;
 
 /**
  * Class NumberUtils
  *
  * Utility functions for interacting with numbers
  */
-
-class NumberUtils extends AbstractModel {
-
-    /**
-     * NumberUtils constructor.
-     * @param Core $core
-     */
-    public function __construct(Core $core) {
-        parent::__construct($core);
-    }
+class NumberUtils {
 
     /**
      *  Gives the closest number to the `value` with respect to `precision`
-     * @param float $value  The     number to round
-     * @param float $precision float The precision with calculation to be made
-     * @return float The rounded result to the nearest multiple of $y
+     * @param float $value The number to round
+     * @param float $precision The precision with calculation to be made
+     * @return float The rounded result to the nearest multiple of precision
      */
     public static function roundPointValue(float $value, float $precision) {
 

--- a/site/app/libraries/NumberUtils.php
+++ b/site/app/libraries/NumberUtils.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\libraries;
+use app\models\AbstractModel;
 
 /**
  * Class NumberUtils
@@ -8,7 +9,7 @@ namespace app\libraries;
  * Utility functions for interacting with numbers
  */
 
-class NumberUtils {
+class NumberUtils extends AbstractModel {
 
     /**
      * NumberUtils constructor.
@@ -19,34 +20,38 @@ class NumberUtils {
     }
 
     /**
-     *  Gives the closest number to the `$value`  with respect to `$precision`
-     * @param $value float The number to round
-     * @param $precision float The precision with calculation to be made
+     *  Gives the closest number to the `value` with respect to `precision`
+     * @param float $value  The     number to round
+     * @param float $precision float The precision with calculation to be made
      * @return float The rounded result to the nearest multiple of $y
      */
-    public static function roundPointValue($value, $precision) {
+    public static function roundPointValue(float $value, float $precision) {
 
         // No $precision, no rounding
-        if ($precision === 0.0) return $value;
+        if ($precision === 0.0) {
+            return $value;
+        }
 
         $value = floatval($value);
         $qtnt_f = $value / $precision;
         $qtnt_i = (int) ($value / $precision);
 
-        if ($qtnt_i == $qtnt_f) return $value;
+        if ($qtnt_i == $qtnt_f) {
+            return $value;
+        }
 
         $mod = $value - $qtnt_i * $precision;
 
         $shift = null;
         // difference is to little to be considered , No shifting needed
-        if(abs($mod) < $precision / 2 ) {
-            $shift = 0 ;
-        } else {
+        if (abs($mod) < $precision / 2) {
+            $shift = 0;
+        }
+        else {
             // shift to one unit in the direction from zero to the quotient
             $shift = $mod > 0 ? 1 : -1;
         }
 
         return ($qtnt_i + $shift) * $precision;
     }
-
 }

--- a/site/app/models/gradeable/Component.php
+++ b/site/app/models/gradeable/Component.php
@@ -7,6 +7,7 @@ use app\exceptions\NotImplementedException;
 use app\libraries\Core;
 use app\libraries\Utils;
 use app\models\AbstractModel;
+use app\libraries\NumberUtils;
 
 /**
  * Class Component
@@ -295,7 +296,7 @@ class Component extends AbstractModel {
 
         // Round after validation because of potential floating point weirdness
         foreach (self::point_properties as $property) {
-            $this->$property = $this->getGradeable()->roundPointValue($points[$property]);
+            $this->$property = NumberUtils::roundPointValue($points[$property], $this->getGradeable()->getPrecision());
         }
         $this->modified = true;
     }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1155,31 +1155,6 @@ class Gradeable extends AbstractModel {
     }
 
     /**
-     * Rounds a provided point value to the nearest multiple of $precision
-     *
-     * @param $points float|string The number to round
-     * @return float The rounded result
-     */
-    public function roundPointValue($points) {
-        // Note that changing the gradeable precision does not trigger
-        //  all of the component/mark point values to update.  This is intended.
-
-        // No precision, no rounding
-        if ($this->precision === 0.0) {
-            return $points;
-        }
-
-        $points = floatval($points);
-        $q = (int) ($points / $this->precision);
-        $r = fmod($points, $this->precision);
-
-        // If the remainder is more than half the precision away from zero, then add one
-        //  times the direction from zero to the quotient.  Multiply by precision
-        return ($q + (abs($r) > $this->precision / 2 ? ($r > 0 ? 1 : -1) : 0)) * $this->precision;
-    }
-
-
-    /**
      * Gets all of the teams formed for this gradeable
      * @return Team[]
      */

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -7,6 +7,7 @@ use app\models\AbstractModel;
 use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\models\User;
+use app\libraries\NumberUtils;
 
 /**
  * Class GradedComponent
@@ -200,7 +201,8 @@ class GradedComponent extends AbstractModel {
         }
         $score += $this->getScore();
         $score = min(max($score, $this->component->getLowerClamp()), $this->component->getUpperClamp());
-        return $this->getTaGradedGradeable()->getGradedGradeable()->getGradeable()->roundPointValue($score);
+        $precision = $this->getTaGradedGradeable()->getGradedGradeable()->getGradeable()->getPrecision();
+        return NumberUtils::roundPointValue($score, $precision);
     }
 
     /**
@@ -308,7 +310,7 @@ class GradedComponent extends AbstractModel {
             //  min(max(a,b),c) will clamp the value 'b' in the range [a,c]
             $this->score = min(max($this->component->getLowerClamp(), $score), $this->component->getUpperClamp());
         }
-        $this->score = $this->getComponent()->getGradeable()->roundPointValue($this->score);
+        $this->score = NumberUtils::roundPointValue($this->score, $this->getComponent()->getGradeable()->getPrecision());
         $this->modified = true;
     }
 

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -6,6 +6,7 @@ use app\libraries\Core;
 use app\libraries\Utils;
 use app\models\AbstractModel;
 use app\models\User;
+use app\libraries\NumberUtils;
 
 /**
  * Class GradedComponentContainer
@@ -216,7 +217,7 @@ class GradedComponentContainer extends AbstractModel {
         // Note: this is called 'safeCalcPercent', but it does not clamp the output to 1.0
         // Note: clamp count(...) to be at least 1 so safeCalcPercent doesn't return NaN
         $points_earned = Utils::safeCalcPercent($points_earned, max(1, count($this->graded_components)));
-        return $this->ta_graded_gradeable->getGradedGradeable()->getGradeable()->roundPointValue($points_earned);
+        return NumberUtils::roundPointValue($points_earned, $this->ta_graded_gradeable->getGradedGradeable()->getGradeable()->getPrecision());
     }
 
     /**

--- a/site/app/models/gradeable/Mark.php
+++ b/site/app/models/gradeable/Mark.php
@@ -4,6 +4,7 @@ namespace app\models\gradeable;
 
 use app\libraries\Core;
 use app\models\AbstractModel;
+use app\libraries\NumberUtils;
 
 /**
  * Class Mark
@@ -118,7 +119,7 @@ class Mark extends AbstractModel {
      */
     public function setPoints($points) {
         if (is_numeric($points)) {
-            $this->points = $this->getComponent()->getGradeable()->roundPointValue($points);
+            $this->points = NumberUtils::roundPointValue($points, $this->getComponent()->getGradeable()->getPrecision());
         }
         else {
             throw new \InvalidArgumentException('Mark points must be a number!');

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -13,6 +13,7 @@ use app\views\AbstractView;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 use app\libraries\DateUtils;
+use app\libraries\NumberUtils;
 
 class AutoGradingView extends AbstractView {
 
@@ -334,7 +335,7 @@ class AutoGradingView extends AbstractView {
         $regrade_message = $this->core->getConfig()->getRegradeMessage();
         //Clamp full gradeable score to zero
         $total_score = max($total_score, 0);
-        $total_score = $gradeable->roundPointValue($total_score);
+        $total_score = NumberUtils::roundPointValue($total_score, $gradeable->getPrecision());
 
         $late_days_url = $this->core->buildCourseUrl(['late_table']);
         $regrade_allowed = $gradeable->isRegradeAllowed();

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -2063,11 +2063,6 @@ parameters:
 			path: app/models/gradeable/Gradeable.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$points float\\|string The number to round\\)\\: Unexpected token \"\\$points\", expected TOKEN_IDENTIFIER at offset 100$#"
-			count: 1
-			path: app/models/gradeable/Gradeable.php
-
-		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var User\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/gradeable/GradeableList.php

--- a/site/tests/app/libraries/NumbersUtilsTester.php
+++ b/site/tests/app/libraries/NumbersUtilsTester.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace tests\app\libraries;
+
+use app\libraries\Core;
+use app\libraries\NumberUtils;
+use app\models\Config;
+
+class NumbersUtilsTester extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @return array -containing the test cases as { expectedValue, value, precision}
+     */
+    public function roundPointValueData()
+    {
+        return array(
+            array(6, 6, 0.05),
+            array(1.002, 1, 0.006),
+            array(0.996, 0.998, 0.006),
+            array(21, 20, 7),
+            array(24, 24, 8),
+            array(15, 15, 0.5),
+            array(49.8, 50, 0.6),
+            array(50.4, 50.2, 0.6),
+            array(190, 194, 10),
+            array(200, 197, 10),
+            array(0.99, 0.992, 0.06),
+        );
+    }
+
+    /**
+     * @param string $expectedValue
+     * @param string $value
+     * @param string $precision
+     *
+     * @dataProvider roundPointValueData
+     */
+    public function testRoundPointValue($expectedValue, $value, $precision)
+    {
+        $this->assertEquals($expectedValue, NumberUtils::roundPointValue($value, $precision));
+    }
+}

--- a/site/tests/app/libraries/NumbersUtilsTester.php
+++ b/site/tests/app/libraries/NumbersUtilsTester.php
@@ -5,14 +5,13 @@ namespace tests\app\libraries;
 use app\libraries\Core;
 use app\libraries\NumberUtils;
 use app\models\Config;
+use PHPUnit\Framework\TestCase;
 
-class NumbersUtilsTester extends \PHPUnit\Framework\TestCase
-{
+class NumbersUtilsTester extends TestCase {
     /**
      * @return array -containing the test cases as { expectedValue, value, precision}
      */
-    public function roundPointValueData()
-    {
+    public function roundPointValueData() {
         return array(
             array(6, 6, 0.05),
             array(1.002, 1, 0.006),
@@ -35,8 +34,7 @@ class NumbersUtilsTester extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider roundPointValueData
      */
-    public function testRoundPointValue($expectedValue, $value, $precision)
-    {
+    public function testRoundPointValue($expectedValue, $value, $precision) {
         $this->assertEquals($expectedValue, NumberUtils::roundPointValue($value, $precision));
     }
 }

--- a/site/tests/app/libraries/NumbersUtilsTester.php
+++ b/site/tests/app/libraries/NumbersUtilsTester.php
@@ -23,7 +23,8 @@ class NumbersUtilsTester extends TestCase {
             array(50.4, 50.2, 0.6),
             array(190, 194, 10),
             array(200, 197, 10),
-            array(0.99, 0.992, 0.06),
+            array(1.02, 0.992, 0.06),
+            array(98, 100, 7),
         );
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Currently there is a floating point bug inside the points calculation, this behavior can be seen by setting the precision of points as 0.05 and total point value as 6, as soon as we focuses out of the points input it gets converted to  6.05 which shouldn't be the case as 6 can be the point value using 0.05 precision. 

### What is the new behavior?
The bug is removed and it closes #4890. It improves the algorithm such that it should now better handle a number of different precisions and values. Given a small enough precision, may still have some (slight) rounding bugs, but it's not clear if we're going to hit those cases in practical usage.

### Other Information
Currently working on developing test cases to check and verify the intended behavior.