### PR TITLE
[Feature:UI] Made all labels toggle checkbox/radio buttons when clicked

### DIFF
--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -15,7 +15,7 @@
             </p>
             <input type="text" id="input-provide-full-path" class="full-width" name="eg_config_path" value="" placeholder="optional/subdirectory"/>
         </label>
-        <label>
+        <div>
             <p class="black-message">
                 Do you want to restrict this course material to some sections?
             </p>
@@ -49,7 +49,7 @@
                 </tr>
             {% endfor %}
             </div>
-        </label>
+        </div>
         <label id="upload_dt">
             <p>
                 <strong>Choose a time to release the files being uploaded:</strong>

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -35,7 +35,7 @@
             <div id = "show_Some_Section_Selection" style="display: none">
             {% for section in reg_sections %}
                 <tr>
-                    <td>Section {{ section['sections_registration_id'] }}</td>
+                    <td><label for="section-{{ section['sections_registration_id'] }}">Section {{ section['sections_registration_id'] }}</label></td>
                     <td><input id="section-{{ section['sections_registration_id'] }}" aria-label="Section {{ section['sections_registration_id'] }}" type="checkbox" value="off"/></td>
                 </tr>
             {% endfor %}

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -37,10 +37,9 @@
                 <tr>
                     <span class = "inline">
                         <td>
-                          <label for="section-{{ section['sections_registration_id'] }}">Section {{ section['sections_registration_id'] }}</label>
+                          <label for="section-{{ section['sections_registration_id'] }}">Section&nbsp;{{section['sections_registration_id']}}</label>
                         </td>
                         <td>
-                            Section&nbsp;{{section['sections_registration_id']}}
                             <input class = "inline" id="section-{{ section['sections_registration_id'] }}" type="checkbox" value="off"/>
                         </td>
                         <td>

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -15,7 +15,7 @@
             </p>
             <input type="text" id="input-provide-full-path" class="full-width" name="eg_config_path" value="" placeholder="optional/subdirectory"/>
         </label>
-        <label id="upload_sections">
+        <label>
             <p class="black-message">
                 Do you want to restrict this course material to some sections?
             </p>

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -31,12 +31,12 @@
                     {# Silent Edit Checkbox #}
                     {% if show_silent_edit %}
                         <div class="col-no-gutters">
-                            <input id="silent-edit-id" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/>Silent Regrade (don't change who graded)
+                            <input id="silent-edit-id" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/><label for="silent-edit-id">Silent Regrade (don't change who graded)</input>
                         </div>
                     {% endif %}
                     {# Edit Mode Checkbox #}
                     <div class="col-no-gutters">
-                        <input id="edit-mode-enabled" type="checkbox" title="Allows editing of mark point values, descriptions, and order" onclick="onToggleEditMode()"/>Edit Rubric
+                        <input id="edit-mode-enabled" type="checkbox" title="Allows editing of mark point values, descriptions, and order" onclick="onToggleEditMode()"/><label for="edit-mode-enabled">Edit Rubric</label>
                     </div>
                 </div>
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id}}" data-can_verify="{{ can_verify }}" hidden></div>
@@ -49,7 +49,7 @@
                                 });
                             });
                         </script>
-                    
+
                     {% else %}
                         <h4>No Submission</h4>
                     {% endif %}

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -40,7 +40,7 @@
                     <input type="radio" name="codeStyle" id="style_dark" autocomplete="off"> Dark
                 </label>
             </div>
-            <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();"> Auto open </span>
+            <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();"> <label for="autoscroll_id">Auto open</label> </span>
             <br />
             {# Files #}
             <div class="inner-container" id="file-container">

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -74,7 +74,7 @@ Required Input:
     {% if show_publish %}
         {% if not first_mark %}
             <span class="col-no-gutters mark-publish-container">
-                Show mark to all students: <input type="checkbox" {{ mark.publish ? 'checked' : '' }} onchange="onMarkPublishChange(this)"/>
+                <label for="show_all_marks_{{mark.id}}">Show mark to all students:</label> <input id="show_all_marks_{{mark.id}}" type="checkbox" {{ mark.publish ? 'checked' : '' }} onchange="onMarkPublishChange(this)"/>
             </span>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When you click a label next to a checkbox it should toggle that checkbox 
Closes #3592

### What is the new behavior?
Every label for a checkbox or radio box should toggle that box. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Some pages dont have a label for a specific checkbox, for example the notifications settings page. So I did not do anything to that page. It does have labels but they dont correspond 1 to 1 to a specific checkbox so I think it should stay as is.

I used regex to find every checkbox and radio box and then I tested them all by hand to see if they work so I am pretty sure I tested every one on the entire website, meaning it is safe to fully close the issue.
