### PR TITLE
[Feature:TAGrading] Remove warnings from peer grading

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -59,6 +59,11 @@ select {
     height: 35px;
 }
 
+.peer-button {
+    background-color: var(--standard-plum-purple);
+    color: white;
+}
+
 a.nav-bar {
     padding: 6px 12px;
     text-decoration: none;

--- a/site/public/templates/grading/EditGradeable.twig
+++ b/site/public/templates/grading/EditGradeable.twig
@@ -19,7 +19,7 @@
 
 {% block footer_content %}
     <input type="button" class="btn btn-primary key_to_click" tabindex="0" value="Add New Component" onclick="onAddComponent(false)" />
-    <input type="button" class="btn btn-danger key_to_click" tabindex="0" value="(DO NOT USE) Add New Peer Component" onclick="onAddComponent(true)"  />
+    <input type="button" class="btn peer-button key_to_click" tabindex="0" value="Add New Peer Component" onclick="onAddComponent(true)"  />
     <a href="{{ export_components_url }}" class="btn btn-default">Export Components</a>
     <label for="import-components-file" class="btn btn-default">Import Components</label>
     <input id="import-components-file" type="file" class="btn ignore" onchange="importComponentsFromFile();" style="display: none;"/>


### PR DESCRIPTION
Up until now, Peer grading has had a warning associated with the introduction of a new component. This PR removes this warning now that necessary peer grading features are in place.

The button color has been set to plum to match the peer grading UI throughout the system. Image included below.

![new_peer_button](https://user-images.githubusercontent.com/11758882/79817585-d490b900-8353-11ea-890c-52c42c2b6585.png)
