### PR TITLE
[VPAT] Switched all table column widths to use css over html attributes

### DIFF
--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -18,42 +18,42 @@
     <table>
         <tbody>
             <tr>
-                <td width="50%">
+                <td style="width:50%">
                     <p> Pushing this button will update the grade summary data used to generate the rainbow grades reports.
                     </p>
                 </td>
-                <td width="5%"> </td>
-                <td width="45%" style="position:relative">
+                <td style="width:5%"> </td>
+                <td style="position:relative;width:45%">
                     <button id="grade-summaries-button" onclick="location.href='{{ summaries_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
                 </td>
             </tr>
             <tr>
-                <td width="50%"> </td>
-                <td width="5%"> </td>
-                <td width="45%" style="text-align: center">
+                <td style="width:50%"> </td>
+                <td style="width:5%"> </td>
+                <td style="text-align: center;width:45%">
                     Last ran: <span id="grade-summaries-last-run">{{ grade_summaries_last_run }}</span>
                 </td>
             </tr>
             <tr class="bar"></tr>
             <tr class="bar"></tr>
             <tr>
-                <td width="50%">
+                <td style="width:50%">
                     <p>Pushing this button will generate a CSV file (for download) with all student grades for all gradeables. </p>
                 </td>
-                <td width="5%"> </td>
-                <td width="45%" style="position:relative">
+                <td style="width:5%"> </td>
+                <td style="position:relative;width:45%">
                     <button onclick="location.href='{{ csv_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
                 </td>
             </tr>
             <tr class="bar"></tr>
             <tr class="bar"></tr>
             <tr>
-                <td width="50%">
+                <td style="width:50%">
                     <p><em><b>NOTE: Work in Progress</b></em><br>Web interface for creation and customization of Rainbow Grades for this course.<br>
                     <a target=_blank href="https://submitty.org/instructor/rainbow_grades/">Rainbow Grades Documentation<i style="font-style:normal;" class="fa-question-circle"></i></a></p>
                 </td>
-                <td width="5%"> </td>
-                <td width="45%" style="position:relative">
+                <td style="width:5%"> </td>
+                <td style="position:relative;width:45%">
                     <button onclick="location.href='{{ rainbow_grades_customization_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Web-Based Rainbow Grades Generation</button>
                 </td>
             </tr>

--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -9,11 +9,11 @@
     <div class="stats-table-container">
         <table class="table table-striped table-bordered persist-area" id="forum_stats_table">
             <tr>
-                <td class = "cursor-pointer" width="15%" id="user_sort"><a href="javascript:void(0)">User</a></td>
+                <td class = "cursor-pointer" style="width:15%" id="user_sort"><a href="javascript:void(0)">User</a></td>
                 <td class = "cursor-pointer"  id="total_posts_sort"><a href="javascript:void(0)">Total Posts (not deleted)</a></td>
-                <td class = "cursor-pointer" width="15%" id="total_threads_sort"><a href="javascript:void(0)">Total Threads</a></td>
-                <td class = "cursor-pointer" width="15%" id="total_deleted_sort"><a href="javascript:void(0)">Total Deleted Posts</a></td>
-                <td width="40%">Show Posts</td>
+                <td class = "cursor-pointer" style="width:15%" id="total_threads_sort"><a href="javascript:void(0)">Total Threads</a></td>
+                <td class = "cursor-pointer" style="width:15%" id="total_deleted_sort"><a href="javascript:void(0)">Total Deleted Posts</a></td>
+                <td style="width:40%">Show Posts</td>
             </tr>
 
             {% for user in userData %}

--- a/site/app/templates/forum/searchResults.twig
+++ b/site/app/templates/forum/searchResults.twig
@@ -13,9 +13,9 @@
         <table class="table table-striped table-bordered persist-area table-hover">
             <thead>
             <tr>
-                <td width="45%">Post Content</td>
-                <td width="25%">Author</td>
-                <td width="10%">Timestamp</td>
+                <td style="width:45%">Post Content</td>
+                <td style="width:25%">Author</td>
+                <td style="width:10%">Timestamp</td>
             </tr>
             </thead>
             <tbody>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -74,7 +74,7 @@
             <tr>
                 {% for column in columns %}
                     {% if column.sort_type %}
-                        <td width="{{ column.width }}">
+                        <td style="width:{{ column.width }}">
                             <a href="{{ details_base_url }}?view={{ (core.getUser().getGradingRegistrationSections()|length == 0) ? 'all' : null }}&sort={{ column.sort_type }}&direction={{ sort == column.sort_type ? (direction == 'ASC' ? 'DESC' : 'ASC') : 'ASC' }}"
                             {% if sort == column.sort_type %}
                                 class="active-sort"
@@ -89,7 +89,7 @@
                             </a>
                         </td>
                     {% else %}
-                        <th width="{{ column.width }}">{{ column.title }}</th>
+                        <th style="width:{{ column.width }}">{{ column.title }}</th>
                     {% endif %}
                 {% endfor %}
             </tr>

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -89,19 +89,19 @@
         {# Table header #}
         <thead>
             <tr>
-                <th width="20"></th>
-                <th width="70">Section</th>
-                <th width="90" style="text-align: left">
+                <th style="width:20px"></th>
+                <th style="width:70px">Section</th>
+                <th style="width:90px" style="text-align: left">
                     <a href="{{ grading_url }}?view={{ view_all ? 'all' : '' }}&sort=id" aria-label="sort by ID">
                         <span class="tooltiptext" title="sort by User ID">User ID </span><i class="fas fa-sort"></i>
                     </a>
                 </th>
-                <th width="110" style="text-align: left">
+                <th style="width:110px" style="text-align: left">
                     <a href="{{ grading_url }}?view={{ view_all ? 'all' : '' }}&sort=first" aria-label="sort by First Name">
                         <span class="tooltiptext" title="sort by First Name">First Name </span><i class="fas fa-sort"></i>
                     </a>
                 </th>
-                <th width="110" style="text-align: left">
+                <th style="width:110px" style="text-align: left">
                     <a href="{{ grading_url }}?view={{ view_all ? 'all' : '' }}&sort=last" aria-label="sort by Last Name">
                         <span class="tooltiptext" title="sort by Last Name">Last Name </span><i class="fas fa-sort"></i>
                     </a>
@@ -110,7 +110,7 @@
                 {% if action == 'lab' %}
                     {% set colspan = 5 + gradeable.getComponents()|length %}
                     {% for component in gradeable.getComponents() %}
-                        <th width="150">
+                        <th style="width:150px">
                             {{ component.getTitle() }}
                         </th>
                     {% endfor %}
@@ -119,14 +119,14 @@
                     {% if components_numeric|length > 0 %}
                         {% set colspan = colspan + 1 %}
                         {% for component in components_numeric %}
-                            <th width="150" style="text-align: center">
+                            <th style="width:150px" style="text-align: center">
                                 {{ component.getTitle() }}({{ component.getMaxValue() }})
                             </th>
                         {% endfor %}
-                        <th width="60" style="text-align: center">Total</th>
+                        <th style="width:60px" style="text-align: center">Total</th>
                     {% endif %}
                     {% for component in components_text %}
-                        <th width="200" style="text-align: center">
+                        <th style="width:200px" style="text-align: center">
                             {{ component.getTitle() }}
                         </th>
                     {% endfor %}

--- a/site/app/templates/grading/simple/StatisticsForm.twig
+++ b/site/app/templates/grading/simple/StatisticsForm.twig
@@ -8,9 +8,9 @@
         <table class="table table-striped table-bordered persist-area">
             <thead>
                 <tr>
-                    <th width="33%"><b>By Section</b></th>
-                    <th width="33%">Average</th>
-                    <th width="33%">Std. Deviation</th>
+                    <th style="width:33%"><b>By Section</b></th>
+                    <th style="width:33%">Average</th>
+                    <th style="width:33%">Std. Deviation</th>
                 </tr>
             </thead>
             {% for section, info in sections |filter((section,info) => section != null) %}
@@ -39,9 +39,9 @@
             {% endfor %}
             <thead>
             <tr>
-                <td width="33%"><b>Total</b></td>
-                <td width="33%" id="avg-total"></td>
-                <td width="33%" id="stddev-total"></td>
+                <td style="width:33%"><b>Total</b></td>
+                <td style="width:33%" id="avg-total"></td>
+                <td style="width:33%" id="stddev-total"></td>
             </tr>
             </thead>
         </table>
@@ -50,8 +50,8 @@
         <table class="table table-striped table-bordered persist-area">
             <tbody>
             <tr>
-                <td width="50%">Students with a nonzero grade</td>
-                <td width="50%" id="num-graded"></td>
+                <td style="width:50%">Students with a nonzero grade</td>
+                <td style="width:50%" id="num-graded"></td>
             </tr>
             </tbody>
         </table>

--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -122,11 +122,11 @@
             <caption />
             <thead class="persist thead">
                 <tr>
-                    <th width="3%"></th>
-                    <th width="10%">First Name</th>
-                    <th width="10%">Last Name</th>
-                    <th width="10%">User ID</th>
-                    <th width="40%">Email</th>
+                    <th style="width:3%"></th>
+                    <th style="width:10%">First Name</th>
+                    <th style="width:10%">Last Name</th>
+                    <th style="width:10%">User ID</th>
+                    <th style="width:40%">Email</th>
                 </tr>
             </thead>
             <tbody>

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -13,14 +13,14 @@
     <table class="table table-striped table-bordered persist-area">
         <thead>
         <tr>
-            <td width="3%"></td>
-            <td width="8%">Timestamp</td>
-            <td width="53%">PDF preview</td>
-            <td width="5%">Full PDF</td>
-            <td width="15%">User ID</td>
+            <td style="width:3%"></td>
+            <td style="width:8%">Timestamp</td>
+            <td style="width:53%">PDF preview</td>
+            <td style="width:5%">Full PDF</td>
+            <td style="width:15%">User ID</td>
             <td>Page Count</td>
-            <td width="8%">Submit</td>
-            <td width="8%">Delete</td>
+            <td style="width:8%">Submit</td>
+            <td style="width:8%">Delete</td>
         </tr>
         </thead>
         <tbody>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -134,7 +134,7 @@ class ElectronicGraderView extends AbstractView {
                 $peer_percentage = 0;
                 $peer_total = 0;
                 $peer_graded = 0;
-                
+
                 if ($peer_count > 0 && array_key_exists("stu_grad", $sections)) {
                     $peer_percentage = number_format(($sections['stu_grad']['graded_components'] / $sections['stu_grad']['total_components']) * 100, 1);
                     $peer_total =  floor($sections['stu_grad']['total_components'] / $peer_count);
@@ -273,10 +273,10 @@ HTML;
 			<div style="padding-left:20px;padding-bottom: 10px;border-radius:3px;padding-right:20px;">
 				<table class="table table-striped table-bordered persist-area" id="content_upload_table">
 					<tr>
-				        <td style = "cursor:pointer;" width="25%" id="user_down">User &darr;</td>
-				        <td style = "cursor:pointer;" width="25%" id="upload_down">Upload Timestamp</td>
-				        <td style = "cursor:pointer;" width="25%" id="submission_down">Submission Timestamp</td>
-				        <td style = "cursor:pointer;" width="25%" id="filepath_down">Filepath</td>
+				        <td style = "cursor:pointer;width:25%" id="user_down">User &darr;</td>
+				        <td style = "cursor:pointer;width:25%" id="upload_down">Upload Timestamp</td>
+				        <td style = "cursor:pointer;width:25%" id="submission_down">Submission Timestamp</td>
+				        <td style = "cursor:pointer;width:25%" id="filepath_down">Filepath</td>
 					</tr>
 HTML;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The width attribute of \<table> is not supported in HTML5. Use CSS instead.
This is reported by the w3 validator as well as it is mentioned at the bottom of this page
https://www.w3schools.com/TAGs/att_table_width.asp

### What is the new behavior?

Switched all table widths to use css
