### PR TITLE
[Testing:Travis] Use pre-release selenium 4.0.0 for E2E tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - pip3 install sqlalchemy
         - pip3 install pylint_runner
         - pip3 install python-dateutil
-        - pip3 install selenium
+        - pip3 install --pre selenium
         - pip3 install pause
         - pip3 install tzlocal
         - pip3 install paramiko
@@ -212,7 +212,7 @@ jobs:
         - pip3 install python-dateutil
         - pip3 install jsonschema
         - pip3 install jsonref
-        - pip3 install selenium
+        - pip3 install --pre selenium
         - pip3 install pause
         - pip3 install paramiko
         - pip3 install psutil


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We currently use selenium 3.141.0 pypi release.

### What is the new behavior?
The selenium 4.0.0a5 has a number of nice improvements to it, fixing a handful of stability issues that we've seen on Travis.
