### PR TITLE
[VPAT:Forum] Removed duplicate ids on html element

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -77,7 +77,7 @@
         {% endif %}
 
         <h7 class="last-edit">
-			<strong id="post_user_id">{{ visible_username }}</strong>
+			<strong class="post_user_id">{{ visible_username }}</strong>
 			{{ post_date }}
             {% if edit_date is not null %}
                 (<i>Last edit at {{ edit_date }}</i>)

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -26,7 +26,7 @@
 	</script>
 {% endif %}
 
-<div id="forum_bar">
+<div class="forum_bar">
 
 	<div class="row">
 

--- a/site/app/templates/forum/MergeThreadsForm.twig
+++ b/site/app/templates/forum/MergeThreadsForm.twig
@@ -9,7 +9,7 @@
         <div>
             <p>Merge current thread into:<p>
             <input type="hidden" id="merge_thread_child" name="merge_thread_child" value="{{ current_thread }}" data-ays-ignore="true">
-            <input type="hidden" id="csrf_token" name="csrf_token" value="{{ csrf_token }}" data-ays-ignore="true"/>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}" data-ays-ignore="true"/>
             <select class="chosen-select" id="merge_thread_parent" name="merge_thread_parent" aria-label="Select thread to merge into" data-ays-ignore="true">
                 {% for threads in possibleMerges %}
                     <option value=({{ threads['id'] }})>({{ threads['id'] }}) {{ threads['title'] }}</option>

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -15,7 +15,7 @@
 
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <span  style="float: right;">
-                <input id="new_category_text" placeholder="New Category" style="resize:none;" rows="1" type="text" name="new_category" id="new_category" maxlength="50" onkeyup="checkInputMaxLength($(this))" />
+                <input id="new_category_text" placeholder="New Category" style="resize:none;" rows="1" type="text" name="new_category" maxlength="50" onkeyup="checkInputMaxLength($(this))" />
                 <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm">
                     <i class="fas fa-plus-circle fa-1x"></i> Add category
                 </button>

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -115,8 +115,8 @@
         <span class="inline-block">
             {# uploadID and input-file + Index required for drag-and-drop.js #}
             <div class="upload_attachment_box cursor-pointer" id="upload{{ post_box_id }}">
-                <label id="file_input_label" class="btn btn-default">Upload Attachment</label>
-                <input type="file" accept="image/*" aria-labelledby="file_input_label" id="input-file{{ post_box_id }}" style="display: none;" onchange="addFilesFromInput({{ post_box_id }});testAndGetAttachments({{ post_box_id }}, true);" multiple />
+                <label id="file_input_label_{{post_box_id}}" class="btn btn-default">Upload Attachment</label>
+                <input type="file" accept="image/*" aria-labelledby="file_input_label_{{post_box_id}}" id="input-file{{ post_box_id }}" style="display: none;" onchange="addFilesFromInput({{ post_box_id }});testAndGetAttachments({{ post_box_id }}, true);" multiple />
                 <br>
                 <table class="file-upload-table" id="file-upload-table-{{ post_box_id }}"></table>
             </div>

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -160,7 +160,7 @@
     {% endif %}
     <span class="inline-block right-zero">
         {% if show_anon %}
-            <label>Anonymous (to class)? <input type="checkbox" class="thread-anon-checkbox" id="{{ anon_edit_post_id | default('thread_post_anon') }}" aria-label="Anonymous (to class)?" name="Anon" value="Anon" data-ays-ignore="true"/></label>
+            <label>Anonymous (to class)? <input type="checkbox" class="thread-anon-checkbox" {% if anon_edit_post_id %} id="{{ anon_edit_post_id }}"{% endif %} aria-label="Anonymous (to class)?" name="Anon" value="Anon" data-ays-ignore="true"/></label>
         {% endif %}
         {% if show_thread_status %}
         <select id="thread_status" name="thread_status" data-ays-ignore="true" aria-label="Select thread status">

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -5,7 +5,7 @@
 >
 
 <div class="form-group row position-relative">
-    <input type="hidden" id="csrf_token" name="csrf_token" value="{{ csrf_token }}" data-ays-ignore="true"/>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" data-ays-ignore="true"/>
 
     {% if show_title %}
     <span class="edit_thread">
@@ -25,10 +25,10 @@
         <a target=_blank href="https://submitty.org/student/discussion_forum#formatting-a-post-using-markdown/"><i id="markdown-info-{{ post_box_id }}" style="font-style:normal;" class="far fa-question-circle disabled"></i></a>
         &nbsp;&nbsp;
         <span style="display: {{ render_markdown?"block":"none" }}" id="markdown_buttons_{{ post_box_id }}">
-            <button id="link_btn" type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Link <i class="fas fa-link fa-1x"></i></button>
-            <button id="code_btn" title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Code <i class="fas fa-code fa-1x"></i></button>
-            <button id="bold_btn" title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Bold <i class="fas fa-bold fa-1x"></i></button>
-            <button id="italic_btn" title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Italics <i class="fas fa-italic fa-1x"></i></button>
+            <button type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Link <i class="fas fa-link fa-1x"></i></button>
+            <button title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Code <i class="fas fa-code fa-1x"></i></button>
+            <button title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
         <a class="btn btn-primary" id="merge-thread-btn" title="Merge Threads" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>
@@ -78,7 +78,7 @@
     </div>
     <div class="form-group row">
         {% set min_height = (post_textarea_large?"40vmin":"100px") %}
-        <textarea name="thread_post_content" id="thread_post_content" class="fill-available post_content_reply" style="resize:none;min-height:{{ min_height }};max-height:300px" rows="10" cols="30" placeholder="{{ post_content_placeholder }}" required aria-label="Thread Post Textarea" maxlength="{{ post_content_limit }}"
+        <textarea name="thread_post_content" class="fill-available post_content_reply thread_post_content" style="resize:none;min-height:{{ min_height }};max-height:300px" rows="10" cols="30" placeholder="{{ post_content_placeholder }}" required aria-label="Thread Post Textarea" maxlength="{{ post_content_limit }}"
         onkeydown="submitNearestForm(event,$(this))"></textarea>
     </div>
 <br/>

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -49,7 +49,7 @@ body {min-width: 925px;}
 .first_post .post_button {
 }
 
-#post_user_id {
+.post_user_id {
     left:5px;
 }
 

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -19,7 +19,7 @@ body {min-width: 925px;}
     margin-bottom: 10px;
 }
 
-#forum_bar {
+.forum_bar {
     margin-right: 10px;
     padding-left:15px;
     margin-top: 10px;
@@ -287,9 +287,9 @@ body {min-width: 925px;}
     display:inline-block;
 }
 
-#forum_bar div div.col-6,
+.forum_bar div div.col-6,
 #search_block div div,
-#forum_bar div div.col-5{
+.forum_bar div div.col-5{
     padding: 0;
     top: 0px;
 }

--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -61,7 +61,7 @@ class TestForum(BaseTestCase):
         attachment_file = None
         self.switch_to_page_create_thread()
         self.driver.find_element_by_id("title").send_keys(title)
-        self.driver.find_element_by_id("thread_post_content").send_keys(first_post)
+        self.driver.find_element_by_class("thread_post_content").send_keys(first_post)
         upload_button = self.driver.find_element_by_xpath("//input[@type='file']")
         self.select_categories(categories_list)
         if upload_attachment:

--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -61,7 +61,7 @@ class TestForum(BaseTestCase):
         attachment_file = None
         self.switch_to_page_create_thread()
         self.driver.find_element_by_id("title").send_keys(title)
-        self.driver.find_element_by_class("thread_post_content").send_keys(first_post)
+        self.driver.find_element_by_class_name("thread_post_content").send_keys(first_post)
         upload_button = self.driver.find_element_by_xpath("//input[@type='file']")
         self.select_categories(categories_list)
         if upload_attachment:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Some parts of the forum had duplicate ids on html elements.

### What is the new behavior?

I removed all the duplicate ids
Closes #5040

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I searched through all the files and I did not see any code that used the ids that I changed. So it should be safe to remove them all.
