### PR TITLE
[VPAT] Stop tabbing from escaping modals

### DIFF
--- a/site/app/templates/forum/SplitPostForm.twig
+++ b/site/app/templates/forum/SplitPostForm.twig
@@ -36,6 +36,7 @@
     <script>
         function disableIfEmpty(obj, id) {
             document.getElementById(id).disabled = obj.value.length === 0;
+              captureTabInModal('popup-post-split', false);
         }
     </script>
 

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -31,7 +31,7 @@
             <button title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown key_to_click"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
-        <a class="btn btn-primary key_to_click" tabindex = "0" id="merge-thread-btn" title="Merge Thread Into Another Thread" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>
+        <a class="btn btn-primary key_to_click" tabindex = "0" id="merge-thread-btn" title="Merge Thread Into Another Thread" onclick="$('#merge-threads').css('display', 'block'); captureTabInModal('merge-threads');">Merge Threads</a>
     {% endif %}
     {% if show_lock_date and core.getUser().getGroup() <= 2 %}
         <label id="label_lock_thread" for="lock_thread_date"> Lock Thread Date

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -31,7 +31,7 @@
             <button title="Insert italic text" type="button" onclick="addMarkdownCode(3, $(this).closest('.thread-post-form').find('[name=thread_post_content]'))" class="btn btn-default btn_markdown key_to_click"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
         </span>
     {% if show_merge_thread_button and core.getUser().accessGrading() %}
-        <a class="btn btn-primary key_to_click" tabindex = "0" id="merge-thread-btn" title="Merge Thread Into Another Thread" onclick="$('#merge-threads').css('display', 'block'); captureTabInModal('merge-threads');">Merge Threads</a>
+        <a class="btn btn-primary key_to_click" tabindex = "0" id="merge-thread-btn" title="Merge Thread Into Another Thread" onclick="$('#merge-threads').css('display', 'block');">Merge Threads</a>
     {% endif %}
     {% if show_lock_date and core.getUser().getGroup() <= 2 %}
         <label id="label_lock_thread" for="lock_thread_date"> Lock Thread Date

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -40,6 +40,7 @@
         $('#' + id).hide();
     }
 
+    // Runs captureTabInModal() automatically when the popup is unhidden
     (function() {
       let targetNode = document.getElementById('{{ block('popup_id') }}');
       let observer = new MutationObserver(function(){

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -39,4 +39,15 @@
     function closePopup(id) {
         $('#' + id).hide();
     }
+
+    (function() {
+      let targetNode = document.getElementById('{{ block('popup_id') }}');
+      let observer = new MutationObserver(function(){
+          if(targetNode.style.display != 'none'){
+              console.log("{{ block('popup_id') }} is visible")
+              captureTabInModal('{{ block('popup_id') }}');
+          }
+      });
+      observer.observe(targetNode, { attributes: true, childList: true });
+    })();
 </script>

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -39,16 +39,4 @@
     function closePopup(id) {
         $('#' + id).hide();
     }
-
-    // Runs captureTabInModal() automatically when the popup is unhidden
-    (function() {
-      let targetNode = document.getElementById('{{ block('popup_id') }}');
-      let observer = new MutationObserver(function(){
-          if(targetNode.style.display != 'none'){
-              console.log("{{ block('popup_id') }} is visible")
-              captureTabInModal('{{ block('popup_id') }}');
-          }
-      });
-      observer.observe(targetNode, { attributes: true, childList: true });
-    })();
 </script>

--- a/site/public/js/directory.js
+++ b/site/public/js/directory.js
@@ -4,6 +4,7 @@ function newDownloadForm() {
     $('.popup-form').css('display', 'none');
     var form = $('#download-form');
     form.css('display', 'block');
+    captureTabInModal("download-form");
     form.find('.form-body').scrollTop(0);
     $("#download-form input:checkbox").each(function() {
         if ($(this).val() === 'NULL') {
@@ -20,6 +21,7 @@ function newClassListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#class-list-form");
     form.css("display", "block");
+    captureTabInModal("class-list-form");
     form.find('.form-body').scrollTop(0);
     $('[name="move_missing"]', form).prop('checked', false);
     $('[name="upload"]', form).val(null);
@@ -30,6 +32,7 @@ function newGraderListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#grader-list-form");
     form.css("display", "block");
+    captureTabInModal("grader-list-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
     $("#grader-list-upload").focus();
@@ -38,6 +41,7 @@ function newGraderListForm() {
 function editRegistrationSectionsForm() {
     var form = $("#registration-sections-form");
     form.css("display","block");
+    captureTabInModal("registration-sections-form");
     form.find('.form-body').scrollTop(0);
     $("#instructor_all").focus();
 }

--- a/site/public/js/directory.js
+++ b/site/public/js/directory.js
@@ -4,7 +4,6 @@ function newDownloadForm() {
     $('.popup-form').css('display', 'none');
     var form = $('#download-form');
     form.css('display', 'block');
-    captureTabInModal("download-form");
     form.find('.form-body').scrollTop(0);
     $("#download-form input:checkbox").each(function() {
         if ($(this).val() === 'NULL') {
@@ -21,7 +20,6 @@ function newClassListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#class-list-form");
     form.css("display", "block");
-    captureTabInModal("class-list-form");
     form.find('.form-body').scrollTop(0);
     $('[name="move_missing"]', form).prop('checked', false);
     $('[name="upload"]', form).val(null);
@@ -32,7 +30,6 @@ function newGraderListForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#grader-list-form");
     form.css("display", "block");
-    captureTabInModal("grader-list-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
     $("#grader-list-upload").focus();
@@ -41,7 +38,6 @@ function newGraderListForm() {
 function editRegistrationSectionsForm() {
     var form = $("#registration-sections-form");
     form.css("display","block");
-    captureTabInModal("registration-sections-form");
     form.find('.form-body').scrollTop(0);
     $("#instructor_all").focus();
 }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -277,6 +277,7 @@ function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_to
                 $('#thread_post_anon_edit').remove();
             }
             $('#edit-user-post').css('display', 'block');
+            captureTabInModal("edit-user-post");
 
             $(".cat-buttons input").prop('checked', false);
 
@@ -681,6 +682,7 @@ function showSplit(post_id) {
         }
       }
       $("#popup-post-split").show();
+      captureTabInModal("popup-post-split");
     },
     error: function(){
       window.alert("Something went wrong while trying to get post information for splitting. Try again later.");
@@ -711,6 +713,7 @@ function showHistory(post_id) {
                 return;
             }
             $("#popup-post-history").show();
+            captureTabInModal("popup-post-history");
             $("#popup-post-history .post_box.history_box").remove();
             $("#popup-post-history .form-body").css("padding", "5px");
             var dummy_box = $($("#popup-post-history .post_box")[0]);
@@ -1399,7 +1402,7 @@ function updateSelectedThreadContent(selected_thread_first_post_id){
                 $('#messages').append(message);
                 return;
             }
-            
+
             json = json['data'];
             $("#thread-content").html(json['post']);
             if (json.markdown === true) {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -277,7 +277,6 @@ function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_to
                 $('#thread_post_anon_edit').remove();
             }
             $('#edit-user-post').css('display', 'block');
-            captureTabInModal("edit-user-post");
 
             $(".cat-buttons input").prop('checked', false);
 
@@ -662,6 +661,7 @@ function showSplit(post_id) {
       } else {
         document.getElementById("split_post_previously_merged").style.display = "block";
         document.getElementById("split_post_submit").disabled = false;
+        captureTabInModal('popup-post-split', false);
       }
       document.getElementById("split_post_input").value = json['title'];
       document.getElementById("split_post_id").value = post_id;
@@ -682,7 +682,6 @@ function showSplit(post_id) {
         }
       }
       $("#popup-post-split").show();
-      captureTabInModal("popup-post-split");
     },
     error: function(){
       window.alert("Something went wrong while trying to get post information for splitting. Try again later.");
@@ -713,7 +712,6 @@ function showHistory(post_id) {
                 return;
             }
             $("#popup-post-history").show();
-            captureTabInModal("popup-post-history");
             $("#popup-post-history .post_box.history_box").remove();
             $("#popup-post-history .form-body").css("padding", "5px");
             var dummy_box = $($("#popup-post-history .post_box")[0]);

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -277,6 +277,7 @@ function editPost(post_id, thread_id, shouldEditThread, render_markdown, csrf_to
                 $('#thread_post_anon_edit').remove();
             }
             $('#edit-user-post').css('display', 'block');
+            captureTabInModal("edit-user-post");
 
             $(".cat-buttons input").prop('checked', false);
 
@@ -682,6 +683,7 @@ function showSplit(post_id) {
         }
       }
       $("#popup-post-split").show();
+      captureTabInModal("popup-post-split");
     },
     error: function(){
       window.alert("Something went wrong while trying to get post information for splitting. Try again later.");
@@ -712,6 +714,7 @@ function showHistory(post_id) {
                 return;
             }
             $("#popup-post-history").show();
+            captureTabInModal("popup-post-history");
             $("#popup-post-history .post_box.history_box").remove();
             $("#popup-post-history .form-body").css("padding", "5px");
             var dummy_box = $($("#popup-post-history .post_box")[0]);

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -194,6 +194,7 @@ function newDeleteGradeableForm(form_action, gradeable_name) {
     $('[id="delete-gradeable-message"]', form).append('<b>'+gradeable_name+'</b>');
     $('[name="delete-confirmation"]', form).attr('action', form_action);
     form.css("display", "block");
+    captureTabInModal("delete-gradeable-form");
 }
 
 function displayCloseSubmissionsWarning(form_action,gradeable_name) {
@@ -203,6 +204,7 @@ function displayCloseSubmissionsWarning(form_action,gradeable_name) {
     $('[id="close-submissions-message"]', form).append('<b>'+gradeable_name+'</b>');
     $('[name="close-submissions-confirmation"]', form).attr('action', form_action);
     form.css("display", "block");
+    captureTabInModal("close-submissions-form");
     form.find('.form-body').scrollTop(0);
 }
 
@@ -229,6 +231,7 @@ function newDeleteCourseMaterialForm(path, file_name) {
     $('.delete-course-material-message', form).append('<b>'+file_name+'</b>');
     $('[name="delete-confirmation"]', form).attr('action', url);
     form.css("display", "block");
+    captureTabInModal("delete-course-material-form");
     form.find('.form-body').scrollTop(0);
 }
 
@@ -236,6 +239,7 @@ function newUploadImagesForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#upload-images-form");
     form.css("display", "block");
+    captureTabInModal("upload-images-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
 }
@@ -260,6 +264,7 @@ function newUploadCourseMaterialsForm() {
     $('[name="existing-file-list"]', form).append('<b>'+JSON.stringify(files)+'</b>');
 
     form.css("display", "block");
+    captureTabInModal("upload-course-materials-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
 
@@ -298,6 +303,7 @@ function newEditCourseMaterialsForm(path, this_file_section, this_hide_from_stud
     }
     $("#material-edit-form", form).attr('data-directory', path);
     form.css("display", "block");
+    captureTabInModal("edit-course-materials-form");
 }
 function captureTabInModal(formName, resetFocus=true){
     releaseTabFromModal(formName);
@@ -344,6 +350,8 @@ function setFolderRelease(changeActionVariable,releaseDates,id,inDir){
     var form = $("#set-folder-release-form");
     form.css("display", "block");
 
+    captureTabInModal("set-folder-release-form");
+
     form.find('.form-body').scrollTop(0);
     $('[id="release_title"]',form).attr('data-path',changeActionVariable);
     $('[name="release_date"]', form).val(releaseDates);
@@ -363,6 +371,7 @@ function deletePlagiarismResultAndConfigForm(form_action, gradeable_title) {
     $('[name="delete"]', form).attr('action', form_action);
     form.css("display", "block");
     form.find('.form-body').scrollTop(0);
+    captureTabInModal("delete-plagiarism-result-and-config-form");
 }
 
 function addMorePriorTermGradeable(prior_term_gradeables) {
@@ -581,6 +590,7 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
     $('.popup-form').css('display', 'none');
     var form = $("#admin-team-form");
     form.css("display", "block");
+    captureTabInModal("admin-team-form");
 
     form.find('.form-body').scrollTop(0);
     $("#admin-team-form-submit").prop('disabled',false);
@@ -763,6 +773,7 @@ function importTeamForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#import-team-form");
     form.css("display", "block");
+    captureTabInModal("import-team-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload_team"]', form).val(null);
 }
@@ -772,6 +783,7 @@ function randomizeRotatingGroupsButton() {
     $('.popup-form').css('display', 'none');
     var form = $("#randomize-button-warning");
     form.css("display", "block");
+    captureTabInModal("randomize-button-warning");
     form.find('.form-body').scrollTop(0);
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -305,10 +305,15 @@ function newEditCourseMaterialsForm(path, this_file_section, this_hide_from_stud
     form.css("display", "block");
     captureTabInModal("edit-course-materials-form");
 }
+
+var lastActiveElement = null;
 function captureTabInModal(formName, resetFocus=true){
-    releaseTabFromModal(formName);
+    if(resetFocus){
+        lastActiveElement = document.activeElement;
+    }
 
     var form = $("#".concat(formName));
+    form.off('keydown');//Remove any old redirects
 
     /*get all the elements to tab through*/
     var inputs = form.find(':focusable').filter(':visible');
@@ -332,15 +337,19 @@ function captureTabInModal(formName, resetFocus=true){
         }
     });
 
-    form.on('hidden.bs.modal', function () {
-        releaseTabFromModal(formName);
-    })
+    //Watch for the modal to be hidden
+    let observer = new MutationObserver(function(){
+        if(form[0].style.display === 'none'){
+            releaseTabFromModal(formName);
+        }
+    });
+    observer.observe(form[0], { attributes: true, childList: true });
 }
 
 function releaseTabFromModal(formName){
-
     var form = $("#".concat(formName));
     form.off('keydown');
+    lastActiveElement.focus();
 }
 
 function setFolderRelease(changeActionVariable,releaseDates,id,inDir){

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -303,10 +303,12 @@ function newEditCourseMaterialsForm(path, this_file_section, this_hide_from_stud
     }
     $("#material-edit-form", form).attr('data-directory', path);
     form.css("display", "block");
+    captureTabInModal("edit-course-materials-form");
 }
-function captureTabInModal(formName){
+function captureTabInModal(formName, resetFocus=true){
+    releaseTabFromModal(formName);
 
-  var form = $("#".concat(formName));
+    var form = $("#".concat(formName));
 
     /*get all the elements to tab through*/
     var inputs = form.find(':focusable').filter(':visible');
@@ -314,7 +316,9 @@ function captureTabInModal(formName){
     var lastInput = inputs.last();
 
     /*set focus on first element*/
-    firstInput.focus();
+    if(resetFocus){
+      firstInput.focus();
+    }
 
     /*redirect last tab to first element*/
     form.on('keydown', function (e) {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -194,7 +194,6 @@ function newDeleteGradeableForm(form_action, gradeable_name) {
     $('[id="delete-gradeable-message"]', form).append('<b>'+gradeable_name+'</b>');
     $('[name="delete-confirmation"]', form).attr('action', form_action);
     form.css("display", "block");
-    captureTabInModal("delete-gradeable-form");
 }
 
 function displayCloseSubmissionsWarning(form_action,gradeable_name) {
@@ -204,7 +203,6 @@ function displayCloseSubmissionsWarning(form_action,gradeable_name) {
     $('[id="close-submissions-message"]', form).append('<b>'+gradeable_name+'</b>');
     $('[name="close-submissions-confirmation"]', form).attr('action', form_action);
     form.css("display", "block");
-    captureTabInModal("close-submissions-form");
     form.find('.form-body').scrollTop(0);
 }
 
@@ -231,7 +229,6 @@ function newDeleteCourseMaterialForm(path, file_name) {
     $('.delete-course-material-message', form).append('<b>'+file_name+'</b>');
     $('[name="delete-confirmation"]', form).attr('action', url);
     form.css("display", "block");
-    captureTabInModal("delete-course-material-form");
     form.find('.form-body').scrollTop(0);
 }
 
@@ -239,7 +236,6 @@ function newUploadImagesForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#upload-images-form");
     form.css("display", "block");
-    captureTabInModal("upload-images-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
 }
@@ -264,7 +260,6 @@ function newUploadCourseMaterialsForm() {
     $('[name="existing-file-list"]', form).append('<b>'+JSON.stringify(files)+'</b>');
 
     form.css("display", "block");
-    captureTabInModal("upload-course-materials-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload"]', form).val(null);
 
@@ -303,7 +298,6 @@ function newEditCourseMaterialsForm(path, this_file_section, this_hide_from_stud
     }
     $("#material-edit-form", form).attr('data-directory', path);
     form.css("display", "block");
-    captureTabInModal("edit-course-materials-form");
 }
 function captureTabInModal(formName, resetFocus=true){
     releaseTabFromModal(formName);
@@ -350,8 +344,6 @@ function setFolderRelease(changeActionVariable,releaseDates,id,inDir){
     var form = $("#set-folder-release-form");
     form.css("display", "block");
 
-    captureTabInModal("set-folder-release-form");
-
     form.find('.form-body').scrollTop(0);
     $('[id="release_title"]',form).attr('data-path',changeActionVariable);
     $('[name="release_date"]', form).val(releaseDates);
@@ -371,7 +363,6 @@ function deletePlagiarismResultAndConfigForm(form_action, gradeable_title) {
     $('[name="delete"]', form).attr('action', form_action);
     form.css("display", "block");
     form.find('.form-body').scrollTop(0);
-    captureTabInModal("delete-plagiarism-result-and-config-form");
 }
 
 function addMorePriorTermGradeable(prior_term_gradeables) {
@@ -590,7 +581,6 @@ function adminTeamForm(new_team, who_id, reg_section, rot_section, user_assignme
     $('.popup-form').css('display', 'none');
     var form = $("#admin-team-form");
     form.css("display", "block");
-    captureTabInModal("admin-team-form");
 
     form.find('.form-body').scrollTop(0);
     $("#admin-team-form-submit").prop('disabled',false);
@@ -773,7 +763,6 @@ function importTeamForm() {
     $('.popup-form').css('display', 'none');
     var form = $("#import-team-form");
     form.css("display", "block");
-    captureTabInModal("import-team-form");
     form.find('.form-body').scrollTop(0);
     $('[name="upload_team"]', form).val(null);
 }
@@ -783,7 +772,6 @@ function randomizeRotatingGroupsButton() {
     $('.popup-form').css('display', 'none');
     var form = $("#randomize-button-warning");
     form.css("display", "block");
-    captureTabInModal("randomize-button-warning");
     form.find('.form-body').scrollTop(0);
 }
 

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -137,6 +137,7 @@ function showSimpleGraderStats(action) {
         calcSimpleGraderStats(action);
         $('.popup').css('display', 'none');
         $("#simple-stats-popup").css("display", "block");
+        captureTabInModal("simple-stats-popup");
         $(document).on("click", function(e) {                                           // event handler: when clicking on the document...
             if($(e.target).attr("id") != "simple-stats-btn"                             // ...if neither the stats button..
                && $(e.target).closest('div').attr('id') != "simple-stats-popup") {      // ...nor the stats popup are being clicked...

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -137,7 +137,6 @@ function showSimpleGraderStats(action) {
         calcSimpleGraderStats(action);
         $('.popup').css('display', 'none');
         $("#simple-stats-popup").css("display", "block");
-        captureTabInModal("simple-stats-popup");
         $(document).on("click", function(e) {                                           // event handler: when clicking on the document...
             if($(e.target).attr("id") != "simple-stats-btn"                             // ...if neither the stats button..
                && $(e.target).closest('div').attr('id') != "simple-stats-popup") {      // ...nor the stats popup are being clicked...

--- a/site/public/js/ta-grading-keymap.js
+++ b/site/public/js/ta-grading-keymap.js
@@ -84,6 +84,7 @@ function isSettingsVisible() {
 function showSettings() {
     generateHotkeysList();
     $("#settings-popup").show();
+    captureTabInModal("settings-popup");
 }
 
 function hideSettings() {

--- a/site/public/js/ta-grading-keymap.js
+++ b/site/public/js/ta-grading-keymap.js
@@ -84,7 +84,6 @@ function isSettingsVisible() {
 function showSettings() {
     generateHotkeysList();
     $("#settings-popup").show();
-    captureTabInModal("settings-popup");
 }
 
 function hideSettings() {

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -66,7 +66,6 @@ function newUserForm() {
         $("#user_lastname")[0].setCustomValidity("user_lastname is required");
     }
     checkValidEntries();
-    captureTabInModal("edit-user-form");
 }
 
 //opens modal with initial settings for edit user
@@ -102,7 +101,6 @@ function editUserForm(user_id) {
             }
             completeUserFormInformation(json);
             clearValidityWarnings();
-            captureTabInModal("edit-user-form");
         },
         error: function() {
             alert("Could not load user data, please refresh the page and try again.");
@@ -186,8 +184,8 @@ function checkValidEntries() {
     }
     else {
         $("#user-form-submit").prop('disabled',false);
-        captureTabInModal("edit-user-form", false);
     }
+    captureTabInModal("edit-user-form", false);
 }
 
 function setRedOrTransparent(input,reg_expression) {

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -66,6 +66,7 @@ function newUserForm() {
         $("#user_lastname")[0].setCustomValidity("user_lastname is required");
     }
     checkValidEntries();
+    captureTabInModal("edit-user-form");
 }
 
 //opens modal with initial settings for edit user
@@ -101,6 +102,7 @@ function editUserForm(user_id) {
             }
             completeUserFormInformation(json);
             clearValidityWarnings();
+            captureTabInModal("edit-user-form");
         },
         error: function() {
             alert("Could not load user data, please refresh the page and try again.");

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -87,7 +87,7 @@ function editUserForm(user_id) {
             }
             else {
                 $("#edit-student-modal-title").css('display','none');
-                $("#edit-student-modal-title").css('display','block');
+                $("#edit-grader-modal-title").css('display','block');
             }
             $("#new-student-modal-title").css('display','none');
             $("#new-grader-modal-title").css('display','none');

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -66,6 +66,7 @@ function newUserForm() {
         $("#user_lastname")[0].setCustomValidity("user_lastname is required");
     }
     checkValidEntries();
+    captureTabInModal("edit-user-form");
 }
 
 //opens modal with initial settings for edit user
@@ -87,7 +88,7 @@ function editUserForm(user_id) {
             }
             else {
                 $("#edit-student-modal-title").css('display','none');
-                $("#edit-grader-modal-title").css('display','block');
+                $("#edit-student-modal-title").css('display','block');
             }
             $("#new-student-modal-title").css('display','none');
             $("#new-grader-modal-title").css('display','none');
@@ -101,6 +102,7 @@ function editUserForm(user_id) {
             }
             completeUserFormInformation(json);
             clearValidityWarnings();
+            captureTabInModal("edit-user-form");
         },
         error: function() {
             alert("Could not load user data, please refresh the page and try again.");
@@ -184,6 +186,7 @@ function checkValidEntries() {
     }
     else {
         $("#user-form-submit").prop('disabled',false);
+        captureTabInModal("edit-user-form", false);
     }
 }
 
@@ -334,6 +337,7 @@ function clearValidityWarnings() {
         $(this)[0].setCustomValidity("");
     });
     $("#user-form-submit").prop('disabled',false);
+    captureTabInModal("edit-user-form", false);
 }
 
 function closeButton() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

On many modals when you use tab to move among elements, you can escape the modal and tab on elements behind the modal on the main page


### What is the new behavior?

fixes #3830
when you press tab from the last element in a modal instead of cycling to the page behind the modal, it will move the focus back to the first item

I also made it so that the captureTabInModal() function runs automatically as long as a modal is generated with Popup.twig (which as far as I can tell they all are)
This will mean going forward no extra work should need to be done when making a new modal.

There is still one situation captureTabInModal() will need to be run manually. If a modal disables the submit button for any reason, the function must be run every time the state of the submit button is changed. (so both when it is disabled as well as when it is no longer disabled)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I went around the website and tried to find and test every modal but there is a chance I missed one.
