### PR TITLE
[Feature:RainbowGrades] Added 'release_date' field to customization.json

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -6,6 +6,7 @@ use app\exceptions\ValidationException;
 use app\libraries\Core;
 use app\libraries\database\DatabaseQueries;
 use app\libraries\DatabaseUtils;
+use app\libraries\DateUtils;
 use app\libraries\FileUtils;
 use app\libraries\GradeableType;
 
@@ -94,7 +95,8 @@ class RainbowCustomization extends AbstractModel {
             $this->customization_data[$bucket][] = [
                 "id" => $gradeable->getId(),
                 "title" => $gradeable->getTitle(),
-                "max_score" => $max_score
+                "max_score" => $max_score,
+                "grade_release_date" => DateUtils::dateTimeToString($gradeable->getGradeReleasedDate())
             ];
         }
 

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -109,7 +109,13 @@
                                     <ol style="list-style-type: none;" id="gradeables-list-{{ bucket }}">
                                         {% for gradeable in gradeables %}
                                             <li>
-                                                <input type="text" aria-label="{{gradeable["title"]}} max score" value="{{ gradeable["max_score"] }}" id="maxscore-{{ gradeable["id"] }}" style="margin-right: 10px;display:inline;" onblur="ClampPoints(this);">
+                                                <input type="text"
+                                                       aria-label="{{gradeable["title"]}} max score"
+                                                       value="{{ gradeable["max_score"] }}"
+                                                       id="maxscore-{{ gradeable["id"] }}"
+                                                       data-grade-release-date="{{ gradeable["grade_release_date"] }}"
+                                                       style="margin-right: 10px;display:inline;"
+                                                       onblur="ClampPoints(this);">
                                                 {{ gradeable["title"] }}
                                                 <span style="font-style: italic;font-size: 0.8em;" class="gradeable-id">{{ gradeable["id"] }}</span>
                                             </li>

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -153,6 +153,9 @@ function getGradeableBuckets()
                 // Get max points
                 gradeable.max = parseFloat(children[0].value);
 
+                // Get gradeable release date
+                gradeable.release_date = children[0].dataset.gradeReleaseDate;
+
                 // Get gradeable id
                 gradeable.id = children[1].innerHTML;
 


### PR DESCRIPTION
Partially handles #4961

### What is the current behavior?
When the rainbow grades web gui builds the customization.json file it doesn't include any information about the release time for each gradeable.

### What is the new behavior?
The web gui now captures the time for each gradeable when it should become visible to students.  This time was captured from the release time in the gradeable 'date' tab.  This information is passed forward to the customization.json file and recorded inside the ids array.

### Other information?
The timestamp is formatted by the [DateUtils format function](https://github.com/Submitty/Submitty/blob/204c9b550ca09db3c0c15ad9de4e01c0549afee5/site/app/libraries/DateUtils.php#L113-L123).  This format is YYYY-MM-DD 24H:MM:SS-Offset.
