### PR TITLE
[Feature:Autograding] Log dispatched actions for a submission

### DIFF
--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -8,7 +8,7 @@
 export AnalysisTools_Version=v.18.06.00
 export Lichen_Version=v20.05.00
 export RainbowGrades_Version=v19.07.00
-export Tutorial_Version=v20.01.00
+export Tutorial_Version=v20.05.00
 export SysadminTools_Version=v20.01.00
 
 # JAVA

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -1125,7 +1125,7 @@ void cin_reader(std::mutex* lock, std::queue<std::string>* input_queue, bool* CH
 
   std::ofstream dispatched_actions_file;
 
-  dispatched_actions_file.open ("dispatched_actions.txt");
+  dispatched_actions_file.open ("dispatched_actions.txt", std::ofstream::app);
 
   try
   {

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -1123,6 +1123,10 @@ void cin_reader(std::mutex* lock, std::queue<std::string>* input_queue, bool* CH
   std::cout << "thread function " << getpid() << std::endl;
   std::string my_string;
 
+  std::ofstream dispatched_actions_file;
+
+  dispatched_actions_file.open ("dispatched_actions.txt");
+
   try
   {
     struct pollfd fds;
@@ -1140,6 +1144,7 @@ void cin_reader(std::mutex* lock, std::queue<std::string>* input_queue, bool* CH
         lock->lock();
         input_queue->push(my_string);
         lock->unlock();
+        dispatched_actions_file << getTimestamp() << my_string  << std::endl;
       }
     }
   }
@@ -1161,7 +1166,7 @@ std::string getTimestamp() {
       now.time_since_epoch()) % 1000;
   std::stringstream nowSs;
   nowSs
-      << std::put_time(std::localtime(&nowAsTimeT), "%m/%d/%y %T")
+      << std::put_time(std::localtime(&nowAsTimeT), "%Y/%m/%d %T")
       << '.' << std::setfill('0') << std::setw(3) << nowMs.count() << " ";
   return nowSs.str();
 }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -53,6 +53,8 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
     whole_config["autograding"]["work_to_details"].push_back("input_*.txt");
     //todo check up on how this works.
     whole_config["autograding"]["work_to_details"].push_back("test*/input_*.txt");
+    // archive the timestamped dispatcher actions
+    whole_config["autograding"]["work_to_details"].push_back("**/dispatched_actions.txt");
   }
 
   if (whole_config["autograding"].find("use_checkout_subdirectory") == whole_config["autograding"].end()) {


### PR DESCRIPTION
This PR:
1. Adds a ```dispatched_actions.txt``` file per container (or one for a jailed sandbox) when autograding. This file contains the timestamped dispatcher actions taken against the student's code.
2. Changes timestamping from ```%m/%d/%y %T``` to ```%Y/%m/%d %T``` to allow simple  lexicographical sorting.

For discussion: right now there are three "signals" that an instructor can send to a student process, "stop," "start," and "kill." Internally, these are represented by the strings ```SUBMITTY_SIGNAL:STOP```, ```SUBMITTY_SIGNAL:START```, and ```SUBMITTY_SIGNAL:KILL```. Additionally, there is a ```SUBMITTY_SIGNAL:FINALMESSAGE```, which is always the last message sent by the dispatcher.

In its current state, this PR exposes these strings to the student/instructor, as it adds them to the ```dispatched_actions.txt``` file. However, if we prefer, it would be simple to convert them to more user friendly strings (e.g. ```STOP SIGNAL RECEIVED```). 