### PR TITLE
[Feature:InstructorUI] link back from upload config page

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -244,7 +244,7 @@ class AdminGradeableController extends AbstractController {
 
             'timezone_string' => $this->core->getConfig()->getTimezone()->getName(),
 
-            'upload_config_url' => $this->core->buildCourseUrl(['autograding_config']),
+            'upload_config_url' => $this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $gradeable->getId(),
             'rebuild_url' => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'rebuild']),
             'csrf_token' => $this->core->getCsrfToken()
         ]);

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -22,7 +22,7 @@ class AutogradingConfigController extends AbstractController {
      * @param string $g_id gradeable Id
      * @return Response
      */
-    public function showConfig($g_id='') {
+    public function showConfig($g_id = '') {
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
         $all_files = FileUtils::getAllFiles($target_dir);
         $all_paths = array();

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -19,9 +19,10 @@ use Symfony\Component\Routing\Annotation\Route;
 class AutogradingConfigController extends AbstractController {
     /**
      * @Route("/{_semester}/{_course}/autograding_config", methods={"GET"})
+     * @param string $g_id gradeable Id
      * @return Response
      */
-    public function showConfig() {
+    public function showConfig($g_id='') {
         $target_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
         $all_files = FileUtils::getAllFiles($target_dir);
         $all_paths = array();
@@ -42,6 +43,7 @@ class AutogradingConfigController extends AbstractController {
                 'uploadConfigForm',
                 $target_dir,
                 $all_files,
+                $gradeable_id = $g_id,
                 $inuse_config
             )
         );

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -55,10 +55,13 @@ class AutogradingConfigController extends AbstractController {
      * @return Response
      */
     public function uploadConfig($g_id = '') {
+        $redirect_url = empty($g_id) ? $this->core->buildCourseUrl((['autograding_config']))
+            : $this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id;
+
         if (empty($_FILES) || !isset($_FILES['config_upload'])) {
             $this->core->addErrorMessage("Upload failed: No file to upload");
             return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+                new RedirectResponse($redirect_url)
             );
         }
 
@@ -66,7 +69,7 @@ class AutogradingConfigController extends AbstractController {
         if (!isset($upload['tmp_name']) || $upload['tmp_name'] === "") {
             $this->core->addErrorMessage("Upload failed: Empty tmp name for file");
             return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+                new RedirectResponse($redirect_url)
             );
         }
 
@@ -92,7 +95,7 @@ class AutogradingConfigController extends AbstractController {
                 $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
                 $this->core->addErrorMessage("Upload failed: {$error_message}");
                 return Response::RedirectOnlyResponse(
-                    new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+                    new RedirectResponse($redirect_url)
                 );
             }
         }
@@ -101,13 +104,13 @@ class AutogradingConfigController extends AbstractController {
                 FileUtils::recursiveRmdir($target_dir);
                 $this->core->addErrorMessage("Upload failed: Could not copy file");
                 return Response::RedirectOnlyResponse(
-                    new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+                    new RedirectResponse($redirect_url)
                 );
             }
         }
         $this->core->addSuccessMessage("Gradeable config uploaded");
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+            new RedirectResponse($redirect_url)
         );
     }
 
@@ -142,8 +145,10 @@ class AutogradingConfigController extends AbstractController {
                 }
             }
         }
+        $redirect_url = empty($g_id) ? $this->core->buildCourseUrl((['autograding_config']))
+            : $this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id;
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+            new RedirectResponse($redirect_url)
         );
     }
 
@@ -178,8 +183,10 @@ class AutogradingConfigController extends AbstractController {
                 $this->core->addErrorMessage("Deleting config failed.");
             }
         }
+        $redirect_url = empty($g_id) ? $this->core->buildCourseUrl((['autograding_config']))
+            : $this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id;
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
+            new RedirectResponse($redirect_url)
         );
     }
 

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -43,7 +43,7 @@ class AutogradingConfigController extends AbstractController {
                 'uploadConfigForm',
                 $target_dir,
                 $all_files,
-                $gradeable_id = $g_id,
+                $g_id,
                 $inuse_config
             )
         );
@@ -51,13 +51,14 @@ class AutogradingConfigController extends AbstractController {
 
     /**
      * @Route("/{_semester}/{_course}/autograding_config/upload", methods={"POST"})
+     * @param string $g_id gradeable Id
      * @return Response
      */
-    public function uploadConfig() {
+    public function uploadConfig($g_id = '') {
         if (empty($_FILES) || !isset($_FILES['config_upload'])) {
             $this->core->addErrorMessage("Upload failed: No file to upload");
             return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+                new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
             );
         }
 
@@ -65,7 +66,7 @@ class AutogradingConfigController extends AbstractController {
         if (!isset($upload['tmp_name']) || $upload['tmp_name'] === "") {
             $this->core->addErrorMessage("Upload failed: Empty tmp name for file");
             return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+                new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
             );
         }
 
@@ -91,7 +92,7 @@ class AutogradingConfigController extends AbstractController {
                 $error_message = ($res == 19) ? "Invalid or uninitialized Zip object" : $zip->getStatusString();
                 $this->core->addErrorMessage("Upload failed: {$error_message}");
                 return Response::RedirectOnlyResponse(
-                    new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+                    new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
                 );
             }
         }
@@ -100,21 +101,22 @@ class AutogradingConfigController extends AbstractController {
                 FileUtils::recursiveRmdir($target_dir);
                 $this->core->addErrorMessage("Upload failed: Could not copy file");
                 return Response::RedirectOnlyResponse(
-                    new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+                    new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
                 );
             }
         }
         $this->core->addSuccessMessage("Gradeable config uploaded");
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
         );
     }
 
     /**
      * @Route("/{_semester}/{_course}/autograding_config/rename", methods={"POST"})
+     * @param string $g_id gradeable Id
      * @return Response
      */
-    public function renameConfig() {
+    public function renameConfig($g_id = '') {
         $config_file_path = $_POST['curr_config_name'] ?? null;
         if ($config_file_path == null) {
             $this->core->addErrorMessage("Unable to find file");
@@ -141,15 +143,16 @@ class AutogradingConfigController extends AbstractController {
             }
         }
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
         );
     }
 
     /**
      * @Route("/{_semester}/{_course}/autograding_config/delete", methods={"POST"})
+     * @param string $g_id gradeable Id
      * @return Response
      */
-    public function deleteConfig() {
+    public function deleteConfig($g_id = '') {
         $config_path = $_POST['config_path'] ?? null;
         $in_use = false;
         foreach ($this->core->getQueries()->getGradeableConfigs(null) as $gradeable) {
@@ -176,7 +179,7 @@ class AutogradingConfigController extends AbstractController {
             }
         }
         return Response::RedirectOnlyResponse(
-            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']))
+            new RedirectResponse($this->core->buildCourseUrl(['autograding_config']) . '?g_id=' . $g_id)
         );
     }
 

--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -26,6 +26,8 @@
         Upload Config: <input type="file" name="config_upload" /><br />
         <input type="submit" value="Upload" />
     </form>
+    <br>
+    <a class="btn btn-primary" style="margin-top: 6px" href={{ back_url }}>Go Back To AutoGrading Page</a>
 </div>
 
 {% if all_files|length > 0 %}

--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -1,5 +1,11 @@
 {% import _self as self %}
 
+{% if gradeable_id|length %}
+    {% set upload_url = upload_url ~ '?g_id=' ~ gradeable_id %}
+    {% set rename_url = rename_url ~ '?g_id=' ~ gradeable_id %}
+    {% set delete_url = delete_url ~ '?g_id=' ~ gradeable_id %}
+{% endif %}
+
 <div class="content">
     <h1>Upload Autograding Config</h1>
     <br><br>
@@ -27,7 +33,9 @@
         <input type="submit" value="Upload" />
     </form>
     <br>
-    <a class="btn btn-primary" style="margin-top: 6px" href={{ back_url }}>Go Back To AutoGrading Page</a>
+    {% if gradeable_id|length %}
+        <a class="btn btn-primary" style="margin-top: 6px" href={{ back_url }}>Go Back To Autograding Page</a>
+    {% endif %}
 </div>
 
 {% if all_files|length > 0 %}

--- a/site/app/views/admin/GradeableView.php
+++ b/site/app/views/admin/GradeableView.php
@@ -5,7 +5,7 @@ namespace app\views\admin;
 use app\views\AbstractView;
 
 class GradeableView extends AbstractView {
-    public function uploadConfigForm($target_dir, $all_files, $inuse_config) {
+    public function uploadConfigForm($target_dir, $all_files, $gradeable_id, $inuse_config) {
         $this->core->getOutput()->addBreadcrumb("upload config", $this->core->buildCourseUrl(['autograding_config']));
         $course = $this->core->getConfig()->getCourse();
 
@@ -18,6 +18,9 @@ class GradeableView extends AbstractView {
             "rename_url" => $this->core->buildCourseUrl(['autograding_config', 'rename']),
             "delete_url" => $this->core->buildCourseUrl(['autograding_config', 'delete']),
             "display_url" => $this->core->buildCourseUrl(['display_file']),
+            "back_url" => $gradeable_id !== ''
+                ? $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'update?nav_tab=1'])
+                : $this->core->buildCourseUrl(),
             "csrf_token" => $this->core->getCsrfToken()
         ]);
     }

--- a/site/app/views/admin/GradeableView.php
+++ b/site/app/views/admin/GradeableView.php
@@ -13,14 +13,15 @@ class GradeableView extends AbstractView {
             "all_files" => $all_files,
             "target_dir" => $target_dir,
             "course" => $course,
+            "gradeable_id" => $gradeable_id,
             "inuse_config" => $inuse_config,
             "upload_url" => $this->core->buildCourseUrl(['autograding_config', 'upload']),
-            "rename_url" => $this->core->buildCourseUrl(['autograding_config', 'rename']),
             "delete_url" => $this->core->buildCourseUrl(['autograding_config', 'delete']),
+            "rename_url" => $this->core->buildCourseUrl(['autograding_config', 'rename']),
             "display_url" => $this->core->buildCourseUrl(['display_file']),
             "back_url" => $gradeable_id !== ''
                 ? $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'update?nav_tab=1'])
-                : $this->core->buildCourseUrl(),
+                : '',
             "csrf_token" => $this->core->getCsrfToken()
         ]);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
When an instructor is editing a gradeable, and uses the upload config option to upload the config.json & etc through the webpage, there is no way to go back to the edit gradeable page where he came from.

### What is the new behavior?
A link is shown on the config upload screen letting the instructor go back to the gradeable editing page on the exact same location from where he came from.

Closes issue #4619