### PR TITLE
[Feature:Install] Use prefer-dist flag for composer install

### DIFF
--- a/.setup/install_submitty/install_site_dev.sh
+++ b/.setup/install_submitty/install_site_dev.sh
@@ -129,7 +129,7 @@ done
 
 if echo "${result}" | grep -E -q "composer\.(json|lock)"; then
     # install composer dependencies and generate classmap
-    su - ${PHP_USER} -c "composer install -d \"${SUBMITTY_INSTALL_DIR}/site\" --no-dev --optimize-autoloader --no-suggest"
+    su - ${PHP_USER} -c "composer install -d \"${SUBMITTY_INSTALL_DIR}/site\" --no-dev --prefer-dist --optimize-autoloader --no-suggest"
     chown -R ${PHP_USER}:${PHP_USER} ${SUBMITTY_INSTALL_DIR}/site/vendor
 else
     su - ${PHP_USER} -c "composer dump-autoload -d \"${SUBMITTY_INSTALL_DIR}/site\" --optimize --no-dev"

--- a/.setup/install_submitty/install_site_prod.sh
+++ b/.setup/install_submitty/install_site_prod.sh
@@ -63,7 +63,7 @@ if [ -d "${SUBMITTY_INSTALL_DIR}/site/vendor/composer" ]; then
 fi
 
 # install composer dependencies and generate classmap
-su - ${PHP_USER} -c "composer install -d \"${SUBMITTY_INSTALL_DIR}/site\" --no-dev --optimize-autoloader --no-suggest"
+su - ${PHP_USER} -c "composer install -d \"${SUBMITTY_INSTALL_DIR}/site\" --no-dev --prefer-dist --optimize-autoloader --no-suggest"
 
 # Install JS dependencies and then copy them into place
 # We need to create the node_modules folder initially if it


### PR DESCRIPTION
Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There was a chance that composer would use the source of a package, which would require doing a `git clone` instead of downloading.

### What is the new behavior?

Expressly sets the `--prefer-dist` flag when running `composer install`, so that we're always downloading tarballs instead of potentially doing git clones (which can be expensive).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
