### PR TITLE
[Testing:E2E] Attempt to start Chrome several times before throwing exception

### DIFF
--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -77,6 +77,8 @@ class BaseTestCase(unittest.TestCase):
                 break
             except WebDriverException:
                 pass
+        if self.driver is None:
+            self.driver = webdriver.Chrome(options=self.options)
 
         self.driver.set_window_size(1600, 900)
         self.enable_download_in_headless_chrome(self.download_dir)

--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -41,6 +41,7 @@ class BaseTestCase(unittest.TestCase):
         self.driver = None
         """ :type driver: webdriver.Chrome """
         self.options = webdriver.ChromeOptions()
+        self.options.add_argument('--no-sandbox')
         self.options.add_argument('--headless')
         self.options.add_argument("--disable-extensions")
         self.options.add_argument('--hide-scrollbars')

--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 
 from selenium import webdriver
 
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -68,7 +69,15 @@ class BaseTestCase(unittest.TestCase):
         self.use_log_in = log_in
 
     def setUp(self):
-        self.driver = webdriver.Chrome(options=self.options)
+        # attempt to set-up the connection to Chrome. Repeat a handful of times
+        # in-case Chrome crashes during initialization
+        for _ in range(5):
+            try:
+                self.driver = webdriver.Chrome(options=self.options)
+                break
+            except WebDriverException:
+                pass
+
         self.driver.set_window_size(1600, 900)
         self.enable_download_in_headless_chrome(self.download_dir)
         if self.use_log_in:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Travis-Ci has been flaky where it fairly consistently fails the E2E test suite due to Chrome crashing.

### What is the new behavior?

This attempts to fix that by setting the `--no-sandbox` flag which makes it run a bit leaner, and to use a for loop around intitalizing the the driver to attempt a few times before finally surfacing the exception thrown, where hopefully on a second (or third or...) try, Chrome will successfully start up.