### PR TITLE
[Refactor:PHP] Simplify logic to generate submission zip

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -244,7 +244,7 @@ class MiscController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl());
         }
 
-        $folder_names = array();
+        $folder_names = [];
         //See which directories we are allowed to read.
         if ($this->core->getAccess()->canI("path.read.submissions", ["gradeable" => $gradeable, "graded_gradeable" => $graded_gradeable, "gradeable_version" => $gradeable_version->getVersion()])) {
             //These two have the same check
@@ -282,35 +282,32 @@ class MiscController extends AbstractController {
         $active_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $version = $version ?? $active_version;
 
-        $paths = [];
-        foreach ($folder_names as $folder_name) {
-            $paths[] = FileUtils::joinPaths($gradeable_path, $folder_name, $gradeable->getId(), $graded_gradeable->getSubmitter()->getId(), $version);
-        }
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        for ($x = 0; $x < count($paths); $x++) {
-            if (is_dir($paths[$x])) {
+        foreach ($folder_names as $folder_name) {
+            $path = FileUtils::joinPaths($gradeable_path, $folder_name, $gradeable->getId(), $graded_gradeable->getSubmitter()->getId(), $version);
+            if (is_dir($path)) {
                 $files = new \RecursiveIteratorIterator(
-                    new \RecursiveDirectoryIterator($paths[$x]),
+                    new \RecursiveDirectoryIterator($path),
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 );
-                $zip->addEmptyDir($folder_names[$x]);
+                $zip->addEmptyDir($folder_name);
                 foreach ($files as $name => $file) {
                     // Skip directories (they would be added automatically)
                     if (!$file->isDir()) {
                         $file_path = $file->getRealPath();
-                        $relative_path = substr($file_path, strlen($paths[$x]) + 1);
+                        $relative_path = substr($file_path, strlen($path) + 1);
 
                         // For scanned exams, the directories get polluted with the images of the split apart
                         // pages, so we selectively only grab the PDFs there. For all other types,
                         // we can grab all files regardless of type.
                         if ($gradeable->isScannedExam()) {
                             if (mime_content_type($file_path) === 'application/pdf') {
-                                $zip->addFile($file_path, $folder_names[$x] . '/' . $relative_path);
+                                $zip->addFile($file_path, $folder_name . '/' . $relative_path);
                             }
                         }
                         else {
-                            $zip->addFile($file_path, $folder_names[$x] . "/" . $relative_path);
+                            $zip->addFile($file_path, $folder_name . "/" . $relative_path);
                         }
                     }
                 }

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Offset int does not exist on array\\(\\?0 \\=\\> 'results'\\|'results_public'\\|'submissions', \\?1 \\=\\> 'checkout'\\|'results_public', \\?2 \\=\\> 'results'\\|'results_public', \\?3 \\=\\> 'results_public'\\)\\.$#"
-			count: 3
-			path: app/controllers/MiscController.php
-
-		-
 			message: "#^PHPDoc tag @param has invalid value \\(\\$show_all\\)\\: Unexpected token \"\\$show_all\", expected type at offset 18$#"
 			count: 1
 			path: app/controllers/NotificationController.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There's a loop that generates all of the paths, and then another loop through the paths to actually construct the zip.

### What is the new behavior?

Condenses it into a singular loop. As we're never doing anything that uses anything but the current element of `$paths` and `$folder_names`, there's no real reason to construct `$paths` ahead of time.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Blocks #5362 as the phpstan errors that are no longer ignored here were reworded in 0.12.25 which is why that PR is failing.