### PR TITLE
[Bugfix:UI] Fix incorrect usage of localStorage for sidebar

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1837,11 +1837,11 @@ function checkSidebarCollapse() {
     $(".preload").removeClass("preload");//.preload must be removed to allow the animation to work
     var size = $(document.body).width();
     if (size < 1150) {
-        localStorage.sidebar = true;
+        localStorage.setItem('sidebar', 'true');
         $("aside").toggleClass("collapsed", true);
     }
     else{
-        localStorage.sidebar = false;
+        localStorage.setItem('sidebar', 'false');
         $("aside").toggleClass("collapsed", false);
     }
 }
@@ -1852,7 +1852,7 @@ function toggleSidebar() {
     var sidebar = $("aside");
     var shown = sidebar.hasClass("collapsed");
 
-    localStorage.sidebar = !shown;
+    localStorage.setItem('sidebar', (!shown).toString());
     sidebar.toggleClass("collapsed", !shown);
 }
 
@@ -1874,10 +1874,10 @@ $(document).ready(function() {
     });
 
     //Remember sidebar preference
-    if (localStorage.sidebar !== "") {
-        //Apparently !!"false" === true and if you don't cast this to bool then it will animate??
-        $("aside").toggleClass("collapsed", localStorage.sidebar === "true");
-        $("#submitty-body").show();//Once the sidebar is set the page can be unhidden
+    if (localStorage.getItem('sidebar') !== "") {
+        $("aside").toggleClass("collapsed", localStorage.getItem('sidebar') === "true");
+        //Once the sidebar is set the page can be unhidden
+        $("#submitty-body").show();
     }
 
     //If they make their screen too small, collapse the sidebar to allow more horizontal space


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Something I noticed when I was looking at #4953 a bit ago, is that it was using the localStorage incorrectly from its spec, which will undoubtedly cause cross-browser issues, where some browsers may implement the localStorage as read-only, and some do not.

### What is the new behavior?

This fixes localStorage to follow the [defined API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) using the `getItem` and `setItem` functions, instead of directly trying to access properties. I've also fixed the usage here where all values in the localStorage are strings and that passing in the straight booleans were being silently converted, which could lead to some confusion.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I removed the comment as the first part was incorrect (`!!"false" === true`, it's a very common JS pattern), and the second part seemed surprised that not using the [toggleClass jQuery function](https://api.jquery.com/toggleclass/#toggleClass-className-state) correctly (namely the second argument is a boolean) leads to incorrect behavior.
