### PR TITLE
[VPAT] Removed redundant link in breadcrumbs

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -96,26 +96,28 @@
             <div id="menu-overlay"></div>
             <nav class="flex-row shadow">
                 <div id="nav-links">
-                    <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
+                    <div id="mobile_home_link_parent">
+                      <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
                         <img id="submitty-mascot-home-btn"
                          src="{{ base_url }}/img/{{ duck_img }}"
                          alt="Submitty's duck mascot!"
                          height = "50px"
                          />
-                     </a>
+                      </a>
+                    </div>
                     <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}
                                 <span>&gt;</span> {# span required to give conditional rendering #}
                             {% endif %}
-                            <div class="breadcrumb">
+                            <div id="desktop_home_link_parent" class="breadcrumb">
                                 {% if b.getUrl() is not empty and not loop.last %}
-                                    <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
+                                    <a id="desktop_home_link" href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
                                 {% else %}
                                     <span>{{ b.getTitle() }}</span>
                                 {% endif %}
                                 {% if b.getExternalUrl() is not empty %}
-                                    <a class="external-breadcrumb" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
+                                    <a id="desktop_home_link" class="external-breadcrumb" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
                                 {% endif %}
                             </div>
                         {% endfor %}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -96,15 +96,13 @@
             <div id="menu-overlay"></div>
             <nav class="flex-row shadow">
                 <div id="nav-links">
-                    <div>
-                      <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
-                        <img id="submitty-mascot-home-btn"
-                         src="{{ base_url }}/img/{{ duck_img }}"
-                         alt="Submitty's duck mascot!"
-                         height = "50px"
-                         />
-                      </a>
-                    </div>
+                    <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
+                      <img id="submitty-mascot-home-btn"
+                       src="{{ base_url }}/img/{{ duck_img }}"
+                       alt="Submitty's duck mascot!"
+                       height = "50px"
+                       />
+                    </a>
                     <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -97,12 +97,12 @@
             <nav class="flex-row shadow">
                 <div id="nav-links">
                     <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
-                      <img id="submitty-mascot-home-btn"
-                       src="{{ base_url }}/img/{{ duck_img }}"
-                       alt="Submitty's duck mascot!"
-                       height = "50px"
-                       />
-                    </a>
+                        <img id="submitty-mascot-home-btn"
+                         src="{{ base_url }}/img/{{ duck_img }}"
+                         alt="Submitty's duck mascot!"
+                         height = "50px"
+                         />
+                     </a>
                     <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -96,7 +96,7 @@
             <div id="menu-overlay"></div>
             <nav class="flex-row shadow">
                 <div id="nav-links">
-                    <div id="mobile_home_link_parent">
+                    <div>
                       <a id="home-button" class="black-btn" href="{{ base_url }}" aria-label="Go to Submitty Home">
                         <img id="submitty-mascot-home-btn"
                          src="{{ base_url }}/img/{{ duck_img }}"
@@ -110,14 +110,14 @@
                             {% if loop.index0 > 0 %}
                                 <span>&gt;</span> {# span required to give conditional rendering #}
                             {% endif %}
-                            <div id="desktop_home_link_parent" class="breadcrumb">
+                            <div class="breadcrumb">
                                 {% if b.getUrl() is not empty and not loop.last %}
                                     <a id="desktop_home_link" href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
                                 {% else %}
                                     <span>{{ b.getTitle() }}</span>
                                 {% endif %}
                                 {% if b.getExternalUrl() is not empty %}
-                                    <a id="desktop_home_link" class="external-breadcrumb" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
+                                    <a class="external-breadcrumb" href="{{ b.getExternalUrl() }}" target="_blank" aria-label="Go to {{ b.getTitle() }}"><i class="fas fa-external-link-alt"></i></a>
                                 {% endif %}
                             </div>
                         {% endfor %}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -20,25 +20,17 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 
 function loadInBreadcrumbLinks(){
-  if($("#home-button")){
-    mobileHomeLink = $("#home-button")[0].outerHTML;
-  }
-  if($("#desktop_home_link")){
-    desktopHomeLink = $("#desktop_home_link")[0].outerHTML;
-  }
+  mobileHomeLink = $("#home-button").attr('href');
+  desktopHomeLink = $("#desktop_home_link").attr('href');
 }
 
 function adjustBreadcrumbLinks(){
   if($(document).width() > 528){
-    if($("#home-button")){
-      $("#home-button").remove();
-    }
-    $("#desktop_home_link_parent")[0].innerHTML = desktopHomeLink;
+    $("#home-button").attr('href', "");
+    $("#desktop_home_link").attr('href', desktopHomeLink);
   }else{
-    if($("#desktop_home_link")){
-      $("#desktop_home_link").remove();
-    }
-    $("#mobile_home_link_parent")[0].innerHTML = mobileHomeLink;
+    $("#home-button").attr('href', mobileHomeLink);
+    $("#desktop_home_link").attr('href', "");
   }
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -6,11 +6,15 @@ window.addEventListener("load", function() {
   }
 });
 
+window.addEventListener("resize", checkSidebarCollapse);
+
+
+////////////Begin: Removed redundant link in breadcrumbs////////////////////////
+//See this pr for why we might want to remove this code at some point
+//https://github.com/Submitty/Submitty/pull/5071
 window.addEventListener("resize", function(){
-  checkSidebarCollapse();
   adjustBreadcrumbLinks();
 });
-
 
 var mobileHomeLink = null;
 var desktopHomeLink = null;
@@ -33,6 +37,9 @@ function adjustBreadcrumbLinks(){
     $("#desktop_home_link").attr('href', "");
   }
 }
+////////////End: Removed redundant link in breadcrumbs//////////////////////////
+
+
 
 /**
  * Acts in a similar fashion to Core->buildUrl() function within the PHP code

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -6,7 +6,41 @@ window.addEventListener("load", function() {
   }
 });
 
-window.addEventListener("resize", checkSidebarCollapse);
+window.addEventListener("resize", function(){
+  checkSidebarCollapse();
+  adjustBreadcrumbLinks();
+});
+
+
+var mobileHomeLink = null;
+var desktopHomeLink = null;
+document.addEventListener("DOMContentLoaded", function() {
+  loadInBreadcrumbLinks();
+  adjustBreadcrumbLinks();
+});
+
+function loadInBreadcrumbLinks(){
+  if($("#home-button")){
+    mobileHomeLink = $("#home-button")[0].outerHTML;
+  }
+  if($("#desktop_home_link")){
+    desktopHomeLink = $("#desktop_home_link")[0].outerHTML;
+  }
+}
+
+function adjustBreadcrumbLinks(){
+  if($(document).width() > 528){
+    if($("#home-button")){
+      $("#home-button").remove();
+    }
+    $("#desktop_home_link_parent")[0].innerHTML = desktopHomeLink;
+  }else{
+    if($("#desktop_home_link")){
+      $("#desktop_home_link").remove();
+    }
+    $("#mobile_home_link_parent")[0].innerHTML = mobileHomeLink;
+  }
+}
 
 /**
  * Acts in a similar fashion to Core->buildUrl() function within the PHP code


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is a redundant link in the breadcrumbs
Closes #4075

### What is the new behavior?
This uses js to remove and add back the redundant link in the breadcrumbs. The reason for the redundant link was because there is the mobile and desktop version of the button. By removing from the page dom, whichever one was not being show in the first place, it solves the issue.
