### PR TITLE
[Refactor:PHP] Move NotificationFactory to app/libraries namespace

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -11,7 +11,6 @@ use app\libraries\database\DatabaseQueries;
 use app\models\Config;
 use app\models\forum\Forum;
 use app\models\User;
-use app\models\NotificationFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/site/app/libraries/NotificationFactory.php
+++ b/site/app/libraries/NotificationFactory.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace app\models;
+namespace app\libraries;
 
-use app\libraries\Core;
 use app\models\Email;
 use app\models\Notification;
 use app\models\User;
@@ -29,7 +28,7 @@ class NotificationFactory {
     /**
      * @param array $event
      */
-    public function onNewAnnouncement(array $event) {
+    public function onNewAnnouncement(array $event): void {
         $recipients = $this->core->getQueries()->getAllUsersIds();
         $notifications = $this->createNotificationsArray($event, $recipients);
         $this->sendNotifications($notifications);
@@ -42,7 +41,7 @@ class NotificationFactory {
     /**
      * @param array $event
      */
-    public function onNewThread(array $event) {
+    public function onNewThread(array $event): void {
         $recipients = $this->core->getQueries()->getAllUsersWithPreference("all_new_threads");
         $recipients[] = $this->core->getUser()->getId();
         $recipients = array_unique($recipients);
@@ -61,7 +60,7 @@ class NotificationFactory {
      * notifies parent authors, people who want to know about all posts, and people who want to know about new posts in threads they have posted
      * @param array $event
      */
-    public function onNewPost(array $event) {
+    public function onNewPost(array $event): void {
         $current_user_id = $this->core->getUser()->getId();
         $post_id = $event["post_id"];
         $thread_id = $event["thread_id"];
@@ -90,7 +89,7 @@ class NotificationFactory {
      * handles the event of a post deleted, undeleted, edited and merged
      * @param array $event
      */
-    public function onPostModified(array $event) {
+    public function onPostModified(array $event): void {
         $notification_recipients = $this->core->getQueries()->getAllUsersWithPreference($event['preference']);
         $notification_recipients[] = $event['recipient'];
         $notification_recipients[] = $this->core->getUser()->getId();
@@ -114,7 +113,7 @@ class NotificationFactory {
      * @param array $event
      * @param array $recipients
      */
-    public function onTeamEvent(array $event, array $recipients) {
+    public function onTeamEvent(array $event, array $recipients): void {
         $current_user_id = $this->core->getUser()->getId();
         $notification_recipients = [$current_user_id];
         $email_recipients = [$current_user_id];
@@ -145,11 +144,11 @@ class NotificationFactory {
     // ***********************************HELPERS***********************************
 
     /**
-     * @param $event
-     * @param $recipients
+     * @param array $event
+     * @param array $recipients
      * @return array
      */
-    private function createNotificationsArray($event, $recipients) {
+    private function createNotificationsArray(array $event, array $recipients): array {
         $event['sender_id'] = $this->core->getUser()->getId();
         $notifications = array();
         foreach ($recipients as $recipient) {
@@ -160,11 +159,12 @@ class NotificationFactory {
     }
 
     /**
-     * @param $event
-     * @param $recipients
+     * @param array $event
+     * @param array $recipients
+     * @param bool $author
      * @return array of email objects
      */
-    private function createEmailsArray($event, $recipients, $author) {
+    private function createEmailsArray(array $event, array $recipients, bool $author): array {
         $emails = array();
         foreach ($recipients as $recipient) {
             //Checks if a url is in metadata and sets $relevant_url null or that url
@@ -188,10 +188,9 @@ class NotificationFactory {
 
     // ***********************************SENDERS***********************************
     /**
-     * @param array $event
-     * @param array $recipients
+     * @param array $notifications
      */
-    public function sendNotifications(array $notifications) {
+    public function sendNotifications(array $notifications): void {
         if (empty($notifications)) {
             return;
         }
@@ -223,7 +222,7 @@ class NotificationFactory {
      * prepare array of Email objects as param array
      * @param array $emails
      */
-    public function sendEmails(array $emails) {
+    public function sendEmails(array $emails): void {
         if (!$this->core->getConfig()->isEmailEnabled()) {
             throw new LogicException("Email is not enabled");
         }

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -706,26 +706,6 @@ parameters:
 			path: app/models/Notification.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$event\\)\\: Unexpected token \"\\$event\", expected type at offset 18$#"
-			count: 2
-			path: app/models/NotificationFactory.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$recipients\\)\\: Unexpected token \"\\$recipients\", expected type at offset 39$#"
-			count: 2
-			path: app/models/NotificationFactory.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$event$#"
-			count: 1
-			path: app/models/NotificationFactory.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$recipients$#"
-			count: 1
-			path: app/models/NotificationFactory.php
-
-		-
 			message: "#^PHPDoc tag @param has invalid value \\(\\$display The item to add\\)\\: Unexpected token \"\\$display\", expected type at offset 67$#"
 			count: 1
 			path: app/models/RainbowCustomizationJSON.php
@@ -899,4 +879,3 @@ parameters:
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$can_inquirye$#"
 			count: 1
 			path: app/views/submission/HomeworkView.php
-


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

Lifts a refactor from #4329, moving NotificationFactory to a more appropriate place for it as it generates models, though it is not itself a model.