### PR TITLE
[UI/UX] Fix password field having white background in dark mode

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -110,6 +110,7 @@ input[type="color"] {
     font-size: 14px;
     line-height: 20px;
     color: var(--standard-dark-gray);
+    background-color: var(--standard-input-background);
     vertical-align: middle;
     border: 1px solid var(--standard-light-gray);
     -webkit-border-radius: 4px;
@@ -185,10 +186,6 @@ select.disabled,
 textarea.disabled,
 input.disabled {
     background-color: var(--standard-light-gray);
-}
-
-textarea, input[type="text"], input[type="number"], input[type="date"], input[type="checkbox"], select{
-  background-color: var(--standard-input-background);
 }
 
 button,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When going to the login page under dark mode, the password input box had a white background with white text color, making it kind of hard to use.

### What is the new behavior?

Password input box has a dark background.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

I moved the place where the background for certain inputs was defined to the same place as the text color was defined. Given that each of these input types here are all text inputs (with special behavior), it's not clear why there was this differentiation, though there might have been a set reason for it.
