### PR TITLE
[Bugfix:RainbowGrades] gradeable bucket count in GUI tool

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -549,6 +549,7 @@ class ReportController extends AbstractController {
             $this->core->getOutput()->renderTwigOutput('admin/RainbowCustomization.twig', [
                 "customization_data" => $customization->getCustomizationData(),
                 "available_buckets" => $customization->getAvailableBuckets(),
+                'bucket_counts' => $customization->getBucketCounts(),
                 "used_buckets" => $customization->getUsedBuckets(),
                 'display_benchmarks' => $customization->getDisplayBenchmarks(),
                 'sections_and_labels' => (array) $customization->getSectionsAndLabels(),

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -94,7 +94,7 @@
 
                             <div id="config-{{ bucket }}" style="margin-top:25px;min-height:100px;display:none;" class="bucket_detail_div">
                                 <h3 style="display:inline">{{ bucket|capitalize }}</h3>:
-                                <input type="text" aria-label="{{ bucket|capitalize }} config count" value="{{ gradeables|length }}" id="config-count-{{ bucket }}" style="display:inline;"> items
+                                <input type="text" aria-label="{{ bucket|capitalize }} config count" value="{{ bucket_counts[bucket] }}" id="config-count-{{ bucket }}" style="display:inline;"> items
 {#                                <span style="float:right;" id="config-percent-{{ bucket }}">0%</span>#}
 {#                                <div style="float:right">#}
 {#                                    Point Distribution:<br>#}


### PR DESCRIPTION
Partially handles #4961

### What is the current behavior?
In the rainbow grades customization screen, the bucket count which is displayed is *always* the number of gradeables for which there is information in the database.

### What is the new behavior?
The count that is displayed for each gradeable will be one of the following:
1. The number of gradeables found in the database for that bucket
1. The value manually entered in this field by the user (or edited in the customization.json)

The value used will be the greater of these two values.  This was done so that when the bucket count is known ahead of time the instructor may enter that.  However other users may not know the value ahead of time and may instead just rerun the rainbow grades tool every time a new gradeable is created and the GUI tool will still work correctly in this case.

### Other information?
Tested by:
- Created / deleted gradeables to see if the GUI tool picked up these counts correctly
- Changing the value in this field, saving, and refreshing the page to ensure this change was picked up correctly
