### PR TITLE
[VPAT] Removed device dependent event handlers from popups

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -2,9 +2,9 @@
 <div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;">
     {% block form %}
         {# This lets us center the window #}
-        <div class="popup-box"  onclick="event.stopPropagation(); closePopup();">
+        <div class="popup-box">
             {# Actual displayed window #}
-            <div class="popup-window" onclick="event.stopPropagation();">
+            <div class="popup-window">
                 {% block title_panel %}
                     <div class="form-title">
                         {% block title_tag %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Every popup made using the popup.twig file would cause 2 WAVE `Device dependent event handler` errors. 

### What is the new behavior?

I do not believe either of theses onclick attributes even has a use anything anymore, they are just there from old code and currently do nothing. So I just removed them. For whoever tests this, if you are able to find a change in page functionality by removing them please let me know but I dont think there is any.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

![image](https://user-images.githubusercontent.com/18558130/83456748-4584bf80-a42e-11ea-80f4-11e9a9f02c6a.png)

