### PR TITLE
[Bugfix:Sidebar] Fixed room seating pictures being shifted off the page

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -74,7 +74,7 @@
             <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="left_sidebar" src="{{ wrapper_urls['left_sidebar.html'] }}" frameborder="0"></iframe>
         {% endif %}
         {# separates our content from user custom bars #}
-        <div id="submitty-body" class="flex-col" style="display:none;">
+        <div id="submitty-body" class="flex-col" style="visibility: hidden;">
             <div id="mobile-menu">
                 <div id="menu-header" class="flex-row">
                 <a href="{{ base_url }}" aria-label="Go to Submitty Home"><h1>Submitty</h1></a>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1877,7 +1877,7 @@ $(document).ready(function() {
     if (localStorage.getItem('sidebar') !== "") {
         $("aside").toggleClass("collapsed", localStorage.getItem('sidebar') === "true");
         //Once the sidebar is set the page can be unhidden
-        $("#submitty-body").show();
+        $("#submitty-body").css('visibility', 'visible');
     }
 
     //If they make their screen too small, collapse the sidebar to allow more horizontal space


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The room seating picture has been shifted to be half off the page
![image](https://user-images.githubusercontent.com/18558130/73721256-d9998100-46f1-11ea-8d5b-440dd0722563.png)

### What is the new behavior?
The room seating chart now looks correct and back to how it always looked.
![image](https://user-images.githubusercontent.com/18558130/73721247-d3a3a000-46f1-11ea-9932-76f2ad4fdd50.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested on linux using firefox
