### PR TITLE
[Feature:Forum] Hides show history button when there is no history to show.

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -566,6 +566,10 @@ WHERE status = 1"
         return intval($this->course_db->rows()[0]['user_group']) <= 3;
     }
 
+    public function postHasHistory($post_id){
+        $this->course_db->query("SELECT * FROM forum_posts_history WHERE post_id = ?", array($post_id));
+        return 0 !== count($this->course_db->rows());
+    }
 
     public function getUnviewedPosts($thread_id, $user_id) {
         if ($thread_id == -1) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -566,7 +566,7 @@ WHERE status = 1"
         return intval($this->course_db->rows()[0]['user_group']) <= 3;
     }
 
-    public function postHasHistory($post_id){
+    public function postHasHistory($post_id) {
         $this->course_db->query("SELECT * FROM forum_posts_history WHERE post_id = ?", array($post_id));
         return 0 !== count($this->course_db->rows());
     }

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -46,7 +46,7 @@
             <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="$('html, #posts_list').animate({ scrollTop: document.getElementById('posts_list').scrollHeight }, 'slow');"> Reply</a>
         {% endif %}
 
-        {% if userGroup <= 3 %}
+        {% if userGroup <= 3 and has_history %}
             <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showHistory({{ post.id }})">Show History</a>
         {% endif %}
 

--- a/site/app/templates/forum/GeneratePostList.twig
+++ b/site/app/templates/forum/GeneratePostList.twig
@@ -39,7 +39,8 @@
         "thread_id": post_d.thread_id,
         "parent_id": post_d.parent_id,
         "show_unresolve": show_unresolve,
-        "render_markdown": post_d.render_markdown
+        "render_markdown": post_d.render_markdown,
+        "has_history": post_d.has_history
     } only %}
 
 {% endfor %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -932,6 +932,8 @@ class ForumThreadView extends AbstractView {
             $GLOBALS['post_box_id'] = $post_box_id = isset($GLOBALS['post_box_id']) ? $GLOBALS['post_box_id'] + 1 : 1;
         }
 
+        $has_history = $this->core->getQueries()->postHasHistory($post_id);
+
         return [
             "classes" => $classes,
             "post_id" => $post_id,
@@ -958,7 +960,8 @@ class ForumThreadView extends AbstractView {
             "post_box_id" => $post_box_id,
             "thread_id" => $thread_id,
             "parent_id" => $post_id,
-            "render_markdown" => $markdown
+            "render_markdown" => $markdown,
+            "has_history" => $has_history
         ];
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is a show history button even though there is no history to show
![image](https://user-images.githubusercontent.com/18558130/75617329-b369d400-5b2b-11ea-8a1b-e25404bf62e3.png)
![image](https://user-images.githubusercontent.com/18558130/75617331-bf559600-5b2b-11ea-9699-1ade50e844ad.png)


### What is the new behavior?
That button is no longer visible
![image](https://user-images.githubusercontent.com/18558130/75617342-d5fbed00-5b2b-11ea-908d-1b8bc7fbe0fe.png)

