### PR TITLE
[VPAT:InstructorUI] Fixed low contrast on red and green buttons as well as red notification icon

### DIFF
--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -174,7 +174,7 @@ fieldset[disabled] .btn-primary.focus {
     background-color: var(--default-white);
 }
 .btn-success {
-    color: var(--text-white);
+    color: var(--text-black)!important;
     background-color: var(--good-green);
 
 }

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -5,7 +5,7 @@
 
     /*buttons, primarily but also can be used for notifications/anything
     that requires this color scheme*/
-    --danger-red: #e84848;
+    --danger-red: #dc3545;
     --focus-danger-red: #ff5555;
     --hover-active-danger-red: #ff6661;
     --disabled-danger-red: #ad3937;

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1755,7 +1755,7 @@ end of styles used in the admin gradeable page
 }
 
 .notification-badge {
-    background-color: red;
+    background-color: var(--danger-red);
     padding: 1px 5px;
     color: white;
     font-weight: bold;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Wave gives contrast errors on the red and green buttons
fixes #5142

![image](https://user-images.githubusercontent.com/18558130/76380744-fb59d980-6329-11ea-89bf-00200b68a974.png)

![image](https://user-images.githubusercontent.com/18558130/76380731-f3019e80-6329-11ea-8143-96056c7cf0a6.png)

![image](https://user-images.githubusercontent.com/18558130/76380723-ebda9080-6329-11ea-91c3-957d0dedeb8e.png)


### What is the new behavior?
I changed around the color red slightly to make it give a better contrast
I also made the text on green buttons black instead of white which fixes the contrast issue

![image](https://user-images.githubusercontent.com/18558130/76380685-d5343980-6329-11ea-810d-f12452d39a88.png)
![image](https://user-images.githubusercontent.com/18558130/76380695-dc5b4780-6329-11ea-8953-647cfffbf877.png)
![image](https://user-images.githubusercontent.com/18558130/76380702-e0876500-6329-11ea-9aa5-260a729cee24.png)

