### PR TITLE
[Feature:Submission] assignment url on gradeable submission page

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -250,7 +250,7 @@
         return "";
     }
     window.onload = function () {
-        //determine if folders have been left open or close
+        //determine if folders have been left open or closed
         var folderCookie = getCookie('foldersOpen');
         //if the cookie says it is open
         if(folderCookie == "open"){

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -250,7 +250,7 @@
         return "";
     }
     window.onload = function () {
-        //determine if folders have been left open or closed
+        //determine if folders have been left open or close
         var folderCookie = getCookie('foldersOpen');
         //if the cookie says it is open
         if(folderCookie == "open"){

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -5,9 +5,13 @@
         {{ gradeable.getTitle() }}
     </h1>
     <p>
-        {% if gradeable.getTaInstructions() != "" %}
-            Overall TA Instructions: {{ gradeable.getTaInstructions() }}
-        {% endif %}
+        Overall TA Instructions:
+        {% for url in instruction_urls if url|trim !="" %}
+            <br>
+            <a class="external" href="{{ url }}" target="_blank" aria-label="Instructions for {{ gradeable_name }}">
+                <i>{{ url }}</i>
+            </a>
+        {% endfor %}
     </p>
 
     <div class="column-wrapper" style="margin: 1em 0;">

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -3,15 +3,16 @@
 <div class="content">
     <h1>
         {{ gradeable.getTitle() }}
+        {% if gradeable_url|trim != "" %}
+            <a class="external" href="{{ gradeable_url }}" target="_blank" aria-label="Go to instructions for {{ gradeable_name }}">
+                <i class="fas fa-external-link-alt"></i>
+            </a>
+        {% endif %}
     </h1>
     <p>
-        Overall TA Instructions:
-        {% for url in instruction_urls if url|trim !="" %}
-            <br>
-            <a class="external" href="{{ url }}" target="_blank" aria-label="Instructions for {{ gradeable_name }}">
-                <i>{{ url }}</i>
-            </a>
-        {% endfor %}
+        {% if gradeable.getTaInstructions()|trim != "" %}
+            Overall TA Instructions: <a class="external" href="{{  gradeable.getTaInstructions() }}" target="_blank" aria-label="Overall TA Instructions for {{ gradeable.getTitle() }}"><i>{{  gradeable.getTaInstructions()  }}</i></a>
+        {% endif %}
     </p>
 
     <div class="column-wrapper" style="margin: 1em 0;">

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -13,7 +13,7 @@
     <header id="gradeable-info">
         <h1>
             New submission for: {{ gradeable_name }}
-            {% if gradeable_url %}
+            {% if gradeable_url|trim !== "" %}
                 <a class="external" href="{{ gradeable_url }}" target="_blank" aria-label="Go to instructions for {{ gradeable_name }}">
                     <i class="fas fa-external-link-alt"></i>
                 </a>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -11,7 +11,14 @@
 
 <div class="content">
     <header id="gradeable-info">
-        <h1>New submission for: {{ gradeable_name }}</h1>
+        <h1>
+            New submission for: {{ gradeable_name }}
+            {% if gradeable_url %}
+                <a class="external" href="{{ gradeable_url }}" target="_blank" aria-label="Go to instructions for {{ gradeable_name }}">
+                    <i class="fas fa-external-link-alt"></i>
+                </a>
+            {% endif %}
+        </h1>
         {% if has_due_date %}
             <h2>Due: {{ formatted_due_date }}</h2>
         {% endif %}

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -13,7 +13,7 @@
     <header id="gradeable-info">
         <h1>
             New submission for: {{ gradeable_name }}
-            {% if gradeable_url|trim !== "" %}
+            {% if gradeable_url|trim != "" %}
                 <a class="external" href="{{ gradeable_url }}" target="_blank" aria-label="Go to instructions for {{ gradeable_name }}">
                     <i class="fas fa-external-link-alt"></i>
                 </a>

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -93,7 +93,7 @@ class SimpleGraderView extends AbstractView {
             "component_ids" => $component_ids,
             "print_lab_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'print']),
             "grading_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading']),
-            "instruction_urls" => [$gradeable->getInstructionsUrl(), $gradeable->getTaInstructions()]
+            "gradeable_url" => $gradeable->getInstructionsUrl()
         ]);
 
         $return .= $this->core->getOutput()->renderTwigTemplate("grading/simple/StatisticsForm.twig", [

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -92,7 +92,8 @@ class SimpleGraderView extends AbstractView {
             "sections" => $sections,
             "component_ids" => $component_ids,
             "print_lab_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'print']),
-            "grading_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading'])
+            "grading_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading']),
+            "instruction_urls" => [$gradeable->getInstructionsUrl(), $gradeable->getTaInstructions()]
         ]);
 
         $return .= $this->core->getOutput()->renderTwigTemplate("grading/simple/StatisticsForm.twig", [

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -382,6 +382,7 @@ class HomeworkView extends AbstractView {
             'base_url' => $this->core->getConfig()->getBaseUrl(),
             'gradeable_id' => $gradeable->getId(),
             'gradeable_name' => $gradeable->getTitle(),
+            'gradeable_url' => $gradeable->getInstructionsUrl(),
             'formatted_due_date' => $gradeable->getSubmissionDueDate()->format($DATE_FORMAT),
             'part_names' => $gradeable->getAutogradingConfig()->getPartNames(),
             'one_part_only' => $gradeable->getAutogradingConfig()->getOnePartOnly(),


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
If a Gradeable assignment has instruction URL set then there is a link shown in the list of gradeable, but there is no such link given to the student on the submission page, which should be present.

### What is the new behavior?
A link has been added to the submission page to assist the students with the instructions for the specific gradeable.
Closes #4926 