### PR TITLE
[Bugfix:Forum] Fix enter inputs being eaten in popups

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -4,7 +4,7 @@
         {# This lets us center the window #}
         <div class="popup-box"  onclick="event.stopPropagation(); closePopup();">
             {# Actual displayed window #}
-            <div class="popup-window">
+            <div class="popup-window" onclick="event.stopPropagation();">
                 {% block title_panel %}
                     <div class="form-title">
                         {% block title_tag %}

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -2,7 +2,7 @@
 <div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;">
     {% block form %}
         {# This lets us center the window #}
-        <div class="popup-box">
+        <div class="popup-box"  onclick="event.stopPropagation(); closePopup();">
             {# Actual displayed window #}
             <div class="popup-window">
                 {% block title_panel %}

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -2,9 +2,9 @@
 <div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;">
     {% block form %}
         {# This lets us center the window #}
-        <div class="popup-box key_to_click" tabindex="0" onclick="event.stopPropagation(); closePopup();">
+        <div class="popup-box">
             {# Actual displayed window #}
-            <div class="popup-window key_to_click" tabindex="0" onclick="event.stopPropagation();">
+            <div class="popup-window">
                 {% block title_panel %}
                     <div class="form-title">
                         {% block title_tag %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Cannot press enter in text fields in popups.

### What is the new behavior?
Can now press enter in text fields in popups.

### Other information?
Tested enter in popups, made sure that the buttons in the popups could still be pressed with tab/enter.