### PR TITLE
[Feature:Vagrant] Set memsize and cpus for VMWare to match VirtualBox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,6 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider 'virtualbox' do |vb|
-
     vb.memory = 2048
     vb.cpus = 2
     # When you put your computer (while running the VM) to sleep, then resume work some time later the VM will be out
@@ -74,6 +73,11 @@ Vagrant.configure(2) do |config|
     # See https://serverfault.com/a/453260 for more info.
     # vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+    
+  config.vm.provider "vmware_desktop" do |vm|
+    vm.vmx["memsize"] = "2048"
+    vm.vmx["numvcpus"] = "2"
   end
 
   config.vm.provision :shell, :inline => " sudo timedatectl set-timezone America/New_York", run: "once"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Someone using VMWare will probably end up with a VM with different amount of RAM / CPUs than VirtualBox, which may lead to subtle differences / bugs that we do not want to worry about.

### What is the new behavior?

Minimally set the memory and cpu for vmware to match VirtualBox. This does not imply we are offering official support of using VMWare to develop at this time, just doing the minimum though of keeping the two consistent, and this setting has been consistent now for years.