### PR TITLE
[Bugfix: Discussion Forum] Removes sorting options for forum with no threads

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -258,6 +258,7 @@ class ForumThreadView extends AbstractView {
         if (!$threadExists) {
             $button_params["show_threads"] = false;
             $button_params["thread_exists"] = false;
+            $button_params["show_more"] = false;
         }
         else {
             $more_data = array(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Addresses #4924
For forums with no threads, the more button displays sorting options that are not displayed properly and would serve no function.

### What is the new behavior?
If a forum for a class has no threads, the more button is removed.
If the last thread in a forum is "deleted" then the more button is considered removed

### Other information?
Tested on blank course with forum enabled and observed forum bar.
Then created a thread and deleted it and observed forum bar.

One edge case that remains unaddressed is if an instructor deletes all the threads in a course but wishes to see the deleted threads. In order to do so, an instructor would need to create a new dummy thread and then select the show deleted threads option in More.

@xprilion I was looking through the CSS for in the file [forum.css](https://github.com/Submitty/Submitty/blob/master/site/public/css/forum.css) and was wondering why for the class `.forum_show_threads`  the option `overflow:hidden` is set. Is there anything that would break if we were to set `overflow:visible`? If we do so we can address both #4924 and the case when an instructor deletes all threads.