### PR TITLE
[Bugfix:Install] Fix cache directory having wrong owner for site_install_dev

### DIFF
--- a/.setup/bin/install_site_dev.sh
+++ b/.setup/bin/install_site_dev.sh
@@ -76,6 +76,9 @@ for entry in "${result_array[@]}"; do
     chown ${PHP_USER}:${PHP_GROUP} "${SUBMITTY_INSTALL_DIR}/${entry:12}"
 done
 
+# Update ownership for cache directory
+chown -R ${PHP_USER}:${PHP_GROUP} ${SUBMITTY_INSTALL_DIR}/site/cache
+
 # Update ownership for cgi-bin to CGI_USER
 find ${SUBMITTY_INSTALL_DIR}/site/cgi-bin -exec chown ${CGI_USER}:${CGI_GROUP} {} \;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Running the submitty_install_site_dev.sh script would result in a cache directory that had the wrong owner, which when combined with debugging set to false would result in site errors when Twig attempted to cache a template.

### What is the new behavior?

Fixes the ownership problem on the cache directory so that Twig can operate as expected.