### PR TITLE
[VPAT:Forum] replace 'invisible' h1 with breadcrumb h1

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -528,8 +528,8 @@ HTML;
         return $this->use_mobile_viewport;
     }
 
-    public function addBreadcrumb($string, $url = null, $external_link = false) {
-        $this->breadcrumbs[] = new Breadcrumb($this->core, $string, $url, $external_link);
+    public function addBreadcrumb($string, $url = null, $external_link = false, $use_as_heading = false) {
+        $this->breadcrumbs[] = new Breadcrumb($this->core, $string, $url, $external_link, $use_as_heading);
     }
 
     public function addRoomTemplatesTwigPath() {

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -31,6 +31,9 @@ class Breadcrumb extends AbstractModel {
     protected $url = null;
     /** @prop string|null */
     protected $external_url = false;
+    /** @prop string|null */
+    protected $use_as_heading = false;
+
 
     /**
      * Breadcrumb constructor.
@@ -39,10 +42,15 @@ class Breadcrumb extends AbstractModel {
      * @param string|null $url
      * @param string|null $external_url
      */
-    public function __construct(Core $core, string $title, $url = null, $external_url = null) {
+    public function __construct(Core $core, string $title, $url = null, $external_url = null, $use_as_heading = false) {
         parent::__construct($core);
         $this->title = $title;
         $this->url = $url;
         $this->external_url = $external_url;
+        $this->use_as_heading = $use_as_heading;
+    }
+
+    public function useAsHeading() {
+        return $this->use_as_heading;
     }
 }

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -111,6 +111,8 @@
                             <div class="breadcrumb">
                                 {% if b.getUrl() is not empty and not loop.last %}
                                     <a href='{{ b.getUrl() }}'>{{ b.getTitle() }}</a>
+                                {% elseif b.useAsHeading() %}
+                                    <h1 class="breadcrumb_heading">{{ b.getTitle() }}</h1>
                                 {% else %}
                                     <span>{{ b.getTitle() }}</span>
                                 {% endif %}

--- a/site/app/templates/forum/ShowForumThreads.twig
+++ b/site/app/templates/forum/ShowForumThreads.twig
@@ -1,5 +1,3 @@
-<h1 id="hidden-forum-header">Discussion Forum</h1>
-
 <script>
 
     $( document ).ready(function(){
@@ -26,7 +24,7 @@
 
 <div class="full_height content forum_content forum_show_threads">
 
-    {% if not thread_exists  %}        
+    {% if not thread_exists  %}
         {%  include "forum/ForumBar.twig" with {
                 "current_thread" : button_params.current_thread,
                 "forum_bar_buttons_right" : button_params.forum_bar_buttons_right,

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -14,7 +14,7 @@ class ForumThreadView extends AbstractView {
 
     public function searchResult($threads) {
 
-        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']), null, $use_as_heading = true);
         $this->core->getOutput()->addBreadcrumb("Search");
 
         $buttons = array(
@@ -123,7 +123,7 @@ class ForumThreadView extends AbstractView {
         $threadFiltering = $threadExists && !$filteredThreadExists && !(empty($_COOKIE[$currentCourse . '_forum_categories']) && empty($_COOKIE['forum_thread_status']) && empty($_COOKIE['unread_select_value']) === 'false');
 
         if (!$ajax) {
-            $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+            $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']), null, $use_as_heading = true);
 
             //Body Style is necessary to make sure that the forum is still readable...
             $this->core->getOutput()->addVendorCss('codemirror/codemirror.css');
@@ -968,7 +968,7 @@ class ForumThreadView extends AbstractView {
             return;
         }
 
-        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']), null, $use_as_heading = true);
         $this->core->getOutput()->addBreadcrumb("Create Thread", $this->core->buildCourseUrl(['forum', 'threads', 'new']));
 
         $this->core->getOutput()->addInternalJs('drag-and-drop.js');
@@ -1022,7 +1022,7 @@ class ForumThreadView extends AbstractView {
             return;
         }
 
-        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']), null, $use_as_heading = true);
         $this->core->getOutput()->addBreadcrumb("Manage Categories", $this->core->buildCourseUrl(['forum', 'categories']));
 
         $this->core->getOutput()->addInternalJs('drag-and-drop.js');
@@ -1079,7 +1079,7 @@ class ForumThreadView extends AbstractView {
             return;
         }
 
-        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']));
+        $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']), null, $use_as_heading = true);
         $this->core->getOutput()->addBreadcrumb("Statistics", $this->core->buildCourseUrl(['forum', 'stats']));
 
         $this->core->getOutput()->addInternalJs('forum.js');

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -419,11 +419,6 @@ body {min-width: 925px;}
     margin-left: 1em;
 }
 
-#hidden-forum-header{
-    font-size:1px;
-    color: #f6fbfe;
-}
-
 .thread-list-item{
     font-weight: bold;
     display: block;

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -64,6 +64,10 @@ nav a > i.f {
     padding-left: 7px;
 }
 
+.breadcrumb_heading{
+  font-size: 24px
+}
+
 #logout-button {
     margin: 15px;
     text-decoration: none;

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -49,11 +49,15 @@ class TestSidebar(BaseTestCase):
             if expected_text in title_map:
                 expected_text = title_map[expected_text]
 
-            self.assertEqual(
-                expected_text,
-                self.driver.find_element_by_id('main')
-                    .find_elements_by_tag_name('h1')[0].text
-            )
+            heading_text = []
+            heading_text.append(self.driver.find_element_by_id('main')
+                                .find_elements_by_tag_name('h1')[0].text)
+            if(self.driver.find_element_by_id('breadcrumbs')
+               and len(self.driver.find_element_by_id('breadcrumbs')
+                       .find_elements_by_tag_name('h1')) > 0):
+                heading_text.append(self.driver.find_element_by_id('breadcrumbs')
+                                    .find_elements_by_tag_name('h1')[0].text)
+            self.assertIn(expected_text, heading_text)
             current_idx += 1
 
     def test_click_sidebar_links_instructor(self):


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently the forum has a temporary hidden h1 heading but we would like to make the breadcrumb into the heading for the forum.

### What is the new behavior?
While the page looks exactly the same, on the forum, the breadcrumb that says "Discussion Forum" is now a h1 tag. Every other page still has the normal h1 tag in the main section of the page.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
this solves one of the issues in #4491
See this specific comment for more details:
https://github.com/Submitty/Submitty/issues/4491#issuecomment-590667020
