### PR TITLE
[Feature:InstructorUI] Option to collect contact information for office hours queue

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -1237,7 +1237,8 @@ CREATE TABLE IF NOT EXISTS queue(
   time_out TIMESTAMP,
   added_by TEXT NOT NULL REFERENCES users(user_id),
   help_started_by TEXT REFERENCES users(user_id),
-  removed_by TEXT REFERENCES users(user_id)
+  removed_by TEXT REFERENCES users(user_id),
+  contact_info TEXT
 );
 CREATE TABLE IF NOT EXISTS queue_settings(
   id serial PRIMARY KEY,

--- a/migration/migrator/migrations/course/20200311135223_oh_queue_contact_info.py
+++ b/migration/migrator/migrations/course/20200311135223_oh_queue_contact_info.py
@@ -1,5 +1,6 @@
 """Migration for a given Submitty course database."""
-
+import json
+from pathlib import Path
 
 def up(config, database, semester, course):
     """
@@ -15,6 +16,19 @@ def up(config, database, semester, course):
     :type course: str
     """
     database.execute("ALTER TABLE queue ADD IF NOT EXISTS contact_info TEXT");
+
+    course_dir = Path(config.submitty['submitty_data_dir'], 'courses', semester, course)
+    # add boolean to course config
+    config_file = Path(course_dir, 'config', 'config.json')
+    if config_file.is_file():
+        with open(config_file, 'r') as in_file:
+            j = json.load(in_file)
+
+        if 'queue_contact_info' not in j['course_details']:
+            j['course_details']['queue_contact_info'] = False
+
+        with open(config_file, 'w') as out_file:
+            json.dump(j, out_file, indent=4)
 
 
 def down(config, database, semester, course):

--- a/migration/migrator/migrations/course/20200311135223_oh_queue_contact_info.py
+++ b/migration/migrator/migrations/course/20200311135223_oh_queue_contact_info.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE queue ADD IF NOT EXISTS contact_info TEXT");
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -114,6 +114,13 @@ class OfficeHoursQueueController extends AbstractController {
             );
         }
 
+        if (empty($_POST['contact_info'])) {
+            $this->core->addErrorMessage("Missing contact info");
+            return Response::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
+            );
+        }
+
         $queue_code = preg_replace('/\s+/', '_', trim($queue_code));
         $token = preg_replace('/\s+/', '_', trim($_POST['token']));
 
@@ -132,7 +139,7 @@ class OfficeHoursQueueController extends AbstractController {
             );
         }
 
-        $this->core->getQueries()->addToQueue($validated_code, $this->core->getUser()->getId(), $_POST['name']);
+        $this->core->getQueries()->addToQueue($validated_code, $this->core->getUser()->getId(), $_POST['name'], $_POST['contact_info']);
         $this->core->addSuccessMessage("Added to queue");
         return Response::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -114,11 +114,16 @@ class OfficeHoursQueueController extends AbstractController {
             );
         }
 
-        if (empty($_POST['contact_info'])) {
-            $this->core->addErrorMessage("Missing contact info");
-            return Response::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
-            );
+        $contact_info = null;
+        if($this->core->getConfig()->getQueueContactInfo()){
+          if (empty($_POST['contact_info'])) {
+              $this->core->addErrorMessage("Missing contact info");
+              return Response::RedirectOnlyResponse(
+                  new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
+              );
+          }else{
+            $contact_info = $_POST['contact_info'];
+          }
         }
 
         $queue_code = preg_replace('/\s+/', '_', trim($queue_code));
@@ -139,7 +144,7 @@ class OfficeHoursQueueController extends AbstractController {
             );
         }
 
-        $this->core->getQueries()->addToQueue($validated_code, $this->core->getUser()->getId(), $_POST['name'], $_POST['contact_info']);
+        $this->core->getQueries()->addToQueue($validated_code, $this->core->getUser()->getId(), $_POST['name'], $contact_info);
         $this->core->addSuccessMessage("Added to queue");
         return Response::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -121,7 +121,8 @@ class OfficeHoursQueueController extends AbstractController {
                 return Response::RedirectOnlyResponse(
                     new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
                 );
-            }else {
+            }
+            else {
                 $contact_info = $_POST['contact_info'];
             }
         }

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -115,15 +115,15 @@ class OfficeHoursQueueController extends AbstractController {
         }
 
         $contact_info = null;
-        if($this->core->getConfig()->getQueueContactInfo()){
-          if (empty($_POST['contact_info'])) {
-              $this->core->addErrorMessage("Missing contact info");
-              return Response::RedirectOnlyResponse(
-                  new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
-              );
-          }else{
-            $contact_info = $_POST['contact_info'];
-          }
+        if ($this->core->getConfig()->getQueueContactInfo()) {
+            if (empty($_POST['contact_info'])) {
+                $this->core->addErrorMessage("Missing contact info");
+                return Response::RedirectOnlyResponse(
+                    new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
+                );
+            }else {
+                $contact_info = $_POST['contact_info'];
+            }
         }
 
         $queue_code = preg_replace('/\s+/', '_', trim($queue_code));

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -53,6 +53,7 @@ class ConfigurationController extends AbstractController {
             'seating_only_for_instructor'    => $this->core->getConfig()->isSeatingOnlyForInstructor(),
             'auto_rainbow_grades'            => $this->core->getConfig()->getAutoRainbowGrades(),
             'queue_enabled'                  => $this->core->getConfig()->isQueueEnabled(),
+            'queue_contact_info'             => $this->core->getConfig()->getQueueContactInfo(),
         );
         $seating_options = $this->getGradeableSeatingOptions();
         $admin_in_course = false;
@@ -147,6 +148,8 @@ class ConfigurationController extends AbstractController {
             $entry = $entry === "true" ? true : false;
         }
         elseif ($name === 'queue_enabled') {
+            $entry = $entry === "true" ? true : false;
+        }elseif ($name === 'queue_contact_info') {
             $entry = $entry === "true" ? true : false;
         }
         elseif ($name === 'upload_message') {

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -149,7 +149,8 @@ class ConfigurationController extends AbstractController {
         }
         elseif ($name === 'queue_enabled') {
             $entry = $entry === "true" ? true : false;
-        }elseif ($name === 'queue_contact_info') {
+        }
+        elseif ($name === 'queue_contact_info') {
             $entry = $entry === "true" ? true : false;
         }
         elseif ($name === 'upload_message') {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5312,7 +5312,7 @@ AND gc_id IN (
         return 0 < count($this->course_db->rows());
     }
 
-    public function addToQueue($queue_code, $user_id, $name) {
+    public function addToQueue($queue_code, $user_id, $name, $contact_info) {
         $this->course_db->query("INSERT INTO queue
             (
                 current_state,
@@ -5325,7 +5325,8 @@ AND gc_id IN (
                 time_out,
                 added_by,
                 help_started_by,
-                removed_by
+                removed_by,
+                contact_info
             ) VALUES (
                 'waiting',
                 NULL,
@@ -5337,8 +5338,9 @@ AND gc_id IN (
                 NULL,
                 ?,
                 NULL,
-                NULL
-            )", array($queue_code,$user_id,$name,$user_id));
+                NULL,
+                ?
+            )", array($queue_code,$user_id,$name,$user_id,$contact_info));
     }
 
     public function removeUserFromQueue($user_id, $remove_type, $queue_code) {
@@ -5437,6 +5439,14 @@ AND gc_id IN (
             return null;
         }
         return $this->course_db->rows()[0]['name'];
+    }
+
+    public function getLastUsedContactInfo() {
+        $this->course_db->query("SELECT * from queue where user_id = ? order by time_in desc limit 1", array($this->core->getUser()->getId()));
+        if (count($this->course_db->rows()) <= 0) {
+            return null;
+        }
+        return $this->course_db->rows()[0]['contact_info'];
     }
 
     public function getCurrentQueueState() {

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -58,6 +58,7 @@ use app\libraries\FileUtils;
  * @method string getAutoRainbowGrades()
  * @method string|null getVerifiedSubmittyAdminUser()
  * @method bool isQueueEnabled()
+ * @method bool getQueueContactInfo()
  * @method void setSemester(string $semester)
  * @method void setCourse(string $course)
  * @method void setCoursePath(string $course_path)
@@ -218,6 +219,8 @@ class Config extends AbstractModel {
     protected $verified_submitty_admin_user = null;
     /** @prop @var bool */
     protected $queue_enabled;
+    /** @prop @var bool */
+    protected $queue_contact_info;
 
     /** @prop-read @var array */
     protected $feature_flags = [];
@@ -397,7 +400,7 @@ class Config extends AbstractModel {
             'zero_rubric_grades', 'upload_message', 'display_rainbow_grades_summary',
             'display_custom_message', 'room_seating_gradeable_id', 'course_email', 'vcs_base_url', 'vcs_type',
             'private_repository', 'forum_enabled', 'forum_create_thread_message', 'regrade_enabled', 'seating_only_for_instructor',
-            'regrade_message', 'auto_rainbow_grades', 'queue_enabled'
+            'regrade_message', 'auto_rainbow_grades', 'queue_enabled', 'queue_contact_info'
         ];
         $this->setConfigValues($this->course_json, 'course_details', $array);
 
@@ -419,7 +422,7 @@ class Config extends AbstractModel {
         }
 
         $array = array('zero_rubric_grades', 'display_rainbow_grades_summary',
-            'display_custom_message', 'forum_enabled', 'regrade_enabled', 'seating_only_for_instructor', "queue_enabled");
+            'display_custom_message', 'forum_enabled', 'regrade_enabled', 'seating_only_for_instructor', "queue_enabled", 'queue_contact_info');
         foreach ($array as $key) {
             $this->$key = ($this->$key == true) ? true : false;
         }

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -74,6 +74,14 @@ class OfficeHoursQueueModel extends AbstractModel {
         return $name;
     }
 
+    public function getContactInfo() {
+        $contact_info = $this->core->getQueries()->getLastUsedContactInfo();
+        if (is_null($contact_info)) {
+            return "";
+        }
+        return $contact_info;
+    }
+
     public function getCurrentQueue() {
         return $this->current_queue;
     }

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -168,4 +168,8 @@ class OfficeHoursQueueModel extends AbstractModel {
     public function removeUnderScores($value) {
         return preg_replace('/_/', ' ', $value);
     }
+
+    public function isContactInfoEnabled(){
+      return $this->core->getConfig()->getQueueContactInfo();
+    }
 }

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -169,7 +169,7 @@ class OfficeHoursQueueModel extends AbstractModel {
         return preg_replace('/_/', ' ', $value);
     }
 
-    public function isContactInfoEnabled(){
-      return $this->core->getConfig()->getQueueContactInfo();
+    public function isContactInfoEnabled() {
+        return $this->core->getConfig()->getQueueContactInfo();
     }
 }

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -59,7 +59,7 @@
             <label for="queue-contact-info">
                 <span class="option-title">Contact Info for Office Hours/Lab Queue</span>
                 <br>
-                <span class="option-alt">Choose whether students must put in their contact info when joining the queue for this course. (NOTE: Most likely you do no want to enable this setting, this setting should only be enabled if you plan to use the queue for situations where students are not in the same room as the people helping them)</span>
+                <span class="option-alt">Check this box to require that students specify their contact information for office hours help (e.g., email address, video chat, virtual meeting URL, phone number).  This setting should only be enabled if the queue is used for remote or online instruction and tutoring.</san>
             </label>
         </div>
 

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -54,6 +54,14 @@
                 <span class="option-alt">Choose whether to enable an office hours/lab queue for this course.</span>
             </label>
         </div>
+        <div id="queue-contact-info-wrapper" class="config-row checkbox-row">
+            <input type="checkbox" name="queue_contact_info" id="queue-contact-info" value="true" {{ fields['queue_contact_info'] ? 'checked': '' }} />
+            <label for="queue-contact-info">
+                <span class="option-title">Contact Info for Office Hours/Lab Queue</span>
+                <br>
+                <span class="option-alt">Choose whether students must put in their contact info when joining the queue for this course. (This should only be enabled in the case of a pandemic where office hours are being held online and not in person)</span>
+            </label>
+        </div>
 
         <h2>Submissions</h2>
         <hr>

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -59,7 +59,7 @@
             <label for="queue-contact-info">
                 <span class="option-title">Contact Info for Office Hours/Lab Queue</span>
                 <br>
-                <span class="option-alt">Choose whether students must put in their contact info when joining the queue for this course. (This should only be enabled in the case of a pandemic where office hours are being held online and not in person)</span>
+                <span class="option-alt">Choose whether students must put in their contact info when joining the queue for this course. (NOTE: Most likely you do no want to enable this setting, this setting should only be enabled if you plan to use the queue for situations where students are not in the same room as the people helping them)</span>
             </label>
         </div>
 

--- a/site/app/templates/officeHoursQueue/CurrentQueue.twig
+++ b/site/app/templates/officeHoursQueue/CurrentQueue.twig
@@ -69,9 +69,11 @@
             </a>
           </td>
         </tr>
-        <tr class="contact_info row_color_{{viewer.getIndexFromCode(entry['queue_code'])}} queue_current_{{viewer.cleanForId(entry['queue_code'])}} current_queue_row" style="display:none;border-top:0px">
-          <td colspan="7" style="border-top:0px">{{entry['contact_info']}}</td>
-        </tr>
+        {% if viewer.isContactInfoEnabled() %}
+          <tr class="contact_info row_color_{{viewer.getIndexFromCode(entry['queue_code'])}} queue_current_{{viewer.cleanForId(entry['queue_code'])}} current_queue_row" style="display:none;border-top:0px">
+            <td colspan="7" style="border-top:0px">{{entry['contact_info']}}</td>
+          </tr>
+        {% endif %}
       {% endfor %}
     </tbody>
   </table>

--- a/site/app/templates/officeHoursQueue/CurrentQueue.twig
+++ b/site/app/templates/officeHoursQueue/CurrentQueue.twig
@@ -69,6 +69,9 @@
             </a>
           </td>
         </tr>
+        <tr class="contact_info row_color_{{viewer.getIndexFromCode(entry['queue_code'])}} queue_current_{{viewer.cleanForId(entry['queue_code'])}} current_queue_row" style="display:none;border-top:0px">
+          <td colspan="7" style="border-top:0px">{{entry['contact_info']}}</td>
+        </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -67,8 +67,13 @@
 
     var queue_rows = document.getElementsByClassName('shown_queue_row');
     var row_count = 0;
+    var real_row_count = 0;
     for (; row_count < queue_rows.length; row_count++) {
-      queue_rows[row_count].childNodes[1].innerHTML = row_count + 1;
+      if(queue_rows[row_count].classList.contains('contact_info')){
+        continue;
+      }
+      queue_rows[row_count].childNodes[1].innerHTML = real_row_count + 1;
+      real_row_count++;
     }
     if (queue_rows.length === 0) {
       $("#queue_empty_msg").show();

--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -24,7 +24,7 @@
         <input type="text" name="token" id="token_box" placeholder="Queue Code" style="margin:.5rem" autocomplete="on" required="required">
         <br>
         {% if viewer.isContactInfoEnabled() %}
-          <label for="contact_info">Contact info:</label>
+          <label for="contact_info">My Contact Information (follow instructor directions):</label>
           <input type="text" name="contact_info" id="contact_info" style="width: 500px" placeholder="Contact Information (follow instructor directions)" value="{{viewer.getContactInfo()}}" style="margin:.5rem" autocomplete="on" required="required">
           <br>
         {% endif %}

--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -23,6 +23,9 @@
         <label for="token_box">Queue Code:</label>
         <input type="text" name="token" id="token_box" placeholder="Queue Code" style="margin:.5rem" autocomplete="on" required="required">
         <br>
+        <label for="contact_info">Contact info:</label>
+        <input type="text" name="contact_info" id="contact_info" placeholder="Contact Information (follow instructor directions)" value="{{viewer.getContactInfo()}}" style="margin:.5rem" autocomplete="on" required="required">
+        <br>
         <button id="join_queue_btn" type="submit" class="btn btn-primary">Join</button>
       </form>
     {% elseif viewer.getCurrentQueueStatus() == 'waiting' %}

--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -23,9 +23,11 @@
         <label for="token_box">Queue Code:</label>
         <input type="text" name="token" id="token_box" placeholder="Queue Code" style="margin:.5rem" autocomplete="on" required="required">
         <br>
-        <label for="contact_info">Contact info:</label>
-        <input type="text" name="contact_info" id="contact_info" placeholder="Contact Information (follow instructor directions)" value="{{viewer.getContactInfo()}}" style="margin:.5rem" autocomplete="on" required="required">
-        <br>
+        {% if viewer.isContactInfoEnabled() %}
+          <label for="contact_info">Contact info:</label>
+          <input type="text" name="contact_info" id="contact_info" style="width: 500px" placeholder="Contact Information (follow instructor directions)" value="{{viewer.getContactInfo()}}" style="margin:.5rem" autocomplete="on" required="required">
+          <br>
+        {% endif %}
         <button id="join_queue_btn" type="submit" class="btn btn-primary">Join</button>
       </form>
     {% elseif viewer.getCurrentQueueStatus() == 'waiting' %}

--- a/site/config/course_template.json
+++ b/site/config/course_template.json
@@ -22,6 +22,7 @@
         "seating_only_for_instructor": false,
         "room_seating_gradeable_id": "",
         "auto_rainbow_grades": false,
-        "queue_enabled": false
+        "queue_enabled": false,
+        "queue_contact_info": false
     }
 }

--- a/site/tests/app/controllers/admin/ConfigurationControllerTester.php
+++ b/site/tests/app/controllers/admin/ConfigurationControllerTester.php
@@ -41,7 +41,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
         $this->course_config = FileUtils::joinPaths($this->test_dir, 'course.json');
         file_put_contents(
             $this->course_config,
-            '{"database_details":{"dbname":"submitty_f19_sample"},"course_details":{"course_name":"Submitty Sample","course_home_url":"","default_hw_late_days":0,"default_student_late_days":0,"zero_rubric_grades":false,"upload_message":"Hit Submit","display_rainbow_grades_summary":false,"display_custom_message":false,"course_email":"Please contact your TA or instructor to submit a grade inquiry.","vcs_base_url":"","vcs_type":"git","private_repository":"","forum_enabled":true,"forum_create_thread_message":"","regrade_enabled":false,"regrade_message":"Regrade Message","seating_only_for_instructor":false,"room_seating_gradeable_id":"","auto_rainbow_grades":false, "queue_enabled": false}}'
+            '{"database_details":{"dbname":"submitty_f19_sample"},"course_details":{"course_name":"Submitty Sample","course_home_url":"","default_hw_late_days":0,"default_student_late_days":0,"zero_rubric_grades":false,"upload_message":"Hit Submit","display_rainbow_grades_summary":false,"display_custom_message":false,"course_email":"Please contact your TA or instructor to submit a grade inquiry.","vcs_base_url":"","vcs_type":"git","private_repository":"","forum_enabled":true,"forum_create_thread_message":"","regrade_enabled":false,"regrade_message":"Regrade Message","seating_only_for_instructor":false,"room_seating_gradeable_id":"","auto_rainbow_grades":false, "queue_enabled": false, "queue_contact_info": false}}'
         );
         FileUtils::createDir(FileUtils::joinPaths($this->test_dir, 'courses', 'f19', 'sample', 'reports', 'seating'), true);
         foreach ($seating_dirs as $dir) {
@@ -103,7 +103,8 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'room_seating_gradeable_id'      => '',
             'seating_only_for_instructor'    => false,
             'auto_rainbow_grades'            => false,
-            'queue_enabled'                  => false
+            'queue_enabled'                  => false,
+            'queue_contact_info'             => false
         ];
 
         $gradeable_seating_options = [
@@ -181,7 +182,8 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'room_seating_gradeable_id'      => '',
             'seating_only_for_instructor'    => false,
             'auto_rainbow_grades'            => false,
-            'queue_enabled'                  => false
+            'queue_enabled'                  => false,
+            'queue_contact_info'             => false
         ];
 
         $gradeable_seating_options = [

--- a/site/tests/app/controllers/admin/ConfigurationControllerTester.php
+++ b/site/tests/app/controllers/admin/ConfigurationControllerTester.php
@@ -268,7 +268,8 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
             'room_seating_gradeable_id'      => '',
             'seating_only_for_instructor'    => false,
             'auto_rainbow_grades'            => false,
-            'queue_enabled'                  => false
+            'queue_enabled'                  => false,
+            'queue_contact_info'             => false
         ];
 
         $gradeable_seating_options = [

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -114,6 +114,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
                 'room_seating_gradeable_id' => "",
                 'auto_rainbow_grades' => false,
                 'queue_enabled' => true,
+                'queue_contact_info' => true,
             ),
             'feature_flags' => [
 
@@ -268,6 +269,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
                     'room_seating_gradeable_id' => "",
                     'auto_rainbow_grades' => false,
                     'queue_enabled' => true,
+                    'queue_contact_info' => true,
                 ],
                 'feature_flags' => []
             ],
@@ -292,6 +294,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'latest_tag' => 'v19.07.00',
             'verified_submitty_admin_user' => null,
             'queue_enabled' => true,
+            'queue_contact_info' => true,
             'feature_flags' => []
         );
         $actual = $config->toArray();
@@ -465,7 +468,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
                 'course_name', 'course_home_url', 'default_hw_late_days', 'default_student_late_days',
                 'zero_rubric_grades', 'upload_message', 'display_rainbow_grades_summary',
                 'display_custom_message', 'course_email', 'vcs_base_url', 'vcs_type', 'private_repository',
-                'forum_enabled', 'forum_create_thread_message', 'regrade_enabled', 'seating_only_for_instructor', 'regrade_message', 'room_seating_gradeable_id', 'queue_enabled'
+                'forum_enabled', 'forum_create_thread_message', 'regrade_enabled', 'seating_only_for_instructor', 'regrade_message', 'room_seating_gradeable_id', 'queue_enabled', 'queue_contact_info'
             ],
         ];
         $return = array();

--- a/tests/e2e/test_office_hours_queue.py
+++ b/tests/e2e/test_office_hours_queue.py
@@ -15,6 +15,8 @@ class TestOfficeHoursQueue(BaseTestCase):
         self.get(self.get_current_semester()+"/sample/config")
         if(not self.driver.find_element_by_id('queue-enabled').is_selected()):
             self.driver.find_element_by_id('queue-enabled').click()
+        if(self.driver.find_element_by_id('queue-contact-info').is_selected()):
+            self.driver.find_element_by_id('queue-contact-info').click()
 
         # Delete any old queues (this should remove anyone that was currently in the queue as well)
         deleteAllQueues(self)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

RPI has shut down the campus and we have no way to run office hours

### What is the new behavior?

I added a setting to the course settings page to enable the ability for students to add contact info to the office hours queue.
![image](https://user-images.githubusercontent.com/18558130/76478156-1e45c580-63de-11ea-8a6a-a78653f6638f.png)
Once checked, students will not be required to add their contact info to join the office hours queue for that class.
![image](https://user-images.githubusercontent.com/18558130/76478174-3289c280-63de-11ea-929f-7e3fa9c4a708.png)
Contact info is just a required textbox, so you can send an email, a url, or anything else.
For instructors/mentors/tas they will see this contact info under the student in the queue
![image](https://user-images.githubusercontent.com/18558130/76478230-5b11bc80-63de-11ea-86ed-080e4bd5a7e8.png)

