### PR TITLE
[Bugfix:PHP] Lint error

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1048,7 +1048,7 @@ class ElectronicGraderController extends AbstractController {
         if ($previousVersion && $late_status !== LateDayInfo::STATUS_GOOD) {
             while ($previousVersion) {
                 $prevVersionInstance = $graded_gradeable->getAutoGradedGradeable()->getAutoGradedVersionInstance($previousVersion);
-                if($prevVersionInstance == null) {
+                if ($prevVersionInstance == null) {
                     $rollbackSubmission = -1;
                     break;
                 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Following error
FILE: ...mitty/Submitty/site/app/controllers/grading/ElectronicGraderController.php

--------------------------------------------------------------------------------

FOUND 2 ERRORS AFFECTING 1 LINE

--------------------------------------------------------------------------------

 1051 | ERROR | [ ] Expected "if (...) {\n"; found "if(...) {\n"

      |       |     (SubmittyStandard.ControlStructures.StroustrupStructure.Found)

 1051 | ERROR | [x] Expected 1 space(s) after IF keyword; 0 found

      |       |     (Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword)

--------------------------------------------------------------------------------

PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY

--------------------------------------------------------------------------------

### What is the new behavior?
Fixes php linting error that snuck into master

### Other information?
<!-- Is this a breaking change? --> no
<!-- How did you test --> phpcbf
