### PR TITLE
[Bugfix:Autograding] empty autograding_DONE on worker restart

### DIFF
--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -196,18 +196,13 @@ def read_autograding_worker_json():
 # ==================================================================================
 # Removes any existing files or folders in the autograding_done folder.
 def cleanup_old_jobs():
-    autograding_done_filepath = os.path.join(SUBMITTY_DATA_DIR,"autograding_DONE")
-    print(autograding_done_filepath)
-    for filename in os.listdir(autograding_done_filepath):
-        file_path = os.path.join(folder, filename)
+    for file_path in Path(SUBMITTY_DATA_DIR, "autograding_DONE").glob("*"):
+        file_path = str(file_path)
+        autograding_utils.log_message(AUTOGRADING_LOG_PATH, JOB_ID, message="Remove autograding DONE file: " + file_path)
         try:
-            if os.path.isfile(file_path) or os.path.islink(file_path):
-                os.unlink(file_path)
-            elif os.path.isdir(file_path):
-                shutil.rmtree(file_path)
+            os.remove(file_path)
         except Exception as e:
             autograding_utils.log_stack_trace(AUTOGRADING_STACKTRACE_PATH, JOB_ID,trace=traceback.format_exc())
-
 
 # ==================================================================================
 

--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -194,6 +194,26 @@ def read_autograding_worker_json():
         raise SystemExit("ERROR loading autograding_worker.json file: {0}".format(e))
     return name, stats
 # ==================================================================================
+# Removes any existing files or folders in the autograding_done folder.
+def cleanup_old_jobs():
+    autograding_done_filepath = os.path.join(SUBMITTY_DATA_DIR,"autograding_DONE")
+    print(autograding_done_filepath)
+    for filename in os.listdir(autograding_done_filepath):
+        file_path = os.path.join(folder, filename)
+        try:
+            if os.path.isfile(file_path) or os.path.islink(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            autograding_utils.log_stack_trace(AUTOGRADING_STACKTRACE_PATH, JOB_ID,trace=traceback.format_exc())
+
+
+# ==================================================================================
+
+
 if __name__ == "__main__":
+    cleanup_old_jobs()
+    print('cleaned up old jobs')
     my_name, my_stats = read_autograding_worker_json()
     launch_workers(my_name, my_stats)

--- a/sbin/submitty_autograding_worker.py
+++ b/sbin/submitty_autograding_worker.py
@@ -11,6 +11,7 @@ import contextlib
 import traceback
 import tempfile
 import zipfile
+from pathlib import Path
 
 from autograder import autograding_utils
 from autograder import grade_item


### PR DESCRIPTION
Closes #5045

Stale results files in the ```autograding_DONE``` directory on worker machines were causing bad results to be returned in rare cases when the ```update_and_restart_workers``` script was run. To fix the issue, worker daemons now clean up any stale files in the ```autograding_DONE``` directory on restart.