### PR TITLE
[Refactor:PHP] Remove PHP 5.6 testing shim

### DIFF
--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -137,10 +137,7 @@ class GradeableList extends AbstractModel {
             'graded_gradeables' => 'getGradeReleasedDate'
         );
         foreach ($sort_array as $list => $function) {
-            // We have to use @ since on calling Mocked PHPUnit classes within this
-            // causes a warning to be raised as the mocked object tracks some debug
-            // information which changes the internal object in PHP < 7.0. Annoying!
-            @uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
+            uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
                 if ($a->$function() == $b->$function()) {
                     if ($a->getId() < $b->getId()) {
                         return -1;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We use the `@` to suppress errors on this `uasort` as it would issue them when running under phpunit in PHP <7. 

### What is the new behavior?

Given that we're now PHP 7.2+ only, it's safe to remove, and makes our codebase a bit better as we should never be using the `@`.