### PR TITLE
[Bugfix:Forum] Split post button w/o edit history

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -50,15 +50,15 @@
         {% endif %}
         {% if userGroup <= 3 and has_history %}
             <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="showHistory({{ post.id }})">Show History</a>
-            {% if (isThreadLocked != 1 or accessFullGrading) and first != 1 %}
-                <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showSplit({{ post.id }})">
-                {% if thread_previously_merged %}
-                    Unmerge Thread
-                {% else %}
-                    Split Post
-                {% endif %}
-                </a>
+        {% endif %}
+        {% if (isThreadLocked != 1 or accessFullGrading) and first != 1 %}
+            <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showSplit({{ post.id }})">
+            {% if thread_previously_merged %}
+                Unmerge Thread
+            {% else %}
+                Split Post
             {% endif %}
+            </a>
         {% endif %}
 
     {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
Aphacker does not have a history and therefore split post does not appear.
![t2](https://user-images.githubusercontent.com/16356240/78180630-0daecb00-7431-11ea-8c78-8bb9bb35583b.png)

### What is the new behavior?
Split post now appears for the aphacker post.
![t1](https://user-images.githubusercontent.com/16356240/78180565-f8d23780-7430-11ea-9921-6b1862445904.png)