### PR TITLE
[Bugfix:TAGrading] Fixed open close icon for PDF

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -108,7 +108,11 @@
             }
         }
         if(!iframe.hasClass("full_panel")){
-            if (!iframe.hasClass('shown')) {
+            if (url_file.substring(url_file.length - 3) === "pdf") {
+                iframe.removeClass('shown');
+                $($($(iframe.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-minus-circle').addClass('fa-plus-circle');
+            }
+            else if (!iframe.hasClass('shown')) {
                 iframe.show();
                 iframe.addClass('shown');
                 $($($(iframe.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-plus-circle').addClass('fa-minus-circle');

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -107,12 +107,9 @@
                 iframe.addClass('open');
             }
         }
-        if(!iframe.hasClass("full_panel")){
-            if (url_file.substring(url_file.length - 3) === "pdf") {
-                iframe.removeClass('shown');
-                $($($(iframe.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-minus-circle').addClass('fa-plus-circle');
-            }
-            else if (!iframe.hasClass('shown')) {
+        if (!iframe.hasClass("full_panel") && url_file.substring(url_file.length - 3) !== "pdf"){
+            
+             if (!iframe.hasClass('shown')) {
                 iframe.show();
                 iframe.addClass('shown');
                 $($($(iframe.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-plus-circle').addClass('fa-minus-circle');

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -108,7 +108,7 @@
             }
         }
         if (!iframe.hasClass("full_panel") && url_file.substring(url_file.length - 3) !== "pdf") {
-             if (!iframe.hasClass('shown')) {
+            if (!iframe.hasClass('shown')) {
                 iframe.show();
                 iframe.addClass('shown');
                 $($($(iframe.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-plus-circle').addClass('fa-minus-circle');

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -107,8 +107,7 @@
                 iframe.addClass('open');
             }
         }
-        if (!iframe.hasClass("full_panel") && url_file.substring(url_file.length - 3) !== "pdf"){
-            
+        if (!iframe.hasClass("full_panel") && url_file.substring(url_file.length - 3) !== "pdf") {
              if (!iframe.hasClass('shown')) {
                 iframe.show();
                 iframe.addClass('shown');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

closes #5034 

The `+ / -` icon in the file list viewer changes to the opposite when opening a PDF (plus becomes minus, minus becomes plus) for annotation.

### What is the new behavior?
The icon will now be constant for PDF's, but continue its original behaviour for viewing other files.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
