### PR TITLE
[Bugfix:Queue] page crashes with lengthy queue history

### DIFF
--- a/site/app/templates/OfficeHoursQueue.twig
+++ b/site/app/templates/OfficeHoursQueue.twig
@@ -229,10 +229,12 @@
       </tr>
     </thead>
     <tbody>
-      {% for entry in viewer.getPastQueue() %}
-        {% if viewer.isGrader()or entry['user_id'] == viewer.getUserId() %}
+      {% set history_count = 0 %}
+      {% for entry in viewer.getPastQueue() if history_count < 25 %}
+        {% if viewer.isGrader() or entry['user_id'] == viewer.getUserId() %}
+          {% set history_count = history_count + 1 %}
           <tr class="queue_history_{{entry['queue_code']}}">
-            <th scope="row">{{entry['row_number']}}</th>
+            <th scope="row">{{history_count}}</th>
             <td class="mobile-hide">
               <a class="post-user-info" onclick="unhideId(this, '{{ entry['user_id'] }}')" title="Show user id" aria-label="Show user id">
                 <i class="fas fa-eye"></i>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When the office hours queue's history is very large the page will crash on some phones.

### What is the new behavior?

This pr limits the history to the most recent 25 people in the queue.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is just a small pr to make sure that the queue does not crash. This PR does not fix any of the other smaller bugs that are less important, see #5001 
If that PR is merged this one does not have to be, however, this one is much smaller so it should be easier to review and merge before the Wednesday CS1 and DS labs.