### PR TITLE
[VPAT] Fixed blank blank primary headers on the forum

### DIFF
--- a/site/app/templates/forum/EditPostForm.twig
+++ b/site/app/templates/forum/EditPostForm.twig
@@ -1,6 +1,6 @@
 {% extends 'generic/Popup.twig' %}
 {% block popup_id %}edit-user-post{% endblock %}
-{% block title_tag %}<h1 id="edit_user_prompt"></h1>{% endblock %}
+{% block title_tag %}<h1 id="edit_user_prompt">Editing a post</h1>{% endblock %}
 {% block body %}
     <input type="hidden" id="edit_thread_id" name="edit_thread_id" value="" data-ays-ignore="true"/>
     <input type="hidden" id="edit_post_id" name="edit_post_id" value="" data-ays-ignore="true"/>

--- a/site/app/templates/forum/HistoryForm.twig
+++ b/site/app/templates/forum/HistoryForm.twig
@@ -6,7 +6,7 @@
         <pre class="pre_forum"><p class="post_content" style="white-space: pre-wrap; "></p></pre>
         <hr style="margin-bottom:3px;">
         <span style="margin-top:8px;margin-left:10px;float:right;">
-        <h7 style="position:relative; right:5px;"></h7>
+        <h7 style="position:relative; right:5px;"><strong>Loading author</strong></h7>
     </span>
     </div>
 {% endblock %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The forum has 2 models that load into the page with h tags but without a value. When you run WAVE it reports them as missing values which should never happen in a h tag.
Closes #5038

### What is the new behavior?
The h tags get filled in with javascript when the modal is loaded, however WAVE does not know this and therefore it reports them as empty. I fixed this by giving them a more generic default value that works for every post. Just like how it was before, that value will be overwritten with JavaScript with a more detailed value as soon as the modal is opened.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I did not include screenshots as the issue only happens when the elements are hidden so there is nothing I can show.
