### PR TITLE
[Bugfix:TAgrading] Peer grading team interface fixes

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1744,6 +1744,11 @@ ORDER BY g.sections_rotating_id, g.user_id",
     public function getUsersByRotatingSections($sections, $orderBy = "rotating_section") {
         $return = array();
         if (count($sections) > 0) {
+            $orderBy = str_replace(
+                "Peer",
+                1,
+                $orderBy
+            );
             $placeholders = $this->createParamaterList(count($sections));
             $this->course_db->query("SELECT * FROM users AS u WHERE rotating_section IN {$placeholders} ORDER BY {$orderBy}", $sections);
             foreach ($this->course_db->rows() as $row) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -303,7 +303,7 @@ class NavigationView extends AbstractView {
         $im_a_grader = $this->core->getUser()->accessGrading() && $this->core->getUser()->getGroup() <= $gradeable->getMinGradingGroup();
 
         // students can only view the submissions & grading interface if its a peer grading assignment
-        $im_a_peer_grader = $this->core->getUser()->getGroup() === User::GROUP_STUDENT && $gradeable->isPeerGrading() && $this->core->getQueries()->getPeerGradingAssignmentsForGrader($this->core->getUser()->getId());
+        $im_a_peer_grader = $this->core->getUser()->getGroup() === User::GROUP_STUDENT && $gradeable->isPeerGrading() && !empty($this->core->getQueries()->getPeerAssignment($gradeable->getId(), $this->core->getUser()->getId()));
 
         // TODO: look through this logic and put into new access system
         return $im_a_peer_grader || $im_a_grader || $im_allowed_to_view_submissions;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Peer team rotating section assignments will produce a robot when a student tries to grade them.

Students can see all peer assignments in the navigation menu if they are assigned to grade one peer assignment

### What is the new behavior?
Fixes these errors: peer team rotatin section assignments can be graded properly, students can only see gradeables they are assigned to grade in the navigation menu.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
