### PR TITLE
[Feature:Submission] Tie multiple 'testcase_label' to single 'testcase_ref'

### DIFF
--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -166,7 +166,12 @@ class AutoGradedVersion extends AbstractModel {
 
                 // If a testcase_label exists then get the auto grading messages
                 if ($testcase_label != "") {
-                    $output[$testcase_label] = array();
+
+                    // If this testcase_label doesn't already exist as a key in the output array, then create a
+                    // child array for that testcase_label
+                    if (!array_key_exists($testcase_label, $output)) {
+                        $output[$testcase_label] = array();
+                    }
 
                     $autochecks = $graded_testcase->getAutochecks();
 

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -166,7 +166,6 @@ class AutoGradedVersion extends AbstractModel {
 
                 // If a testcase_label exists then get the auto grading messages
                 if ($testcase_label != "") {
-
                     // If this testcase_label doesn't already exist as a key in the output array, then create a
                     // child array for that testcase_label
                     if (!array_key_exists($testcase_label, $output)) {


### PR DESCRIPTION
Closes #4386 

### What is the current behavior?
Previously when constructing a notebook gradeable only a single 'testcase_label' was allowed to reference a single 'testcase_ref'.

### What is the new behavior?
Duplicate 'testcase_label' may point to a single 'testcase_ref'.  This now allows multiple testcases to be tied to a single notebook input type.  For example both compilation tests and regular tests may reference a single 'testcase_ref'.

### Other information?
See #4386 for what changes are not addressed here and why.

<!-- How did you test -->
Tests were done on the CPP crash_course gradeable.  I made multiple 'testcase_label's point to a single 'testcase_ref' and ensured the correct number of error messages made it into the browser window.
