### PR TITLE
[VAPT] Tabbing now works for file input in modals

### DIFF
--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -69,7 +69,7 @@
         <div id="upload-boxes">
             {# upload1 and input-file1 required for drag-and-drop.js #}
             <div id="upload1" class="file-input">
-                <label class="label" for="input-file1">"Drag your file(s) here or click to open file browser"</label>
+                <label class="label key_to_click" for="input-file1" tabindex="0">"Drag your file(s) here or click to open file browser"</label>
                 <input type="file" name="files" id="input-file1" onchange="addFilesFromInput(1,false)" multiple />
                 <table class="file-upload-table" id="file-upload-table-1"></table>
             </div>

--- a/site/app/templates/grading/UploadImagesForm.twig
+++ b/site/app/templates/grading/UploadImagesForm.twig
@@ -17,7 +17,7 @@
         <div id="upload-boxes">
             {# upload1 and input-file1 required for drag-and-drop.js #}
             <div id="upload1" class="file-input">
-                <label class="label" for="input-file1">"Drag your file(s) here or click to open file browser"</label>
+                <label class="label key_to_click" for="input-file1" tabindex="0">"Drag your file(s) here or click to open file browser"</label>
                 <input type="file" name="files" id="input-file1" onchange="addFilesFromInput(1,false)" multiple />
                 <table class="file-upload-table" id="file-upload-table-1"></table>
             </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

You cannot use the file input boxes in modals when just tabbing. see #5446

### What is the new behavior?
fixes #5446

you are now able to tab to file input boxes and if you press enter it will open the file input box

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

The issue before was that the file input is hidden and what the user clicks on is actually a label for that input. However, the captureInModal() function only detects visible inputs because otherwise you would get stuff like the csrf token. The best solution I could think of was just to make that label able to be tabbed to in the 2 places I found it on the website. This allows the captureInModal() function to detect it. 