### PR TITLE
[VPAT] Fixed a number of WAVE errors across the website

### DIFF
--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -57,7 +57,7 @@
                 </li>
             {% endif %}
             <li class="li_with_drop_down">
-                <b id="time_zone_selector_label" data-user_time_zone="{{ user_time_zone }}" data-available_time_zones="{{ available_time_zones }}">Time Zone (<span id="utc_offset_stub">UTC Offset <span id="user_utc_offset">{{ user_utc_offset }}</span></span>): <a target=_blank href="https://submitty.org/student#how-can-i-specify-my-local-timezone">
+                <b id="time_zone_selector_label" data-user_time_zone="{{ user_time_zone }}" data-available_time_zones="{{ available_time_zones }}">Time Zone (<span id="utc_offset_stub">UTC Offset <span id="user_utc_offset">{{ user_utc_offset }}</span></span>): <a target=_blank href="https://submitty.org/student#how-can-i-specify-my-local-timezone" aria-label="How can I specify my local timezone">
                     <i style="font-style:normal;" class="fa-question-circle"></i></a></b>
                     <em>Important Note: All due dates are currently displayed in server timezone.</em>
                 <label for="time_zone_general_drop_down">General Area:</label>

--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -67,7 +67,7 @@
             </li>
             <li class="li_with_drop_down">
                 <b>Color Theme:</b>
-                <select id="theme_change_select" class="form-control" aria-label="Change Submitty's Theme" onchange="updateTheme();">
+                <select id="theme_change_select" class="form-control" aria-label="Change Submitty's Theme">
                     <option value="system">Follow Device Theme</option>
                     <option value="system_black">Follow Device Theme (Black)</option>
                     <option value="light">Light Mode</option>

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -63,7 +63,7 @@
             </label>
         </div>
 
-        <label for="upload-message" class="config-row">
+        <label for="queue-message" class="config-row">
             <span class="option-title">Office Hours Queue Welcome Message (Optional)</span>
             <br>
             <span class="option-alt">

--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -8,7 +8,7 @@
         <input type="hidden" name="option" value="-1" />
         <div class="option">
             <label for="gradeable-select" class="option-title">Select Gradeable:</label><br>
-            <select name="g_id" id="gradeable-select" onchange="updateGradeableForExtensions()">
+            <select name="g_id" id="gradeable-select">
                 <option disabled {% if current_gradeable is null %} selected {% endif %} value> -- select an option -- </option>
                 {% for index, value in gradeables %}
                     <option

--- a/site/app/templates/admin/users/StudentList.twig
+++ b/site/app/templates/admin/users/StudentList.twig
@@ -47,7 +47,7 @@
                                 <form method="post" action="{{ view_grades_url }}">
                                   <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                                   <input type="hidden" name="student_id" value="{{ student.getId() }}"/>
-                                  <button type="submit" class="btn btn-primary" title="View Grades">View Grades</button>
+                                  <button type="submit" class="btn btn-primary">View Grades</button>
                                 </form>
                             </td>
                         </tr>

--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -9,11 +9,11 @@
     <div class="stats-table-container">
         <table class="table table-striped table-bordered persist-area" id="forum_stats_table">
             <tr>
-                <td class = "cursor-pointer" style="width:15%" id="user_sort"><a href="javascript:void(0)">User</a></td>
-                <td class = "cursor-pointer"  id="total_posts_sort"><a href="javascript:void(0)">Total Posts (not deleted)</a></td>
-                <td class = "cursor-pointer" style="width:15%" id="total_threads_sort"><a href="javascript:void(0)">Total Threads</a></td>
-                <td class = "cursor-pointer" style="width:15%" id="total_deleted_sort"><a href="javascript:void(0)">Total Deleted Posts</a></td>
-                <td style="width:40%">Show Posts</td>
+                <th class = "cursor-pointer" style="width:15%" id="user_sort"><a href="#">User</a></th>
+                <th class = "cursor-pointer"  id="total_posts_sort"><a href="#">Total Posts (not deleted)</a></th>
+                <th class = "cursor-pointer" style="width:15%" id="total_threads_sort"><a href="#">Total Threads</a></th>
+                <th class = "cursor-pointer" style="width:15%" id="total_deleted_sort"><a href="#">Total Deleted Posts</a></th>
+                <th style="width:40%">Show Posts</th>
             </tr>
 
             {% for user in userData %}

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -96,13 +96,15 @@
                 No categories exists please create one.
             </span>
         {% endif %}
-        <fieldset id='categories-pick-list'>
-          <legend id="cat_label">Categories</legend>
-          {% for category in categories %}
-              <div tabindex="0" class="btn cat-buttons" data-color="{{ category.color }}" aria-labelledby="cat_label" style="word-wrap: break-word; background-color: {{ category.color }}; color: white; max-width: 350px; text-align: left !important; white-space: unset !important;">{{ category.category_desc }}
-                  <input type="checkbox" name="cat[]" value="{{ category.category_id }}" aria-label="Category {{ category.category_desc }}">
-              </div>
-          {% endfor %}
+        <fieldset>
+          <legend id="cat_label">Categories:</legend>
+          <div id=id='categories-pick-list'>
+            {% for category in categories %}
+                <div tabindex="0" class="btn cat-buttons" data-color="{{ category.color }}" aria-labelledby="cat_label" style="word-wrap: break-word; background-color: {{ category.color }}; color: white; max-width: 350px; text-align: left !important; white-space: unset !important;">{{ category.category_desc }}
+                    <input type="checkbox" name="cat[]" value="{{ category.category_id }}" aria-label="Category {{ category.category_desc }}">
+                </div>
+            {% endfor %}
+          </div>
         </fieldset>
     <script>
     $(function() {
@@ -177,8 +179,8 @@
             {% set announcement_text = email_enabled ? "Pin Thread?(w/email & notification)" : "Pin Thread?(w/ notification)" %}
             <label class="inline-block" for="Announcement">{{ announcement_text }}</label>
             <input type="checkbox" id="Announcement" class="thread-announcement-checkbox" name="Announcement" value="Announcement" data-ays-ignore="true"/>
-            <label class="inline-block" for="Announcement">{{ "Pin Thread" }}</label>
-            <input type="checkbox" class="pinThread-checkbox" name="pinThread" value="pinThread" data-ays-ignore="true"/>
+            <label class="inline-block" for="pinThread">{{ "Pin Thread" }}</label>
+            <input type="checkbox" class="pinThread-checkbox" name="pinThread" id="pinThread" value="pinThread" data-ays-ignore="true"/>
         {% endif %}
         {% if show_cancel_edit_form %}
         <a onclick="$('#edit-user-post').css('display', 'none');

--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -76,7 +76,7 @@
         <h3>Invite new teammates by their user ID:</h3>
         <br />
         <form action="{{ send_invitation_url }}" method="post">
-            <input type="text" name="invite_id" id="invite_id" placeholder="User ID" />
+            <input type="text" name="invite_id" id="invite_id" placeholder="User ID" aria-label="User ID"/>
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <input type="submit" value = "Invite" class="btn btn-primary" />
         </form>
@@ -122,7 +122,7 @@
             <caption />
             <thead class="persist thead">
                 <tr>
-                    <th style="width:3%"></th>
+                    <th style="width:3%">Index</th>
                     <th style="width:10%">First Name</th>
                     <th style="width:10%">Last Name</th>
                     <th style="width:10%">User ID</th>

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -18,7 +18,7 @@ class PlagiarismView extends AbstractView {
         <a class="btn btn-primary" href="{$this->core->buildCourseUrl(['plagiarism', 'configuration', 'new'])}">+ Configure New Gradeable for Plagiarism Detection</a>
     </div><br /><br />
     <div class="sub">
-    <center>
+    <div>
     <table style="border-collapse: separate;border-spacing: 15px 10px;">
 HTML;
         $course_path = $this->core->getConfig()->getCoursePath();
@@ -138,7 +138,7 @@ HTML;
         }
 
         $return .= <<<HTML
-    </table></center>
+    </table></div>
     </div>
 </div>
 HTML;
@@ -240,7 +240,7 @@ HTML;
                         <input type="hidden" name="csrf_token" value="{$this->core->getCsrfToken()}" />
                         <p>Note: Deleting plagiarism results will also delete the saved configuration for the gradeable.</p><br>
                         Are you sure to delete Plagiarism Results for
-                        <b><div name="gradeable_title"></div></b>
+                        <div name="gradeable_title"></div>
                         <div class="form-buttons">
                             <div class="form-button-container">
                                 <a onclick="$('#delete-plagiarism-result-and-config-form').css('display', 'none');" class="btn btn-default">Cancel</a>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -273,10 +273,10 @@ HTML;
 			<div style="padding-left:20px;padding-bottom: 10px;border-radius:3px;padding-right:20px;">
 				<table class="table table-striped table-bordered persist-area" id="content_upload_table">
 					<tr>
-				        <td style = "cursor:pointer;width:25%" id="user_down">User &darr;</td>
-				        <td style = "cursor:pointer;width:25%" id="upload_down">Upload Timestamp</td>
-				        <td style = "cursor:pointer;width:25%" id="submission_down">Submission Timestamp</td>
-				        <td style = "cursor:pointer;width:25%" id="filepath_down">Filepath</td>
+				        <th style = "cursor:pointer;width:25%" id="user_down">User &darr;</th>
+				        <th style = "cursor:pointer;width:25%" id="upload_down">Upload Timestamp</th>
+				        <th style = "cursor:pointer;width:25%" id="submission_down">Submission Timestamp</th>
+				        <th style = "cursor:pointer;width:25%" id="filepath_down">Filepath</th>
 					</tr>
 HTML;
 
@@ -517,7 +517,7 @@ HTML;
             foreach ($gradeable->getComponents() as $component) {
                 $graded_component = $row->getOrCreateTaGradedGradeable()->getGradedComponent($component, $this->core->getUser());
                 $grade_inquiry = $graded_component !== null ? $row->getGradeInquiryByGcId($graded_component->getComponentId()) : null;
-                
+
                 if ($component->isPeer() && $row->getOrCreateTaGradedGradeable()->isComplete() && $graded_component === null) {
                     $info["graded_groups"][] = 4;
                 }
@@ -842,7 +842,7 @@ HTML;
         if ($peer && $this->core->getUser()->getGroup() == 4) {
             $i_am_a_peer = true;
         }
-        
+
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "progress" => $progress,
             "peer_gradeable" => $peer,

--- a/site/public/js/extensions.js
+++ b/site/public/js/extensions.js
@@ -1,4 +1,4 @@
-function updateGradeableForExtensions() {
+$("#gradeable-select").change(function(){
     var g_id = $('#gradeable-select').val();
     var expiration_date = new Date(Date.now());
     expiration_date.setDate(expiration_date.getDate() + 1);

--- a/site/public/js/homepage.js
+++ b/site/public/js/homepage.js
@@ -81,6 +81,10 @@ function populateSpecificTimeZoneDropDown(general_selection, selected_option = n
 
 $(document).ready(function() {
 
+    $('#theme_change_select').change(function() {
+        updateTheme();
+    });
+
     // Populate the general area time zone selector box with options
     let general_area_set = getGeneralTimeZoneOptions();
     general_area_set.forEach(function(elem) {

--- a/tests/e2e/accessibility_baseline.json
+++ b/tests/e2e/accessibility_baseline.json
@@ -16,6 +16,7 @@
     "/s20/sample/gradeable/future_no_tas_lab/grading?view=all": [],
     "/s20/sample/gradeable/future_no_tas_test/grading?view=all": [],
     "/s20/sample/gradeable/open_homework/grading/status": [],
+    "/s20/sample/gradeable/open_homework/bulk_stats": [],
     "/s20/sample/gradeable/open_homework/grading/details?view=all": [],
     "/s20/sample/gradeable/open_homework": [
         "Bad value “text” for attribute “role” on element “div”.",
@@ -25,6 +26,8 @@
     "/s20/sample/gradeable/grades_released_homework_autota": [
         "Bad value “text” for attribute “role” on element “div”.",
         "Attribute “fname” not allowed on element “tr” at this point.",
+        "Duplicate ID “confetti_canvas”.",
+        "The first occurrence of ID “confetti_canvas” was here.",
         "CSS: The value “break-word” is deprecated"
     ],
     "/s20/sample/notifications": [],
@@ -39,18 +42,14 @@
     "/s20/sample/office_hours_queue": [
         "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)"
     ],
-    "/s20/sample/course_materials": [
-        "Bad value “sample folder” for attribute “id” on element “a”: An ID must not contain whitespace."
-    ],
+    "/s20/sample/course_materials": [],
     "/s20/sample/forum": [
         "The element “input” must not appear as a descendant of the “a” element.",
         "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
-        "Bad value “button” for attribute “type” on element “a”: Subtype missing.",
         "Consider using the “h1” element as a top-level heading only (all “h1” elements are treated as top-level headings by many screen readers and other tools)."
     ],
     "/s20/sample/forum/threads/new": [
-        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
-        "Element “p” not allowed as child of element “span” in this context. (Suppressing further errors from this subtree.)"
+        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)"
     ],
     "/s20/sample/forum/categories": [],
     "/s20/sample/forum/stats": [
@@ -66,8 +65,7 @@
     "/s20/sample/extensions": [],
     "/s20/sample/grade_override": [],
     "/s20/sample/plagiarism": [
-        "The “center” element is obsolete. Use CSS instead.",
-        "Element “div” not allowed as child of element “b” in this context. (Suppressing further errors from this subtree.)"
+        "Attribute “name” not allowed on element “div” at this point."
     ],
     "/s20/sample/plagiarism/configuration/new": [
         "Attribute “name” not allowed on element “div” at this point.",
@@ -75,11 +73,5 @@
     ],
     "/s20/sample/reports": [],
     "/s20/sample/late_table": [],
-    "/s20/sample/grades": [
-        "Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)",
-        "The “align” attribute on the “td” element is obsolete. Use CSS instead.",
-        "The “font” element is obsolete. Use CSS instead.",
-        "Element “div” not allowed as child of element “font” in this context. (Suppressing further errors from this subtree.)",
-        "Too many messages."
-    ]
+    "/s20/sample/grades": []
 }

--- a/tests/e2e/test_accessibility.py
+++ b/tests/e2e/test_accessibility.py
@@ -24,6 +24,7 @@ class TestAccessibility(BaseTestCase):
         '/{}/{}/gradeable/future_no_tas_lab/grading?view=all',
         '/{}/{}/gradeable/future_no_tas_test/grading?view=all',
         '/{}/{}/gradeable/open_homework/grading/status',
+        '/{}/{}/gradeable/open_homework/bulk_stats',
         '/{}/{}/gradeable/open_homework/grading/details?view=all',
         '/{}/{}/gradeable/open_homework',
         '/{}/{}/gradeable/open_team_homework/team',
@@ -50,7 +51,6 @@ class TestAccessibility(BaseTestCase):
         '/{}/{}/plagiarism/configuration/new',
         '/{}/{}/reports',
         '/{}/{}/late_table',
-        '/{}/{}/theme',
         '/{}/{}/grades',
     ]
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There a still some wave errors on the website

### What is the new behavior?

The goal of this PR is to get rid of some of the last remaining WAVE errors.
Sorry that there is really no organization to this PR and it is from a bunch of different pages. I thought it was better to do it all in this pr than make a ton of small ones.

My goal is that after this pr, there will be no wave errors on the website and and the only wave alerts will be `Skipped heading level` and `Noscript element` which as far as I can tell, are fine. If they are not fine we are going to have to go back and fix them.
There are some slight caveats to this claim that there are no more WAVE errors:
1) #5435 should deal with all device dependent event handlers so I did not remove them here
2) I am still working on a large number of changes for the new/edit gradable pages as they have a number of errors.
3) I am still trying to figure out the best fix for the `Layout table` error in the file upload boxes
![image](https://user-images.githubusercontent.com/18558130/83483729-5c98d100-a471-11ea-848f-f52acbc767be.png)

Other than the 3 things I just listed, if you see any other WAVE errors please let me know so that I can fix them

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
