### PR TITLE
[Bugfix:Forum] Fix for overlaping text on the anonymous checkbox label

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -124,7 +124,7 @@
                 <table class="file-upload-table" id="file-upload-table-{{ post_box_id }}"></table>
             </div>
         </span>
-        <br>
+        <br style="margin-right:1rem;">
 
         {% if attachment_script %}
             {# To be executed at last attachment box #}
@@ -161,7 +161,7 @@
             </script>
         {% endif %}
     {% endif %}
-    <span class="inline-block right-zero position-absolute">
+    <span class="inline-block right-zero">
         {% if show_anon %}
             <label>Anonymous (to class)? <input type="checkbox" class="thread-anon-checkbox" id="{{ anon_edit_post_id | default('thread_post_anon') }}" aria-label="Anonymous (to class)?" name="Anon" value="Anon" data-ays-ignore="true"/></label>
         {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
On a small screen some text on the forum would overlap with a button
![image](https://user-images.githubusercontent.com/11095297/70741195-c2897480-1ce8-11ea-8747-a88e97d6c4f9.png)
### What is the new behavior?

This text now moves to the next line instead of overlapping.
![image](https://user-images.githubusercontent.com/18558130/73117253-992b4d80-3f10-11ea-93e9-ad7ae7cdd776.png)

closes  #4861

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested on Linux using Firefox