### PR TITLE
[Bugfix:InstructorUI] Fix using invalid variable when uploading CSV with passwords

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -893,7 +893,7 @@ class UsersController extends AbstractController {
                 case $row4_validation_function():
                     // Database password cannot be blank, no check on format.
                     // Automatically validate if NOT using database authentication (e.g. using PAM authentication).
-                case !$use_database || User::validateUserData('user_password', $row[5]):
+                case !$use_database || User::validateUserData('user_password', $vals[5]):
                     // Preferred first and last name must be alpha characters, white-space, or certain punctuation.
                     // Automatically validate if not set (this field is optional).
                 case !isset($vals[$pref_firstname_idx]) || User::validateUserData('user_preferred_firstname', $vals[$pref_firstname_idx]):


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If uploading a CSV while using database for passwords, an error would be thrown due to referencing an undefined variable.

### What is the new behavior?
Corrects the code to use the right variable for referencing the values in a given row of the CSV for password.
