### PR TITLE
[Bugfix:Submission] Fix programming language coloring not working for notebooks

### DIFF
--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -409,11 +409,8 @@ class FileUtils {
      * extension will get the content type "text/x-sh" even though just "text" would probably be more
      * appropriate. This is a weaker check for binary files than mime_content_type which does
      * some basic analysis of the actual file to determine the information as opposed to just the filename.
-     *
-     * @param $filename
-     * @return null|string
      */
-    public static function getContentType($filename) {
+    public static function getContentType(?string $filename): ?string {
         if ($filename === null) {
             return null;
         }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -330,4 +330,55 @@ class Utils {
         }
         return $arr;
     }
+
+    /**
+     * Converts a plain text string to the appropriate CodeMirror mime type mode.
+     */
+    public static function getCodeMirrorMode(?string $type): string {
+        switch (strtolower($type)) {
+            case 'c':
+                return 'text/x-csrc';
+            case 'c++':
+            case 'cpp':
+            case 'h':
+            case 'hpp':
+                return 'text/x-c++src';
+            case 'c#':
+                return 'text/x-csharp';
+            case 'objective-c':
+                return 'text/x-objectivec';
+            case 'java':
+                return 'text/x-java';
+            case 'scala':
+                return 'text/scala';
+            case 'node':
+            case 'nodejs':
+            case 'javascript':
+            case 'js':
+                return 'text/javascript';
+            case 'typescript':
+                return 'text/typescript';
+            case 'json':
+                return 'application/json';
+            case 'python':
+                return 'text/x-python';
+            case 'oz':
+                return 'text/x-oz';
+            case 'sql':
+                return 'text/x-sql';
+            case 'mysql':
+                return 'text/x-mysql';
+            case 'pgsql':
+            case 'postgres':
+            case 'postgresql':
+                return 'text/x-pgsql';
+            case 'scheme':
+                return 'text/x-scheme';
+            case 'bash':
+            case 'sh':
+                return 'text/x-sh';
+            default:
+                return 'text/plain';
+        }
+    }
 }

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -182,10 +182,17 @@ class AutogradingConfig extends AbstractModel {
                         }
                     }
                 }
+                elseif (
+                    $notebook_cell['type'] === 'short_answer'
+                    && !empty($notebook_cell['programming_language'])
+                    && empty($notebook_cell['codemirror_mode'])
+                ) {
+                    $notebook_cell['codemirror_mode'] = Utils::getCodeMirrorMode($notebook_cell['programming_language']);
+                }
 
                 // Add this cell $this->notebook
                 if ($do_add) {
-                    array_push($this->notebook, $notebook_cell);
+                    $this->notebook[] = $notebook_cell;
                 }
 
                 // If cell is a type of input add it to the $actual_inputs array
@@ -193,7 +200,7 @@ class AutogradingConfig extends AbstractModel {
                     isset($notebook_cell['type'])
                     && ($notebook_cell['type'] === 'short_answer' || $notebook_cell['type'] === 'multiple_choice')
                 ) {
-                    array_push($actual_input, $notebook_cell);
+                    $actual_input[] = $notebook_cell;
                 }
             }
         }

--- a/site/app/models/gradeable/SubmissionCodeBox.php
+++ b/site/app/models/gradeable/SubmissionCodeBox.php
@@ -3,23 +3,26 @@
 namespace app\models\gradeable;
 
 use app\libraries\Core;
+use app\libraries\Utils;
 use app\models\gradeable\AbstractTextBox;
 
 /**
- * Class SubmissionCodeBox
- * @package app\models\gradeable
- *
  * Information required to load code box submissions on the submission page
  *
  * @method string getLanguage()
+ * @method string getCodeMirrorMode()
  */
 class SubmissionCodeBox extends AbstractTextBox {
     /** @prop @var string The programming language of the text box */
     protected $language;
 
+    /** @prop @var string The mode to use for code mirror */
+    protected $codeMirrorMode;
+
     public function __construct(Core $core, array $details) {
         parent::__construct($core, $details);
 
         $this->language = $details['programming_language'];
+        $this->codeMirrorMode = $details['codemirror_mode'] ?? Utils::getCodeMirrorMode($this->language);
     }
 }

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -288,10 +288,9 @@
                                 <button type="button" id="codebox_{{ num_codeboxes }}_recent_button" class="btn btn-primary codebox-clear-reset">Use Most Recent Submission</button>
 
                                 <script>
-
                                     var editor_{{num_codeboxes}} = CodeMirror(document.getElementById("codebox_{{ num_codeboxes }}"),
                                         {
-                                            "mode": "{{ cell.programming_language }}",
+                                            "mode": "{{- cell.codemirror_mode | escape('js') -}}",
                                             lineNumbers: true,
                                             "theme": "eclipse"
                                         }

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -356,7 +356,6 @@ class AutoGradingView extends AbstractView {
             ];
         }, $ta_graded_components);
 
-
         $uploaded_pdfs = [];
         foreach ($uploaded_files['submissions'] as $file) {
             if (array_key_exists('path', $file) && mime_content_type($file['path']) === "application/pdf") {
@@ -516,7 +515,6 @@ class AutoGradingView extends AbstractView {
                     return $grader->getId();
                 }, $container->getGraders())),
                 'marks' => $component_marks,
-                    
             ];
         }, $peer_graded_components);
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -417,6 +417,8 @@ class HomeworkView extends AbstractView {
 
         $DATE_FORMAT = "m/d/Y @ h:i A T";
         $numberUtils = new NumberUtils();
+
+        // TODO: go through this list and remove the variables that are not used
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
             'base_url' => $this->core->getConfig()->getBaseUrl(),
             'gradeable_id' => $gradeable->getId(),
@@ -646,7 +648,7 @@ class HomeworkView extends AbstractView {
 
         $peer_grading_max = $gradeable->getPeerPoints();
         $ta_grading_max   = $gradeable->getTaPoints();
-        
+
         $ta_grading_earned = 0;
         $peer_grading_earned = 0;
 
@@ -814,7 +816,7 @@ class HomeworkView extends AbstractView {
         else {
             $no_autograding = true;
         }
-        
+
         // If there is no autograding at all, only explicitly let the student know that before
         // TA grades are released.
         if (

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -426,11 +426,6 @@ parameters:
 			path: app/libraries/FileUtils.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$filename\\)\\: Unexpected token \"\\$filename\", expected type at offset 637$#"
-			count: 1
-			path: app/libraries/FileUtils.php
-
-		-
 			message: "#^PHPDoc tag @param for parameter \\$type with type app\\\\libraries\\\\GradeableType\\|int is not subtype of native type int\\.$#"
 			count: 1
 			path: app/libraries/GradeableType.php

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -394,7 +394,7 @@ STRING;
         $this->assertEquals($expected, $actual);
     }
 
-    public function fileExtensions() {
+    public function contentTypeDataProvider(): array {
         return [
             ['test.pdf', 'application/pdf'],
             ['test.png', 'image/png'],
@@ -420,12 +420,10 @@ STRING;
     }
 
     /**
-     * @dataProvider fileExtensions
-     * @param $filename
-     * @param $expected
+     * @dataProvider contentTypeDataProvider
      */
-    public function testContentType($filename, $expected) {
-        $this->assertEquals($expected, FileUtils::getContentType($filename));
+    public function testContentType(?string $filename, ?string $expected): void {
+        $this->assertSame($expected, FileUtils::getContentType($filename));
     }
 
     public function testRecursiveChmod() {

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -659,4 +659,44 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
             Utils::mb_str_split("αβγδεfg", 2)
         );
     }
+
+    /**
+     * @dataProvider codeMirrorModeDataProvider
+     */
+    public function testGetCodeMirrorMode(?string $type, string $expected): void {
+        $this->assertSame($expected, Utils::getCodeMirrorMode($type));
+    }
+
+    public function codeMirrorModeDataProvider(): array {
+        return [
+            ['c', 'text/x-csrc'],
+            ['c++', 'text/x-c++src'],
+            ['cpp', 'text/x-c++src'],
+            ['h', 'text/x-c++src'],
+            ['hpp', 'text/x-c++src'],
+            ['c#', 'text/x-csharp'],
+            ['objective-c', 'text/x-objectivec'],
+            ['java', 'text/x-java'],
+            ['scala', 'text/scala'],
+            ['node', 'text/javascript'],
+            ['nodejs', 'text/javascript'],
+            ['javascript', 'text/javascript'],
+            ['js', 'text/javascript'],
+            ['typescript', 'text/typescript'],
+            ['json', 'application/json'],
+            ['python', 'text/x-python'],
+            ['oz', 'text/x-oz'],
+            ['sql', 'text/x-sql'],
+            ['mysql', 'text/x-mysql'],
+            ['pgsql', 'text/x-pgsql'],
+            ['postgres', 'text/x-pgsql'],
+            ['postgresql', 'text/x-pgsql'],
+            ['scheme', 'text/x-scheme'],
+            ['sh', 'text/x-sh'],
+            ['bash', 'text/x-sh'],
+            ['txt', 'text/plain'],
+            ['invalid', 'text/plain'],
+            [null, 'text/plain']
+        ];
+    }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #5256

The notebook codebox was not properly doing syntax coloring for most languages that we might support there. For example:
![Screenshot 2020-04-18 11 43 01](https://user-images.githubusercontent.com/1845314/79673031-85297c00-81df-11ea-8bb3-3073520baca1.png)

### What is the new behavior?

Gets syntax highlighting to work given a programming language that instructors might type in (e.g. `C++`).

For example:
![Screenshot 2020-04-18 11 42 35](https://user-images.githubusercontent.com/1845314/79673004-5ca18200-81df-11ea-9262-78b1e6d21d7c.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Technically breaks using `clike` as a programming language, but given that we show the programming language to the student as a title on the textarea, I am not sure why an instructor would ever want to use that over `C++` or `Java` or whatever.
