### PR TITLE
Display message to student if one_part_only is True in gradeable config

### DIFF
--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -27,6 +27,7 @@ use app\models\AbstractModel;
  * @method int getTotalNonHiddenExtraCredit()
  * @method int getTotalHiddenNonExtraCredit()
  * @method int getTotalHiddenExtraCredit()
+ * @method bool getOnePartyOnly()
  */
 class AutogradingConfig extends AbstractModel {
 

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -47,7 +47,7 @@ class AutogradingConfig extends AbstractModel {
 
     /** @property @var string[] The names of different upload bins on the submission page (1-indexed) */
     protected $part_names = [];
-    /** @property @var bool Variable representing if only one of the available parts can be used for submission */
+    /** @prop @var bool Variable representing if only one of the available parts can be used for submission */
     protected $one_part_only;
 
     /** @property @var array Array of notebook objects */

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -47,6 +47,8 @@ class AutogradingConfig extends AbstractModel {
 
     /** @property @var string[] The names of different upload bins on the submission page (1-indexed) */
     protected $part_names = [];
+    /** @property @var bool Variable representing if only one of the available parts can be used for submission */
+    protected $one_part_only;
 
     /** @property @var array Array of notebook objects */
     private $notebook = [];
@@ -163,7 +165,7 @@ class AutogradingConfig extends AbstractModel {
                     unset($notebook_cell['markdown_string']);
                     unset($notebook_cell['markdown_file']);
 
-                    // Readd as data
+                    // Read as data
                     $notebook_cell['markdown_data'] = $markdown;
 
                     // If next entry is an input type, we assign this as a label - otherwise it is plain markdown
@@ -211,8 +213,9 @@ class AutogradingConfig extends AbstractModel {
             }
         }
 
-        // defaults to 1 if no set
+        // defaults num of parts to 1 if value is not set
         $num_parts = count($details['part_names'] ?? [1]);
+        $this->one_part_only = $details['one_part_only'] ?? false;
 
         // Get all of the part names
         for ($i = 1; $i <= $num_parts; $i++) {
@@ -290,6 +293,14 @@ class AutogradingConfig extends AbstractModel {
      */
     public function getNumParts() {
         return count($this->getPartNames());
+    }
+
+    /**
+     * Gets the value of one_part_only
+     * @return boolean
+     */
+    public function getOnePartOnly() {
+        return $this->one_part_only;
     }
 
     /**

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -297,14 +297,6 @@ class AutogradingConfig extends AbstractModel {
     }
 
     /**
-     * Gets the value of one_part_only
-     * @return boolean
-     */
-    public function getOnePartOnly() {
-        return $this->one_part_only;
-    }
-
-    /**
      * Gets the number of inputs on the submission page
      * @return int
      */

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -22,7 +22,9 @@
     </header>
 
     {% if part_names|length > 1 and one_part_only %}
-        <h4 style="color: red;">Only first non empty part will be graded!</h4>
+        <h4 style="color: red;">
+            Please drag and drop your files into only one area below. Files submitted to additional areas will not be graded.
+        </h4>
     {% endif %}
 
     {% if show_no_late_submission_warning %}

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -21,6 +21,10 @@
         </div>
     </header>
 
+    {% if part_names|length > 1 and one_part_only %}
+        <h4 style="color: red;">Only first non empty part will be graded!</h4>
+    {% endif %}
+
     {% if show_no_late_submission_warning %}
         <i class="red-message">Warning, you are making a late submission for a gradeable without late submissions enabled!</i>
     {% endif %}
@@ -423,7 +427,7 @@
                 >
                     <h2 class="label" id="label{{ loop.index }}">
                         {% if part_names|length > 1 %}
-                            Drag your {{ part }} here or click to open file browser
+                            Drag your {{ part }} file(s) here or click to open file browser
                         {% else %}
                             Drag your file(s) here or click to open file browser
                         {% endif %}

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -384,6 +384,7 @@ class HomeworkView extends AbstractView {
             'gradeable_name' => $gradeable->getTitle(),
             'formatted_due_date' => $gradeable->getSubmissionDueDate()->format($DATE_FORMAT),
             'part_names' => $gradeable->getAutogradingConfig()->getPartNames(),
+            'one_part_only' => $gradeable->getAutogradingConfig()->getOnePartOnly(),
             'is_vcs' => $gradeable->isVcs(),
             'vcs_subdirectory' => $gradeable->getVcsSubdirectory(),
             'vcs_host_type' => $gradeable->getVcsHostType(),

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1638,6 +1638,11 @@ parameters:
 			path: app/models/gradeable/AutogradingConfig.php
 
 		-
+		    message: "#^PHPDoc tag @property has invalid value \\(@var bool Variable representing if only one of the available parts can be used for submission\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+		    count: 1
+		    path: app/models/gradeable/AutogradingConfig.php
+
+		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var array Array of notebook objects\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
 			count: 1
 			path: app/models/gradeable/AutogradingConfig.php

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1638,9 +1638,9 @@ parameters:
 			path: app/models/gradeable/AutogradingConfig.php
 
 		-
-		    message: "#^PHPDoc tag @property has invalid value \\(@var bool Variable representing if only one of the available parts can be used for submission\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
-		    count: 1
-		    path: app/models/gradeable/AutogradingConfig.php
+			message: "#^PHPDoc tag @property has invalid value \\(@var bool Variable representing if only one of the available parts can be used for submission\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
 
 		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var array Array of notebook objects\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1626,11 +1626,6 @@ parameters:
 			path: app/models/gradeable/AutogradingConfig.php
 
 		-
-			message: "#^PHPDoc tag @property has invalid value \\(@var bool Variable representing if only one of the available parts can be used for submission\\)\\: Unexpected token \"@var\", expected type at offset 14$#"
-			count: 1
-			path: app/models/gradeable/AutogradingConfig.php
-
-		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var array Array of notebook objects\\)\\: Unexpected token \"@var\", expected type at offset 14$#"
 			count: 1
 			path: app/models/gradeable/AutogradingConfig.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behaviour?
When a user tries to submit an assignment with more than one part there is no indication given to the user that whether this gradeable allows only one part for the submisison. This creates confusion for the user as submissions made to buckets other than the first non-empty part are ignored & evaluated as 0.

### What is the new behaviour?
Closes #2726 
Now, a message is being displayed to the user while submitting an assignment,  based on the condition on value of `one_part_only` boolean value and the number of parts of the submission. 
![one_part_only](https://user-images.githubusercontent.com/48342617/71915938-d23e9080-31a2-11ea-8f94-cfa71edab65b.jpg)

