### PR TITLE
[Bugfix:TAGrading] default full credit mark message grade by count down

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2535,6 +2535,7 @@ function scrollToComponent(component_id) {
 function closeComponentInstructorEdit(component_id, saveChanges) {
     let sequence = Promise.resolve();
     let component = getComponentFromDOM(component_id);
+    let countUp = getCountDirection(component_id) !== COUNT_DIRECTION_DOWN;
     if (saveChanges) {
         sequence = sequence
             .then(function () {
@@ -2549,10 +2550,10 @@ function closeComponentInstructorEdit(component_id, saveChanges) {
                     component.marks[0].title = mark_title;
                     $('#mark-'+component.marks[0].id.toString()).find(':input')[1].value = "No Extra Credit Awarded";
                 }
-                else{
-                    let mark_title = "No Credit Awarded";
+                else if (countUp) {
+                    let mark_title = "No Credit";
                     component.marks[0].title = mark_title;
-                    $('#mark-'+component.marks[0].id.toString()).find(':input')[1].value = "No Credit Awarded";
+                    $('#mark-'+component.marks[0].id.toString()).find(':input')[1].value = "No Credit";
 
                 }
                 return saveMarkList(component_id);

--- a/site/public/templates/grading/EditComponent.twig
+++ b/site/public/templates/grading/EditComponent.twig
@@ -89,7 +89,7 @@
                        onchange="onComponentPointsChange(this)"
                        onmouseup="onComponentPointsChange(this)"/>
             </div>
-            <div class="col"><i>Student scores will be clamped from below to min(0,Negative Penalty Points)</i></div>
+            <div class="col"><i>Student scores will be clamped from below to min(0,-Negative Penalty Points)</i></div>
         </div>
 
         {# Count up / down #}


### PR DESCRIPTION
Bug introduced in PR #4504 
When a regular, non zero points component is grade by count down, the default mark 0 message should be "Full Credit".