### PR TITLE
[Testing:Travis] Disable clang 6.0.0 tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -351,9 +351,9 @@ jobs:
         - sudo bash .setup/travis/setup_test_suite.sh
       script:
         - travis_wait 45 sudo python3 /usr/local/submitty/test_suite/integrationTests/run.py
-    - <<: *04-integration
-      env: CLANG_VER="6.0.0"
-      if: branch = master OR type = pull_request
+    #- <<: *04-integration
+    #  env: CLANG_VER="6.0.0"
+    #  if: branch = master OR type = pull_request
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -321,11 +321,11 @@ jobs:
             - libpcre3-dev
             - unzip
             - libboost-all-dev
-      env: CLANG_VER="5.0.1"
+      env: CLANG_VER="5.0.2"
       before_install: source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
       install:
         - export LLVM_ARCHIVE_PATH=${HOME}/clang+llvm.tar.xz
-        - wget http://releases.llvm.org/${CLANG_VER}/clang+llvm-${CLANG_VER}-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O ${LLVM_ARCHIVE_PATH}
+        - wget http://releases.llvm.org/${CLANG_VER}/clang+llvm-${CLANG_VER}-x86_64-linux-gnu-ubuntu-16.04.tar.xz -O ${LLVM_ARCHIVE_PATH}
         - mkdir ${HOME}/clang+llvm
         - tar xf ${LLVM_ARCHIVE_PATH} -C ${HOME}/clang+llvm --strip-components 1
         - export PATH=${HOME}/clang+llvm/bin:${PATH}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Download for Clang 6.0.0 is failing as the site is returning a 503 error (true for attempting to manually download it as well).

### What is the new behavior?

Test using this version of clang is disabled for now.