### PR TITLE
[Feature:Vagrant] Set vagrant to use localhost to access site

### DIFF
--- a/.setup/apache/submitty.conf
+++ b/.setup/apache/submitty.conf
@@ -1,6 +1,6 @@
 # If hosting more than just Submitty on Apache, you should set the
 # VirtualHost * to the domain name you use for Submitty (e.g. example.com)
-<VirtualHost *:80>
+<VirtualHost *:1501>
     AddDefaultCharset utf-8
 
     # Set the email address of your webmaster/sysadmin to be displayed incase

--- a/.setup/apache/submitty.conf
+++ b/.setup/apache/submitty.conf
@@ -1,6 +1,6 @@
 # If hosting more than just Submitty on Apache, you should set the
 # VirtualHost * to the domain name you use for Submitty (e.g. example.com)
-<VirtualHost *:1501>
+<VirtualHost *:80>
     AddDefaultCharset utf-8
 
     # Set the email address of your webmaster/sysadmin to be displayed incase

--- a/.setup/bin/recreate_sample_courses.sh
+++ b/.setup/bin/recreate_sample_courses.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Automated regeneration of sample course data 
+# Automated regeneration of sample course data
 
 ########################################################################
 
@@ -23,7 +23,7 @@ fi
 cd ../../
 
 python3 ./.setup/bin/partial_reset.py
-python3 ./.setup/bin/setup_sample_courses.py --no_submissions --submission_url http://192.168.56.111
+python3 ./.setup/bin/setup_sample_courses.py
 
 PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
 service php${PHP_VERSION}-fpm restart

--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -7,7 +7,7 @@ if [[ "$UID" -ne "0" ]] ; then
 fi
 
 if [ ${VAGRANT} == 1 ]; then
-    export SUBMISSION_URL='http://192.168.56.111'
+    export SUBMISSION_URL='http://localhost:1501'
     export DATABASE_PORT=16432
 fi
 

--- a/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/bionic/setup_distro.sh
@@ -8,6 +8,7 @@ fi
 
 if [ ${VAGRANT} == 1 ]; then
     export SUBMISSION_URL='http://localhost:1501'
+    export SUBMISSION_PORT=1501
     export DATABASE_PORT=16432
 fi
 

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -445,6 +445,7 @@ if [ ${WORKER} == 0 ]; then
         cp ${SUBMITTY_REPOSITORY}/.setup/apache/submitty.conf /etc/apache2/sites-available/submitty.conf
 
         sed -i -e "s/Require host __your_domain__/Require host localhost/g" /etc/apache2/sites-available/submitty.conf
+        sed -i -e "s/\*:80/*:${SUBMISSION_PORT}/g" /etc/apache2/sites-available/submitty.conf
 
         # permissions: rw- r-- ---
         chmod 0640 /etc/apache2/sites-available/*.conf

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -434,13 +434,17 @@ if [ ${WORKER} == 0 ]; then
         # comment out directory configs - should be converted to something more flexible
         sed -i '153,174s/^/#/g' /etc/apache2/apache2.conf
 
+        if ! grep -E -q "Listen 1501" /etc/apache2/ports.conf; then
+            echo "Listen 1501" >> /etc/apache2/ports.conf
+        fi
+
         # remove default sites which would cause server to mess up
         rm /etc/apache2/sites*/000-default.conf
         rm /etc/apache2/sites*/default-ssl.conf
 
         cp ${SUBMITTY_REPOSITORY}/.setup/apache/submitty.conf /etc/apache2/sites-available/submitty.conf
 
-        sed -i -e "s/Require host __your_domain__/Require ip ${SUBMISSION_URL:7}/g" /etc/apache2/sites-available/submitty.conf
+        sed -i -e "s/Require host __your_domain__/Require host localhost/g" /etc/apache2/sites-available/submitty.conf
 
         # permissions: rw- r-- ---
         chmod 0640 /etc/apache2/sites-available/*.conf

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,8 +48,9 @@ Vagrant.configure(2) do |config|
   # Our primary development target, this is what RPI uses as of Fall 2018
   config.vm.define 'ubuntu-18.04', primary: true do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-18.04'
-    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432
-    ubuntu.vm.network 'private_network', ip: '192.168.56.111'
+    ubuntu.vm.network 'forwarded_port', guest: 1501, host: 1501   # site
+    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432  # database
+
   end
 
   config.vm.provider 'virtualbox' do |vb|

--- a/site/tests/app/controllers/admin/ConfigurationControllerTester.php
+++ b/site/tests/app/controllers/admin/ConfigurationControllerTester.php
@@ -31,7 +31,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'email' => '{"email_enabled":true,"email_user":"","email_password":"","email_sender":"submitty@vagrant","email_reply_to":"do-not-reply@vagrant","email_server_hostname":"localhost","email_server_port":25}',
             'secrets_submitty_php' => '{"session":"cGRZSDnVxdDjQwGyiq4ECnJyiZ8IQXEL1guSsJ1XlSKSEqisqvdCPhCRcYDEjpjm"}',
             'submitty_admin' => '{"submitty_admin_username":"submitty-admin","submitty_admin_password":"submitty-admin","token":"token"}',
-            'submitty' => '{"submitty_install_dir":' . json_encode($this->test_dir) . ',"submitty_repository":' . json_encode($this->test_dir) . ',"submitty_data_dir":' . json_encode($this->test_dir) . ',"autograding_log_path":' . json_encode($this->test_dir) . ',"site_log_path":' . json_encode($this->test_dir) . ',"submission_url":"http:\/\/192.168.56.111","vcs_url":"","cgi_url":"http:\/\/192.168.56.111\/cgi-bin","institution_name":"","username_change_text":"foo","institution_homepage":"","timezone":"America\/New_York","worker":false}',
+            'submitty' => '{"submitty_install_dir":' . json_encode($this->test_dir) . ',"submitty_repository":' . json_encode($this->test_dir) . ',"submitty_data_dir":' . json_encode($this->test_dir) . ',"autograding_log_path":' . json_encode($this->test_dir) . ',"site_log_path":' . json_encode($this->test_dir) . ',"submission_url":"http:\/\/localhost:1501","vcs_url":"","cgi_url":"http:\/\/localhost:1501\/cgi-bin","institution_name":"","username_change_text":"foo","institution_homepage":"","timezone":"America\/New_York","worker":false}',
             'submitty_users' => '{"num_grading_scheduler_workers":5,"num_untrusted":60,"first_untrusted_uid":900,"first_untrusted_gid":900,"daemon_uid":1003,"daemon_gid":1006,"daemon_user":"submitty_daemon","course_builders_group":"submitty_course_builders","php_uid":1001,"php_gid":1004,"php_user":"submitty_php","cgi_user":"submitty_cgi","daemonphp_group":"submitty_daemonphp","daemoncgi_group":"submitty_daemoncgi","verified_submitty_admin_user":"submitty-admin"}',
             'version' => '{"installed_commit":"7da8417edd6ff46f1d56e1a938b37c054a7dd071","short_installed_commit":"7da8417ed","most_recent_git_tag":"v19.09.04"}'
         ];
@@ -93,7 +93,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'display_rainbow_grades_summary' => false,
             'display_custom_message'         => false,
             'course_email'                   => 'Please contact your TA or instructor to submit a grade inquiry.',
-            'vcs_base_url'                   => 'http://192.168.56.111/{$vcs_type}/f19/sample/',
+            'vcs_base_url'                   => 'http://localhost:1501/{$vcs_type}/f19/sample/',
             'vcs_type'                       => 'git',
             'forum_enabled'                  => true,
             'regrade_enabled'                => false,
@@ -170,7 +170,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'display_rainbow_grades_summary' => false,
             'display_custom_message'         => false,
             'course_email'                   => 'Please contact your TA or instructor to submit a grade inquiry.',
-            'vcs_base_url'                   => 'http://192.168.56.111/{$vcs_type}/f19/sample/',
+            'vcs_base_url'                   => 'http://localhost:1501/{$vcs_type}/f19/sample/',
             'vcs_type'                       => 'git',
             'forum_enabled'                  => true,
             'regrade_enabled'                => false,
@@ -254,7 +254,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'display_rainbow_grades_summary' => false,
             'display_custom_message'         => false,
             'course_email'                   => 'Please contact your TA or instructor to submit a grade inquiry.',
-            'vcs_base_url'                   => 'http://192.168.56.111/{$vcs_type}/f19/sample/',
+            'vcs_base_url'                   => 'http://localhost:1501/{$vcs_type}/f19/sample/',
             'vcs_type'                       => 'git',
             'forum_enabled'                  => true,
             'regrade_enabled'                => false,
@@ -385,7 +385,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
         $config->loadMasterConfigs($this->master_configs_dir);
         $config->loadCourseJson('f19', 'sample', $this->course_config);
         $core->setConfig($config);
-        
+
         $_POST['name'] = 'forum_enabled';
         $_POST['entry'] = 'true';
         $queries = $this->createMock(DatabaseQueries::class);

--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -25,7 +25,7 @@ class BaseTestCase(unittest.TestCase):
     override user_id, user_name, and user_password as necessary for a
     particular testcase and this class will handle the rest to setup the test.
     """
-    TEST_URL = "http://192.168.56.111"
+    TEST_URL = "http://localhost:1501"
     USER_ID = "student"
     USER_NAME = "Joe"
     USER_PASSWORD = "student"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Submitty under vagrant is accessible via a IP address (e.g. http://192.168.56.111/) which is a historical remanent when this was necessary as we were running multiple components under different URLs (submission, vcs, cgi) as well as potentially multiple different distros.

### What is the new behavior?

Submitty would be accessible under localhost with a port specific to a given distro. This is set-up so that the same URL (e.g. http://localhost:1501) would be accessible both within and outside the VM so that all things continue to work as expected where some requests are from the host (e.g. from the user) and within the guest (e.g. requests to cgi-bin, submitty admin usage, etc.).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

I tested that after doing a fresh `vagrant up`, I could:
* access the site and log in
* use git