### PR TITLE
[Bugfix:Forum] Stop split post button from showing up when it shouldn't

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -45,18 +45,21 @@
         {% else %}
             <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="$('html, #posts_list').animate({ scrollTop: document.getElementById('posts_list').scrollHeight }, 'slow');"> Reply</a>
         {% endif %}
-        {% if userGroup <= 3 and has_history %}
-            <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="showHistory({{ post.id }})">Show History</a>
-        {% endif %}
-        {% if (isThreadLocked != 1 or accessFullGrading) and first != 1 %}
-            <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showSplit({{ post.id }})">
-            {% if thread_previously_merged %}
-                Unmerge Thread
-            {% else %}
-                Split Post
+        {% if userGroup <= 3 %}
+            {% if has_history %}
+                <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="showHistory({{ post.id }})">Show History</a>
             {% endif %}
-            </a>
+            {% if (isThreadLocked != 1 or accessFullGrading) and first != 1 %}
+                <a class="btn btn-default btn-sm post_button_color text-decoration-none" tabindex = "0" onClick="showSplit({{ post.id }})">
+                    {% if thread_previously_merged %}
+                        Unmerge Thread
+                    {% else %}
+                        Split Post
+                    {% endif %}
+                </a>
+            {% endif %}
         {% endif %}
+
 
     {% endif %}
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Split post button can show up for students, who do not have access to it (it prints an error when pressing it) 

### What is the new behavior?
Split post button no longer shows up for students

### Other information?
Tested by logging into a user with permission and a user without permission, and comparing before and after making changes.
