### PR TITLE
[Feature:InstructorUI] notification on student join an empty queue

### DIFF
--- a/site/app/templates/officeHoursQueue/FilterQueues.twig
+++ b/site/app/templates/officeHoursQueue/FilterQueues.twig
@@ -1,10 +1,13 @@
 {% if viewer.isGrader()%}
   <p>
-    <button id="toggle_filter_settings" class="btn btn-primary" type="button" onclick="$('#filgerSettingsCollapse').toggleClass('collapse')">
+    <button id="toggle_filter_settings" class="btn btn-primary filter_btn" type="button" onclick="$('#filgerSettingsCollapse').toggleClass('collapse')">
       Toggle Filter Settings
     </button>
-    <button id="auto_refresh_btn" class="btn btn-default" type="button" onclick="toggleAutoRefresh()">
+    <button id="auto_refresh_btn" class="btn btn-default filter_btn" type="button" onclick="toggleAutoRefresh()">
       Turn On Auto Refresh
+    </button>
+    <button id="notification_btn" class="btn btn-default filter_btn" type="button" onclick="enableNotifications()">
+      Enable Notifications
     </button>
   </p>
   <div class="collapse" id="filgerSettingsCollapse">

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -109,6 +109,13 @@
       $('#auto_refresh_btn').html("Turn Off Auto Refresh");
     }
 
+    var notifications_enabled = localStorage.getItem('office_hour_queue_notifications') === "true";
+    if ("Notification" in window && Notification.permission === "granted" && notifications_enabled) {
+      setNotificationState(true);
+    }else{
+      setNotificationState(false);
+    }
+
     let refreshSpeed = 1000 * 30;
     setInterval(refreshQueue, refreshSpeed);
     function refreshQueue() {
@@ -117,21 +124,30 @@
       }
       $.get("{{base_url}}/check_updates", function(data) {
         if (lastQueueEdit < JSON.parse(data)['data']) {
+          var queueEmpty = $( ".help_btn:visible" ).length === 0;
           $.get("{{base_url}}/current_queue", function(newQueue) {
             $("#current_queue").replaceWith(newQueue);
             filterQueues();
+            if(notifications_enabled && queueEmpty && $( ".help_btn:visible" ).length > 0){
+              new Notification("A student has joined the queue");
+            }
           });
         }
       });
     }
 
     function toggleAutoRefresh() {
-      auto_refresh = !auto_refresh;
+      setAutoRefresh(!auto_refresh);
+    }
+
+    function setAutoRefresh(turnOn){
+      auto_refresh = turnOn;
       localStorage.setItem('office_hour_queue_auto_refresh', auto_refresh);
       if (auto_refresh) {
         $('#auto_refresh_btn').html("Turn Off Auto Refresh");
       } else {
         $('#auto_refresh_btn').html("Turn On Auto Refresh");
+        setNotificationState(false);
       }
     }
   {% endif %}
@@ -144,6 +160,42 @@
       result += characters.charAt(Math.floor(Math.random() * charactersLength));
     }
     $('#' + id).val(result);
+  }
+
+  function setNotificationState(turnOn){
+    if(turnOn){
+      setAutoRefresh(true);
+    }
+    notifications_enabled = turnOn;
+    localStorage.setItem('office_hour_queue_notifications', turnOn ? "true":"false");
+    $('#notification_btn').html(turnOn ? "Disable Notifications":"Enable Notifications");
+  }
+
+  function enableNotifications() {
+    if(notifications_enabled){
+      setNotificationState(false);
+      return;
+    }
+
+    if (!("Notification" in window)) {
+      alert("This browser does not support desktop notification");
+    }
+
+    else if (Notification.permission === "granted") {
+      new Notification("Notifications have been enabled. You will be notified only when somebody joins the queue and there was nobody previously waiting for help.");
+      setNotificationState(true);
+    }
+
+    else if (Notification.permission !== "denied") {
+      Notification.requestPermission().then(function (permission) {
+        if (permission === "granted") {
+          new Notification("Notifications have been enabled. You will be notified only when somebody joins the queue and there was nobody previously waiting for help.");
+          setNotificationState(true);
+        }else{
+          setNotificationState(false);
+        }
+      });
+    }
   }
 </script>
 </div>

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -11,6 +11,10 @@ th{
   vertical-align: middle;
 }
 
+.filter_btn{
+  margin-bottom: .5rem;
+}
+
 /*
   This will hide elements on phones. This is useful for extra content that
   is not normally needed such as a user id


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is no way to know if a student has joined the queue unless you are looking at the queue
Closes #5052

### What is the new behavior?
If the queue has nobody waiting (so everyone is being helped or the queue is just empty), and you enable notifications, then the page will send a browser notification letting you know when somebody joins. If the queue has people waiting and somebody else joins, no notification will be sent. So in a busy office hours with a full queue, no notifications will be send. However in a quiet office hours with a mostly empty queue, you will get a notification whenever somebody joins.
![image](https://user-images.githubusercontent.com/18558130/74961156-9d496e80-53db-11ea-8c56-045150ee645c.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Because of how notifications work, you need to test them over https, however I dont know how to make Submitty use https on my vagrant install. I did find a workaround for chrome but not firefox. In chrome if you go to [chrome://flags/#unsafely-treat-insecure-origin-as-secure](chrome://flags/#unsafely-treat-insecure-origin-as-secure) and input http://192.168.56.111 and enable it, chrome will act as if that url is secure and allow notifications.

