### PR TITLE
[Testing] Fix phpunit warnings for 4 tests

### DIFF
--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -220,12 +220,9 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * Checks whether a mocked method was called or not
-     *
-     * @param string $method
-     * @return bool
+     * Asserts whether a mocked method was called or not
      */
-    public function assertMethodCalled(string $method): bool {
-        return array_key_exists($method, $this->mocked_methods) && $this->mocked_methods[$method];
+    public function assertMethodCalled(string $method): void {
+        $this->assertTrue(array_key_exists($method, $this->mocked_methods) && $this->mocked_methods[$method]);
     }
 }

--- a/site/tests/app/controllers/admin/GradeOverrideControllerTester.php
+++ b/site/tests/app/controllers/admin/GradeOverrideControllerTester.php
@@ -24,7 +24,6 @@ class GradeOverrideControllerTester extends BaseUnitTest {
         $this->controller = new GradeOverrideController($this->core);
     }
 
-    /** @test */
     public function testQueriesAreCalledInViewOverriddenGrades() {
         $this->controller->viewOverriddenGrades();
 

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -402,7 +402,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         unlink(FileUtils::joinPaths($this->temp_dir, 'config', 'database.json'));
         $config = new Config($this->core);
         $this->expectException(\app\exceptions\ConfigException::class);
-        $this->expectExceptionMessageRegExp('/Could not find database config: .*\/config\/database.json/');
+        $this->expectExceptionMessageMatches('/Could not find database config: .*\/config\/database.json/');
         $config->loadMasterConfigs($this->config_path);
     }
 
@@ -411,7 +411,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         unlink(FileUtils::joinPaths($this->temp_dir, 'config', 'submitty.json'));
         $config = new Config($this->core);
         $this->expectException(\app\exceptions\ConfigException::class);
-        $this->expectExceptionMessageRegExp('/Could not find submitty config: .*\/config\/submitty.json/');
+        $this->expectExceptionMessageMatches('/Could not find submitty config: .*\/config\/submitty.json/');
         $config->loadMasterConfigs($this->config_path);
     }
 
@@ -436,7 +436,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         unlink(FileUtils::joinPaths($this->temp_dir, 'config', 'email.json'));
         $config = new Config($this->core);
         $this->expectException(\app\exceptions\ConfigException::class);
-        $this->expectExceptionMessageRegExp('/Could not find email config: .*\/config\/email.json/');
+        $this->expectExceptionMessageMatches('/Could not find email config: .*\/config\/email.json/');
         $config->loadMasterConfigs($this->config_path);
     }
 
@@ -549,7 +549,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $this->createConfigFile();
         unlink(FileUtils::joinPaths($this->temp_dir, 'config', 'secrets_submitty_php.json'));
         $this->expectException(ConfigException::class);
-        $this->expectExceptionMessageRegExp('/^Could not find secrets config: .*\/config\/secrets_submitty_php\.json$/');
+        $this->expectExceptionMessageMatches('/^Could not find secrets config: .*\/config\/secrets_submitty_php\.json$/');
         $config = new Config($this->core);
         $config->loadMasterConfigs($this->config_path);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

4 tests used a deprecate phpunit function `expectExceptionMessageRegExp` which will be removed in a future version of phpunit. 1 test did not assert anything.

### What is the new behavior?

Updates the 4 functions to use `expectExceptionMessageMatches` which is not deprecated and adds proper asserts to the one test.
