### PR TITLE
[Refactor:PHP] Fix a handful of code style errors

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -205,11 +205,11 @@ class GlobalController extends AbstractController {
             if ($this->core->getUser()->accessGrading()) {
                 $images_course_path = $this->core->getConfig()->getCoursePath();
                 // FIXME: this code is duplicated in ImagesController.php
-                $images_path = Fileutils::joinPaths($images_course_path, "uploads/student_images");
-                $common_images_path_1 = Fileutils::joinPaths("/var/local/submitty/student_images");
+                $images_path = FileUtils::joinPaths($images_course_path, "uploads/student_images");
+                $common_images_path_1 = FileUtils::joinPaths("/var/local/submitty/student_images");
                 $term = explode('/', $this->core->getConfig()->getCoursePath());
                 $term = $term[count($term) - 2];
-                $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images", $term);
+                $common_images_path_2 = FileUtils::joinPaths("/var/local/submitty/student_images", $term);
                 // FIXME: consider searching through the common location for matches to my students
                 // (but this would be expensive)
                 $any_images_files = array_merge(

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -783,6 +783,5 @@ class PlagiarismController extends AbstractController {
         }
 
         $this->core->getOutput()->renderString("NO_REFRESH");
-        return;
     }
 }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -471,14 +471,14 @@ class ElectronicGraderController extends AbstractController {
         $show_all = $view_all && $can_show_all;
 
         $order = new GradingOrder($this->core, $gradeable, $this->core->getUser(), $show_all);
-        
+
         $order->sort($sort, $direction);
 
         $section_submitters = $order->getSectionSubmitters();
         $section_key = $order->getSectionKey();
         $graders = $order->getSectionGraders();
         $sections = $order->getSectionNames();
-                
+
         $student_ids = [];
         foreach ($section_submitters as $section) {
             $student_ids = array_merge($student_ids, array_map(function (Submitter $submitter) {
@@ -728,7 +728,6 @@ class ElectronicGraderController extends AbstractController {
         }
 
         $this->core->redirect($return_url);
-        return;
     }
 
     /**
@@ -1107,7 +1106,7 @@ class ElectronicGraderController extends AbstractController {
         if ($gradeable === false) {
             return;
         }
-        
+
         // checks if user has permission
         if (!$this->core->getAccess()->canI("grading.electronic.grade", ["gradeable" => $gradeable])) {
             $this->core->getOutput()->renderJsonFail('Insufficient permissions to get gradeable rubric data');
@@ -1154,7 +1153,7 @@ class ElectronicGraderController extends AbstractController {
         if ($gradeable === false) {
             return;
         }
-        
+
         $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $this->core->getUser()->getId(), false);
 
         // Get the component
@@ -1201,9 +1200,9 @@ class ElectronicGraderController extends AbstractController {
         if ($submitter_id === false) {
             return;
         }
-        
+
         $section = null;
-        
+
         if ($gradeable->isGradeByRegistration()) {
             $section = $this->core->getQueries()->getSubmitterById($submitter_id)->getRegistrationSection();
         }
@@ -1689,7 +1688,7 @@ class ElectronicGraderController extends AbstractController {
         if ($gradeable === false) {
             return;
         }
-        
+
         $peer = $_POST['peer'] === 'true';
 
         // checks if user has permission

--- a/site/app/controllers/grading/ImagesController.php
+++ b/site/app/controllers/grading/ImagesController.php
@@ -16,11 +16,11 @@ class ImagesController extends AbstractController {
         $user_group = $this->core->getUser()->getGroup();
         $images_course_path = $this->core->getConfig()->getCoursePath();
         // FIXME: this code is duplicated in GlobalController.php
-        $images_path = Fileutils::joinPaths($images_course_path, "uploads/student_images");
-        $common_images_path_1 = Fileutils::joinPaths("/var/local/submitty/student_images");
+        $images_path = FileUtils::joinPaths($images_course_path, "uploads/student_images");
+        $common_images_path_1 = FileUtils::joinPaths("/var/local/submitty/student_images");
         $term = explode('/', $this->core->getConfig()->getCoursePath());
         $term = $term[count($term) - 2];
-        $common_images_path_2 = Fileutils::joinPaths("/var/local/submitty/student_images", $term);
+        $common_images_path_2 = FileUtils::joinPaths("/var/local/submitty/student_images", $term);
         // FIXME: consider searching through the common location for matches to my students
         // (but this would be expensive)
         $any_images_files = array_merge(
@@ -28,7 +28,7 @@ class ImagesController extends AbstractController {
             FileUtils::getAllFiles($common_images_path_1, array(), true),
             FileUtils::getAllFiles($common_images_path_2, array(), true)
         );
-        if ($user_group === USER::GROUP_STUDENT || (($user_group === USER::GROUP_FULL_ACCESS_GRADER || $user_group === USER::GROUP_LIMITED_ACCESS_GRADER) && count($any_images_files) === 0)) { // student has no permissions to view image page
+        if ($user_group === User::GROUP_STUDENT || (($user_group === User::GROUP_FULL_ACCESS_GRADER || $user_group === User::GROUP_LIMITED_ACCESS_GRADER) && count($any_images_files) === 0)) { // student has no permissions to view image page
             $this->core->addErrorMessage("You have no permissions to see images.");
             $this->core->redirect($this->core->buildCourseUrl());
             return;
@@ -36,12 +36,12 @@ class ImagesController extends AbstractController {
         $grader_sections = $this->core->getUser()->getGradingRegistrationSections();
 
         //limited-access graders with no assigned sections have no permissions to view images
-        if ($user_group === USER::GROUP_LIMITED_ACCESS_GRADER && empty($grader_sections)) {
+        if ($user_group === User::GROUP_LIMITED_ACCESS_GRADER && empty($grader_sections)) {
             $this->core->addErrorMessage("You have no assigned sections and no permissions to see images.");
             return;
         }
 
-        if ($user_group !== USER::GROUP_LIMITED_ACCESS_GRADER) {
+        if ($user_group !== User::GROUP_LIMITED_ACCESS_GRADER) {
             $grader_sections = array();  //reset grader section to nothing so permission for every image
         }
         else {
@@ -49,7 +49,7 @@ class ImagesController extends AbstractController {
                 return;
             }
         }
-        $instructor_permission = ($user_group === USER::GROUP_INSTRUCTOR);
+        $instructor_permission = ($user_group === User::GROUP_INSTRUCTOR);
         $students = $this->core->getQueries()->getAllUsers();
         $this->core->getOutput()->renderOutput(array('grading', 'Images'), 'listStudentImages', $students, $grader_sections, $instructor_permission);
     }
@@ -75,7 +75,7 @@ class ImagesController extends AbstractController {
             return $this->core->getOutput()->renderResultMessage("No files to be submitted.", false);
         }
 
-        $status = Fileutils::validateUploadedFiles($_FILES["files1"]);
+        $status = FileUtils::validateUploadedFiles($_FILES["files1"]);
         //check if we couldn't validate the uploaded files
         if (array_key_exists("failed", $status)) {
             return $this->core->getOutput()->renderResultMessage("Failed to validate uploads " . $status["failed"], false);

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -31,8 +31,6 @@
         <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar" />
         <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar" />
         <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
-        <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
-        <exclude name="Squiz.PHP.NonExecutableCode.ReturnNotRequired" />
 
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall" />
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant" />
@@ -46,12 +44,9 @@
         <exclude name="SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter" />
         <exclude name="SlevomatCodingStandard.Functions.UselessParameterDefaultValue.UselessParameterDefaultValue" />
         <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse" />
-        <exclude name="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash.UseStartsWithBackslash" />
         <exclude name="SlevomatCodingStandard.Namespaces.UseFromSameNamespace.UseFromSameNamespace" />
-        <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity" />
         <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator" />
         <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator" />
-        <exclude name="SlevomatCodingStandard.PHP.UselessSemicolon.UselessSemicolon" />
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceBeforeColon" />
         <exclude name="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable" />
     </rule>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes the following style errors:
- Squiz.PHP.NonExecutableCode.ReturnNotRequired (do not have a blank return at the end of a function)
- SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash.UseStartsWithBackslash (Do not do `use \Class\Name`, rather `use Class\Name` at top of file)
- SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity (`Fileutils` != `FileUtils`)
- SlevomatCodingStandard.PHP.UselessSemicolon.UselessSemicolon (`print('test');;` would error on second semi-colon).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Tested locally via phpcs, and Travis as well will test it.