### PR TITLE
[UI:Mobile] Add mobile screen view for the grade-report page 

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -41,6 +41,7 @@ class ReportController extends AbstractController {
         }
 
         $grade_summaries_last_run = $this->getGradeSummariesLastRun();
+        $this->core->getOutput()->enableMobileViewport();
 
         $this->core->getOutput()->renderOutput(array('admin', 'Report'), 'showReportUpdates', $grade_summaries_last_run);
     }

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -1,63 +1,67 @@
-<div class="content">
-
+<div id="grade-report-cont" class="content">
     <script>
-
         $(document).ready(function() {
-
             // Bind click listener to grade summaries button
             $('#grade-summaries-button').click(function() {
                 $('#grade-summaries-last-run').html('Running...');
             });
-
         });
-
     </script>
 
-    <h1>Grade Reports</h1>
     {# This is a layout table #}
-    <table>
-        <tbody>
-            <tr>
-                <th style="width:50%;font-weight:normal;text-align:left">
-                    <p> Pushing this button will update the grade summary data used to generate the rainbow grades reports.
-                    </p>
-                </td>
-                <td style="width:5%"> </td>
-                <td style="position:relative;width:45%">
-                    <button id="grade-summaries-button" onclick="location.href='{{ summaries_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate Grade Summaries</button>
-                </td>
-            </tr>
-            <tr style="height:10px"><td colspan="3"></td></tr>
-            <tr>
-                <td style="width:50%"> </td>
-                <td style="width:5%"> </td>
-                <td style="text-align: center;width:45%">
+    <div id="grade-report">
+        <h1>Grade Reports</h1>
+        <div id="grade-report-summary" class="card">
+            <div class="title-cont">
+                Pushing this button will update the grade summary data used to generate the rainbow grades reports.
+            </div>
+            <div class="card-btn-cont">
+                <button id="grade-summaries-button"
+                        onclick="location.href='{{ summaries_url }}'"
+                        class="btn btn-primary key_to_click"
+                        tabindex="0"
+                >
+                    Generate Grade Summaries
+                </button>
+                <div class="card-btn-info">
                     Last ran: <span id="grade-summaries-last-run">{{ grade_summaries_last_run }}</span>
-                </td>
-            </tr>
-            <tr class="bar"><td colspan="3"></td></tr>
-            <tr class="bar"><td colspan="3"></td></tr>
-            <tr>
-                <th style="width:50%;font-weight:normal;text-align:left">
-                    <p>Pushing this button will generate a CSV file (for download) with all student grades for all gradeables. </p>
-                </td>
-                <td style="width:5%"> </td>
-                <td style="width:45%; position:relative">
-                    <button onclick="location.href='{{ csv_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Generate CSV Report</button>
-                </td>
-            </tr>
-            <tr class="bar"><td colspan="3"></td></tr>
-            <tr class="bar"><td colspan="3"></td></tr>
-            <tr>
-                <th style="width:50%;font-weight:normal;text-align:left">
-                    <p><em><b>NOTE: Work in Progress</b></em><br>Web interface for creation and customization of Rainbow Grades for this course.<br>
-                    <a target=_blank href="https://submitty.org/instructor/rainbow_grades/">Rainbow Grades Documentation<i style="font-style:normal;" class="fa-question-circle"></i></a></p>
-                </td>
-                <td style="width:5%"> </td>
-                <td style="position:relative;width:45%">
-                    <button onclick="location.href='{{ rainbow_grades_customization_url }}'" class="btn btn-primary key_to_click" tabindex="0" style="width:100%;position:absolute;top:50%;transform:translate(0,-50%);">Web-Based Rainbow Grades Generation</button>
-                </td>
-            </tr>
-            <tbody>
-    </table>
+                </div>
+            </div>
+        </div>
+        <div id="grade-report-summary" class="card">
+            <div class="title-cont">
+                Pushing this button will generate a CSV file (for download) with all student grades for all gradeables.
+            </div>
+            <div class="card-btn-cont">
+                <button onclick="location.href='{{ csv_url }}'"
+                        class="btn btn-primary key_to_click"
+                        tabindex="0"
+                >
+                    Generate CSV Report
+                </button>
+            </div>
+        </div>
+        <div id="grade-report-summary" class="card">
+            <div class="title-cont">
+                <em><b>NOTE: Work in Progress</b></em>
+                <br>
+                Web interface for creation and customization of Rainbow Grades for this course.
+                <br>
+                <a target=_blank
+                   href="https://submitty.org/instructor/rainbow_grades/"
+                >
+                    Rainbow Grades Documentation
+                    <i style="font-style:normal;" class="fa-question-circle"></i>
+                </a>
+            </div>
+            <div class="card-btn-cont">
+                <button onclick="location.href='{{ rainbow_grades_customization_url }}'"
+                        class="btn btn-primary key_to_click"
+                        tabindex="0"
+                >
+                    Web-Based Rainbow Grades Generation
+                </button>
+            </div>
+        </div>
+    </div>
 </div>

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -8,7 +8,6 @@
         });
     </script>
 
-    {# This is a layout table #}
     <div id="grade-report">
         <h1>Grade Reports</h1>
         <div id="grade-report-summary" class="card">
@@ -28,6 +27,7 @@
                 </div>
             </div>
         </div>
+        <hr>
         <div id="grade-report-csv" class="card">
             <div class="title-cont">
                 Pushing this button will generate a CSV file (for download) with all student grades for all gradeables.
@@ -41,6 +41,7 @@
                 </button>
             </div>
         </div>
+        <hr>
         <div id="grade-report-rainbow" class="card">
             <div class="title-cont">
                 <em><b>NOTE: Work in Progress</b></em>

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -28,7 +28,7 @@
                 </div>
             </div>
         </div>
-        <div id="grade-report-summary" class="card">
+        <div id="grade-report-csv" class="card">
             <div class="title-cont">
                 Pushing this button will generate a CSV file (for download) with all student grades for all gradeables.
             </div>
@@ -41,7 +41,7 @@
                 </button>
             </div>
         </div>
-        <div id="grade-report-summary" class="card">
+        <div id="grade-report-rainbow" class="card">
             <div class="title-cont">
                 <em><b>NOTE: Work in Progress</b></em>
                 <br>

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -7,6 +7,7 @@ use app\views\AbstractView;
 class ReportView extends AbstractView {
     public function showReportUpdates($grade_summaries_last_run) {
         $this->core->getOutput()->addBreadcrumb('Grade Reports');
+        $this->core->getOutput()->addInternalCss('grade-report.css');
         return $this->core->getOutput()->renderTwigTemplate("admin/Report.twig", [
             'summaries_url' => $this->core->buildCourseUrl(['reports', 'summaries']),
             'csv_url' => $this->core->buildCourseUrl(['reports', 'csv']),

--- a/site/public/css/grade-report.css
+++ b/site/public/css/grade-report.css
@@ -1,0 +1,56 @@
+.card {
+    display: flex;
+    padding: 24px 0;
+    text-align: left;
+}
+
+.title-cont {
+    flex: 1;
+    margin-right: 15px;
+}
+
+.card-btn-cont {
+    flex: 1;
+    text-align: center;
+}
+.card-btn-cont .btn {
+    white-space: normal;
+    width: 90%;
+}
+
+
+@media (max-width: 780px) {
+    .card {
+        /*border: 1px solid var(--btn-text-black); */
+        text-align: center;
+        flex-direction: column;
+        padding: 24px 12px;
+        margin-bottom: 14px;
+        transition: all 0.2s;
+        border: 1px solid var(--text-black);
+    }
+    .card:hover {
+        box-shadow: 1px 3px 5px;
+        translate: 0 -5px;
+    }
+    .title-cont {
+        width: unset;
+    }
+    .card-btn-cont {
+        width: unset;
+        margin: 12px 0;
+    }
+    .card-btn-info {
+        margin-top: 8px;
+    }
+}
+
+@media (max-width: 541px) {
+    #grade-report-cont.content {
+        padding: 20px;
+        margin: 15px 0;
+    }
+    #grade-report h1 {
+        font-weight: 500;
+    }
+}

--- a/site/public/css/grade-report.css
+++ b/site/public/css/grade-report.css
@@ -1,7 +1,17 @@
+#grade-report-cont.content {
+    padding: 20px;
+    margin: 15px 0;
+}
+#grade-report h1 {
+    font-weight: 500;
+}
+
 .card {
     display: flex;
-    padding: 24px 0;
-    text-align: left;
+    text-align: center;
+    flex-direction: column;
+    padding: 24px 12px;
+    margin-bottom: 14px;
 }
 
 .title-cont {
@@ -12,45 +22,38 @@
 .card-btn-cont {
     flex: 1;
     text-align: center;
+    margin: 12px 0;
 }
+
+.card-btn-info {
+    margin-top: 8px;
+}
+
 .card-btn-cont .btn {
     white-space: normal;
     width: 90%;
 }
 
-
-@media (max-width: 780px) {
-    .card {
-        /*border: 1px solid var(--btn-text-black); */
-        text-align: center;
-        flex-direction: column;
-        padding: 24px 12px;
-        margin-bottom: 14px;
-        transition: all 0.2s;
-        border: 1px solid var(--text-black);
+@media (min-width: 541px) {
+    #grade-report-cont.content {
+        padding: 30px;
+        margin: 30px;
     }
-    .card:hover {
-        box-shadow: 1px 3px 5px;
-        translate: 0 -5px;
-    }
-    .title-cont {
-        width: unset;
-    }
-    .card-btn-cont {
-        width: unset;
-        margin: 12px 0;
-    }
-    .card-btn-info {
-        margin-top: 8px;
+    #grade-report h1 {
+        font-weight: bold;
     }
 }
 
-@media (max-width: 541px) {
-    #grade-report-cont.content {
-        padding: 20px;
-        margin: 15px 0;
+@media (min-width: 780px) {
+    .card {
+        padding: 24px 0;
+        text-align: left;
+        flex-direction: row;
     }
-    #grade-report h1 {
-        font-weight: 500;
+    .card-btn-cont {
+        margin: 0;
+    }
+    .card-btn-info {
+        margin-top: 0;
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currenlty the page layout breaks on smaller screen devices...
![Screenshot 2020-05-25 at 7 51 32 PM](https://user-images.githubusercontent.com/48342617/82837732-d1906780-9ec1-11ea-93c1-cc50a287ec49.png)

### What is the new behavior?
Added responsiveness and now the page looks like this
![image](https://user-images.githubusercontent.com/48342617/82837829-2d5af080-9ec2-11ea-987c-43a1975bfda8.png)

### Other information?
Involves a little code refactoring also as I scrapped out the table layout plus inline styling in the report page and created a different CSS file for styling.