### PR TITLE
[Feature:TAGrading] "Rollback Available" TA grading

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1042,6 +1042,29 @@ class ElectronicGraderController extends AbstractController {
         else {
             $late_status = $ldi->getStatus();
         }
+        $rollbackSubmission = -1;
+        $previousVersion = $display_version-1;
+        // check for rollback submission only if the Active version is greater than 1 and that too is late.
+        if ($previousVersion && $late_status !== LateDayInfo::STATUS_GOOD) {
+            while($previousVersion) {
+                $graded_gradeable->getAutoGradedGradeable()->setActiveVersion($previousVersion);
+                $prevVersionInstance = $graded_gradeable->getAutoGradedGradeable()->getAutoGradedVersionInstance($previousVersion);
+                $lateInfo = LateDays::fromUser($this->core, $late_days_user)->getLateDayInfoByGradeable($gradeable);
+                $newLateInfo =  LateDays::fromUser($this->core, $late_days_user)->getLateDaysRemainingByContext($prevVersionInstance->getSubmissionTime());
+                $mkj =$graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
+                echo 'checking for version'.$previousVersion.$lateInfo->getStatus().'<-late status , new status->'.$newLateInfo.'\n';
+                echo  'Active version is ' . $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
+                if ($lateInfo == null or ($lateInfo->getStatus($newLateInfo) == LateDayInfo::STATUS_GOOD) ) {
+                    echo 'found good one\n';
+                    $rollbackSubmission = $previousVersion;
+                    break;
+                }
+                // check the same thing for previous version.
+                $previousVersion-=1;
+            }
+        }
+        // set the active version back to what it was
+        $graded_gradeable->getAutoGradedGradeable()->setActiveVersion($display_version);
 
         $logger_params = array(
             "course_semester" => $this->core->getConfig()->getSemester(),
@@ -1059,7 +1082,7 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalCss('grade-inquiry.css');
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $sort, $direction, $who_id);
+        $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id);
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupStudents');
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(array('grading', 'ElectronicGrader'), 'popupSettings');

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -105,17 +105,17 @@ class LateDayInfo extends AbstractModel {
 
     /**
      * Gets the late status of the gradeable
-     * @param int $relative_days optional - if passed, calculations will be made with reference to this.
+     * @param int $days_late optional - calculate the late day status based on if the gradeable used $days_late late days
      * @return int One of self::STATUS_NO_ACTIVE_VERSION, self::STATUS_BAD, self::STATUS_LATE, or self::STATUS_GOOD
      */
-    public function getStatus(int $relative_days = null) {
+    public function getStatus(int $days_late = null) {
 
         // No late days info, so NO_SUBMISSION
         if (!$this->hasLateDaysInfo()) {
             return self::STATUS_NO_ACTIVE_VERSION;
         }
 
-        $days = $relative_days !== null ? $relative_days : $this->getDaysLate();
+        $days = $days_late !== null ? $days_late : $this->getDaysLate();
 
         // If the number of days late is more than the number allowed, then its BAD
         if ($days > $this->getLateDaysAllowed()) {

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -105,7 +105,7 @@ class LateDayInfo extends AbstractModel {
 
     /**
      * Gets the late status of the gradeable
-     * @param int $relative_days optional
+     * @param int $relative_days optional - if passed, calculations will be made with reference to this.
      * @return int One of self::STATUS_NO_ACTIVE_VERSION, self::STATUS_BAD, self::STATUS_LATE, or self::STATUS_GOOD
      */
     public function getStatus(int $relative_days = null) {
@@ -115,7 +115,7 @@ class LateDayInfo extends AbstractModel {
             return self::STATUS_NO_ACTIVE_VERSION;
         }
 
-        $days = $relative_days !==null ? $relative_days : $this->getDaysLate();
+        $days = $relative_days !== null ? $relative_days : $this->getDaysLate();
 
         // If the number of days late is more than the number allowed, then its BAD
         if ($days > $this->getLateDaysAllowed()) {

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -105,21 +105,25 @@ class LateDayInfo extends AbstractModel {
 
     /**
      * Gets the late status of the gradeable
+     * @param int $relative_days optional
      * @return int One of self::STATUS_NO_ACTIVE_VERSION, self::STATUS_BAD, self::STATUS_LATE, or self::STATUS_GOOD
      */
-    public function getStatus() {
+    public function getStatus(int $relative_days = null) {
+
         // No late days info, so NO_SUBMISSION
         if (!$this->hasLateDaysInfo()) {
             return self::STATUS_NO_ACTIVE_VERSION;
         }
 
+        $days = $relative_days !==null ? $relative_days : $this->getDaysLate();
+
         // If the number of days late is more than the number allowed, then its BAD
-        if ($this->getDaysLate() > $this->getLateDaysAllowed()) {
+        if ($days > $this->getLateDaysAllowed()) {
             return self::STATUS_BAD;
         }
 
         // if the student submitted after the deadline (plus extensions) then its late
-        if ($this->getDaysLate() > $this->getLateDayException()) {
+        if ($days > $this->getLateDayException()) {
             return self::STATUS_LATE;
         }
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -709,7 +709,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $sort, $direction, $from) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $rollbackSubmission, $sort, $direction, $from) {
         $peer = false;
         // WIP: Replace this logic when there is a definitive way to get my peer-ness
         // If this is a peer gradeable but I am not allowed to view the peer panel, then I must be a peer.
@@ -765,6 +765,12 @@ HTML;
                 ]);
             }
         }
+        elseif ($rollbackSubmission != -1) {
+            $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
+                "color" => "var(--standard-creamsicle-orange)", // fire engine red
+                "message" => "Late Submission (Rollback to on-time submission" . $rollbackSubmission . ")"
+            ]);
+        }
         else {
             if ($late_status != LateDayInfo::STATUS_GOOD && $late_status != LateDayInfo::STATUS_LATE) {
                 $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
@@ -773,7 +779,6 @@ HTML;
                 ]);
             }
         }
-
         return $return;
     }
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -768,17 +768,16 @@ HTML;
         elseif ($rollbackSubmission != -1) {
             $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
                 "color" => "var(--standard-creamsicle-orange)", // fire engine red
-                "message" => "Late Submission (Rollback to on-time submission" . $rollbackSubmission . ")"
+                "message" => "Late Submission (Rollback to on-time submission - " . $rollbackSubmission . ")"
             ]);
         }
-        else {
-            if ($late_status != LateDayInfo::STATUS_GOOD && $late_status != LateDayInfo::STATUS_LATE) {
-                $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
-                    "color" => "var(--standard-red-orange)", // fire engine red
-                    "message" => "Late Submission"
-                ]);
-            }
+        elseif ($late_status != LateDayInfo::STATUS_GOOD && $late_status != LateDayInfo::STATUS_LATE) {
+            $return .= $this->core->getOutput()->renderTwigTemplate("grading/electronic/ErrorMessage.twig", [
+                "color" => "var(--standard-red-orange)", // fire engine red
+                "message" => "Late Submission (No on time submission available)"
+            ]);
         }
+
         return $return;
     }
 

--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -41,7 +41,7 @@
     position:relative;
     display: block;
     float: left;
-    width: 290px;
+    width: 400px;
     height: 25px;
     top: 2px;
     left: 120px;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Currently, if a student submits multiple times (i.e multiple versions) then by default the most recent version is set to be graded (student can, however, decides this and selects which version is to be graded by the grader). But Sometimes the student uploads the assignment in a late period even when s/he already has a good submission, this may lead to evaluation as zero. 

### What is the new behavior?
Closes #4891 
Provides a visual clue to the instructor that the student has one of their assignment submitted on time, if s/he has more than one good submissions then submitty suggests the most recent good submission to `rollback`. This helps to avoid any accidental misevaluation as the instructor can `"roll-back"` to that suggested version for grading.
### Other information?
Rollback is Available
![Screenshot 2020-02-21 at 1 56 53 PM](https://user-images.githubusercontent.com/48342617/75040231-3480f580-54b2-11ea-8093-a9e7cd49c61d.png)

No Good Submission Found.
![Screenshot 2020-02-21 at 1 57 31 PM](https://user-images.githubusercontent.com/48342617/75040307-55e1e180-54b2-11ea-8f66-87ae67003c91.png)
