### PR TITLE
[Bugfix:CourseMaterials] Fix Set folder release date 

### DIFF
--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -56,15 +56,7 @@
                 return "var(--date-picker-yellow)";
             }
         }
-        function setChildPerm(dirArr,handleData){
-            changeFolderPermission(dirArr,'1',function (output) {
-                if(output){
-                    if(handleData){
-                        handleData(true);
-                    }
-                }
-            });
-        }
+       
         function setChild(dirArr,releaseDate,handleData) {
             //send the array of folder paths and set the time to the new one
             changeFolderNewDateTime(dirArr,releaseDate.value,function (output) {
@@ -88,22 +80,20 @@
                 window.alert("No blank time allowed");
                 return;
             }
-            setChildPerm(dirArr,function (output) {
-                if(output){
-                    setChild(dirArr,releaseDate,function (output) {
-                        //when done reload
-                        if(output) {
-                            var selectedDiv = 'date_to_release_'+ID;
-                            //change value immediately and background color (will only appear after refresh bc you have to reload the stylesheet)
-                            $("[id^="+selectedDiv+"]").val(releaseDate.value);
-                            $("[id^='date_to_release_']").css("backgroundColor", 'determineRelease(releaseDate.value)').show();
-                            //delay so function can finish most of the way
-                            //window.setTimeout('parent.location.reload()',100);
-                            parent.location.reload();
-                        }
-                    });
+            
+            setChild(dirArr,releaseDate,function (output) {
+                //when done reload
+                if(output) {
+                    var selectedDiv = 'date_to_release_'+ID;
+                    //change value immediately and background color (will only appear after refresh bc you have to reload the stylesheet)
+                    $("[id^="+selectedDiv+"]").val(releaseDate.value);
+                    $("[id^='date_to_release_']").css("backgroundColor", 'determineRelease(releaseDate.value)').show();
+                    //delay so function can finish most of the way
+                    //window.setTimeout('parent.location.reload()',100);
+                    parent.location.reload();
                 }
             });
+            
         }
 
         flatpickr("#date_to_release", {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

If an instructor has a folder structure in their course material and tries to change the release date of the structure through the "Set folder release date" button nothing happens due to a javascript error of a missing function.

### What is the new behavior?
Set folder release date works as expected now

### Other information?
Originally part of the refactor that removed the unused 'check' status in course materials  #4907
I guess no one has used this feature since that pr
