### PR TITLE
[Testing:Travis] Simplify and speed-up running the e2e matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -261,10 +261,10 @@ jobs:
         - sudo apache2ctl -t
         - sudo service apache2 restart
       script:
-        - echo "Authentication Method: $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
+        - echo "Authentication Method => $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
         - TEST_URL="http://localhost" python3 -m unittest discover -v --start-directory tests
         - sudo sed -ie "s/Pam/Database/g" /usr/local/submitty/config/database.json
-        - echo "Authentication Method: $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
+        - echo "Authentication Method => $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
         - TEST_URL="http://localhost" python3 -m unittest tests.e2e.test_login
         - SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         - sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework

--- a/.travis.yml
+++ b/.travis.yml
@@ -260,7 +260,9 @@ jobs:
         - sudo apache2ctl -t
         - sudo service apache2 restart
       script:
-        - TEST_URL="http://localhost" python -m unittest discover -v --start-directory tests
+        - TEST_URL="http://localhost" python3 -m unittest discover -v --start-directory tests
+        - sed -ie "s/Pam/Database/g" /usr/local/submitty/config/database.json
+        - TEST_URL="http://localhost" python3 -m unittest tests.e2e.test_login
         - SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         - sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework
         - pushd /tmp
@@ -284,14 +286,6 @@ jobs:
         - sudo chown -R ${USER}:${USER} ${HOME}/.composer/cache
     - <<: *03-e2e
       php: 7.3
-      if: branch = master OR type = pull_request
-    - <<: *03-e2e
-      php: 7.2
-      env: AUTH_METHOD=2
-      if: branch = master OR type = pull_request
-    - <<: *03-e2e
-      php: 7.3
-      env: AUTH_METHOD=2
       if: branch = master OR type = pull_request
 
     # To add additional test cases of Clang, you should choose a version that has a binary built and distributed for

--- a/.travis.yml
+++ b/.travis.yml
@@ -260,8 +260,10 @@ jobs:
         - sudo apache2ctl -t
         - sudo service apache2 restart
       script:
+        - echo "Authentication Method: $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
         - TEST_URL="http://localhost" python3 -m unittest discover -v --start-directory tests
         - sudo sed -ie "s/Pam/Database/g" /usr/local/submitty/config/database.json
+        - echo "Authentication Method: $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
         - TEST_URL="http://localhost" python3 -m unittest tests.e2e.test_login
         - SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         - sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework

--- a/.travis.yml
+++ b/.travis.yml
@@ -261,7 +261,7 @@ jobs:
         - sudo service apache2 restart
       script:
         - TEST_URL="http://localhost" python3 -m unittest discover -v --start-directory tests
-        - sed -ie "s/Pam/Database/g" /usr/local/submitty/config/database.json
+        - sudo sed -ie "s/Pam/Database/g" /usr/local/submitty/config/database.json
         - TEST_URL="http://localhost" python3 -m unittest tests.e2e.test_login
         - SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         - sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,6 +192,7 @@ jobs:
             - google-chrome-stable
             - libpam-passwdqc
             - libboost-all-dev
+            - jq
       before_install:
         - source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
         - phpenv config-rm xdebug.ini


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We were running the full E2E tests twice per PHP version, just changing the login method, which caused a lot of wasted time spinning up the environment, and such.

### What is the new behavior?

We create one E2E suite per PHP version, and just toggle the authentication method and re-run the test_login.py file, ensuring that both login methods work as expected, while only running the rest of the suite once (and only having to do the rest of VM setup once per version).