### PR TITLE
[Refactor:JS] Remove usage of deprecated jQuery.trim

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -200,7 +200,7 @@
 <script>
     $(function(){
         $("input[name='title']").change(function () {
-            $(this).val($.trim($(this).val()));
+            $(this).val($(this).val().trim());
         });
 
         $(".thread-announcement-checkbox").click(function (){

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -64,7 +64,7 @@ function onGradeInquirySubmitClicked(button) {
   var text_area = $("#reply-text-area-"+component_id);
   var submit_button_id = button_clicked.attr('id');
   if (submit_button_id != null && submit_button_id.includes('grading-close')){
-    if ($.trim(text_area.val())) {
+    if (text_area.val().trim()) {
       if (!confirm("The text you entered will not be posted. Are you sure you want to close the grade inquiry?")) {
         return;
       }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

jQuery.trim is deprecated in jQuery 3.5.0, as [`String.prototype.trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) exists and is supported basically everywhere.

### What is the new behavior?

Use `String.prototype.trim` instead of `jQuery.trim`.