### PR TITLE
[Bugfix:System] Do not construct mail client if email disabled

### DIFF
--- a/sbin/send_email.py
+++ b/sbin/send_email.py
@@ -190,9 +190,9 @@ def send_email():
     """Send queued emails."""
     db, metadata = setup_db()
     queued_emails = get_email_queue(db)
-    mail_client = construct_mail_client()
-    if not EMAIL_ENABLED or len(queued_emails) == 0:
+    if len(queued_emails) == 0:
         return
+    mail_client = construct_mail_client()
 
     success_count = 0
 
@@ -230,6 +230,8 @@ def send_email():
 
 
 def main():
+    if not EMAIL_ENABLED:
+        return
     """Send queued Submitty emails and log any errors."""
     try:
         send_email()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #5402 

The send email script would construct the mail client (which requires the username / password, etc.) before checking if email was enabled. The script would crash on setting up the mail client as email was not configured as it's not enabled.

### What is the new behavior?

Check to see if email is enabled before doing any other email related steps (create DB connection, etc.). Secondly, if we have no emails to send, do not bother setting up the email client.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
