### PR TITLE
[Bugfix: Discussion Forum] Fixes more dropdown menu behavior for empty discussion forum

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -110,6 +110,7 @@
               <li title="Click to edit categories" class='dropdown-item'>
             	<a href ="{{ manage_categories_url }}" title="Edit Categories" target="_blank" >Edit Categories</a>
 			{% endif %}
+			{% if thread_exists %}
 	          <li class="dropdown-divider"></li>
 	          <li title="Click to toggle all post attachments" class='dropdown-item'>
 	          	<a href="#" onclick="loadAllInlineImages()">
@@ -122,6 +123,7 @@
 	              {% if user_group <= core.getUser().accessGrading() %}
 	              	<li title="Sort posts by author's last name" id="alpha" class='dropdown-item'><a href="#" onclick="changeDisplayOptions('alpha')">Alphabetical</a></li>
 	              {% endif %}
+	        {% endif %}
 	        </ul>
 	    </div>
 	{% endif %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -258,7 +258,7 @@ class ForumThreadView extends AbstractView {
         if (!$threadExists) {
             $button_params["show_threads"] = false;
             $button_params["thread_exists"] = false;
-            $button_params["show_more"] = false;
+            $button_params["show_more"] =  $this->core->getUser()->accessGrading();
         }
         else {
             $more_data = array(

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -10,7 +10,7 @@ body {min-width: 925px;}
 }
 
 .forum_show_threads {
-    overflow: hidden;
+    overflow: visible;
     flex-direction: column;
     display: flex;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #4924 and undoes ##4943.
Currently the more button is missing for Discussion Forums with no threads which makes it hard for instructors/graders to create category.
Overflow still technically is cut off for the more dropdown menu.

### What is the new behavior?
Overflow is now fixed for the forum bar.
Instructors and graders have access to the "edit categories" option from the more dropdown menu even for empty Discussion Forums.
Students looking at empty Discussion Forum do not access to the more dropdown
![more](https://user-images.githubusercontent.com/34754780/73868714-f5e30e00-4816-11ea-9855-86756b4fdffd.png)

### Other information?

