### PR TITLE
[Feature:InstructorUI] benchmark percents input for Rainbow Grades UI

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -552,6 +552,7 @@ class ReportController extends AbstractController {
                 'bucket_counts' => $customization->getBucketCounts(),
                 "used_buckets" => $customization->getUsedBuckets(),
                 'display_benchmarks' => $customization->getDisplayBenchmarks(),
+                'benchmark_percents' => (array)$customization->getBenchmarkPercent(),
                 'sections_and_labels' => (array) $customization->getSectionsAndLabels(),
                 'bucket_percentages' => $customization->getBucketPercentages(),
                 'messages' => $customization->getMessages(),

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -552,7 +552,7 @@ class ReportController extends AbstractController {
                 'bucket_counts' => $customization->getBucketCounts(),
                 "used_buckets" => $customization->getUsedBuckets(),
                 'display_benchmarks' => $customization->getDisplayBenchmarks(),
-                'benchmark_percents' => (array)$customization->getBenchmarkPercent(),
+                'benchmark_percents' => (array) $customization->getBenchmarkPercent(),
                 'sections_and_labels' => (array) $customization->getSectionsAndLabels(),
                 'bucket_percentages' => $customization->getBucketPercentages(),
                 'messages' => $customization->getMessages(),

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -213,6 +213,32 @@ class RainbowCustomization extends AbstractModel {
     }
 
     /**
+     * Get benchmark percentages
+     *
+     * @return object An object which maps benchmarks to the percentage (as a decimal) that is needed to obtain that
+     *                letter grade
+     */
+    public function getBenchmarkPercent() {
+        // If RCJSON exists use the values from it
+        if(!is_null($this->RCJSON)) {
+
+            return $this->RCJSON->getBenchmarkPercent();
+
+        // Else just return a default benchmark percent object
+        } else {
+
+            return (object)
+                [
+                    'lowest_a-' => 0.9,
+                    'lowest_b-' => 0.8,
+                    'lowest_c-' => 0.7,
+                    'lowest_d' => 0.6,
+                ];
+
+        }
+    }
+
+    /**
      * Get section ids and labels
      *
      * If no customization.json file exists then this function will generate defaults

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -219,23 +219,23 @@ class RainbowCustomization extends AbstractModel {
      *                letter grade
      */
     public function getBenchmarkPercent() {
-        // If RCJSON exists use the values from it
         if(!is_null($this->RCJSON)) {
+            $percent_obj = $this->RCJSON->getBenchmarkPercent();
 
-            return $this->RCJSON->getBenchmarkPercent();
-
-        // Else just return a default benchmark percent object
-        } else {
-
-            return (object)
-                [
-                    'lowest_a-' => 0.9,
-                    'lowest_b-' => 0.8,
-                    'lowest_c-' => 0.7,
-                    'lowest_d' => 0.6,
-                ];
-
+            // If the RCJSON was found and it contains the benchmark percent fields then return it
+            if ($percent_obj != (object)[]) {
+                return $percent_obj;
+            }
         }
+
+        // Otherwise return a default benchmark percent object
+        return (object)
+            [
+                'lowest_a-' => 0.9,
+                'lowest_b-' => 0.8,
+                'lowest_c-' => 0.7,
+                'lowest_d' => 0.6,
+            ];
     }
 
     /**
@@ -299,6 +299,12 @@ class RainbowCustomization extends AbstractModel {
         if (isset($form_json->display_benchmark)) {
             foreach ($form_json->display_benchmark as $benchmark) {
                 $this->RCJSON->addDisplayBenchmarks($benchmark);
+            }
+        }
+
+        if (isset($form_json->benchmark_percent)) {
+            foreach ($form_json->benchmark_percent as $key => $value) {
+                $this->RCJSON->addBenchmarkPercent((string) $key, $value);
             }
         }
 

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -219,18 +219,17 @@ class RainbowCustomization extends AbstractModel {
      *                letter grade
      */
     public function getBenchmarkPercent() {
-        if(!is_null($this->RCJSON)) {
+        if (!is_null($this->RCJSON)) {
             $percent_obj = $this->RCJSON->getBenchmarkPercent();
 
             // If the RCJSON was found and it contains the benchmark percent fields then return it
-            if ($percent_obj != (object)[]) {
+            if ($percent_obj != (object) []) {
                 return $percent_obj;
             }
         }
 
         // Otherwise return a default benchmark percent object
-        return (object)
-            [
+        return (object) [
                 'lowest_a-' => 0.9,
                 'lowest_b-' => 0.8,
                 'lowest_c-' => 0.7,

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -189,6 +189,21 @@ class RainbowCustomizationJSON extends AbstractModel {
         $this->section->$sectionID = $label;
     }
 
+
+    /**
+     * Add a benchmark percent
+     *
+     * @param $benchmark The benchmark, this is the key for the field
+     * @param $percent The percent, this is the value for the field
+     */
+    public function addBenchmarkPercent($benchmark, $percent) {
+        if (empty($percent)) {
+            throw new BadArgumentException('The benchmark percent may not be empty.');
+        }
+
+        $this->benchmark_percent->$benchmark = (float)$percent;
+    }
+
     /**
      * Get the section object
      *

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -193,8 +193,8 @@ class RainbowCustomizationJSON extends AbstractModel {
     /**
      * Add a benchmark percent
      *
-     * @param $benchmark string The benchmark - this is the key for this json field
-     * @param $percent float The percent - this is the value for this json field
+     * @param string $benchmark The benchmark - this is the key for this json field
+     * @param float $percent The percent - this is the value for this json field
      * @throws BadArgumentException The passed in percent was empty
      */
     public function addBenchmarkPercent($benchmark, $percent) {

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -193,8 +193,9 @@ class RainbowCustomizationJSON extends AbstractModel {
     /**
      * Add a benchmark percent
      *
-     * @param $benchmark The benchmark, this is the key for the field
-     * @param $percent The percent, this is the value for the field
+     * @param $benchmark string The benchmark - this is the key for this json field
+     * @param $percent float The percent - this is the value for this json field
+     * @throws BadArgumentException The passed in percent was empty
      */
     public function addBenchmarkPercent($benchmark, $percent) {
         if (empty($percent)) {

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -201,7 +201,7 @@ class RainbowCustomizationJSON extends AbstractModel {
             throw new BadArgumentException('The benchmark percent may not be empty.');
         }
 
-        $this->benchmark_percent->$benchmark = (float)$percent;
+        $this->benchmark_percent->$benchmark = (float) $percent;
     }
 
     /**

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -66,6 +66,15 @@ class RainbowCustomizationJSON extends AbstractModel {
     }
 
     /**
+     * Gets the benchmark percentages object
+     *
+     * @return object The benchmark percentages object
+     */
+    public function getBenchmarkPercent() {
+        return $this->benchmark_percent;
+    }
+
+    /**
      * Adds a benchmark to the display_benchmarks
      * If it already exists in the array no changes are made
      *

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -37,6 +37,18 @@
             {% endfor %}
             </div>
         </div>
+        <div id="benchmark_percents" class="customization_item">
+            <h2>Benchmark Percents</h2>
+            <div id="benchmark_percents_collapse" class="collapsible_area">
+                <p>You may adjust the minimum percent required to receive certain letter grades.</p>
+                {% for benchmark, percent in benchmark_percents %}
+                    <p>
+                        <label for="benchmark_{{ benchmark }}">{{ benchmark }}</label>
+                        <input type="text" id="benchmark_{{ benchmark }}" value="{{ percent }}">
+                    </p>
+                {% endfor %}
+            </div>
+        </div>
         <div id="cust_messages" class="customization_item">
             <h2>Messages</h2>
             <div id="cust_messages_collapse" class="collapsible_area">

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -42,11 +42,11 @@
         <div id="benchmark_percents" class="customization_item">
             <h2>Benchmark Percents</h2>
             <div id="benchmark_percents_collapse" class="collapsible_area">
-                <p>You may adjust the minimum percent required to receive certain letter grades.</p>
+                <p>You may adjust the minimum percent required to receive certain letter grades.  Enter this percentage as a decimal number.</p>
                 {% for benchmark, percent in benchmark_percents %}
                     <p>
                         <label for="benchmark_{{ benchmark }}">{{ benchmark }}</label>
-                        <input type="text" id="benchmark_{{ benchmark }}" value="{{ percent }}">
+                        <input type="text" id="benchmark_{{ benchmark }}" class="benchmark_percent_input" data-benchmark="{{ benchmark }}" value="{{ percent }}">
                     </p>
                 {% endfor %}
             </div>

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -187,12 +187,43 @@ function getMessages()
     return messages;
 }
 
+function getBenchmarkPercent()
+{
+    // Collect benchmark percents
+    var benchmark_percent = {};
+
+    $.each($("input[class='benchmark_percent_input']"), function(){
+
+        // Get data
+        var benchmark = this.getAttribute('data-benchmark').toString();
+        var percent = this.value;
+
+        // Verify percent is not empty
+        if(percent === "")
+        {
+            throw "All benchmarks must have a value before saving."
+        }
+
+        // Verify percent is a floating point number
+        if(isNaN(parseFloat(percent)))
+        {
+            throw "Benchmark percent input must be a floating point number."
+        }
+
+        // Add to sections
+        benchmark_percent[benchmark] = percent;
+    });
+
+    return benchmark_percent;
+}
+
 // This function constructs a JSON representation of all the form input
 function buildJSON(){
 
     // Build the overall json
     let ret = {
         'display_benchmark': getDisplayBenchmark(),
+        'benchmark_percent': getBenchmarkPercent(),
         'section' : getSection(),
         'gradeables' : getGradeableBuckets(),
         'messages' : getMessages()

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -297,6 +297,10 @@ $(document).ready(function () {
         $('#display_benchmarks_collapse').toggle();
     });
 
+    $('#benchmark_percents h2').click(function() {
+        $('#benchmark_percents_collapse').toggle();
+    });
+
     $('#section_labels h2').click(function() {
         $('#section_labels_collapse').toggle();
     });


### PR DESCRIPTION
Partially handles #4961

### What is the current behavior?
There is currently no way to modify the course wide 'benchmark_percent' field for the rainbow grades customization.json from the web ui.

### What is the new behavior?
This functionality has now been added.
