### PR TITLE
[Bugfix:Autograding] Fix random input/output

### DIFF
--- a/autograder/autograder/execution_environments/secure_execution_environment.py
+++ b/autograder/autograder/execution_environments/secure_execution_environment.py
@@ -133,10 +133,19 @@ class SecureExecutionEnvironment():
     # that have the field      "copy_access_files" : true,
     # for example, more_autograding_examples/notebook_time_limit/config/config.json
     shutil.copy(self.tmp_submission+"/queue_file.json",directory)
-    shutil.copy(self.tmp_submission+"/user_assignment_settings.json",directory)
-    shutil.copy(self.tmp_submission+"/submission/.submit.timestamp",directory)
-    if os.path.exists(self.tmp_submission+"/user_assignment_access.json"):
-      shutil.copy(self.tmp_submission+"/user_assignment_access.json",directory)
+
+    user_assignment_settings = os.path.join(self.tmp_submission, "user_assignment_settings.json")
+    submit_timestamp = os.path.join(self.tmp_submission, "submission", ".submit.timestamp")
+    user_assignment_access = os.path.join(self.tmp_submission, "user_assignment_access.json")
+
+    if os.path.exists(user_assignment_settings):
+      shutil.copy(user_assignment_settings, directory)
+
+    if os.path.exists(submit_timestamp):
+      shutil.copy(submit_timestamp, directory)
+
+    if os.path.exists(user_assignment_access):
+      shutil.copy(user_assignment_access, directory)
 
     # Copy in checkout code.
     if self.is_vcs:

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -246,7 +246,8 @@ def prepare_autograding_and_submission_zip(which_machine,which_untrusted,next_di
 
     if os.path.exists(user_assignment_access_json):
         shutil.copy(user_assignment_access_json,  os.path.join(tmp_submission,"user_assignment_access.json"))
-    shutil.copy(user_assignment_settings_json,os.path.join(tmp_submission,"user_assignment_settings.json"))
+    if os.path.exists(user_assignment_settings_json):
+        shutil.copy(user_assignment_settings_json,os.path.join(tmp_submission,"user_assignment_settings.json"))
 
     grading_began_longstring = dateutils.write_submitty_date(grading_began)
     with open(os.path.join(tmp_submission,".grading_began"), 'w') as f:

--- a/bin/make_generated_output.py
+++ b/bin/make_generated_output.py
@@ -46,7 +46,11 @@ def main():
         "required_capabilities": required_capabilities,
         "queue_time": dateutils.write_submitty_date(microseconds=True),
         "generate_output": True,
+        "max_possible_grading_time" : -1,
+        "who" : "build",
+        "regrade" : False,
     }
+
     should_generated_output = False
     for testcase in testcases:  
         input_generation_commands = testcase.get('input_generation_commands',[])


### PR DESCRIPTION
After a recent change a number of new files were being copied in while autograding (e.g. ```user_assignment_access.json```).  However, autograding crashed when these files did not exist, as is the case when generating random input/and expected output files. 

This PR adds logic so that a crash does not occur when these files do not exist.