### PR TITLE
[Bugfix:UI] Fixes buttons not following css styling on ios

### DIFF
--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -154,3 +154,7 @@ footer .footer-separator {
 #loading-bar-percentage{
     margin-left: 10px;
 }
+
+input{
+  -webkit-appearance: none;
+}

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -154,7 +154,3 @@ footer .footer-separator {
 #loading-bar-percentage{
     margin-left: 10px;
 }
-
-input{
-  -webkit-appearance: none;
-}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -182,6 +182,10 @@ input.disabled {
     background-color: var(--standard-light-gray);
 }
 
+input{
+  -webkit-appearance: none;
+}
+
 /****************************
  * TABLE STYLES
  ***************************/


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
ios buttons don't follow the css style and so they are extra small and look different. I believe this only happens for buttons inside forms.

![image](https://user-images.githubusercontent.com/18558130/73376462-7a6be480-428b-11ea-9f6f-90c2b01e6609.png)


### What is the new behavior?

This should make them ignore the built in css and therefore look the same as they do on computers and android phones

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I did not test this. I dont have an iphone and so I have no way to test this. I found this fix here https://stackoverflow.com/questions/5449412/styling-input-buttons-for-ipad-and-iphone
and was hoping somebody with an iphone can test this for me.

I have been told this can also be tested on the ios simulator on an apple computer.
