### PR TITLE
[VPAT] Remove unnecessary type from script tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -265,7 +265,9 @@ jobs:
         - TEST_URL="http://localhost" python3 -m unittest discover -v --start-directory tests
         - sudo sed -ie "s/Pam/Database/g" /usr/local/submitty/config/database.json
         - echo "Authentication Method => $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
-        - TEST_URL="http://localhost" python3 -m unittest tests.e2e.test_login
+        - pushd tests
+        - TEST_URL="http://localhost" python3 -m unittest e2e.test_login
+        - popd
         - SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         - sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework
         - pushd /tmp

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -173,7 +173,7 @@ Form
         </legend>
 {% endif %}
 
-<script type="text/javascript">
+<script>
 
     // Updates the checkboxes for all sections for a student
     //  This feature purely a front-end convenience.
@@ -229,7 +229,7 @@ Form
         //used by rotating sections tables and radio buttons on page documentation
         disableElementChildren('.g2', false);
         disableElementChildren('.g3', false);
-       
+
         switch ($('#minimum_grading_group').val()) {
             case '1': // Instructor only?
                 // $('.g1').hide();
@@ -244,7 +244,7 @@ Form
                 break;
         }
     }
-    
+
     $(document).ready(function() {
         // Hide rotating sections settings if on registration sections
         onSectionTypeChange();

--- a/site/app/templates/grading/electronic/PeerPanel.twig
+++ b/site/app/templates/grading/electronic/PeerPanel.twig
@@ -5,7 +5,7 @@
                 <span class="col grading_label">Peer Grading</span>
                 <div class="inner-container" id="peer-grading-box">
                     {% if has_active_version %}
-                        <script type="application/javascript">
+                        <script>
                             $(document).ready(function () {
                                 loadTemplates().then(function() {
                                     return reloadPeerRubric('{{ gradeable_id }}', '{{ anon_id }}');

--- a/site/app/templates/grading/electronic/PeerResultsPanel.twig
+++ b/site/app/templates/grading/electronic/PeerResultsPanel.twig
@@ -5,14 +5,14 @@
         <span>Student Grader: </span>
         <div class="inner-container_peer_results" id="grading-box-peer">
                     {% if has_active_version %}
-                        <script type="application/javascript">
+                        <script>
                             $(document).ready(function () {
                                 loadTemplates().then(function() {
                                     return reloadGradingRubric('{{ gradeable_id }}', '{{ anon_id }}');
                                 });
                             });
                         </script>
-                    
+
                     {% else %}
                         <h4>No Submission</h4>
                     {% endif %}

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -42,7 +42,7 @@
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id}}" data-can_verify="{{ can_verify }}" hidden></div>
                 <div class="inner-container" id="grading-box">
                     {% if has_active_version %}
-                        <script type="application/javascript">
+                        <script>
                             $(document).ready(function () {
                                 loadTemplates().then(function() {
                                     return reloadGradingRubric('{{ gradeable_id }}', '{{ anon_id }}');

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -44,7 +44,7 @@ Required Parameters:
                     class="general-comment-entry noscroll key_to_click" tabindex="0">{{comment|escape }}</textarea>
         {% endfor %}
     </div>
-    <script type="application/javascript">
+    <script>
         var grader = "{{overall_comment["logged_in_user"]["user_id"] | escape('js') }}";
         $(document).on('input','#overall-comment-' + grader,function () {
             var currentOverallComment  = $('textarea#overall-comment-' + grader).val();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Travis is failing after merging #5154 due to changes from #5125 which inserted a usage of `<script type='text/javascript'>`.

### What is the new behavior?

Removes the `type='text/javascript'`  from the script tag as it's implied by default if the `type` is omitted. Also removes a `type='application/javascript'` as it's also unnecessary, though not necessarily a VPAT/W3C error.