### PR TITLE
[Bugfix:InstructorUI] Newlines now work in office hours queue and upload messages

### DIFF
--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -150,7 +150,7 @@ class ConfigurationController extends AbstractController {
         ) {
             $entry = $entry === "true" ? true : false;
         }
-        elseif ($name === 'upload_message' || $name === 'queue_message') {
+        elseif ($name === 'upload_message') {
             $entry = nl2br($entry);
         }
         elseif ($name == "course_home_url") {

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -150,9 +150,6 @@ class ConfigurationController extends AbstractController {
         ) {
             $entry = $entry === "true" ? true : false;
         }
-        elseif ($name === 'upload_message') {
-            $entry = nl2br($entry);
-        }
         elseif ($name == "course_home_url") {
             if (!filter_var($entry, FILTER_VALIDATE_URL) && !empty($entry)) {
                 return Response::JsonOnlyResponse(

--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -1,6 +1,6 @@
 {% if viewer.getQueueMessage()|length > 0 %}
   <div class="content gradeable_message">
-    <p>{{viewer.getQueueMessage()}}</p>
+    <p>{{viewer.getQueueMessage() | markdown}}</p>
   </div>
 {% endif %}
 <div class="content">

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -438,7 +438,7 @@
         {# /Page selector #}
 
         <p>
-            {{ upload_message }}
+            {{ upload_message | markdown}}
         </p>
 
         <button type="button" id="submit" class="btn btn-success">Submit</button>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

you cannot use newlines and/or markdown on the upload message and office hours queue welcome message
closes  #1821
![image](https://user-images.githubusercontent.com/18558130/77260512-d9802100-6c5e-11ea-8c6c-adee0049af05.png)

### What is the new behavior?

Both normal newlines as well as markdown now work on both messages

![image](https://user-images.githubusercontent.com/18558130/77260456-8dcd7780-6c5e-11ea-830e-c148c65d587a.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I know this issue was meant for @DefinitiveAbove but when looking into fixing something else I stumbled across this fix. I spoke with him and he had not started so we agreed I would just submit a pr for it.
