### PR TITLE
[Bugfix: Discussion Forum] Fixes button overlap for search results

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -30,7 +30,7 @@ class ForumThreadView extends AbstractView {
             array(
                 "required_rank" => 4,
                 "display_text" => 'Back to Threads',
-                "style" => 'position:relative;float:right;top:3px;margin-right:5px;',
+                "style" => 'position:relative;float:right;top:3px;margin-right:102px;',
                 "link" => array(true, $this->core->buildCourseUrl(['forum', 'threads'])),
                 "optional_class" => '',
                 "title" => 'Back to threads',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #5334
Search results have overlap between `Back To Threads` and `Create Thread` button

### What is the new behavior?
Buttons are now properly spaced
![image](https://user-images.githubusercontent.com/34754780/81489608-934e4380-9245-11ea-99b5-a38f05adb5ae.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
