### PR TITLE
[Bugfix:InstructorUI] Fix server error response on saving unwritable config file

### DIFF
--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -200,14 +200,19 @@ class ConfigurationController extends AbstractController {
             }
         }
 
-        $config_ini = $this->core->getConfig()->getCourseJson();
-        if (!isset($config_ini['course_details'][$name])) {
+        $config_json = $this->core->getConfig()->getCourseJson();
+        if (!isset($config_json['course_details'][$name])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Not a valid config name')
             );
         }
-        $config_ini['course_details'][$name] = $entry;
-        $this->core->getConfig()->saveCourseJson(['course_details' => $config_ini['course_details']]);
+        $config_json['course_details'][$name] = $entry;
+
+        if (!$this->core->getConfig()->saveCourseJson(['course_details' => $config_json['course_details']])) {
+            return Response::JsonOnlyResponse(
+                JsonResponse::getFailResponse('Could not save config file')
+            );
+        }
 
         return Response::JsonOnlyResponse(
             JsonResponse::getSuccessResponse(null)

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -277,9 +277,29 @@ class FileUtils {
         return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
-    public static function writeJsonFile($filename, $data) {
+    /**
+     * Given some data, encode it as pretty printed JSON and write it to a file.
+     *
+     * @param string $filename filename to write data to
+     * @param mixed  $data JSON data to write to the file
+     * @return bool
+     */
+    public static function writeJsonFile(string $filename, $data): bool {
         $data = FileUtils::encodeJson($data);
         if ($data === false) {
+            return false;
+        }
+        return static::writeFile($filename, $data);
+    }
+
+    /**
+     * Given some data, write it to a file.
+     * @param string $filename
+     * @param mixed  $data
+     * @return bool
+     */
+    public static function writeFile(string $filename, $data): bool {
+        if (file_exists($filename) && !is_writable($filename)) {
             return false;
         }
         return file_put_contents($filename, $data) !== false;

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -85,8 +85,8 @@ class Config extends AbstractModel {
     /** @property @var string path to the json file that contains all the course specific settings */
     protected $course_json_path;
 
-    /** @property @var array */
-    protected $course_json;
+    /** @prop @var array */
+    protected $course_json = array();
 
     /**
     * Indicates whether a course config has been successfully loaded.
@@ -502,8 +502,8 @@ class Config extends AbstractModel {
         return $this->submitty_log_path;
     }
 
-    public function saveCourseJson($save) {
-        FileUtils::writeJsonFile($this->course_json_path, array_merge($this->course_json, $save));
+    public function saveCourseJson($save): bool {
+        return FileUtils::writeJsonFile($this->course_json_path, array_merge($this->course_json, $save));
     }
 
     public function wrapperEnabled() {

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -769,7 +769,7 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @property has invalid value \\(@var array\\)\\: Unexpected token \"@var\", expected TOKEN_IDENTIFIER at offset 14$#"
-			count: 5
+			count: 4
 			path: app/models/Config.php
 
 		-
@@ -2381,5 +2381,3 @@ parameters:
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$can_inquirye$#"
 			count: 1
 			path: app/views/submission/HomeworkView.php
-
-

--- a/site/tests/app/controllers/admin/ConfigurationControllerTester.php
+++ b/site/tests/app/controllers/admin/ConfigurationControllerTester.php
@@ -333,4 +333,51 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
         ];
         $this->assertEquals($expected, $response->json_response->json);
     }
+
+    public function testUpdateConfigFile() {
+        $this->setUpConfig();
+        $core = new Core();
+        $config = new Config($core);
+        $config->loadMasterConfigs($this->master_configs_dir);
+        $config->loadCourseJson('f19', 'sample', $this->course_config);
+        $core->setConfig($config);
+        $_POST['name'] = 'default_hw_late_days';
+        $_POST['entry'] = '2';
+        $controller = new ConfigurationController($core);
+        $response = $controller->updateConfiguration();
+        $this->assertNull($response->web_response);
+        $this->assertNull($response->redirect_response);
+        $expected = [
+            'status' => 'success',
+            'data' => null
+        ];
+        $this->assertEquals($expected, $response->json_response->json);
+    }
+
+    public function testUpdateConfigNonWriteable() {
+        $this->setUpConfig();
+        $core = new Core();
+        $config = new Config($core);
+        $config->loadMasterConfigs($this->master_configs_dir);
+        $config->loadCourseJson('f19', 'sample', $this->course_config);
+        chmod($this->course_config, 0400);
+        try {
+            $core->setConfig($config);
+            $_POST['name'] = 'default_hw_late_days';
+            $_POST['entry'] = '2';
+            $controller = new ConfigurationController($core);
+            $response = $controller->updateConfiguration();
+            $this->assertNull($response->web_response);
+            $this->assertNull($response->redirect_response);
+            $expected = [
+                'status' => 'fail',
+                'message' => 'Could not save config file'
+            ];
+            $this->assertEquals($expected, $response->json_response->json);
+        }
+        finally {
+            chmod($this->course_config, 0600);
+        }
+
+    }
 }

--- a/site/tests/app/controllers/admin/ConfigurationControllerTester.php
+++ b/site/tests/app/controllers/admin/ConfigurationControllerTester.php
@@ -378,6 +378,5 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
         finally {
             chmod($this->course_config, 0600);
         }
-
     }
 }

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -269,16 +269,14 @@ STRING;
 
     public function testWriteFile() {
         FileUtils::createDir($this->path);
-        $permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
-        $file = FileUtils::joinPaths($this->path, substr(str_shuffle($permitted_chars), 0, 10));
+        $file = FileUtils::joinPaths($this->path, 'test_file');
         $this->assertTrue(FileUtils::writeFile($file, "test"));
         $this->assertStringEqualsFile($file, "test");
     }
 
     public function testWriteFileNonWritableFile() {
         FileUtils::createDir($this->path);
-        $permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
-        $file = FileUtils::joinPaths($this->path, substr(str_shuffle($permitted_chars), 0, 10));
+        $file = FileUtils::joinPaths($this->path, 'test_file');
         touch($file);
         try {
             chmod($file, 0400);

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -249,14 +249,44 @@ STRING;
         $this->assertStringEqualsFile(FileUtils::joinPaths($this->path, 'test.json'), '"aa"');
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testWriteJsonFileFailEncode() {
-        $this->getFunctionMock("app\\libraries", "json_encode")
-            ->expects($this->once())
-            ->willReturn(false);
-        $this->assertFalse(FileUtils::writeJsonFile(FileUtils::joinPaths($this->path, 'test.json'), 'aa'));
+        $data = ['a' => 1, 'b' => tmpfile()];
+        $this->assertFalse(FileUtils::writeJsonFile(FileUtils::joinPaths($this->path, 'test.json'), $data));
+    }
+
+    public function testWriteJsonFileNonWritable() {
+        FileUtils::createDir($this->path);
+        $file = FileUtils::joinPaths($this->path, 'test.json');
+        touch($file);
+        try {
+            chmod($file, 0400);
+            $this->assertFalse(FileUtils::writeJsonFile($file, 'aa'));
+        }
+        finally {
+            chmod($file, 0660);
+        }
+    }
+
+    public function testWriteFile() {
+        FileUtils::createDir($this->path);
+        $permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+        $file = FileUtils::joinPaths($this->path, substr(str_shuffle($permitted_chars), 0, 10));
+        $this->assertTrue(FileUtils::writeFile($file, "test"));
+        $this->assertStringEqualsFile($file, "test");
+    }
+
+    public function testWriteFileNonWritableFile() {
+        FileUtils::createDir($this->path);
+        $permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+        $file = FileUtils::joinPaths($this->path, substr(str_shuffle($permitted_chars), 0, 10));
+        touch($file);
+        try {
+            chmod($file, 0400);
+            $this->assertFalse(FileUtils::writeFile($file, "test"));
+        }
+        finally {
+            chmod($file, 0660);
+        }
     }
 
     public function testGetZipSize() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If the config.json file is unwritable for whatever reason, the system will fail to write, but show the instructor a message that reads "Server error", with a JSON object indicating things were successful.

### What is the new behavior?
Now returns a JSON object properly indicating that there was an error writing the config to file.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Added unit tests for both the underlying utility functions and the controller itself. Also manually tested on the web page.