### PR TITLE
[Bugfix:System] systemctl starts for services on vagrant ssh

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -146,6 +146,7 @@ alias submitty_restart_services='submitty_restart_autograding && systemctl resta
 alias migrator='python3 ${SUBMITTY_REPOSITORY}/migration/run_migrator.py -c ${SUBMITTY_INSTALL_DIR}/config'
 alias vagrant_info='cat /etc/motd'
 alias ntp_sync='service ntp stop && ntpd -gq && service ntp start'
+systemctl start nullsmtpd
 cd ${SUBMITTY_INSTALL_DIR}" >> /root/.bashrc
 else
     #TODO: We should get options for ./.setup/CONFIGURE_SUBMITTY.py script

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -146,6 +146,9 @@ alias submitty_restart_services='submitty_restart_autograding && systemctl resta
 alias migrator='python3 ${SUBMITTY_REPOSITORY}/migration/run_migrator.py -c ${SUBMITTY_INSTALL_DIR}/config'
 alias vagrant_info='cat /etc/motd'
 alias ntp_sync='service ntp stop && ntpd -gq && service ntp start'
+systemctl start submitty_autograding_shipper
+systemctl start submitty_autograding_worker
+systemctl start submitty_daemon_jobs_handler
 systemctl start nullsmtpd
 cd ${SUBMITTY_INSTALL_DIR}" >> /root/.bashrc
 else


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Even though nullsmtpd is set to be enabled, for whatever reason inside the vagrant machines multiple people are experiencing it not running. 
Here is some other conversation on the topic https://github.com/Submitty/submitty.github.io/pull/203

### What is the new behavior?
This pr starts nullsmtpd whenever you ssh to the vagrant machine by adding it to the bashrc file. This ensures that it is always running when you want to develop code related to emails as long as your first ssh to the vagrant vm (which you will need to do anyway to view the output of the emails you are sending).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I tested this by running a fully vagrant destroy and vagrant up just to be sure.
