### PR TITLE
[Bugfix:Submission] empty submitter error for instructor team submission

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -314,13 +314,6 @@
                     {# Handle if cell is multiple choice #}
                     {% elseif cell.type == "multiple_choice" %}
                         {% if cell.randomize_order == true %}
-
-                            {% if team_assignment %}
-                                {% set student_id = submitter.getUser().getLeaderId() %}
-                            {% else %}
-                                {% set student_id = submitter.getUser().getId() %}
-                            {% endif %}
-
                             {% set choices_indices = numberUtils.getRandomIndices(cell.choices|length, student_id, gradeable_id ) %}
                         {% else %}
                             {% set choices_indices = numberUtils.getIndices(cell.choices) %}

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -354,6 +354,12 @@ class HomeworkView extends AbstractView {
         $input_data = array_map(function (AbstractGradeableInput $inp) {
             return $inp->toArray();
         }, $inputs);
+        $student_id = '';
+        if (!is_null($graded_gradeable)) {
+            $student_id = ($graded_gradeable->getSubmitter()->isTeam()) ?
+                $graded_gradeable->getSubmitter()->getTeam()->getLeaderId() :
+                $graded_gradeable->getSubmitter()->getId();
+        }
 
         $highest_version = $graded_gradeable !== null ? $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : 0;
 
@@ -410,7 +416,7 @@ class HomeworkView extends AbstractView {
             'student_page' => $student_page,
             'students_full' => $students_full,
             'team_assignment' => $gradeable->isTeamAssignment(),
-            'submitter' => $graded_gradeable->getSubmitter(),
+            'student_id' => $student_id,
             'numberUtils' => $numberUtils,
             'late_days_use' => $late_days_use,
             'old_files' => $old_files,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
1. Login as instructor
2. Go to sample course
3. Click on a team assignment
![error](https://user-images.githubusercontent.com/34754780/75615987-ddfe6180-5b18-11ea-9f62-af6b49c4f004.png)


### What is the new behavior?
Added check for null `$graded_gradeable` object
Cleaned up twig code
