### PR TITLE
[Feature:Autograding] Allow newlines in autocheck messages

### DIFF
--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -58,7 +58,7 @@ class GradeableAutocheck extends AbstractModel {
 
         if (isset($details['messages'])) {
             foreach ($details['messages'] as $message) {
-                $this->messages[] = array('message' => Utils::prepareHtmlString($message['message']),
+                $this->messages[] = array('message' => $message['message'],
                                             'type' => Utils::prepareHtmlString($message['type']));
             }
         }

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -65,7 +65,7 @@
               {% elseif message['type'] == "warning" %}
                  {% set type_class = "yellow-message" %}
               {% endif %}
-              <span class="{{ type_class }}">{{ message['message'] }}</span><br />
+              <span class="{{ type_class }}">{{ message['message'] | nl2br }}</span><br />
         {% endfor %}
 
         <div id="container_{{ index }}_{{ check_index }}_{{ side }}">
@@ -109,6 +109,6 @@
       {% elseif message['type'] == "warning" %}
          {% set type_class = "yellow-message" %}
       {% endif %}
-      <span class="{{ type_class }}">{{ message['message'] }}</span><br />
+      <span class="{{ type_class }}">{{ message['message'] | nl2br }}</span><br />
    {% endfor %}
 {% endmacro %}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -180,6 +180,8 @@ function loadTestcaseOutput(div_name, gradeable_id, who_id, index, version = '')
             },
             error: function(e) {
                 alert("Could not load diff, please refresh the page and try again.");
+                console.log(e);
+                displayAjaxError(e);
             }
         })
     }


### PR DESCRIPTION
### What is the current behavior?
Newlines were converted to ```<br/>```, but were then escaped and displayed in a gradeable autocheck message. Other html elements were escaped as well, but were  displayed in their escaped form.

### What is the new behavior?
Newlines are converted to ```<br/>```, and are then properly interpreted as html, allowing newlines to be added to autocheck messages. Other html elements are properly escaped and displayed.

Before:
![before](https://user-images.githubusercontent.com/11758882/80139366-59f2b400-8574-11ea-8b47-4e2e844f7117.png)

After:
![after](https://user-images.githubusercontent.com/11758882/80139360-552e0000-8574-11ea-958f-e24c609ac552.png)
