### PR TITLE
[Bugfix:Install] Switched http to https for maven.org

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -341,12 +341,12 @@ chmod -R 751 ${SUBMITTY_INSTALL_DIR}/java_tools
 
 pushd ${SUBMITTY_INSTALL_DIR}/java_tools/JUnit > /dev/null
 rm -rf junit*jar
-wget http://repo1.maven.org/maven2/junit/junit/${JUNIT_VERSION}/junit-${JUNIT_VERSION}.jar -o /dev/null > /dev/null 2>&1
+wget https://repo1.maven.org/maven2/junit/junit/${JUNIT_VERSION}/junit-${JUNIT_VERSION}.jar -o /dev/null > /dev/null 2>&1
 popd > /dev/null
 
 pushd ${SUBMITTY_INSTALL_DIR}/java_tools/hamcrest > /dev/null
 rm -rf hamcrest*.jar
-wget http://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/${HAMCREST_VERSION}/hamcrest-core-${HAMCREST_VERSION}.jar -o /dev/null > /dev/null 2>&1
+wget https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/${HAMCREST_VERSION}/hamcrest-core-${HAMCREST_VERSION}.jar -o /dev/null > /dev/null 2>&1
 popd > /dev/null
 
 # TODO:  Want to Install JUnit 5.0


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When running vagrant up for a fresh install it fails because 2 lines need to be https not http

You can see the problem if you run vagrant up or to see the problem more quickly run
`wget http://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar` and take a look at the output

The first time I run it with http and it fails, the second time I run the same command with https and it works
![image](https://user-images.githubusercontent.com/18558130/72552849-b8b5dc80-3865-11ea-8043-c1dbe3747e33.png)


### What is the new behavior?

Vagrant up now works and does not crash

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I tested this by running vagrant up and after my change it worked for me.