### PR TITLE
[Bugfix:Forum] Fixed edit categories page not loading and remove eye icon when there is nothing to show 

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -880,7 +880,7 @@ class ForumController extends AbstractController {
 
     /**
      * @Route("/{_semester}/{_course}/forum/categories", methods={"GET"})
-     * @AccessControl(permission="forum.modify_category")
+     * @AccessControl(permission="forum.view_modify_category")
      */
     public function showCategories() {
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'showCategories', $this->getAllowedCategoryColor());

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -190,7 +190,8 @@ class Access {
 
 
         //Forum permissions
-        $this->permissions["forum.modify_category"] = self::ALLOW_MIN_LIMITED_ACCESS_GRADER | self::CHECK_CSRF;
+        $this->permissions["forum.view_modify_category"] = self::ALLOW_MIN_LIMITED_ACCESS_GRADER;//allows you to view the page to modify forum categorys
+        $this->permissions["forum.modify_category"] = self::ALLOW_MIN_LIMITED_ACCESS_GRADER | self::CHECK_CSRF;//allows you to actually modify the categorys
         $this->permissions["forum.publish"] = self::ALLOW_MIN_STUDENT | self::CHECK_CSRF;
         $this->permissions["forum.modify_announcement"] = self::ALLOW_MIN_FULL_ACCESS_GRADER | self::CHECK_CSRF;
         $this->permissions["forum.modify_post"] = self::ALLOW_MIN_STUDENT | self::CHECK_CSRF | self::REQUIRE_FORUM_SAME_STUDENT;

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -675,6 +675,9 @@ function showHistory(post_id) {
                 var visible_user_json = JSON.stringify(visible_username);
                 info_name = JSON.stringify(info_name);
                 var user_button_code = "<a style='margin-right:2px;display:inline-block; color:black;' onClick='changeName(this.parentNode, " + info_name + ", " + visible_user_json + ", false)' title='Show full user information'><i class='fas fa-eye' aria-hidden='true'></i></a>&nbsp;";
+                if(!author_user_id){
+                  user_button_code = ""
+                }
                 box.find("h7").html("<strong>"+visible_username+"</strong> "+post['post_time']);
                 box.find("h7").before(user_button_code);
                 $("#popup-post-history .form-body").prepend(box);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There are 2 bugs with the forum. The first one is that users cannot view the page to modify categories because a normal get request does not contain a csrf token. This fix makes it so that to load the page you dont need the token, but to actually modify the categories you still need the token.
This is a bug introduced in a previous pr that attempted to limit students from viewing the page, but in the process limited anyone trying to view the page if they did not have a csrf token.

The second issue is that the eye button is visible in the history for a post even though when you click it there is nothing to reveal. This happens for limited access graders who cannot unhide somebody's real name.
![image](https://user-images.githubusercontent.com/18558130/74508306-bbd7d300-4ecc-11ea-9cb9-932debfba1b0.png)


### What is the new behavior?

The modify categories page now loads (only if you have access to modify the categories)


The eye button when you view the history of a post no longer shows up for limited access graders
![image](https://user-images.githubusercontent.com/18558130/74508267-9cd94100-4ecc-11ea-82b3-82f6b7df9ade.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
These are 2 small fixes code wise so I thought it might be better to put them in one pr. If it is better to split them let me know.