### PR TITLE
[Bugfix:Submission] re-enable submit button after editing prior notebook answers

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -281,7 +281,7 @@
                                      class="codebox"
                                      data-initial_value="{{ cell.initial_value }}"
                                      data-recent_submission="{{ cell.recent_submission }}"
-                                     onKeyPress="handle_input_keypress();">
+                                     onkeyup="handle_input_keypress();">
                                 </div>
 
                                 <button type="button" id="codebox_{{ num_codeboxes }}_clear_button" class="btn btn-primary codebox-clear-reset">Clear</button>
@@ -305,7 +305,7 @@
                                     {% else %}
                                         setCodeBox("codebox_{{ num_codeboxes }}", "recent");
                                         document.getElementById("codebox_{{ num_codeboxes }}_clear_button").disabled = false;
-                                        document.getElementById("codebox_{{ num_codeboxes }}_clear_button").disabled = true;
+                                        document.getElementById("codebox_{{ num_codeboxes }}_recent_button").disabled = true;
                                     {% endif %}
                                 </script>
                             {% set num_codeboxes = num_codeboxes + 1 %}
@@ -672,7 +672,7 @@
                     {% else %}
                         value="{{ short_answer.initial_value }}"
                     {% endif %}
-                    onKeyPress="handle_input_keypress();"
+                    onkeyup="handle_input_keypress();"
                 />
             </label>
         {% else %}
@@ -697,7 +697,7 @@
                     class="sa-box"
                     data-initial_value="{{ short_answer.initial_value }}"
                     data-recent_submission="{{ short_answer.recent_submission }}"
-                    onKeyPress="handle_input_keypress()"
+                    onkeyup="handle_input_keypress()"
                 >{% if short_answer.recent_submission|length  %}{{ short_answer.recent_submission }}{% else %}{{ short_answer.initial_value }}{% endif %}</textarea>
             </label>
             {#

--- a/site/public/js/gradeable-notebook.js
+++ b/site/public/js/gradeable-notebook.js
@@ -102,14 +102,35 @@ $(document).ready(function () {
     });
 
     // Register handler to detect changes inside codeboxes and then enable buttons
-    $("div .codebox").keypress(function() {
-
+    $("div .codebox").keyup(function() {
         // Get index of codebox so we can select appropriate buttons to enable
         var index = this.id.substr(-1);
 
-        // Enable buttons
-        $("#codebox_" + index + "_clear_button").attr("disabled", false);
-        $("#codebox_" + index + "_recent_button").attr("disabled", false);
+        var initial_value = this.getAttribute("data-initial_value");
+        var recent_submission = this.getAttribute("data-recent_submission");
+
+        var codebox = $("#codebox_" + index + " .CodeMirror").get(0).CodeMirror;
+        var code = codebox.getValue();
+        var clear_button_id = "#codebox_" + index + "_clear_button";
+        var recent_button_id = "#codebox_" + index + "_recent_button";
+
+        if(code === initial_value)
+        {
+          $(clear_button_id).attr("disabled", true);
+        }
+        else
+        {
+          $(clear_button_id).attr("disabled", false);
+        }
+
+        if(code === recent_submission)
+        {
+          $(recent_button_id).attr("disabled", true);
+        }
+        else
+        {
+          $(recent_button_id).attr("disabled", false);
+        }
     });
 
     // Register click handler for multiple choice buttons
@@ -180,9 +201,7 @@ $(document).ready(function () {
     // Setup keyup event for short answer boxes
     $(".sa-box").keyup(function() {
 
-        var items = this.id.split("_");
-
-        var index_num = items[2];
+        var index_num = this.id.split("_")[2];
 
         var initial_value = this.getAttribute("data-initial_value");
         var recent_submission = this.getAttribute("data-recent_submission");


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Editing codebox answers and textbox answers are not setting the status of buttons ( `submit`, `clear`, `use most recent`) correctly. 

### What is the new behavior?
Closes #4422 
Editing codebox and textbox answers now set the status of all three buttons correctly.
