### PR TITLE
[Bugfix:RainbowGrades] add group write perm to rainbowgrades dir

### DIFF
--- a/migration/migrator/migrations/course/20200118230033_rainbow_grades_permissions.py
+++ b/migration/migrator/migrations/course/20200118230033_rainbow_grades_permissions.py
@@ -1,0 +1,29 @@
+"""Migration for a given Submitty course database."""
+import os
+from pathlib import Path
+
+
+def up(config, database, semester, course):
+
+    course_dir = Path(config.submitty['submitty_data_dir'], 'courses', semester, course)
+
+    course_rainbow_grades_dir = Path(course_dir, 'rainbow_grades')
+
+    # add group write permission, missing from new courses
+    os.system("chmod -R g+rwxs "+str(course_rainbow_grades_dir))
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass

--- a/sbin/create_course.sh
+++ b/sbin/create_course.sh
@@ -225,6 +225,7 @@ create_and_set  u=rwx,g=rwxs,o=   $instructor  $ta_www_group   $course_dir/custo
 #               drwxr-s---       $PHP_USER        ta_www_group    uploads/student_images/
 #               drwxr-s---       $PHP_USER        ta_www_group    uploads/student_images/tmp
 #               drwxrws---       $PHP_USER        ta_www_group    uploads/seating
+#               drwxrws---       $PHP_USER        ta_www_group    rainbow_grades
 #               drwxrws---       $DAEMON_USER     ta_www_group    lichen/
 #               drwxrws---       $PHP_USER        ta_www_group    lichen/config
 #               drwxrws---       $PHP_USER        ta_www_group    lichen/provided_code
@@ -244,7 +245,7 @@ create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/up
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads/course_materials
 create_and_set  u=rwx,g=rwxs,o=  $DAEMON_USER     $ta_www_group   $course_dir/uploads/split_pdf
 create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/uploads/seating
-create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/rainbow_grades
+create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/rainbow_grades
 create_and_set  u=rwx,g=rwxs,o=  $DAEMON_USER     $ta_www_group   $course_dir/lichen
 create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/lichen/config
 create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/lichen/provided_code


### PR DESCRIPTION
Add group write permissions to rainbowgrades directory
to allow the use of the RainbowGrades web UI.