### PR TITLE
[Testing:InstructorUI] Added e2e tests to check for new w3 validator errors

### DIFF
--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -19,7 +19,7 @@
 
                 {% if is_debug %}
                     <span class="footer-separator">|</span>
-                    <a href="#" onClick="togglePageDetails();" class="black-btn">Show Page Details</a>
+                    <a href="#" onClick="togglePageDetails();" class="black-btn key_to_click" tabindex="0">Show Page Details</a>
                 {% endif %}
             </footer>
         </div> {# /#submitty-body #}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -140,6 +140,7 @@
                          height = "50"
                          {% if enable_banner %}
                             style="position:absolute; right: 10px;"
+                            class="key_to_click"
                             onclick="ducky();"
                             tabindex="0"
                          {% endif %}
@@ -198,7 +199,7 @@
                             {% endif %}
                             {{ message.error | nl2br }}
                         </span>
-                        <a class="fas fa-times" onClick="removeMessagePopup('{{ message.type }}-{{ message.key }}');"></a>
+                        <a class="fas fa-times key_to_click" tabindex="0" onClick="removeMessagePopup('{{ message.type }}-{{ message.key }}');"></a>
                     </div>
                 {% endfor %}
             </div>

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -77,7 +77,7 @@
     {% if button is null %}
         <div class="button-placeholder"></div>
     {% else %}
-        <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }}"
+        <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }} {% if button.hasOnclick() %} key_to_click {% endif %}" tabindex="0"
             {% if button.isDisabled() %}
                 disabled
             {% else %}

--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -17,15 +17,15 @@
                 {# When adding a new notification setting make sure to add the notification-setting-input or the email-setting-input #}
                 <div class="button-group">
                     <div class="button-row">
-                        <button type="button" class="notification-setting-button btn" data-selector=".notification-setting-input" onclick="checkAll(this)">Subscribe to all notifications</button>
-                        <button type="button" class="notification-setting-button btn" data-selector=".notification-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional notifications</button>
-                        <button type="button" class="notification-setting-button btn" data-selector=".notification-setting-input" onclick="resetNotification(this)">Reset notification settings</button>
+                        <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="checkAll(this)">Subscribe to all notifications</button>
+                        <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional notifications</button>
+                        <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="resetNotification(this)">Reset notification settings</button>
                     </div>
                     {% if email_enabled %}
                         <div class="button-row">
-                            <button type="button" class="notification-setting-button btn" data-selector=".email-setting-input" onclick="checkAll(this)">Subscribe to all emails</button>
-                            <button type="button" class="notification-setting-button btn" data-selector=".email-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional emails</button>
-                            <button type="button" class="notification-setting-button btn" data-selector=".email-setting-input" onclick="resetNotification(this)">Reset email settings</button>
+                            <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="checkAll(this)">Subscribe to all emails</button>
+                            <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional emails</button>
+                            <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="resetNotification(this)">Reset email settings</button>
                         </div>
                     {% endif %}
                 </div>
@@ -321,13 +321,13 @@
                     try {
                         var json = JSON.parse(data);
                         if(json['status'] == 'fail') {
-                            var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
+                            var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close key_to_click" tabindex="0" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
                         }
                         else {
-                            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['data'] + '</div>';
+                            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close key_to_click" tabindex="0" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['data'] + '</div>';
                         }
                     } catch(err) {
-                        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
+                        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close key_to_click" tabindex="0" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
                     }
                     $('#notification-settings').css('display', 'none');
                     $('#messages').empty();

--- a/site/app/templates/admin/GradeOverride.twig
+++ b/site/app/templates/admin/GradeOverride.twig
@@ -28,7 +28,7 @@
                         <option value="{{value['g_id']}}" >{{ value['g_title'] }}</option>
                     {% endfor %}
                 </select>
-                <button type="button" class="btn btn-primary" style="margin-top: 10px" onclick="loadOverriddenGrades($('#g_id').val())"> Apply Changes </button>
+                <button type="button" class="btn btn-primary key_to_click" tabindex="0" style="margin-top: 10px" onclick="loadOverriddenGrades($('#g_id').val())"> Apply Changes </button>
             </div>
         </div>
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -17,7 +17,7 @@
             No changes to save
         </div>
         <div id="save_status_buttons">
-            <input id="save_status_button" type="button" value="Save Changes" onclick="ajaxUpdateJSON();" />
+            <input id="save_status_button" class="key_to_click" tabindex="0" type="button" value="Save Changes" onclick="ajaxUpdateJSON();" />
             <input id="show_log_button" type="button" value="Log" />
         </div>
         <div id="save_status_log"></div>

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -24,7 +24,7 @@
                 </td>
                 <td width="5%"> </td>
                 <td width="45%" style="position:relative">
-                    <button id="grade-summaries-button" onclick="location.href='{{ summaries_url }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
+                    <button id="grade-summaries-button" onclick="location.href='{{ summaries_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
                 </td>
             </tr>
             <tr>
@@ -42,7 +42,7 @@
                 </td>
                 <td width="5%"> </td>
                 <td width="45%" style="position:relative">
-                    <button onclick="location.href='{{ csv_url }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
+                    <button onclick="location.href='{{ csv_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
                 </td>
             </tr>
             <tr class="bar"></tr>
@@ -54,7 +54,7 @@
                 </td>
                 <td width="5%"> </td>
                 <td width="45%" style="position:relative">
-                    <button onclick="location.href='{{ rainbow_grades_customization_url }}'" class="btn btn-primary" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Web-Based Rainbow Grades Generation</button>
+                    <button onclick="location.href='{{ rainbow_grades_customization_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Web-Based Rainbow Grades Generation</button>
                 </td>
             </tr>
             <tbody>

--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -87,20 +87,20 @@
         {% if file.files != null %}
             <div>
                 {% if indent == 1 %}
-                    <a class="fas fa-pencil-alt" onclick="openRenamePopup('{{ file.path }}')"></a>
+                    <a class="fas fa-pencil-alt key_to_click" tabindex="0" onclick="openRenamePopup('{{ file.path }}')"></a>
                     {% if file.path not in inuse_config %}
-                        <a class="fas fa-trash" onclick="openDeletePopup('{{ file.path }}')"></a>
+                        <a class="fas fa-trash key_to_click" tabindex="0" onclick="openDeletePopup('{{ file.path }}')"></a>
                     {% endif %}
                 {% endif %}
-                <span id='{{ id }}-span' class='fa icon-folder-closed'></span><a onclick='openDiv("{{ id }}");'>{{ seen_root ? name : file.path }}</a>
+                <span id='{{ id }}-span' class='fa icon-folder-closed'></span><a class="key_to_click" tabindex="0" onclick='openDiv("{{ id }}");'>{{ seen_root ? name : file.path }}</a>
                 <div id='{{ id }}' style='margin-left: {{ margin_left }}px; display: none'>
                     {{ self.display_files(self, file.files, indent + 1, true, inuse_config, display_url) }}
                 </div>
             </div>
         {% else %}
             <div>
-                <div class="file-viewer"><a onclick='openFrame("{{ display_url }}?dir=config_upload&path={{ file.path | url_encode }}", "{{ id }}", "{{ file.name }}")'>
-                    <span class='icon-plus'></span>{{ file.name }}</a> <a onclick='openUrl("{{ display_url }}?dir=config_upload&path={{ file.path | url_encode }}")'>(Popout)</a>
+                <div class="file-viewer"><a class="key_to_click" tabindex="0" onclick='openFrame("{{ display_url }}?dir=config_upload&path={{ file.path | url_encode }}", "{{ id }}", "{{ file.name }}")'>
+                    <span class='icon-plus'></span>{{ file.name }}</a> <a class="key_to_click" tabindex="0" onclick='openUrl("{{ display_url }}?dir=config_upload&path={{ file.path | url_encode }}")'>(Popout)</a>
                 </div>
                 <div id="file_viewer_{{ id }}" style='margin-left: {{ neg_margin_left }}px'></div>
             </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -46,7 +46,7 @@
     <div class="settings">
         <input class="config_search ignore" type="text" id="config_search" list="path_data" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
             autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration" />
-        <a class="fas fa-times" id= "clear_search_button" onclick="clearButtonPress();">
+        <a class="fas fa-times" id= "clear_search_button" onclick="clearButtonPress();" class="key_to_click" tabindex="0">
         <datalist id="path_data" style="display:none" >
         {% for path in all_config_paths %}
             <option class="path_autofill_option" data-value="{{path.1}}"  style="display:none" >{{path.0}}</option>
@@ -63,7 +63,7 @@
     <br><br>
 
     <div class="btn-container" id="rebuild-gradeable-button">
-        <a class="btn btn-primary" onclick="ajaxRebuildGradeableButton()">Rebuild Gradeable</a>
+        <a class="btn btn-primary key_to_click" tabindex="0" onclick="ajaxRebuildGradeableButton()">Rebuild Gradeable</a>
     </div>
 
     <div id="rebuild-status-panel">
@@ -72,8 +72,8 @@
     </div>
 
     <div id="rebuild-log-button">
-        <input type="button" class="btn btn-default" id="open-build-log" type="button" value="Open Build Log" onclick="showBuildLog()" />
-        <input type="button" class="btn btn-primary" id="close-build-log" type="button" value="Close Build Log" onclick="hideBuildLog()" />
+        <input type="button" class="btn btn-default key_to_click" tabindex="0" id="open-build-log" type="button" value="Open Build Log" onclick="showBuildLog()" />
+        <input type="button" class="btn btn-primary key_to_click" tabindex="0" id="close-build-log" type="button" value="Close Build Log" onclick="hideBuildLog()" />
     </div>
 
     <div class="log-container" hidden>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -23,11 +23,11 @@
         </div>
         <br/>
         <div class="tab-bar-wrapper">
-            <a class="nav-bar" id="page_0_nav" href="javascript:onChangeNavTab(0);">General</a>
-            <a class="nav-bar" id="page_1_nav" href="javascript:onChangeNavTab(1);">Submissions/Autograding</a>
-            <a class="nav-bar" id="page_2_nav" href="javascript:onChangeNavTab(2);">Rubric</a>
-            <a class="nav-bar" id="page_3_nav" href="javascript:onChangeNavTab(3);">Grader Assignment</a>
-            <a class="nav-bar" id="page_4_nav" href="javascript:onChangeNavTab(4);">Dates</a>
+            <a class="nav-bar key_to_click" id="page_0_nav" onclick="onChangeNavTab(0);">General</a>
+            <a class="nav-bar key_to_click" id="page_1_nav" onclick="onChangeNavTab(1);">Submissions/Autograding</a>
+            <a class="nav-bar key_to_click" id="page_2_nav" onclick="onChangeNavTab(2);">Rubric</a>
+            <a class="nav-bar key_to_click" id="page_3_nav" onclick="onChangeNavTab(3);">Grader Assignment</a>
+            <a class="nav-bar key_to_click" id="page_4_nav" onclick="onChangeNavTab(4);">Dates</a>
         </div>
         <br/>
         <br/>
@@ -44,8 +44,8 @@
         </div>
         <br/>
         <div id="nav-controls">
-            <!--<button class="btn btn-primary" id="next_button" onClick="onChangeNavTab(adminGradeableNavTab+1);" style="margin-right:10px; float: right;">Next</button>
-            <button class="btn btn-primary" id="prev_button" onClick="onChangeNavTab(adminGradeableNavTab-1);" style="margin-right:10px; float: right;">Previous</button>-->
+            <!--<button class="btn btn-primary key_to_click" tabindex="0" id="next_button" onClick="onChangeNavTab(adminGradeableNavTab+1);" style="margin-right:10px; float: right;">Next</button>
+            <button class="btn btn-primary key_to_click" tabindex="0" id="prev_button" onClick="onChangeNavTab(adminGradeableNavTab-1);" style="margin-right:10px; float: right;">Previous</button>-->
             <!--<button class="btn btn-primary" type="submit" style="margin-right:10px; float: right;">Discard Changes</button>-->
         </div>
     </form>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -84,8 +84,8 @@
 
     <br />
 
-    <input type="button" class="btn btn-default" value="Show All Dates" id="show_all_dates" onclick="showAllDates()" />
-    <input type="button" class="btn btn-primary" value="Hide Irrelevant Dates" id="hide_dates" onclick="hideDates()" hidden/>
+    <input type="button" class="btn btn-default key_to_click" tabindex="0" value="Show All Dates" id="show_all_dates" onclick="showAllDates()" />
+    <input type="button" class="btn btn-primary key_to_click" tabindex="0" value="Hide Irrelevant Dates" id="hide_dates" onclick="hideDates()" hidden/>
 
     <br />
     <span id="gray_date_warning" hidden>Note: grayed-out dates are for debugging & consistency checks.  These dates are not relevant with your current assignment configuration.</span>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -8,11 +8,11 @@ Macros
     {% for grader in graders %}
         <tr class="{{ prefix }}">
             <th>{{ grader[1] ~ " " ~ grader[2] ~ "(" ~ grader[0] ~ ")" }}</th>
-            <td><input type="checkbox" name="{{ prefix }}_all_{{ grader[0] }}" id="{{ prefix }}_all_{{ grader[0] }}"
+            <td><input class="key_to_click" tabindex="0" type="checkbox" name="{{ prefix }}_all_{{ grader[0] }}" id="{{ prefix }}_all_{{ grader[0] }}"
                        aria-label="all rotating sections"
                        onclick='updateCheckBoxes("{{ prefix }}", "{{ grader[0] }}", 0)'/></td>
             {% for rs in section_numbers %}
-                <td><input type="checkbox" name="grader_{{ prefix }}_{{ rs }}_{{ grader[0] }}"
+                <td><input class="key_to_click" tabindex="0" type="checkbox" name="grader_{{ prefix }}_{{ rs }}_{{ grader[0] }}"
                         id="grader_{{ prefix }}_{{ rs }}_{{ grader[0] }}"
                         aria-label="rotating section {{ rs }}"
                         onclick='updateCheckBoxes("{{ prefix }}", "{{ grader[0] }}", {{ rs }});'

--- a/site/app/templates/admin/users/DownloadForm.twig
+++ b/site/app/templates/admin/users/DownloadForm.twig
@@ -29,7 +29,7 @@
 {% block buttons %}
     <div class="btn-wrapper wrap-reverse float-right">
         {{ block('close_button') }}
-        <input class="btn btn-primary" type="button" value="Download CSV" onclick="downloadCSV('{{ code }}');" />
-        <input class="btn btn-primary" type="button" id="copybuttonid" value="Copy Emails to Clipboard" onclick="copyToClipboard('{{ code }}');" />
+        <input class="btn btn-primary key_to_click" tabindex="0" type="button" value="Download CSV" onclick="downloadCSV('{{ code }}');" />
+        <input class="btn btn-primary key_to_click" tabindex="0" type="button" id="copybuttonid" value="Copy Emails to Clipboard" onclick="copyToClipboard('{{ code }}');" />
     </div>
 {% endblock %}

--- a/site/app/templates/admin/users/RegistrationSectionsForm.twig
+++ b/site/app/templates/admin/users/RegistrationSectionsForm.twig
@@ -1,5 +1,5 @@
 {% import _self as self %} {# Required to use macros in same template #}
-{# 
+{#
 Macros
 #}
 {# Display the checkboxes for a given set of graders at a grader level #}
@@ -10,9 +10,9 @@ Macros
             <td>
 				<label>
 					<span class="screen-reader">Can {{ grader.getId() }} grade all sections</span>
-					<input type="checkbox" name="{{ grader.getId() }}_all" id="{{ grader.getId() }}_all" 
-						{{ grader.getGradingRegistrationSections()|length == reg_sections|length ? 'checked' : ''}} 
-						onclick="fixCheckBoxes('{{ grader.getId() }}',true);" 
+					<input class="key_to_click" tabindex="0" type="checkbox" name="{{ grader.getId() }}_all" id="{{ grader.getId() }}_all"
+						{{ grader.getGradingRegistrationSections()|length == reg_sections|length ? 'checked' : ''}}
+						onclick="fixCheckBoxes('{{ grader.getId() }}',true);"
 					/>
 				</label>
 			</td>
@@ -20,9 +20,9 @@ Macros
 			<td>
 				<label>
 					<span class="screen-reader">Can {{ grader.getId() }} grade section {{ section['sections_registration_id'] }}</span>
-					<input type="checkbox" name="{{ grader.getId() }}_{{section['sections_registration_id']}}" 
-						id="{{ grader.getId() }}_{{section['sections_registration_id']}}" 
-						{{ section['sections_registration_id'] in grader.getGradingRegistrationSections() ? 'checked' : ''}} 
+					<input class="key_to_click" tabindex="0" type="checkbox" name="{{ grader.getId() }}_{{section['sections_registration_id']}}"
+						id="{{ grader.getId() }}_{{section['sections_registration_id']}}"
+						{{ section['sections_registration_id'] in grader.getGradingRegistrationSections() ? 'checked' : ''}}
 						onclick="fixCheckBoxes('{{ grader.getId() }}',false);"
 					/>
 				</label>
@@ -63,7 +63,7 @@ Macros
 			{{ self.display_graders(graders[3], reg_sections) }}
 		{% elseif num_rotating_sections == 0 %}
 			<p><b>
-				Rotating Sections have not been set up yet. <br/> 
+				Rotating Sections have not been set up yet. <br/>
 				You can set up Rotating Sections using the "Manage Sections" option on the sidebar.
 			</b></p>
 		{% endif %}

--- a/site/app/templates/admin/users/UserForm.twig
+++ b/site/app/templates/admin/users/UserForm.twig
@@ -14,7 +14,7 @@
 			<p id="user-form-already-exists-error-message">
 				User is already in this course. Click to edit:
 				<td>
-					<a id="redirect-link-icon" onclick="redirectToEdit();" aria-label="edit entered user">
+					<a id="redirect-link-icon" class="key_to_click" tabindex="0" onclick="redirectToEdit();" aria-label="edit entered user">
 						<i class="fas fa-pencil-alt"></i>
 					</a>
 				</td>
@@ -105,6 +105,6 @@
     </form>
 {% endblock %}
 {% block buttons %}
-    <a onclick="closeButton()" class="btn btn-default close-button">Close</a>
+    <a onclick="closeButton()" class="btn btn-default close-button key_to_click" tabindex="0">Close</a>
     <input class="btn btn-primary" type="submit" value="Submit" id="user-form-submit" />
 {% endblock %}

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -10,7 +10,7 @@
         <br>
         {% if check.actual %}
         <div style="height:23px; float:right;">
-            <a id="show_char_{{ index }}_{{ loop.index0 }}" class="btn btn-default" style="float:right;" onclick="changeDiffView('container_{{ index }}_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ who }}', '{{ display_version }}', '{{ index }}', '{{ loop.index0 }}', 'white_space_helper_{{ index }}')">Visualize whitespace characters</a>
+            <a id="show_char_{{ index }}_{{ loop.index0 }}" class="btn btn-default key_to_click" tabindex="0" style="float:right;" onclick="changeDiffView('container_{{ index }}_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ who }}', '{{ display_version }}', '{{ index }}', '{{ loop.index0 }}', 'white_space_helper_{{ index }}')">Visualize whitespace characters</a>
         </div>
         <div><span style="margin-left: 20px" class="line_code" id='white_space_helper_{{ index }}'></span></div>
         {% endif %}
@@ -48,7 +48,7 @@
         <h4>
             {{ element.title }}
             {% if element.show_popup %}
-                <span onclick="openPopUp('{{ popup_css_file }}', '{{ element.title }}', {{ index }}, {{ check_index }}, {{ side }});">
+                <span onclick="openPopUp('{{ popup_css_file }}', '{{ element.title }}', {{ index }}, {{ check_index }}, {{ side }});" class="key_to_click" tabindex="0">
                     <i class="fas fa-window-restore" style="cursor: pointer;"></i>
                 </span>
             {% endif %}
@@ -112,4 +112,3 @@
       <span class="{{ type_class }}">{{ message['message'] }}</span><br />
    {% endfor %}
 {% endmacro %}
-

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -18,7 +18,7 @@
     {% if num_visible_testcases > 0 %}
         {# check if instructor grades exist and change title, display hidden points when TA grades are released (if hidden tests exist) #}
 
-        <div class="box-title submission-page-total-header"
+        <div class="box-title submission-page-total-header key_to_click" tabindex="0"
             {% if nonhidden_earned >= nonhidden_max and nonhidden_max > 0 %}
                 onclick="addConfetti();"
                 style="cursor:pointer;"
@@ -28,7 +28,7 @@
             <h4>Autograding Total {% if show_hidden_breakdown %} <i>(Without Hidden Points)</i>{% endif %}</h4>
         </div>
         {% if show_hidden_breakdown %}
-            <div class="box submission-page-total-header"
+            <div class="box submission-page-total-header key_to_click" tabindex="0"
                 {% if hidden_earned >= hidden_max and hidden_max > 0 %}
                     onclick="addConfetti();"
                     style="cursor:pointer;"
@@ -48,7 +48,7 @@
                 {% set can_view = (not testcase.hidden or show_hidden) %}
                 {% set can_view_details = (not testcase.hidden or show_hidden_details and show_hidden) %}
                 <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#D3D3D3;'" : "" }}>
-                    <div id='tc_{{ loop.index0 }}' class="box-title"
+                    <div id='tc_{{ loop.index0 }}' class="box-title key_to_click" tabindex="0"
                             {% if can_view_details and testcase.has_extra_results %}
                                 style="cursor: pointer"
                                 onclick="loadTestcaseOutput('testcase_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ submitter_id }}', '{{ loop.index0 }}', {{ display_version }});"

--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -67,10 +67,10 @@ $( document ).ready(function() {
                             <p style="text-align:center">
                                 {# download icon if student can download files #}
                                 {% if can_download %}
-                                    <button class = 'btn btn-default' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download the file"> Download
+                                    <button class = 'btn btn-default key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download the file"> Download
                                         <i class="fas fa-download" title="Download the file"></i></button>
                                 {% endif %}
-                                <a class="btn btn-primary" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.relative_name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a>
+                                <a class="btn btn-primary key_to_click" tabindex="0" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.relative_name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a>
                             </p>
                             {% if loop.index != files|length %}
                                 <br />
@@ -79,7 +79,7 @@ $( document ).ready(function() {
                         {% if can_download and files|length > 1 %}
                             <hr>
                             <p style="text-align:center">
-                                Download all files: <button class = "btn btn-default" onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}")' aria-label="Download zip of all files" > Download Zip
+                                Download all files: <button class = "btn btn-default key_to_click" tabindex="0" onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}")' aria-label="Download zip of all files" > Download Zip
                                     <i class="fas fa-download" title="Download zip of all files"></i></button>
                             </p>
                         {% endif %}
@@ -89,12 +89,12 @@ $( document ).ready(function() {
                             {% if file.name in annotated_file_names %}
                                 {% if loop.index != uploaded_pdfs|length %}
                                     <div style="margin-bottom: 1.28em">
-                                        <p style="text-align:center"> {#<a class="btn btn-primary" onclick="openUrl('{{ core.buildUrl({'component':'student', 'page':'PDF', 'action':'download_annotated_pdf', 'gradeable_id': gradeable_id, 'file_name': file.name}) }}')">Download <i class="fas fa-download"></i></a>#}
-                                            <a class="btn btn-success" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
+                                        <p style="text-align:center"> {#<a class="btn btn-primary key_to_click" tabindex="0" onclick="openUrl('{{ core.buildUrl({'component':'student', 'page':'PDF', 'action':'download_annotated_pdf', 'gradeable_id': gradeable_id, 'file_name': file.name}) }}')">Download <i class="fas fa-download"></i></a>#}
+                                            <a class="btn btn-success key_to_click" tabindex="0" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
                                     </div>
                                 {% else %}
-                                    <p style="text-align:center"> {#<a class="btn btn-primary" onclick="openUrl('{{ core.buildUrl({'component':'student', 'page':'PDF', 'action':'download_annotated_pdf', 'gradeable_id': gradeable_id, 'file_name': file.name}) }}')">Download <i class="fas fa-download"></i></a>#}
-                                        <a class="btn btn-success" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
+                                    <p style="text-align:center"> {#<a class="btn btn-primary key_to_click" tabindex="0" onclick="openUrl('{{ core.buildUrl({'component':'student', 'page':'PDF', 'action':'download_annotated_pdf', 'gradeable_id': gradeable_id, 'file_name': file.name}) }}')">Download <i class="fas fa-download"></i></a>#}
+                                        <a class="btn btn-success key_to_click" tabindex="0" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a></p>
                                 {% endif %}
                             {% else %}
                                 {% if loop.index != uploaded_pdfs|length %}
@@ -117,7 +117,7 @@ $( document ).ready(function() {
         {% if ta_components | length > 0 %}
             {# TA/Instructor Manual total #}
             <div class="box submission-page-total-header">
-                <div class="box-title"
+                <div class="box-title key_to_click" tabindex="0"
                     {% if ta_score >= ta_max %}
                         onclick="addConfetti();" style="cursor:pointer;"
                      {% endif %}>
@@ -186,7 +186,7 @@ $( document ).ready(function() {
     {% endif %}
     {% if regrade_available %}
         <div id="ShowRegradeRequestButton">
-            <button type="button" title="Open Grade Inquiry" onclick="$('#regradeBoxSection').show();$([document.documentElement, document.body]).animate({scrollTop: $('#regradeBoxSection').offset().top}, 1000);$(this).hide()" style="margin-right:10px;" class="btn btn-default">Open Grade Inquiry</button>
+            <button type="button" title="Open Grade Inquiry" onclick="$('#regradeBoxSection').show();$([document.documentElement, document.body]).animate({scrollTop: $('#regradeBoxSection').offset().top}, 1000);$(this).hide()" style="margin-right:10px;" class="btn btn-default key_to_click" tabindex="0">Open Grade Inquiry</button>
         </div>
     {% endif %}
 {% endif %}

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -20,14 +20,14 @@
     {% if userGroup == 1 %}
         <div style="float: right; margin-bottom: 20px;">
             {# button to open all of the subfolders and cookie it#}
-            <a onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary">Open/Close All Folders</a>
+            <a onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary key_to_click" tabindex="0">Open/Close All Folders</a>
             {# button to set the release dates of all files in the page/course materials #}
             <a onclick='setFolderRelease("{{ folderPath }}","{{ fileReleaseDates[folderPath] }}","{{ id }}",
                     [{% for file in inDir %}
                         "{{ file }}",
                     {% endfor %}]
-                    )' class="btn btn-primary">Set All Release Dates</a>
-            <a onclick="newUploadCourseMaterialsForm()" class="btn btn-primary">Upload Course Materials</a>
+                    )' class="btn btn-primary key_to_click" tabindex="0">Set All Release Dates</a>
+            <a onclick="newUploadCourseMaterialsForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Course Materials</a>
         </div>
     {% endif %}
     <h1>Course Materials</h1>
@@ -96,14 +96,14 @@
             {{ dir }}&nbsp;
             {% set dirExtension = dir|split('.')|last|lower %}
             {% if '.' ~ dirExtension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
-                 <a target="_blank" href="{{ display_file_url }}?dir=course_materials&path={{ path | url_encode }}" aria-label="Pop up {{ dir }} in a new window"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
+                 <a target="_blank" href="{{ display_file_url }}?dir=course_materials&path={{ path | url_encode }}" aria-label="Pop up {{ dir }} in a new window" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
             {% endif %}
-            <a onclick='downloadFile("{{ path | url_encode }}", "course_materials")' aria-label="Download {{ dir }}"><i class="fas fa-download" title="Download the file"></i></a>
+            <a class="key_to_click" onclick='downloadFile("{{ path | url_encode }}", "course_materials")' aria-label="Download {{ dir }}" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
             {% if userGroup == 1 %}
 
-               <a onclick='editCourseMaterialsInitialization({{this_file_section|json_encode|raw}}, "{{this_hide_from_students}}", "{{ dir }}", "{{ fileReleaseDates[path]}}")'> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+               <a class="key_to_click" tabindex="0" onclick='editCourseMaterialsInitialization({{this_file_section|json_encode|raw}}, "{{this_hide_from_students}}", "{{ dir }}", "{{ fileReleaseDates[path]}}")'> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
 
-               <a onclick='newDeleteCourseMaterialForm("{{ path | url_encode }}", "{{ dir }}");' aria-label="Delete {{ dir }}"> <i class="fas fa-trash" title="Delete the file" style="font-size: 16px; margin: 5px;"></i></a>
+               <a class="key_to_click" tabindex="0" onclick='newDeleteCourseMaterialForm("{{ path | url_encode }}", "{{ dir }}");' aria-label="Delete {{ dir }}"> <i class="fas fa-trash" title="Delete the file" style="font-size: 16px; margin: 5px;"></i></a>
                 <label for="date_to_release_{{ id }}">Share to student on</label>
                 <input name="release_date" id="date_to_release_{{ id }}" class="date_picker" type="text" size="26"  value="{{ fileReleaseDates[path]}}"/>
                 {% if not(this_file_section is null) %}
@@ -212,14 +212,14 @@
 
         <div class="div-viewer">
             {# button to open each folder #}
-            <a class='openAllDiv openAllDiv{{ title }} openable-element-{{ title }}' id='{{ dir }}' onclick='setCookie("{{ folderPath }}",openDivForCourseMaterials("{{ id }}")+"{{ id }}")'>
+            <a class='openAllDiv key_to_click openAllDiv{{ title }} openable-element-{{ title }}' id='{{ dir }}' onclick='setCookie("{{ folderPath }}",openDivForCourseMaterials("{{ id }}")+"{{ id }}")' tabindex="0">
                 <span class="fas fa-folder open-all-folder" style='vertical-align:text-top;font-size:20px'></span>
                 {{ dir }}
             </a>
-            <a onclick='downloadCourseMaterialZip("{{ dir }}", "{{ folderPath | url_encode }}")' aria-label="Download the folder: {{ dir }}"><i class="fas fa-download" title="Download the folder"></i></a>
+            <a onclick='downloadCourseMaterialZip("{{ dir }}", "{{ folderPath | url_encode }}")' aria-label="Download the folder: {{ dir }}" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the folder"></i></a>
             {% if userGroup == 1 %}
-                <a onclick='editCourseMaterialsInitialization({{this_file_section|json_encode|raw}}, "{{this_hide_from_students}}", "{{dir}}", "{{ fileReleaseDates[path]}}")'> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
-                <a onclick='newDeleteCourseMaterialForm("{{ folderPath | url_encode  }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+                <a class="key_to_click" tabindex="0" onclick='editCourseMaterialsInitialization({{this_file_section|json_encode|raw}}, "{{this_hide_from_students}}", "{{dir}}", "{{ fileReleaseDates[path]}}")'> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+                <a class="key_to_click" tabindex="0" onclick='newDeleteCourseMaterialForm("{{ folderPath | url_encode  }}", "{{ dir }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
                 {# button to choose release date for all files in folder and subfolders #}
                 <a onclick='setFolderRelease("{{ folderPath }}","{{ fileReleaseDates[folderPath] }}","{{ id }}",
                 [{% for file in inDir %}
@@ -227,7 +227,7 @@
                             "{{ file }}",
                         {% endif %}
                 {% endfor %}]
-                        )' class="btn btn-primary">Set Folder Release Date</a>
+                        )' class="btn btn-primary key_to_click" tabindex="0">Set Folder Release Date</a>
             {% endif %}
         </div>
         <div id='div_viewer_{{ id }}' style='margin-left:15px; display: none' data-file_name="{{ dir }}">

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -155,6 +155,6 @@
 
 {% block buttons %}
     {{ block('close_button') }}
-    <input name="submit" class="btn btn-primary" id="submit_time" type="submit" value="Submit" data-iden=" " data-inDir=' ' onclick="confirmReleaseDate()"/>
+    <input name="submit" class="btn btn-primary key_to_click" tabindex="0" id="submit_time" type="submit" value="Submit" data-iden=" " data-inDir=' ' onclick="confirmReleaseDate()"/>
 
 {% endblock %}

--- a/site/app/templates/forum/CategoriesForm.twig
+++ b/site/app/templates/forum/CategoriesForm.twig
@@ -8,5 +8,5 @@
     {{ parent() }}
 {% endblock %}
 {% block buttons %}
-    <a onclick="$('#ui-category-list').find('.fa-times').click();$('#category-list').css('display', 'none');" class="float-right btn btn-default close-button">Close</a>
+    <a onclick="$('#ui-category-list').find('.fa-times').click();$('#category-list').css('display', 'none');" class="float-right btn btn-default close-button key_to_click" tabindex="0">Close</a>
 {% endblock %}

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -4,7 +4,7 @@
 
             {% if userGroup <= 2 and activeThreadAnnouncement %}
 
-                <a class="active-thread-remove-announcement" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to remove this thread as an announcement?', 0, '{{ csrf_token }}')" title="Remove Announcement" aria-label="Remove Announcement"><i class="fas fa-star" onmouseleave="changeColor(this, 'gold')" onmouseover="changeColor(this, '#e0e0e0')"></i></a>
+                <a class="active-thread-remove-announcement key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to remove this thread as an announcement?', 0, '{{ csrf_token }}')" title="Remove Announcement" aria-label="Remove Announcement"><i class="fas fa-star" onmouseleave="changeColor(this, 'gold')" onmouseover="changeColor(this, '#e0e0e0')"></i></a>
 
             {% elseif activeThreadAnnouncement %}
 
@@ -12,17 +12,17 @@
 
             {% elseif userGroup <= 2 and not activeThreadAnnouncement %}
 
-                <a class="not-active-thread-announcement" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to make this thread an announcement?', 1, '{{ csrf_token }}')" title="Make thread an announcement" aria-label="Make Announcement"><i class="fas fa-star" title = "Make Announcement" onmouseleave="changeColor(this, '#e0e0e0')" onmouseover="changeColor(this, 'gold')"></i></a>
+                <a class="not-active-thread-announcement key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to make this thread an announcement?', 1, '{{ csrf_token }}')" title="Make thread an announcement" aria-label="Make Announcement"><i class="fas fa-star" title = "Make Announcement" onmouseleave="changeColor(this, '#e0e0e0')" onmouseover="changeColor(this, 'gold')"></i></a>
 
             {% endif %}
 
             {% if isCurrentFavorite %}
 
-                <a class="current-favorite" onClick="pinThread({{ activeThread.id }}, '0');" title="Pin Thread" aria-label="Pin Thread"><i class="fas fa-thumbtack" onmouseleave="changeColor(this, 'gold')" onmouseover="changeColor(this, '#e0e0e0')"></i></a>
+                <a class="current-favorite key_to_click" tabindex="0" onClick="pinThread({{ activeThread.id }}, '0');" title="Pin Thread" aria-label="Pin Thread"><i class="fas fa-thumbtack" onmouseleave="changeColor(this, 'gold')" onmouseover="changeColor(this, '#e0e0e0')"></i></a>
 
             {% else %}
 
-                <a class="pinned-thread" onClick="pinThread({{ activeThread.id }}, '1');" title="Pin Thread" aria-label="Pin Thread"><i class="fas fa-thumbtack" onmouseleave="changeColor(this, '#e0e0e0')" onmouseover="changeColor(this, 'gold')"></i></a>
+                <a class="pinned-thread key_to_click" tabindex="0" onClick="pinThread({{ activeThread.id }}, '1');" title="Pin Thread" aria-label="Pin Thread"><i class="fas fa-thumbtack" onmouseleave="changeColor(this, '#e0e0e0')" onmouseover="changeColor(this, 'gold')"></i></a>
 
             {% endif %}
 
@@ -41,13 +41,12 @@
         {% if not (isThreadLocked != 1 or userAccessFullGrading) %}
             {# pass #}
         {% elseif not first %}
-            <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="replyPost({{ post.id }})"> Reply</a>
+            <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="replyPost({{ post.id }})"> Reply</a>
         {% else %}
-            <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="$('html, #posts_list').animate({ scrollTop: document.getElementById('posts_list').scrollHeight }, 'slow');"> Reply</a>
+            <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="$('html, #posts_list').animate({ scrollTop: document.getElementById('posts_list').scrollHeight }, 'slow');"> Reply</a>
         {% endif %}
-
         {% if userGroup <= 3 and has_history %}
-            <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showHistory({{ post.id }})">Show History</a>
+            <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="showHistory({{ post.id }})">Show History</a>
             {% if (isThreadLocked != 1 or accessFullGrading) and first != 1 %}
                 <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showSplit({{ post.id }})">
                 {% if thread_previously_merged %}
@@ -62,26 +61,26 @@
     {% endif %}
 
     {% if includeReply and (userGroup <= 3 or post.author_user_id == current_user) and first and thread_resolve_state == -1 %}
-        <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="changeThreadStatus({{ post.thread_id }})" title="Mark thread as resolved">Mark as resolved</a>
+        <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="changeThreadStatus({{ post.thread_id }})" title="Mark thread as resolved">Mark as resolved</a>
     {% endif %}
 
     <span class="post-action-container">
 
         {% if userGroup <= 2 and post.author_user_id != current_user %}
-            <a class="post-email-toggle" tabindex = "0" onClick='$(this).next().toggle();' title="Show/Hide email address" aria-label="Show/Hide email address"><i class="fas fa-envelope"></i></a>
+            <a class="post-email-toggle key_to_click" tabindex = "0" onClick='$(this).next().toggle();' title="Show/Hide email address" aria-label="Show/Hide email address"><i class="fas fa-envelope"></i></a>
             <a href="mailto:{{ author_email }}" style="display: none;">{{ author_email }}</a>
         {% endif %}
 
         {% if userGroup <= 2 %}
-            <a class="post-user-info" tabindex = "0" onClick='changeName(this.parentNode, {{ post_user_info.info_name }}, {{ post_user_info.visible_user_json}}, {{ post_user_info.jscriptAnonFix}})' title="Show full user information" aria-label="Show full user information"><i class="fas fa-eye"></i></a>
+            <a class="post-user-info key_to_click" tabindex = "0" onClick='changeName(this.parentNode, {{ post_user_info.info_name }}, {{ post_user_info.visible_user_json}}, {{ post_user_info.jscriptAnonFix}})' title="Show full user information" aria-label="Show full user information"><i class="fas fa-eye"></i></a>
         {% endif %}
 
         {% if userGroup <= 3 or post.author_user_id == current_user %}
             {% if not (isThreadLocked != 1 or userAccessFullGrading == true) %}
                 {#pass#}
             {% else %}
-                <a class="post_button delete-post-button" tabindex = "0" onClick="deletePostToggle({{ post_buttons.delete.ud_toggle_status }}, {{ post.thread_id }}, {{ post.id }}, '{{ post.author_user_id }}', '{{ post_date }}', '{{ csrf_token }}' )" title="{{ post_buttons.delete.ud_button_title }}" aria-label="{{ post_buttons.delete.ud_button_title }}"><i class="fa {{ post_buttons.delete.ud_button_icon }}"></i></a>
-                <a class="post_button edit-post-button" tabindex = "0" onClick="editPost({{ post.id }}, {{ post.thread_id }}, {{ post_buttons.edit.shouldEditThread }}, {{ render_markdown?1:0 }}, '{{ csrf_token }}')" title="{{ post_buttons.edit.edit_button_title }}" aria-label="{{ post_buttons.edit.edit_button_title }}"><i class="fas fa-edit"></i></a>
+                <a class="post_button delete-post-button key_to_click" tabindex = "0" onClick="deletePostToggle({{ post_buttons.delete.ud_toggle_status }}, {{ post.thread_id }}, {{ post.id }}, '{{ post.author_user_id }}', '{{ post_date }}', '{{ csrf_token }}' )" title="{{ post_buttons.delete.ud_button_title }}" aria-label="{{ post_buttons.delete.ud_button_title }}"><i class="fa {{ post_buttons.delete.ud_button_icon }}"></i></a>
+                <a class="post_button edit-post-button key_to_click" tabindex = "0" onClick="editPost({{ post.id }}, {{ post.thread_id }}, {{ post_buttons.edit.shouldEditThread }}, {{ render_markdown?1:0 }}, '{{ csrf_token }}')" title="{{ post_buttons.edit.edit_button_title }}" aria-label="{{ post_buttons.edit.edit_button_title }}"><i class="fas fa-edit"></i></a>
             {% endif %}
         {% endif %}
 
@@ -96,7 +95,7 @@
 
     {% if post_attachment.exist == true %}
 
-        <a href="#" id="{{ post_attachment.params.button_id }}" onclick="loadInlineImages('{{ post_attachment.params.encoded_data }}');" class="attachment-btn btn btn-default btn-sm" type="button">
+        <a href="#" id="{{ post_attachment.params.button_id }}" onclick="loadInlineImages('{{ post_attachment.params.encoded_data }}');" class="attachment-btn btn btn-default btn-sm key_to_click" tabindex="0" type="button">
                     Attachments <span class="attachment-badge badge">{{ post_attachment.params.num_files }}</span> </a>
 
 

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -62,7 +62,7 @@
 						{% endif %}
 					{% endfor %}
 
-					<a id="clear_filter_button" class="inline-block text-decoration-none" style="color: var(--actionable-blue);" label="Clear Filters" onclick="clearForumFilter(event);">&times; Clear Filters</a>
+					<a id="clear_filter_button" class="inline-block text-decoration-none key_to_click" tabindex="0" style="color: var(--actionable-blue);" label="Clear Filters" onclick="clearForumFilter(event);">&times; Clear Filters</a>
 
 				</div>
 
@@ -97,15 +97,15 @@
 			{% if thread_exists %}
 	          <li class="dropdown-divider"></li>
 	          <li title="Click to toggle all post attachments" class='dropdown-item' role="menuitem">
-	          	<a href="#" onclick="loadAllInlineImages()">
+	          	<a href="#" class="key_to_click" tabindex="0" onclick="loadAllInlineImages()">
    					Attachments <span class="attachment-badge badge">{{ total_attachments }}</span>
    				</a></li>
 	          <li class="dropdown-divider"></li>
-	              <li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item' role="menuitem"><a onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a></li>
-	              <li title="Sort posts by ascending chronological order" id="time" class='dropdown-item' role="menuitem"><a href="#" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a></li>
-				        <li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item' role="menuitem"><a href="#" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological  <i class="fas fa-angle-down"></i> </a></li>
+	              <li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item' role="menuitem"><a class="key_to_click"  onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a></li>
+	              <li title="Sort posts by ascending chronological order" id="time" class='dropdown-item' role="menuitem"><a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a></li>
+				        <li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item' role="menuitem"><a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological  <i class="fas fa-angle-down"></i> </a></li>
 	              {% if user_group <= core.getUser().accessGrading() %}
-	              	<li title="Sort posts by author's last name" id="alpha" class='dropdown-item' role="menuitem"><a href="#" onclick="changeDisplayOptions('alpha')">Alphabetical</a></li>
+	              	<li title="Sort posts by author's last name" id="alpha" class='dropdown-item' role="menuitem"><a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha')">Alphabetical</a></li>
 	              {% endif %}
 	        {% endif %}
 	        </ul>

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -16,7 +16,7 @@
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <span  style="float: right;">
                 <input id="new_category_text" aria-label="New Category" placeholder="New Category" style="resize:none;" rows="1" type="text" name="new_category" maxlength="50" onkeyup="checkInputMaxLength($(this))" />
-                <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm">
+                <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm key_to_click" tabindex="0">
                     <i class="fas fa-plus-circle fa-1x"></i> Add category
                 </button>
             </span>

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -18,20 +18,20 @@
 {% if show_post %}
     <div style="margin-bottom:10px;" class="form-group row position-relative">
         <div role="button" id="markdown_toggle_{{ post_box_id }}"
-        class="markdown-toggle {{ render_markdown?"markdown-active":"markdown-inactive" }}"
+        class="markdown-toggle {{ render_markdown?"markdown-active":"markdown-inactive" }} key_to_click" tabindex="0"
         style="margin-right:10px;padding: unset;cursor: pointer; "
         title="Render markdown" onclick="$('#markdown_buttons_{{ post_box_id }}').toggle(); $(this).toggleClass('markdown-active'); $('#markdown_input_{{ post_box_id }}').val($('#markdown_input_{{ post_box_id }}').val() == 0? '1':'0');$('#markdown-info-{{ post_box_id }}').toggleClass('disabled');"><i class="fab fa-markdown fa-2x"></i></div>
         <input type="hidden" name="markdown_status" id="markdown_input_{{ post_box_id }}" value="{{ render_markdown?1:0 }}" />
         <a target=_blank href="https://submitty.org/student/discussion_forum#formatting-a-post-using-markdown/" aria-label="Markdown Info"><i id="markdown-info-{{ post_box_id }}" style="font-style:normal;" class="far fa-question-circle disabled"></i></a>
         &nbsp;&nbsp;
         <span style="display: {{ render_markdown?"block":"none" }}" id="markdown_buttons_{{ post_box_id }}">
-            <button type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Link <i class="fas fa-link fa-1x"></i></button>
-            <button title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Code <i class="fas fa-code fa-1x"></i></button>
-            <button title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Bold <i class="fas fa-bold fa-1x"></i></button>
-            <button title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown">Italics <i class="fas fa-italic fa-1x"></i></button>
+            <button type="button" title="Insert a link" onclick="addMarkdownCode(1, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown key_to_click"  tabindex="0">Link <i class="fas fa-link fa-1x"></i></button>
+            <button title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown key_to_click"  tabindex="0">Code <i class="fas fa-code fa-1x"></i></button>
+            <button title="Insert bold text" type="button" onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown key_to_click"  tabindex="0">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown key_to_click"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
-        <a class="btn btn-primary" tabindex = "0" id="merge-thread-btn" title="Merge Threads" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>
+        <a class="btn btn-primary key_to_click" tabindex = "0" id="merge-thread-btn" title="Merge Threads" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>
     {% endif %}
     {% if show_lock_date and core.getUser().getGroup() <= 2 %}
         <label id="label_lock_thread" for="lock_thread_date"> Lock Thread Date
@@ -182,7 +182,7 @@
                  $(this).closest('.thread-post-form').find('[name=thread_post_content]').val('');
                  $('#title').val('');
                  $(this).closest('form').trigger('reinitialize.areYouSure');"
-                     class="btn btn-default close-button">Cancel</a>
+                     class="btn btn-default close-button key_to_click" tabindex="0">Cancel</a>
         {% endif %}
         <input type="submit" name="post" value="{{ submit_label }}" class="btn btn-primary inline-block" />
 

--- a/site/app/templates/forum/searchResults.twig
+++ b/site/app/templates/forum/searchResults.twig
@@ -20,11 +20,11 @@
             </thead>
             <tbody>
                 {% for thread in threads %}
-                    <tr class="info hoverable cursor-pointer" title="Go to thread" onclick="window.location = '{{ thread.thread_link }}';">
+                    <tr class="info hoverable cursor-pointer key_to_click" tabindex="0" title="Go to thread" onclick="window.location = '{{ thread.thread_link }}';">
                         <td colspan="10" class="text-center"><h4>{{ thread.thread_title }}</h4></td>
                     </tr>
                     {% for post in thread.posts %}
-                        <tr title="Go to post" class="cursor-pointer" onclick="window.location = '{{ post.post_link }}';" id="search-row-{{ post.count }}" class="hoverable">
+                        <tr title="Go to post" class="cursor-pointer key_to_click" tabindex="0" onclick="window.location = '{{ post.post_link }}';" id="search-row-{{ post.count }}" class="hoverable">
                             <td align="left"><pre style="max-width: 67vw">
                                     <p class="post_content pre-wrap" style="word-wrap: break-word;">
                                         {% include "forum/RenderPost.twig" with { "post_content": post.post_content } only %}

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -2,9 +2,9 @@
 <div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;">
     {% block form %}
         {# This lets us center the window #}
-        <div class="popup-box" onclick="event.stopPropagation(); closePopup();">
+        <div class="popup-box key_to_click" tabindex="0" onclick="event.stopPropagation(); closePopup();">
             {# Actual displayed window #}
-            <div class="popup-window" onclick="event.stopPropagation();">
+            <div class="popup-window key_to_click" tabindex="0" onclick="event.stopPropagation();">
                 {% block title_panel %}
                     <div class="form-title">
                         {% block title_tag %}
@@ -20,7 +20,7 @@
                                 <div class="form-button-container">
                                     {% block buttons %}
                                         {% block close_button %}
-                                            <a href="javascript:closePopup('{{ block('popup_id') }}')" class="btn btn-default close-button">Close</a>
+                                            <a onclick="closePopup('{{ block('popup_id') }}')" class="btn btn-default close-button key_to_click" tabindex="0">Close</a>
                                         {% endblock %}
                                     {% endblock %}
                                 </div>

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -1,7 +1,7 @@
 <div class="content">
     {% if hasInstructorPermission %}
         <div style="float: right; margin-bottom: 20px;">
-            <a onclick="newUploadImagesForm()" class="btn btn-primary">Upload Student Photos</a>
+            <a onclick="newUploadImagesForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Student Photos</a>
         </div>
     {% endif %}
     <h1>Student Photos</h1>

--- a/site/app/templates/grading/electronic/AutogradingPanel.twig
+++ b/site/app/templates/grading/electronic/AutogradingPanel.twig
@@ -1,8 +1,8 @@
 <div id="autograding_results" class="draggable rubric_panel" style="left:15px; top:170px; width:48%; height:36%;">
     <div class="draggable_content">
         <span class="grading_label">Autograding Testcases</span>
-        <button class="btn btn-default" onclick="openAllAutoGrading()">Expand All</button>
-        <button class="btn btn-default" onclick="closeAllAutoGrading()">Close All</button>
+        <button class="btn btn-default key_to_click" tabindex="0" onclick="openAllAutoGrading()">Expand All</button>
+        <button class="btn btn-default key_to_click" tabindex="0" onclick="closeAllAutoGrading()">Close All</button>
         <div class="inner-container">
             {% if version_instance is null %}
                 <h4>No Submission</h4>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -51,14 +51,14 @@
         <a style="float: right;" class="btn btn-primary" href="{{ export_teams_url }}">Export Teams Members</a>
     {% endif %}
     {% if show_export_teams_button %}
-        <button style="float: right;" class="btn btn-primary" onclick="importTeamForm();">Import Teams Members</button>
+        <button style="float: right;" class="btn btn-primary key_to_click" tabindex="0" onclick="importTeamForm();">Import Teams Members</button>
     {% endif %}
     {# /Import+Export teams buttons #}
 
 	{# Randomize team button #}
 	{% if (not gradeable.isGradeByRegistration()) and (show_export_teams_button or show_import_teams_button) %}
 		{% if past_grade_start_date %}
-			<Button style="float: left;" class="btn btn-default" onclick="randomizeRotatingGroupsButton()"> Randomly Re-Assign Teams to Rotating Sections</Button>
+			<Button style="float: left;" class="btn btn-default key_to_click" tabindex="0" onclick="randomizeRotatingGroupsButton()"> Randomly Re-Assign Teams to Rotating Sections</Button>
 		{% else %}
 			<a style="float: left;" class="btn btn-default" href="{{ randomize_team_rotating_sections_url }}"> Randomly Re-Assign Teams to Rotating Sections</a>
 		{% endif %}
@@ -151,7 +151,7 @@
                             {{ display_section }}
                         </td>
                         <td>
-                            <a onclick="{{ empty_team_info[loop.index0].team_edit_onclick }}" aria-label="Edit Team">
+                            <a onclick="{{ empty_team_info[loop.index0].team_edit_onclick }}" aria-label="Edit Team" class="key_to_click" tabindex="0">
                                 <i class="fas fa-pencil-alt"></i>
                             </a>
                         </td>
@@ -404,7 +404,7 @@
 {# Edit Team #}
 {% macro render_column_team_edit(self, context, section, graded_gradeable, index, team_edit_onclick, column) %}
     <td>
-        <a onclick="{{ team_edit_onclick }}" aria-label="Edit Team"><i class="fas fa-pencil-alt"></i></a>
+        <a onclick="{{ team_edit_onclick }}" aria-label="Edit Team" class="key_to_click" tabindex="0"><i class="fas fa-pencil-alt"></i></a>
     </td>
 {% endmacro %}
 

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -17,23 +17,23 @@
         {# /Nav buttons #}
 
         {# Panel buttons #}
-        <button title="Reset Rubric Panel Positions (Press R)" class="invisible-btn" onclick="resetModules(); updateCookies();"> <i class="fas fa-redo icon-header" ></i> </button>
-        <button title="Show/Hide Autograding Testcases (Press A)" class="invisible-btn" onclick="toggleAutograding(); updateCookies();"> <i class="fas fa-list icon-header" ></i> </button>
-        <button title="Show/Hide Grading Rubric (Press G)" class="invisible-btn" onclick="toggleRubric(); updateCookies();"> <i class="fas fa-edit icon-header" ></i> </button>
-        <button title="Show/Hide Submission and Results Browser (Press O)" class="invisible-btn" onclick="toggleSubmissions(); updateCookies();"> <i class="fas fa-folder-open icon-header" ></i> </button>
+        <button title="Reset Rubric Panel Positions (Press R)" class="invisible-btn key_to_click" tabindex="0" onclick="resetModules(); updateCookies();"> <i class="fas fa-redo icon-header" ></i> </button>
+        <button title="Show/Hide Autograding Testcases (Press A)" class="invisible-btn key_to_click" tabindex="0" onclick="toggleAutograding(); updateCookies();"> <i class="fas fa-list icon-header" ></i> </button>
+        <button title="Show/Hide Grading Rubric (Press G)" class="invisible-btn key_to_click" tabindex="0" onclick="toggleRubric(); updateCookies();"> <i class="fas fa-edit icon-header" ></i> </button>
+        <button title="Show/Hide Submission and Results Browser (Press O)" class="invisible-btn key_to_click" tabindex="0" onclick="toggleSubmissions(); updateCookies();"> <i class="fas fa-folder-open icon-header" ></i> </button>
         {% if ((not peer_gradeable) or (peer_gradeable and not i_am_a_peer )) %}
-            <button title="Show/Hide Student Information (Press S)" class="invisible-btn" onclick="toggleInfo(); updateCookies();"> <i class="fas fa-user icon-header" ></i> </button>
+            <button title="Show/Hide Student Information (Press S)" class="invisible-btn key_to_click" tabindex="0" onclick="toggleInfo(); updateCookies();"> <i class="fas fa-user icon-header" ></i> </button>
         {% endif %}
         {% if peer_gradeable and not i_am_a_peer %}
-        <button title="Show/Hide Peer Information (Press P)" class="invisible-btn" onclick="togglePeer(); updateCookies();"> <i class="fas fa-users icon-header" ></i> </button>
+        <button title="Show/Hide Peer Information (Press P)" class="invisible-btn key_to_click" tabindex="0" onclick="togglePeer(); updateCookies();"> <i class="fas fa-users icon-header" ></i> </button>
         {% endif %}
         {% if discussion_based %}
-            <button title="Show/Hide Discussion Posts" class="invisible-btn" onclick="toggleDiscussion(); updateCookies();"> <i class="fas fa-comment-alt icon-header" ></i> </button>
+            <button title="Show/Hide Discussion Posts" class="invisible-btn key_to_click" tabindex="0" onclick="toggleDiscussion(); updateCookies();"> <i class="fas fa-comment-alt icon-header" ></i> </button>
         {% endif %}
         {% if regrade_panel_available %}
-            <button title="Show/Hide Grade Inquiry Information (Press X)" class="invisible-btn" onclick="toggleRegrade(); updateCookies();"> <i class="fas {{ grade_inquiry_pending ? 'fa-exclamation' : 'fa-hand-paper' }} grade_inquiry_icon icon-header" ></i> </button>
+            <button title="Show/Hide Grade Inquiry Information (Press X)" class="invisible-btn key_to_click" tabindex="0" onclick="toggleRegrade(); updateCookies();"> <i class="fas {{ grade_inquiry_pending ? 'fa-exclamation' : 'fa-hand-paper' }} grade_inquiry_icon icon-header" ></i> </button>
         {% endif %}
-        <button title="Show Grading Settings" class="invisible-btn" onclick="showSettings();"> <i class="fas fa-wrench icon-header" ></i> </button>
+        <button title="Show Grading Settings" class="invisible-btn key_to_click" tabindex="0" onclick="showSettings();"> <i class="fas fa-wrench icon-header" ></i> </button>
         {# /Panel buttons #}
     </div>
 

--- a/site/app/templates/grading/electronic/PDFAnnotationBar.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationBar.twig
@@ -50,7 +50,7 @@
                          '#F06291',
                          '#FF0000'] %}
         {% for color in colors %}
-            <a class="color" value="{{ color }}" style="background: {{ color }}" onclick="emitEvent(this)"></a>
+            <a class="color key_to_click" tabindex="0" value="{{ color }}" style="background: {{ color }}" onclick="emitEvent(this)"></a>
         {% endfor %}
     </div>
 </div>

--- a/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
+++ b/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
@@ -8,6 +8,6 @@
     </p><br />
 {% endblock %}
 {% block buttons %}
-    <a style="float: left;" onclick="$('#{{ block('popup_id') }}').css('display', 'none'); event.stopPropagation();" class="btn btn-default close-button"> Cancel </a>
+    <a style="float: left;" onclick="$('#{{ block('popup_id') }}').css('display', 'none'); event.stopPropagation();" class="btn btn-default close-button key_to_click" tabindex="0"> Cancel </a>
     <a style="float: right;" class="btn btn-primary" href="{{ randomize_team_rotating_sections_url }}"> Randomly Re-Assign Teams to Rotating Sections </a>
 {% endblock %}

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -25,18 +25,18 @@
                     {# Verify all button #}
                     {% if show_verify_all %}
                         <div class="col-no-gutters">
-                            <input id="verify-all" type="button" class="btn btn-default" value="Verify All" onclick="onVerifyAll(this)"/>
+                            <input id="verify-all" type="button" class="btn btn-default key_to_click" tabindex="0" value="Verify All" onclick="onVerifyAll(this)"/>
                         </div>
                     {% endif %}
                     {# Silent Edit Checkbox #}
                     {% if show_silent_edit %}
                         <div class="col-no-gutters">
-                            <input id="silent-edit-id" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/><label for="silent-edit-id">Silent Regrade (don't change who graded)</input>
+                            <input id="silent-edit-id" class="key_to_click" tabindex="0" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/><label for="silent-edit-id">Silent Regrade (don't change who graded)</input>
                         </div>
                     {% endif %}
                     {# Edit Mode Checkbox #}
                     <div class="col-no-gutters">
-                        <input id="edit-mode-enabled" type="checkbox" title="Allows editing of mark point values, descriptions, and order" onclick="onToggleEditMode()"/><label for="edit-mode-enabled">Edit Rubric</label>
+                        <input id="edit-mode-enabled" class="key_to_click" tabindex="0" type="checkbox" title="Allows editing of mark point values, descriptions, and order" onclick="onToggleEditMode()"/><label for="edit-mode-enabled">Edit Rubric</label>
                     </div>
                 </div>
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id}}" data-can_verify="{{ can_verify }}" hidden></div>

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -167,10 +167,10 @@
     {% else %}
         <div class = "tab">
             <div class =tab-bar-wrapper">
-                <a class="nav-bar normal-btn"  onclick="openStat(event, 'numerical-data'), this.blur()" id="defaultOpen">Data</a>
-                <a class="nav-bar normal-btn"  id="btn-hist-auto" onclick="openStat(event, 'autograding-score-histogram'), this.blur()">Autograding Histogram</a>
-                <a class="nav-bar normal-btn"  id="btn-comp" onclick="openStat(event, 'component-averages'), this.blur()">Manual Grading Component Averages</a>
-                <a class="nav-bar normal-btn"  id="btn-hist-tot" onclick="openStat(event, 'total-score-histogram'), this.blur()">Overall Histogram</a>
+                <a class="nav-bar normal-btn key_to_click" tabindex="0"  onclick="openStat(this, 'numerical-data'), this.blur()" id="defaultOpen">Data</a>
+                <a class="nav-bar normal-btn key_to_click" tabindex="0"  id="btn-hist-auto" onclick="openStat(this, 'autograding-score-histogram'), this.blur()">Autograding Histogram</a>
+                <a class="nav-bar normal-btn key_to_click" tabindex="0"  id="btn-comp" onclick="openStat(this, 'component-averages'), this.blur()">Manual Grading Component Averages</a>
+                <a class="nav-bar normal-btn key_to_click" tabindex="0"  id="btn-hist-tot" onclick="openStat(this, 'total-score-histogram'), this.blur()">Overall Histogram</a>
             </div>
             {% set bTA = [] %}
             {% set tTA = [] %}
@@ -247,7 +247,7 @@
                 {# Setup for Histogram of Total Scores #}
                     <br>
                     <input style='width: auto' type='text' id='bucket-size-total' name='bucket-val' value="" aria-label="Enter bucket size" placeholder="Enter bucket size" />
-                    <input name="sub-tot" class="btn btn-primary" id="submit_bucket" type="submit" value="Submit Bucket Size for Total" onclick="createNewBuckets(rangeT,betterBuckets,xValueT,yValue,xBuckets,mode,modeCount,maxT,minT)"/>
+                    <input name="sub-tot" class="btn btn-primary key_to_click" tabindex="0" id="submit_bucket" type="submit" value="Submit Bucket Size for Total" onclick="createNewBuckets(rangeT,betterBuckets,xValueT,yValue,xBuckets,mode,modeCount,maxT,minT)"/>
                 <div id="myDiv"><!-- Plotly chart will be drawn inside this DIV --></div>
 
                 <script>
@@ -453,7 +453,7 @@
                 <div id="autograding-score-histogram" class="page-content">
                     <br>
                     <input style='width: auto' type='text' id='bucket-size-auto' name='bucket-val' value="" placeholder="Enter bucket size" />
-                    <input name = "sub-auto" class="btn btn-primary" id="submit_bucket_auto" type="submit" value="Submit Bucket Size for Auto" onclick="createNewBuckets(rangeA,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA)"/>
+                    <input name = "sub-auto" class="btn btn-primary key_to_click" tabindex="0" id="submit_bucket_auto" type="submit" value="Submit Bucket Size for Auto" onclick="createNewBuckets(rangeA,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA)"/>
                     <div id="myDiv3"><!-- Plotly chart will be drawn inside this DIV --></div>
                     <script>
                         var buckets = new Map();
@@ -761,7 +761,7 @@
 
         // Show the current tab, and add an "active" class to the button that opened the tab
         document.getElementById(statName).style.display = "block";
-        evt.currentTarget.className += " active-btn";
+        evt.className += " active-btn";
 
     }
     // Get the element with id="defaultOpen" and click on it

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -29,7 +29,7 @@
             </script>
 
             {% if not peer %}
-                <button class="btn btn-default" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ submitter_id }}', {{ active_version }})">Download Zip File</button>
+                <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ submitter_id }}', {{ active_version }})">Download Zip File</button>
             {% endif %}
 
             <div id="changeCodeStyle" class="btn-group btn-group-toggle" onchange="changeEditorStyle($('[name=codeStyle]:checked')[0].id);" data-toggle="buttons">
@@ -40,7 +40,7 @@
                     <input type="radio" name="codeStyle" id="style_dark" autocomplete="off"> Dark
                 </label>
             </div>
-            <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();"> <label for="autoscroll_id">Auto open</label> </span>
+            <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
             <br />
             {# Files #}
             <div class="inner-container" id="file-container">
@@ -69,7 +69,7 @@
             <strong id="save_status" style="position: sticky; top: 27px; margin: 10px; float:right; z-index: 30; display: none">No changes</strong>
             <span class="grading_label" style="padding-bottom: 0px">Submissions and Results Browser ></span>
             <span class="grading_label" style="padding-top: 5px; margin-left: -15px" id="grading_file_name"></span>
-            <a onclick='collapseFile()' aria-label="Collapse File"><i class="fas fa-reply" style="font-size:24px" title="Back"></i></a>
+            <a onclick='collapseFile()' aria-label="Collapse File" class="key_to_click" tabindex="0"><i class="fas fa-reply" style="font-size:24px" title="Back"></i></a>
             {% include "grading/electronic/PDFAnnotationBar.twig" %}
             <div id="file_content" style="overflow: auto; height:90%;position: absolute;width: 100%;"></div>
         </div>
@@ -227,12 +227,12 @@
 {% macro display_file(self, dir, path, id, indent, title) %}
     <div>
         <div class="file-viewer">
-            <a class='openAllFile{{ title }} openable-element-{{ title }}' file-url="{{ path }}" onclick='openFrame("{{ dir }}", "{{ path }}", "{{ id }}"); updateCookies();'>
+            <a class='openAllFile{{ title }} openable-element-{{ title }}' file-url="{{ path }} key_to_click" onclick='openFrame("{{ dir }}", "{{ path }}", "{{ id }}"); updateCookies();'>
                 <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
                 {{ dir }}</a> &nbsp;
-            <a onclick='openFile("{{ dir }}", "{{ path }}")' aria-label="Pop up the file in a new window"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
-            <a onclick='expandFile("{{ dir }}", "{{ path }}")' aria-label="Show file in full panel"><i class="fas fa-share" title="Show file in full panel"></i></a>
-            <a onclick='downloadFile("{{ path }}", "{{ title }}")' aria-label="Download the file"><i class="fas fa-download" title="Download the file"></i></a>
+            <a onclick='openFile("{{ dir }}", "{{ path }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
+            <a onclick='expandFile("{{ dir }}", "{{ path }}")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></a>
+            <a onclick='downloadFile("{{ path }}", "{{ title }}")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
         </div>
         <div id="file_viewer_{{ id }}" style="margin-left:{{ indent * -15 }}px" data-file_name="{{ dir }}" data-file_url="{{ path }}"></div>
     </div>
@@ -241,7 +241,7 @@
 {% macro display_dir(self, dir, contents, id, indent, title) %}
     <div>
         <div class="div-viewer">
-            <a class='openAllDiv openAllDiv{{ title }} openable-element-{{ title }}' id='{{ dir }}' onclick='openDiv("{{ id }}"); updateCookies();'>
+            <a class='openAllDiv openAllDiv{{ title }} openable-element-{{ title }} key_to_click' id='{{ dir }}' onclick='openDiv("{{ id }}"); updateCookies();'>
                 <span class="fas fa-folder open-all-folder" style='vertical-align:text-top;'></span>
                 {{ dir }}
             </a>

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -20,14 +20,14 @@
             {% include "grading/simple/StudentSearch.twig" %}
             <div>
                 <p class="not-sticky">Undo/Redo Changes</p>
-                <button id="checkpoint-undo" class="btn btn-primary" onclick="checkpointRollTo('{{ gradeable.getId() }}', -1)" disabled><i class="fas fa-undo"></i></button>
-                <button id="checkpoint-redo" class="btn btn-primary" onclick="checkpointRollTo('{{ gradeable.getId() }}', 1)" disabled><i class="fas fa-redo"></i></button>
+                <button id="checkpoint-undo" class="btn btn-primary key_to_click" tabindex="0" onclick="checkpointRollTo('{{ gradeable.getId() }}', -1)" disabled><i class="fas fa-undo"></i></button>
+                <button id="checkpoint-redo" class="btn btn-primary key_to_click" tabindex="0" onclick="checkpointRollTo('{{ gradeable.getId() }}', 1)" disabled><i class="fas fa-redo"></i></button>
             </div>
         </div>
 
         <div>
-            <button class="btn btn-primary" id="settings-btn" onclick='showSettings()'>Settings/Hotkeys</button>
-            <button class="btn btn-primary" id="simple-stats-btn" onclick='showSimpleGraderStats("{{ action }}")'>View Statistics</button>
+            <button class="btn btn-primary key_to_click" tabindex="0" id="settings-btn" onclick='showSettings()'>Settings/Hotkeys</button>
+            <button class="btn btn-primary key_to_click" tabindex="0" id="simple-stats-btn" onclick='showSimpleGraderStats("{{ action }}")'>View Statistics</button>
         </div>
     </div>
 
@@ -252,7 +252,7 @@
             {% set total = total + component_grade.getScore() %}
             <td class="option-small-input">
                 <input
-                    class="option-small-box cell-grade"
+                    class="option-small-box cell-grade key_to_click" tabindex="0"
                     style="text-align: center; {{ component_grade.getScore() == 0 ? "color: var(--standard-light-medium-gray);" : "" }}
                         {{ component_grade.getScore() == 0 ? "background-color: var(--alert-background-blue);" : "background-color: var(--default-white);" }}"
                     type="text"
@@ -284,7 +284,7 @@
         {% set component_grade = ta_grade.getGradedComponent(component) %}
         <td class="option-small-input">
             <input
-                class="option-small-box cell-grade"
+                class="option-small-box cell-grade key_to_click" tabindex="0"
                 type="text"
                 id="cell-{{ index }}-{{ text_start + loop.index0 }}"
                 value="{{ component_grade.getComment() }}"

--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -81,7 +81,7 @@
             <input type="submit" value = "Invite" class="btn btn-primary" />
         </form>
         <br />
-        <button class="btn btn-danger" onclick="location.href='{{ leave_team_url }}'">Leave Team</button>
+        <button class="btn btn-danger key_to_click" tabindex="0" onclick="location.href='{{ leave_team_url }}'">Leave Team</button>
     </div>
 {% elseif team == null %}
     <div class="content">
@@ -102,12 +102,12 @@
 
         {# Create new team button #}
         <br />
-        <button class="btn btn-primary" onclick="location.href='{{ create_team_url }}'">Create New Team </button>
+        <button class="btn btn-primary key_to_click" tabindex="0" onclick="location.href='{{ create_team_url }}'">Create New Team </button>
 
         {% if seeking_partner %}
-            <button class="btn btn-danger" onclick="location.href='{{ stop_seek_url }}'">Stop Seeking Team/Partner </button>
+            <button class="btn btn-danger key_to_click" tabindex="0" onclick="location.href='{{ stop_seek_url }}'">Stop Seeking Team/Partner </button>
         {% else %}
-            &nbsp;or&nbsp;<button class="btn btn-primary" onclick="location.href='{{ seek_url }}'">Seek Team/Partner </button>
+            &nbsp;or&nbsp;<button class="btn btn-primary key_to_click" tabindex="0" onclick="location.href='{{ seek_url }}'">Seek Team/Partner </button>
         {% endif %}
     </div>
 {% endif %}

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -6,8 +6,8 @@
     {% endif %}
 
     <div style="text-align:center;margin:10px;padding:5px;">
-        <button type="button" id="bulk_submit_all" class="btn btn-primary" onclick="submitAll(1)">Submit All Uploaded PDFS</button>
-        <button type="button" id="bulk_delete_all" class="btn btn-default" onclick="confirmDeleteAll()">Delete All Uploaded PDFS</button>
+        <button type="button" id="bulk_submit_all" class="btn btn-primary key_to_click" tabindex="0" onclick="submitAll(1)">Submit All Uploaded PDFS</button>
+        <button type="button" id="bulk_delete_all" class="btn btn-default key_to_click" tabindex="0" onclick="confirmDeleteAll()">Delete All Uploaded PDFS</button>
     </div>
 
     <table class="table table-striped table-bordered persist-area">
@@ -76,11 +76,11 @@
                         {{ file["page_count"] }}
                     </td>
                     <td>
-                        <button type="button" id="bulk_submit_{{ loop.index }}" class="btn btn-primary"
+                        <button type="button" id="bulk_submit_{{ loop.index }}" class="btn btn-primary key_to_click" tabindex="0"
                         onclick="uploadSplit( {{ loop.index }} )">Submit</button>
                     </td>
                     <td>
-                        <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default" onclick="deleteSplit({{ loop.index }})">Delete</button>
+                        <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default key_to_click" tabindex="0" onclick="deleteSplit({{ loop.index }})">Delete</button>
                     </td>
                 </tr>
             {% endfor %}
@@ -138,7 +138,7 @@
             if(parts[i].length > 1 && parts[i].includes('-')){
                 //handle range
                 tmp = parts[i].split('-');
-                if (tmp.length != 2){ 
+                if (tmp.length != 2){
                     continue;
                 }
 

--- a/site/app/templates/submission/homework/BulkUploadProgressBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadProgressBox.twig
@@ -1,6 +1,6 @@
 <div class="content" id="bulk_progress_box">
-	<h2>Bulk upload processing progress 
-		<button onClick="window.location.reload()" id="refresh_btn" style="margin:15px;" class="btn btn-default" disabled>Refresh</button>
+	<h2>Bulk upload processing progress
+		<button onClick="window.location.reload()" id="refresh_btn" style="margin:15px;" class="btn btn-default key_to_click" tabindex="0" disabled>Refresh</button>
 	</h2>
 	<div>
 		<h3 style="float:left;">Processing</h3>
@@ -43,7 +43,7 @@
     	}
     	if(completed_count > 0)
     		document.getElementById("refresh_btn").disabled = false;
-    	var message = document.createTextNode(completed_count.toString() + " files ready to assign"); 
+    	var message = document.createTextNode(completed_count.toString() + " files ready to assign");
     	assign_box.appendChild(message);
     }
 </script>

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -12,7 +12,7 @@
 
                 {# download icon if student can download files #}
                 {% if can_download %}
-                    <button class = 'btn btn-primary' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
+                    <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
                         <i class="fas fa-download" title="Download the file"></i></button>
                 {% endif %}
 
@@ -23,7 +23,7 @@
             {% if can_download and files|length > 1 %}
                 <br />
                 <br />
-                Download all files: <a onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}", "submission")' aria-label="Download zip of all files"><i class="fas fa-download" title="Download zip of all files"></i></a>
+                Download all files: <a onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}", "submission")' aria-label="Download zip of all files" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download zip of all files"></i></a>
             {% endif %}
         </div>
         <div class="box col-md-6">

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -334,7 +334,7 @@
 
                                 {% for idx in choices_indices %}
                                     <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
-                                        <input type="checkbox"
+                                        <input type="checkbox" class="key_to_click" tabindex="0"
                                                name="multiple_choice_{{ num_multiple_choice }}"
                                                id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                                value="{{ cell.choices[idx].value }}"
@@ -356,7 +356,7 @@
 
                                 {% for idx in choices_indices %}
                                     <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
-                                        <input type="radio"
+                                        <input type="radio" class="key_to_click" tabindex="0"
                                                name="multiple_choice_{{ num_multiple_choice }}"
                                                id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                                value="{{ cell.choices[idx].value }}"

--- a/site/app/templates/submission/regrade/ComponentTabs.twig
+++ b/site/app/templates/submission/regrade/ComponentTabs.twig
@@ -1,6 +1,6 @@
 <div class="component-tabs">
     {% for component in gradeable_components %}
-        <a class="component-tab component-{{ component.id }} {{ grade_inquiries[component.id].status == -1 ? 'component-unresolved' : '' }}" data-component_id="{{ component.id }}" href="javascript:void(0)" onclick="onComponentTabClicked(this)">
+        <a class="component-tab key_to_click component-{{ component.id }} {{ grade_inquiries[component.id].status == -1 ? 'component-unresolved' : '' }}" tabindex="0" data-component_id="{{ component.id }}" href="javascript:void(0)" onclick="onComponentTabClicked(this)">
             {{ component.title }}
             {% if grade_inquiries[component.id].status == -1%}
                 <i class="fas component-tab-icon fa-exclamation notification-badge"></i>

--- a/site/app/templates/submission/regrade/Discussion.twig
+++ b/site/app/templates/submission/regrade/Discussion.twig
@@ -74,40 +74,40 @@
                         </div>
                             {% if grade_inquiries[component.id] is not defined%}
                                 {# No request yet #}
-                                <button disabled type="button" formaction="{{ request_regrade_url }}" class="gi-submit btn btn-primary" style="float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ request_regrade_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Submit Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status == -1 and is_grading %}
                                 {# Grader view,request is open #}
-                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-primary" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Respond and Resolve Grade Inquiry
                                 </button>
-                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Post Additional Information
                                 </button>
-                                <button type="button" id="grading-close gi-ignore-disabled" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button type="button" id="grading-close gi-ignore-disabled" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Close Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status == -1 %}
                                 {# Request pending, we can submit new posts #}
-                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Post Additional Information
                                 </button>
-                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Close Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status == 0 and is_grading %}
                                 {# Grader view, Request closed #}
                                 {# Letting Instructor reply(comment) to the inquiry without reopening the grade_inquiry #}
-                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Add Comment
                                 </button>
-                                <button type="button" id="gi-ignore-disabled" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-primary" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button type="button" id="gi-ignore-disabled" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Reopen Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status == 0 %}
                                 {# Request closed #}
-                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Reopen Grade Inquiry
                                 </button>
                             {% endif %}
@@ -121,36 +121,36 @@
 {% endif %}
 
 {% macro markdown_buttons() %}
-    <button type="button" 
-            title="Insert a link" 
-            onclick="addMarkdownCode(1, '#reply-text-area')" 
-            style="margin-right:10px;" 
-            class="btn btn-default"> Link 
-            <i 
+    <button type="button"
+            title="Insert a link"
+            onclick="addMarkdownCode(1, '#reply-text-area')"
+            style="margin-right:10px;"
+            class="btn btn-default key_to_click" tabindex="0"> Link
+            <i
                 class="fas fa-link fa-1x">
             </i>
     </button>
-    <button title="Insert a code segment" 
-            type="button" 
-            onclick="addMarkdownCode(0, '#reply-text-area')" 
-            class="btn btn-default"> Code 
-            <i 
+    <button title="Insert a code segment"
+            type="button"
+            onclick="addMarkdownCode(0, '#reply-text-area')"
+            class="btn btn-default key_to_click" tabindex="0"> Code
+            <i
                 class="fas fa-code fa-1x">
             </i>
     </button>
-    <button title="Insert bold text" 
-            type="button" 
+    <button title="Insert bold text"
+            type="button"
             onclick="addMarkdownCode(2, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))"
-            class="btn btn-default"> Bold 
-            <i 
+            class="btn btn-default key_to_click" tabindex="0"> Bold
+            <i
                 class="fas fa-bold fa-1x">
             </i>
     </button>
-    <button title="Insert italic text" 
-            type="button" 
-            onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))"class="btn btn-default"> Italics 
-            <i 
-                class="fas fa-italic fa-1x">  
+    <button title="Insert italic text"
+            type="button"
+            onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))"class="btn btn-default key_to_click" tabindex="0"> Italics
+            <i
+                class="fas fa-italic fa-1x">
             </i>
     </button>
 {% endmacro %}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -176,6 +176,7 @@ function loadTestcaseOutput(div_name, gradeable_id, who_id, index, version = '')
 
                 loadingTools.find("span").hide();
                 loadingTools.find(".loading-tools-hide").show();
+                enableKeyToClick();
             },
             error: function(e) {
                 alert("Could not load diff, please refresh the page and try again.");
@@ -1646,4 +1647,28 @@ function resizeNoScrollTextareas() {
     $('textarea.noscroll').each(function() {
         auto_grow(this);
     })
+}
+
+$(document).ready(function() {
+  enableKeyToClick();
+});
+
+function enableKeyToClick(){
+  var key_to_click = document.getElementsByClassName("key_to_click");
+  for (var i = 0; i < key_to_click.length; i++) {
+    key_to_click[i].addEventListener('keydown', function(event) {
+      if (event.keyCode === 13) {//ENTER key
+        event.preventDefault();
+        event.stopPropagation();
+        $(event.target).click();
+      }
+    });
+    key_to_click[i].addEventListener('keyup', function(event) {
+      if (event.keyCode === 32) { //SPACE key
+        event.preventDefault();
+        event.stopPropagation();
+        $(event.target).click();
+      }
+    });
+  }
 }

--- a/site/public/templates/grading/Component.twig
+++ b/site/public/templates/grading/Component.twig
@@ -34,7 +34,7 @@ Required Input:
 
     {# Title bar (only part that triggers collapse on click) #}
     <div class="box-title container">
-        <div class="row header-block" onclick="{% block component_click %}{% endblock %}">
+        <div class="row header-block key_to_click" tabindex="0" onclick="{% block component_click %}{% endblock %}">
             {% block header_block %}
             {% endblock %}
         </div>
@@ -52,7 +52,7 @@ Required Input:
         {% endblock %}
         {% if edit_marks_enabled %}
             <div class="add-new-mark-container">
-                <input type="button" class="btn btn-primary add-new-mark" value="Add New Mark" onclick="onAddNewMark(this)"/>
+                <input type="button" class="btn btn-primary add-new-mark key_to_click" tabindex="0" value="Add New Mark" onclick="onAddNewMark(this)"/>
             </div>
         {% endif %}
         {% block extra_mark_rows %}

--- a/site/public/templates/grading/EditComponent.twig
+++ b/site/public/templates/grading/EditComponent.twig
@@ -97,14 +97,14 @@
             <div class="col-label-fixed">How should points be assigned?</div>
             <div class="col">
                 <span class="radio-input">
-                    <input type="radio" class="count-up-selector count-type-selector"
+                    <input type="radio" class="count-up-selector count-type-selector key_to_click" tabindex="0"
                            name="count-type-{{ component.id }}" {{ component.default == 0 ? 'checked' : '' }}
                            onclick="onClickCountUp(this)" id="grade_by_count_up_{{ component.id }}"> <label for="grade_by_count_up_{{ component.id }}">Grade by Count Up (from zero)</label>
                 </span>
             </div>
             <div class="col">
                 <span class="radio-input">
-                    <input type="radio" class="count-down-selector count-type-selector"
+                    <input type="radio" class="count-down-selector count-type-selector key_to_click" tabindex="0"
                            name="count-type-{{ component.id }}" {{ component.default != 0 ? 'checked' : '' }}
                            onclick="onClickCountDown(this)" id="grade_by_count_down_{{ component.id }}"> <label for="grade_by_count_down_{{ component.id }}">Grade by Count Down (from "Points")</label>
                 </span>

--- a/site/public/templates/grading/EditComponentHeader.twig
+++ b/site/public/templates/grading/EditComponentHeader.twig
@@ -24,9 +24,9 @@
     } only %}
 </span>
 
-<span class="col-no-gutters reorder-component-container" onclick="event.stopPropagation()" aria-label="Click and drag to reorder components">
-    <i class="fas fa-ellipsis-v" title="Click and drag to reorder components"></i>
+<span class="col-no-gutters reorder-component-container" tabindex="0" onclick="event.stopPropagation()" aria-label="Click and drag to reorder components">
+    <i class="fas fa-grip-lines" title="Click and drag to reorder components"></i>
 </span>
-<span class="col-no-gutters" onclick="onDeleteComponent(this); event.stopPropagation()">
+<span class="col-no-gutters key_to_click" tabindex="0" onclick="onDeleteComponent(this); event.stopPropagation()">
     <i class="fas fa-trash" title="Delete this component"></i>
 </span>

--- a/site/public/templates/grading/EditGradeable.twig
+++ b/site/public/templates/grading/EditGradeable.twig
@@ -18,8 +18,8 @@
 {% endblock %}
 
 {% block footer_content %}
-    <input type="button" class="btn btn-primary" value="Add New Component" onclick="onAddComponent(false)" />
-    <input type="button" class="btn btn-danger" value="(DO NOT USE) Add New Peer Component" onclick="onAddComponent(true)"  />
+    <input type="button" class="btn btn-primary key_to_click" tabindex="0" value="Add New Component" onclick="onAddComponent(false)" />
+    <input type="button" class="btn btn-danger key_to_click" tabindex="0" value="(DO NOT USE) Add New Peer Component" onclick="onAddComponent(true)"  />
     <a href="{{ export_components_url }}" class="btn btn-default">Export Components</a>
     <label for="import-components-file" class="btn btn-default">Import Components</label>
     <input id="import-components-file" type="file" class="btn ignore" onchange="importComponentsFromFile();" style="display: none;"/>

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -58,7 +58,7 @@ Required inputs:
         <div class="custom-mark-container mark-container row"
              data-mark_id="0">
             <span class="mark-selector-container">
-                <span class="{{ graded_component.custom_mark_selected ? "mark-selected" : "" }} mark-selector col-no-gutters"
+                <span class="{{ graded_component.custom_mark_selected ? "mark-selected" : "" }} mark-selector col-no-gutters key_to_click" tabindex="0"
                       data-mark_id="0"
                       onclick="onToggleCustomMark(this)">
                 </span>

--- a/site/public/templates/grading/GradingComponentHeader.twig
+++ b/site/public/templates/grading/GradingComponentHeader.twig
@@ -43,7 +43,7 @@
 {% else %}
     {% if show_verify_grader %}
         <span class="verify-container col-no-gutters">
-            <input type="button" class="btn btn-default" onclick="onVerifyComponent(this); event.stopPropagation()" value="Verify Grader"/>
+            <input type="button" class="btn btn-default key_to_click" tabindex="0" onclick="onVerifyComponent(this); event.stopPropagation()" value="Verify Grader"/>
         </span>
     {% endif %}
 {% endif %}

--- a/site/public/templates/grading/Mark.twig
+++ b/site/public/templates/grading/Mark.twig
@@ -9,7 +9,7 @@ Required Input:
     show_publish: True to show the 'publish' option
 #}
 <div id="mark-{{ mark.id }}"
-     class="mark-container row {{ mark.publish ? 'mark-publish' : '' }} {{ first_mark ? 'mark-first' : '' }} {{ not edit_marks_enabled and mark_disabled ? 'mark-disabled' : '' }} {{ mark.deleted ? 'mark-deleted' : '' }}"
+     class="mark-container key_to_click row {{ mark.publish ? 'mark-publish' : '' }} {{ first_mark ? 'mark-first' : '' }} {{ not edit_marks_enabled and mark_disabled ? 'mark-disabled' : '' }} {{ mark.deleted ? 'mark-deleted' : '' }}" tabindex="0"
      data-component_id="{{ component.id }}"
      data-mark_id="{{ mark.id }}"
      data-publish="{{ mark.publish }}"
@@ -77,7 +77,7 @@ Required Input:
             </span>
         {% endif %}
     {% endif %}
-    <span class="col-no-gutters mark-tools" onclick="onGetMarkStats(this);event.stopPropagation()">
+    <span class="col-no-gutters mark-tools key_to_click" tabindex="0" onclick="onGetMarkStats(this);event.stopPropagation()">
         <i class="fas fa-users icon-mark-stats" title="See who got this mark"></i>
     </span>
     {% if edit_marks_enabled %}
@@ -87,10 +87,10 @@ Required Input:
                 <i class="fas fa-trash hidden"></i>
             </span>
         {% else %}
-            <span class="delete-mark-container col-no-gutters mark-tools" onclick="onDeleteMark(this)" title="Tag for deletion">
+            <span class="delete-mark-container col-no-gutters mark-tools key_to_click" tabindex="0" onclick="onDeleteMark(this)" title="Tag for deletion">
                 <i class="fas fa-trash"></i>
             </span>
-            <span class="restore-mark-container col-no-gutters mark-tools" onclick="onRestoreMark(this)" title="Don't delete" hidden>
+            <span class="restore-mark-container col-no-gutters mark-tools key_to_click" tabindex="0" onclick="onRestoreMark(this)" title="Don't delete" hidden>
                 <i class="fas fa-undo"></i>
             </span>
         {% endif %}

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -5,7 +5,7 @@ Required Parameters:
 -overall_comment: the text to show in box
 
 #}
-<div class="box general-comment container"
+<div class="box general-comment container key_to_click" tabindex="0"
      onclick="{{ grading_disabled ? '' : 'onClickOverallComment(this)'}}">
     <div class="row">
         <div class="col">
@@ -24,7 +24,7 @@ Required Parameters:
         {% if editable %}
             <textarea id="overall-comment"
                       rows="5"
-                      class="general-comment-entry noscroll"
+                      class="general-comment-entry noscroll key_to_click" tabindex="0"
                       onclick="event.stopPropagation()"
                       onkeyup="auto_grow(this)"
                       placeholder="Overall message for student about the gradeable..."

--- a/site/public/templates/grading/SavingTools.twig
+++ b/site/public/templates/grading/SavingTools.twig
@@ -8,7 +8,7 @@ Required Parameters:
 #}
 <span class="save-tools">
     {% if show_save_tools %}
-        <span class="btn btn-default save-tools-cancel" onclick="{{ cancel_on_click }} ;event.stopPropagation()">
+        <span class="btn btn-default save-tools-cancel key_to_click" tabindex="0" onclick="{{ cancel_on_click }} ;event.stopPropagation()">
             Cancel
         </span>
         <span class="btn btn-primary save-tools-save">

--- a/site/public/templates/grading/settings/HotkeyList.twig
+++ b/site/public/templates/grading/settings/HotkeyList.twig
@@ -7,12 +7,12 @@
                     <button id="remap-{{ loop.index0 }}" class="btn btn-default remap-button" disabled="disabled">{{ hotkey.code }}</button>
                 {% else %}
                     {% set class = (hotkey.code == hotkey.originalCode) ? "btn-default" : "btn-primary" %}
-                    <button id="remap-{{ loop.index0 }}" class="btn {{ class }} remap-button remap-disable" onclick="remapHotkey({{ loop.index0 }});">{{ hotkey.code }}</button>
+                    <button id="remap-{{ loop.index0 }}" class="btn {{ class }} remap-button remap-disable key_to_click" tabindex="0" onclick="remapHotkey({{ loop.index0 }});">{{ hotkey.code }}</button>
                 {% endif %}
             </td>
             <td>
                 {% if hotkey.code != hotkey.originalCode %}
-                    <button id="remap-unset-{{ loop.index0 }}" class="btn btn-danger remap-disable" onclick="remapUnset({{ loop.index0 }});">&times;</button>
+                    <button id="remap-unset-{{ loop.index0 }}" class="btn btn-danger remap-disable key_to_click" tabindex="0" onclick="remapUnset({{ loop.index0 }});">&times;</button>
                 {% endif %}
             </td>
         </tr>

--- a/tests/e2e/accessibility.py
+++ b/tests/e2e/accessibility.py
@@ -1,0 +1,118 @@
+from .base_testcase import BaseTestCase
+import requests
+import json
+
+class TestAccessibility(BaseTestCase):
+    """
+    Test cases revolving around the logging in functionality of the site
+    """
+    def __init__(self, testname):
+        super().__init__(testname, log_in=False)
+
+
+    # This should contain a url for every type of page on the webiste
+    urls = [
+        '/home',
+        '/s20/sample',
+        '/s20/sample/gradeable/future_no_tas_homework/update?nav_tab=0',
+        '/s20/sample/gradeable/future_no_tas_lab/grading?view=all',
+        '/s20/sample/gradeable/future_no_tas_test/grading?view=all',
+        '/s20/sample/gradeable/open_homework/grading/status',
+        '/s20/sample/gradeable/open_homework/grading/details?view=all',
+        '/s20/sample/gradeable/open_homework',
+        '/s20/sample/gradeable/open_team_homework/team',
+        '/s20/sample/gradeable/grades_released_homework_autota',
+        '/s20/sample/notifications',
+        '/s20/sample/notifications/settings',
+        '/s20/sample/gradeable',
+        '/s20/sample/config',
+        '/s20/sample/theme',
+        '/s20/sample/office_hours_queue',
+        '/s20/sample/course_materials',
+        '/s20/sample/forum',
+        '/s20/sample/forum/threads/new',
+        '/s20/sample/forum/categories',
+        '/s20/sample/users',
+        '/s20/sample/graders',
+        '/s20/sample/sections',
+        '/s20/sample/student_photos',
+        '/s20/sample/late_days',
+        '/s20/sample/extensions',
+        '/s20/sample/grade_override',
+        '/s20/sample/plagiarism',
+        '/s20/sample/plagiarism/configuration/new',
+        '/s20/sample/reports',
+        '/s20/sample/reports/rainbow_grades_customization',
+        '/s20/sample/late_table'
+    ]
+
+    def test_w3_validator(self):
+        # Uncomment this to generate a new baseline for all pages on the website
+        # genBaseline(self)
+
+        # Uncomment this to generate a new baseline for a specific url
+        # url = '' # your url here
+        # genBaseline(self, url)
+
+
+        validatePages(self)
+
+
+
+def validatePages(self):
+    self.log_out()
+    self.log_in(user_id='instructor')
+    self.click_class('sample')
+
+    with open('e2e/accessibility_baseline.json') as f:
+        baseline = json.load(f)
+
+    foundError = False
+    for url in self.urls:
+        self.get(url=url)
+
+        payload = self.driver.page_source
+        headers = {
+          'Content-Type': 'text/html; charset=utf-8'
+        }
+        response = requests.request("POST", "https://validator.w3.org/nu/?out=json", headers=headers, data = payload.encode('utf-8'))
+
+
+
+        for error in response.json()['messages']:
+            if error['message'] not in baseline[url]:
+                error['url'] = url
+                print(json.dumps(error, indent=4, sort_keys=True))
+                foundError = True
+
+    self.assertEqual(foundError, False)
+
+
+
+def genBaseline(self, new_url=None):
+    self.log_out()
+    self.log_in(user_id='instructor')
+    self.click_class('sample')
+
+    baseline = {}
+    urls = self.urls
+    if new_url:
+        with open('e2e/accessibility_baseline.json') as f:
+            baseline = json.load(f)
+        urls = [new_url]
+
+    for url in urls:
+        self.get(url=url)
+        payload = self.driver.page_source
+        headers = {
+          'Content-Type': 'text/html; charset=utf-8'
+        }
+        response = requests.request("POST", "https://validator.w3.org/nu/?out=json", headers=headers, data = payload.encode('utf-8'))
+
+        if new_url == None or url == new_url:
+            baseline[url] = {}
+        for error in response.json()['messages']:
+            if error['message'] not in baseline[url]:
+                baseline[url][error['message']] = error
+    with open('e2e/accessibility_baseline.json', 'w') as f:
+        json.dump(baseline, f, ensure_ascii=False, indent=4)

--- a/tests/e2e/accessibility_baseline.json
+++ b/tests/e2e/accessibility_baseline.json
@@ -1,0 +1,2721 @@
+{
+    "/home": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 135,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 305,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “disabled” not allowed on element “a” at this point.": {
+            "type": "error",
+            "lastLine": 553,
+            "lastColumn": 130,
+            "firstColumn": 84,
+            "message": "Attribute “disabled” not allowed on element “a” at this point.",
+            "extract": "          <a class=\"btn btn-default btn-nav\" disabled=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 47
+        },
+        "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
+            "type": "error",
+            "lastLine": 1417,
+            "lastColumn": 76,
+            "firstColumn": 9,
+            "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
+            "extract": ">\n        <form name=\"close-submissions-confirmation\" method=\"post\" action=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 68
+        }
+    },
+    "/s20/sample/gradeable/future_no_tas_homework/update?nav_tab=0": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 294,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 291,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 317,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.": {
+            "type": "info",
+            "lastLine": 625,
+            "lastColumn": 46,
+            "firstColumn": 13,
+            "subType": "warning",
+            "message": "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.",
+            "extract": "          <div aria-hidden=\"true\" hidden=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 34
+        },
+        "Attribute “placeholder” not allowed on element “input” at this point.": {
+            "type": "error",
+            "lastLine": 1117,
+            "lastColumn": 273,
+            "firstColumn": 17,
+            "message": "Attribute “placeholder” not allowed on element “input” at this point.",
+            "extract": "          <input style=\"width: 83%\" type=\"hidden\" id=\"input-provide-full-path\" name=\"autograding_config_path\" value=\"PROVIDED: test_notes_upload (expects single file, 2 mb maximum, 2-page pdf student submission)\" class=\"required\" placeholder=\"(Required)\" disabled=\"\">\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 257
+        },
+        "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.": {
+            "type": "error",
+            "lastLine": 1117,
+            "lastColumn": 273,
+            "firstColumn": 17,
+            "message": "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.",
+            "extract": "          <input style=\"width: 83%\" type=\"hidden\" id=\"input-provide-full-path\" name=\"autograding_config_path\" value=\"PROVIDED: test_notes_upload (expects single file, 2 mb maximum, 2-page pdf student submission)\" class=\"required\" placeholder=\"(Required)\" disabled=\"\">\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 257
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 2299,
+            "lastColumn": 172,
+            "firstColumn": 87,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "ontainer\"><span class=\"flatpickr-day prevMonthDay\" aria-label=\"November 27, 9994\" tabindex=\"-1\">27</sp",
+            "hiliteStart": 10,
+            "hiliteLength": 86
+        }
+    },
+    "/s20/sample/gradeable/future_no_tas_lab/grading?view=all": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 287,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 284,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 310,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 586,
+            "firstLine": 585,
+            "lastColumn": 31,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <th width=\"20\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 3562,
+            "firstLine": 3561,
+            "lastColumn": 31,
+            "firstColumn": 25,
+            "message": "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "  </tbody>\n                        <thead>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 3584,
+            "firstLine": 3583,
+            "lastColumn": 32,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <td width=\"33%\"><b>Tot",
+            "hiliteStart": 10,
+            "hiliteLength": 33
+        }
+    },
+    "/s20/sample/gradeable/future_no_tas_test/grading?view=all": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 287,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 284,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 310,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 587,
+            "firstLine": 586,
+            "lastColumn": 31,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <th width=\"20\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Attribute “type” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 647,
+            "lastColumn": 137,
+            "firstColumn": 13,
+            "message": "Attribute “type” not allowed on element “div” at this point.",
+            "extract": "          <div class=\"option-small-box cell-total\" style=\"text-align: center\" type=\"text\" border=\"none\" id=\"total-0\" data-total=\"true\">0</div",
+            "hiliteStart": 10,
+            "hiliteLength": 125
+        },
+        "Attribute “border” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 647,
+            "lastColumn": 137,
+            "firstColumn": 13,
+            "message": "Attribute “border” not allowed on element “div” at this point.",
+            "extract": "          <div class=\"option-small-box cell-total\" style=\"text-align: center\" type=\"text\" border=\"none\" id=\"total-0\" data-total=\"true\">0</div",
+            "hiliteStart": 10,
+            "hiliteLength": 125
+        },
+        "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 4488,
+            "firstLine": 4487,
+            "lastColumn": 31,
+            "firstColumn": 25,
+            "message": "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "  </tbody>\n                        <thead>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 4510,
+            "firstLine": 4509,
+            "lastColumn": 32,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <td width=\"33%\"><b>Tot",
+            "hiliteStart": 10,
+            "hiliteLength": 33
+        }
+    },
+    "/s20/sample/gradeable/open_homework/grading/status": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 285,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 282,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 308,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/gradeable/open_homework/grading/details?view=all": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 283,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 280,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 309,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 569,
+            "firstLine": 568,
+            "lastColumn": 75,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                                                            <th width=\"2%\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 571,
+            "firstLine": 570,
+            "lastColumn": 96,
+            "firstColumn": 108,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "ction</th>\n                                                                                <td width=\"13%\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 97
+        }
+    },
+    "/s20/sample/gradeable/open_homework": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 299,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 296,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 322,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Bad value “true” for attribute “checked” on element “input”.": {
+            "type": "error",
+            "lastLine": 557,
+            "lastColumn": 96,
+            "firstColumn": 21,
+            "message": "Bad value “true” for attribute “checked” on element “input”.",
+            "extract": "          <input type=\"radio\" id=\"radio-normal\" name=\"submission_type\" checked=\"true\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.": {
+            "type": "error",
+            "lastLine": 567,
+            "lastColumn": 131,
+            "firstColumn": 25,
+            "message": "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.",
+            "extract": "          <a aria-label=\"Bulk PDF Upload Help\" href=\"https://submitty.org/instructor/bulk_pdf_upload\" target=\"_none\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Bad value “text” for attribute “role” on element “div”.": {
+            "type": "error",
+            "lastLine": 708,
+            "lastColumn": 205,
+            "firstColumn": 57,
+            "message": "Bad value “text” for attribute “role” on element “div”.",
+            "extract": "          <div tabindex=\"0\" id=\"upload1\" class=\"upload-box\" onkeypress=\"clicked_on_box(event)\" role=\"text\" aria-label=\"Press enter to upload your Part 1 file\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 149
+        }
+    },
+    "/s20/sample/gradeable/open_team_homework/team": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 283,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 280,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 306,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 542,
+            "firstLine": 541,
+            "lastColumn": 35,
+            "firstColumn": 21,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                    <th width=\"3%\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 36
+        }
+    },
+    "/s20/sample/gradeable/grades_released_homework_autota": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 301,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 298,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 324,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Bad value “true” for attribute “checked” on element “input”.": {
+            "type": "error",
+            "lastLine": 559,
+            "lastColumn": 96,
+            "firstColumn": 21,
+            "message": "Bad value “true” for attribute “checked” on element “input”.",
+            "extract": "          <input type=\"radio\" id=\"radio-normal\" name=\"submission_type\" checked=\"true\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.": {
+            "type": "error",
+            "lastLine": 569,
+            "lastColumn": 131,
+            "firstColumn": 25,
+            "message": "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.",
+            "extract": "          <a aria-label=\"Bulk PDF Upload Help\" href=\"https://submitty.org/instructor/bulk_pdf_upload\" target=\"_none\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Bad value “text” for attribute “role” on element “div”.": {
+            "type": "error",
+            "lastLine": 710,
+            "lastColumn": 205,
+            "firstColumn": 57,
+            "message": "Bad value “text” for attribute “role” on element “div”.",
+            "extract": "          <div tabindex=\"0\" id=\"upload1\" class=\"upload-box\" onkeypress=\"clicked_on_box(event)\" role=\"text\" aria-label=\"Press enter to upload your Part 1 file\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 149
+        },
+        "Attribute “fname” not allowed on element “tr” at this point.": {
+            "type": "error",
+            "lastLine": 716,
+            "firstLine": 715,
+            "lastColumn": 69,
+            "firstColumn": 79,
+            "message": "Attribute “fname” not allowed on element “tr” at this point.",
+            "extract": "-table-1\">\n                    <tr fname=\"fork_bomb_print.c\" class=\"file-label\"><td",
+            "hiliteStart": 10,
+            "hiliteLength": 70
+        },
+        "Bad value “text” for attribute “role” on element “i”.": {
+            "type": "error",
+            "lastLine": 716,
+            "lastColumn": 246,
+            "firstColumn": 127,
+            "message": "Bad value “text” for attribute “role” on element “i”.",
+            "extract": "\">0.37KB  <i role=\"text\" aria-label=\"Press enter to remove file fork_bomb_print.c\" tabindex=\"0\" class=\"fas fa-trash custom-focus\"></i></",
+            "hiliteStart": 10,
+            "hiliteLength": 120
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 1110,
+            "lastColumn": 129,
+            "firstColumn": 29,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "          <span class=\"loading-tools-in-progress\" aria-label=\"Loading Details for Test 2 ./a.out 10\" hidden=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 101
+        },
+        "CSS: The value “break-word” is deprecated": {
+            "type": "error",
+            "lastLine": 1181,
+            "lastColumn": 97,
+            "firstColumn": 17,
+            "message": "CSS: The value “break-word” is deprecated",
+            "extract": "          <div class=\"box half\" style=\"padding: 10px; width: 30%; word-break: break-word;\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 81
+        }
+    },
+    "/s20/sample/notifications": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 285,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 282,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 308,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/notifications/settings": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 284,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 281,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 310,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “style” not allowed as child of element “main” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 524,
+            "lastColumn": 7,
+            "firstColumn": 1,
+            "message": "Element “style” not allowed as child of element “main” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "=\"main\">\n\n<style>\n    i",
+            "hiliteStart": 10,
+            "hiliteLength": 7
+        },
+        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 565,
+            "lastColumn": 50,
+            "firstColumn": 25,
+            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div class=\"option-title\">New An",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        },
+        "Bad value “true” for attribute “checked” on element “input”.": {
+            "type": "error",
+            "lastLine": 712,
+            "lastColumn": 152,
+            "firstColumn": 79,
+            "message": "Bad value “true” for attribute “checked” on element “input”.",
+            "extract": "ng-input\"><input type=\"checkbox\" name=\"team_invite\" id=\"team_invite\" checked=\"true\"></div>",
+            "hiliteStart": 10,
+            "hiliteLength": 74
+        },
+        "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
+            "type": "error",
+            "lastLine": 564,
+            "lastColumn": 47,
+            "firstColumn": 21,
+            "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
+            "extract": "          <label for=\"forum_enabled\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 27
+        }
+    },
+    "/s20/sample/gradeable": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 289,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 286,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 312,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.": {
+            "type": "info",
+            "lastLine": 625,
+            "lastColumn": 46,
+            "firstColumn": 13,
+            "subType": "warning",
+            "message": "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.",
+            "extract": "          <div aria-hidden=\"true\" hidden=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 34
+        }
+    },
+    "/s20/sample/config": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 286,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 283,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 309,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 537,
+            "lastColumn": 38,
+            "firstColumn": 13,
+            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div class=\"option-title\">Full C",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        },
+        "Attribute “alt” not allowed on element “a” at this point.": {
+            "type": "error",
+            "lastLine": 555,
+            "lastColumn": 130,
+            "firstColumn": 17,
+            "message": "Attribute “alt” not allowed on element “a” at this point.",
+            "extract": "          <a id=\"forum-enabled-message\" href=\"http://localhost:1501/s20/sample/forum/categories\" alt=\"Customize Categories\">Custom",
+            "hiliteStart": 10,
+            "hiliteLength": 114
+        },
+        "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 596,
+            "lastColumn": 42,
+            "firstColumn": 17,
+            "message": "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div class=\"option-title\">Versio",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        },
+        "The element “a” must not appear as a descendant of the “button” element.": {
+            "type": "error",
+            "lastLine": 709,
+            "lastColumn": 106,
+            "firstColumn": 21,
+            "message": "The element “a” must not appear as a descendant of the “button” element.",
+            "extract": "          <a href=\"http://localhost:1501/s20/sample/email_room_seating\" class=\"btn btn-primary\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 86
+        }
+    },
+    "/s20/sample/theme": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 283,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 280,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 306,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/office_hours_queue": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 285,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 282,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 308,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 609,
+            "lastColumn": 9,
+            "firstColumn": 3,
+            "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "  <br>\n\n  <style>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 7
+        }
+    },
+    "/s20/sample/course_materials": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 290,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 287,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 313,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “k” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 615,
+            "lastColumn": 71,
+            "firstColumn": 13,
+            "message": "Element “k” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <k class=\"fas fa-file\" style=\"vertical-align:text-bottom;\"></k>\n ",
+            "hiliteStart": 10,
+            "hiliteLength": 59
+        },
+        "The “center” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 3997,
+            "lastColumn": 12,
+            "firstColumn": 5,
+            "message": "The “center” element is obsolete. Use CSS instead.",
+            "extract": "   \n\n\n    <center>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 8
+        },
+        "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 4176,
+            "lastColumn": 15,
+            "firstColumn": 13,
+            "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <p>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 3
+        },
+        "The element “label” must not appear as a descendant of the “label” element.": {
+            "type": "error",
+            "lastLine": 4474,
+            "lastColumn": 33,
+            "firstColumn": 13,
+            "message": "The element “label” must not appear as a descendant of the “label” element.",
+            "extract": "          <label class=\"radio\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 21
+        },
+        "The “label” element may contain at most one “button”, “input”, “meter”, “output”, “progress”, “select”, or “textarea” descendant.": {
+            "type": "error",
+            "lastLine": 4479,
+            "lastColumn": 150,
+            "firstColumn": 17,
+            "message": "The “label” element may contain at most one “button”, “input”, “meter”, “output”, “progress”, “select”, or “textarea” descendant.",
+            "extract": "          <input id=\"all-sections-showing-yes\" name=\"show-some-section-selection-edit\" type=\"radio\" onchange=\"toggleRegistrationSectionsEdit()\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 134
+        },
+        "“label” element with multiple labelable descendants.": {
+            "type": "info",
+            "lastLine": 4470,
+            "lastColumn": 34,
+            "firstColumn": 9,
+            "subType": "warning",
+            "message": "“label” element with multiple labelable descendants.",
+            "extract": ">\n        <label id=\"edit_sections\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        },
+        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 4482,
+            "lastColumn": 77,
+            "firstColumn": 13,
+            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div id=\"show-some-section-selection-edit\" style=\"display: none\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 65
+        },
+        "The “type” attribute is unnecessary for JavaScript resources.": {
+            "type": "info",
+            "lastLine": 4594,
+            "lastColumn": 43,
+            "firstColumn": 13,
+            "subType": "warning",
+            "message": "The “type” attribute is unnecessary for JavaScript resources.",
+            "extract": "          <script type=\"text/javascript\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 31
+        },
+        "Duplicate ID “upload_dt”.": {
+            "type": "error",
+            "lastLine": 4600,
+            "lastColumn": 30,
+            "firstColumn": 9,
+            "message": "Duplicate ID “upload_dt”.",
+            "extract": ">\n        <label id=\"upload_dt\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The first occurrence of ID “upload_dt” was here.": {
+            "type": "info",
+            "lastLine": 4333,
+            "lastColumn": 30,
+            "firstColumn": 9,
+            "subType": "warning",
+            "message": "The first occurrence of ID “upload_dt” was here.",
+            "extract": ">\n        <label id=\"upload_dt\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “name” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 4702,
+            "lastColumn": 47,
+            "firstColumn": 5,
+            "message": "Attribute “name” not allowed on element “div” at this point.",
+            "extract": "elete\n    <div name=\"delete-course-material-message\">\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 43
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 4741,
+            "lastColumn": 172,
+            "firstColumn": 87,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "ontainer\"><span class=\"flatpickr-day prevMonthDay\" aria-label=\"December 28, 9997\" tabindex=\"-1\">28</sp",
+            "hiliteStart": 10,
+            "hiliteLength": 86
+        },
+        "Too many messages.": {
+            "type": "error",
+            "subType": "fatal",
+            "message": "Too many messages."
+        }
+    },
+    "/s20/sample/forum": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 300,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 297,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 323,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “p” not allowed as child of element “pre” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 726,
+            "lastColumn": 87,
+            "firstColumn": 32,
+            "message": "Element “p” not allowed as child of element “pre” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "re_forum\"><p class=\"post_content\" style=\"white-space: pre-wrap; \"></p></",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “h7” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 729,
+            "lastColumn": 50,
+            "firstColumn": 9,
+            "message": "Element “h7” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)",
+            "extract": ">\n        <h7 style=\"position:relative; right:5px;\"><stron",
+            "hiliteStart": 10,
+            "hiliteLength": 42
+        },
+        "Bad value “input” for attribute “type” on element “input”.": {
+            "type": "error",
+            "lastLine": 767,
+            "lastColumn": 179,
+            "firstColumn": 9,
+            "message": "Bad value “input” for attribute “type” on element “input”.",
+            "extract": ">\n        <input type=\"input\" id=\"split_post_input\" name=\"split_post_input\" oninput=\"disableIfEmpty(this, 'split_post_submit')\" placeholder=\"Name of new thread\" style=\"width: 100%\">\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 171
+        },
+        "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.": {
+            "type": "error",
+            "lastLine": 767,
+            "lastColumn": 179,
+            "firstColumn": 9,
+            "message": "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.",
+            "extract": ">\n        <input type=\"input\" id=\"split_post_input\" name=\"split_post_input\" oninput=\"disableIfEmpty(this, 'split_post_submit')\" placeholder=\"Name of new thread\" style=\"width: 100%\">\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 171
+        },
+        "The element “input” must not appear as a descendant of the “a” element.": {
+            "type": "error",
+            "lastLine": 773,
+            "lastColumn": 93,
+            "firstColumn": 17,
+            "message": "The element “input” must not appear as a descendant of the “a” element.",
+            "extract": "          <input type=\"checkbox\" name=\"cat[]\" value=\"2\" aria-label=\"Category Question\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 77
+        },
+        "The “type” attribute is unnecessary for JavaScript resources.": {
+            "type": "info",
+            "lastLine": 792,
+            "lastColumn": 35,
+            "firstColumn": 5,
+            "subType": "warning",
+            "message": "The “type” attribute is unnecessary for JavaScript resources.",
+            "extract": "=\"\">\n\n    <script type=\"text/javascript\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 31
+        },
+        "Attribute “label” not allowed on element “a” at this point.": {
+            "type": "error",
+            "lastLine": 866,
+            "lastColumn": 171,
+            "firstColumn": 6,
+            "message": "Attribute “label” not allowed on element “a” at this point.",
+            "extract": "\t\t\t\t\n\t\t\t\t\t<a id=\"clear_filter_button\" class=\"inline-block text-decoration-none\" style=\"color: var(--actionable-blue);\" label=\"Clear Filters\" onclick=\"clearForumFilter(event);\">× Clea",
+            "hiliteStart": 10,
+            "hiliteLength": 166
+        },
+        "Attribute “checked” not allowed on element “li” at this point.": {
+            "type": "error",
+            "lastLine": 896,
+            "lastColumn": 130,
+            "firstColumn": 16,
+            "message": "Attribute “checked” not allowed on element “li” at this point.",
+            "extract": "          <li title=\"Sort posts by reply hierarchy\" id=\"tree\" class=\"dropdown-item active\" role=\"menuitem\" checked=\"checked\"><a onc",
+            "hiliteStart": 10,
+            "hiliteLength": 115
+        },
+        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 908,
+            "lastColumn": 10,
+            "firstColumn": 4,
+            "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "</div>\n\t\t\t<style>\n\t\t\t\t\t",
+            "hiliteStart": 10,
+            "hiliteLength": 7
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 939,
+            "lastColumn": 109,
+            "firstColumn": 4,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "true\">\n\t\t\t<div id=\"thread_category\" aria-label=\"Select thread category\" class=\"inline-block\" data-ays-ignore=\"true\">\n\t\t\t\t\t",
+            "hiliteStart": 10,
+            "hiliteLength": 106
+        },
+        "Attribute “cat-id” not allowed on element “button” at this point.": {
+            "type": "error",
+            "lastLine": 940,
+            "lastColumn": 116,
+            "firstColumn": 10,
+            "message": "Attribute “cat-id” not allowed on element “button” at this point.",
+            "extract": "\n\t\t\t\t\t\t\t\t\t<button class=\"btn btn-sm filter-inactive\" type=\"button\" id=\"categoryid_2\" cat-id=\"2\" btn-selected=\"false\">Questi",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Attribute “btn-selected” not allowed on element “button” at this point.": {
+            "type": "error",
+            "lastLine": 940,
+            "lastColumn": 116,
+            "firstColumn": 10,
+            "message": "Attribute “btn-selected” not allowed on element “button” at this point.",
+            "extract": "\n\t\t\t\t\t\t\t\t\t<button class=\"btn btn-sm filter-inactive\" type=\"button\" id=\"categoryid_2\" cat-id=\"2\" btn-selected=\"false\">Questi",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Attribute “sel-id” not allowed on element “button” at this point.": {
+            "type": "error",
+            "lastLine": 945,
+            "lastColumn": 104,
+            "firstColumn": 5,
+            "message": "Attribute “sel-id” not allowed on element “button” at this point.",
+            "extract": "rue\">\n\t\t\t\t<button class=\"btn btn-sm btn-default inline-block filter-inactive\" sel-id=\"0\" btn-selected=\"false\">Commen",
+            "hiliteStart": 10,
+            "hiliteLength": 100
+        },
+        "Attribute “prev_page” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 985,
+            "lastColumn": 76,
+            "firstColumn": 13,
+            "message": "Attribute “prev_page” not allowed on element “div” at this point.",
+            "extract": "          <div id=\"thread_list\" class=\"col-3\" prev_page=\"0\" next_page=\"2\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 64
+        },
+        "Attribute “next_page” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 985,
+            "lastColumn": 76,
+            "firstColumn": 13,
+            "message": "Attribute “next_page” not allowed on element “div” at this point.",
+            "extract": "          <div id=\"thread_list\" class=\"col-3\" prev_page=\"0\" next_page=\"2\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 64
+        },
+        "Attribute “data” not allowed on element “a” at this point.": {
+            "type": "error",
+            "lastLine": 989,
+            "lastColumn": 112,
+            "firstColumn": 21,
+            "message": "Attribute “data” not allowed on element “a” at this point.",
+            "extract": "          <a href=\"http://localhost:1501/s20/sample/forum/threads/1\" class=\"thread_box_link\" data=\"1\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 92
+        },
+        "Attribute “reply-level” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 1132,
+            "lastColumn": 107,
+            "firstColumn": 5,
+            "message": "Attribute “reply-level” not allowed on element “div” at this point.",
+            "extract": "     \n    <div class=\"post_box first_post viewed_post important\" id=\"1\" style=\"margin-left:0px;\" reply-level=\"1\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 103
+        },
+        "Attribute “post_box_id” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 1180,
+            "lastColumn": 54,
+            "firstColumn": 9,
+            "message": "Attribute “post_box_id” not allowed on element “div” at this point.",
+            "extract": "\n\n        <div class=\"thread-post-form\" post_box_id=\"1\">\n\n<div",
+            "hiliteStart": 10,
+            "hiliteLength": 46
+        },
+        "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.": {
+            "type": "error",
+            "lastLine": 1201,
+            "lastColumn": 363,
+            "firstColumn": 17,
+            "message": "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.",
+            "extract": "          <textarea name=\"thread_post_content\" class=\"fill-available post_content_reply thread_post_content\" style=\"resize: none; min-height: 100px; max-height: 300px; height: 0px;\" rows=\"10\" cols=\"30\" placeholder=\"Enter your reply to Quinn I. here...\" required=\"\" aria-label=\"Thread Post Textarea\" maxlength=\"\" onkeydown=\"submitNearestForm(event,$(this))\"></text",
+            "hiliteStart": 10,
+            "hiliteLength": 347
+        },
+        "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 1207,
+            "lastColumn": 87,
+            "firstColumn": 25,
+            "message": "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div class=\"upload_attachment_box cursor-pointer\" id=\"upload1\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 63
+        },
+        "Consider using the “h1” element as a top-level heading only (all “h1” elements are treated as top-level headings by many screen readers and other tools).": {
+            "type": "info",
+            "lastLine": 303,
+            "lastColumn": 99,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "Consider using the “h1” element as a top-level heading only (all “h1” elements are treated as top-level headings by many screen readers and other tools).",
+            "extract": "          <h1 class=\"breadcrumb_heading\">Discus",
+            "hiliteStart": 10,
+            "hiliteLength": 31
+        }
+    },
+    "/s20/sample/forum/threads/new": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 291,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 288,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 317,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “align” attribute on the “div” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 562,
+            "lastColumn": 52,
+            "firstColumn": 5,
+            "message": "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
+            "extract": "/h3>\n\n    <div id=\"manage_categories_view\" align=\"center\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 48
+        },
+        "Attribute “rows” not allowed on element “input” at this point.": {
+            "type": "error",
+            "lastLine": 567,
+            "lastColumn": 215,
+            "firstColumn": 17,
+            "message": "Attribute “rows” not allowed on element “input” at this point.",
+            "extract": "          <input id=\"new_category_text\" aria-label=\"New Category\" placeholder=\"New Category\" style=\"resize:none;\" rows=\"1\" type=\"text\" name=\"new_category\" maxlength=\"50\" onkeyup=\"checkInputMaxLength($(this))\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 199
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 576,
+            "lastColumn": 122,
+            "firstColumn": 21,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "          <i class=\"fas fa-bars handle ui-sortable-handle\" aria-label=\"Drag to reorder\" title=\"Drag to reorder\"></i>\n ",
+            "hiliteStart": 10,
+            "hiliteLength": 102
+        },
+        "Attribute “label” not allowed on element “a” at this point.": {
+            "type": "error",
+            "lastLine": 790,
+            "lastColumn": 171,
+            "firstColumn": 6,
+            "message": "Attribute “label” not allowed on element “a” at this point.",
+            "extract": "\t\t\t\t\n\t\t\t\t\t<a id=\"clear_filter_button\" class=\"inline-block text-decoration-none\" style=\"color: var(--actionable-blue);\" label=\"Clear Filters\" onclick=\"clearForumFilter(event);\">× Clea",
+            "hiliteStart": 10,
+            "hiliteLength": 166
+        },
+        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 809,
+            "lastColumn": 10,
+            "firstColumn": 4,
+            "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "</div>\n\t\t\t<style>\n\t\t\t\t\t",
+            "hiliteStart": 10,
+            "hiliteLength": 7
+        },
+        "Attribute “cat-id” not allowed on element “button” at this point.": {
+            "type": "error",
+            "lastLine": 841,
+            "lastColumn": 116,
+            "firstColumn": 10,
+            "message": "Attribute “cat-id” not allowed on element “button” at this point.",
+            "extract": "\n\t\t\t\t\t\t\t\t\t<button class=\"btn btn-sm filter-inactive\" type=\"button\" id=\"categoryid_2\" cat-id=\"2\" btn-selected=\"false\">Questi",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Attribute “btn-selected” not allowed on element “button” at this point.": {
+            "type": "error",
+            "lastLine": 841,
+            "lastColumn": 116,
+            "firstColumn": 10,
+            "message": "Attribute “btn-selected” not allowed on element “button” at this point.",
+            "extract": "\n\t\t\t\t\t\t\t\t\t<button class=\"btn btn-sm filter-inactive\" type=\"button\" id=\"categoryid_2\" cat-id=\"2\" btn-selected=\"false\">Questi",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Attribute “sel-id” not allowed on element “button” at this point.": {
+            "type": "error",
+            "lastLine": 846,
+            "lastColumn": 104,
+            "firstColumn": 5,
+            "message": "Attribute “sel-id” not allowed on element “button” at this point.",
+            "extract": "rue\">\n\t\t\t\t<button class=\"btn btn-sm btn-default inline-block filter-inactive\" sel-id=\"0\" btn-selected=\"false\">Commen",
+            "hiliteStart": 10,
+            "hiliteLength": 100
+        },
+        "Attribute “post_box_id” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 859,
+            "lastColumn": 54,
+            "firstColumn": 9,
+            "message": "Attribute “post_box_id” not allowed on element “div” at this point.",
+            "extract": "\n\n        <div class=\"thread-post-form\" post_box_id=\"1\">\n\n<div",
+            "hiliteStart": 10,
+            "hiliteLength": 46
+        },
+        "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.": {
+            "type": "error",
+            "lastLine": 927,
+            "lastColumn": 353,
+            "firstColumn": 17,
+            "message": "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.",
+            "extract": "          <textarea name=\"thread_post_content\" class=\"fill-available post_content_reply thread_post_content\" style=\"resize: none; min-height: 40vmin; max-height: 300px; height: 358px;\" rows=\"10\" cols=\"30\" placeholder=\"Enter your post here...\" required=\"\" aria-label=\"Thread Post Textarea\" maxlength=\"\" onkeydown=\"submitNearestForm(event,$(this))\"></text",
+            "hiliteStart": 10,
+            "hiliteLength": 337
+        },
+        "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 944,
+            "lastColumn": 87,
+            "firstColumn": 25,
+            "message": "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div class=\"upload_attachment_box cursor-pointer\" id=\"upload1\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 63
+        }
+    },
+    "/s20/sample/forum/categories": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 288,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 285,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 314,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “align” attribute on the “div” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 555,
+            "lastColumn": 52,
+            "firstColumn": 5,
+            "message": "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
+            "extract": "/h3>\n\n    <div id=\"manage_categories_view\" align=\"center\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 48
+        },
+        "Attribute “rows” not allowed on element “input” at this point.": {
+            "type": "error",
+            "lastLine": 560,
+            "lastColumn": 215,
+            "firstColumn": 17,
+            "message": "Attribute “rows” not allowed on element “input” at this point.",
+            "extract": "          <input id=\"new_category_text\" aria-label=\"New Category\" placeholder=\"New Category\" style=\"resize:none;\" rows=\"1\" type=\"text\" name=\"new_category\" maxlength=\"50\" onkeyup=\"checkInputMaxLength($(this))\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 199
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 569,
+            "lastColumn": 122,
+            "firstColumn": 21,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "          <i class=\"fas fa-bars handle ui-sortable-handle\" aria-label=\"Drag to reorder\" title=\"Drag to reorder\"></i>\n ",
+            "hiliteStart": 10,
+            "hiliteLength": 102
+        }
+    },
+    "/s20/sample/users": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 289,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 286,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 312,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "A table row was 8 columns wide and exceeded the column count established by the first row (7).": {
+            "type": "info",
+            "lastLine": 551,
+            "lastColumn": 30,
+            "firstColumn": 26,
+            "subType": "warning",
+            "message": "A table row was 8 columns wide and exceeded the column count established by the first row (7).",
+            "extract": "     </th></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        },
+        "Table column 8 established by element “th” has no cells beginning in it.": {
+            "type": "error",
+            "lastLine": 550,
+            "firstLine": 549,
+            "lastColumn": 62,
+            "firstColumn": 38,
+            "message": "Table column 8 established by element “th” has no cells beginning in it.",
+            "extract": "ss=\"info\">\n                        <th class=\"section-break\" colspan=\"8\">Studen",
+            "hiliteStart": 10,
+            "hiliteLength": 63
+        },
+        "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 1861,
+            "lastColumn": 91,
+            "firstColumn": 58,
+            "message": "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "     <h1>\t<div id=\"edit-grader-modal-title\">Edit G",
+            "hiliteStart": 10,
+            "hiliteLength": 34
+        },
+        "Duplicate ID “edit-user-form”.": {
+            "type": "error",
+            "lastLine": 1870,
+            "lastColumn": 29,
+            "firstColumn": 5,
+            "message": "Duplicate ID “edit-user-form”.",
+            "extract": "lse\">\n    <div id=\"edit-user-form\">\n\t\t<la",
+            "hiliteStart": 10,
+            "hiliteLength": 25
+        },
+        "The first occurrence of ID “edit-user-form” was here.": {
+            "type": "info",
+            "lastLine": 1856,
+            "lastColumn": 67,
+            "firstColumn": 1,
+            "subType": "warning",
+            "message": "The first occurrence of ID “edit-user-form” was here.",
+            "extract": "   </div>\n<div class=\"popup-form\" id=\"edit-user-form\" style=\"display: none;\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 67
+        },
+        "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 1872,
+            "lastColumn": 50,
+            "firstColumn": 4,
+            "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "idth\">\n\t\t\t<p id=\"user-form-already-exists-error-message\">\n\t\t\t\tU",
+            "hiliteStart": 10,
+            "hiliteLength": 47
+        },
+        "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
+            "type": "error",
+            "lastLine": 1871,
+            "lastColumn": 85,
+            "firstColumn": 3,
+            "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
+            "extract": "-form\">\n\t\t<label for=\"user-form-already-exists-error-message\" class=\"red-message full-width\">\n\t\t\t<p",
+            "hiliteStart": 10,
+            "hiliteLength": 83
+        }
+    },
+    "/s20/sample/graders": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 289,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 286,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 312,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "A table row was 8 columns wide and exceeded the column count established by the first row (6).": {
+            "type": "info",
+            "lastLine": 549,
+            "lastColumn": 34,
+            "firstColumn": 30,
+            "subType": "warning",
+            "message": "A table row was 8 columns wide and exceeded the column count established by the first row (6).",
+            "extract": "     </th></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        },
+        "Duplicate ID “section-”.": {
+            "type": "error",
+            "lastLine": 575,
+            "firstLine": 574,
+            "lastColumn": 40,
+            "firstColumn": 69,
+            "message": "Duplicate ID “section-”.",
+            "extract": "  </tbody>\n\t\t\t                <tbody id=\"section-\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 41
+        },
+        "The first occurrence of ID “section-” was here.": {
+            "type": "info",
+            "lastLine": 546,
+            "firstLine": 545,
+            "lastColumn": 40,
+            "firstColumn": 26,
+            "subType": "warning",
+            "message": "The first occurrence of ID “section-” was here.",
+            "extract": "r></thead>\n\t\t\t                <tbody id=\"section-\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 41
+        },
+        "Table columns in range 7…8 established by element “th” have no cells beginning in them.": {
+            "type": "error",
+            "lastLine": 548,
+            "firstLine": 547,
+            "lastColumn": 66,
+            "firstColumn": 62,
+            "message": "Table columns in range 7…8 established by element “th” have no cells beginning in them.",
+            "extract": "ss=\"info\">\n                            <th class=\"section-break\" colspan=\"8\">Instru",
+            "hiliteStart": 10,
+            "hiliteLength": 67
+        },
+        "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 632,
+            "lastColumn": 91,
+            "firstColumn": 58,
+            "message": "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "     <h1>\t<div id=\"edit-grader-modal-title\">Edit G",
+            "hiliteStart": 10,
+            "hiliteLength": 34
+        },
+        "Duplicate ID “edit-user-form”.": {
+            "type": "error",
+            "lastLine": 641,
+            "lastColumn": 29,
+            "firstColumn": 5,
+            "message": "Duplicate ID “edit-user-form”.",
+            "extract": "lse\">\n    <div id=\"edit-user-form\">\n\t\t<la",
+            "hiliteStart": 10,
+            "hiliteLength": 25
+        },
+        "The first occurrence of ID “edit-user-form” was here.": {
+            "type": "info",
+            "lastLine": 627,
+            "lastColumn": 67,
+            "firstColumn": 1,
+            "subType": "warning",
+            "message": "The first occurrence of ID “edit-user-form” was here.",
+            "extract": "   </div>\n<div class=\"popup-form\" id=\"edit-user-form\" style=\"display: none;\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 67
+        },
+        "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 643,
+            "lastColumn": 50,
+            "firstColumn": 4,
+            "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "idth\">\n\t\t\t<p id=\"user-form-already-exists-error-message\">\n\t\t\t\tU",
+            "hiliteStart": 10,
+            "hiliteLength": 47
+        },
+        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 1430,
+            "lastColumn": 7,
+            "firstColumn": 1,
+            "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "</table>\n\n<style>\n\t.gra",
+            "hiliteStart": 10,
+            "hiliteLength": 7
+        },
+        "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
+            "type": "error",
+            "lastLine": 642,
+            "lastColumn": 85,
+            "firstColumn": 3,
+            "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
+            "extract": "-form\">\n\t\t<label for=\"user-form-already-exists-error-message\" class=\"red-message full-width\">\n\t\t\t<p",
+            "hiliteStart": 10,
+            "hiliteLength": 83
+        }
+    },
+    "/s20/sample/sections": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 284,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 281,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 307,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 631,
+            "lastColumn": 33,
+            "firstColumn": 8,
+            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "\">\n\t\t\t\t\t\t\t<div class=\"option-title\">Add Re",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        }
+    },
+    "/s20/sample/student_photos": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 286,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 283,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 309,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “font” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 538,
+            "lastColumn": 194,
+            "firstColumn": 176,
+            "message": "The “font” element is obsolete. Use CSS instead.",
+            "extract": "   <td><i><font color=\"gray\"><img a",
+            "hiliteStart": 10,
+            "hiliteLength": 19
+        },
+        "Element “img” is missing required attribute “src”.": {
+            "type": "error",
+            "lastLine": 538,
+            "lastColumn": 224,
+            "firstColumn": 195,
+            "message": "Element “img” is missing required attribute “src”.",
+            "extract": "or=\"gray\"><img alt=\"No Image Available\"></font",
+            "hiliteStart": 10,
+            "hiliteLength": 30
+        },
+        "A table row was 5 columns wide, which is less than the column count established by the first row (8).": {
+            "type": "info",
+            "lastLine": 557,
+            "firstLine": 556,
+            "lastColumn": 69,
+            "firstColumn": 30,
+            "subType": "warning",
+            "message": "A table row was 5 columns wide, which is less than the column count established by the first row (8).",
+            "extract": "     </td>\n                                                                </tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 70
+        },
+        "A table row was 4 columns wide, which is less than the column count established by the first row (8).": {
+            "type": "info",
+            "lastLine": 604,
+            "firstLine": 603,
+            "lastColumn": 97,
+            "firstColumn": 30,
+            "subType": "warning",
+            "message": "A table row was 4 columns wide, which is less than the column count established by the first row (8).",
+            "extract": "     </td>\n                                                                                            </tr></tbod",
+            "hiliteStart": 10,
+            "hiliteLength": 98
+        },
+        "A table row was 2 columns wide, which is less than the column count established by the first row (8).": {
+            "type": "info",
+            "lastLine": 672,
+            "firstLine": 671,
+            "lastColumn": 97,
+            "firstColumn": 30,
+            "subType": "warning",
+            "message": "A table row was 2 columns wide, which is less than the column count established by the first row (8).",
+            "extract": "     </td>\n                                                                                            </tr></tbod",
+            "hiliteStart": 10,
+            "hiliteLength": 98
+        },
+        "A table row was 3 columns wide, which is less than the column count established by the first row (8).": {
+            "type": "info",
+            "lastLine": 1316,
+            "firstLine": 1315,
+            "lastColumn": 97,
+            "firstColumn": 30,
+            "subType": "warning",
+            "message": "A table row was 3 columns wide, which is less than the column count established by the first row (8).",
+            "extract": "     </td>\n                                                                                            </tr></tbod",
+            "hiliteStart": 10,
+            "hiliteLength": 98
+        },
+        "Table columns in range 6…8 established by element “td” have no cells beginning in them.": {
+            "type": "error",
+            "lastLine": 530,
+            "firstLine": 529,
+            "lastColumn": 63,
+            "firstColumn": 61,
+            "message": "Table columns in range 6…8 established by element “td” have no cells beginning in them.",
+            "extract": "ss=\"info\">\n                    <td colspan=\"8\" style=\"text-align: center\">Studen",
+            "hiliteStart": 10,
+            "hiliteLength": 64
+        }
+    },
+    "/s20/sample/late_days": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 291,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 288,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 314,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “type” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 528,
+            "lastColumn": 32,
+            "firstColumn": 1,
+            "message": "Attribute “type” not allowed on element “div” at this point.",
+            "extract": "=\"main\">\n\n<div type=\"hidden\" id=\"message\"></div>",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 558,
+            "lastColumn": 44,
+            "firstColumn": 17,
+            "message": "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div id=\"csv_upload_format\">Do not",
+            "hiliteStart": 10,
+            "hiliteLength": 28
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 627,
+            "lastColumn": 181,
+            "firstColumn": 87,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "ontainer\"><span class=\"flatpickr-day today\" aria-label=\"March 1, 2020\" aria-current=\"date\" tabindex=\"-1\">1</spa",
+            "hiliteStart": 10,
+            "hiliteLength": 95
+        }
+    },
+    "/s20/sample/extensions": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 291,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 288,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 314,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “type” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 528,
+            "lastColumn": 32,
+            "firstColumn": 1,
+            "message": "Attribute “type” not allowed on element “div” at this point.",
+            "extract": "=\"main\">\n\n<div type=\"hidden\" id=\"message\"></div>",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
+            "type": "error",
+            "lastLine": 531,
+            "lastColumn": 108,
+            "firstColumn": 5,
+            "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
+            "extract": "</h1>\n    <form id=\"extensions-form\" class=\"exception-form\" method=\"post\" enctype=\"multipart/form-data\" action=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 104
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 699,
+            "lastColumn": 181,
+            "firstColumn": 87,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "ontainer\"><span class=\"flatpickr-day today\" aria-label=\"March 1, 2020\" aria-current=\"date\" tabindex=\"-1\">1</spa",
+            "hiliteStart": 10,
+            "hiliteLength": 95
+        }
+    },
+    "/s20/sample/grade_override": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 284,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 281,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 307,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
+            "type": "error",
+            "lastLine": 540,
+            "lastColumn": 135,
+            "firstColumn": 5,
+            "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
+            "extract": "<br>\n\n    <form id=\"gradeOverrideForm\" method=\"post\" enctype=\"multipart/form-data\" action=\"\" onsubmit=\"return updateGradeOverride($(this));\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 131
+        },
+        "The “align” attribute on the “div” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 590,
+            "lastColumn": 56,
+            "firstColumn": 9,
+            "message": "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
+            "extract": ">\n        <div id=\"load-overridden-grades\" align=\"center\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 48
+        },
+        "The “align” attribute on the “table” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 592,
+            "lastColumn": 136,
+            "firstColumn": 27,
+            "message": "The “align” attribute on the “table” element is obsolete. Use CSS instead.",
+            "extract": "    </div><table id=\"my_table\" class=\"table table-striped table-bordered persist-area\" style=\"width:70%\" align=\"center\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 110
+        }
+    },
+    "/s20/sample/plagiarism": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 283,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 280,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 306,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “center” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 526,
+            "lastColumn": 12,
+            "firstColumn": 5,
+            "message": "The “center” element is obsolete. Use CSS instead.",
+            "extract": "sub\">\n    <center>\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 8
+        },
+        "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
+            "type": "error",
+            "lastLine": 532,
+            "lastColumn": 52,
+            "firstColumn": 9,
+            "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
+            "extract": ">\n        <form name=\"delete\" method=\"post\" action=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 44
+        },
+        "Element “div” not allowed as child of element “b” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 542,
+            "lastColumn": 55,
+            "firstColumn": 28,
+            "message": "Element “div” not allowed as child of element “b” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "       <b><div name=\"gradeable_title\"></div>",
+            "hiliteStart": 10,
+            "hiliteLength": 28
+        }
+    },
+    "/s20/sample/plagiarism/configuration/new": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 283,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 280,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 309,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “name” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 586,
+            "lastColumn": 92,
+            "firstColumn": 17,
+            "message": "Attribute “name” not allowed on element “div” at this point.",
+            "extract": "          <div style=\"width:70%;float:right;overflow:auto;\" name=\"prev_gradeable_div\">      ",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "Attribute “name” not allowed on element “span” at this point.": {
+            "type": "error",
+            "lastLine": 596,
+            "lastColumn": 79,
+            "firstColumn": 21,
+            "message": "Attribute “name” not allowed on element “span” at this point.",
+            "extract": "          <span name=\"add_more_prev_gradeable\" aria-label=\"Add more\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 59
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 596,
+            "lastColumn": 79,
+            "firstColumn": 21,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "          <span name=\"add_more_prev_gradeable\" aria-label=\"Add more\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 59
+        }
+    },
+    "/s20/sample/reports": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 283,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 280,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 306,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 539,
+            "firstLine": 538,
+            "lastColumn": 32,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <td width=\"50%\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 33
+        },
+        "Row 3 of a row group established by a “tbody” element has no cells beginning on it.": {
+            "type": "error",
+            "lastLine": 555,
+            "lastColumn": 33,
+            "firstColumn": 29,
+            "message": "Row 3 of a row group established by a “tbody” element has no cells beginning on it.",
+            "extract": "ass=\"bar\"></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        },
+        "A table row was 0 columns wide, which is less than the column count established by the first row (3).": {
+            "type": "info",
+            "lastLine": 555,
+            "lastColumn": 33,
+            "firstColumn": 29,
+            "subType": "warning",
+            "message": "A table row was 0 columns wide, which is less than the column count established by the first row (3).",
+            "extract": "ass=\"bar\"></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        },
+        "Row 4 of a row group established by a “tbody” element has no cells beginning on it.": {
+            "type": "error",
+            "lastLine": 556,
+            "lastColumn": 33,
+            "firstColumn": 29,
+            "message": "Row 4 of a row group established by a “tbody” element has no cells beginning on it.",
+            "extract": "ass=\"bar\"></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        },
+        "Row 6 of a row group established by a “tbody” element has no cells beginning on it.": {
+            "type": "error",
+            "lastLine": 566,
+            "lastColumn": 33,
+            "firstColumn": 29,
+            "message": "Row 6 of a row group established by a “tbody” element has no cells beginning on it.",
+            "extract": "ass=\"bar\"></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        },
+        "Row 7 of a row group established by a “tbody” element has no cells beginning on it.": {
+            "type": "error",
+            "lastLine": 567,
+            "lastColumn": 33,
+            "firstColumn": 29,
+            "message": "Row 7 of a row group established by a “tbody” element has no cells beginning on it.",
+            "extract": "ass=\"bar\"></tr>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 5
+        }
+    },
+    "/s20/sample/reports/rainbow_grades_customization": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 285,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 282,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 308,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/late_table": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 286,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 283,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 309,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Bad value “” for attribute “id” on element “td”: An ID must not be the empty string.": {
+            "type": "error",
+            "lastLine": 549,
+            "firstLine": 548,
+            "lastColumn": 31,
+            "firstColumn": 34,
+            "message": "Bad value “” for attribute “id” on element “td”: An ID must not be the empty string.",
+            "extract": "\">N/A</td>\n            <td class=\"\" id=\"\">Good</",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Duplicate ID “”.": {
+            "type": "error",
+            "lastLine": 550,
+            "firstLine": 549,
+            "lastColumn": 47,
+            "firstColumn": 41,
+            "message": "Duplicate ID “”.",
+            "extract": ">Good</td>\n                            <td class=\"\" id=\"\">0</td>",
+            "hiliteStart": 10,
+            "hiliteLength": 48
+        },
+        "The first occurrence of ID “” was here.": {
+            "type": "info",
+            "lastLine": 549,
+            "firstLine": 548,
+            "lastColumn": 31,
+            "firstColumn": 34,
+            "subType": "warning",
+            "message": "The first occurrence of ID “” was here.",
+            "extract": "\">N/A</td>\n            <td class=\"\" id=\"\">Good</",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        }
+    }
+}

--- a/tests/e2e/accessibility_baseline.json
+++ b/tests/e2e/accessibility_baseline.json
@@ -54,7 +54,7 @@
         },
         "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
             "type": "error",
-            "lastLine": 1417,
+            "lastLine": 1415,
             "lastColumn": 76,
             "firstColumn": 9,
             "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
@@ -634,7 +634,7 @@
             "lastColumn": 69,
             "firstColumn": 79,
             "message": "Attribute “fname” not allowed on element “tr” at this point.",
-            "extract": "-table-1\">\n                    <tr fname=\"fork_bomb_print.c\" class=\"file-label\"><td",
+            "extract": "-table-1\">\n                    <tr fname=\"fork_bomb_print.c\" class=\"file-label\"><td>fo",
             "hiliteStart": 10,
             "hiliteLength": 70
         },
@@ -1683,6 +1683,28 @@
             "extract": "          <i class=\"fas fa-bars handle ui-sortable-handle\" aria-label=\"Drag to reorder\" title=\"Drag to reorder\"></i>\n ",
             "hiliteStart": 10,
             "hiliteLength": 102
+        }
+    },
+    "http://localhost:1501/s20/sample/forum/stats": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 135,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
         }
     },
     "/s20/sample/users": {

--- a/tests/e2e/accessibility_baseline.json
+++ b/tests/e2e/accessibility_baseline.json
@@ -566,6 +566,47 @@
             "hiliteStart": 0,
             "hiliteLength": 16
         },
+        "The \u201ctype\u201d attribute is unnecessary for JavaScript resources.":{
+            "extract": "          <script type=\"text/javascript\">\n     ",
+            "firstColumn": 25,
+            "hiliteLength": 31,
+            "hiliteStart": 10,
+            "lastColumn": 55,
+            "lastLine": 1015,
+            "message": "The \u201ctype\u201d attribute is unnecessary for JavaScript resources.",
+            "subType": "warning",
+            "type": "info"
+        },
+        "Element \u201chead\u201d is missing a required instance of child element \u201ctitle\u201d.":{
+            "extract": "en\"><head></head><body ",
+            "firstColumn": 23,
+            "hiliteLength": 7,
+            "hiliteStart": 10,
+            "lastColumn": 29,
+            "lastLine": 1,
+            "message": "Element \u201chead\u201d is missing a required instance of child element \u201ctitle\u201d.",
+            "type": "error"
+        },
+        "Element \u201ctitle\u201d not allowed as child of element \u201cbody\u201d in this context. (Suppressing further errors from this subtree.)":{
+            "extract": "r>\n\n\n\n    <title>Submit",
+            "firstColumn": 5,
+            "hiliteLength": 7,
+            "hiliteStart": 10,
+            "lastColumn": 11,
+            "lastLine": 6,
+            "message": "Element \u201ctitle\u201d not allowed as child of element \u201cbody\u201d in this context. (Suppressing further errors from this subtree.)",
+            "type": "error"
+        },
+        "itle>\n    <link rel=\"shortcut icon\" href=\"http://localhost/img/favicon.ico\" type=\"image/x-icon\">\n\n    ":{
+            "extract": "itle>\n    <link rel=\"shortcut icon\" href=\"http://localhost/img/favicon.ico\" type=\"image/x-icon\">\n\n    ",
+            "firstColumn": 5,
+            "hiliteLength": 86,
+            "hiliteStart": 10,
+            "lastColumn": 90,
+            "lastLine": 7,
+            "message": "A \u201clink\u201d element must not appear as a descendant of a \u201cbody\u201d element unless the \u201clink\u201d element has an \u201citemprop\u201d attribute or has a \u201crel\u201d attribute whose value contains \u201cdns-prefetch\u201d, \u201cmodulepreload\u201d, \u201cpingback\u201d, \u201cpreconnect\u201d, \u201cprefetch\u201d, \u201cpreload\u201d, \u201cprerender\u201d, or \u201cstylesheet\u201d.",
+            "type": "error"
+        },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
             "lastLine": 291,
@@ -2599,6 +2640,47 @@
             "extract": "<html lang=\"en\"><head>",
             "hiliteStart": 0,
             "hiliteLength": 16
+        },
+        "The \u201ctype\u201d attribute is unnecessary for JavaScript resources.":{
+            "extract": "          <script type=\"text/javascript\">\n     ",
+            "firstColumn": 25,
+            "hiliteLength": 31,
+            "hiliteStart": 10,
+            "lastColumn": 55,
+            "lastLine": 1015,
+            "message": "The \u201ctype\u201d attribute is unnecessary for JavaScript resources.",
+            "subType": "warning",
+            "type": "info"
+        },
+        "Element \u201chead\u201d is missing a required instance of child element \u201ctitle\u201d.":{
+            "extract": "en\"><head></head><body ",
+            "firstColumn": 23,
+            "hiliteLength": 7,
+            "hiliteStart": 10,
+            "lastColumn": 29,
+            "lastLine": 1,
+            "message": "Element \u201chead\u201d is missing a required instance of child element \u201ctitle\u201d.",
+            "type": "error"
+        },
+        "Element \u201ctitle\u201d not allowed as child of element \u201cbody\u201d in this context. (Suppressing further errors from this subtree.)":{
+            "extract": "r>\n\n\n\n    <title>Submit",
+            "firstColumn": 5,
+            "hiliteLength": 7,
+            "hiliteStart": 10,
+            "lastColumn": 11,
+            "lastLine": 6,
+            "message": "Element \u201ctitle\u201d not allowed as child of element \u201cbody\u201d in this context. (Suppressing further errors from this subtree.)",
+            "type": "error"
+        },
+        "itle>\n    <link rel=\"shortcut icon\" href=\"http://localhost/img/favicon.ico\" type=\"image/x-icon\">\n\n    ":{
+            "extract": "itle>\n    <link rel=\"shortcut icon\" href=\"http://localhost/img/favicon.ico\" type=\"image/x-icon\">\n\n    ",
+            "firstColumn": 5,
+            "hiliteLength": 86,
+            "hiliteStart": 10,
+            "lastColumn": 90,
+            "lastLine": 7,
+            "message": "A \u201clink\u201d element must not appear as a descendant of a \u201cbody\u201d element unless the \u201clink\u201d element has an \u201citemprop\u201d attribute or has a \u201crel\u201d attribute whose value contains \u201cdns-prefetch\u201d, \u201cmodulepreload\u201d, \u201cpingback\u201d, \u201cpreconnect\u201d, \u201cprefetch\u201d, \u201cpreload\u201d, \u201cprerender\u201d, or \u201cstylesheet\u201d.",
+            "type": "error"
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",

--- a/tests/e2e/accessibility_baseline.json
+++ b/tests/e2e/accessibility_baseline.json
@@ -34,7 +34,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 305,
+            "lastLine": 295,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -44,17 +44,17 @@
         },
         "Attribute “disabled” not allowed on element “a” at this point.": {
             "type": "error",
-            "lastLine": 553,
-            "lastColumn": 130,
+            "lastLine": 533,
+            "lastColumn": 144,
             "firstColumn": 84,
             "message": "Attribute “disabled” not allowed on element “a” at this point.",
-            "extract": "          <a class=\"btn btn-default btn-nav\" disabled=\"\">\n     ",
+            "extract": "          <a class=\"btn btn-default btn-nav \" tabindex=\"0\" disabled=\"\">\n     ",
             "hiliteStart": 10,
-            "hiliteLength": 47
+            "hiliteLength": 61
         },
         "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
             "type": "error",
-            "lastLine": 1415,
+            "lastLine": 1395,
             "lastColumn": 76,
             "firstColumn": 9,
             "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
@@ -64,656 +64,6 @@
         }
     },
     "/s20/sample/gradeable/future_no_tas_homework/update?nav_tab=0": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 294,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 291,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 317,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.": {
-            "type": "info",
-            "lastLine": 625,
-            "lastColumn": 46,
-            "firstColumn": 13,
-            "subType": "warning",
-            "message": "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.",
-            "extract": "          <div aria-hidden=\"true\" hidden=\"\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 34
-        },
-        "Attribute “placeholder” not allowed on element “input” at this point.": {
-            "type": "error",
-            "lastLine": 1117,
-            "lastColumn": 273,
-            "firstColumn": 17,
-            "message": "Attribute “placeholder” not allowed on element “input” at this point.",
-            "extract": "          <input style=\"width: 83%\" type=\"hidden\" id=\"input-provide-full-path\" name=\"autograding_config_path\" value=\"PROVIDED: test_notes_upload (expects single file, 2 mb maximum, 2-page pdf student submission)\" class=\"required\" placeholder=\"(Required)\" disabled=\"\">\n    <",
-            "hiliteStart": 10,
-            "hiliteLength": 257
-        },
-        "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.": {
-            "type": "error",
-            "lastLine": 1117,
-            "lastColumn": 273,
-            "firstColumn": 17,
-            "message": "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.",
-            "extract": "          <input style=\"width: 83%\" type=\"hidden\" id=\"input-provide-full-path\" name=\"autograding_config_path\" value=\"PROVIDED: test_notes_upload (expects single file, 2 mb maximum, 2-page pdf student submission)\" class=\"required\" placeholder=\"(Required)\" disabled=\"\">\n    <",
-            "hiliteStart": 10,
-            "hiliteLength": 257
-        },
-        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
-            "type": "info",
-            "lastLine": 2299,
-            "lastColumn": 172,
-            "firstColumn": 87,
-            "subType": "warning",
-            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
-            "extract": "ontainer\"><span class=\"flatpickr-day prevMonthDay\" aria-label=\"November 27, 9994\" tabindex=\"-1\">27</sp",
-            "hiliteStart": 10,
-            "hiliteLength": 86
-        }
-    },
-    "/s20/sample/gradeable/future_no_tas_lab/grading?view=all": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 287,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 284,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 310,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 586,
-            "firstLine": 585,
-            "lastColumn": 31,
-            "firstColumn": 17,
-            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
-            "extract": "      <tr>\n                <th width=\"20\"></th>\n",
-            "hiliteStart": 10,
-            "hiliteLength": 32
-        },
-        "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 3562,
-            "firstLine": 3561,
-            "lastColumn": 31,
-            "firstColumn": 25,
-            "message": "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "  </tbody>\n                        <thead>\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 32
-        },
-        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 3584,
-            "firstLine": 3583,
-            "lastColumn": 32,
-            "firstColumn": 17,
-            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
-            "extract": "      <tr>\n                <td width=\"33%\"><b>Tot",
-            "hiliteStart": 10,
-            "hiliteLength": 33
-        }
-    },
-    "/s20/sample/gradeable/future_no_tas_test/grading?view=all": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 287,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 284,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 310,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 587,
-            "firstLine": 586,
-            "lastColumn": 31,
-            "firstColumn": 17,
-            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
-            "extract": "      <tr>\n                <th width=\"20\"></th>\n",
-            "hiliteStart": 10,
-            "hiliteLength": 32
-        },
-        "Attribute “type” not allowed on element “div” at this point.": {
-            "type": "error",
-            "lastLine": 647,
-            "lastColumn": 137,
-            "firstColumn": 13,
-            "message": "Attribute “type” not allowed on element “div” at this point.",
-            "extract": "          <div class=\"option-small-box cell-total\" style=\"text-align: center\" type=\"text\" border=\"none\" id=\"total-0\" data-total=\"true\">0</div",
-            "hiliteStart": 10,
-            "hiliteLength": 125
-        },
-        "Attribute “border” not allowed on element “div” at this point.": {
-            "type": "error",
-            "lastLine": 647,
-            "lastColumn": 137,
-            "firstColumn": 13,
-            "message": "Attribute “border” not allowed on element “div” at this point.",
-            "extract": "          <div class=\"option-small-box cell-total\" style=\"text-align: center\" type=\"text\" border=\"none\" id=\"total-0\" data-total=\"true\">0</div",
-            "hiliteStart": 10,
-            "hiliteLength": 125
-        },
-        "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 4488,
-            "firstLine": 4487,
-            "lastColumn": 31,
-            "firstColumn": 25,
-            "message": "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "  </tbody>\n                        <thead>\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 32
-        },
-        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 4510,
-            "firstLine": 4509,
-            "lastColumn": 32,
-            "firstColumn": 17,
-            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
-            "extract": "      <tr>\n                <td width=\"33%\"><b>Tot",
-            "hiliteStart": 10,
-            "hiliteLength": 33
-        }
-    },
-    "/s20/sample/gradeable/open_homework/grading/status": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 285,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 282,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 308,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        }
-    },
-    "/s20/sample/gradeable/open_homework/grading/details?view=all": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 283,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 280,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 309,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 569,
-            "firstLine": 568,
-            "lastColumn": 75,
-            "firstColumn": 17,
-            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
-            "extract": "      <tr>\n                                                            <th width=\"2%\"></th>\n",
-            "hiliteStart": 10,
-            "hiliteLength": 76
-        },
-        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 571,
-            "firstLine": 570,
-            "lastColumn": 96,
-            "firstColumn": 108,
-            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
-            "extract": "ction</th>\n                                                                                <td width=\"13%\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 97
-        }
-    },
-    "/s20/sample/gradeable/open_homework": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 299,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 296,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 322,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "Bad value “true” for attribute “checked” on element “input”.": {
-            "type": "error",
-            "lastLine": 557,
-            "lastColumn": 96,
-            "firstColumn": 21,
-            "message": "Bad value “true” for attribute “checked” on element “input”.",
-            "extract": "          <input type=\"radio\" id=\"radio-normal\" name=\"submission_type\" checked=\"true\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 76
-        },
-        "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.": {
-            "type": "error",
-            "lastLine": 567,
-            "lastColumn": 131,
-            "firstColumn": 25,
-            "message": "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.",
-            "extract": "          <a aria-label=\"Bulk PDF Upload Help\" href=\"https://submitty.org/instructor/bulk_pdf_upload\" target=\"_none\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 107
-        },
-        "Bad value “text” for attribute “role” on element “div”.": {
-            "type": "error",
-            "lastLine": 708,
-            "lastColumn": 205,
-            "firstColumn": 57,
-            "message": "Bad value “text” for attribute “role” on element “div”.",
-            "extract": "          <div tabindex=\"0\" id=\"upload1\" class=\"upload-box\" onkeypress=\"clicked_on_box(event)\" role=\"text\" aria-label=\"Press enter to upload your Part 1 file\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 149
-        }
-    },
-    "/s20/sample/gradeable/open_team_homework/team": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 283,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 280,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 306,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 542,
-            "firstLine": 541,
-            "lastColumn": 35,
-            "firstColumn": 21,
-            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
-            "extract": "      <tr>\n                    <th width=\"3%\"></th>\n",
-            "hiliteStart": 10,
-            "hiliteLength": 36
-        }
-    },
-    "/s20/sample/gradeable/grades_released_homework_autota": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 301,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 298,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 324,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "Bad value “true” for attribute “checked” on element “input”.": {
-            "type": "error",
-            "lastLine": 559,
-            "lastColumn": 96,
-            "firstColumn": 21,
-            "message": "Bad value “true” for attribute “checked” on element “input”.",
-            "extract": "          <input type=\"radio\" id=\"radio-normal\" name=\"submission_type\" checked=\"true\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 76
-        },
-        "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.": {
-            "type": "error",
-            "lastLine": 569,
-            "lastColumn": 131,
-            "firstColumn": 25,
-            "message": "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.",
-            "extract": "          <a aria-label=\"Bulk PDF Upload Help\" href=\"https://submitty.org/instructor/bulk_pdf_upload\" target=\"_none\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 107
-        },
-        "Bad value “text” for attribute “role” on element “div”.": {
-            "type": "error",
-            "lastLine": 710,
-            "lastColumn": 205,
-            "firstColumn": 57,
-            "message": "Bad value “text” for attribute “role” on element “div”.",
-            "extract": "          <div tabindex=\"0\" id=\"upload1\" class=\"upload-box\" onkeypress=\"clicked_on_box(event)\" role=\"text\" aria-label=\"Press enter to upload your Part 1 file\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 149
-        },
-        "Attribute “fname” not allowed on element “tr” at this point.": {
-            "type": "error",
-            "lastLine": 716,
-            "firstLine": 715,
-            "lastColumn": 69,
-            "firstColumn": 79,
-            "message": "Attribute “fname” not allowed on element “tr” at this point.",
-            "extract": "-table-1\">\n                    <tr fname=\"fork_bomb_print.c\" class=\"file-label\"><td>fo",
-            "hiliteStart": 10,
-            "hiliteLength": 70
-        },
-        "Bad value “text” for attribute “role” on element “i”.": {
-            "type": "error",
-            "lastLine": 716,
-            "lastColumn": 246,
-            "firstColumn": 127,
-            "message": "Bad value “text” for attribute “role” on element “i”.",
-            "extract": "\">0.37KB  <i role=\"text\" aria-label=\"Press enter to remove file fork_bomb_print.c\" tabindex=\"0\" class=\"fas fa-trash custom-focus\"></i></",
-            "hiliteStart": 10,
-            "hiliteLength": 120
-        },
-        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
-            "type": "info",
-            "lastLine": 1110,
-            "lastColumn": 129,
-            "firstColumn": 29,
-            "subType": "warning",
-            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
-            "extract": "          <span class=\"loading-tools-in-progress\" aria-label=\"Loading Details for Test 2 ./a.out 10\" hidden=\"\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 101
-        },
-        "CSS: The value “break-word” is deprecated": {
-            "type": "error",
-            "lastLine": 1181,
-            "lastColumn": 97,
-            "firstColumn": 17,
-            "message": "CSS: The value “break-word” is deprecated",
-            "extract": "          <div class=\"box half\" style=\"padding: 10px; width: 30%; word-break: break-word;\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 81
-        }
-    },
-    "/s20/sample/notifications": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 285,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 282,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 308,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        }
-    },
-    "/s20/sample/notifications/settings": {
         "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
             "type": "error",
             "lastLine": 1,
@@ -747,7 +97,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 310,
+            "lastLine": 307,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -755,48 +105,330 @@
             "hiliteStart": 10,
             "hiliteLength": 22
         },
-        "Element “style” not allowed as child of element “main” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 524,
-            "lastColumn": 7,
-            "firstColumn": 1,
-            "message": "Element “style” not allowed as child of element “main” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "=\"main\">\n\n<style>\n    i",
+        "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.": {
+            "type": "info",
+            "lastLine": 605,
+            "lastColumn": 46,
+            "firstColumn": 13,
+            "subType": "warning",
+            "message": "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.",
+            "extract": "          <div aria-hidden=\"true\" hidden=\"\">\n     ",
             "hiliteStart": 10,
-            "hiliteLength": 7
+            "hiliteLength": 34
         },
-        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+        "Attribute “placeholder” not allowed on element “input” at this point.": {
             "type": "error",
-            "lastLine": 565,
-            "lastColumn": 50,
-            "firstColumn": 25,
-            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <div class=\"option-title\">New An",
+            "lastLine": 1097,
+            "lastColumn": 273,
+            "firstColumn": 17,
+            "message": "Attribute “placeholder” not allowed on element “input” at this point.",
+            "extract": "          <input style=\"width: 83%\" type=\"hidden\" id=\"input-provide-full-path\" name=\"autograding_config_path\" value=\"PROVIDED: test_notes_upload (expects single file, 2 mb maximum, 2-page pdf student submission)\" class=\"required\" placeholder=\"(Required)\" disabled=\"\">\n    <",
             "hiliteStart": 10,
-            "hiliteLength": 26
+            "hiliteLength": 257
         },
-        "Bad value “true” for attribute “checked” on element “input”.": {
+        "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.": {
             "type": "error",
-            "lastLine": 712,
-            "lastColumn": 152,
-            "firstColumn": 79,
-            "message": "Bad value “true” for attribute “checked” on element “input”.",
-            "extract": "ng-input\"><input type=\"checkbox\" name=\"team_invite\" id=\"team_invite\" checked=\"true\"></div>",
+            "lastLine": 1097,
+            "lastColumn": 273,
+            "firstColumn": 17,
+            "message": "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.",
+            "extract": "          <input style=\"width: 83%\" type=\"hidden\" id=\"input-provide-full-path\" name=\"autograding_config_path\" value=\"PROVIDED: test_notes_upload (expects single file, 2 mb maximum, 2-page pdf student submission)\" class=\"required\" placeholder=\"(Required)\" disabled=\"\">\n    <",
             "hiliteStart": 10,
-            "hiliteLength": 74
+            "hiliteLength": 257
         },
-        "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
-            "type": "error",
-            "lastLine": 564,
-            "lastColumn": 47,
-            "firstColumn": 21,
-            "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
-            "extract": "          <label for=\"forum_enabled\">\n     ",
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 2271,
+            "lastColumn": 172,
+            "firstColumn": 87,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "ontainer\"><span class=\"flatpickr-day prevMonthDay\" aria-label=\"November 27, 9994\" tabindex=\"-1\">27</sp",
             "hiliteStart": 10,
-            "hiliteLength": 27
+            "hiliteLength": 86
         }
     },
-    "/s20/sample/gradeable": {
+    "/s20/sample/gradeable/future_no_tas_lab/grading?view=all": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 277,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 274,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 300,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 566,
+            "firstLine": 565,
+            "lastColumn": 31,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <th width=\"20\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 3542,
+            "firstLine": 3541,
+            "lastColumn": 31,
+            "firstColumn": 25,
+            "message": "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "  </tbody>\n                        <thead>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 3564,
+            "firstLine": 3563,
+            "lastColumn": 32,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <td width=\"33%\"><b>Tot",
+            "hiliteStart": 10,
+            "hiliteLength": 33
+        }
+    },
+    "/s20/sample/gradeable/future_no_tas_test/grading?view=all": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 277,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 274,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 300,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 567,
+            "firstLine": 566,
+            "lastColumn": 31,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <th width=\"20\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "Attribute “type” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 627,
+            "lastColumn": 137,
+            "firstColumn": 13,
+            "message": "Attribute “type” not allowed on element “div” at this point.",
+            "extract": "          <div class=\"option-small-box cell-total\" style=\"text-align: center\" type=\"text\" border=\"none\" id=\"total-0\" data-total=\"true\">0</div",
+            "hiliteStart": 10,
+            "hiliteLength": 125
+        },
+        "Attribute “border” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 627,
+            "lastColumn": 137,
+            "firstColumn": 13,
+            "message": "Attribute “border” not allowed on element “div” at this point.",
+            "extract": "          <div class=\"option-small-box cell-total\" style=\"text-align: center\" type=\"text\" border=\"none\" id=\"total-0\" data-total=\"true\">0</div",
+            "hiliteStart": 10,
+            "hiliteLength": 125
+        },
+        "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 4468,
+            "firstLine": 4467,
+            "lastColumn": 31,
+            "firstColumn": 25,
+            "message": "Element “thead” not allowed as child of element “table” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "  </tbody>\n                        <thead>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 32
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 4490,
+            "firstLine": 4489,
+            "lastColumn": 32,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                <td width=\"33%\"><b>Tot",
+            "hiliteStart": 10,
+            "hiliteLength": 33
+        }
+    },
+    "/s20/sample/gradeable/open_homework/grading/status": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 275,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 272,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 298,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/gradeable/open_homework/grading/details?view=all": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 273,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 270,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 299,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 549,
+            "firstLine": 548,
+            "lastColumn": 75,
+            "firstColumn": 17,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                                                            <th width=\"2%\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 551,
+            "firstLine": 550,
+            "lastColumn": 96,
+            "firstColumn": 108,
+            "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
+            "extract": "ction</th>\n                                                                                <td width=\"13%\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 97
+        }
+    },
+    "/s20/sample/gradeable/open_homework": {
         "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
             "type": "error",
             "lastLine": 1,
@@ -838,9 +470,377 @@
             "hiliteStart": 10,
             "hiliteLength": 22
         },
+        "Bad value “true” for attribute “checked” on element “input”.": {
+            "type": "error",
+            "lastLine": 537,
+            "lastColumn": 96,
+            "firstColumn": 21,
+            "message": "Bad value “true” for attribute “checked” on element “input”.",
+            "extract": "          <input type=\"radio\" id=\"radio-normal\" name=\"submission_type\" checked=\"true\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.": {
+            "type": "error",
+            "lastLine": 547,
+            "lastColumn": 131,
+            "firstColumn": 25,
+            "message": "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.",
+            "extract": "          <a aria-label=\"Bulk PDF Upload Help\" href=\"https://submitty.org/instructor/bulk_pdf_upload\" target=\"_none\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Bad value “text” for attribute “role” on element “div”.": {
+            "type": "error",
+            "lastLine": 688,
+            "lastColumn": 205,
+            "firstColumn": 57,
+            "message": "Bad value “text” for attribute “role” on element “div”.",
+            "extract": "          <div tabindex=\"0\" id=\"upload1\" class=\"upload-box\" onkeypress=\"clicked_on_box(event)\" role=\"text\" aria-label=\"Press enter to upload your Part 1 file\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 149
+        }
+    },
+    "/s20/sample/gradeable/open_team_homework/team": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 273,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 270,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 296,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The “width” attribute on the “th” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 522,
+            "firstLine": 521,
+            "lastColumn": 35,
+            "firstColumn": 21,
+            "message": "The “width” attribute on the “th” element is obsolete. Use CSS instead.",
+            "extract": "      <tr>\n                    <th width=\"3%\"></th>\n",
+            "hiliteStart": 10,
+            "hiliteLength": 36
+        }
+    },
+    "/s20/sample/gradeable/grades_released_homework_autota": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 291,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 288,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 314,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Bad value “true” for attribute “checked” on element “input”.": {
+            "type": "error",
+            "lastLine": 539,
+            "lastColumn": 96,
+            "firstColumn": 21,
+            "message": "Bad value “true” for attribute “checked” on element “input”.",
+            "extract": "          <input type=\"radio\" id=\"radio-normal\" name=\"submission_type\" checked=\"true\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 76
+        },
+        "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.": {
+            "type": "error",
+            "lastLine": 549,
+            "lastColumn": 131,
+            "firstColumn": 25,
+            "message": "Bad value “_none” for attribute “target” on element “a”: Reserved keyword “none” used.",
+            "extract": "          <a aria-label=\"Bulk PDF Upload Help\" href=\"https://submitty.org/instructor/bulk_pdf_upload\" target=\"_none\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 107
+        },
+        "Bad value “text” for attribute “role” on element “div”.": {
+            "type": "error",
+            "lastLine": 690,
+            "lastColumn": 205,
+            "firstColumn": 57,
+            "message": "Bad value “text” for attribute “role” on element “div”.",
+            "extract": "          <div tabindex=\"0\" id=\"upload1\" class=\"upload-box\" onkeypress=\"clicked_on_box(event)\" role=\"text\" aria-label=\"Press enter to upload your Part 1 file\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 149
+        },
+        "Attribute “fname” not allowed on element “tr” at this point.": {
+            "type": "error",
+            "lastLine": 696,
+            "firstLine": 695,
+            "lastColumn": 69,
+            "firstColumn": 79,
+            "message": "Attribute “fname” not allowed on element “tr” at this point.",
+            "extract": "-table-1\">\n                    <tr fname=\"fork_bomb_print.c\" class=\"file-label\"><td>fo",
+            "hiliteStart": 10,
+            "hiliteLength": 70
+        },
+        "Bad value “text” for attribute “role” on element “i”.": {
+            "type": "error",
+            "lastLine": 696,
+            "lastColumn": 246,
+            "firstColumn": 127,
+            "message": "Bad value “text” for attribute “role” on element “i”.",
+            "extract": "\">0.37KB  <i role=\"text\" aria-label=\"Press enter to remove file fork_bomb_print.c\" tabindex=\"0\" class=\"fas fa-trash custom-focus\"></i></",
+            "hiliteStart": 10,
+            "hiliteLength": 120
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 1090,
+            "lastColumn": 129,
+            "firstColumn": 29,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "          <span class=\"loading-tools-in-progress\" aria-label=\"Loading Details for Test 2 ./a.out 10\" hidden=\"\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 101
+        },
+        "CSS: The value “break-word” is deprecated": {
+            "type": "error",
+            "lastLine": 1161,
+            "lastColumn": 97,
+            "firstColumn": 17,
+            "message": "CSS: The value “break-word” is deprecated",
+            "extract": "          <div class=\"box half\" style=\"padding: 10px; width: 30%; word-break: break-word;\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 81
+        }
+    },
+    "/s20/sample/notifications": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 275,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 272,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 298,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/notifications/settings": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 274,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 271,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 300,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Element “style” not allowed as child of element “main” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 504,
+            "lastColumn": 7,
+            "firstColumn": 1,
+            "message": "Element “style” not allowed as child of element “main” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "=\"main\">\n\n<style>\n    i",
+            "hiliteStart": 10,
+            "hiliteLength": 7
+        },
+        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 545,
+            "lastColumn": 50,
+            "firstColumn": 25,
+            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div class=\"option-title\">New An",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        },
+        "Bad value “true” for attribute “checked” on element “input”.": {
+            "type": "error",
+            "lastLine": 692,
+            "lastColumn": 152,
+            "firstColumn": 79,
+            "message": "Bad value “true” for attribute “checked” on element “input”.",
+            "extract": "ng-input\"><input type=\"checkbox\" name=\"team_invite\" id=\"team_invite\" checked=\"true\"></div>",
+            "hiliteStart": 10,
+            "hiliteLength": 74
+        },
+        "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
+            "type": "error",
+            "lastLine": 544,
+            "lastColumn": 47,
+            "firstColumn": 21,
+            "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
+            "extract": "          <label for=\"forum_enabled\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 27
+        }
+    },
+    "/s20/sample/gradeable": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
+        "Duplicate ID “desktop_home_link”.": {
+            "type": "error",
+            "lastLine": 279,
+            "lastColumn": 134,
+            "firstColumn": 69,
+            "message": "Duplicate ID “desktop_home_link”.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
+            "hiliteStart": 10,
+            "hiliteLength": 66
+        },
+        "The first occurrence of ID “desktop_home_link” was here.": {
+            "type": "info",
+            "lastLine": 276,
+            "lastColumn": 124,
+            "firstColumn": 69,
+            "subType": "warning",
+            "message": "The first occurrence of ID “desktop_home_link” was here.",
+            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
+            "hiliteStart": 10,
+            "hiliteLength": 56
+        },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 302,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
         "Attribute “aria-hidden” is unnecessary for elements that have attribute “hidden”.": {
             "type": "info",
-            "lastLine": 625,
+            "lastLine": 605,
             "lastColumn": 46,
             "firstColumn": 13,
             "subType": "warning",
@@ -863,7 +863,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 286,
+            "lastLine": 276,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -873,7 +873,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -884,7 +884,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 309,
+            "lastLine": 299,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -894,7 +894,7 @@
         },
         "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 537,
+            "lastLine": 517,
             "lastColumn": 38,
             "firstColumn": 13,
             "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
@@ -904,7 +904,7 @@
         },
         "Attribute “alt” not allowed on element “a” at this point.": {
             "type": "error",
-            "lastLine": 555,
+            "lastLine": 535,
             "lastColumn": 130,
             "firstColumn": 17,
             "message": "Attribute “alt” not allowed on element “a” at this point.",
@@ -914,7 +914,7 @@
         },
         "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 596,
+            "lastLine": 576,
             "lastColumn": 42,
             "firstColumn": 17,
             "message": "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)",
@@ -924,7 +924,7 @@
         },
         "The element “a” must not appear as a descendant of the “button” element.": {
             "type": "error",
-            "lastLine": 709,
+            "lastLine": 689,
             "lastColumn": 106,
             "firstColumn": 21,
             "message": "The element “a” must not appear as a descendant of the “button” element.",
@@ -946,7 +946,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -956,7 +956,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 280,
+            "lastLine": 270,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -967,7 +967,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 306,
+            "lastLine": 296,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -987,9 +987,31 @@
             "hiliteStart": 0,
             "hiliteLength": 16
         },
+        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 135,
+            "lastColumn": 38,
+            "firstColumn": 17,
+            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <style media=\"screen\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        }
+    },
+    "/s20/sample/course_materials": {
+        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
+            "type": "error",
+            "lastLine": 1,
+            "lastColumn": 16,
+            "firstColumn": 1,
+            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
+            "extract": "<html lang=\"en\"><head>",
+            "hiliteStart": 0,
+            "hiliteLength": 16
+        },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 285,
+            "lastLine": 280,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -999,7 +1021,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 282,
+            "lastLine": 277,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -1010,7 +1032,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 308,
+            "lastLine": 303,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -1018,18 +1040,137 @@
             "hiliteStart": 10,
             "hiliteLength": 22
         },
-        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
+        "Element “k” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 609,
-            "lastColumn": 9,
-            "firstColumn": 3,
-            "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "  <br>\n\n  <style>\n     ",
+            "lastLine": 595,
+            "lastColumn": 71,
+            "firstColumn": 13,
+            "message": "Element “k” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <k class=\"fas fa-file\" style=\"vertical-align:text-bottom;\"></k>\n ",
             "hiliteStart": 10,
-            "hiliteLength": 7
+            "hiliteLength": 59
+        },
+        "The “center” element is obsolete. Use CSS instead.": {
+            "type": "error",
+            "lastLine": 3977,
+            "lastColumn": 12,
+            "firstColumn": 5,
+            "message": "The “center” element is obsolete. Use CSS instead.",
+            "extract": "   \n\n\n    <center>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 8
+        },
+        "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 4156,
+            "lastColumn": 15,
+            "firstColumn": 13,
+            "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <p>\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 3
+        },
+        "The element “label” must not appear as a descendant of the “label” element.": {
+            "type": "error",
+            "lastLine": 4454,
+            "lastColumn": 33,
+            "firstColumn": 13,
+            "message": "The element “label” must not appear as a descendant of the “label” element.",
+            "extract": "          <label class=\"radio\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 21
+        },
+        "The “label” element may contain at most one “button”, “input”, “meter”, “output”, “progress”, “select”, or “textarea” descendant.": {
+            "type": "error",
+            "lastLine": 4459,
+            "lastColumn": 150,
+            "firstColumn": 17,
+            "message": "The “label” element may contain at most one “button”, “input”, “meter”, “output”, “progress”, “select”, or “textarea” descendant.",
+            "extract": "          <input id=\"all-sections-showing-yes\" name=\"show-some-section-selection-edit\" type=\"radio\" onchange=\"toggleRegistrationSectionsEdit()\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 134
+        },
+        "“label” element with multiple labelable descendants.": {
+            "type": "info",
+            "lastLine": 4450,
+            "lastColumn": 34,
+            "firstColumn": 9,
+            "subType": "warning",
+            "message": "“label” element with multiple labelable descendants.",
+            "extract": ">\n        <label id=\"edit_sections\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 26
+        },
+        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
+            "type": "error",
+            "lastLine": 4462,
+            "lastColumn": 77,
+            "firstColumn": 13,
+            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
+            "extract": "          <div id=\"show-some-section-selection-edit\" style=\"display: none\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 65
+        },
+        "The “type” attribute is unnecessary for JavaScript resources.": {
+            "type": "info",
+            "lastLine": 4574,
+            "lastColumn": 43,
+            "firstColumn": 13,
+            "subType": "warning",
+            "message": "The “type” attribute is unnecessary for JavaScript resources.",
+            "extract": "          <script type=\"text/javascript\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 31
+        },
+        "Duplicate ID “upload_dt”.": {
+            "type": "error",
+            "lastLine": 4580,
+            "lastColumn": 30,
+            "firstColumn": 9,
+            "message": "Duplicate ID “upload_dt”.",
+            "extract": ">\n        <label id=\"upload_dt\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "The first occurrence of ID “upload_dt” was here.": {
+            "type": "info",
+            "lastLine": 4313,
+            "lastColumn": 30,
+            "firstColumn": 9,
+            "subType": "warning",
+            "message": "The first occurrence of ID “upload_dt” was here.",
+            "extract": ">\n        <label id=\"upload_dt\">\n     ",
+            "hiliteStart": 10,
+            "hiliteLength": 22
+        },
+        "Attribute “name” not allowed on element “div” at this point.": {
+            "type": "error",
+            "lastLine": 4682,
+            "lastColumn": 47,
+            "firstColumn": 5,
+            "message": "Attribute “name” not allowed on element “div” at this point.",
+            "extract": "elete\n    <div name=\"delete-course-material-message\">\n    <",
+            "hiliteStart": 10,
+            "hiliteLength": 43
+        },
+        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
+            "type": "info",
+            "lastLine": 4721,
+            "lastColumn": 172,
+            "firstColumn": 87,
+            "subType": "warning",
+            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
+            "extract": "ontainer\"><span class=\"flatpickr-day prevMonthDay\" aria-label=\"December 28, 9997\" tabindex=\"-1\">28</sp",
+            "hiliteStart": 10,
+            "hiliteLength": 86
+        },
+        "Too many messages.": {
+            "type": "error",
+            "subType": "fatal",
+            "message": "Too many messages."
         }
     },
-    "/s20/sample/course_materials": {
+    "/s20/sample/forum": {
         "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
             "type": "error",
             "lastLine": 1,
@@ -1071,181 +1212,9 @@
             "hiliteStart": 10,
             "hiliteLength": 22
         },
-        "Element “k” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 615,
-            "lastColumn": 71,
-            "firstColumn": 13,
-            "message": "Element “k” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <k class=\"fas fa-file\" style=\"vertical-align:text-bottom;\"></k>\n ",
-            "hiliteStart": 10,
-            "hiliteLength": 59
-        },
-        "The “center” element is obsolete. Use CSS instead.": {
-            "type": "error",
-            "lastLine": 3997,
-            "lastColumn": 12,
-            "firstColumn": 5,
-            "message": "The “center” element is obsolete. Use CSS instead.",
-            "extract": "   \n\n\n    <center>\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 8
-        },
-        "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 4176,
-            "lastColumn": 15,
-            "firstColumn": 13,
-            "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <p>\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 3
-        },
-        "The element “label” must not appear as a descendant of the “label” element.": {
-            "type": "error",
-            "lastLine": 4474,
-            "lastColumn": 33,
-            "firstColumn": 13,
-            "message": "The element “label” must not appear as a descendant of the “label” element.",
-            "extract": "          <label class=\"radio\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 21
-        },
-        "The “label” element may contain at most one “button”, “input”, “meter”, “output”, “progress”, “select”, or “textarea” descendant.": {
-            "type": "error",
-            "lastLine": 4479,
-            "lastColumn": 150,
-            "firstColumn": 17,
-            "message": "The “label” element may contain at most one “button”, “input”, “meter”, “output”, “progress”, “select”, or “textarea” descendant.",
-            "extract": "          <input id=\"all-sections-showing-yes\" name=\"show-some-section-selection-edit\" type=\"radio\" onchange=\"toggleRegistrationSectionsEdit()\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 134
-        },
-        "“label” element with multiple labelable descendants.": {
-            "type": "info",
-            "lastLine": 4470,
-            "lastColumn": 34,
-            "firstColumn": 9,
-            "subType": "warning",
-            "message": "“label” element with multiple labelable descendants.",
-            "extract": ">\n        <label id=\"edit_sections\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 26
-        },
-        "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 4482,
-            "lastColumn": 77,
-            "firstColumn": 13,
-            "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <div id=\"show-some-section-selection-edit\" style=\"display: none\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 65
-        },
-        "The “type” attribute is unnecessary for JavaScript resources.": {
-            "type": "info",
-            "lastLine": 4594,
-            "lastColumn": 43,
-            "firstColumn": 13,
-            "subType": "warning",
-            "message": "The “type” attribute is unnecessary for JavaScript resources.",
-            "extract": "          <script type=\"text/javascript\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 31
-        },
-        "Duplicate ID “upload_dt”.": {
-            "type": "error",
-            "lastLine": 4600,
-            "lastColumn": 30,
-            "firstColumn": 9,
-            "message": "Duplicate ID “upload_dt”.",
-            "extract": ">\n        <label id=\"upload_dt\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "The first occurrence of ID “upload_dt” was here.": {
-            "type": "info",
-            "lastLine": 4333,
-            "lastColumn": 30,
-            "firstColumn": 9,
-            "subType": "warning",
-            "message": "The first occurrence of ID “upload_dt” was here.",
-            "extract": ">\n        <label id=\"upload_dt\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
-        "Attribute “name” not allowed on element “div” at this point.": {
-            "type": "error",
-            "lastLine": 4702,
-            "lastColumn": 47,
-            "firstColumn": 5,
-            "message": "Attribute “name” not allowed on element “div” at this point.",
-            "extract": "elete\n    <div name=\"delete-course-material-message\">\n    <",
-            "hiliteStart": 10,
-            "hiliteLength": 43
-        },
-        "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
-            "type": "info",
-            "lastLine": 4741,
-            "lastColumn": 172,
-            "firstColumn": 87,
-            "subType": "warning",
-            "message": "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)",
-            "extract": "ontainer\"><span class=\"flatpickr-day prevMonthDay\" aria-label=\"December 28, 9997\" tabindex=\"-1\">28</sp",
-            "hiliteStart": 10,
-            "hiliteLength": 86
-        },
-        "Too many messages.": {
-            "type": "error",
-            "subType": "fatal",
-            "message": "Too many messages."
-        }
-    },
-    "/s20/sample/forum": {
-        "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.": {
-            "type": "error",
-            "lastLine": 1,
-            "lastColumn": 16,
-            "firstColumn": 1,
-            "message": "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
-            "extract": "<html lang=\"en\"><head>",
-            "hiliteStart": 0,
-            "hiliteLength": 16
-        },
-        "Duplicate ID “desktop_home_link”.": {
-            "type": "error",
-            "lastLine": 300,
-            "lastColumn": 134,
-            "firstColumn": 69,
-            "message": "Duplicate ID “desktop_home_link”.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/s20/sample\">sample",
-            "hiliteStart": 10,
-            "hiliteLength": 66
-        },
-        "The first occurrence of ID “desktop_home_link” was here.": {
-            "type": "info",
-            "lastLine": 297,
-            "lastColumn": 124,
-            "firstColumn": 69,
-            "subType": "warning",
-            "message": "The first occurrence of ID “desktop_home_link” was here.",
-            "extract": "          <a id=\"desktop_home_link\" href=\"http://localhost:1501/\">Submit",
-            "hiliteStart": 10,
-            "hiliteLength": 56
-        },
-        "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
-            "type": "error",
-            "lastLine": 323,
-            "lastColumn": 38,
-            "firstColumn": 17,
-            "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
-            "extract": "          <style media=\"screen\">\n     ",
-            "hiliteStart": 10,
-            "hiliteLength": 22
-        },
         "Element “p” not allowed as child of element “pre” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 726,
+            "lastLine": 706,
             "lastColumn": 87,
             "firstColumn": 32,
             "message": "Element “p” not allowed as child of element “pre” in this context. (Suppressing further errors from this subtree.)",
@@ -1255,7 +1224,7 @@
         },
         "Element “h7” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 729,
+            "lastLine": 709,
             "lastColumn": 50,
             "firstColumn": 9,
             "message": "Element “h7” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)",
@@ -1265,7 +1234,7 @@
         },
         "Bad value “input” for attribute “type” on element “input”.": {
             "type": "error",
-            "lastLine": 767,
+            "lastLine": 747,
             "lastColumn": 179,
             "firstColumn": 9,
             "message": "Bad value “input” for attribute “type” on element “input”.",
@@ -1275,7 +1244,7 @@
         },
         "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.": {
             "type": "error",
-            "lastLine": 767,
+            "lastLine": 747,
             "lastColumn": 179,
             "firstColumn": 9,
             "message": "Attribute “placeholder” is only allowed when the input type is “email”, “number”, “password”, “search”, “tel”, “text”, or “url”.",
@@ -1285,7 +1254,7 @@
         },
         "The element “input” must not appear as a descendant of the “a” element.": {
             "type": "error",
-            "lastLine": 773,
+            "lastLine": 753,
             "lastColumn": 93,
             "firstColumn": 17,
             "message": "The element “input” must not appear as a descendant of the “a” element.",
@@ -1295,7 +1264,7 @@
         },
         "The “type” attribute is unnecessary for JavaScript resources.": {
             "type": "info",
-            "lastLine": 792,
+            "lastLine": 772,
             "lastColumn": 35,
             "firstColumn": 5,
             "subType": "warning",
@@ -1306,27 +1275,27 @@
         },
         "Attribute “label” not allowed on element “a” at this point.": {
             "type": "error",
-            "lastLine": 866,
-            "lastColumn": 171,
+            "lastLine": 846,
+            "lastColumn": 197,
             "firstColumn": 6,
             "message": "Attribute “label” not allowed on element “a” at this point.",
-            "extract": "\t\t\t\t\n\t\t\t\t\t<a id=\"clear_filter_button\" class=\"inline-block text-decoration-none\" style=\"color: var(--actionable-blue);\" label=\"Clear Filters\" onclick=\"clearForumFilter(event);\">× Clea",
+            "extract": "\t\t\t\t\n\t\t\t\t\t<a id=\"clear_filter_button\" class=\"inline-block text-decoration-none key_to_click\" tabindex=\"0\" style=\"color: var(--actionable-blue);\" label=\"Clear Filters\" onclick=\"clearForumFilter(event);\">× Clea",
             "hiliteStart": 10,
-            "hiliteLength": 166
+            "hiliteLength": 192
         },
         "Attribute “checked” not allowed on element “li” at this point.": {
             "type": "error",
-            "lastLine": 896,
+            "lastLine": 876,
             "lastColumn": 130,
             "firstColumn": 16,
             "message": "Attribute “checked” not allowed on element “li” at this point.",
-            "extract": "          <li title=\"Sort posts by reply hierarchy\" id=\"tree\" class=\"dropdown-item active\" role=\"menuitem\" checked=\"checked\"><a onc",
+            "extract": "          <li title=\"Sort posts by reply hierarchy\" id=\"tree\" class=\"dropdown-item active\" role=\"menuitem\" checked=\"checked\"><a cla",
             "hiliteStart": 10,
             "hiliteLength": 115
         },
         "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 908,
+            "lastLine": 888,
             "lastColumn": 10,
             "firstColumn": 4,
             "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
@@ -1336,7 +1305,7 @@
         },
         "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
             "type": "info",
-            "lastLine": 939,
+            "lastLine": 919,
             "lastColumn": 109,
             "firstColumn": 4,
             "subType": "warning",
@@ -1347,7 +1316,7 @@
         },
         "Attribute “cat-id” not allowed on element “button” at this point.": {
             "type": "error",
-            "lastLine": 940,
+            "lastLine": 920,
             "lastColumn": 116,
             "firstColumn": 10,
             "message": "Attribute “cat-id” not allowed on element “button” at this point.",
@@ -1357,7 +1326,7 @@
         },
         "Attribute “btn-selected” not allowed on element “button” at this point.": {
             "type": "error",
-            "lastLine": 940,
+            "lastLine": 920,
             "lastColumn": 116,
             "firstColumn": 10,
             "message": "Attribute “btn-selected” not allowed on element “button” at this point.",
@@ -1367,7 +1336,7 @@
         },
         "Attribute “sel-id” not allowed on element “button” at this point.": {
             "type": "error",
-            "lastLine": 945,
+            "lastLine": 925,
             "lastColumn": 104,
             "firstColumn": 5,
             "message": "Attribute “sel-id” not allowed on element “button” at this point.",
@@ -1377,7 +1346,7 @@
         },
         "Attribute “prev_page” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 985,
+            "lastLine": 965,
             "lastColumn": 76,
             "firstColumn": 13,
             "message": "Attribute “prev_page” not allowed on element “div” at this point.",
@@ -1387,7 +1356,7 @@
         },
         "Attribute “next_page” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 985,
+            "lastLine": 965,
             "lastColumn": 76,
             "firstColumn": 13,
             "message": "Attribute “next_page” not allowed on element “div” at this point.",
@@ -1397,7 +1366,7 @@
         },
         "Attribute “data” not allowed on element “a” at this point.": {
             "type": "error",
-            "lastLine": 989,
+            "lastLine": 969,
             "lastColumn": 112,
             "firstColumn": 21,
             "message": "Attribute “data” not allowed on element “a” at this point.",
@@ -1407,7 +1376,7 @@
         },
         "Attribute “reply-level” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 1132,
+            "lastLine": 1129,
             "lastColumn": 107,
             "firstColumn": 5,
             "message": "Attribute “reply-level” not allowed on element “div” at this point.",
@@ -1417,7 +1386,7 @@
         },
         "Attribute “post_box_id” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 1180,
+            "lastLine": 1176,
             "lastColumn": 54,
             "firstColumn": 9,
             "message": "Attribute “post_box_id” not allowed on element “div” at this point.",
@@ -1427,7 +1396,7 @@
         },
         "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.": {
             "type": "error",
-            "lastLine": 1201,
+            "lastLine": 1197,
             "lastColumn": 363,
             "firstColumn": 17,
             "message": "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.",
@@ -1437,7 +1406,7 @@
         },
         "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 1207,
+            "lastLine": 1203,
             "lastColumn": 87,
             "firstColumn": 25,
             "message": "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)",
@@ -1447,7 +1416,7 @@
         },
         "Consider using the “h1” element as a top-level heading only (all “h1” elements are treated as top-level headings by many screen readers and other tools).": {
             "type": "info",
-            "lastLine": 303,
+            "lastLine": 293,
             "lastColumn": 99,
             "firstColumn": 69,
             "subType": "warning",
@@ -1470,7 +1439,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 291,
+            "lastLine": 281,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -1480,7 +1449,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 288,
+            "lastLine": 278,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -1491,7 +1460,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 317,
+            "lastLine": 307,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -1501,7 +1470,7 @@
         },
         "The “align” attribute on the “div” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 562,
+            "lastLine": 542,
             "lastColumn": 52,
             "firstColumn": 5,
             "message": "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
@@ -1511,7 +1480,7 @@
         },
         "Attribute “rows” not allowed on element “input” at this point.": {
             "type": "error",
-            "lastLine": 567,
+            "lastLine": 547,
             "lastColumn": 215,
             "firstColumn": 17,
             "message": "Attribute “rows” not allowed on element “input” at this point.",
@@ -1521,7 +1490,7 @@
         },
         "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
             "type": "info",
-            "lastLine": 576,
+            "lastLine": 556,
             "lastColumn": 122,
             "firstColumn": 21,
             "subType": "warning",
@@ -1532,17 +1501,17 @@
         },
         "Attribute “label” not allowed on element “a” at this point.": {
             "type": "error",
-            "lastLine": 790,
-            "lastColumn": 171,
+            "lastLine": 770,
+            "lastColumn": 197,
             "firstColumn": 6,
             "message": "Attribute “label” not allowed on element “a” at this point.",
-            "extract": "\t\t\t\t\n\t\t\t\t\t<a id=\"clear_filter_button\" class=\"inline-block text-decoration-none\" style=\"color: var(--actionable-blue);\" label=\"Clear Filters\" onclick=\"clearForumFilter(event);\">× Clea",
+            "extract": "\t\t\t\t\n\t\t\t\t\t<a id=\"clear_filter_button\" class=\"inline-block text-decoration-none key_to_click\" tabindex=\"0\" style=\"color: var(--actionable-blue);\" label=\"Clear Filters\" onclick=\"clearForumFilter(event);\">× Clea",
             "hiliteStart": 10,
-            "hiliteLength": 166
+            "hiliteLength": 192
         },
         "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 809,
+            "lastLine": 789,
             "lastColumn": 10,
             "firstColumn": 4,
             "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
@@ -1552,7 +1521,7 @@
         },
         "Attribute “cat-id” not allowed on element “button” at this point.": {
             "type": "error",
-            "lastLine": 841,
+            "lastLine": 821,
             "lastColumn": 116,
             "firstColumn": 10,
             "message": "Attribute “cat-id” not allowed on element “button” at this point.",
@@ -1562,7 +1531,7 @@
         },
         "Attribute “btn-selected” not allowed on element “button” at this point.": {
             "type": "error",
-            "lastLine": 841,
+            "lastLine": 821,
             "lastColumn": 116,
             "firstColumn": 10,
             "message": "Attribute “btn-selected” not allowed on element “button” at this point.",
@@ -1572,7 +1541,7 @@
         },
         "Attribute “sel-id” not allowed on element “button” at this point.": {
             "type": "error",
-            "lastLine": 846,
+            "lastLine": 826,
             "lastColumn": 104,
             "firstColumn": 5,
             "message": "Attribute “sel-id” not allowed on element “button” at this point.",
@@ -1582,7 +1551,7 @@
         },
         "Attribute “post_box_id” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 859,
+            "lastLine": 839,
             "lastColumn": 54,
             "firstColumn": 9,
             "message": "Attribute “post_box_id” not allowed on element “div” at this point.",
@@ -1592,7 +1561,7 @@
         },
         "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.": {
             "type": "error",
-            "lastLine": 927,
+            "lastLine": 907,
             "lastColumn": 353,
             "firstColumn": 17,
             "message": "Bad value “” for attribute “maxlength” on element “textarea”: The empty string is not a valid non-negative integer.",
@@ -1602,7 +1571,7 @@
         },
         "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 944,
+            "lastLine": 924,
             "lastColumn": 87,
             "firstColumn": 25,
             "message": "Element “div” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)",
@@ -1624,7 +1593,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 288,
+            "lastLine": 278,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -1634,7 +1603,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 285,
+            "lastLine": 275,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -1645,7 +1614,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 314,
+            "lastLine": 304,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -1655,7 +1624,7 @@
         },
         "The “align” attribute on the “div” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 555,
+            "lastLine": 535,
             "lastColumn": 52,
             "firstColumn": 5,
             "message": "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
@@ -1665,7 +1634,7 @@
         },
         "Attribute “rows” not allowed on element “input” at this point.": {
             "type": "error",
-            "lastLine": 560,
+            "lastLine": 540,
             "lastColumn": 215,
             "firstColumn": 17,
             "message": "Attribute “rows” not allowed on element “input” at this point.",
@@ -1675,7 +1644,7 @@
         },
         "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
             "type": "info",
-            "lastLine": 569,
+            "lastLine": 549,
             "lastColumn": 122,
             "firstColumn": 21,
             "subType": "warning",
@@ -1720,7 +1689,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 289,
+            "lastLine": 279,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -1730,7 +1699,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 286,
+            "lastLine": 276,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -1741,7 +1710,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 312,
+            "lastLine": 302,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -1751,7 +1720,7 @@
         },
         "A table row was 8 columns wide and exceeded the column count established by the first row (7).": {
             "type": "info",
-            "lastLine": 551,
+            "lastLine": 531,
             "lastColumn": 30,
             "firstColumn": 26,
             "subType": "warning",
@@ -1762,8 +1731,8 @@
         },
         "Table column 8 established by element “th” has no cells beginning in it.": {
             "type": "error",
-            "lastLine": 550,
-            "firstLine": 549,
+            "lastLine": 530,
+            "firstLine": 529,
             "lastColumn": 62,
             "firstColumn": 38,
             "message": "Table column 8 established by element “th” has no cells beginning in it.",
@@ -1773,7 +1742,7 @@
         },
         "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 1861,
+            "lastLine": 1841,
             "lastColumn": 91,
             "firstColumn": 58,
             "message": "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)",
@@ -1783,7 +1752,7 @@
         },
         "Duplicate ID “edit-user-form”.": {
             "type": "error",
-            "lastLine": 1870,
+            "lastLine": 1850,
             "lastColumn": 29,
             "firstColumn": 5,
             "message": "Duplicate ID “edit-user-form”.",
@@ -1793,7 +1762,7 @@
         },
         "The first occurrence of ID “edit-user-form” was here.": {
             "type": "info",
-            "lastLine": 1856,
+            "lastLine": 1836,
             "lastColumn": 67,
             "firstColumn": 1,
             "subType": "warning",
@@ -1804,7 +1773,7 @@
         },
         "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 1872,
+            "lastLine": 1852,
             "lastColumn": 50,
             "firstColumn": 4,
             "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
@@ -1814,7 +1783,7 @@
         },
         "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
             "type": "error",
-            "lastLine": 1871,
+            "lastLine": 1851,
             "lastColumn": 85,
             "firstColumn": 3,
             "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
@@ -1836,7 +1805,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 289,
+            "lastLine": 279,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -1846,7 +1815,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 286,
+            "lastLine": 276,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -1857,7 +1826,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 312,
+            "lastLine": 302,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -1867,7 +1836,7 @@
         },
         "A table row was 8 columns wide and exceeded the column count established by the first row (6).": {
             "type": "info",
-            "lastLine": 549,
+            "lastLine": 529,
             "lastColumn": 34,
             "firstColumn": 30,
             "subType": "warning",
@@ -1878,8 +1847,8 @@
         },
         "Duplicate ID “section-”.": {
             "type": "error",
-            "lastLine": 575,
-            "firstLine": 574,
+            "lastLine": 555,
+            "firstLine": 554,
             "lastColumn": 40,
             "firstColumn": 69,
             "message": "Duplicate ID “section-”.",
@@ -1889,8 +1858,8 @@
         },
         "The first occurrence of ID “section-” was here.": {
             "type": "info",
-            "lastLine": 546,
-            "firstLine": 545,
+            "lastLine": 526,
+            "firstLine": 525,
             "lastColumn": 40,
             "firstColumn": 26,
             "subType": "warning",
@@ -1901,8 +1870,8 @@
         },
         "Table columns in range 7…8 established by element “th” have no cells beginning in them.": {
             "type": "error",
-            "lastLine": 548,
-            "firstLine": 547,
+            "lastLine": 528,
+            "firstLine": 527,
             "lastColumn": 66,
             "firstColumn": 62,
             "message": "Table columns in range 7…8 established by element “th” have no cells beginning in them.",
@@ -1912,7 +1881,7 @@
         },
         "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 632,
+            "lastLine": 612,
             "lastColumn": 91,
             "firstColumn": 58,
             "message": "Element “div” not allowed as child of element “h1” in this context. (Suppressing further errors from this subtree.)",
@@ -1922,7 +1891,7 @@
         },
         "Duplicate ID “edit-user-form”.": {
             "type": "error",
-            "lastLine": 641,
+            "lastLine": 621,
             "lastColumn": 29,
             "firstColumn": 5,
             "message": "Duplicate ID “edit-user-form”.",
@@ -1932,7 +1901,7 @@
         },
         "The first occurrence of ID “edit-user-form” was here.": {
             "type": "info",
-            "lastLine": 627,
+            "lastLine": 607,
             "lastColumn": 67,
             "firstColumn": 1,
             "subType": "warning",
@@ -1943,7 +1912,7 @@
         },
         "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 643,
+            "lastLine": 623,
             "lastColumn": 50,
             "firstColumn": 4,
             "message": "Element “p” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
@@ -1953,7 +1922,7 @@
         },
         "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 1430,
+            "lastLine": 1410,
             "lastColumn": 7,
             "firstColumn": 1,
             "message": "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
@@ -1963,7 +1932,7 @@
         },
         "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.": {
             "type": "error",
-            "lastLine": 642,
+            "lastLine": 622,
             "lastColumn": 85,
             "firstColumn": 3,
             "message": "The value of the “for” attribute of the “label” element must be the ID of a non-hidden form control.",
@@ -1985,7 +1954,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 284,
+            "lastLine": 274,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -1995,7 +1964,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 281,
+            "lastLine": 271,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2006,7 +1975,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 307,
+            "lastLine": 297,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2016,7 +1985,7 @@
         },
         "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 631,
+            "lastLine": 611,
             "lastColumn": 33,
             "firstColumn": 8,
             "message": "Element “div” not allowed as child of element “label” in this context. (Suppressing further errors from this subtree.)",
@@ -2038,7 +2007,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 286,
+            "lastLine": 276,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2048,7 +2017,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2059,7 +2028,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 309,
+            "lastLine": 299,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2069,7 +2038,7 @@
         },
         "The “font” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 538,
+            "lastLine": 518,
             "lastColumn": 194,
             "firstColumn": 176,
             "message": "The “font” element is obsolete. Use CSS instead.",
@@ -2079,7 +2048,7 @@
         },
         "Element “img” is missing required attribute “src”.": {
             "type": "error",
-            "lastLine": 538,
+            "lastLine": 518,
             "lastColumn": 224,
             "firstColumn": 195,
             "message": "Element “img” is missing required attribute “src”.",
@@ -2089,8 +2058,8 @@
         },
         "A table row was 5 columns wide, which is less than the column count established by the first row (8).": {
             "type": "info",
-            "lastLine": 557,
-            "firstLine": 556,
+            "lastLine": 537,
+            "firstLine": 536,
             "lastColumn": 69,
             "firstColumn": 30,
             "subType": "warning",
@@ -2101,8 +2070,8 @@
         },
         "A table row was 4 columns wide, which is less than the column count established by the first row (8).": {
             "type": "info",
-            "lastLine": 604,
-            "firstLine": 603,
+            "lastLine": 584,
+            "firstLine": 583,
             "lastColumn": 97,
             "firstColumn": 30,
             "subType": "warning",
@@ -2113,8 +2082,8 @@
         },
         "A table row was 2 columns wide, which is less than the column count established by the first row (8).": {
             "type": "info",
-            "lastLine": 672,
-            "firstLine": 671,
+            "lastLine": 652,
+            "firstLine": 651,
             "lastColumn": 97,
             "firstColumn": 30,
             "subType": "warning",
@@ -2125,8 +2094,8 @@
         },
         "A table row was 3 columns wide, which is less than the column count established by the first row (8).": {
             "type": "info",
-            "lastLine": 1316,
-            "firstLine": 1315,
+            "lastLine": 1296,
+            "firstLine": 1295,
             "lastColumn": 97,
             "firstColumn": 30,
             "subType": "warning",
@@ -2137,8 +2106,8 @@
         },
         "Table columns in range 6…8 established by element “td” have no cells beginning in them.": {
             "type": "error",
-            "lastLine": 530,
-            "firstLine": 529,
+            "lastLine": 510,
+            "firstLine": 509,
             "lastColumn": 63,
             "firstColumn": 61,
             "message": "Table columns in range 6…8 established by element “td” have no cells beginning in them.",
@@ -2160,7 +2129,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 291,
+            "lastLine": 281,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2170,7 +2139,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 288,
+            "lastLine": 278,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2181,7 +2150,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 314,
+            "lastLine": 304,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2191,7 +2160,7 @@
         },
         "Attribute “type” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 528,
+            "lastLine": 508,
             "lastColumn": 32,
             "firstColumn": 1,
             "message": "Attribute “type” not allowed on element “div” at this point.",
@@ -2201,7 +2170,7 @@
         },
         "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 558,
+            "lastLine": 538,
             "lastColumn": 44,
             "firstColumn": 17,
             "message": "Element “div” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)",
@@ -2211,7 +2180,7 @@
         },
         "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
             "type": "info",
-            "lastLine": 627,
+            "lastLine": 607,
             "lastColumn": 181,
             "firstColumn": 87,
             "subType": "warning",
@@ -2234,7 +2203,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 291,
+            "lastLine": 281,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2244,7 +2213,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 288,
+            "lastLine": 278,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2255,7 +2224,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 314,
+            "lastLine": 304,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2265,7 +2234,7 @@
         },
         "Attribute “type” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 528,
+            "lastLine": 508,
             "lastColumn": 32,
             "firstColumn": 1,
             "message": "Attribute “type” not allowed on element “div” at this point.",
@@ -2275,7 +2244,7 @@
         },
         "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
             "type": "error",
-            "lastLine": 531,
+            "lastLine": 511,
             "lastColumn": 108,
             "firstColumn": 5,
             "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
@@ -2285,7 +2254,7 @@
         },
         "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
             "type": "info",
-            "lastLine": 699,
+            "lastLine": 679,
             "lastColumn": 181,
             "firstColumn": 87,
             "subType": "warning",
@@ -2308,7 +2277,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 284,
+            "lastLine": 274,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2318,7 +2287,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 281,
+            "lastLine": 271,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2329,7 +2298,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 307,
+            "lastLine": 297,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2339,7 +2308,7 @@
         },
         "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
             "type": "error",
-            "lastLine": 540,
+            "lastLine": 520,
             "lastColumn": 135,
             "firstColumn": 5,
             "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
@@ -2349,7 +2318,7 @@
         },
         "The “align” attribute on the “div” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 590,
+            "lastLine": 570,
             "lastColumn": 56,
             "firstColumn": 9,
             "message": "The “align” attribute on the “div” element is obsolete. Use CSS instead.",
@@ -2359,7 +2328,7 @@
         },
         "The “align” attribute on the “table” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 592,
+            "lastLine": 572,
             "lastColumn": 136,
             "firstColumn": 27,
             "message": "The “align” attribute on the “table” element is obsolete. Use CSS instead.",
@@ -2381,7 +2350,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2391,7 +2360,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 280,
+            "lastLine": 270,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2402,7 +2371,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 306,
+            "lastLine": 296,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2412,7 +2381,7 @@
         },
         "The “center” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 526,
+            "lastLine": 506,
             "lastColumn": 12,
             "firstColumn": 5,
             "message": "The “center” element is obsolete. Use CSS instead.",
@@ -2422,7 +2391,7 @@
         },
         "Bad value “” for attribute “action” on element “form”: Must be non-empty.": {
             "type": "error",
-            "lastLine": 532,
+            "lastLine": 512,
             "lastColumn": 52,
             "firstColumn": 9,
             "message": "Bad value “” for attribute “action” on element “form”: Must be non-empty.",
@@ -2432,7 +2401,7 @@
         },
         "Element “div” not allowed as child of element “b” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 542,
+            "lastLine": 522,
             "lastColumn": 55,
             "firstColumn": 28,
             "message": "Element “div” not allowed as child of element “b” in this context. (Suppressing further errors from this subtree.)",
@@ -2454,7 +2423,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2464,7 +2433,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 280,
+            "lastLine": 270,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2475,7 +2444,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 309,
+            "lastLine": 299,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2485,7 +2454,7 @@
         },
         "Attribute “name” not allowed on element “div” at this point.": {
             "type": "error",
-            "lastLine": 586,
+            "lastLine": 566,
             "lastColumn": 92,
             "firstColumn": 17,
             "message": "Attribute “name” not allowed on element “div” at this point.",
@@ -2495,7 +2464,7 @@
         },
         "Attribute “name” not allowed on element “span” at this point.": {
             "type": "error",
-            "lastLine": 596,
+            "lastLine": 576,
             "lastColumn": 79,
             "firstColumn": 21,
             "message": "Attribute “name” not allowed on element “span” at this point.",
@@ -2505,7 +2474,7 @@
         },
         "Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)": {
             "type": "info",
-            "lastLine": 596,
+            "lastLine": 576,
             "lastColumn": 79,
             "firstColumn": 21,
             "subType": "warning",
@@ -2528,7 +2497,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2538,7 +2507,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 280,
+            "lastLine": 270,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2549,7 +2518,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 306,
+            "lastLine": 296,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2559,8 +2528,8 @@
         },
         "The “width” attribute on the “td” element is obsolete. Use CSS instead.": {
             "type": "error",
-            "lastLine": 539,
-            "firstLine": 538,
+            "lastLine": 519,
+            "firstLine": 518,
             "lastColumn": 32,
             "firstColumn": 17,
             "message": "The “width” attribute on the “td” element is obsolete. Use CSS instead.",
@@ -2570,7 +2539,7 @@
         },
         "Row 3 of a row group established by a “tbody” element has no cells beginning on it.": {
             "type": "error",
-            "lastLine": 555,
+            "lastLine": 535,
             "lastColumn": 33,
             "firstColumn": 29,
             "message": "Row 3 of a row group established by a “tbody” element has no cells beginning on it.",
@@ -2580,7 +2549,7 @@
         },
         "A table row was 0 columns wide, which is less than the column count established by the first row (3).": {
             "type": "info",
-            "lastLine": 555,
+            "lastLine": 535,
             "lastColumn": 33,
             "firstColumn": 29,
             "subType": "warning",
@@ -2591,7 +2560,7 @@
         },
         "Row 4 of a row group established by a “tbody” element has no cells beginning on it.": {
             "type": "error",
-            "lastLine": 556,
+            "lastLine": 536,
             "lastColumn": 33,
             "firstColumn": 29,
             "message": "Row 4 of a row group established by a “tbody” element has no cells beginning on it.",
@@ -2601,7 +2570,7 @@
         },
         "Row 6 of a row group established by a “tbody” element has no cells beginning on it.": {
             "type": "error",
-            "lastLine": 566,
+            "lastLine": 546,
             "lastColumn": 33,
             "firstColumn": 29,
             "message": "Row 6 of a row group established by a “tbody” element has no cells beginning on it.",
@@ -2611,7 +2580,7 @@
         },
         "Row 7 of a row group established by a “tbody” element has no cells beginning on it.": {
             "type": "error",
-            "lastLine": 567,
+            "lastLine": 547,
             "lastColumn": 33,
             "firstColumn": 29,
             "message": "Row 7 of a row group established by a “tbody” element has no cells beginning on it.",
@@ -2633,7 +2602,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 285,
+            "lastLine": 275,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2643,7 +2612,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 282,
+            "lastLine": 272,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2654,7 +2623,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 308,
+            "lastLine": 298,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2676,7 +2645,7 @@
         },
         "Duplicate ID “desktop_home_link”.": {
             "type": "error",
-            "lastLine": 286,
+            "lastLine": 276,
             "lastColumn": 134,
             "firstColumn": 69,
             "message": "Duplicate ID “desktop_home_link”.",
@@ -2686,7 +2655,7 @@
         },
         "The first occurrence of ID “desktop_home_link” was here.": {
             "type": "info",
-            "lastLine": 283,
+            "lastLine": 273,
             "lastColumn": 124,
             "firstColumn": 69,
             "subType": "warning",
@@ -2697,7 +2666,7 @@
         },
         "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)": {
             "type": "error",
-            "lastLine": 309,
+            "lastLine": 299,
             "lastColumn": 38,
             "firstColumn": 17,
             "message": "Element “style” not allowed as child of element “noscript” in this context. (Suppressing further errors from this subtree.)",
@@ -2707,8 +2676,8 @@
         },
         "Bad value “” for attribute “id” on element “td”: An ID must not be the empty string.": {
             "type": "error",
-            "lastLine": 549,
-            "firstLine": 548,
+            "lastLine": 529,
+            "firstLine": 528,
             "lastColumn": 31,
             "firstColumn": 34,
             "message": "Bad value “” for attribute “id” on element “td”: An ID must not be the empty string.",
@@ -2718,8 +2687,8 @@
         },
         "Duplicate ID “”.": {
             "type": "error",
-            "lastLine": 550,
-            "firstLine": 549,
+            "lastLine": 530,
+            "firstLine": 529,
             "lastColumn": 47,
             "firstColumn": 41,
             "message": "Duplicate ID “”.",
@@ -2729,8 +2698,8 @@
         },
         "The first occurrence of ID “” was here.": {
             "type": "info",
-            "lastLine": 549,
-            "firstLine": 548,
+            "lastLine": 529,
+            "firstLine": 528,
             "lastColumn": 31,
             "firstColumn": 34,
             "subType": "warning",

--- a/tests/e2e/test_accessibility.py
+++ b/tests/e2e/test_accessibility.py
@@ -32,6 +32,7 @@ class TestAccessibility(BaseTestCase):
         '/s20/sample/forum',
         '/s20/sample/forum/threads/new',
         '/s20/sample/forum/categories',
+        'http://localhost:1501/s20/sample/forum/stats',
         '/s20/sample/users',
         '/s20/sample/graders',
         '/s20/sample/sections',

--- a/tests/e2e/test_accessibility.py
+++ b/tests/e2e/test_accessibility.py
@@ -64,8 +64,7 @@ def validatePages(self):
     self.log_out()
     self.log_in(user_id='instructor')
     self.click_class('sample')
-
-    with open('e2e/accessibility_baseline.json') as f:
+    with open('/'.join(__file__.split('/')[:-1])+'/accessibility_baseline.json') as f:
         baseline = json.load(f)
 
     foundError = False

--- a/tests/e2e/test_accessibility.py
+++ b/tests/e2e/test_accessibility.py
@@ -97,7 +97,7 @@ def genBaseline(self, new_url=None):
     baseline = {}
     urls = self.urls
     if new_url:
-        with open('e2e/accessibility_baseline.json') as f:
+        with open('/'.join(__file__.split('/')[:-1])+'/accessibility_baseline.json') as f:
             baseline = json.load(f)
         urls = [new_url]
 
@@ -114,5 +114,5 @@ def genBaseline(self, new_url=None):
         for error in response.json()['messages']:
             if error['message'] not in baseline[url]:
                 baseline[url][error['message']] = error
-    with open('e2e/accessibility_baseline.json', 'w') as f:
-        json.dump(baseline, f, ensure_ascii=False, indent=4)
+    with open('/'.join(__file__.split('/')[:-1])+'/accessibility_baseline.json', 'w') as file:
+        json.dump(baseline, file, ensure_ascii=False, indent=4)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently we must check for new w3 validator https://validator.w3.org/nu/#file errors by hand. This means that we have no easy way to knowing when new errors appear.

### What is the new behavior?
Usually fixing a w3 validator error is pretty easy however, it is easier to fix them if we catch them early. This adds a test that goes to every type of page on the website, that I could find, and checks against a baseline of known errors. If a new error is added the tests will fail until it is fixed.

As we fix errors, we can remove them from the baseline file shrinking it over time.
This will greatly help with #5086 going forward
