### PR TITLE
[Bugfix:TAGrading] Fixed Manual Grading Total Display

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1227,9 +1227,10 @@ class ElectronicGraderController extends AbstractController {
         // If it is graded at all, then send ta score information
         $response_data['ta_grading_total'] = $gradeable->getTaPoints();
         if ($ta_graded_gradeable->getPercentGraded() !== 0.0) {
-            if( $gradeable->isPeerGrading() ) {
+            if ($gradeable->isPeerGrading()) {
                 $response_data['ta_grading_earned'] = $ta_graded_gradeable->getTotalScore($grading_done_by);
-            } else {
+            }
+            else {
                 $response_data['ta_grading_earned'] = $ta_graded_gradeable->getTotalScore(null);
             }
         }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1227,7 +1227,11 @@ class ElectronicGraderController extends AbstractController {
         // If it is graded at all, then send ta score information
         $response_data['ta_grading_total'] = $gradeable->getTaPoints();
         if ($ta_graded_gradeable->getPercentGraded() !== 0.0) {
-            $response_data['ta_grading_earned'] = $ta_graded_gradeable->getTotalScore($grading_done_by);
+            if( $gradeable->isPeerGrading() ) {
+                $response_data['ta_grading_earned'] = $ta_graded_gradeable->getTotalScore($grading_done_by);
+            } else {
+                $response_data['ta_grading_earned'] = $ta_graded_gradeable->getTotalScore(null);
+            }
         }
 
         $response_data['anon_id'] = $graded_gradeable->getSubmitter()->getAnonId();


### PR DESCRIPTION
The ```Manual Grading Total``` on the TA grading page was errantly being computed based only upon components graded by the currently logged in user. This PR fixes this issue by ensuring that TA grading total is instead totaled over all graders for non-peer gradeables.