### PR TITLE
Revert "[Bugfix:UI] buttons not following css styling on ios (#4980)"

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -182,10 +182,6 @@ input.disabled {
     background-color: var(--standard-light-gray);
 }
 
-input{
-  -webkit-appearance: none;
-}
-
 /****************************
  * TABLE STYLES
  ***************************/


### PR DESCRIPTION
This reverts commit 383baba1fc55790cf17312a1238e6c870b2b0e1b.

Revert "[Bugfix:UI] buttons not following css styling on ios (#4980)"

radio buttons were not displaying on mac Chrome, mac Safari or Linux Chrome (didn't test anything else)

<img width="769" alt="Screen Shot 2020-02-04 at 12 19 13 AM" src="https://user-images.githubusercontent.com/5871417/73716891-49a20a00-46e6-11ea-85bc-1f3a4539083b.png">
