### PR TITLE
[Bugfix:Submission] Make links in assignment message white

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -311,6 +311,10 @@ td>a.active-sort {
     color: var(--text-white);
 }
 
+.content.gradeable_message a{
+    color: var(--text-white);
+}
+
 .content.gradeable_message p:not(:last-child){
     padding-bottom: 20px;
 }


### PR DESCRIPTION
Previously, markdown links the "assignment_message" were rendered in blue, but the background is dark blue, nearly impossible to read.  Now they are white like the rest of the text.

Fixes #4419 