### PR TITLE
[Bugfix:Submission] Fix available total display for hidden testcases

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -641,10 +641,10 @@ class HomeworkView extends AbstractView {
         if ($version_instance !== null) {
             $total_score += $version_instance->getTotalPoints();
             if ($show_hidden) {
-                $total_max += $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit();
+                $total_max += $gradeable->getAutogradingConfig()->getTotalNonExtraCredit();
             }
             else {
-                $total_max += $gradeable->getAutogradingConfig()->getTotalNonExtraCredit();
+                $total_max += $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit();
             }
         }
         //Clamp full gradeable score to zero


### PR DESCRIPTION
Closes #5224 

### What is the current behavior?
The number of overall points available was improperly displayed when a gradeable had visible hidden testcases (hidden testcases weren't taken into account).

### What is the new behavior?
Overall total points available are now properly displayed.