### PR TITLE
[Dependency:JS] fix npm lock file for rollbacked twig package

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3,14 +3,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@babel/runtime": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@braintree/sanitize-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
@@ -647,11 +639,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
-    "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-    },
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -739,11 +726,10 @@
       "integrity": "sha512-ikUlS+/BcImLhNYyIgZcEmq4byc31QpC+46/6Jm5ECWkVFhf8SM2Fp/0pMVXPX6vk45SMCwrP4Taxucne8I0VA=="
     },
     "twig": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/twig/-/twig-1.14.0.tgz",
-      "integrity": "sha512-ut1LslUKAeF56TYQglabJaATUqbNuGO3EcXDhUspAdNbxez5VwTk2n8H00V0VfNy9Scet+VGQP8oPxt4v6mykQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/twig/-/twig-1.13.3.tgz",
+      "integrity": "sha512-Kjart2102Kf0IdsEmLonSJKcByU7o9uiJhBde3GhrNHrX4XenT5WSKu4Hpkx+rF6Kyppeyd48BKsCREIOPXd/g==",
       "requires": {
-        "@babel/runtime": "^7.6.3",
         "locutus": "^2.0.5",
         "minimatch": "3.0.x",
         "walk": "2.3.x"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

From #4972, the package.json file was updated, but not the package-lock.json file, which can lead to potential unexpected behavior then in package installation on production.

### What is the new behavior?

Updates the package-lock.json file to match the package.json on specified twig.js version.