### PR TITLE
[UI:InstructorUI] On page documentation for edit rubric page radio buttons

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -71,13 +71,13 @@ Form
 <div id="doc_all_access">
     <br />
 
-    All <span class="g1_hidden"> instructors </span><span class="g2_hidden"> full access graders </span><span class="g3_hidden"> limited access graders </span> will have access to grade all students, organized by rotating sections.
+    All <span class="g3"> limited access graders, </span> <span class="g2"> full access graders</span><span class ="g3">,</span> <span class ="g2"> and </span> </span><span class="g1"> instructors </span> will have access to grade all students, organized by rotating sections.
     <br />
 </div>
 
 <div id="doc_registration">
     <br />
-    All <span class="g1_hidden"> instructors </span><span class="g2_hidden"> full access graders </span><span class="g3_hidden"> limited access graders </span> will have access to grade students in registration sections assigned on the 'Manage Sections' page (click on the pencil to edit a grader's assigned registration sections).
+    All <span class="g3"> limited access graders, </span> <span class="g2"> full access graders</span><span class ="g3">,</span> <span class ="g2"> and </span> </span><span class="g1"> instructors </span> will have access to grade students in registration sections assigned on the 'Manage Sections' page (click on the pencil to edit a grader's assigned registration sections).
     <br />
 </div>
 
@@ -201,31 +201,21 @@ Form
         // $('.g1').show();
         // $('.g2').show();
 
-        //rotating sections tables: all shown on page by default,
+        //used by rotating sections tables and radio buttons on page documentation
+        //: all shown on page by default,
         //and less privileged graders hidden as access is more restricted
         disableElementChildren('.g2', false);
         disableElementChildren('.g3', false);
 
-        //radio buttons documentation: hidden by default
-        //and shown when the specific class is selected
-        disableElementChildren('.g1_hidden', true);
-        disableElementChildren('.g2_hidden', true);
-        disableElementChildren('.g3_hidden', true);
-
+       
         switch ($('#minimum_grading_group').val()) {
             case '1': // Instructor only?
                 // $('.g1').hide();
-                disableElementChildren('.g1_hidden', false);
                 disableElementChildren('.g2', true);
-                disableElementChildren('.g3', true);
-                break;
             case '2': // Instructors and TA's
                 // $('.g2').hide();
-                disableElementChildren('.g2_hidden', false);
                 disableElementChildren('.g3', true);
-                break;
             case '3': // Everyone
-                disableElementChildren('.g3_hidden', false);
                 break;
             default:
                 alert('Error!  Invalid Minimum Grader!');

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -59,7 +59,7 @@ Form
         <a class="fa-question-circle" target=_blank aria-label="Help for grading by registration or rotating section" href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section"></a>
     </legend>
 	<input type="radio" name="grader_assignment_method" value="2" id="all_access"
-        {{ (gradeable.getGraderAssignmentMethod() == 2) ? 'checked' : '' }}> <label for="grader_assignment_method">All Access Grading</label>
+        {{ (gradeable.getGraderAssignmentMethod() == 2) ? 'checked' : '' }}> <label for="all_access">All Access Grading</label>
 
     <input type="radio" name="grader_assignment_method" value="1" id="registration_section"
         {{ (gradeable.getGraderAssignmentMethod() == 1 or action == "new") ? 'checked' : '' }}> <label for="registration_section">Registration Section</label>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -58,7 +58,7 @@ Form
         How should graders be assigned to grade this item?
         <a class="fa-question-circle" target=_blank aria-label="Help for grading by registration or rotating section" href="http://submitty.org/instructor/create_edit_gradeable#grading-by-registration-section-or-rotating-section"></a>
     </legend>
-	<input type="radio" name="grader_assignment_method" id="grader_assignment_method" value="2" id="all_access"
+	<input type="radio" name="grader_assignment_method" value="2" id="all_access"
         {{ (gradeable.getGraderAssignmentMethod() == 2) ? 'checked' : '' }}> <label for="grader_assignment_method">All Access Grading</label>
 
     <input type="radio" name="grader_assignment_method" value="1" id="registration_section"
@@ -67,6 +67,21 @@ Form
     <input type='radio' name="grader_assignment_method" value="0" id="rotating_section"
         {{ (gradeable.getGraderAssignmentMethod() == 0) ? 'checked' : '' }}> <label for="rotating_section">Rotating Section</label>
 </fieldset>
+
+<div id="doc_all_access">
+    <br />
+
+    All <span class="g1_hidden"> instructors </span><span class="g2_hidden"> full access graders </span><span class="g3_hidden"> limited access graders </span> will have access to grade all students, organized by rotating sections.
+    <br />
+</div>
+
+<div id="doc_registration">
+    <br />
+    All <span class="g1_hidden"> instructors </span><span class="g2_hidden"> full access graders </span><span class="g3_hidden"> limited access graders </span> will have access to grade students in registration sections assigned on the 'Manage Sections' page (click on the pencil to edit a grader's assigned registration sections).
+    <br />
+</div>
+
+
 <div id="rotating_data">
     {% if rotating_gradeables|length != 0 and num_rotating_sections > 0 %}
         <br />
@@ -162,15 +177,21 @@ Form
     }
 
     function onSectionTypeChange() {
+
+        disableElementChildren('#doc_all_access', true);
+        disableElementChildren('#doc_registration', true);
+
         if ($('#rotating_section').is(':checked')) {
             disableElementChildren('#rotating_data', false);
             disableElementChildren('#grader-warning',false);
         }
         else if ($('#all_access').is(':checked')) {
+            disableElementChildren('#doc_all_access', false);
             disableElementChildren('#rotating_data', true);
             disableElementChildren('#grader-warning',false);
         }
         else {
+            disableElementChildren('#doc_registration', false);
             disableElementChildren('#rotating_data', true);
             disableElementChildren('#grader-warning',true);
         }
@@ -180,24 +201,38 @@ Form
         // $('.g1').show();
         // $('.g2').show();
 
+        //rotating sections tables: all shown on page by default,
+        //and less privileged graders hidden as access is more restricted
         disableElementChildren('.g2', false);
         disableElementChildren('.g3', false);
+
+        //radio buttons documentation: hidden by default
+        //and shown when the specific class is selected
+        disableElementChildren('.g1_hidden', true);
+        disableElementChildren('.g2_hidden', true);
+        disableElementChildren('.g3_hidden', true);
 
         switch ($('#minimum_grading_group').val()) {
             case '1': // Instructor only?
                 // $('.g1').hide();
+                disableElementChildren('.g1_hidden', false);
                 disableElementChildren('.g2', true);
+                disableElementChildren('.g3', true);
+                break;
             case '2': // Instructors and TA's
                 // $('.g2').hide();
+                disableElementChildren('.g2_hidden', false);
                 disableElementChildren('.g3', true);
+                break;
             case '3': // Everyone
+                disableElementChildren('.g3_hidden', false);
                 break;
             default:
                 alert('Error!  Invalid Minimum Grader!');
                 break;
         }
     }
-
+    
     $(document).ready(function() {
         // Hide rotating sections settings if on registration sections
         onSectionTypeChange();

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -81,7 +81,6 @@ Form
     <br />
 </div>
 
-
 <div id="rotating_data">
     {% if rotating_gradeables|length != 0 and num_rotating_sections > 0 %}
         <br />
@@ -202,11 +201,8 @@ Form
         // $('.g2').show();
 
         //used by rotating sections tables and radio buttons on page documentation
-        //: all shown on page by default,
-        //and less privileged graders hidden as access is more restricted
         disableElementChildren('.g2', false);
         disableElementChildren('.g3', false);
-
        
         switch ($('#minimum_grading_group').val()) {
             case '1': // Instructor only?


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?

Part 1 of #4988 (doesn't close the issue because there's a second part about limited access graders & all access grading errors)
Currently, there is no on page documentation for when all "access grading" or "registration section grading" radio buttons are selected on the edit rubric page under the "grader assignment" tab for instructors.

### What is the new behavior?

The descriptions were added under the radio buttons, and it is updated when a different access grader is selected from the dropdown menu.
![PRnew](https://user-images.githubusercontent.com/43322572/75506743-f5b8d700-59ac-11ea-8397-c8457646ed62.gif)