### PR TITLE
[Bugfix:Submission] Fix clear not showing submission table clearing

### DIFF
--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -216,7 +216,7 @@ function deleteFiles(part) {
         previous_files[part-1] = [];
     }
     var dropzone = document.getElementById("file-upload-table-" + part);
-    var labels = dropzone.getElementsByClassName("label");
+    var labels = dropzone.getElementsByClassName("file-label");
     while(labels[0]){
         dropzone.removeChild(labels[0]);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
When pressing the "Clear" button on a submission, it clears it internally but doesn't show that clear to the user. This can stack, resulting in unusual behavior as shown below:
![image](https://user-images.githubusercontent.com/15370948/73155829-e3940200-40a9-11ea-8f0d-43e3d67d1a5e.png)

### What is the new behavior?
Pressing the "Clear" button on a submission now properly clears the table visually.

### Other information?
Tested by pressing the "Clear" button after adding files, making sure that it was disabled after and readding the same file and different files and clearing again.