### PR TITLE
[Feature:Forum] Instructor/TA/Mentor posts now are yellow in thread list

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -619,6 +619,11 @@ class ForumThreadView extends AbstractView {
             if ($thread["deleted"]) {
                 $class .= " deleted";
             }
+
+            if($this->core->getQueries()->getUserById($thread['created_by'])->getGroup() <= 3){
+              $class .= " important";
+            }
+
             //fix legacy code
             $titleDisplay = $thread['title'];
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -620,7 +620,7 @@ class ForumThreadView extends AbstractView {
                 $class .= " deleted";
             }
 
-            if ($this->core->getQueries()->getUserById($thread['created_by'])->getGroup() <= 3) {
+            if ($this->core->getQueries()->getUserById($thread['created_by'])->accessGrading()) {
                 $class .= " important";
             }
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -620,8 +620,8 @@ class ForumThreadView extends AbstractView {
                 $class .= " deleted";
             }
 
-            if($this->core->getQueries()->getUserById($thread['created_by'])->getGroup() <= 3){
-              $class .= " important";
+            if ($this->core->getQueries()->getUserById($thread['created_by'])->getGroup() <= 3) {
+                $class .= " important";
             }
 
             //fix legacy code

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -534,12 +534,6 @@ td>a.active-sort {
     padding: 5px 5px 10px;
 }
 
-.active {
-    background-color: var(--default-white);
-    /*    color: #4a4a4a;*/
-    border: 4px solid var(--submitty-logo-blue);
-}
-
 .viewed_post{
     background-color: var(--default-white);
 }
@@ -562,6 +556,12 @@ td>a.active-sort {
     border-style: solid;
     border-width: 4px;
     border-color: var(--important-post); /* gold */
+}
+
+.active {
+    background-color: var(--default-white);
+    /*    color: #4a4a4a;*/
+    border: 4px solid var(--submitty-logo-blue);
 }
 
 .new_thread{


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Threads posted by Instructor/TA/Mentor show up exactly the same in the thread list as a normal student post (unless they are an announcement in which case they have a star)
![image](https://user-images.githubusercontent.com/18558130/73602990-c26c5f00-454a-11ea-84a6-e21621288a99.png)

### What is the new behavior?

Threads in the thread list now have the yellow border if they were made by an Instructor/TA/Mentor which matches how they look when you actually open the thread.
![image](https://user-images.githubusercontent.com/18558130/73603040-97363f80-454b-11ea-955d-4bd809d1e68b.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This was talked about at a DS mentor meeting last semester because it is not always clear when an important thread is posted. Anyone who uses the forum knows that they yellow border on a reply means it was made by course staff so it seems to me that it makes sense to have the sidebar follow this same format.
