### PR TITLE
[Bugfix:PHP] Fix undefined variable warning in ExceptionHandler

### DIFF
--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -72,7 +72,7 @@ class ExceptionHandler {
             $log_exception = $exception->logException();
         }
 
-        $trace_string = array();
+        $trace_string = [];
         foreach ($exception->getTrace() as $elem => $frame) {
             $trace_string[] = sprintf(
                 "#%s %s(%s): %s(%s)",
@@ -80,7 +80,7 @@ class ExceptionHandler {
                 isset($frame['file']) ? $frame['file'] : 'unknown file',
                 isset($frame['line']) ? $frame['line'] : 'unknown line',
                 (isset($frame['class']))  ? $frame['class'] . $frame['type'] . $frame['function'] : $frame['function'],
-                static::parseArgs(is_a($exception, '\app\exceptions\AuthenticationException') ? array() : $frame['args'])
+                static::parseArgs((is_a($exception, '\app\exceptions\AuthenticationException') || !isset($frame['args'])) ? [] : $frame['args'])
             );
         }
         $trace_string = implode("\n", $trace_string);
@@ -152,8 +152,8 @@ HTML;
      */
     private static function parseArgs($args) {
         $return = "";
-        if (isset($args)) {
-            $return_args = array();
+        if (!empty($args)) {
+            $return_args = [];
             foreach ($args as $arg) {
                 if (is_string($arg)) {
                     $return_args[] = "'" . $arg . "'";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

From #4955. In some cases, the stack trace for an exception would not contain args in some of the frames, causing an undefined index warning to be issued.

### What is the new behavior?

Checks that `$frame['args']` is set before attempting to access it. Does not fix the underlying issue causing the exception from the issue however, so leaving the issue open.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
