### PR TITLE
[Refactor:System] Remove unused jquery-timepicker plugin

### DIFF
--- a/.setup/install_submitty/install_site_dev.sh
+++ b/.setup/install_submitty/install_site_dev.sh
@@ -197,9 +197,6 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
     mkdir ${VENDOR_FOLDER}/jquery-ui
     cp ${NODE_FOLDER}/jquery-ui-dist/*.min.* ${VENDOR_FOLDER}/jquery-ui
     cp -R ${NODE_FOLDER}/jquery-ui-dist/images ${VENDOR_FOLDER}/jquery-ui/
-    # jquery-ui-timepicker-addon
-    mkdir ${VENDOR_FOLDER}/jquery-ui-timepicker-addon
-    cp ${NODE_FOLDER}/jquery-ui-timepicker-addon/dist/*.min.* ${VENDOR_FOLDER}/jquery-ui-timepicker-addon
     # pdfjs
     mkdir ${VENDOR_FOLDER}/pdfjs
     cp ${NODE_FOLDER}/pdfjs-dist/build/pdf.min.js ${VENDOR_FOLDER}/pdfjs

--- a/.setup/install_submitty/install_site_prod.sh
+++ b/.setup/install_submitty/install_site_prod.sh
@@ -118,9 +118,6 @@ cp ${NODE_FOLDER}/jquery.are-you-sure/jquery.are-you-sure.js ${VENDOR_FOLDER}/jq
 mkdir ${VENDOR_FOLDER}/jquery-ui
 cp ${NODE_FOLDER}/jquery-ui-dist/*.min.* ${VENDOR_FOLDER}/jquery-ui
 cp -R ${NODE_FOLDER}/jquery-ui-dist/images ${VENDOR_FOLDER}/jquery-ui/
-# jquery-ui-timepicker-addon
-mkdir ${VENDOR_FOLDER}/jquery-ui-timepicker-addon
-cp ${NODE_FOLDER}/jquery-ui-timepicker-addon/dist/*.min.* ${VENDOR_FOLDER}/jquery-ui-timepicker-addon
 # pdfjs
 mkdir ${VENDOR_FOLDER}/pdfjs
 cp ${NODE_FOLDER}/pdfjs-dist/build/pdf.min.js ${VENDOR_FOLDER}/pdfjs

--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -10,7 +10,6 @@ we utilize several third-party libraries to help power various components. Below
 | jQuery    | Copyright jQuery Foundation and other contributors | https://jquery.com | [MIT License](https://github.com/jquery/jquery/blob/master/LICENSE.txt) |
 | jQuery-UI | Copyright jQuery Foundation and other contributors | https://jquery.com | [MIT License](https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt) |
 | jQuery-Color | Copyright jQuery Foundation and other contributors | https://jquery.com | [MIT License](https://github.com/jquery/jquery-color/blob/master/LICENSE.txt) |
-| jQuery-Timepicker-Addon | Copyright (c) 2013 Trent Richardson | https://github.com/trentrichardson/jQuery-Timepicker-Addon | [MIT License](https://github.com/trentrichardson/jQuery-Timepicker-Addon/blob/master/LICENSE-MIT) |
 | CodeMirror | Copyright (c) 2019 Marijn Haverbeke \<marijnh@gmail.com\> and others | https://codemirror.net/ | [MIT License](https://github.com/codemirror/CodeMirror/blob/master/LICENSE) |
 | Bootstrap | Copyright (c) 2011-2016 Twitter, Inc. | https://getbootstrap.com/ | [MIT License](https://github.com/twbs/bootstrap/blob/master/LICENSE) |
 | ramsey/uuid | Copyright (c) 2012 - 2018 Ben Ramsey \<ben@benramsey.com\> | https://github.com/ramsey/uuid | [MIT License](https://github.com/ramsey/uuid/blob/master/LICENSE) |

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -65,9 +65,6 @@ class AdminGradeableController extends AbstractController {
         $vcs_base_url = $this->core->getConfig()->getVcsBaseUrl();
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'flatpickr.min.js'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'shortcut-buttons-flatpickr.min.js'));
-        $this->core->getOutput()->addVendorJs(
-            FileUtils::joinPaths('jquery-ui-timepicker-addon', 'jquery-ui-timepicker-addon.min.js')
-        );
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -498,11 +498,6 @@
       "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz",
       "integrity": "sha1-XAgV08xvkP9fqvWyaKbiO0ypBPo="
     },
-    "jquery-ui-timepicker-addon": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/jquery-ui-timepicker-addon/-/jquery-ui-timepicker-addon-1.6.3.tgz",
-      "integrity": "sha1-gDfDmwtjAoLdCzfditf8XhFjN38="
-    },
     "jquery.are-you-sure": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/jquery.are-you-sure/-/jquery.are-you-sure-1.9.0.tgz",

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,6 @@
     "flatpickr": "4.6.3",
     "jquery": "3.5.0",
     "jquery-ui-dist": "1.12.1",
-    "jquery-ui-timepicker-addon": "1.6.3",
     "jquery.are-you-sure": "1.9.0",
     "mermaid": "8.4.8",
     "pdfjs-dist": "2.2.228",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

jquery-ui-timepicker-addon was an older timepicker plugin we used to use before flatpickr.

### What is the new behavior?

Removes the timepicker dependency as it's no longer used anywhere.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
