### PR TITLE
[Bugfix:TAGrading] Fixing inability to switch to drawing sometimes

### DIFF
--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -2,7 +2,6 @@ if (PDFAnnotate.default) {
   PDFAnnotate = PDFAnnotate.default;
 }
 
-var loaded = sessionStorage.getItem('toolbar_loaded');
 window.onbeforeunload = function() {
     sessionStorage.removeItem('toolbar_loaded');
 };
@@ -176,9 +175,7 @@ window.onbeforeunload = function() {
     function handleToolbarClick(e){
         setActiveToolbarItem(e.target.getAttribute('value'));
     }
-    if(!loaded){
-        document.getElementById('pdf_annotation_icons').addEventListener('click', handleToolbarClick);
-    }
+    document.getElementById('pdf_annotation_icons').addEventListener('click', handleToolbarClick);
     sessionStorage.setItem('toolbar_loaded', true);
 })();
 
@@ -214,11 +211,9 @@ window.onbeforeunload = function() {
             document.getElementById('color_selector').style.backgroundColor = color;
         }
     }
-    if(!loaded){
-        document.getElementById("color_selector").addEventListener('click', colorMenuToggle);
-        document.getElementById("size_selector").addEventListener('click', sizeMenuToggle);
-        document.addEventListener('colorchange', changeColor);
-    }
+    document.getElementById("color_selector").addEventListener('click', colorMenuToggle);
+    document.getElementById("size_selector").addEventListener('click', sizeMenuToggle);
+    document.addEventListener('colorchange', changeColor);
     initColors();
 })();
 
@@ -300,14 +295,12 @@ window.onbeforeunload = function() {
             PDFAnnotate.UI.setText(textSize, textColor);
         }
     }
-    if(!loaded){
-        document.addEventListener('colorchange', function(e){
-            setText(textSize, e.srcElement.getAttribute('value'));
-        });
-        document.getElementById('text_size_selector').addEventListener('change', function(e) {
-            let value = e.target.value ? e.target.value : e.srcElement.value;
-            setText(value, textColor);
-        });
-    }
+    document.addEventListener('colorchange', function(e){
+        setText(textSize, e.srcElement.getAttribute('value'));
+    });
+    document.getElementById('text_size_selector').addEventListener('change', function(e) {
+        let value = e.target.value ? e.target.value : e.srcElement.value;
+        setText(value, textColor);
+    });
     initText();
 })();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Sometimes, when a grader attempts to annotate a pdf and clicks the pencil icon, the pencil will be highlighted, but when the uses tries to draw an annotation, the pencil icon is unhighlighted and the user cannot draw an annotation. This seems to occur when the user tries to interact with the pdf annotation bar before everything is fully loaded (the panel gives no feedback as to when everything is loaded, so it's easy to interact with the page before it's loaded).

I've had trouble reproducing this bug realiable. 

### What is the new behavior?

The grader will be able to select the pencil and annotate as normal all the time.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
