### PR TITLE
[VPAT] Fixed w3 validator error by removing style element from noscript tag

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -75,7 +75,7 @@
             <iframe sandbox="allow-top-navigation-by-user-activation allow-top-navigation" id="left_sidebar" src="{{ wrapper_urls['left_sidebar.html'] }}" frameborder="0"></iframe>
         {% endif %}
         {# separates our content from user custom bars #}
-        <div id="submitty-body" class="flex-col invisible">
+        <div id="submitty-body" class="flex-col">
             <div id="mobile-menu">
                 <div id="menu-header" class="flex-row">
                 <a href="{{ base_url }}" aria-label="Go to Submitty Home"><span class="mobile-title">Submitty</span></a>
@@ -176,11 +176,6 @@
             </nav>
             <noscript class="system-message danger">
                 You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.
-                <style media="screen">
-                  #submitty-body{
-                    visibility: visible;
-                  }
-                </style>
             </noscript>
             {% if system_message is not null and system_message|length > 0 %}
             <div class="system-message warning">
@@ -205,7 +200,7 @@
             </div>
             <div id="wrapper">
                 {% if sidebar_buttons|length > 0 %}
-                    <aside class="preload">
+                    <aside class="{{collapse_sidebar?'collapsed':''}}">
                         <ul>
                             {% for button in sidebar_buttons %}
                                 {{ self.render_sidebar_button(button, false) }}
@@ -252,7 +247,7 @@
                 >
                     <span class="flex-line"> {# col in flex-row #}
                         {% if button.getIcon() != null %}
-                            <i class="fa {{ button.getIcon() }} preload"></i>
+                            <i class="fa {{ button.getIcon() }}"></i>
                         {% endif %}
 
                         <span class="icon-title"> {{ button.getTitle() }} </span>

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -57,7 +57,7 @@ class GlobalView extends AbstractView {
             "enable_banner" => $config_data['duck_special_effects'],
             "duck_img" => $duck_img,
             "use_mobile_viewport" => $this->output->useMobileViewport(),
-            "collapse_sidebar" => array_key_exists('collapse_sidebar',$_COOKIE)?$_COOKIE['collapse_sidebar']==='true':false
+            "collapse_sidebar" => array_key_exists('collapse_sidebar', $_COOKIE) ? $_COOKIE['collapse_sidebar'] === 'true' : false
         ]);
     }
 

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -56,7 +56,8 @@ class GlobalView extends AbstractView {
             "csrf_token" => $this->core->getCsrfToken(),
             "enable_banner" => $config_data['duck_special_effects'],
             "duck_img" => $duck_img,
-            "use_mobile_viewport" => $this->output->useMobileViewport()
+            "use_mobile_viewport" => $this->output->useMobileViewport(),
+            "collapse_sidebar" => array_key_exists('collapse_sidebar',$_COOKIE)?$_COOKIE['collapse_sidebar']==='true':false
         ]);
     }
 

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -2,11 +2,6 @@ aside {
     display: none;
 }
 
-/* Used to keep the page invisible just long enough for the sidebar to close */
-.invisible{
-  visibility: hidden;
-}
-
 @media (min-width: 541px) {
     aside {
         display: block;
@@ -17,7 +12,7 @@ aside {
         z-index: 1;
     }
 
-    aside:not(.preload){
+    aside{
       transition: all 0.3s ease-out;
     }
 
@@ -33,7 +28,7 @@ aside {
         margin: 0 0 0 15px;
     }
 
-    aside i:not(.preload){
+    aside i{
       transition: margin 0.3s ease-out;
     }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1564,25 +1564,23 @@ $.fn.isInViewport = function() {                                        // jQuer
 };
 
 function checkSidebarCollapse() {
-    $(".preload").removeClass("preload");//.preload must be removed to allow the animation to work
     var size = $(document.body).width();
     if (size < 1150) {
-        localStorage.setItem('sidebar', 'true');
+        document.cookie = "collapse_sidebar=true;";
         $("aside").toggleClass("collapsed", true);
     }
     else{
-        localStorage.setItem('sidebar', 'false');
+        document.cookie = "collapse_sidebar=false;";
         $("aside").toggleClass("collapsed", false);
     }
 }
 
 //Called from the DOM collapse button, toggle collapsed and save to localStorage
 function toggleSidebar() {
-    $(".preload").removeClass("preload");//.preload must be removed to allow the animation to work
     var sidebar = $("aside");
     var shown = sidebar.hasClass("collapsed");
 
-    localStorage.setItem('sidebar', (!shown).toString());
+    document.cookie = "collapse_sidebar=" + (!shown).toString() + ";";
     sidebar.toggleClass("collapsed", !shown);
 }
 
@@ -1602,13 +1600,6 @@ $(document).ready(function() {
             }
         }
     });
-
-    //Remember sidebar preference
-    if (localStorage.getItem('sidebar') !== "") {
-        $("aside").toggleClass("collapsed", localStorage.getItem('sidebar') === "true");
-        //Once the sidebar is set the page can be unhidden
-        $("#submitty-body").removeClass( "invisible" )
-    }
 
     //If they make their screen too small, collapse the sidebar to allow more horizontal space
     $(document.body).resize(function() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Due to how the sidebar works it needs to have a style element inside the \<noscript> element.
This is an issue shown in the w3 validator https://validator.w3.org/nu/#file

### What is the new behavior?

The sidebar used to save its current state (open/closed) on the client and so when the page is rendered it was sent with the sidebar always open and the client would shut the sidebar if it should be closed.
This pr moves the variable that stores the last sidebar state from local storage to a cookie which the server can read and therefore send the sidebar already collapsed if it needs to be. Because of this change there now no longer needs to be a style element inside of the \<noscript> tag

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This hope with this and the other few w3 validator related prs open is that once they are merged I can merge a e2e test that will check for w3 validator errors going forward and we wont have to keep going back and fix them as people will fix them before any pr is merged. I have this code done, it is just waiting for the rest of the errors to be fixed in this and the last few other open prs.
