### PR TITLE
[Bugfix:TAGrading] Stop TA Grading from Failing on Teams

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1173,10 +1173,10 @@ class ElectronicGraderController extends AbstractController {
         $section = null;
         
         if ($gradeable->isGradeByRegistration()) {
-            $section = $this->core->getQueries()->getUserById($submitter_id)->getRegistrationSection();
+            $section = $this->core->getQueries()->getSubmitterById($submitter_id)->getRegistrationSection();
         }
         else {
-            $section = $this->core->getQueries()->getUserById($submitter_id)->getRotatingSection();
+            $section = $this->core->getQueries()->getSubmitterById($submitter_id)->getRotatingSection();
         }
 
         // Get the graded gradeable


### PR DESCRIPTION
Updated the ```ajaxGetGradedGradeable``` function to use ```getSubmitterById``` rather than ```getUserById```. ```getSubmitterById``` is preferred, as it is a wrapper for ```getUserById``` and ```getTeamById``` which works for either team or user ids.