### PR TITLE
[Refactor:JS] Remove usage of deprecated jQuery positional selectors

### DIFF
--- a/site/app/templates/forum/MergeThreadsForm.twig
+++ b/site/app/templates/forum/MergeThreadsForm.twig
@@ -24,7 +24,7 @@
                     $(".chosen-select").chosen({ width: "100%" });
                     // Make AJAX call to get the content of the
                     // first post.
-                    var selected_thread_first_post_id = $(".chosen-select").children("option:first").attr('data-first-post-id');
+                    var selected_thread_first_post_id = $(".chosen-select").children("option").first().attr('data-first-post-id');
                     updateSelectedThreadContent(selected_thread_first_post_id);
                     $(".chosen-select").change(function() {
                         selected_thread_first_post_id = $(this).children("option:selected").attr('data-first-post-id');

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -365,16 +365,15 @@ function openFile(url_full) {
 // moving to next input for split item submissions
 // referenced https://stackoverflow.com/questions/18150090/jquery-scroll-element-to-the-middle-of-the-screen-instead-of-to-the-top-with-a
 function moveNextInput(count) {
-    var next_count = count+1;
-    var next_input = "#users_" + next_count + " :first";
-    if ($(next_input).length) {
-        $(next_input).focus();
-        $(next_input).select();
+    const next_input = $("#users_" + (count + 1)).first();
+    if (next_input) {
+        next_input.focus();
+        next_input.select();
 
-        var inputOffset = $(next_input).offset().top;
-        var inputHeight = $(next_input).height();
-        var windowHeight = $(window).height();
-        var offset;
+        const inputOffset = next_input.offset().top;
+        const inputHeight = next_input.height();
+        const windowHeight = $(window).height();
+        let offset;
 
         if (inputHeight < windowHeight) {
             offset = inputOffset - ((windowHeight / 2) - (inputHeight / 2));
@@ -382,12 +381,9 @@ function moveNextInput(count) {
         else {
             offset = inputOffset;
         }
-        var speed = 500;
-        $('html, body').animate({scrollTop:offset}, speed);
+        $('html, body').animate({scrollTop: offset}, 500);
     }
 }
-
-
 
 // HANDLE SUBMISSION
 //========================================================================================

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -1,7 +1,7 @@
 $( document ).ready(function () {
   // open last opened grade inquiry or open first component with grade inquiry
   var component_selector = localStorage.getItem('selected_tab');
-  var first_unresolved_component = $('.component-unresolved:first');
+  var first_unresolved_component = $('.component-unresolved').first();
   if (component_selector !== null) {
     $(component_selector).click();
     localStorage.removeItem('selected_tab');
@@ -10,7 +10,7 @@ $( document ).ready(function () {
     first_unresolved_component.click();
   }
   else {
-    $('.component-tab:first').click();
+    $('.component-tab').first().click();
   }
 
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -171,7 +171,7 @@ function createRightUsersList(data, select = null) {
         append_options += users[2]+ ' '+users[3]+' &lt;'+users[0]+'&gt; (version:'+users[1]+')</option>';
     });
     $('[name="user_id_2"]', form).find('option').remove().end().append(append_options).val('');
-    $('[name="user_id_2"] option:eq(' + position.toString() + ')', form).prop('selected', true);
+    $('[name="user_id_2"] option', form).eq(position).prop('selected', true);
 }
 
 function createLeftUserVersionDropdown(version_data, active_version_user_1, max_matching_version, code_version_user_1) {
@@ -256,4 +256,3 @@ function setCodeInEditor(changed) {
         }
     }
 }
-


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Usage of positionals (e.g. `:first`, `:eq`, `:last`) in jQuery selectors is deprecated in jQuery 3.x, and will be removed in jQuery 4.

### What is the new behavior?
Uses the built-in jQuery positional functions instead that provide same behavior in our cases, while also being faster to execute, and not being deprecated.