### PR TITLE
[Feature:Developer] convert bools & dates to correct sql

### DIFF
--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -143,6 +143,16 @@ abstract class AbstractDatabase {
     public function query($query, $parameters = array()) {
         try {
             $this->query_count++;
+            foreach ($parameters as &$parameter) {
+                if (gettype($parameter) === "boolean") {
+                    $parameter = $this->convertBoolean($parameter);
+                }
+                elseif (gettype($parameter) === "object") {
+                    if (get_class($parameter) === "DateTime") {
+                        $parameter = $parameter->format("Y-m-d H:i:sO");
+                    }
+                }
+            }
             $this->all_queries[] = array($query, $parameters);
             $statement = $this->link->prepare($query);
             $result = $statement->execute($parameters);

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -149,7 +149,7 @@ abstract class AbstractDatabase {
                 }
                 elseif (gettype($parameter) === "object") {
                     if (get_class($parameter) === "DateTime") {
-                        $parameter = $parameter->format("Y-m-d H:i:sO") . " " . $parameter->getTimezone()->getName();
+                        $parameter = $parameter->format("Y-m-d H:i:sO");
                     }
                 }
             }

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -149,7 +149,7 @@ abstract class AbstractDatabase {
                 }
                 elseif (gettype($parameter) === "object") {
                     if (get_class($parameter) === "DateTime") {
-                        $parameter = $parameter->format("Y-m-d H:i:sO");
+                        $parameter = $parameter->format("Y-m-d H:i:sO") . " " . $parameter->getTimezone()->getName();
                     }
                 }
             }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4382,7 +4382,7 @@ AND gc_id IN (
             $mark->getPoints(),
             $mark->getTitle(),
             $mark->getOrder(),
-            $this->course_db->convertBoolean($mark->isPublish())
+            $mark->isPublish()
         ];
         $this->course_db->query(
             "
@@ -4411,7 +4411,7 @@ AND gc_id IN (
             $mark->getPoints(),
             $mark->getTitle(),
             $mark->getOrder(),
-            $this->course_db->convertBoolean($mark->isPublish()),
+            $mark->isPublish(),
             $mark->getId()
         ];
         $this->course_db->query(
@@ -4467,9 +4467,9 @@ AND gc_id IN (
             $component->getDefault(),
             $component->getMaxValue(),
             $component->getUpperClamp(),
-            $this->course_db->convertBoolean($component->isText()),
+            $component->isText(),
             $component->getOrder(),
-            $this->course_db->convertBoolean($component->isPeer()),
+            $component->isPeer(),
             $component->getPage()
         ];
         $this->course_db->query(
@@ -4549,9 +4549,9 @@ AND gc_id IN (
                 $component->getDefault(),
                 $component->getMaxValue(),
                 $component->getUpperClamp(),
-                $this->course_db->convertBoolean($component->isText()),
+                $component->isText(),
                 $component->getOrder(),
-                $this->course_db->convertBoolean($component->isPeer()),
+                $component->isPeer(),
                 $component->getPage(),
                 $component->getId()
             ];
@@ -4665,28 +4665,28 @@ AND gc_id IN (
                 $gradeable->getId(),
                 DateUtils::dateTimeToString($gradeable->getSubmissionOpenDate()),
                 DateUtils::dateTimeToString($gradeable->getSubmissionDueDate()),
-                $this->course_db->convertBoolean($gradeable->isVcs()),
+                $gradeable->isVcs(),
                 $gradeable->getVcsSubdirectory(),
                 $gradeable->getVcsHostType(),
-                $this->course_db->convertBoolean($gradeable->isTeamAssignment()),
+                $gradeable->isTeamAssignment(),
                 $gradeable->getTeamSizeMax(),
                 DateUtils::dateTimeToString($gradeable->getTeamLockDate()),
-                $this->course_db->convertBoolean($gradeable->isTaGrading()),
-                $this->course_db->convertBoolean($gradeable->isScannedExam()),
-                $this->course_db->convertBoolean($gradeable->isStudentView()),
-                $this->course_db->convertBoolean($gradeable->isStudentViewAfterGrades()),
-                $this->course_db->convertBoolean($gradeable->isStudentSubmit()),
-                $this->course_db->convertBoolean($gradeable->hasDueDate()),
+                $gradeable->isTaGrading(),
+                $gradeable->isScannedExam(),
+                $gradeable->isStudentView(),
+                $gradeable->isStudentViewAfterGrades(),
+                $gradeable->isStudentSubmit(),
+                $gradeable->hasDueDate(),
                 $gradeable->getAutogradingConfigPath(),
                 $gradeable->getLateDays(),
-                $this->course_db->convertBoolean($gradeable->isLateSubmissionAllowed()),
+                $gradeable->isLateSubmissionAllowed(),
                 $gradeable->getPrecision(),
-                $this->course_db->convertBoolean($gradeable->isPeerGrading()),
+                $gradeable->isPeerGrading(),
                 $gradeable->getPeerGradeSet(),
                 DateUtils::dateTimeToString($gradeable->getRegradeRequestDate()),
-                $this->course_db->convertBoolean($gradeable->isRegradeAllowed()),
+                $gradeable->isRegradeAllowed(),
                 $gradeable->getDiscussionThreadId(),
-                $this->course_db->convertBoolean($gradeable->isDiscussionBased())
+                $gradeable->isDiscussionBased()
             ];
             $this->course_db->query(
                 "
@@ -4811,29 +4811,29 @@ AND gc_id IN (
                 $params = [
                     DateUtils::dateTimeToString($gradeable->getSubmissionOpenDate()),
                     DateUtils::dateTimeToString($gradeable->getSubmissionDueDate()),
-                    $this->course_db->convertBoolean($gradeable->isVcs()),
+                    $gradeable->isVcs(),
                     $gradeable->getVcsSubdirectory(),
                     $gradeable->getVcsHostType(),
-                    $this->course_db->convertBoolean($gradeable->isTeamAssignment()),
+                    $gradeable->isTeamAssignment(),
                     $gradeable->getTeamSizeMax(),
                     DateUtils::dateTimeToString($gradeable->getTeamLockDate()),
-                    $this->course_db->convertBoolean($gradeable->isTaGrading()),
-                    $this->course_db->convertBoolean($gradeable->isScannedExam()),
-                    $this->course_db->convertBoolean($gradeable->isStudentView()),
-                    $this->course_db->convertBoolean($gradeable->isStudentViewAfterGrades()),
-                    $this->course_db->convertBoolean($gradeable->isStudentSubmit()),
-                    $this->course_db->convertBoolean($gradeable->hasDueDate()),
+                    $gradeable->isTaGrading(),
+                    $gradeable->isScannedExam(),
+                    $gradeable->isStudentView(),
+                    $gradeable->isStudentViewAfterGrades(),
+                    $gradeable->isStudentSubmit(),
+                    $gradeable->hasDueDate(),
                     $gradeable->getAutogradingConfigPath(),
                     $gradeable->getLateDays(),
-                    $this->course_db->convertBoolean($gradeable->isLateSubmissionAllowed()),
+                    $gradeable->isLateSubmissionAllowed(),
                     $gradeable->getPrecision(),
-                    $this->course_db->convertBoolean($gradeable->isPeerGrading()),
+                    $gradeable->isPeerGrading(),
                     $gradeable->getPeerGradeSet(),
                     DateUtils::dateTimeToString($gradeable->getRegradeRequestDate()),
-                    $this->course_db->convertBoolean($gradeable->isRegradeAllowed()),
-                    $this->course_db->convertBoolean($gradeable->isGradeInquiryPerComponentAllowed()),
+                    $gradeable->isRegradeAllowed(),
+                    $gradeable->isGradeInquiryPerComponentAllowed(),
                     $gradeable->getDiscussionThreadId(),
-                    $this->course_db->convertBoolean($gradeable->isDiscussionBased()),
+                    $gradeable->isDiscussionBased(),
                     $gradeable->getId()
                 ];
                 $this->course_db->query(

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -314,6 +314,19 @@ SELECT * FROM test ORDER BY pid");
         $database->query("SELECT * FROM invalid_table");
     }
 
+    public function testAutoConvertTypes() {
+        $database = new SqliteDatabase(array('memory' => true));
+        $database->connect();
+        $database->query("CREATE TABLE test(val_bool bit, val_date datetime)");
+        $now = new \DateTime();
+        $database->query("INSERT INTO test VALUES (?, ?)", array(true, $now));
+        $this->assertEquals(1, $database->getRowCount());
+        $database->query("SELECT * FROM test");
+        $this->assertEquals($database->rows()[0]["val_bool"], true);
+        $this->assertEquals($database->rows()[0]["val_date"], $now->format("Y-m-d H:i:sO"));
+        $database->disconnect();
+    }
+
     public function booleanConverts() {
         return array(
             array(true, 1),

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -323,7 +323,7 @@ SELECT * FROM test ORDER BY pid");
         $this->assertEquals(1, $database->getRowCount());
         $database->query("SELECT * FROM test");
         $this->assertEquals($database->rows()[0]["val_bool"], true);
-        $this->assertEquals($database->rows()[0]["val_date"], $now->format("Y-m-d H:i:sO"));
+        $this->assertEquals($database->rows()[0]["val_date"], $now->format("Y-m-d H:i:sO") . " " . $now->getTimezone()->getName());
         $database->disconnect();
     }
 

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -323,7 +323,7 @@ SELECT * FROM test ORDER BY pid");
         $this->assertEquals(1, $database->getRowCount());
         $database->query("SELECT * FROM test");
         $this->assertEquals($database->rows()[0]["val_bool"], true);
-        $this->assertEquals($database->rows()[0]["val_date"], $now->format("Y-m-d H:i:sO") . " " . $now->getTimezone()->getName());
+        $this->assertEquals($database->rows()[0]["val_date"], $now->format("Y-m-d H:i:sO"));
         $database->disconnect();
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When you want to add a bool or a date to a sql query, you have to convert it to the correct format first before adding it to the parameter array.

### What is the new behavior?

The code now auto converts bools and dates, when added to the parameter array, to the correct format
fixes #5211

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I only made it auto convert bools and dates however, if there are other types that need to be converted that I do not know about let me know and I can add them.
