### PR TITLE
[Bugfix:TAGrading] Fix bug where graders cannot view a students files

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -100,7 +100,7 @@ $core->getOutput()->addBreadcrumb("Submitty", $core->getConfig()->getBaseUrl());
 date_default_timezone_set($core->getConfig()->getTimezone()->getName());
 
 // Stops clickjacking on all pages
-header('X-Frame-Options: DENY');
+header('X-Frame-Options: SAMEORIGIN');
 
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', 1);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Because of how files are viewed when grading a student, they use iframes which were disabled in #5375 

![image](https://user-images.githubusercontent.com/18558130/83210732-9db77b00-a129-11ea-98fe-0de80578ecca.png)


### What is the new behavior?

This makes it so that iframes can be used on the same origin meaning that the iframs to view student files will now work again

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
