### PR TITLE
[Bugfix:InstructorUI] Office Hours Queue contact info will now wrap to the next line when too long

### DIFF
--- a/site/app/templates/officeHoursQueue/CurrentQueue.twig
+++ b/site/app/templates/officeHoursQueue/CurrentQueue.twig
@@ -75,7 +75,7 @@
         </tr>
         {% if viewer.isContactInfoEnabled() %}
           <tr class="contact_info row_color_{{viewer.getIndexFromCode(entry['queue_code'])}} queue_current_{{viewer.cleanForId(entry['queue_code'])}} current_queue_row" style="display:none;border-top:0px">
-            <td colspan="7" style="border-top:0px">{{entry['contact_info']}}</td>
+            <td colspan="7" style="border-top:0px; word-wrap:anywhere;">{{entry['contact_info']}}</td>
           </tr>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If the info put into the contact info box is too large, the office hours queue page will expand sideways to fit it
![image](https://user-images.githubusercontent.com/18558130/83675802-9e2b9800-a5a7-11ea-93b3-341eb50476eb.png)
(it keeps on going to the right)

### What is the new behavior?

The contact info will now wrap to a new line when too long
![image](https://user-images.githubusercontent.com/18558130/83675774-91a73f80-a5a7-11ea-83f2-0cf8c30f0d4f.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
