### PR TITLE
[Bugfix:User] Fix regression in PHP 7.4 when passing string to setPassword

### DIFF
--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -221,7 +221,7 @@ class User extends AbstractModel {
     public function setPassword($password) {
         if (!empty($password)) {
             $info = password_get_info($password);
-            if ($info['algo'] === 0) {
+            if (empty($info['algo'])) {
                 $this->password = password_hash($password, PASSWORD_DEFAULT);
             }
             else {

--- a/site/tests/app/models/UserTester.php
+++ b/site/tests/app/models/UserTester.php
@@ -95,11 +95,10 @@ class UserTester extends \PHPUnit\Framework\TestCase {
         );
         $user = new User($this->core, $details);
         $this->assertTrue(password_verify("test", $user->getPassword()));
-        $user->setPassword("test");
-        $hashed_password = password_hash("test", PASSWORD_DEFAULT);
-        password_verify("test", $hashed_password);
-        $user->setPassword($hashed_password);
-        password_verify("test", $hashed_password);
+        $user->setPassword("test1");
+        $this->assertTrue(password_verify("test1", $user->getPassword()));
+        $user->setPassword(password_hash("test2", PASSWORD_DEFAULT));
+        $this->assertTrue(password_verify("test2", $user->getPassword()));
     }
 
     public function testToObject() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

In PHP 7.4, `password_get_info` function changed on what it returns when passing it an unhashed password. Instead of `algo` being `0`, it would now be `null`.

### What is the new behavior?

Fixes the regression on PHP 7.4 (tested locally), while retaining backwards compatibility with previous versions of PHP.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
The unit tests here are sufficient to ensure correctness.