### PR TITLE
[Bugfix:Testing] Fix warnings issued from PamAuthenticationTester

### DIFF
--- a/site/tests/app/authentication/PamAuthenticationTester.php
+++ b/site/tests/app/authentication/PamAuthenticationTester.php
@@ -9,6 +9,7 @@ use app\libraries\database\DatabaseQueries;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 use app\models\Config;
+use app\models\User;
 use tests\BaseUnitTest;
 
 class PamAuthenticationTester extends BaseUnitTest {
@@ -16,8 +17,14 @@ class PamAuthenticationTester extends BaseUnitTest {
     private function getMockCore($curl_response) {
         $config = $this->createMockModel(Config::class);
         $queries = $this->createMock(DatabaseQueries::class);
-        $queries->method('getSubmittyUser')->willReturn(true);
         $core = $this->createMock(Core::class);
+        $user = new User($core, [
+            'user_id' => 'test',
+            'user_firstname' => 'Test',
+            'user_lastname' => 'Person',
+            'user_email' => '',
+        ]);
+        $queries->method('getSubmittyUser')->willReturn($user);
         $core->method('getConfig')->willReturn($config);
         $core->method('getQueries')->willReturn($queries);
         $core->method('curlRequest')->willReturn($curl_response);
@@ -103,8 +110,14 @@ class PamAuthenticationTester extends BaseUnitTest {
     public function testCurlThrow() {
         $config = $this->createMockModel(Config::class);
         $queries = $this->createMock(DatabaseQueries::class);
-        $queries->method('getSubmittyUser')->willReturn(true);
         $core = $this->createMock(Core::class);
+        $user = new User($core, [
+            'user_id' => 'test',
+            'user_firstname' => 'Test',
+            'user_lastname' => 'Person',
+            'user_email' => '',
+        ]);
+        $queries->method('getSubmittyUser')->willReturn($user);
         $core->method('getConfig')->willReturn($config);
         $core->method('getQueries')->willReturn($queries);
         $ch = curl_init();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The tests issue warnings when running, but execute fine.

### What is the new behavior?

Warnings are fixed.
