### PR TITLE
[UI/UX:TAGrading] Improve styling for statistics table for simple gradeables

### DIFF
--- a/site/app/templates/grading/simple/StatisticsForm.twig
+++ b/site/app/templates/grading/simple/StatisticsForm.twig
@@ -13,15 +13,15 @@
                     <th style="width:33%">Std. Deviation</th>
                 </tr>
             </thead>
-            {% for section, info in sections |filter((section,info) => section != null) %}
-                <tbody>
+            <tbody>
+            {% for section, info in sections|filter((info, section) => section != '') %}
                 <tr>
                     <td>{{ section }}</td>
                     <td id="avg-section-{{ section }}"></td>
                     <td id="stddev-section-{{ section }}"></td>
                 </tr>
-                </tbody>
             {% endfor %}
+            </tbody>
         </table>
         <br>
         <table class="table table-striped table-bordered persist-area">
@@ -32,36 +32,32 @@
                 <th style="width:33%">Std. Deviation</th>
             </tr>
             </thead>
+            <tbody>
             {% for component in components_numeric %}
-                <tbody>
                 <tr>
                     <td>{{ component.getTitle() }}</td>
                     <td id="avg-component-{{ loop.index0 }}"></td>
                     <td id="stddev-component-{{ loop.index0 }}"></td>
                 </tr>
-                </tbody>
             {% endfor %}
-        </table>
-        <br>
-        <table class="table table-striped table-bordered persist-area">
-            <thead>
-            <tr>
-                <th style="width:33%"><b>Total</b></th>
-                <th style="width:33%" id="avg-total">0</th>
-                <th style="width:33%" id="stddev-total">0</th>
-            </tr>
-            </thead>
-        </table>
-        <br>
-        {# This is a layout table #}
-        <table class="table table-striped table-bordered persist-area">
-            <tbody>
-            <tr>
-                <th style="width:50%">Students with a nonzero grade</th>
-                <th style="width:50%" id="num-graded">0</th>
-            </tr>
             </tbody>
         </table>
+        <br>
+        <div class="layout-table-div">
+            <div class="layout-table-div-row layout-table-div-header">
+                <div style="width: 33%" class="layout-table-div-cell"><b>Total</b></div>
+                <div style="width: 33%" class="layout-table-div-cell" id="avg-total">0</div>
+                <div style="width: 33%" class="layout-table-div-cell" id="stddev-total">0</div>
+            </div>
+        </div>
+        <br>
+        {# This is a layout table #}
+        <div class="layout-table-div">
+            <div class="layout-table-div-row">
+                <div style="width: 50%" class="layout-table-div-cell">Students with a nonzero grade</div>
+                <div style="width: 50%" class="layout-table-div-cell" id="num-graded">0</div>
+            </div>
+        </div>
     {% else %}
         <p style="text-align: center">No Statistics To View.</p>
     {% endif %}

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -29,7 +29,7 @@ class SimpleGraderView extends AbstractView {
         $components_numeric = [];
         $components_text = [];
 
-        $comp_ids = array();
+        $comp_ids = [];
         foreach ($gradeable->getComponents() as $component) {
             if ($component->isText()) {
                 $components_text[] = $component;
@@ -43,7 +43,7 @@ class SimpleGraderView extends AbstractView {
         }
 
         $num_users = 0;
-        $sections = array();
+        $sections = [];
 
         // Iterate through every row
         /** @var GradedGradeable $graded_gradeable */

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -290,6 +290,25 @@ td>a.active-sort {
 /* layout table classes  */
 /* Layout tables do not have <caption>, <thead>, and <th> tags */
 
+.layout-table-div {
+    display: table;
+    width: 100%;
+    text-align: center;
+    border: 1px solid var(--standard-medium-gray);
+}
+
+.layout-table-div-row {
+    display: table-row;
+}
+
+.layout-table-div-cell {
+    display: table-cell;
+}
+
+.layout-table-div-header {
+    background-color: var(--standard-hover-light-gray);
+}
+
 /* styling used in a <th> cell, except this is for a layout table */
 .layout_th_cell {
     font-weight: bold;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

In looking at #5314, there were a number of issues with how the tables were defined that while not a violation of WAVE/W3C, were still not good design. This was things like having each row in a table have its own `<tbody>` and defining a table with one row using `<th>`.

### What is the new behavior?

Better defines the HTML in a more logical fashion, such that the tables have one tbody that go around the entire data, and that the single row tables with just a header are now constructed using divs.

### Other Information

There was a bug in the filter such that it was not properly filtering out the null section (key, value pair is reversed for filter tag in Twig) and so there was an extra empty row at the bottom of the first table. This is fixed in this PR as well. Additionally, the array key for the null section is the empty string (`$a[null] = 0` corresponds to `$a[''] = 0;`) and so the check for it (`!= null`) was also incorrect.