### PR TITLE
[UI:TAGrading] Updated Peer Panel and Component Colors

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1396,7 +1396,7 @@ end of styles used in the admin gradeable page
 
 /* color for student/peer grading */
 .grader-4 {
-    color: var(--standard-vibrant-purple) /* purple */
+    color: var(--standard-plum-purple) /* purple */
 }
 
 /* color for a limited access grader */

--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -79,8 +79,8 @@
 }
 
 .icon-selected.fa-comment-alt {
-    box-shadow: 0px 0px 3px 3px var(--standard-plum-purple);
-    background-color: var(--standard-plum-purple);
+    box-shadow: 0px 0px 3px 3px var(--standard-light-seafoam);
+    background-color: var(--standard-light-seafoam);
 }
 
 .icon-files {
@@ -107,8 +107,8 @@
     background-color: rgba(0, 0, 0, 0.4);
 }
 .icon-selected.fa-users {
-    box-shadow: 0px 0px 3px 3px var(--standard-light-seafoam);
-    background-color: var(--standard-light-seafoam);
+    box-shadow: 0px 0px 3px 3px var(--standard-plum-purple);
+    background-color: var(--standard-plum-purple);
 }
 .icon-selected.grade_inquiry_icon{
     box-shadow: 0px 0px 3px 3px var(--standard-vibrant-orange);
@@ -206,7 +206,7 @@ progress::-webkit-progress-value {
     border:5px solid var(--text-black);
 }
 #peer_info.rubric_panel {
-    border:5px solid var(--standard-light-seafoam);
+    border:5px solid var(--standard-plum-purple);
 }
 
 .grading_label {
@@ -409,6 +409,10 @@ tr.is_publish {
 
 .gradeable .component {
     cursor: default;
+}
+
+.gradeable .peer-border {
+    border: 3px solid var(--standard-plum-purple);
 }
 
 .gradeable .component .badge-container.edit-mode {
@@ -785,7 +789,7 @@ tr.is_publish {
 }
 
 #discussion_browser.rubric_panel {
-    border:5px solid #72518a;
+    border:5px solid var(--standard-light-seafoam);
 }
 
 #directory_view {

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -200,7 +200,6 @@ function renderGradingComponent(grader_id, component, graded_component, grading_
     return new Promise(function (resolve, reject) {
         // Make sure we prep the graded component before rendering
         graded_component = prepGradedComponent(component, graded_component);
-
         // TODO: i don't think this is async
         resolve(Twig.twig({ref: "GradingComponent"}).render({
             'component': component,
@@ -213,6 +212,7 @@ function renderGradingComponent(grader_id, component, graded_component, grading_
             'can_verify_graders': canVerifyGraders,
             'grader_id': grader_id,
             'component_version_conflict': componentVersionConflict,
+            'peer_component' : component.peer,
         }));
     });
 }
@@ -276,7 +276,8 @@ function renderEditComponent(component, precision, showMarkList) {
             'precision': precision,
             'show_mark_list': showMarkList,
             'edit_marks_enabled': true,
-            'decimal_precision': DECIMAL_PRECISION
+            'decimal_precision': DECIMAL_PRECISION,
+            'peer_component' : component.peer,
         }));
     });
 }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1127,7 +1127,8 @@ function getComponentFromDOM(component_id) {
             default: countUp ? 0.0 : maxValue,
             max_value: maxValue,
             upper_clamp: maxValue + extraCreditPoints,
-            marks: getMarkListFromDOM(component_id)
+            marks: getMarkListFromDOM(component_id),
+            peer: (domElement.attr('data-peer') === 'true')
         };
     }
     return {
@@ -1140,7 +1141,8 @@ function getComponentFromDOM(component_id) {
         default: parseFloat(domElement.attr('data-default')),
         max_value: parseFloat(domElement.attr('data-max_value')),
         upper_clamp: parseFloat(domElement.attr('data-upper_clamp')),
-        marks: getMarkListFromDOM(component_id)
+        marks: getMarkListFromDOM(component_id),
+        peer: (domElement.attr('data-peer') === 'true')
     };
 }
 

--- a/site/public/templates/grading/Component.twig
+++ b/site/public/templates/grading/Component.twig
@@ -4,16 +4,21 @@ Required Input:
     edit_marks_enabled: If the marks table should be in edit mode
     show_mark_list: If the marks table should be started hidden or not
     peer_component: boolean, defines what data is stored in the component.
+    peer_panel: boolean, true if this component is being displayed in the peer panel.
 #}
 
 {% set mark_list_visibility = show_mark_list ? '' : 'hidden' %}
 
-{% if peer_component %}
+{% if peer_panel %}
 <div id="peer-component-{{ component.id }}"
      class="box">
 {% else %}
 <div id="component-{{ component.id }}"
-     class="box component"
+     class="box component
+     {% if peer_component %}
+        peer-border
+    {% endif %}
+    "
      data-component_id="{{ component.id }}"
      data-title="{{ component.title|escape }}"
      data-ta_comment="{{ component.ta_comment|escape }}"
@@ -21,6 +26,7 @@ Required Input:
      data-page="{{ component.page }}"
      data-lower_clamp="{{ component.lower_clamp }}"
      data-default="{{ component.default }}"
+     data-peer="{{ component.peer }}"
      data-max_value="{{ component.max_value }}"
      data-upper_clamp="{{ component.upper_clamp }}">
 {% endif %}

--- a/site/public/templates/grading/EditGradeable.twig
+++ b/site/public/templates/grading/EditGradeable.twig
@@ -10,7 +10,8 @@
         <div class="component-container edit-component-container">
             {% include "EditComponent.twig" with {
                 'precision': gradeable.precision,
-                'show_mark_list': false
+                'show_mark_list': false,
+                'peer_component' : component.peer,
             } %}
         </div>
     {% endfor %}

--- a/site/public/templates/grading/GradingGradeable.twig
+++ b/site/public/templates/grading/GradingGradeable.twig
@@ -16,6 +16,7 @@
                 'precision': gradeable.precision,
                 'show_mark_list': false,
                 'component_version_conflict': graded_component.graded_version is defined and graded_component.graded_version != display_version,
+                'peer_component' : component.peer,
             } %}
         </div>
     {% endfor %}

--- a/site/public/templates/grading/PeerGradeable.twig
+++ b/site/public/templates/grading/PeerGradeable.twig
@@ -11,6 +11,7 @@
                     'precision': gradeable.precision,
                     'show_mark_list': false,
                     'peer_details' : peer_details[component.id],
+                    'peer_panel' : true,
                     'peer_component' : true
                 } %}
             </div>


### PR DESCRIPTION
This PR:
1. Updates the color of peer grading related elements to ```standard-plum-purple``` per prior conversations.
2. Adds a border around peer components to help graders distinguish them from non-peer components.
3. Changes the color of discussion forum related UI elements from ```standard-plum-purple``` to ```standard-light-seafoam```
___
![new_peer_colors](https://user-images.githubusercontent.com/11758882/73773628-83a7f600-4750-11ea-929c-14af37f23012.png)
![new_peer_colors_2](https://user-images.githubusercontent.com/11758882/73773633-8571b980-4750-11ea-9b00-da60e0e43e2c.png)
