### PR TITLE
[Feature:PHP] Add support for gating features behind feature flags

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -117,9 +117,12 @@ HTML;
             if ($this->core->getConfig()->wrapperEnabled()) {
                 $this->twig_loader->addPath(
                     FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'site'),
-                    $namespace = 'site_uploads'
+                    'site_uploads'
                 );
             }
+            $this->twig->addFunction(new \Twig\TwigFunction("feature_flag_enabled", function(string $flag): bool {
+                return $this->core->getConfig()->checkFeatureFlagEnabled($flag);
+            }));
         }
         $engine = new ParsedownEngine();
         $engine->setSafeMode(true);

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -120,7 +120,7 @@ HTML;
                     'site_uploads'
                 );
             }
-            $this->twig->addFunction(new \Twig\TwigFunction("feature_flag_enabled", function(string $flag): bool {
+            $this->twig->addFunction(new \Twig\TwigFunction("feature_flag_enabled", function (string $flag): bool {
                 return $this->core->getConfig()->checkFeatureFlagEnabled($flag);
             }));
         }

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -218,6 +218,9 @@ class Config extends AbstractModel {
     /** @property @var bool */
     protected $queue_enabled;
 
+    /** @prop-read @var array */
+    protected $feature_flags = [];
+
     /**
      * Config constructor.
      *
@@ -420,6 +423,10 @@ class Config extends AbstractModel {
             $this->$key = ($this->$key == true) ? true : false;
         }
 
+        if (!empty($this->course_json['feature_flags']) && is_array($this->course_json['feature_flags'])) {
+            $this->feature_flags = $this->course_json['feature_flags'];
+        }
+
         $wrapper_files_path = FileUtils::joinPaths($this->getCoursePath(), 'site');
         foreach (WrapperController::WRAPPER_FILES as $file) {
             $path = FileUtils::joinPaths($wrapper_files_path, $file);
@@ -514,5 +521,18 @@ class Config extends AbstractModel {
     public function getWrapperFiles() {
         //Return empty if not logged in because we can't access them
         return ($this->core->getUser() === null ? [] : $this->wrapper_files);
+    }
+
+    /**
+     * Checks to see if a given feature flag is enabled or not. If the site
+     * is running under debug, we assume all flags are enabled, else, the
+     * flag must exist in the course config.json file and be set to true.
+     */
+    public function checkFeatureFlagEnabled(string $flag): bool {
+        return $this->debug
+            || (
+                isset($this->feature_flags[$flag])
+                && $this->feature_flags[$flag] === true
+            );
     }
 }

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -270,7 +270,8 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
                     'room_seating_gradeable_id' => "",
                     'auto_rainbow_grades' => false,
                     'queue_enabled' => true,
-                ]
+                ],
+                'feature_flags' => []
             ],
             'course_loaded' => true,
             'forum_enabled' => true,
@@ -291,7 +292,8 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'latest_commit' => 'd150131c',
             'latest_tag' => 'v19.07.00',
             'verified_submitty_admin_user' => null,
-            'queue_enabled' => true
+            'queue_enabled' => true,
+            'feature_flags' => []
         );
         $actual = $config->toArray();
 

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -114,7 +114,10 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
                 'room_seating_gradeable_id' => "",
                 'auto_rainbow_grades' => false,
                 'queue_enabled' => true,
-            )
+            ),
+            'feature_flags' => [
+
+            ]
         );
 
         $config = array_replace_recursive($config, $extra);
@@ -555,5 +558,50 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
 
         $config = new Config($this->core);
         $config->loadMasterConfigs($this->config_path);
+    }
+
+    public function testFeatureFlagTrueDebug() {
+        $extra = ['debugging_enabled' => true];
+        $this->createConfigFile($extra);
+
+        $config = new Config($this->core);
+        $config->loadMasterConfigs($this->config_path);
+        $course_path = FileUtils::joinPaths($config->getSubmittyPath(), "courses", "s17", "csci0000");
+        $course_json_path = FileUtils::joinPaths($course_path, "config", "config.json");
+        $config->loadCourseJson("s17", "csci0000", $course_json_path);
+
+        $this->assertTrue($config->isDebug());
+        $this->assertTrue($config->checkFeatureFlagEnabled('non_existing_name'));
+    }
+
+    public function testFeatureFlagEnabled() {
+        $extra = ['feature_flags' => ['feature_1' => true, 'feature_2' => false]];
+        $this->createConfigFile($extra);
+
+        $config = new Config($this->core);
+        $config->loadMasterConfigs($this->config_path);
+        $course_path = FileUtils::joinPaths($config->getSubmittyPath(), "courses", "s17", "csci0000");
+        $course_json_path = FileUtils::joinPaths($course_path, "config", "config.json");
+        $config->loadCourseJson("s17", "csci0000", $course_json_path);
+
+        $this->assertFalse($config->isDebug());
+        $this->assertFalse($config->checkFeatureFlagEnabled('non_existing_name'));
+        $this->assertTrue($config->checkFeatureFlagEnabled('feature_1'));
+        $this->assertFalse($config->checkFeatureFlagEnabled('feature_2'));
+    }
+
+    public function testNonexistingFeatureFlagConfig() {
+        $extra = ['feature_flags' => null];
+        $this->createConfigFile($extra);
+
+        $config = new Config($this->core);
+        $config->loadMasterConfigs($this->config_path);
+        $course_path = FileUtils::joinPaths($config->getSubmittyPath(), "courses", "s17", "csci0000");
+        $course_json_path = FileUtils::joinPaths($course_path, "config", "config.json");
+        $config->loadCourseJson("s17", "csci0000", $course_json_path);
+
+        $this->assertFalse($config->isDebug());
+        $this->assertFalse($config->checkFeatureFlagEnabled('non_existing_name'));
+        $this->assertFalse($config->checkFeatureFlagEnabled('feature_1'));
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #4923. 

New features that are under-development, but not ready for production are still shown to instructors with a warning to not use them. This is not ideal as instructors could still use them and cause things to break in unexpected ways.

### What is the new behavior?
Can gate features behind feature flags where in the PHP code:
```php
if ($this->core->getConfig()->checkFeatureFlagEnabled('flag_name')) { }
```
and in twig:
```twig
{% if feature_flag_enabled('flag_name') %}
```

Feature flags are on by default if debug mode is enabled (such as within vagrant) or if in the course config file, a top-level key "feature_flags" object is added where the value is a map where each key is a feature flag and the value is boolean true/false indicating if it's enabled. The feature flag is only considered enabled if they key exists and it is true, ensuring full backwards compatibility with existing courses. It is fine for the course config file to also have old flags no longer used, assuming that we always use a unique name for each flag to prevent accidental collisions.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Not a breaking change, and does not require any migrations to take advantage of it.