### PR TITLE
[Bugfix:Submission] incorrect page images for bulk upload submissions

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_upload_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_upload_split.py
@@ -65,8 +65,8 @@ def main(args):
             # save pdfs as images (start indexing at one)
             pdf_images = convert_from_bytes(open(output_filename, 'rb').read())
             for k in range(len(pdf_images)):
-                pdf_images[k].save(format(output_filename[:-4]) +
-                                   '_' + str(k + 1).zfill(2) + '.jpg',
+                pdf_images[k].save(output_filename[:-4] +
+                                   '_' + str(k + 1).zfill(3) + '.jpg',
                                    "JPEG", quality=100)
 
             with open(cover_filename, 'wb') as out:

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -552,10 +552,13 @@ class SubmissionController extends AbstractController {
         //get any and all images associated with this PDF if they exist.
         //images are order <original>_<split-number>_<page-number>, so grab everuthing with the same suffixes
         preg_match("/\d*$/", pathinfo($path, PATHINFO_FILENAME), $matches);
-        $split_number = count($matches) >= 1 ? reset($matches) : "-1";
         $image_files = glob(FileUtils::joinPaths(dirname($uploaded_file), "*.*"));
 
-        $regex = "/.*_{$split_number}_\d*\.\w*$/";
+
+        $combined_pdf_path = FileUtils::joinPaths(pathinfo($uploaded_file)['dirname'], pathinfo($uploaded_file)['filename']);
+        $combined_pdf_path = str_replace("/", "\/", $combined_pdf_path);
+
+        $regex = "/{$combined_pdf_path}_\d*\.\w*$/";
         $image_files = preg_grep($regex, $image_files);
 
         $image_extension = count($image_files) > 0 ? pathinfo(reset($image_files), PATHINFO_EXTENSION) : "";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X ] Tests for the changes have been added/updated (if possible)
* [ X ] Documentation has been updated/added if relevant

### What is the current behavior?
When the bulk upload process splits a pdf up, the pages are stored as images, on submitting split pdf images from other students can be placed in the wrong student's submission

Issue caused when multiple combined pdfs are uploaded at once, this would create 1 shared folder for all the processes to save images to. The previous incorrect regex would match images from multiple students since it was only looking at the split number and the page number, it now compares the split pdf filename to the original combined pdf filename along with the other information to match the correct student.

### What is the new behavior?
Fixes incorrect regex, only the correct students images are matched.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested bulk uploads for normal and qr,
tested first submission and multiple versions

closes #4609