### PR TITLE
[Bugfix:Autograding] Handle RLIM_INFINITY when limiting docker containers

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -235,7 +235,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         self.verify_execution_status()
     except Exception as e:
       self.log_stack_trace(traceback.format_exc())
-      self.log("ERROR: Could not verify execution mode status.")
+      self.log_message("ERROR: Could not verify execution mode status.")
       return
 
     more_than_one = True if len(containers) > 1 else False
@@ -246,7 +246,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         container.create(my_script, arguments, more_than_one)
         created_containers.append(container)
       except Exception as e:
-        self.log(f"ERROR: Could not create container {container.name} with image {container.image}")
+        self.log_message(f"ERROR: Could not create container {container.name} with image {container.image}")
         self.log_stack_trace(traceback.format_exc())
 
         # Failing to create a container is a critical error.

--- a/autograder/autograder/execution_environments/rlimit_utils.py
+++ b/autograder/autograder/execution_environments/rlimit_utils.py
@@ -55,6 +55,11 @@ def build_ulimit_argument(resource_limits, container_image):
 
     # fill in instructor resource limits if specified
     for resource, limit in resource_limits.items():
+
+        # Not setting a docker limit should be equivalent to infinity.
+        if limit == 'RLIM_INFINITY':
+            continue
+
         if resource in rlimit_to_ulimit_mapping:
             ulimit_name = rlimit_to_ulimit_mapping[resource]
             ulimit_arg = docker.types.Ulimit(name=ulimit_name, soft=limit, hard=limit)


### PR DESCRIPTION
Closes #5428 

### What is the current behavior?
Docker container creation fails for assignments which set an `RLIMIT` to the submitty specific macro `RLIM_INFINITY`. 

### What is the new behavior?
`RLIM_INFINITY` is now respected when grading via docker.

### Other information
*  Docker containers are not limited by default. As a result, not setting a `ulimit` on a container where `RLIM_INFINITY` has been requested should be roughly equivalent to setting the value to `18446744073709551615` as in the Submitty `C++` grading code.
*  This PR also fixes two calls to the non-existent function `self.log` that snuck into `container_network`.