### PR TITLE
[Bugfix:TAGrading] "who got this mark" links

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1556,6 +1556,9 @@ function openMarkStatsPopup(component_title, mark_title, stats) {
     // Create an array of links for each submitter
     let submitterHtmlElements = [];
     let [base_url, search_params] = location.href.split('?');
+    if(base_url.slice(base_url.length-6) == "update"){
+        base_url = base_url.slice(0, -6) + "grading/grade";
+    }
     search_params = new URLSearchParams(search_params);
     stats.submitter_ids.forEach(function (id) {
         search_params.set('who_id', id);
@@ -1762,6 +1765,7 @@ function onMarkPointsChange(me) {
  * @param me DOM Element of the mark stats button
  */
 function onGetMarkStats(me) {
+    console.log(me);
     let component_id = getComponentIdFromDOMElement(me);
     let mark_id = getMarkIdFromDOMElement(me);
     ajaxGetMarkStats(getGradeableId(), component_id, mark_id)

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1556,7 +1556,7 @@ function openMarkStatsPopup(component_title, mark_title, stats) {
     // Create an array of links for each submitter
     let submitterHtmlElements = [];
     let [base_url, search_params] = location.href.split('?');
-    if(base_url.slice(base_url.length-6) == "update"){
+    if(base_url.slice(base_url.length - 6) == "update") {
         base_url = base_url.slice(0, -6) + "grading/grade";
     }
     search_params = new URLSearchParams(search_params);
@@ -1765,7 +1765,6 @@ function onMarkPointsChange(me) {
  * @param me DOM Element of the mark stats button
  */
 function onGetMarkStats(me) {
-    console.log(me);
     let component_id = getComponentIdFromDOMElement(me);
     let mark_id = getMarkIdFromDOMElement(me);
     ajaxGetMarkStats(getGradeableId(), component_id, mark_id)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
On the instructor rubric page, if an instructor clicks on the link to view all students who recieved a given mark, the link will direct to the instructor rubric page (the link is broken)

### What is the new behavior?
Fixes #5261. The who got what mark links work as intended

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
