### PR TITLE
[UI/UX] Improved a number of pages when in dark mode

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -65,6 +65,8 @@
 
         //determines if the user has a set theme
         function detectColorScheme(){
+            document.documentElement.setAttribute("data-theme", "");
+            document.documentElement.setAttribute("data-black_mode", "");
             let theme="light";    //default to light
             //local storage is used to override OS theme settings
             if(localStorage.getItem("theme")){

--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -57,14 +57,16 @@
                 </li>
             {% endif %}
 
-            <br>
-            <select id="theme_change_select" class="form-control" aria-label="Change Submitty's Theme" onchange="updateTheme();">
-              <option value="system">Follow Device Theme</option>
-              <option value="system_black">Follow Device Theme (Black)</option>
-              <option value="light">Light Mode</option>
-              <option value="dark">Dark Mode</option>
-              <option value="dark_black">Dark Mode (Black)</option>
-            </select>
+            <li>
+              <br>
+              <select id="theme_change_select" class="form-control" aria-label="Change Submitty's Theme" onchange="updateTheme();">
+                <option value="system">Follow Device Theme</option>
+                <option value="system_black">Follow Device Theme (Black)</option>
+                <option value="light">Light Mode</option>
+                <option value="dark">Dark Mode</option>
+                <option value="dark_black">Dark Mode (Black)</option>
+              </select>
+            </li>
         </ul>
     </div>
 </div>

--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -56,15 +56,15 @@
                     </a>
                 </li>
             {% endif %}
-            <li>
-                <br>
-                <input id="theme_change" type="checkbox" title="Enable Dark Mode" class="key_to_click" onclick="toggleTheme();"></input>
-                <label for="theme_change">Enable Dark Mode</label>
-            </li>
-            <li class="light_mode_hide">
-                <input id="theme_change_black" type="checkbox" title="Enable Black Mode" class="key_to_click" onclick="toggleTheme('black');"></input>
-                <label for="theme_change_black">Enable Black Mode</label>
-            </li>
+
+            <br>
+            <select id="theme_change_select" class="form-control" aria-label="Change Submitty's Theme" onchange="updateTheme();">
+              <option value="system">Follow Device Theme</option>
+              <option value="system_black">Follow Device Theme (Black)</option>
+              <option value="light">Light Mode</option>
+              <option value="dark">Dark Mode</option>
+              <option value="dark_black">Dark Mode (Black)</option>
+            </select>
         </ul>
     </div>
 </div>

--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -17,15 +17,15 @@
                 {# When adding a new notification setting make sure to add the notification-setting-input or the email-setting-input #}
                 <div class="button-group">
                     <div class="button-row">
-                        <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="checkAll(this)">Subscribe to all notifications</button>
-                        <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional notifications</button>
-                        <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="resetNotification(this)">Reset notification settings</button>
+                        <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="checkAll(this)">Subscribe to all notifications</button>
+                        <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional notifications</button>
+                        <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="resetNotification(this)">Reset notification settings</button>
                     </div>
                     {% if email_enabled %}
                         <div class="button-row">
-                            <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="checkAll(this)">Subscribe to all emails</button>
-                            <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional emails</button>
-                            <button type="button" class="notification-setting-button btn key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="resetNotification(this)">Reset email settings</button>
+                            <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="checkAll(this)">Subscribe to all emails</button>
+                            <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional emails</button>
+                            <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="resetNotification(this)">Reset email settings</button>
                         </div>
                     {% endif %}
                 </div>

--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -52,7 +52,7 @@
                 {% set can_view = (not testcase.hidden or show_hidden) %}
                 {% set can_view_details = (not testcase.hidden or show_hidden_details and show_hidden) %}
 
-                <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:#e5e5e5;'" : "" }}>
+                <div class="box" {{ testcase.hidden and show_hidden ? "style='background-color:var(--standard-hover-light-gray);'" : "" }}>
                     <div id='tc_{{ loop.index0 }}' class="box-title key_to_click" tabindex="0"
 
                             {% if can_view_details and testcase.has_extra_results %}
@@ -64,10 +64,10 @@
                         {# Details button #}
                         {% if testcase.has_extra_results and can_view_details %}
                             <span class="loading-tools" id="details_tc_{{ loop.index0 }}" style="float:right">
-                            <span class="loading-tools-hide" style="color: #0000EE; text-decoration: underline;" hidden>
+                            <span class="loading-tools-hide" style="color: var(--standard-deep-blue); text-decoration: underline;" hidden>
                                 Hide Details
                             </span>
-                            <span class="loading-tools-show" style="color: #0000EE; text-decoration: underline;">
+                            <span class="loading-tools-show" style="color: var(--standard-deep-blue); text-decoration: underline;">
                                 Show Details
                             </span>
                             <span class="loading-tools-in-progress" aria-label="Loading Details for {{testcase.name}}" hidden>
@@ -100,11 +100,11 @@
                             <code>{{ testcase.details }}</code>
                             &nbsp;&nbsp;
                             {% if testcase.extra_credit %}
-                                <span class='italics' style="color: #0a6495;">Extra Credit</span>
+                                <span class='italics' style="color: var(--extra-credit-blue);">Extra Credit</span>
                             {% endif %}
                             &nbsp;&nbsp;
                             {% if can_view and testcase.view_testcase_message %}
-                                <span class='italics' style="color: #af0000;">{{ testcase.testcase_message }}</span>
+                                <span class='red-message'>{{ testcase.testcase_message }}</span>
                             {% endif %}
                         </h4>
                     </div>

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -67,22 +67,22 @@ fieldset[disabled] a.btn {
     pointer-events: none;
 }
 .btn-default {
-    color: var(--standard-deep-dark-gray);
+    color: var(--btn-default-text);
     background-color: var(--btn-default-white);
 }
 .btn-default:focus,
 .btn-default.focus {
-    color: var(--standard-deep-dark-gray);
+    color: var(--btn-default-text);
     background-color: var(--btn-standard-pale-blue-gray);
 }
 .btn-default:hover {
-    color: var(--standard-deep-dark-gray);
-    background-color: var(--standard-pale-gray);
+    color: var(--btn-default-text);
+    background-color: var(--btn-default-hover);
 }
 .btn-default:active,
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
-    color: var(--standard-deep-dark-gray);
+    color: var(--btn-default-text);
     background-color: var(--btn-standard-pale-blue-gray);
 }
 .btn-default:active:hover,
@@ -96,6 +96,12 @@ fieldset[disabled] a.btn {
 .open > .dropdown-toggle.btn-default.focus {
     color: var(--standard-deep-dark-gray);
     background-color: var(--standard-pale-blue);
+}
+[data-theme="dark"] .btn-default:active:focus,
+[data-theme="dark"] .btn-default:focus,
+[data-theme="dark"] .btn-default:active {
+  color: var(--btn-default-text);
+  background-color: var(--btn-default-active);
 }
 .btn-default:active,
 .btn-default.active,
@@ -223,7 +229,7 @@ fieldset[disabled] .btn-success.focus {
 }
 .btn-success .badge {
     color: var(--good-green);
-    background-color: var(--btn-default-white);
+    background-color: var(--always-default-white);
 }
 .btn-info {
     color: var(--btn-text-white);
@@ -274,7 +280,7 @@ fieldset[disabled] .btn-info.focus {
 }
 .btn-info .badge {
     color: var(--info-blue);
-    background-color: var(--btn-default-white);
+    background-color: var(--always-default-white);
 }
 .btn-warning {
     color: var(--btn-text-white);
@@ -325,7 +331,7 @@ fieldset[disabled] .btn-warning.focus {
 }
 .btn-warning .badge {
     color: var(--standard-light-orange);
-    background-color: var(--btn-default-white);
+    background-color: var(--always-default-white);
 }
 .btn-danger {
     color: var(--btn-text-white);
@@ -376,7 +382,7 @@ fieldset[disabled] .btn-danger.focus {
 }
 .btn-danger .badge {
     color: var(--dark-badge-background-red);
-    background-color: var(--btn-default-white);
+    background-color: var(--always-default-white);
 }
 .btn-link {
     font-weight: normal;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -188,7 +188,6 @@
     --standard-input-background: #ffffff;
     --checkbox-black: #000000;
     --overall-comment: #E9EFEF;
-    /* --dark-mode-black: #202225; */
     --alternating-row-color-light: #eee;
 
 
@@ -196,7 +195,6 @@
 }
 
 [data-black_mode="black"][data-theme="dark"] {
-      /* --dark-mode-black: #000000; */
       --default-white: #000000;
       --background-blue: #000000;
 }

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -34,7 +34,7 @@
 
     --default-white: #ffffff;
 
-    --btn-default-white: #ffffff;
+    --always-default-white: #ffffff;
 
     --badge-backgroud-red: #ff0000;
     --dark-badge-background-red: #ad3937;
@@ -57,6 +57,9 @@
 
     --standard-pale-blue-gray: #e8f0f7;
     --btn-standard-pale-blue-gray: #e8f0f7;
+    --btn-default-active: #e8f0f7;
+    --btn-default-white: #ffffff;
+    --btn-default-hover: #f5f5f5;
     --standard-light-blue-gray: #ddddff;
     --standard-pale-gray: #f5f5f5;
     --standard-hover-light-gray: #e5e5e5;
@@ -140,6 +143,7 @@
     --text-white: #ffffff; /*use on all colors*/
     --btn-text-white: #ffffff;
     --btn-text-black: #000000;
+    --btn-default-text: #2e2e2e;
 
     /*discussion forum*/
     --viewed-discussion-post-blue: #e8f0f7;
@@ -184,7 +188,7 @@
     --standard-input-background: #ffffff;
     --checkbox-black: #000000;
     --overall-comment: #E9EFEF;
-    --dark-mode-black: #202225;
+    /* --dark-mode-black: #202225; */
     --alternating-row-color-light: #eee;
 
 
@@ -192,7 +196,9 @@
 }
 
 [data-black_mode="black"][data-theme="dark"] {
-      --dark-mode-black: #000000;
+      /* --dark-mode-black: #000000; */
+      --default-white: #000000;
+      --background-blue: #000000;
 }
 
 [data-theme="dark"] {
@@ -229,9 +235,9 @@
       --hover-focus-info-blue: #31b0d5;
       --hover-active-all-info-blue: #269abc;
 
-      --default-white: var(--dark-mode-black);
+      --default-white: #36393f;
 
-      --btn-default-white: #ffffff;
+      --always-default-white: #ffffff;
 
       --badge-backgroud-red: #ff0000;
       --dark-badge-background-red: #ad3937;
@@ -254,6 +260,9 @@
 
       --standard-pale-blue-gray: #2a2224;
       --btn-standard-pale-blue-gray: #e8f0f7;
+      --btn-default-active: #6d6d6d;
+      --btn-default-white: #515151;
+      --btn-default-hover: #595959;
       --standard-light-blue-gray: #ddddff;
       --standard-pale-gray: #f5f5f5;
       --standard-hover-light-gray: #2B2B2B;
@@ -323,7 +332,7 @@
       --standard-light-seafoam: #a4dad5;
 
       /*the look of the webpage itself*/
-      --background-blue: var(--dark-mode-black);
+      --background-blue: #202225;
       --main-body-white: #ffffff;
       --subheading-underscore-grey: #888888;
 
@@ -337,6 +346,7 @@
       --text-white: #000000; /*use on all colors*/
       --btn-text-white: #ffffff;
       --btn-text-black: #000000;
+      --btn-default-text: #ffffff;
 
       /*discussion forum*/
       --viewed-discussion-post-blue: #e8f0f7;
@@ -375,8 +385,8 @@
       --date-picker-red: #953d3d;
 
       /* other */
-      --box-shadow-very-transparent: rgba(255,255,255,0.12);
-      --box-shadow-slightly-transparent: rgba(255,255,255,0.20);
+      --box-shadow-very-transparent: rgba(255,255,255,0);
+      --box-shadow-slightly-transparent: rgba(255,255,255,0);
       --no-image-available: #ADADAD;
       --standard-input-background: #4a4a4a;
       --checkbox-black: #5296db;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -150,6 +150,7 @@
     --deleted-discussion-post-grey: #dcdcdc;
     --important-post: #ffd700; /*is also for star color*/
     --attachment-box-color: #f5f5f5;
+    --file-upload-table-hover: #d1d1d1;
 
 
         /*these differ from the colors on the posts for some reason?
@@ -189,6 +190,9 @@
     --checkbox-black: #000000;
     --overall-comment: #E9EFEF;
     --alternating-row-color-light: #eee;
+    --grading-note: #777;
+    --file-browser-blue: #2627ee;
+    --extra-credit-blue: #0a6495;
 
 
 
@@ -239,11 +243,11 @@
 
       --badge-backgroud-red: #ff0000;
       --dark-badge-background-red: #ad3937;
-      --error-alert-dark-red: #FF4242;
+      --error-alert-dark-red: #FF7A7A;
       --gray-red: #b94a48;
 
       --alert-background-bronze: #fcf8e3;
-      --alert-border-bronze: #fbeed5;
+      --alert-border-bronze: #514123;
       --alert-bronze: #c09853;
       --alert-success-green: #468847;
       --alert-background-success-green: #dff0d8;
@@ -264,9 +268,9 @@
       --standard-light-blue-gray: #ddddff;
       --standard-pale-gray: #f5f5f5;
       --standard-hover-light-gray: #2B2B2B;
-      --standard-light-gray: #8a8a8a;
+      --standard-light-gray: #757575;
       --standard-light-medium-gray: #bbbbbb;
-      --standard-medium-gray: #888888;
+      --standard-medium-gray: #A3A3A3;
       --standard-medium-dark-gray: #666666;
       --standard-dark-gray: #5555555;
       --standard-deep-dark-gray: #2e2e2e;
@@ -280,7 +284,7 @@
       --standard-aqua: #00b3fa;
       --standard-dark-blue: #23527c;
       --standard-medium-dark-blue: #286090;
-      --standard-deep-blue: #0000ff;
+      --standard-deep-blue: #9E9EFF;
       --standard-gray-blue: #0088bf;
 
       --standard-light-red:  #d9534f;
@@ -302,7 +306,7 @@
 
       --standard-vibrant-green: #33cc33;
       --standard-medium-green: #449d44;
-      --standard-dark-green: #008000;
+      --standard-dark-green: #00BD00;
       --standard-deep-dark-green: #006600;
 
       --standard-mint-green: #00e08e;
@@ -314,14 +318,14 @@
       --standard-medium-dark-lime-green: #7dfa78;
 
       --standard-vibrant-dark-blue: #006699;
-      --standard-bronze: #856404;
+      --standard-bronze: #E6AC00;
       --standard-pastel-pink: #f2dede;
       --standard-light-pink: #ff9999;
       --standard-tangerine-yellow: #ffcc00;
       --standard-pastel-yellow: #fcf8e3;
       --standard-pale-yellow: #ffff99;
       --standard-light-yellow: #ffff66;
-      --standard-light-yellow-brown: #eac73d;
+      --standard-light-yellow-brown: #8E7306;
       --standard-beige: rgb(119, 119, 106);
       --standard-light-gold: #fff3cd;
       --standard-light-green: #427742;
@@ -351,6 +355,7 @@
       --deleted-discussion-post-grey: #dcdcdc;
       --important-post: #ffd700; /*is also for star color*/
       --attachment-box-color: #4a4a4a;
+      --file-upload-table-hover: #4a4a4a;
 
 
           /*these differ from the colors on the posts for some reason?
@@ -362,7 +367,7 @@
           black-message: #000000*/
 
       /*links*/
-      --external-link-blue: #8888F2;
+      --external-link-blue: #9B9BF3;
       --external-link-hover: #a1a1ec;
       --external-link-disabled: #888888;
       --external-link-active: #991313;
@@ -390,4 +395,7 @@
       --checkbox-black: #5296db;
       --overall-comment: #4E5353;
       --alternating-row-color-light: #4d4848;
+      --grading-note: #A8A8A8;
+      --file-browser-blue: #ffffff;
+      --extra-credit-blue: #2DACF0;
 }

--- a/site/public/css/fileinput.css
+++ b/site/public/css/fileinput.css
@@ -1,14 +1,14 @@
 #upload-boxes {
-    display: table; 
-    border-spacing: 5px; 
+    display: table;
+    border-spacing: 5px;
     width:100%;
 }
 
 .file-input {
-    cursor: pointer; 
-    text-align: center; 
-    border: dashed 2px var(--standard-light-gray); 
-    display:table-cell; 
+    cursor: pointer;
+    text-align: center;
+    border: dashed 2px var(--standard-light-gray);
+    display:table-cell;
     height: 20px;
 }
 
@@ -27,4 +27,8 @@
 /* Give file submission boxes a blue outline when they have focus (for VPAT compliance) */
 #upload-boxes > div:focus {
     outline: 2px solid var(--standard-focus-cornflowe-blue);
+}
+
+.openAllDiv {
+    color: var(--file-browser-blue);
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -593,3 +593,9 @@ body {min-width: 925px;}
 .category-sortable {
   background-color: var(--always-default-white);
 }
+
+[data-theme="dark"] .post_box,
+[data-theme="dark"] .create_thread_button,
+[data-theme="dark"] .well {
+  box-shadow: none;
+}

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -591,5 +591,5 @@ body {min-width: 925px;}
 }
 
 .category-sortable {
-  background-color: var(--btn-default-white);
+  background-color: var(--always-default-white);
 }

--- a/site/public/css/homepage.css
+++ b/site/public/css/homepage.css
@@ -12,11 +12,3 @@
     white-space: normal;
     word-wrap: break-word;
 }
-
-[data-theme="dark"] .light_mode_hide{
-  display: inline-block!important;
-}
-
-.light_mode_hide {
-  display: none!important;
-}

--- a/site/public/css/notifications.css
+++ b/site/public/css/notifications.css
@@ -74,7 +74,6 @@
 .notification-setting-button {
     flex-grow: 1;
     margin: 5px;
-    background-color: white;
 }
 
 @media (min-width: 768px) {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -242,7 +242,7 @@ table tr.table-header {
 }
 
 tr.info, tr.info td, tr.info th {
-    background-color: var(--table-info);
+    background-color: var(--alert-border-blue);
 }
 
 td>a.active-sort {
@@ -523,7 +523,7 @@ td>a.active-sort {
 }
 
 .file-upload-table tr:hover {
-    background: #d1d1d1;
+    background: var(--file-upload-table-hover);
 }
 
 .green-message {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -64,21 +64,21 @@ a.btn-default,
 a.fa.btn-default,
 a.fa,
 a > i.fa {
-    color: var(--text-black);
+    color: var(--btn-default-text);
 }
 
 a.btn-default,
 a.fas.btn-default,
 a.fas,
 a > i.fas {
-    color: var(--text-black);
+    color: var(--btn-default-text);
 }
 
 a.btn-default,
 a.far.btn-default,
 a.far,
 a > i.far {
-    color: var(--btn-text-black);
+    color: var(--btn-default-text);
 }
 
 a.btn, a.icon {
@@ -158,7 +158,7 @@ input[type="checkbox"]:checked{
 input[type="checkbox"]:checked:before {
     font-family: 'Font Awesome\ 5 Free';
     content: "\f00c";
-    color: var(--btn-default-white);
+    color: var(--always-default-white);
     font-size: 18px;
     font-weight: 900
 }
@@ -334,17 +334,21 @@ td>a.active-sort {
     flex-grow: 1;
 }
 
+[data-theme="dark"] .content {
+  box-shadow: none;
+}
+
 .content:last-child {
     flex-grow: 1;
 }
 
 .content.gradeable_message {
     background-color: var(--actionable-blue);
-    color: var(--text-white);
+    color: var(--always-default-white);
 }
 
 .content.gradeable_message a{
-    color: var(--text-white);
+    color: var(--always-default-white);
 }
 
 .content.gradeable_message p:not(:last-child){
@@ -700,7 +704,7 @@ td>a.active-sort {
 
 .green-background {
     background-color: var(--standard-deep-dark-green);
-    color: var(--btn-default-white);
+    color: var(--always-default-white);
 }
 
 .yellow-background {
@@ -1799,6 +1803,10 @@ end of styles used in the admin gradeable page
 .shadow {
     box-shadow: 0 2px 15px -5px var(--standard-medium-gray);
     border-radius: 3px;
+}
+
+[data-theme="dark"] .shadow{
+  box-shadow: none;
 }
 
 .content {

--- a/site/public/css/ta-grading.css
+++ b/site/public/css/ta-grading.css
@@ -225,7 +225,7 @@ progress::-webkit-progress-value {
 .file-viewer a:link,
 .file-viewer a:visited,
 .file-viewer a:active {
-    color: var(--external-link-blue);
+    color: var(--file-browser-blue);
 }
 
 .file-viewer a:hover {
@@ -243,7 +243,7 @@ progress::-webkit-progress-value {
 .div-viewer a:link,
 .div-viewer a:visited,
 .div-viewer a:active {
-    color: var(--external-link-blue);
+    color: var(--file-browser-blue);
 }
 
 .div-viewer a:hover {
@@ -428,7 +428,7 @@ tr.is_publish {
 }
 
 .gradeable .version-warning {
-    color:rgb(200, 0, 0);
+    color:var(--error-alert-dark-red);
     font-weight: bold;
     font-size:medium;
 }
@@ -441,7 +441,7 @@ tr.is_publish {
 }
 
 .gradeable .ta-student-comment {
-    color: #777;
+    color: var(--grading-note);
 }
 
 .gradeable .verify-container {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1580,7 +1580,6 @@ function checkSidebarCollapse() {
 
 function updateTheme(){
   let choice = $("#theme_change_select option:selected").val();
-  console.log(choice)
   if(choice === "system_black"){
     localStorage.removeItem("theme");
     localStorage.setItem("black_mode", "black");

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1578,35 +1578,43 @@ function checkSidebarCollapse() {
     }
 }
 
-//Changes the theme from light to dark mode or the reverse
-//if mode='black' it will toggle the black mode instead of the normal mode
-function toggleTheme(mode='normal'){
-  if(mode==='normal'){
-    if((!localStorage.getItem("theme") && document.documentElement.getAttribute("data-theme") !== "dark") || localStorage.getItem("theme") === "light"){
-        localStorage.setItem("theme", "dark");
-        document.documentElement.setAttribute("data-theme", "dark");
-    }else{
-      localStorage.setItem("theme", "light");
-      document.documentElement.setAttribute("data-theme", "light");
-    }
-  }else if(mode === 'black'){
-    if(localStorage.getItem('black_mode') !== 'black'){
-        localStorage.setItem("black_mode", "black");
-        document.documentElement.setAttribute("data-black_mode", "black");
-    }else{
-      localStorage.setItem("black_mode", "");
-      document.documentElement.setAttribute("data-black_mode", "");
-    }
+function updateTheme(){
+  let choice = $("#theme_change_select option:selected").val();
+  console.log(choice)
+  if(choice === "system_black"){
+    localStorage.removeItem("theme");
+    localStorage.setItem("black_mode", "black");
+  }else if(choice === "light"){
+    localStorage.setItem("theme", "light");
+  }else if(choice === "dark"){
+    localStorage.setItem("theme", "dark");
+    localStorage.setItem("black_mode", "dark");
+  }else if(choice === "dark_black"){
+    localStorage.setItem("theme", "dark");
+    localStorage.setItem("black_mode", "black");
+  }else{ //choice === "system"
+    localStorage.removeItem("black_mode");
+    localStorage.removeItem("theme");
   }
+  detectColorScheme();
 }
 $(document).ready(function() {
-  if(localStorage.getItem("theme") === "dark"){
-    $('#theme_change').prop('checked', true);
-  }else if(localStorage.getItem("theme") === null && window.matchMedia("(prefers-color-scheme: dark)").matches){
-    $('#theme_change').prop('checked', true);
-  }
-  if(localStorage.getItem("black_mode") === "black"){
-    $('#theme_change_black').prop('checked', true);
+  if(localStorage.getItem("theme")){
+      if(localStorage.getItem("theme") === "dark"){
+        if(localStorage.getItem("black_mode") === "black"){
+          $("#theme_change_select").val("dark_black");
+        }else{
+          $("#theme_change_select").val("dark");
+        }
+      }else{
+        $("#theme_change_select").val("light");
+      }
+  }else{
+    if(localStorage.getItem("black_mode") === "black"){
+      $("#theme_change_select").val("system_black");
+    }else{
+      $("#theme_change_select").val("system");
+    }
   }
 });
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There are a number of issues with dark mode.

### What is the new behavior?

Based on user feedback I switched the check-boxes to enable dark mode to a dropdown.
The dropdown has a number of options including allowing Submitty to follow the device theme. (This mostly shows up on phones where they are light theme for half the day and dark theme at night)
![image](https://user-images.githubusercontent.com/18558130/81486533-58d3af00-9223-11ea-9f7a-78ff929a1c44.png)

I also removed a number of shadows across the the website (only in dark mode) which looks a lot better overall.
![image](https://user-images.githubusercontent.com/18558130/81486557-86205d00-9223-11ea-9fa9-96ccfc2e1f72.png)
This is what it used to look like
![image](https://user-images.githubusercontent.com/18558130/81486663-4312b980-9224-11ea-86e8-d13b648b885a.png)


White buttons are no longer white and are instead a less bright color
![image](https://user-images.githubusercontent.com/18558130/81486568-9c2e1d80-9223-11ea-9666-dd4d5f39da4c.png)

Text at the top of the office hours queue is now white on blue instead of black on blue which was hard to read
![image](https://user-images.githubusercontent.com/18558130/81486603-cf70ac80-9223-11ea-81a5-c69f71d0b278.png)


