### PR TITLE
[Dependency:JS] Revert twigjs version which introduced a bug in TA grading

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -25,7 +25,7 @@
     "pdfjs-dist": "2.2.228",
     "plotly.js-dist": "1.50.1",
     "shortcut-buttons-flatpickr": "0.3.0",
-    "twig": "1.14.0"
+    "twig": "1.13.3"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
A bug was introduced in twigjs ```1.14.0``` which causes escaping an empty string to return ```[object Object]```. This affected rubric creation by replacing many defaults with ```[object Object]```. 

This PR reverts  us to twigjs version ```1.13.3``` the version we were previously using.

