### PR TITLE
[BugFix:TAGrading] Peer teams rotation sections fix

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1744,13 +1744,8 @@ ORDER BY g.sections_rotating_id, g.user_id",
     public function getUsersByRotatingSections($sections, $orderBy = "rotating_section") {
         $return = array();
         if (count($sections) > 0) {
-            $orderBy = str_replace(
-                "Peer",
-                1,
-                $orderBy
-            );
             $placeholders = $this->createParamaterList(count($sections));
-            $this->course_db->query("SELECT * FROM users AS u WHERE rotating_section IN {$placeholders} ORDER BY {$orderBy}", $sections);
+            $this->course_db->query("SELECT * FROM users AS u WHERE rotating_section IN {$placeholders}", $sections);
             foreach ($this->course_db->rows() as $row) {
                 $return[] = new User($this->core, $row);
             }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1745,7 +1745,7 @@ ORDER BY g.sections_rotating_id, g.user_id",
         $return = array();
         if (count($sections) > 0) {
             $placeholders = $this->createParamaterList(count($sections));
-            $this->course_db->query("SELECT * FROM users AS u WHERE rotating_section IN {$placeholders}", $sections);
+            $this->course_db->query("SELECT * FROM users AS u WHERE rotating_section IN {$placeholders} ORDER BY {$orderBy}", $sections);
             foreach ($this->course_db->rows() as $row) {
                 $return[] = new User($this->core, $row);
             }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1567,11 +1567,11 @@ class Gradeable extends AbstractModel {
                         $teams[$teamToAdd->getId()] = $this->core->getQueries()->getTeamByGradeableAndUser($this->getId(), $u->getId());
                     }
                 }
-                $g_section = new GradingSection($this->core, false, "Peer", [$user], null, $teams);
+                $g_section = new GradingSection($this->core, false, -1, [$user], null, $teams);
                 return [$g_section];
             }
             $users = $this->core->getQueries()->getUsersById($this->core->getQueries()->getPeerAssignment($this->getId(), $user->getId()));
-            $g_section = new GradingSection($this->core, false, "Peer", [$user], $users, null);
+            $g_section = new GradingSection($this->core, false, -1, [$user], $users, null);
             return [$g_section];
         }
         else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
When a student tries to grade a team assignment with peer components with Rotation Sections, they will get a robot after clicking the team they want to grade
### What is the new behavior?

They will be able to grade the student as normal

Fixes #5278

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
