### PR TITLE
[Bugfix:Forum] Fixed students being able to see the forum category page

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -880,6 +880,7 @@ class ForumController extends AbstractController {
 
     /**
      * @Route("/{_semester}/{_course}/forum/categories", methods={"GET"})
+     * @AccessControl(permission="forum.modify_category")
      */
     public function showCategories() {
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'showCategories', $this->getAllowedCategoryColor());


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Students could see the http://192.168.56.111/s20/development/forum/categories page if they know the url. However anything they try and do on this page will fail to work, so this is not a huge deal.
![image](https://user-images.githubusercontent.com/18558130/73883260-9f36fd80-4831-11ea-8842-0d1060e9f81a.png)


### What is the new behavior?

This now does not allow students to view the page
![image](https://user-images.githubusercontent.com/18558130/73883229-934b3b80-4831-11ea-8486-53fc63b31df0.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
