### PR TITLE
[BugFix:Plagiarism] Fix exception when creating configuration for a new gradeable

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -165,8 +165,7 @@ class PlagiarismController extends AbstractController {
         }
 
         $prior_term_gradeables = $this->getGradeablesFromPriorTerm();
-
-        $this->core->getOutput()->renderOutput(array('admin', 'Plagiarism'), 'configureGradeableForPlagiarismForm', 'new', $gradeable_ids_titles, $prior_term_gradeables, null);
+        $this->core->getOutput()->renderOutput(array('admin', 'Plagiarism'), 'configureGradeableForPlagiarismForm', 'new', $gradeable_ids_titles, $prior_term_gradeables, null, null);
     }
 
     /**


### PR DESCRIPTION
### What is the current behavior?
Submitty will crash on loading configuration page for new gradeables. 

### What is the new behavior?
This fix will prevent the crash.
