### PR TITLE
Fix notebook markdown rendering issues

### DIFF
--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -12,12 +12,6 @@
     margin-right: 0;
 }
 
-.notebook p
-{
-    margin-top: 2px;
-    margin-bottom: 2px;
-}
-
 .notebook ul {
     padding-left: 3rem;
 }
@@ -50,13 +44,6 @@ fieldset.mc {
 .mc > label > :nth-child(2)
 {
     display: inline;
-}
-
-/* Clear top margin for items that live inside a single multiple choice description */
-/* Useful for several newline separated headers inside a single markdown item  */
-.mc > label > *
-{
-    margin-top: 0;
 }
 
 /* Style the color of notebook feedback messages */
@@ -92,4 +79,33 @@ textarea.sa-box {
     width: 60em; 
     height: 100%; 
     min-height: 110px;
+}
+
+.mc label {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.mc input[type='checkbox'],
+.mc input[type='radio'] {
+    margin: 5px;
+}
+
+.mc pre {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+/* Add some margin for informational content that is inside <p> tags */
+.notebook li,
+.notebook p {
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+
+/* Clear that margin for <p> tags that are part of a multiple choice input */
+.notebook fieldset p {
+    margin-top: 0;
+    margin-bottom: 0;
 }


### PR DESCRIPTION
Closes #4381

### What is the current behavior?
Some issues relating to notebook gradeable formatting outlined in #4381

### What is the new behavior?
Notebook gradeable CSS has been cleaned up a bit to add vertical space where it is needed.  Instructors shouldn't need to add 'alignment' spaces when constructing multi-line code multiple choice options.

### Other information?
<!-- How did you test -->
Tested using Lesson 1 and Lesson 3 of the CPP crash course.

![1](https://user-images.githubusercontent.com/7605020/81731294-ba329280-945c-11ea-9566-709cc7a16d4d.png)
![2](https://user-images.githubusercontent.com/7605020/81731300-ba329280-945c-11ea-8a51-a072ba8dbcf5.png)
![3](https://user-images.githubusercontent.com/7605020/81731455-f36b0280-945c-11ea-92b7-c49b35c2850a.png)

