### PR TITLE
[Bugfix:TAGrading] rotating PDF erased annotations

### DIFF
--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -98,7 +98,7 @@ window.onbeforeunload = function() {
     function rotate(){
         window.RENDER_OPTIONS.rotate += 90;
         localStorage.setItem('rotate', window.RENDER_OPTIONS.rotate);
-        render(window.GENERAL_INFORMATION.gradeable_id, window.GENERAL_INFORMATION.user_id, window.RENDER_OPTIONS.grader_id, window.GENERAL_INFORMATION.file_name, window.GENERAL_INFORMATION.file_path);
+        render(window.GENERAL_INFORMATION.gradeable_id, window.GENERAL_INFORMATION.user_id, window.GENERAL_INFORMATION.grader_id, window.GENERAL_INFORMATION.file_name, window.GENERAL_INFORMATION.file_path);
     }
 
     function zoom(option, custom_val){


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
As described in issue #5138 if an instructor has made freeform comments on a pdf and then rotates that pdf, the comments are deleted (even if the instructor saves after making the comments and before rotating).

### What is the new behavior?
Rotating the pdf no longer deletes comments.

### Other information?
Closes #5138