### PR TITLE
[BugFix:TAGrading] Team Gradeable Viewed Grade Checkmarks

### DIFF
--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -109,6 +109,18 @@ class Team extends AbstractModel {
     }
 
     /**
+     * Get users of team, sorted by id
+     * @return User[]
+    */
+    public function getMemberUsersSorted() {
+        $ret = $this->member_users;
+        usort($ret, function($a,$b) {
+            return strcmp($a->getId(),$b->getId());
+        });
+        return $ret;
+    }
+
+    /**
      * Get user ids of those invited to the team
      * @return string[]
     */

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -114,7 +114,7 @@ class Team extends AbstractModel {
     */
     public function getMemberUsersSorted() {
         $ret = $this->member_users;
-        usort($ret, function($a,$b) {
+        usort($ret, function ($a, $b) {
             return strcmp($a->getId(),$b->getId());
         });
         return $ret;

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -115,7 +115,7 @@ class Team extends AbstractModel {
     public function getMemberUsersSorted() {
         $ret = $this->member_users;
         usort($ret, function ($a, $b) {
-            return strcmp($a->getId(),$b->getId());
+            return strcmp($a->getId(), $b->getId());
         });
         return $ret;
     }

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -430,7 +430,7 @@
             {{ graded_gradeable.getSubmitter().getUser().getDisplayedFirstName() }}
             {{ graded_gradeable.getSubmitter().getUser().getDisplayedLastName() }}
         {% else %}
-            {%- for member in graded_gradeable.getSubmitter().getTeam().getMemberUsers() -%}
+            {%- for member in graded_gradeable.getSubmitter().getTeam().getMemberUsersSorted() -%}
                 {%- if loop.index != 1 -%}, {% endif -%}
                 {{- member.getDisplayedFirstName() }}
                 {{ member.getDisplayedLastName() -}}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Closes #5331 
Currently, on the Grade Details page of a team assignment (go to grade --> grading index) the order in which Team Members are listed sometimes don't match the order of their corresponding Viewed Grade checkmarks which are ordered by username.

### What is the new behavior?
Now the team member names should be listed based on lexicographical order of the members' usernames.

### Other information?
I wasn't able to recreate the bug on my VM. I tried changing the legal and preferred names of Alyssa P Hacker to be Zalyssa P Zhacker and she still appeared to be listed first (as she should be by her username aphacker). In addition, I made it so that Alyssa did not create the team (Rachel Crona did), and Alyssa is still listed first.
![bug](https://user-images.githubusercontent.com/43322572/81603226-023db080-939c-11ea-8fbe-eb78d078daed.png)
