### PR TITLE
[Bugfix:Travis] use pyenv to set python to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,6 +196,9 @@ jobs:
       before_install:
         - source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
         - phpenv config-rm xdebug.ini
+        - pyenv install 3.6.3
+        - pyenv global 3.6.3
+        - pyenv local 3.6.3
       install:
         - pecl install ds
         - PHP_VERSION=${TRAVIS_PHP_VERSION:0:3}
@@ -322,7 +325,11 @@ jobs:
             - unzip
             - libboost-all-dev
       env: CLANG_VER="5.0.2"
-      before_install: source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
+      before_install:
+        - source ${TRAVIS_BUILD_DIR}/.setup/travis/before_install.sh
+        - pyenv install 3.6.3
+        - pyenv global 3.6.3
+        - pyenv local 3.6.3
       install:
         - export LLVM_ARCHIVE_PATH=${HOME}/clang+llvm.tar.xz
         - wget http://releases.llvm.org/${CLANG_VER}/clang+llvm-${CLANG_VER}-x86_64-linux-gnu-ubuntu-16.04.tar.xz -O ${LLVM_ARCHIVE_PATH}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Travis uses Python 3.5 by default if no version of python is specified. This causes issues with Submitty as we potentially move to using more python 3.6 features (like f-strings), such as in #5465. 

### What is the new behavior?

Explicitly set that we are using python 3.6 in tests were we do not specify the python version, but utilize python scripts (e2e, integration tests). Adds a few minutes to these cases, but unfortunately it's not really avoidable.