### PR TITLE
[Documentation:PHP] Add types to several @param tags missing them

### DIFF
--- a/site/app/controllers/AbstractController.php
+++ b/site/app/controllers/AbstractController.php
@@ -32,7 +32,7 @@ abstract class AbstractController {
     /**
      * Gets a gradeable config from its id.
      * @param string $gradeable_id
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return Gradeable|bool false in the fail/error case
      */
     protected function tryGetGradeable(string $gradeable_id, bool $render_json = true) {
@@ -64,7 +64,7 @@ abstract class AbstractController {
      * Gets a gradeable component from its id and a gradeable
      * @param Gradeable $gradeable
      * @param string $component_id
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return Component|bool false in the fail/error case
      */
     protected function tryGetComponent(Gradeable $gradeable, string $component_id, bool $render_json = true) {
@@ -96,7 +96,7 @@ abstract class AbstractController {
      * Gets a mark from its id and a component
      * @param Component $component
      * @param string $mark_id
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return Mark|bool false in the fail/error case
      */
     protected function tryGetMark(Component $component, string $mark_id, bool $render_json = true) {
@@ -127,7 +127,7 @@ abstract class AbstractController {
     /**
      * Gets a submitter id from an anon id
      * @param string $anon_id
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return string|bool false in the fail/error case
      */
     protected function tryGetSubmitterIdFromAnonId(string $anon_id, bool $render_json = true) {
@@ -160,7 +160,7 @@ abstract class AbstractController {
      * Gets a graded gradeable for a given gradeable and submitter id
      * @param Gradeable $gradeable
      * @param string $submitter_id
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return \app\models\gradeable\GradedGradeable|bool false in the fail/error case
      */
     protected function tryGetGradedGradeable(Gradeable $gradeable, string $submitter_id, bool $render_json = true) {
@@ -192,7 +192,7 @@ abstract class AbstractController {
      * Gets a submission version for a given auto graded gradeable and version number
      * @param AutoGradedGradeable $auto_graded_gradeable
      * @param string $version
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return AutoGradedVersion|bool false in the fail/error case
      */
     protected function tryGetVersion(AutoGradedGradeable $auto_graded_gradeable, string $version, bool $render_json = true) {
@@ -222,7 +222,7 @@ abstract class AbstractController {
      * Gets a testcase for a given version and testcase index
      * @param AutoGradedVersion $version
      * @param string $testcase_index
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return AutoGradedTestcase|bool false in the fail/error case
      */
     protected function tryGetTestcase(AutoGradedVersion $version, string $testcase_index, bool $render_json = true) {
@@ -253,7 +253,7 @@ abstract class AbstractController {
      * Gets an autocheck for a given testcase and autocheck index
      * @param AutoGradedTestcase $testcase
      * @param string $autocheck_index
-     * @param $render_json true to render a JSEND response to the output in the failure/error case
+     * @param bool $render_json true to render a JSEND response to the output in the failure/error case
      * @return \app\models\GradeableAutocheck|bool false in the fail/error case
      */
     protected function tryGetAutocheck(AutoGradedTestcase $testcase, string $autocheck_index, bool $render_json = true) {

--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -78,10 +78,11 @@ class HomePageController extends AbstractController {
     }
 
     /**
-     * @param $user_id
-     * @param $as_instructor
      * @Route("/api/courses", methods={"GET"})
      * @Route("/home/courses", methods={"GET"})
+     *
+     * @param string|null $user_id
+     * @param bool|string $as_instructor
      * @return Response
      */
     public function getCourses($user_id = null, $as_instructor = false) {

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1,51 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 97$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 150$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 130$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 91$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 158$#"
-			count: 2
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 191$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$render_json true to render a JSEND response to the output in the failure/error case\\)\\: Unexpected token \"\\$render_json\", expected type at offset 165$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$as_instructor\\)\\: Unexpected token \"\\$as_instructor\", expected type at offset 41$#"
-			count: 1
-			path: app/controllers/HomePageController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$user_id\\)\\: Unexpected token \"\\$user_id\", expected type at offset 18$#"
-			count: 1
-			path: app/controllers/HomePageController.php
-
-		-
 			message: "#^Offset int does not exist on array\\(\\?0 \\=\\> 'results'\\|'results_public'\\|'submissions', \\?1 \\=\\> 'checkout'\\|'results_public', \\?2 \\=\\> 'results'\\|'results_public', \\?3 \\=\\> 'results_public'\\)\\.$#"
 			count: 3
 			path: app/controllers/MiscController.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes a handful of phpstan baseline errors for phpDoc `@param` elements that lacked a type 