### PR TITLE
[Bugfix:InstructorUI] Page content no longer overlaps with sidebar

### DIFF
--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -9,6 +9,7 @@ aside {
         padding-top: 30px;
         width: 250px;
         min-width: 250px;
+        z-index: 1;
     }
 
     aside{


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When the sidebar is small, the page content overlaps with the sidebar making it hard to click the buttons 

### What is the new behavior?

closes #5269
Reverted a change so that the sidebar has a higher z-index so that it is always on top of the page content. This means that all clicks will click on the sidebar instead of the margin of the page content
