### PR TITLE
[Feature:Forum] Adds Markdown Templates

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -27,6 +27,8 @@
         <span style="display: {{ render_markdown?"block":"none" }}" id="markdown_buttons_{{ post_box_id }}">
             <button id="link_btn" type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Link <i class="fas fa-link fa-1x"></i></button>
             <button id="code_btn" title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default">Code <i class="fas fa-code fa-1x"></i></button>
+            <button id="bold_btn" title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button id="italic_btn" title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
         <a class="btn btn-primary" id="merge-thread-btn" title="Merge Threads" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -25,10 +25,10 @@
         <a target=_blank href="https://submitty.org/student/discussion_forum#formatting-a-post-using-markdown/"><i id="markdown-info-{{ post_box_id }}" style="font-style:normal;" class="far fa-question-circle disabled"></i></a>
         &nbsp;&nbsp;
         <span style="display: {{ render_markdown?"block":"none" }}" id="markdown_buttons_{{ post_box_id }}">
-            <button id="link_btn" type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Link <i class="fas fa-link fa-1x"></i></button>
-            <button id="code_btn" title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Code <i class="fas fa-code fa-1x"></i></button>
-            <button id="bold_btn" title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Bold <i class="fas fa-bold fa-1x"></i></button>
-            <button id="italic_btn" title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Italics <i class="fas fa-italic fa-1x"></i></button>
+            <button id="link_btn" type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Link <i class="fas fa-link fa-1x"></i></button>
+            <button id="code_btn" title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Code <i class="fas fa-code fa-1x"></i></button>
+            <button id="bold_btn" title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button id="italic_btn" title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
         <a class="btn btn-primary" id="merge-thread-btn" title="Merge Threads" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -26,9 +26,9 @@
         &nbsp;&nbsp;
         <span style="display: {{ render_markdown?"block":"none" }}" id="markdown_buttons_{{ post_box_id }}">
             <button id="link_btn" type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Link <i class="fas fa-link fa-1x"></i></button>
-            <button id="code_btn" title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default">Code <i class="fas fa-code fa-1x"></i></button>
-            <button id="bold_btn" title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default">Bold <i class="fas fa-bold fa-1x"></i></button>
-            <button id="italic_btn" title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default">Italics <i class="fas fa-italic fa-1x"></i></button>
+            <button id="code_btn" title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Code <i class="fas fa-code fa-1x"></i></button>
+            <button id="bold_btn" title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button id="italic_btn" title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" style="margin-right:10px;" class="btn btn-default">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
         <a class="btn btn-primary" id="merge-thread-btn" title="Merge Threads" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>

--- a/site/app/templates/submission/regrade/Discussion.twig
+++ b/site/app/templates/submission/regrade/Discussion.twig
@@ -110,10 +110,36 @@
 {% endif %}
 
 {% macro markdown_buttons() %}
-    <button type="button" title="Insert a link" onclick="addMarkdownCode(1, '#reply-text-area')" style="margin-right:10px;" class="btn btn-default">
-        Link <i class="fas fa-link fa-1x"></i>
+    <button type="button" 
+            title="Insert a link" 
+            onclick="addMarkdownCode(1, '#reply-text-area')" 
+            style="margin-right:10px;" 
+            class="btn btn-default"> Link 
+            <i 
+                class="fas fa-link fa-1x">
+            </i>
     </button>
-    <button title="Insert a code segment" type="button" onclick="addMarkdownCode(0, '#reply-text-area')" class="btn btn-default">
-        Code <i class="fas fa-code fa-1x"></i>
+    <button title="Insert a code segment" 
+            type="button" 
+            onclick="addMarkdownCode(0, '#reply-text-area')" 
+            class="btn btn-default"> Code 
+            <i 
+                class="fas fa-code fa-1x">
+            </i>
+    </button>
+    <button title="Insert bold text" 
+            type="button" 
+            onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))"
+            class="btn btn-default"> Bold 
+            <i 
+                class="fas fa-bold fa-1x">
+            </i>
+    </button>
+    <button title="Insert italic text" 
+            type="button" 
+            onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))"class="btn btn-default"> Italics 
+            <i 
+                class="fas fa-italic fa-1x">  
+            </i>
     </button>
 {% endmacro %}

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -141,6 +141,10 @@ body {min-width: 925px;}
     font-size: 1.17em;
 }
 
+.btn_markdown {
+    margin-right:10px;
+}
+
 .active-thread-remove-announcement{
     display: inline-block;
     color: orange;

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1040,6 +1040,12 @@ function addMarkdownCode(type, divTitle){
         insert = "```" +
             "\ncode\n```";
     }
+    else if(type == 2){
+        insert = "__bold text__ ";
+    }
+    else if(type == 3){
+        insert = "_italic text_ ";
+    }
     $(divTitle).val(text.substring(0, cursor) + insert + text.substring(cursor));
 }
 


### PR DESCRIPTION
### What is the current behavior?
When selecting the markdown option it allows you to add code blocks and URLs to a discussion forum post.

### What is the new behavior?
In addition to the previous options, it now includes bold and italics

### Other information?
This should not break anything since its text in the discussion forum text box. Worst case if they mess with the spacing the markdown may not work as expected but by default, there are spaces inserted between so it would not be an issue unless they delete any of the preformatted inserted text
