### PR TITLE
[Feature:InstructorUI] student photo common location improvements

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -208,12 +208,14 @@ class GlobalController extends AbstractController {
                 $common_images_path_1 = Fileutils::joinPaths("/var/local/submitty/student_images");
                 $term = explode('/', $this->core->getConfig()->getCoursePath());
                 $term = $term[count($term) - 2];
-                $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images",$term);
+                $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images", $term);
                 // FIXME: consider searching through the common location for matches to my students
                 // (but this would be expensive)
-                $any_images_files = array_merge ( FileUtils::getAllFiles($images_path, array(), true),
-                                                  FileUtils::getAllFiles($common_images_path_1, array(), true),
-                                                  FileUtils::getAllFiles($common_images_path_2, array(), true) );
+                $any_images_files = array_merge(
+                    FileUtils::getAllFiles($images_path, array(), true),
+                    FileUtils::getAllFiles($common_images_path_1, array(), true),
+                    FileUtils::getAllFiles($common_images_path_2, array(), true)
+                );
                 if ($this->core->getUser()->accessAdmin() && count($any_images_files) === 0) {
                     $at_least_one_grader_link = true;
                     $sidebar_buttons[] = new Button($this->core, [

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -203,8 +203,17 @@ class GlobalController extends AbstractController {
 
             if ($this->core->getUser()->accessGrading()) {
                 $images_course_path = $this->core->getConfig()->getCoursePath();
+                // FIXME: this code is duplicated in ImagesController.php
                 $images_path = Fileutils::joinPaths($images_course_path, "uploads/student_images");
-                $any_images_files = FileUtils::getAllFiles($images_path, array(), true);
+                $common_images_path_1 = Fileutils::joinPaths("/var/local/submitty/student_images");
+                $term = explode('/', $this->core->getConfig()->getCoursePath());
+                $term = $term[count($term) - 2];
+                $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images",$term);
+                // FIXME: consider searching through the common location for matches to my students
+                // (but this would be expensive)
+                $any_images_files = array_merge ( FileUtils::getAllFiles($images_path, array(), true),
+                                                  FileUtils::getAllFiles($common_images_path_1, array(), true),
+                                                  FileUtils::getAllFiles($common_images_path_2, array(), true) );
                 if ($this->core->getUser()->accessAdmin() && count($any_images_files) === 0) {
                     $at_least_one_grader_link = true;
                     $sidebar_buttons[] = new Button($this->core, [

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -15,8 +15,17 @@ class ImagesController extends AbstractController {
     public function viewImagesPage() {
         $user_group = $this->core->getUser()->getGroup();
         $images_course_path = $this->core->getConfig()->getCoursePath();
+        // FIXME: this code is duplicated in GlobalController.php
         $images_path = Fileutils::joinPaths($images_course_path, "uploads/student_images");
-        $any_images_files = FileUtils::getAllFiles($images_path, array(), true);
+        $common_images_path_1 = Fileutils::joinPaths("/var/local/submitty/student_images");
+        $term = explode('/', $this->core->getConfig()->getCoursePath());
+        $term = $term[count($term) - 2];
+        $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images",$term);
+        // FIXME: consider searching through the common location for matches to my students
+        // (but this would be expensive)
+        $any_images_files = array_merge ( FileUtils::getAllFiles($images_path, array(), true),
+                                          FileUtils::getAllFiles($common_images_path_1, array(), true),
+                                          FileUtils::getAllFiles($common_images_path_2, array(), true) );
         if ($user_group === USER::GROUP_STUDENT || (($user_group === USER::GROUP_FULL_ACCESS_GRADER || $user_group === USER::GROUP_LIMITED_ACCESS_GRADER) && count($any_images_files) === 0)) { // student has no permissions to view image page
             $this->core->addErrorMessage("You have no permissions to see images.");
             $this->core->redirect($this->core->buildCourseUrl());

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -20,12 +20,14 @@ class ImagesController extends AbstractController {
         $common_images_path_1 = Fileutils::joinPaths("/var/local/submitty/student_images");
         $term = explode('/', $this->core->getConfig()->getCoursePath());
         $term = $term[count($term) - 2];
-        $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images",$term);
+        $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images", $term);
         // FIXME: consider searching through the common location for matches to my students
         // (but this would be expensive)
-        $any_images_files = array_merge ( FileUtils::getAllFiles($images_path, array(), true),
-                                          FileUtils::getAllFiles($common_images_path_1, array(), true),
-                                          FileUtils::getAllFiles($common_images_path_2, array(), true) );
+        $any_images_files = array_merge(
+            FileUtils::getAllFiles($images_path, array(), true),
+            FileUtils::getAllFiles($common_images_path_1, array(), true),
+            FileUtils::getAllFiles($common_images_path_2, array(), true)
+        );
         if ($user_group === USER::GROUP_STUDENT || (($user_group === USER::GROUP_FULL_ACCESS_GRADER || $user_group === USER::GROUP_LIMITED_ACCESS_GRADER) && count($any_images_files) === 0)) { // student has no permissions to view image page
             $this->core->addErrorMessage("You have no permissions to see images.");
             $this->core->redirect($this->core->buildCourseUrl());


### PR DESCRIPTION
Will now search multiple common locations for student photos:

/var/local/submity/student_photos
/var/local/submity/student_photos/<CURRENT_TERM>

And it will also display the student photos to full/limited graders if these locations are non-empty
(previously it would not show student photos to graders if the course did not have course-specific photos)

closes #4936 

future work:  refactor code & consider searching the common locations for matches with students who are in the course.  (should not show if there are no matches).  but that could be unnecessarily expensive(?).