### PR TITLE
[VPAT] Fix wave errors on numeric grading page

### DIFF
--- a/site/app/templates/grading/SettingsForm.twig
+++ b/site/app/templates/grading/SettingsForm.twig
@@ -4,5 +4,5 @@
 {% block body %}
     <h2>Hotkeys</h2>
     <br>
-    <table id="hotkeys-list"></table>
+    <div id="hotkeys-list"></div>
 {% endblock %}

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -269,6 +269,7 @@
                         data-grade-time="{{ component_grade.getGradeTime()|date("Y-m-d H:i:s") }}"
                     {% endif %}
                     data-num="true"
+                    aria-label="{{component.getTitle()}} value for {{grade.getSubmitter().getUser().getDisplayedFirstName()}} {{grade.getSubmitter().getUser().getDisplayedLastName()}}"
                 />
             </td>
         {% endfor %}
@@ -290,6 +291,7 @@
                 value="{{ component_grade.getComment() }}"
                 onclick="this.select()"
                 data-id="{{ component.getId() }}"
+                aria-label="{{component.getTitle()}} value for {{grade.getSubmitter().getUser().getDisplayedFirstName()}} {{grade.getSubmitter().getUser().getDisplayedLastName()}}" 
             />
         </td>
     {% endfor %}

--- a/site/app/templates/grading/simple/StatisticsForm.twig
+++ b/site/app/templates/grading/simple/StatisticsForm.twig
@@ -27,8 +27,9 @@
         <table class="table table-striped table-bordered persist-area">
             <thead>
             <tr>
-                <td><b>By Component</b></td>
-                <td colspan="2"></td>
+                <th style="width:33%">By Component</th>
+                <th style="width:33%">Average</th>
+                <th style="width:33%">Std. Deviation</th>
             </tr>
             </thead>
             {% for component in components_numeric %}
@@ -45,9 +46,9 @@
         <table class="table table-striped table-bordered persist-area">
             <thead>
             <tr>
-                <td style="width:33%"><b>Total</b></td>
-                <td style="width:33%" id="avg-total"></td>
-                <td style="width:33%" id="stddev-total"></td>
+                <th style="width:33%"><b>Total</b></th>
+                <th style="width:33%" id="avg-total">0</th>
+                <th style="width:33%" id="stddev-total">0</th>
             </tr>
             </thead>
         </table>
@@ -56,8 +57,8 @@
         <table class="table table-striped table-bordered persist-area">
             <tbody>
             <tr>
-                <td style="width:50%">Students with a nonzero grade</td>
-                <td style="width:50%" id="num-graded"></td>
+                <th style="width:50%">Students with a nonzero grade</th>
+                <th style="width:50%" id="num-graded">0</th>
             </tr>
             </tbody>
         </table>

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -256,7 +256,7 @@
       --btn-standard-pale-blue-gray: #e8f0f7;
       --standard-light-blue-gray: #ddddff;
       --standard-pale-gray: #f5f5f5;
-      --standard-hover-light-gray: #686868;
+      --standard-hover-light-gray: #2B2B2B;
       --standard-light-gray: #8a8a8a;
       --standard-light-medium-gray: #bbbbbb;
       --standard-medium-gray: #888888;

--- a/site/public/templates/grading/settings/HotkeyList.twig
+++ b/site/public/templates/grading/settings/HotkeyList.twig
@@ -1,4 +1,8 @@
 <table id="hotkeys-list">
+        <tr>
+          <th>Action</th>
+          <th>Hotkey</th>
+        </tr>
     {% for hotkey in keymap %}
         <tr>
             <td>{{ hotkey.name }}</td>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The numeric grading page had a large number of WAVE errors
http://localhost:1501/s20/sample/gradeable/future_tas_test/grading?view=all

![image](https://user-images.githubusercontent.com/18558130/80659560-473a1c80-8a57-11ea-9e2a-1b5c7ba9293d.png)

### What is the new behavior?
This pr fixes all the wave errors
