### PR TITLE
[Bugfix:TAGrading] Fix not being able to view/annotate PDFs

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -50,8 +50,6 @@ class MiscController extends AbstractController {
         }
         $check_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $directory, $gradeable_id, $id, $active_version);
 
-        $section = null;
-
         if ($gradeable->isGradeByRegistration()) {
             $section = $submitter->getRegistrationSection();
         }
@@ -59,19 +57,13 @@ class MiscController extends AbstractController {
             $section = $submitter->getRotatingSection();
         }
 
-        $dir = "submissions";
-        $path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $dir, $gradeable_id, $id, $active_version, $file_name);
-
-        //See if we are allowed to access this path
-        $path = $this->core->getAccess()->resolveDirPath($dir, $path);
-      
         if ($file_path !== $_POST['file_path'] || !Utils::startsWith($file_path, $check_path)) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Invalid file path")
             );
         }
-      
-        if (!$this->core->getAccess()->canI("path.read", ["dir" => $dir, "path" => $path, "gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "section" => $section])) {
+
+        if (!$this->core->getAccess()->canI("path.read", ["dir" => $directory, "path" => $file_path, "gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "section" => $section])) {
             return Response::JsonOnlyResponse(
                 JsonResponse::getFailResponse("You do not have access to this file")
             );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Not able to view or annotate PDFs in the checkout directory or in a subfolder. This was broken by a bad master merge in #5033 that had reverted some key changes in #5016.

### What is the new behavior?

Can view and annotate PDFs that are in checkout folder or in a subfolder in submissions folder.
