### PR TITLE
[Bugfix:Autograding] Ensure results json is utf8 encoded

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -16,6 +16,7 @@ import zipfile
 import stat
 import subprocess
 import shutil
+import codecs
 import glob
 
 def just_write_grade_history(json_file,assignment_deadline,submission_time,
@@ -389,7 +390,16 @@ def archive_autograding_results(working_directory, job_id, which_untrusted, is_b
         waittime = queue_obj["waittime"]
 
         try:
-            shutil.move(os.path.join(tmp_work, "results.json"), os.path.join(tmp_results, "results.json"))
+
+            # Make certain results.json is utf-8 encoded.
+            results_json_path = os.path.join(tmp_work, 'results.json')
+            with codecs.open(results_json_path, 'r', encoding='utf-8', errors='ignore') as infile:
+                results_str = "".join(line.rstrip() for line in infile)
+                results_obj = json.loads(results_str)
+            with open(results_json_path, 'w') as outfile:
+                json.dump(results_obj, outfile, indent=4)
+
+            shutil.move(results_json_path, os.path.join(tmp_results, "results.json"))
         except:
             with open(os.path.join(tmp_logs,"overall.txt"),'a') as f:
                 print ("\n\nERROR: Grading incomplete -- Could not open/write ",os.path.join(tmp_work,"results.json"))


### PR DESCRIPTION
This PR makes certain that the results json created by ```main_validator``` is utf-8 encoded by reading and re-writing the file during archival. Non utf-8 characters are stripped when reading the file.