### PR TITLE
[Bugfix:System] Fix program name in help message of create_term.sh

### DIFF
--- a/sbin/create_term.sh
+++ b/sbin/create_term.sh
@@ -30,7 +30,7 @@ fi
 
 # Check that there are exactly 4 command line arguments.
 if [[ $# -ne "4" ]] ; then
-    echo "Usage: create_course.sh  <term>  '<name of term>'  <start date>  <end date>"
+    echo "Usage: create_term.sh  <term>  '<name of term>'  <start date>  <end date>"
     echo "  <name of term> must be properly escaped."
     echo "  <start date> and <end date> must be in 'MM/DD/YYYY' format."
     exit 1


### PR DESCRIPTION
Fixing the error-message when using create_term.sh with not exactly 4 arguments because the stated correct usage was incorrect.

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### Related issue
Fixes #5360
