### PR TITLE
Logging in after attempting to view page with query string does not work

### DIFF
--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -211,9 +211,17 @@ class WebRouter {
     private function loginRedirectCheck($logged_in) {
         if (!$logged_in && !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')) {
             $old_request_url = $this->request->getUriForPath($this->request->getPathInfo());
+
+            $query_obj = $this->request->query->all();
+            $filtered_query_obj = array_filter($query_obj, function ($k) {
+                return $k !== "url";
+            }, ARRAY_FILTER_USE_KEY);
+
+            $query_string = empty($filtered_query_obj) ? null : '?' . http_build_query($filtered_query_obj);
+
             return Response::RedirectOnlyResponse(
                 new RedirectResponse(
-                    $this->core->buildUrl(['authentication', 'login']) . '?old=' . urlencode($old_request_url)
+                    $this->core->buildUrl(['authentication', 'login']) . '?old=' . urlencode($old_request_url . $query_string)
                 )
             );
         }

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -41,7 +41,7 @@ class WebRouterTester extends BaseUnitTest {
         );
         $response = WebRouter::getWebResponse($request, $core);
         $this->assertEquals(
-            $core->buildUrl(['authentication', 'login']) . '?old=' . urlencode($request->getUriForPath($request->getPathInfo())),
+            $core->buildUrl(['authentication', 'login']) . '?old=' . urlencode($request->getUriForPath('/s19/sample')),
             $response->redirect_response->url
         );
     }
@@ -74,8 +74,9 @@ class WebRouterTester extends BaseUnitTest {
             ['_controller' => 'app\controllers\OtherController', '_method' => 'otherMethod']
         );
         $response = WebRouter::getWebResponse($request, $core);
+        /* `\' is represented as '%5C' which in turn itself is represented as '%255C' (coz, % encodes to %25) */
         $this->assertEquals(
-            $core->buildUrl(['authentication', 'login']) . '?old=' . urlencode($request->getUriForPath($request->getPathInfo())),
+            $core->buildUrl(['authentication', 'login']) . '?old=' . urlencode($request->getUriForPath('/s19/sample') . '?_controller=app%5Ccontrollers%5COtherController&_method=otherMethod'),
             $response->redirect_response->url
         );
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
Currently, if we get logged-out on a page with some query parameters we are asked to log in (`intended`) and then after successfully logging-in you will get redirected to the page but without query parameters. So query-parameter is not working within log-out events.

### What is the new behavior?
Closes #4556 
Now, If you get logged-out at any page which is having query-params, you will be redirected to the same old URL you are were initially at with correct params.

