### PR TITLE
 [Bugfix:InstructorUI] Stops submitty from being used in iframe and stops external domain redirects on login

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -75,7 +75,6 @@ class AuthenticationController extends AbstractController {
         if (!is_null($old) && !Utils::startsWith(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
             $old = null;
         }
-        header('X-Frame-Options: DENY'); // Stops clickjacking on all pages
         return MultiResponse::webOnlyResponse(
             new WebResponse('Authentication', 'loginForm', $old)
         );

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -72,6 +72,10 @@ class AuthenticationController extends AbstractController {
      * @return MultiResponse
      */
     public function loginForm($old = null) {
+        if (!is_null($old) && !Utils::startsWith($old, $this->core->getConfig()->getBaseUrl())) {
+            $old = null;
+        }
+        header('X-Frame-Options: DENY'); // Stops clickjacking on all pages
         return MultiResponse::webOnlyResponse(
             new WebResponse('Authentication', 'loginForm', $old)
         );
@@ -89,6 +93,9 @@ class AuthenticationController extends AbstractController {
      * @return MultiResponse
      */
     public function checkLogin($old = null) {
+        if (!is_null($old) && !Utils::startsWith($old, $this->core->getConfig()->getBaseUrl())) {
+            $old = null;
+        }
         if (isset($old)) {
             $old = urldecode($old);
         }

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -72,7 +72,7 @@ class AuthenticationController extends AbstractController {
      * @return MultiResponse
      */
     public function loginForm($old = null) {
-        if (!is_null($old) && !Utils::startsWith($old, $this->core->getConfig()->getBaseUrl())) {
+        if (!is_null($old) && !Utils::startsWith(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
             $old = null;
         }
         header('X-Frame-Options: DENY'); // Stops clickjacking on all pages
@@ -93,7 +93,7 @@ class AuthenticationController extends AbstractController {
      * @return MultiResponse
      */
     public function checkLogin($old = null) {
-        if (!is_null($old) && !Utils::startsWith($old, $this->core->getConfig()->getBaseUrl())) {
+        if (!is_null($old) && !Utils::startsWith(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
             $old = null;
         }
         if (isset($old)) {

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -99,6 +99,9 @@ $core->getOutput()->addBreadcrumb("Submitty", $core->getConfig()->getBaseUrl());
 
 date_default_timezone_set($core->getConfig()->getTimezone()->getName());
 
+// Stops clickjacking on all pages
+header('X-Frame-Options: DENY');
+
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', 1);
 if ($core->getConfig()->isDebug()) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Submitty has the chance of redirecting users to other domains when they log in.
Submitty could be put into an iframe to trick users into giving their passwords to another website

### What is the new behavior?

Redirects now always check that the url they are redirecting to on login comes from submitty's domain
The Submitty login page will no longer work in an iframe
fixes #5265
fixes #5264

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
To test:
Log out of submitty 
make an html file with the content of this issue #5264 
the page should not work
then go to this url http://localhost:1501/authentication/login?old=https://duck.com and log in
it should not redirect to duck.com and just go to the main submitty homepage
