### PR TITLE
[Testing] Refactor e2e tests to not use deprecated functions

### DIFF
--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
-
 import shutil
 import tempfile
 from datetime import date
 import os
-import time
 import unittest
 
 from urllib.parse import urlencode
@@ -109,44 +106,44 @@ class BaseTestCase(unittest.TestCase):
         self.get(url)
         # print(self.driver.page_source)
         self.assertIn(title, self.driver.title)
-        self.driver.find_element_by_name('user_id').send_keys(user_id)
-        self.driver.find_element_by_name('password').send_keys(user_password)
-        self.driver.find_element_by_name('login').click()
+        self.driver.find_element(By.NAME, 'user_id').send_keys(user_id)
+        self.driver.find_element(By.NAME, 'password').send_keys(user_password)
+        self.driver.find_element(By.NAME, 'login').click()
 
-        # OLD self.assertEqual(user_name, self.driver.find_element_by_id("login-id").get_attribute('innerText').strip(' \t\r\n'))
+        # OLD self.assertEqual(user_name, self.driver.find_element(By.ID, "login-id").get_attribute('innerText').strip(' \t\r\n'))
 
         # FIXME: WANT SOMETHING LIKE THIS...  WHEN WE HAVE JUST ONE ELEMENT WITH THIS ID
-        # self.assertEqual("Logout "+user_name, self.driver.find_element_by_id("logout").get_attribute('innerText').strip(' \t\r\n'))
+        # self.assertEqual("Logout "+user_name, self.driver.find_element(By.ID, "logout").get_attribute('innerText').strip(' \t\r\n'))
 
         # instead, just make sure this element exists
-        self.driver.find_element_by_id("logout")
+        self.driver.find_element(By.ID, "logout")
 
         self.logged_in = True
 
     def log_out(self):
         if self.logged_in:
             self.logged_in = False
-            self.driver.find_element_by_id('logout').click()
-            self.driver.find_element_by_id('login-guest')
+            self.driver.find_element(By.ID, 'logout').click()
+            self.driver.find_element(By.ID, 'login-guest')
 
     def click_class(self, course, course_name=None):
         if course_name is None:
             course_name = course
         course_name = course_name.title()
-        self.driver.find_element_by_id(self.get_current_semester() + '_' + course).click()
+        self.driver.find_element(By.ID, self.get_current_semester() + '_' + course).click()
         # print(self.driver.page_source)
         WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(EC.title_is('Submitty ' + course_name + ' Gradeables'))
 
     # see Navigation.twig for html attributes to use as arguments
     # loaded_selector must recognize an element on the page being loaded (test_simple_grader.py has xpath example)
     def click_nav_grade_button(self, gradeable_category, gradeable_id, button_name, loaded_selector):
-        self.driver.find_element_by_xpath(
+        self.driver.find_element(By.XPATH,
             "//div[@id='{}']/div[@class='course-button']/a[contains(@class, 'btn-nav-grade')]".format(
                 gradeable_id)).click()
         WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(EC.presence_of_element_located(loaded_selector))
 
     def click_nav_submit_button(self, gradeable_category, gradeable_id, button_name, loaded_selector):
-        self.driver.find_element_by_xpath(
+        self.driver.find_element(By.XPATH,
             "//div[@id='{}']/div[@class='course-button']/a[contains(@class, 'btn-nav-submit')]".format(
                 gradeable_id)).click()
         WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(EC.presence_of_element_located(loaded_selector))
@@ -154,8 +151,10 @@ class BaseTestCase(unittest.TestCase):
     # clicks the navigation header text to 'go back' pages
     # for homepage, selector can be gradeable list
     def click_header_link_text(self, text, loaded_selector):
-        self.driver.find_element_by_xpath(
-            "//div[@id='breadcrumbs']/div[@class='breadcrumb']/a[text()='{}']".format(text)).click()
+        self.driver.find_element(
+            By.XPATH,
+            "//div[@id='breadcrumbs']/div[@class='breadcrumb']/a[text()='{}']".format(text)
+        ).click()
         WebDriverWait(self.driver, BaseTestCase.WAIT_TIME).until(EC.presence_of_element_located(loaded_selector))
 
     def wait_after_ajax(self):
@@ -212,4 +211,4 @@ class BaseTestCase(unittest.TestCase):
         self.driver.command_executor._commands["send_command"] = ("POST", '/session/$sessionId/chromium/send_command')
 
         params = {'cmd': 'Page.setDownloadBehavior', 'params': {'behavior': 'allow', 'downloadPath': download_dir}}
-        command_result = self.driver.execute("send_command", params)
+        self.driver.execute("send_command", params)

--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -61,7 +61,7 @@ class TestForum(BaseTestCase):
         attachment_file = None
         self.switch_to_page_create_thread()
         self.driver.find_element(By.ID, "title").send_keys(title)
-        self.driver.find_element(By.CLASS_NAME, ("thread_post_content").send_keys(first_post)
+        self.driver.find_element(By.CLASS_NAME, "thread_post_content").send_keys(first_post)
         upload_button = self.driver.find_element(By.XPATH, "//input[@type='file']")
         self.select_categories(categories_list)
         if upload_attachment:
@@ -129,7 +129,7 @@ class TestForum(BaseTestCase):
             posts[0].find_element(By.XPATH, ".//a[starts-with(@id, 'button_attachments_')]").click()
             self.wait_after_ajax()
             self.wait_for_element(
-                (By.XPATH, posts_selector + "//div[contains(@class, 'attachment-well')]").format(content))
+                (By.XPATH, (posts_selector + "//div[contains(@class, 'attachment-well')]").format(content))
             )
             attachmentSrc = posts[0].find_elements(By.XPATH, ".//img[contains(@src, '{}')]".format(check_attachment))
             assert len(attachmentSrc) > 0

--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -15,25 +15,25 @@ class TestForum(BaseTestCase):
 
     def init_and_enable_discussion(self):
         self.click_class('sample')
-        if len(self.driver.find_elements_by_xpath("//a[@id='nav-sidebar-forum']")) == 0:
-            self.driver.find_element_by_xpath("//a[@id='nav-sidebar-course-settings']").click()
-            self.driver.find_element_by_name("forum_enabled").click()
-            self.driver.find_element_by_xpath("//a[contains(text(),'sample')]").click()
-        self.driver.find_element_by_xpath("//a[@id='nav-sidebar-forum']").click()
+        if len(self.driver.find_elements(By.XPATH, "//a[@id='nav-sidebar-forum']")) == 0:
+            self.driver.find_element(By.XPATH, "//a[@id='nav-sidebar-course-settings']").click()
+            self.driver.find_element(By.NAME, "forum_enabled").click()
+            self.driver.find_element(By.XPATH, "//a[contains(text(),'sample')]").click()
+        self.driver.find_element(By.XPATH, "//a[@id='nav-sidebar-forum']").click()
         self.forum_page_url = self.driver.current_url
 
     def switch_to_page_create_thread(self):
         if '/threads/new' in self.driver.current_url:
             pass
         elif '/forum' in self.driver.current_url:
-            self.driver.find_element_by_xpath("//a[contains(text(),'Create Thread')]").click()
+            self.driver.find_element(By.XPATH, "//a[contains(text(),'Create Thread')]").click()
         else:
             assert False
         assert '/threads/new' in self.driver.current_url
 
     def switch_to_page_view_thread(self):
         if '/threads/new' in self.driver.current_url:
-            self.driver.find_element_by_xpath("//a[contains(text(),'Back to Threads')]").click()
+            self.driver.find_element(By.XPATH, "//a[contains(text(),'Back to Threads')]").click()
         elif '/threads' in self.driver.current_url:
             pass
         else:
@@ -48,7 +48,7 @@ class TestForum(BaseTestCase):
     def select_categories(self, categories_list):
         assert '/threads/new' in self.driver.current_url
         for category, set_it in categories_list:
-            category_button = self.driver.find_element_by_xpath(
+            category_button = self.driver.find_element(By.XPATH,
                 "//div[contains(@class,'cat-buttons') and contains(string(),'{}')]".format(category))
             if ('cat-selected' in category_button.get_attribute('class')) ^ set_it:
                 category_button.click()
@@ -60,13 +60,13 @@ class TestForum(BaseTestCase):
             return
         attachment_file = None
         self.switch_to_page_create_thread()
-        self.driver.find_element_by_id("title").send_keys(title)
-        self.driver.find_element_by_class_name("thread_post_content").send_keys(first_post)
-        upload_button = self.driver.find_element_by_xpath("//input[@type='file']")
+        self.driver.find_element(By.ID, "title").send_keys(title)
+        self.driver.find_element(By.CLASS_NAME, ("thread_post_content").send_keys(first_post)
+        upload_button = self.driver.find_element(By.XPATH, "//input[@type='file']")
         self.select_categories(categories_list)
         if upload_attachment:
             attachment_file = self.upload_attachment(upload_button)
-        self.driver.find_element_by_xpath("//input[@value='Submit Post']").click()
+        self.driver.find_element(By.XPATH, "//input[@value='Submit Post']").click()
         if len([cat for cat in categories_list if cat[1]]) == 0:
             # Test thread should not be created
             self.driver.switch_to.alert.accept()
@@ -84,7 +84,7 @@ class TestForum(BaseTestCase):
         thread_count = int(self.driver.execute_script('return $("#thread_list .thread_box").length;'))
         while True:
             # Scroll down in thread list until required thread is found
-            divs = self.driver.find_elements_by_xpath(target_xpath)
+            divs = self.driver.find_elements(By.XPATH, target_xpath)
             if len(divs) > 0:
                 # Thread Found
                 break
@@ -96,12 +96,12 @@ class TestForum(BaseTestCase):
             if thread_count == new_thread_count:
                 break
             thread_count = new_thread_count
-        return len(self.driver.find_elements_by_xpath(target_xpath)) > 0
+        return len(self.driver.find_elements(By.XPATH, target_xpath)) > 0
 
     def view_thread(self, title, return_info=False):
         assert '/threads' in self.driver.current_url
         assert self.thread_exists(title)
-        div = self.driver.find_element_by_xpath(
+        div = self.driver.find_element(By.XPATH,
             "//div[contains(@class, 'thread_box') and contains(string(),'{}')]".format(title))
         if return_info:
             categories = []
@@ -110,7 +110,7 @@ class TestForum(BaseTestCase):
             return {'categories': categories}
         div.click()
         self.wait_after_ajax()
-        thread_title = self.driver.find_elements_by_xpath(
+        thread_title = self.driver.find_elements(By.XPATH,
             "//div[contains(@class, 'post_box') and contains(@class, 'first_post')]/h2[contains(string(),'{}')]".format(
                 title))
         assert len(thread_title) > 0
@@ -122,14 +122,14 @@ class TestForum(BaseTestCase):
         if move_to_thread is not None:
             self.view_thread(move_to_thread)
         posts_selector = "//div[contains(@class, 'post_box') and contains(string(),'{}')]"
-        posts = self.driver.find_elements_by_xpath(posts_selector.format(content))
+        posts = self.driver.find_elements(By.XPATH, posts_selector.format(content))
         if must_exists:
             assert len(posts) > 0
         if check_attachment is not None:
             posts[0].find_element(By.XPATH, ".//a[starts-with(@id, 'button_attachments_')]").click()
             self.wait_after_ajax()
             self.wait_for_element(
-                (By.XPATH, (posts_selector + "//div[contains(@class, 'attachment-well')]").format(content))
+                (By.XPATH, posts_selector + "//div[contains(@class, 'attachment-well')]").format(content))
             )
             attachmentSrc = posts[0].find_elements(By.XPATH, ".//img[contains(@src, '{}')]".format(check_attachment))
             assert len(attachmentSrc) > 0
@@ -139,7 +139,7 @@ class TestForum(BaseTestCase):
         attachment_file = None
         post = self.find_posts(post_content)[0]
         post_id = post.get_attribute("id")
-        edit_form = self.driver.find_elements_by_xpath("//input[@value='{}' and @name='parent_id']/..".format(post_id))[-1]  # Last One
+        edit_form = self.driver.find_elements(By.XPATH, "//input[@value='{}' and @name='parent_id']/..".format(post_id))[-1]  # Last One
         text_area = edit_form.find_element(By.XPATH, ".//textarea")
         upload_button = edit_form.find_element(By.XPATH, ".//input[@type='file']")
         submit_button = edit_form.find_element(By.XPATH, ".//input[@type='submit']")
@@ -166,7 +166,7 @@ class TestForum(BaseTestCase):
 
     def delete_thread(self, title):
         self.view_thread(title)
-        self.driver.find_elements_by_xpath("//a[@title='Remove post']")[0].click()
+        self.driver.find_elements(By.XPATH, "//a[@title='Remove post']")[0].click()
         self.driver.switch_to.alert.accept()
         # Workaround, not working without force redirection
         self.driver.get(self.forum_page_url)
@@ -180,8 +180,8 @@ class TestForum(BaseTestCase):
 
     def merge_threads(self, child_thread_title, parent_thread_title, press_cancel=False):
         self.view_thread(child_thread_title)
-        merge_threads_div = self.driver.find_element_by_id("merge-threads")
-        self.driver.find_element_by_xpath("//a[contains(text(),'Merge Threads')]").click()
+        merge_threads_div = self.driver.find_element(By.ID, "merge-threads")
+        self.driver.find_element(By.XPATH, "//a[contains(text(),'Merge Threads')]").click()
         cancel_button = merge_threads_div.find_element(By.XPATH, ".//a[contains(normalize-space(.), 'Close')]")
         assert merge_threads_div.value_of_css_property("display") == "block"
         if parent_thread_title is None:
@@ -196,7 +196,7 @@ class TestForum(BaseTestCase):
                 cancel_button.click()
             else:
                 submit_button.click()
-            assert self.driver.find_element_by_id("merge-threads").value_of_css_property("display") == "none"
+            assert self.driver.find_element(By.ID, "merge-threads").value_of_css_property("display") == "none"
 
     def test_basic_operations_thread(self):
         title = "E2E Sample Title E2E"

--- a/tests/e2e/test_grade_inquiry.py
+++ b/tests/e2e/test_grade_inquiry.py
@@ -7,36 +7,37 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 
+
 class TestGradeInquiry(BaseTestCase):
     def __init__(self, testname):
         super().__init__(testname, log_in=False)
 
     def set_grade_inquiries_for_course(self, allowed):
         # ensure that grade inquiries are enabled for the course
-        self.driver.find_element_by_id("nav-sidebar-course-settings").click()
-        regrade_enabled_checkbox = self.driver.find_element_by_id("regrade-enabled")
+        self.driver.find_element(By.ID, "nav-sidebar-course-settings").click()
+        regrade_enabled_checkbox = self.driver.find_element(By.ID, "regrade-enabled")
 
         if not regrade_enabled_checkbox.is_selected() and allowed:
             regrade_enabled_checkbox.click()
         elif regrade_enabled_checkbox.is_selected() and not allowed:
             regrade_enabled_checkbox.click()
         # navigate back to gradeable page
-        self.driver.find_element_by_id('nav-sidebar-submitty').click()
+        self.driver.find_element(By.ID, 'nav-sidebar-submitty').click()
 
     def set_grade_inquiries_for_gradeable(self, gradeable_id, date=None, allowed=True):
         # ensure that grade inquiries are enabled for grades_released_homework gradeable
-        self.driver.find_element_by_xpath("//div[@id='"+gradeable_id+"']//*[contains(@class, 'fa-pencil-alt')]").click()
+        self.driver.find_element(By.XPATH, "//div[@id='"+gradeable_id+"']//*[contains(@class, 'fa-pencil-alt')]").click()
 
         if allowed:
-            self.driver.find_element_by_id("yes_regrade_allowed").click()
+            self.driver.find_element(By.ID, "yes_regrade_allowed").click()
         else:
-            self.driver.find_element_by_id("no_regrade_allowed").click()
+            self.driver.find_element(By.ID, "no_regrade_allowed").click()
 
         # set deadline
         if date is not None:
-            self.driver.find_element_by_xpath("//a[text()='Dates']").click()
+            self.driver.find_element(By.XPATH, "//a[text()='Dates']").click()
 
-            grade_inquiry_date_input = self.driver.find_element_by_name("regrade_request_date")
+            grade_inquiry_date_input = self.driver.find_element(By.NAME, "regrade_request_date")
             # wait for flatpickr to appear
             grade_inquiry_date_input.click()
             wait = WebDriverWait(self.driver, self.WAIT_TIME)
@@ -46,7 +47,7 @@ class TestGradeInquiry(BaseTestCase):
             grade_inquiry_date_input.send_keys(date,Keys.ENTER)
 
         # navigate back to gradeable page
-        self.driver.find_element_by_id("nav-sidebar-submitty").click()
+        self.driver.find_element(By.ID, "nav-sidebar-submitty").click()
 
     # TA GRADING INTERFACE TESTS
     # travis should not run this
@@ -64,12 +65,12 @@ class TestGradeInquiry(BaseTestCase):
         self.set_grade_inquiries_for_gradeable(gradeable_id, date=grade_inquiry_deadline_date, allowed=True)
 
         # navigate to TA grading interface of student with normal submission
-        self.driver.find_element_by_xpath("//div[@id='"+gradeable_id+"']//a[contains(@class,'btn-nav-grade')]").click()
-        self.driver.find_element_by_xpath("//a[contains(text(),'Grading Index')]").click()
-        self.driver.find_element_by_xpath("//a[contains(@href,'grading/grade?who_id=bauchg')]").click()
+        self.driver.find_element(By.XPATH, "//div[@id='"+gradeable_id+"']//a[contains(@class,'btn-nav-grade')]").click()
+        self.driver.find_element(By.XPATH, "//a[contains(text(),'Grading Index')]").click()
+        self.driver.find_element(By.XPATH, "//a[contains(@href,'grading/grade?who_id=bauchg')]").click()
 
         # make sure submit button is present
-        buttons = self.driver.find_elements_by_xpath("//*[contains(@class,'gi-submit')]")
+        buttons = self.driver.find_elements(By.XPATH, "//*[contains(@class,'gi-submit')]")
         assert len(buttons) == 1
         assert buttons[0].text == "Submit Grade Inquiry"
 
@@ -87,16 +88,16 @@ class TestGradeInquiry(BaseTestCase):
         self.set_grade_inquiries_for_gradeable(gradeable_id,date=grade_inquiry_deadline_date,allowed=True)
 
         # navigate to TA grading interface of student with no submission
-        self.driver.find_element_by_xpath("//div[@id='"+gradeable_id+"']//a[contains(@class,'btn-nav-grade')]").click()
-        self.driver.find_element_by_xpath("//a[contains(text(),'Grading Index')]").click()
-        self.driver.find_element_by_xpath("//a[contains(@href,'grading/grade?who_id=lakinh')]").click()
+        self.driver.find_element(By.XPATH, "//div[@id='"+gradeable_id+"']//a[contains(@class,'btn-nav-grade')]").click()
+        self.driver.find_element(By.XPATH, "//a[contains(text(),'Grading Index')]").click()
+        self.driver.find_element(By.XPATH, "//a[contains(@href,'grading/grade?who_id=lakinh')]").click()
 
         try:
-           self.driver.find_element_by_xpath("//div[@id='regrade_info']//*[text()='No Submission']")
+           self.driver.find_element(By.XPATH, "//div[@id='regrade_info']//*[text()='No Submission']")
         except NoSuchElementException:
            assert False
         assert True
-        buttons = self.driver.find_elements_by_xpath("//button[contains(@class,'gi-submit')]")
+        buttons = self.driver.find_elements(By.XPATH, "//button[contains(@class,'gi-submit')]")
         assert len(buttons) == 0
 
     @unittest.skipUnless(os.environ.get('TRAVIS_BUILD_DIR') is None, "cannot run in Travis-CI")
@@ -113,14 +114,14 @@ class TestGradeInquiry(BaseTestCase):
         self.set_grade_inquiries_for_gradeable(gradeable_id,date=grade_inquiry_deadline_date,allowed=True)
 
         # navigate to TA grading interface of student with no inquiry
-        self.driver.find_element_by_xpath("//div[@id='"+gradeable_id+"']//a[contains(@class,'btn-nav-grade')]").click()
-        self.driver.find_element_by_xpath("//a[contains(text(),'Grading Index')]").click()
-        self.driver.find_element_by_xpath("//a[contains(@href,'grading/grade?who_id=bauchg')]").click()
+        self.driver.find_element(By.XPATH, "//div[@id='"+gradeable_id+"']//a[contains(@class,'btn-nav-grade')]").click()
+        self.driver.find_element(By.XPATH, "//a[contains(text(),'Grading Index')]").click()
+        self.driver.find_element(By.XPATH, "//a[contains(@href,'grading/grade?who_id=bauchg')]").click()
 
         # There should be no forms or buttons
-        forms = self.driver.find_elements_by_xpath("//form[contains(@class,'reply-text-form')]")
+        forms = self.driver.find_elements(By.XPATH, "//form[contains(@class,'reply-text-form')]")
         assert len(forms) == 0
-        buttons = self.driver.find_elements_by_xpath("//form[contains(@class,'gi-submit')]")
+        buttons = self.driver.find_elements(By.XPATH, "//form[contains(@class,'gi-submit')]")
         assert len(buttons) == 0
 
 
@@ -141,14 +142,14 @@ class TestGradeInquiry(BaseTestCase):
         self.log_in(user_id='bauchg')
         self.click_class('sample')
 
-        self.driver.find_element_by_xpath("//div[@id='"+gradeable_id+"']//a[contains(text(),'VIEW GRADE')]").click()
+        self.driver.find_element(By.XPATH, "//div[@id='"+gradeable_id+"']//a[contains(text(),'VIEW GRADE')]").click()
 
-        assert not self.driver.find_element_by_id("regradeBoxSection").is_displayed()
-        open_grade_inquiry_button = self.driver.find_element_by_xpath("//button[contains(text(),'Open Grade Inquiry')]")
+        assert not self.driver.find_element(By.ID, "regradeBoxSection").is_displayed()
+        open_grade_inquiry_button = self.driver.find_element(By.XPATH, "//button[contains(text(),'Open Grade Inquiry')]")
         open_grade_inquiry_button.click()
         assert not open_grade_inquiry_button.is_displayed()
 
         # make sure submit button is present
-        buttons = self.driver.find_elements_by_xpath("//button[contains(@class,'gi-submit')]")
+        buttons = self.driver.find_elements(By.XPATH, "//button[contains(@class,'gi-submit')]")
         assert len(buttons) == 1
         assert buttons[0].text == "Submit Grade Inquiry"

--- a/tests/e2e/test_login.py
+++ b/tests/e2e/test_login.py
@@ -1,4 +1,5 @@
 from .base_testcase import BaseTestCase
+from selenium.webdriver.common.by import By
 
 
 class TestLogin(BaseTestCase):
@@ -31,29 +32,29 @@ class TestLogin(BaseTestCase):
 
     def test_bad_login_password(self):
         self.get("/" + self.semester + "/sample")
-        self.driver.find_element_by_id("login-guest")
-        self.driver.find_element_by_name("user_id").send_keys(self.user_id)
-        self.driver.find_element_by_name("password").send_keys("bad_password")
-        self.driver.find_element_by_name("login").click()
-        error = self.driver.find_element_by_id("error-0")
+        self.driver.find_element(By.ID, "login-guest")
+        self.driver.find_element(By.NAME, "user_id").send_keys(self.user_id)
+        self.driver.find_element(By.NAME, "password").send_keys("bad_password")
+        self.driver.find_element(By.NAME, "login").click()
+        error = self.driver.find_element(By.ID, "error-0")
         self.assertEqual("Could not login using that user id or password", error.text)
 
     def test_bad_login_username(self):
         self.get("/" + self.semester + "/sample")
-        self.driver.find_element_by_id("login-guest")
-        self.driver.find_element_by_name("user_id").send_keys("bad_username")
-        self.driver.find_element_by_name("password").send_keys(self.user_password)
-        self.driver.find_element_by_name("login").click()
-        error = self.driver.find_element_by_id("error-0")
+        self.driver.find_element(By.ID, "login-guest")
+        self.driver.find_element(By.NAME, "user_id").send_keys("bad_username")
+        self.driver.find_element(By.NAME, "password").send_keys(self.user_password)
+        self.driver.find_element(By.NAME, "login").click()
+        error = self.driver.find_element(By.ID, "error-0")
         self.assertEqual("Could not login using that user id or password", error.text)
 
     def test_login_non_course_user(self):
         self.get("/" + self.semester + "/sample")
-        self.driver.find_element_by_id("login-guest")
-        self.driver.find_element_by_name("user_id").send_keys("pearsr")
-        self.driver.find_element_by_name("password").send_keys("pearsr")
-        self.driver.find_element_by_name("login").click()
-        element = self.driver.find_element_by_class_name("content")
+        self.driver.find_element(By.ID, "login-guest")
+        self.driver.find_element(By.NAME, "user_id").send_keys("pearsr")
+        self.driver.find_element(By.NAME, "password").send_keys("pearsr")
+        self.driver.find_element(By.NAME, "login").click()
+        element = self.driver.find_element(By.CLASS_NAME, "content")
         self.assertEqual("You don't have access to this course.\nThis is sample for {:s}.\nIf you think this is a mistake, please contact your instructor to gain access.\nclick here to back to homepage and see your courses list.".format(self.full_semester), element.text)
 
     def test_going_to_logout_when_not_logged_in(self):

--- a/tests/e2e/test_navigation_page_non_student.py
+++ b/tests/e2e/test_navigation_page_non_student.py
@@ -1,4 +1,5 @@
 from .base_testcase import BaseTestCase
+from selenium.webdriver.common.by import By
 
 
 class TestNavigationPageNonStudent(BaseTestCase):
@@ -8,63 +9,64 @@ class TestNavigationPageNonStudent(BaseTestCase):
     def test_instructor(self):
         self.log_in(user_id="instructor", user_name="Quinn")
         self.click_class('sample')
-        elements = self.driver.find_elements_by_class_name('course-section-heading')
+        elements = self.driver.find_elements(By.CLASS_NAME, 'course-section-heading')
         self.assertEqual(6, len(elements))
         self.assertEqual("future", elements[0].get_attribute('id'))
         self.assertEqual(3, len(self.driver
-                         .find_element_by_id('future-section')
-                         .find_elements_by_class_name("gradeable-row")))
+                         .find_element(By.ID, 'future-section')
+                         .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("beta", elements[1].get_attribute('id'))
         self.assertEqual(3, len(self.driver
-                                 .find_element_by_id('beta-section')
-                                 .find_elements_by_class_name('gradeable-row')))
+                                 .find_element(By.ID, 'beta-section')
+                                 .find_elements(By.CLASS_NAME, 'gradeable-row')))
         self.assertEqual("open", elements[2].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                                .find_element_by_id('open-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'open-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("closed", elements[3].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                         .find_element_by_id('closed-section')
-                         .find_elements_by_class_name("gradeable-row")))
+                         .find_element(By.ID, 'closed-section')
+                         .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("items_being_graded", elements[4].get_attribute('id'))
         self.assertEqual(6, len(self.driver
-                         .find_element_by_id('items_being_graded-section')
-                         .find_elements_by_class_name("gradeable-row")))
+                         .find_element(By.ID, 'items_being_graded-section')
+                         .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("graded", elements[5].get_attribute('id'))
         self.assertEqual(9, len(self.driver
-                         .find_element_by_id('graded-section')
-                         .find_elements_by_class_name("gradeable-row")))
-        self.assertEqual(4, len(self.driver.find_element_by_class_name(
-            'gradeable-row').find_elements_by_class_name('course-button')))
+                         .find_element(By.ID, 'graded-section')
+                         .find_elements(By.CLASS_NAME, "gradeable-row")))
+        self.assertEqual(4, len(self.driver
+                         .find_element(By.CLASS_NAME, 'gradeable-row')
+                         .find_elements(By.CLASS_NAME, 'course-button')))
 
     def test_ta(self):
         self.log_in(user_id="ta", user_name="Jill")
         self.click_class('sample')
-        elements = self.driver.find_elements_by_class_name('course-section-heading')
+        elements = self.driver.find_elements(By.CLASS_NAME, 'course-section-heading')
         self.assertEqual(5, len(elements))
         self.assertEqual("beta", elements[0].get_attribute('id'))
         self.assertEqual(3, len(self.driver
-                                .find_element_by_id('beta-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'beta-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("open", elements[1].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                                .find_element_by_id('open-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'open-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("closed", elements[2].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                                .find_element_by_id('closed-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'closed-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("items_being_graded", elements[3].get_attribute('id'))
         self.assertEqual(6, len(self.driver
-                                .find_element_by_id('items_being_graded-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'items_being_graded-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("graded", elements[4].get_attribute('id'))
         self.assertEqual(9, len(self.driver
-                                .find_element_by_id('graded-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'graded-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
 
-        self.assertEqual(3, len(self.driver.find_element_by_class_name(
-            'gradeable-row').find_elements_by_class_name('course-button')))
+        self.assertEqual(3, len(self.driver.find_element(By.CLASS_NAME,
+            'gradeable-row').find_elements(By.CLASS_NAME, 'course-button')))
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_navigation_page_student.py
+++ b/tests/e2e/test_navigation_page_student.py
@@ -1,30 +1,31 @@
 from .base_testcase import BaseTestCase
+from selenium.webdriver.common.by import By
 
 
 class TestNavigationPageStudent(BaseTestCase):
     def test_navigation_page(self):
         self.click_class('sample')
-        elements = self.driver.find_elements_by_class_name('course-section-heading')
+        elements = self.driver.find_elements(By.CLASS_NAME, 'course-section-heading')
         self.assertEqual(4, len(elements))
         self.assertEqual("open", elements[0].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                                .find_element_by_id('open-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'open-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("closed", elements[1].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                                .find_element_by_id('closed-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'closed-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("items_being_graded", elements[2].get_attribute('id'))
         self.assertEqual(2, len(self.driver
-                                .find_element_by_id('items_being_graded-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'items_being_graded-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
         self.assertEqual("graded", elements[3].get_attribute('id'))
         self.assertEqual(7, len(self.driver
-                                .find_element_by_id('graded-section')
-                                .find_elements_by_class_name("gradeable-row")))
+                                .find_element(By.ID, 'graded-section')
+                                .find_elements(By.CLASS_NAME, "gradeable-row")))
 
-        self.assertEqual(2, len(self.driver.find_element_by_class_name(
-            'gradeable-row').find_elements_by_class_name('course-button')))
+        self.assertEqual(2, len(self.driver.find_element(By.CLASS_NAME,
+            'gradeable-row').find_elements(By.CLASS_NAME, 'course-button')))
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_office_hours_queue.py
+++ b/tests/e2e/test_office_hours_queue.py
@@ -14,10 +14,10 @@ class TestOfficeHoursQueue(BaseTestCase):
 
         # Turn the queue on
         self.get(self.get_current_semester()+"/sample/config")
-        if(not self.driver.find_element_by_id('queue-enabled').is_selected()):
-            self.driver.find_element_by_id('queue-enabled').click()
-        if(self.driver.find_element_by_id('queue-contact-info').is_selected()):
-            self.driver.find_element_by_id('queue-contact-info').click()
+        if(not self.driver.find_element(By.ID, 'queue-enabled').is_selected()):
+            self.driver.find_element(By.ID, 'queue-enabled').click()
+        if(self.driver.find_element(By.ID, 'queue-contact-info').is_selected()):
+            self.driver.find_element(By.ID, 'queue-contact-info').click()
 
         # Delete any old queues (this should remove anyone that was currently in the queue as well)
         deleteAllQueues(self)
@@ -109,7 +109,7 @@ class TestOfficeHoursQueue(BaseTestCase):
         deleteAllQueues(self)
 
         self.get(self.get_current_semester()+"/sample/config")
-        self.driver.find_element_by_id('queue-enabled').click()
+        self.driver.find_element(By.ID, 'queue-enabled').click()
 
         self.get(self.test_url)
 
@@ -121,34 +121,34 @@ def goToQueuePage(self):
 def openFilterSettings(self):
     goToQueuePage(self)
     self.assertEqual(True,self.driver.execute_script("return $('#filterSettingsCollapse').is(':hidden')"))
-    self.driver.find_element_by_id('toggle_filter_settings').click()
+    self.driver.find_element(By.ID, 'toggle_filter_settings').click()
     self.assertEqual(False,self.driver.execute_script("return $('#filterSettingsCollapse').is(':hidden')"))
 
 
 def deleteAllQueues(self):
     openFilterSettings(self)
-    while(self.driver.find_elements_by_class_name('delete_queue_btn')):
-        self.driver.find_element_by_class_name('delete_queue_btn').click()
+    while(self.driver.find_elements(By.CLASS_NAME, 'delete_queue_btn')):
+        self.driver.find_element(By.CLASS_NAME, 'delete_queue_btn').click()
         self.driver.switch_to.alert.accept()
         openFilterSettings(self)
 
 def openQueue(self, name, code=None):
     openFilterSettings(self)
-    self.driver.find_element_by_id('new_queue_code').send_keys(name)
+    self.driver.find_element(By.ID, 'new_queue_code').send_keys(name)
     if(code):
-        self.driver.find_element_by_id('new_queue_token').send_keys(code)
+        self.driver.find_element(By.ID, 'new_queue_token').send_keys(code)
     else:
-        self.driver.find_element_by_id('new_queue_rand_token').click()
-    self.driver.find_element_by_id('open_new_queue_btn').click()
+        self.driver.find_element(By.ID, 'new_queue_rand_token').click()
+    self.driver.find_element(By.ID, 'open_new_queue_btn').click()
 
 def changeQueueCode(self, name, code=None):
     openFilterSettings(self)
-    self.driver.find_element_by_xpath(f'//*[@id="old_queue_code"]/option[text()="{name}"]').click()
+    self.driver.find_element(By.XPATH, f'//*[@id="old_queue_code"]/option[text()="{name}"]').click()
     if(code):
-        self.driver.find_element_by_id('old_queue_token').send_keys(code)
+        self.driver.find_element(By.ID, 'old_queue_token').send_keys(code)
     else:
-        self.driver.find_element_by_id('old_queue_rand_token').click()
-    self.driver.find_element_by_id('change_code_btn').click()
+        self.driver.find_element(By.ID, 'old_queue_rand_token').click()
+    self.driver.find_element(By.ID, 'change_code_btn').click()
 
 def switchToStudent(self, account):
     self.log_out()
@@ -162,62 +162,62 @@ def switchToInstructor(self, account):
 
 def studentJoinQueue(self, queueName, queueCode, studentName=None):
     if(studentName):
-        self.driver.find_element_by_id('name_box').send_keys(studentName)
-    select = Select(self.driver.find_element_by_id('queue_code'))
+        self.driver.find_element(By.ID, 'name_box').send_keys(studentName)
+    select = Select(self.driver.find_element(By.ID, 'queue_code'))
     select.select_by_visible_text(queueName)
-    self.driver.find_element_by_id('token_box').send_keys(queueCode)
-    self.assertIn("_".join(queueName.split()), self.driver.find_element_by_id('add_to_queue').get_attribute('action'))
-    self.assertEqual(queueCode, self.driver.find_element_by_id('token_box').get_attribute('value'))
-    self.driver.find_element_by_id('join_queue_btn').click()
+    self.driver.find_element(By.ID, 'token_box').send_keys(queueCode)
+    self.assertIn("_".join(queueName.split()), self.driver.find_element(By.ID, 'add_to_queue').get_attribute('action'))
+    self.assertEqual(queueCode, self.driver.find_element(By.ID, 'token_box').get_attribute('value'))
+    self.driver.find_element(By.ID, 'join_queue_btn').click()
 
 def studentRemoveSelfFromQueue(self):
-    self.driver.find_element_by_id('leave_queue').click()
+    self.driver.find_element(By.ID, 'leave_queue').click()
     self.driver.switch_to.alert.accept()
 
 def studentFinishHelpSelf(self):
-    self.driver.find_element_by_id('self_finish_help').click()
+    self.driver.find_element(By.ID, 'self_finish_help').click()
     self.driver.switch_to.alert.accept()
 
 def helpFirstStudent(self):
-    self.driver.find_element_by_class_name('help_btn').click()
+    self.driver.find_element(By.CLASS_NAME, 'help_btn').click()
 
 def finishHelpFirstStudent(self):
-    self.driver.find_element_by_class_name('finish_helping_btn').click()
+    self.driver.find_element(By.CLASS_NAME, 'finish_helping_btn').click()
 
 def removeFirstStudent(self):
-    self.driver.find_element_by_class_name('remove_from_queue_btn').click()
+    self.driver.find_element(By.CLASS_NAME, 'remove_from_queue_btn').click()
     self.driver.switch_to.alert.accept()
 
 def restoreFirstStudent(self):
-    self.driver.find_element_by_class_name('queue_restore_btn').click()
+    self.driver.find_element(By.CLASS_NAME, 'queue_restore_btn').click()
     self.driver.switch_to.alert.accept()
 
 #this checks how many visible students are in the queue
 def toggleQueueFilter(self, code):
-    self.driver.find_element_by_id(f'queue_filter_{code.replace(" ", "_").upper()}').click()
+    self.driver.find_element(By.ID, f'queue_filter_{code.replace(" ", "_").upper()}').click()
 
 def closeFirstQueue(self):
-    self.driver.find_element_by_class_name('close_queue_btn').click()
+    self.driver.find_element(By.CLASS_NAME, 'close_queue_btn').click()
 
 def emptyFirstQueue(self):
-    self.driver.find_element_by_class_name('empty_queue_btn').click()
+    self.driver.find_element(By.CLASS_NAME, 'empty_queue_btn').click()
     self.driver.switch_to.alert.accept()
 
 
 def currentQueueCount(self):
-    return len(self.driver.find_elements_by_class_name("shown_queue_row"))
+    return len(self.driver.find_elements(By.CLASS_NAME, "shown_queue_row"))
 
 # counts the number of rows in the queue history
 # if limited is false it will get the fully history otherwise it will only get the limited history
 def queueHistoryCount(self, limited=True):
     if(limited):
-        return len(self.driver.find_elements_by_class_name("queue_history_row"))
+        return len(self.driver.find_elements(By.CLASS_NAME, "queue_history_row"))
     else:
         if('full_history=true' not in self.driver.current_url):
-            self.driver.find_element_by_id('view_history_button').click()
+            self.driver.find_element(By.ID, 'view_history_button').click()
 
-        count = len(self.driver.find_elements_by_class_name("queue_history_row"))
-        self.driver.find_element_by_id('view_history_button').click()
+        count = len(self.driver.find_elements(By.CLASS_NAME, "queue_history_row"))
+        self.driver.find_element(By.ID, 'view_history_button').click()
         return count
 
 # type is 'id' or 'class'
@@ -225,13 +225,13 @@ def verifyElementMissing(self, type, values):
     for value in values:
         if(type == 'id'):
             try:
-                self.driver.find_element_by_id(value)
+                self.driver.find_element(By.ID, value)
                 return False
             except:
                 pass
         elif(type == 'class'):
             try:
-                self.driver.find_element_by_class_name(value)
+                self.driver.find_element(By.CLASS_NAME, value)
                 return False
             except:
                 pass
@@ -242,13 +242,13 @@ def verifyElementMissing(self, type, values):
     return True
 
 def countAlertSuccess(self, text=[]):
-    alerts = self.driver.find_elements_by_class_name("alert-success")
+    alerts = self.driver.find_elements(By.CLASS_NAME, "alert-success")
     alerts = [ x.text for x in alerts ]
     self.assertEqual(set(alerts), set(text))
     return len(alerts)
 
 def countAlertError(self, text=[]):
-    alerts = self.driver.find_elements_by_class_name("alert-error")
+    alerts = self.driver.find_elements(By.CLASS_NAME, "alert-error")
     alerts = [ x.text for x in alerts ]
     self.assertEqual(set(alerts), set(text))
     return len(alerts)

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -23,20 +23,20 @@ class TestSidebar(BaseTestCase):
         current_idx = 0
 
         while current_idx < len(expected):
-            nav = self.driver.find_element_by_tag_name('aside')
-            links = nav.find_elements_by_tag_name('li')
-            
+            nav = self.driver.find_element(By.TAG_NAME, 'aside')
+            links = nav.find_elements(By.TAG_NAME, 'li')
+
             for link in links:
-                if not link.find_elements_by_tag_name('a'):
+                if not link.find_elements(By.TAG_NAME, 'a'):
                     links.remove(link)
 
             actual = [
-                [link.find_element_by_tag_name('a').get_attribute('href'), link.text]
+                [link.find_element(By.TAG_NAME, 'a').get_attribute('href'), link.text]
                 for link in links
             ]
             self.assertListEqual(expected, actual)
-            
-            a = links[current_idx].find_element_by_tag_name('a')
+
+            a = links[current_idx].find_element(By.TAG_NAME, 'a')
             href = a.get_attribute('href')
             if not href.startswith(base_url):
                 current_idx += 1
@@ -55,13 +55,13 @@ class TestSidebar(BaseTestCase):
                 expected_text = title_map[expected_text]
 
             heading_text = []
-            heading_text.append(self.driver.find_element_by_id('main')
-                                .find_elements_by_tag_name('h1')[0].text)
-            if(self.driver.find_element_by_id('breadcrumbs')
-               and len(self.driver.find_element_by_id('breadcrumbs')
-                       .find_elements_by_tag_name('h1')) > 0):
-                heading_text.append(self.driver.find_element_by_id('breadcrumbs')
-                                    .find_elements_by_tag_name('h1')[0].text)
+            heading_text.append(self.driver.find_element(By.ID, 'main')
+                                .find_elements(By.TAG_NAME, 'h1')[0].text)
+            if(self.driver.find_element(By.ID, 'breadcrumbs')
+               and len(self.driver.find_element(By.ID, 'breadcrumbs')
+                       .find_elements(By.TAG_NAME, 'h1')) > 0):
+                heading_text.append(self.driver.find_element(By.ID, 'breadcrumbs')
+                                    .find_elements(By.TAG_NAME, 'h1')[0].text)
             self.assertIn(expected_text, heading_text)
             current_idx += 1
 

--- a/tests/e2e/test_simple_grader.py
+++ b/tests/e2e/test_simple_grader.py
@@ -4,7 +4,6 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-import time
 
 class TestSimpleGrader(BaseTestCase):
 
@@ -56,9 +55,9 @@ class TestSimpleGrader(BaseTestCase):
     def test_example:
         # func is called once selenium is on the grading page: preloading kwargs means it does not need any arguments
         def template_func():
-            elem1 = self.driver.find_element_by_xpath("//div")
+            elem1 = self.driver.find_element(By.XPATH, "//div")
             self.assertEqual(elem.text, my_var1)
-            elem2 = self.driver.find_element_by_xpath("//span")
+            elem2 = self.driver.find_element(By.XPATH, "//span")
             self.assertEqual(elem.text, my_var2)
 
         # insert the kwargs for each function
@@ -78,8 +77,8 @@ class TestSimpleGrader(BaseTestCase):
     def test_header_text(self):
         def template_func():
             prev_section_num = None
-            for tbody_elem in self.driver.find_elements_by_xpath("//div[@class='content']/table/tbody[not(starts-with(@id, 'section-'))]"):
-                td_elem = tbody_elem.find_element_by_xpath("tr[@class='info']/td[1]")
+            for tbody_elem in self.driver.find_elements(By.XPATH, "//div[@class='content']/table/tbody[not(starts-with(@id, 'section-'))]"):
+                td_elem = tbody_elem.find_element(By.XPATH, "tr[@class='info']/td[1]")
                 # check that the header text is correct
                 self.assertEqual(expected_text, td_elem.text.strip()[:len(expected_text)])
                 preceding_removed = td_elem.text.strip()[len(expected_text)+1:]
@@ -102,7 +101,7 @@ class TestSimpleGrader(BaseTestCase):
         def template_func():
             self.driver.refresh()
             # grade the first cell (as good as any other)
-            grade_elem = self.driver.find_element_by_id("cell-0-0")
+            grade_elem = self.driver.find_element(By.ID, "cell-0-0")
             # attribute where data is stored is different for lab/numeric
             attribute = "data-score" if is_lab else "value"
             score = grade_elem.get_attribute(attribute)
@@ -122,7 +121,7 @@ class TestSimpleGrader(BaseTestCase):
             WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.XPATH, "//*[@id='cell-0-0' and @{}='{}']".format(attribute, next_score))))
             # if numeric, reset value so that test will continue to work as expected
             if next_score == "3.4":
-                grade_elem = self.driver.find_element_by_id("cell-0-0")
+                grade_elem = self.driver.find_element(By.ID, "cell-0-0")
                 grade_elem.clear()
                 grade_elem.send_keys("3.3")
                 grade_elem.send_keys(Keys.ARROW_RIGHT)

--- a/tests/e2e/test_submission.py
+++ b/tests/e2e/test_submission.py
@@ -40,9 +40,9 @@ class TestSubmission(BaseTestCase):
         if drag_and_drop:
             # create an input element of type files
             self.driver.execute_script("seleniumUpload = window.$('<input/>').attr({id: 'seleniumUpload', type:'file', multiple:'', style: 'display: none'}).appendTo('body');")
-            upload_element = self.driver.find_element_by_id("seleniumUpload")
+            upload_element = self.driver.find_element(By.ID, "seleniumUpload")
         else:
-            upload_element = self.driver.find_element_by_id(target_id).find_element_by_xpath("//input[@type='file']")
+            upload_element = self.driver.find_element(By.ID, target_id).find_element(By.XPATH, "//input[@type='file']")
         # send all the files to the element as args
         upload_element.send_keys("\n".join(file_paths))
         if drag_and_drop:
@@ -51,7 +51,7 @@ class TestSubmission(BaseTestCase):
 
     # returns the number of submissions
     def get_submission_count(self, include_zero=False):
-        return len(self.driver.find_elements_by_xpath("//div[@class='content']/select/option"+(""if include_zero else"[not(@value='0')]")))
+        return len(self.driver.find_elements(By.XPATH, "//div[@class='content']/select/option"+(""if include_zero else"[not(@value='0')]")))
 
     def accept_alerts(self, num_alerts):
         try:
@@ -66,13 +66,13 @@ class TestSubmission(BaseTestCase):
         submission_count = self.get_submission_count()
 
         # clear the previous submission files (if any)
-        clear_btn = self.driver.find_element_by_id("startnew")
+        clear_btn = self.driver.find_element(By.ID, "startnew")
         if clear_btn.is_enabled():
             clear_btn.click()
 
         # input and submit the files
         self.input_files(file_paths, drag_and_drop, target_id)
-        self.driver.find_element_by_id("submit").click()
+        self.driver.find_element(By.ID, "submit").click()
 
         # accept submission and late day limit alerts
         self.accept_alerts(2)
@@ -85,7 +85,7 @@ class TestSubmission(BaseTestCase):
 
         # create a set of file names and compare them to the displayed submitted files
         file_names = {os.path.basename(file_path) for file_path in file_paths}
-        submitted_files_text = self.driver.find_element_by_id('submitted-files').text
+        submitted_files_text = self.driver.find_element(By.ID, 'submitted-files').text
         for submitted_file_text in submitted_files_text.strip().split("\n"):
             idx = submitted_file_text.rfind('(')
             file_name = submitted_file_text[:idx-1].strip()
@@ -105,23 +105,23 @@ class TestSubmission(BaseTestCase):
 
     def change_submission_version(self):
         # find the version selection dropdown and click
-        version_select_elem = self.driver.find_element_by_xpath("//div[@class='content']/select")
+        version_select_elem = self.driver.find_element(By.XPATH, "//div[@class='content']/select")
         version_select_elem.click()
 
         # find an unselected version and click
-        new_version_elem = version_select_elem.find_element_by_xpath("//option[not(@selected) and not(@value='0')]")
+        new_version_elem = version_select_elem.find_element(By.XPATH, "//option[not(@selected) and not(@value='0')]")
         new_version = new_version_elem.get_attribute("value")
         new_version_elem.click()
 
         # wait until the page reloads to change the selected version, then click the "Grade This Version" button
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.XPATH, "//div[@class='content']/select/option[@value='{}' and @selected]".format(new_version))))
-        self.driver.find_element_by_xpath("//div[@class='content']/form/input[@type='submit' and @id='version_change']").click()
+        self.driver.find_element(By.XPATH, "//div[@class='content']/form/input[@type='submit' and @id='version_change']").click()
 
         # accept late day alert
         self.accept_alerts(1)
 
         # wait until the page reloads to change the active version, completing the test
-        select = Select(self.driver.find_element_by_id('submission-version-select'))
+        select = Select(self.driver.find_element(By.ID, 'submission-version-select'))
         select_idx = -1
         for i in range(len(select.options)):
             if select.options[i].text.endswith('GRADE THIS VERSION'):
@@ -197,7 +197,7 @@ class TestSubmission(BaseTestCase):
         self.ensure_multiple_versions()
 
         # click button and wait until page reloads to cancel version
-        self.driver.find_element_by_xpath("//div[@class='content']/form/input[@type='submit' and @id='do_not_grade']").click()
+        self.driver.find_element(By.XPATH, "//div[@class='content']/form/input[@type='submit' and @id='do_not_grade']").click()
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.XPATH, "//div[@class='content']/select/option[@value='0' and @selected]")))
 
         # change back to a valid submission version


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `find_element_by_*` and `find_elements_by_*` functions were deprecated in selenium 4. These methods were shortcuts over the `find_element` and `find_elements` methods.

### What is the new behavior?

This PR removes them in-favor of the supported and recommended method.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
