### PR TITLE
[Bugfix:Sidebar] Sidebar no longer changes shape when page loads

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -74,7 +74,7 @@
             <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="left_sidebar" src="{{ wrapper_urls['left_sidebar.html'] }}" frameborder="0"></iframe>
         {% endif %}
         {# separates our content from user custom bars #}
-        <div id="submitty-body" class="flex-col">
+        <div id="submitty-body" class="flex-col" style="display:none;">
             <div id="mobile-menu">
                 <div id="menu-header" class="flex-row">
                 <a href="{{ base_url }}" aria-label="Go to Submitty Home"><h1>Submitty</h1></a>
@@ -196,7 +196,7 @@
             </div>
             <div id="wrapper">
                 {% if sidebar_buttons|length > 0 %}
-                    <aside>
+                    <aside class="preload">
                         <ul>
                             {% for button in sidebar_buttons %}
                                 {{ self.render_sidebar_button(button, false) }}
@@ -243,7 +243,7 @@
                 >
                     <span class="flex-line"> {# col in flex-row #}
                         {% if button.getIcon() != null %}
-                            <i class="fa {{ button.getIcon() }}"></i>
+                            <i class="fa {{ button.getIcon() }} preload"></i>
                         {% endif %}
 
                         <span class="icon-title"> {{ button.getTitle() }} </span>

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -6,11 +6,14 @@ aside {
     aside {
         display: block;
         margin: 0 -30px 0 0;
-        transition: all 0.3s ease-out;
         padding-top: 30px;
         width: 250px;
         min-width: 250px;
         z-index: 1;
+    }
+
+    aside:not(.preload){
+      transition: all 0.3s ease-out;
     }
 
     aside hr {
@@ -18,12 +21,15 @@ aside {
     }
 
     aside i  {
-        transition: margin 0.3s ease-out;
         color: #000;
         width: 30px;
         min-width: 30px;
         text-align: center;
         margin: 0 0 0 15px;
+    }
+
+    aside i:not(.preload){
+      transition: margin 0.3s ease-out;
     }
 
     aside li {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1834,17 +1834,21 @@ $.fn.isInViewport = function() {                                        // jQuer
 };
 
 function checkSidebarCollapse() {
+    $(".preload").removeClass("preload");//.preload must be removed to allow the animation to work
     var size = $(document.body).width();
     if (size < 1150) {
+        localStorage.sidebar = true;
         $("aside").toggleClass("collapsed", true);
     }
     else{
+        localStorage.sidebar = false;
         $("aside").toggleClass("collapsed", false);
     }
 }
 
 //Called from the DOM collapse button, toggle collapsed and save to localStorage
 function toggleSidebar() {
+    $(".preload").removeClass("preload");//.preload must be removed to allow the animation to work
     var sidebar = $("aside");
     var shown = sidebar.hasClass("collapsed");
 
@@ -1873,13 +1877,13 @@ $(document).ready(function() {
     if (localStorage.sidebar !== "") {
         //Apparently !!"false" === true and if you don't cast this to bool then it will animate??
         $("aside").toggleClass("collapsed", localStorage.sidebar === "true");
+        $("#submitty-body").show();//Once the sidebar is set the page can be unhidden
     }
 
     //If they make their screen too small, collapse the sidebar to allow more horizontal space
     $(document.body).resize(function() {
         checkSidebarCollapse();
     });
-    checkSidebarCollapse();
 });
 
 function checkBulkProgress(gradeable_id){


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

issue 1: when you refersh the page the sidebar does not save its current state. So it would choose what to do based on the screen size not the variable in localstorage. (It used to do this I am not sure exactly when this broke but this PR should fix it)

issue 2: If the sidebar had to close on page load it would slowly close and the entire page would shake and move around every time you refreshed the page. This is because the sidebar starts off always open but there is js to close it if the page is skinny or if it should be closed based on local storage


### What is the new behavior?

The sidebar will keep the state it is set at even across page refreshes. The sidebar will start open/closed and never cause the page to move around when a page is first loaded.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested on Arch Linux with Firefox and Chrome

To see what I mean by page shake, open or close the sidebar and you will see how elements on the page move around. This is fine if you are choosing to change the sidebar state but it should not be happening on page load. 
