### PR TITLE
[Bugfix:Submission] Fix viewing annotated PDFs on submission page

### DIFF
--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -19,7 +19,7 @@ class PDFController extends AbstractController {
      * @param $filename
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/pdf")
      */
-    public function showStudentPDF($gradeable_id, $filename = null) {
+    public function showStudentPDF($gradeable_id, $filename, $path) {
         $filename = html_entity_decode($filename);
         $id = $this->core->getUser()->getId();
         $gradeable = $this->tryGetGradeable($gradeable_id);
@@ -53,9 +53,11 @@ class PDFController extends AbstractController {
             "gradeable_id" => $gradeable_id,
             "id" => $id,
             "file_name" => $filename,
+            "file_path" => urldecode($path),
             "annotation_jsons" => $annotation_jsons,
             "is_student" => true,
-            "page_num" => 1
+            "page_num" => 1,
+            'jquery' => true
         ];
 
         $this->core->getOutput()->renderOutput(array('PDF'), 'showPDFEmbedded', $params);

--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -70,7 +70,7 @@ $( document ).ready(function() {
                                     <button class = 'btn btn-default' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download the file"> Download
                                         <i class="fas fa-download" title="Download the file"></i></button>
                                 {% endif %}
-                                <a class="btn btn-primary" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.relative_name }}')">View Popup <i class="fas fa-window-restore"></i></a>
+                                <a class="btn btn-primary" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.relative_name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a>
                             </p>
                             {% if loop.index != files|length %}
                                 <br />
@@ -90,11 +90,11 @@ $( document ).ready(function() {
                                 {% if loop.index != uploaded_pdfs|length %}
                                     <div style="margin-bottom: 1.28em">
                                         <p style="text-align:center"> {#<a class="btn btn-primary" onclick="openUrl('{{ core.buildUrl({'component':'student', 'page':'PDF', 'action':'download_annotated_pdf', 'gradeable_id': gradeable_id, 'file_name': file.name}) }}')">Download <i class="fas fa-download"></i></a>#}
-                                            <a class="btn btn-success" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
+                                            <a class="btn btn-success" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
                                     </div>
                                 {% else %}
                                     <p style="text-align:center"> {#<a class="btn btn-primary" onclick="openUrl('{{ core.buildUrl({'component':'student', 'page':'PDF', 'action':'download_annotated_pdf', 'gradeable_id': gradeable_id, 'file_name': file.name}) }}')">Download <i class="fas fa-download"></i></a>#}
-                                        <a class="btn btn-success" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
+                                        <a class="btn btn-success" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
                                 {% endif %}
                             {% else %}
                                 {% if loop.index != uploaded_pdfs|length %}

--- a/site/app/views/PDFView.php
+++ b/site/app/views/PDFView.php
@@ -29,7 +29,9 @@ class PDFView extends AbstractView {
         $localjs = array();
 
         //This jquery file should not need to be added here as jquery should already be in the header on any page
-        // $localjs[] = $this->core->getOutput()->timestampResource(FileUtils::joinPaths('jquery', 'jquery.min.js'), 'vendor');
+        if (isset($params['jquery']) && $params['jquery'] === true) {
+            $localjs[] = $this->core->getOutput()->timestampResource(FileUtils::joinPaths('jquery', 'jquery.min.js'), 'vendor');
+        }
 
         $localjs[] = $this->core->getOutput()->timestampResource(FileUtils::joinPaths('pdfjs', 'pdf.min.js'), 'vendor');
         $localjs[] = $this->core->getOutput()->timestampResource(FileUtils::joinPaths('pdfjs', 'pdf_viewer.js'), 'vendor');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #5061  

Students would receive an error or blank window when attempting to view the annotated PDF.

### What is the new behavior?

Students can now view the annotated PDF, as well as click the original PDF button.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
During testing, did notice the "Original" button for the PDF shows the annotated version. I am not sure when this last worked properly, given that it goes to the same URL as the annotated URL, can probably make a secondary issue for that.