### PR TITLE
[Bugfix:TAGrading] peer grader pdf permissions fix

### DIFF
--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -74,10 +74,19 @@ class PDFController extends AbstractController {
         $grader_id = $this->core->getUser()->getId();
         $course_path = $this->core->getConfig()->getCoursePath();
         $user_id = $annotation_info['user_id'];
+        
 
         $gradeable = $this->tryGetGradeable($gradeable_id);
         if ($gradeable === false) {
             return false;
+        }
+        
+        if($gradeable->isPeerGrading() && $this->core->getQueries()->getUserById($grader_id)->getGroup() == 4){
+            $user_ids = $this->core->getQueries()->getPeerAssignment($gradeable_id, $grader_id);
+        
+            if(!in_array($user_id, $user_ids)){
+                return $this->core->getOutput()->renderJsonFail('You do not have permission to grade this student');
+            }
         }
 
         $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $user_id);

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -81,10 +81,10 @@ class PDFController extends AbstractController {
             return false;
         }
         
-        if($gradeable->isPeerGrading() && $this->core->getQueries()->getUserById($grader_id)->getGroup() == 4){
+        if ($gradeable->isPeerGrading() && $this->core->getQueries()->getUserById($grader_id)->getGroup() == 4) {
             $user_ids = $this->core->getQueries()->getPeerAssignment($gradeable_id, $grader_id);
         
-            if(!in_array($user_id, $user_ids)){
+            if (!in_array($user_id, $user_ids)) {
                 return $this->core->getOutput()->renderJsonFail('You do not have permission to grade this student');
             }
         }

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -81,7 +81,7 @@ class PDFController extends AbstractController {
             return false;
         }
         
-        if ($gradeable->isPeerGrading() && $this->core->getQueries()->getUserById($grader_id)->getGroup() == 4) {
+        if ($gradeable->isPeerGrading() && $this->core->getQueries()->getUserById($grader_id)->getGroup() === User::GROUP_STUDENT) {
             $user_ids = $this->core->getQueries()->getPeerAssignment($gradeable_id, $grader_id);
         
             if (!in_array($user_id, $user_ids)) {

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -66,7 +66,6 @@ class PDFController extends AbstractController {
     /**
      * @param $gradeable_id
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/pdf/annotations", methods={"POST"})
-     * @AccessControl(role="LIMITED_ACCESS_GRADER")
      */
     public function savePDFAnnotation($gradeable_id) {
         //Save the annotation layer to a folder.
@@ -114,7 +113,6 @@ class PDFController extends AbstractController {
     /**
      * @param $gradeable_id
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/grading/pdf", methods={"POST"})
-     * @AccessControl(role="LIMITED_ACCESS_GRADER")
      */
     public function showGraderPDFEmbedded($gradeable_id) {
         // This is the embedded pdf annotator that we built.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
A peer grader cannot view a pdf submitted by a peer they are assigned to grade (get a permissions error)
### What is the new behavior?
The peer grader can view the pdf. Closes #5234
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
