### PR TITLE
[Bugfix:InstructorUI] fix bugs in dark theme

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -186,7 +186,7 @@
                 </div>
 
                 <a class="flex-col" id="logo-box" href="http://submitty.org" target="_blank" aria-label="Visit submitty dot org">
-                    <img id="logo-submitty-dark" src="{{ base_url }}/img/submitty_logo.png" alt="Submitty Logo">
+                    <img id="logo-submitty" src="{{ base_url }}/img/submitty_logo.png" alt="Submitty Logo">
                     <img id="logo-submitty-light" src="{{ base_url }}/img/submitty_logo_white.png" alt="Submitty Logo">
                 </a>
                 {# assuming that if sidebar_buttons only has len 2 it contains logout and collapse (on index page only) #}

--- a/site/app/templates/admin/UploadWrapperForm.twig
+++ b/site/app/templates/admin/UploadWrapperForm.twig
@@ -48,7 +48,7 @@
             <form action="{{ upload_url }}" method="POST" enctype="multipart/form-data">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                 <input type="hidden" name="location" value="{{ file }}">
-                <input type="file" name="wrapper_upload" aria-labelledby="name_{{ aria_labelledby_id }} type_{{ aria_labelledby_id }}">
+                <input type="file" id="wrapper_upload" name="wrapper_upload" aria-labelledby="name_{{ aria_labelledby_id }} type_{{ aria_labelledby_id }}">
                 <input type="submit" class="btn btn-default" value="Upload" />
             </form>
         </td>

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -21,7 +21,7 @@
                         openAll( 'openable-element-', $(this).data('linked-type'))
                     })
 
-                    var currentCodeStyle = localStorage.getItem('codeDisplayStyle');
+                    var currentCodeStyle = localStorage.getItem('theme');
                     var currentCodeStyleRadio = (currentCodeStyle == null || currentCodeStyle == "light") ? "style_light" : "style_dark";
                     $('#' + currentCodeStyleRadio).parent().addClass('active');
                     $('#' + currentCodeStyleRadio).prop('checked', true);
@@ -32,14 +32,6 @@
                 <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ submitter_id }}', {{ active_version }})">Download Zip File</button>
             {% endif %}
 
-            <div id="changeCodeStyle" class="btn-group btn-group-toggle" onchange="changeEditorStyle($('[name=codeStyle]:checked')[0].id);" data-toggle="buttons">
-                <label class="btn btn-secondary">
-                    <input type="radio" name="codeStyle" id="style_light" autocomplete="off" checked> Light
-                </label>
-                <label class="btn btn-secondary">
-                    <input type="radio" name="codeStyle" id="style_dark" autocomplete="off"> Dark
-                </label>
-            </div>
             <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
             <br />
             {# Files #}

--- a/site/app/templates/misc/SourceSettings.twig
+++ b/site/app/templates/misc/SourceSettings.twig
@@ -13,7 +13,7 @@
     else {
         editor{{ number }}.setSize("100%", "auto");
     }
-    var theme = localStorage.getItem("codeDisplayStyle");
+    var theme = localStorage.getItem("theme");
     editor{{ number }}.setOption("theme", (theme == null || theme === "light") ? "eclipse" : "monokai");
     editor{{ number }}.setOption("mode", "{{ type }}");
     $("#myTab").find("a").click(function (e) {

--- a/site/app/templates/misc/SourceSettings.twig
+++ b/site/app/templates/misc/SourceSettings.twig
@@ -14,6 +14,9 @@
         editor{{ number }}.setSize("100%", "auto");
     }
     var theme = localStorage.getItem("theme");
+    if(theme == null && window.matchMedia("(prefers-color-scheme: dark)").matches){
+      theme = "dark";
+    }
     editor{{ number }}.setOption("theme", (theme == null || theme === "light") ? "eclipse" : "monokai");
     editor{{ number }}.setOption("mode", "{{ type }}");
     $("#myTab").find("a").click(function (e) {

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1055,6 +1055,7 @@ class ForumThreadView extends AbstractView {
         $this->core->getOutput()->addVendorJs('jquery.are-you-sure/jquery.are-you-sure.js');
 
         $this->core->getOutput()->addVendorCss('flatpickr/flatpickr.min.css');
+        $this->core->getOutput()->addInternalCss('forum.css');
 
         $categories = "";
         $category_colors;

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -175,6 +175,7 @@ div.btn-container {
 #rebuild-status-panel {
     display: inline-block;
     background-color: lightgrey;
+    color: var(--btn-text-black);
 
     position: relative;
     top: 5px;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -353,7 +353,7 @@
 
       /*links*/
       --external-link-blue: #8888F2;
-      --external-link-hover: #131399;
+      --external-link-hover: #a1a1ec;
       --external-link-disabled: #888888;
       --external-link-active: #991313;
 

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -145,6 +145,7 @@
     --viewed-discussion-post-blue: #e8f0f7;
     --deleted-discussion-post-grey: #dcdcdc;
     --important-post: #ffd700; /*is also for star color*/
+    --attachment-box-color: #f5f5f5;
 
 
         /*these differ from the colors on the posts for some reason?
@@ -317,7 +318,7 @@
       --standard-beige: rgb(119, 119, 106);
       --standard-light-gold: #fff3cd;
       --standard-light-green: #427742;
-      --standard-pastel-blue: #d9edf7;
+      --standard-pastel-blue: #2f6580;
       --standard-light-blue: #99ccff;
       --standard-light-seafoam: #a4dad5;
 
@@ -341,6 +342,7 @@
       --viewed-discussion-post-blue: #e8f0f7;
       --deleted-discussion-post-grey: #dcdcdc;
       --important-post: #ffd700; /*is also for star color*/
+      --attachment-box-color: #4a4a4a;
 
 
           /*these differ from the colors on the posts for some reason?

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -465,7 +465,7 @@ body {min-width: 925px;}
   min-height: 20px;
   padding: 19px;
   margin-bottom: 20px;
-  background-color: #f5f5f5;
+  background-color: var(--attachment-box-color);
   border: 1px solid #e3e3e3;
   border-radius: 4px;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
@@ -572,4 +572,8 @@ body {min-width: 925px;}
 
 .post_content td {
     border: 1px solid black;
+}
+
+.category-sortable {
+  background-color: var(--btn-default-white);
 }

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -132,8 +132,8 @@ footer .footer-separator {
     #logo-box {
         display: block;
     }
-    
-    #logo-submitty-dark, #logo-submitty-light {
+
+    #logo-submitty, #logo-submitty-light {
       height: 80px;
     }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -184,10 +184,10 @@ input[type="checkbox"]:checked:before {
 select.disabled,
 textarea.disabled,
 input.disabled {
-    background-color: var(--standard-input-background);
+    background-color: var(--standard-light-gray);
 }
 
-textarea, input, input[type="checkbox"], select{
+textarea, input[type="text"], input[type="number"], input[type="date"], input[type="checkbox"], select{
   background-color: var(--standard-input-background);
 }
 
@@ -1554,6 +1554,7 @@ end of styles used in the admin gradeable page
     height: 240px;
     display: flex;
     flex-direction: column;
+    color: var(--btn-text-black);
 }
 .wrapper-example .wrapper-center {
     display: flex;
@@ -1583,12 +1584,25 @@ end of styles used in the admin gradeable page
 }
 .wrapper-body {
     background-color: var(--default-white);
+    color: var(--text-black);
 }
 .wrapper-right {
     background-color: var(--standard-light-green);
+    color: var(--text-black);
 }
 .wrapper-bottom {
     background-color: var(--standard-light-blue);
+}
+.wrapper-css {
+  background-color: var(--default-white);
+  color: var(--text-black);
+}
+#wrapper_upload {
+  color: var(--text-black);
+}
+
+.wrapper-upload {
+  color: var(--btn-text-black);
 }
 
 .wrapper-upload td {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -121,6 +121,7 @@ input[type="color"] {
 input.readonly {
     background-color: var(--standard-pale-gray);
     cursor: not-allowed;
+    color: var(--btn-text-black);
 }
 
 select {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1072,12 +1072,12 @@ div.full_height {
 
 /* Used to pick the Submitty logo to show based on the theme */
 [data-theme="dark"] #logo-submitty-light,
-#logo-submitty-dark {
+#logo-submitty {
   display: block!important;
 }
 
 /* Used to pick the Submitty logo to show based on the theme */
-[data-theme="dark"] #logo-submitty-dark,
+[data-theme="dark"] #logo-submitty,
 #logo-submitty-light {
   display: none!important;
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -157,7 +157,7 @@ input[type="checkbox"]:checked{
 input[type="checkbox"]:checked:before {
     font-family: 'Font Awesome\ 5 Free';
     content: "\f00c";
-    color: var(--default-white);
+    color: var(--btn-default-white);
     font-size: 18px;
     font-weight: 900
 }
@@ -233,7 +233,7 @@ table tr.table-header {
     background: var(--default-white);
 }
 
-.table>thead>tr {
+.table>thead>tr, .table>tfoot>tr {
     background: var(--standard-hover-light-gray);
 }
 
@@ -826,7 +826,7 @@ tbody.collapse.in {
   clear: both;
   font-weight: normal;
   line-height: 1.42857143;
-  color: var(--standard-deep-dark-gray);
+  color: var(--text-black);
   white-space: nowrap;
 }
 .dropdown-menu > li > a:hover,

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -9,7 +9,6 @@ aside {
         padding-top: 30px;
         width: 250px;
         min-width: 250px;
-        z-index: 1;
     }
 
     aside{
@@ -103,5 +102,9 @@ aside {
         font-size: 12px;
         position: absolute;
         margin: 12px 0 0 32px;
+    }
+
+    aside ul {
+      background-color: var(--background-blue);
     }
 }

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -104,7 +104,7 @@ aside {
         margin: 12px 0 0 32px;
     }
 
-    aside ul {
+    [data-theme="dark"] aside ul {
       background-color: var(--background-blue);
     }
 }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1597,7 +1597,9 @@ function toggleTheme(mode='normal'){
   }
 }
 $(document).ready(function() {
-  if(localStorage.getItem("theme") === "dark" || window.matchMedia("(prefers-color-scheme: dark)").matches){
+  if(localStorage.getItem("theme") === "dark"){
+    $('#theme_change').prop('checked', true);
+  }else if(localStorage.getItem("theme") === null && window.matchMedia("(prefers-color-scheme: dark)").matches){
     $('#theme_change').prop('checked', true);
   }
   if(localStorage.getItem("black_mode") === "black"){

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1597,7 +1597,7 @@ function toggleTheme(mode='normal'){
   }
 }
 $(document).ready(function() {
-  if(localStorage.getItem("theme") === "dark"){
+  if(localStorage.getItem("theme") === "dark" || window.matchMedia("(prefers-color-scheme: dark)").matches){
     $('#theme_change').prop('checked', true);
   }
   if(localStorage.getItem("black_mode") === "black"){

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -357,16 +357,6 @@ function updateCookies(){
     document.cookie = "cookie_version=" + cookie_version + "; path=/;";
 }
 
-function changeEditorStyle(newStyle){
-    if(newStyle === 'style_light'){
-        localStorage.setItem("codeDisplayStyle", "light");
-    }
-    else {
-        localStorage.setItem("codeDisplayStyle", "dark");
-    }
-    window.location.reload();
-}
-
 //-----------------------------------------------------------------------------
 // Student navigation
 function gotoPrevStudent(to_ungraded = false) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If an instructor uses custom css the dark mode may have broken some of their css.
The submitty logo may have become very large 
![image](https://user-images.githubusercontent.com/18558130/77856824-d38ec080-71c7-11ea-87da-78f9cc0f9cd6.png)
as well as if they use a light background, the sidebar buttons might be very hard to see when in dark mode
![image](https://user-images.githubusercontent.com/18558130/77856843-ebfedb00-71c7-11ea-8794-aefe9bdaa551.png)

This also fixes an issue where when a user's device defaults them to dark theme (usually on phones with a system wide dark theme) the checkbox to choose the theme is inverted until they click it and refresh the page.


### What is the new behavior?

This fixes the issues listed above.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
