### PR TITLE
[Refactor:PHP] Fix ArrayBracketSpacing style errors

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -552,7 +552,7 @@ class HomeworkView extends AbstractView {
                 continue;
             }
             elseif (array_key_exists('is_qr', $bulk_upload_data) && $bulk_upload_data['is_qr']) {
-                $data = $bulk_upload_data[ $files[$i]['filename_full'] ];
+                $data = $bulk_upload_data[$files[$i]['filename_full']];
             }
 
             $page_count = 0;

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -25,8 +25,6 @@
 
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
 
-        <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceAfterBracket" />
-        <exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceBeforeBracket" />
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
         <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar" />
         <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the new behavior?

Fixes all `Squiz.Arrays.ArrayBracketSpacing` style errors, which is that you should not write `$array[ 0 ];`, rather just `$array[0];`.