### PR TITLE
[Refactor:PHP] Fix styling of doc comments to be proper

### DIFF
--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -12,11 +12,11 @@ use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
-* Class DockerInterfaceController
-*
-* Works with Docker to provide a user inteface
-*
-*/
+ * Class DockerInterfaceController
+ *
+ * Works with Docker to provide a user inteface
+ *
+ */
 class DockerInterfaceController extends AbstractController {
 
     /**

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -22,9 +22,9 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue", methods={"GET"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue", methods={"GET"})
+     * @return MultiResponse
+     */
     public function showQueue($full_history = false) {
         if (!$this->core->getConfig()->isQueueEnabled()) {
             return MultiResponse::RedirectOnlyResponse(
@@ -42,10 +42,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function openQueue() {
         if (empty($_POST['code'])) {
             $this->core->addErrorMessage("Missing queue name");
@@ -89,9 +89,9 @@ class OfficeHoursQueueController extends AbstractController {
 
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/add", methods={"POST"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/add", methods={"POST"})
+     * @return MultiResponse
+     */
     public function addPerson($queue_code) {
         if (empty($_POST['name'])) {
             $this->core->addErrorMessage("Missing user's name");
@@ -154,9 +154,9 @@ class OfficeHoursQueueController extends AbstractController {
 
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/remove", methods={"POST"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/remove", methods={"POST"})
+     * @return MultiResponse
+     */
     public function removePerson($queue_code) {
         if (empty($_POST['user_id'])) {
             $this->core->addErrorMessage("Missing user ID");
@@ -193,10 +193,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/restore", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/restore", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function restorePerson($queue_code) {
         if (empty($_POST['entry_id'])) {
             $this->core->addErrorMessage("Missing entry ID");
@@ -219,10 +219,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/startHelp", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/startHelp", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function startHelpPerson($queue_code) {
         if (empty($_POST['user_id'])) {
             $this->core->addErrorMessage("Missing user ID");
@@ -246,9 +246,9 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/finishHelp", methods={"POST"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/finishHelp", methods={"POST"})
+     * @return MultiResponse
+     */
     public function finishHelpPerson($queue_code) {
         if (empty($_POST['user_id'])) {
             $this->core->addErrorMessage("Missing entry ID");
@@ -285,10 +285,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/empty", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/empty", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function emptyQueue($queue_code) {
         if (empty($queue_code)) {
             $this->core->addErrorMessage("Missing queue name");
@@ -305,10 +305,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/toggle", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/toggle", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function toggleQueue($queue_code) {
         if (empty($queue_code)) {
             $this->core->addErrorMessage("Missing queue name");
@@ -332,10 +332,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/deleteQueue", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/deleteQueue", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function deleteQueue($queue_code) {
         if (empty($queue_code)) {
             $this->core->addErrorMessage("Missing queue name");
@@ -352,9 +352,9 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/check_updates", methods={"GET"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/check_updates", methods={"GET"})
+     * @return MultiResponse
+     */
     public function checkUpdates() {
         return MultiResponse::JsonOnlyResponse(
             JsonResponse::getSuccessResponse($this->core->getQueries()->getLastQueueUpdate())
@@ -362,10 +362,10 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/change_token", methods={"POST"})
-    * @AccessControl(role="LIMITED_ACCESS_GRADER")
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/{queue_code}/change_token", methods={"POST"})
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
+     * @return MultiResponse
+     */
     public function changeToken($queue_code) {
         if (empty($queue_code)) {
             $this->core->addErrorMessage("Missing queue name");
@@ -395,9 +395,9 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/current_queue", methods={"GET"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/current_queue", methods={"GET"})
+     * @return MultiResponse
+     */
     public function showCurrentQueue() {
         if (!$this->core->getConfig()->isQueueEnabled()) {
             return MultiResponse::RedirectOnlyResponse(
@@ -417,9 +417,9 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/queue_history", methods={"GET"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/queue_history", methods={"GET"})
+     * @return MultiResponse
+     */
     public function showQueueHistory($full_history = false) {
         if (!$this->core->getConfig()->isQueueEnabled()) {
             return MultiResponse::RedirectOnlyResponse(
@@ -439,9 +439,9 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
-    * @Route("/{_semester}/{_course}/office_hours_queue/new_status", methods={"GET"})
-    * @return MultiResponse
-    */
+     * @Route("/{_semester}/{_course}/office_hours_queue/new_status", methods={"GET"})
+     * @return MultiResponse
+     */
     public function showNewStatus() {
         if (!$this->core->getConfig()->isQueueEnabled()) {
             return MultiResponse::RedirectOnlyResponse(

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1691,9 +1691,9 @@ class ElectronicGraderController extends AbstractController {
     }
 
 /**
-     * Route for adding a new component to a gradeable
-     * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/components/new", methods={"POST"})
-     */
+ * Route for adding a new component to a gradeable
+ * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/components/new", methods={"POST"})
+ */
     public function ajaxAddComponent($gradeable_id) {
         // Get the gradeable
         $gradeable = $this->tryGetGradeable($gradeable_id);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -209,7 +209,7 @@ class SubmissionController extends AbstractController {
      * If success, also returns highest version of the student gradeable.
      *
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/verify", methods={"POST"})
-    */
+     */
     public function ajaxValidGradeable($gradeable_id) {
 
         if (!isset($_POST['user_id'])) {
@@ -307,7 +307,7 @@ class SubmissionController extends AbstractController {
      *
      * @AccessControl(role="FULL_ACCESS_GRADER")
      * @Route("/{_semester}/{_course}/gradeable/{gradeable_id}/bulk", methods={"POST"})
-    */
+     */
     public function ajaxBulkUpload($gradeable_id) {
         if (empty($_POST)) {
             $max_size =  Utils::returnBytes(ini_get('post_max_size'));

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -561,10 +561,10 @@ class Core {
     }
 
      /**
-     * Returns either the 'actual' coursename or the coursename set by the professor.
-     *
-     * @return string
-     */
+      * Returns either the 'actual' coursename or the coursename set by the professor.
+      *
+      * @return string
+      */
     public function getDisplayedCourseName() {
         if ($this->getConfig()->getCourseName() !== "") {
             return htmlentities($this->getConfig()->getCourseName());

--- a/site/app/libraries/ErrorMessages.php
+++ b/site/app/libraries/ErrorMessages.php
@@ -41,11 +41,11 @@ class ErrorMessages {
     }
 
      /**
-     * Given a response code after opening a Zip Archive, check if anything went wrong
-     * @param bool | int $res Error code or status for opening archive
-     *
-     * @return string Message for what went wront with upload
-     */
+      * Given a response code after opening a Zip Archive, check if anything went wrong
+      * @param bool | int $res Error code or status for opening archive
+      *
+      * @return string Message for what went wront with upload
+      */
     public static function getZipErrorMessage($res) {
        
         if ($res === true) {

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -304,13 +304,13 @@ class Utils {
     }
 
     /**
-    * Convert bytes to a specified format thats human readable
-    * E.g : MB, 10485760 => 10MB
-    * @param string $format
-    * @param int $bytes
-    * @param bool $round should the result be rounded to the nearest number
-    * @return string
-    */
+     * Convert bytes to a specified format thats human readable
+     * E.g : MB, 10485760 => 10MB
+     * @param string $format
+     * @param int $bytes
+     * @param bool $round should the result be rounded to the nearest number
+     * @return string
+     */
     public static function formatBytes(string $format, int $bytes, bool $round = false): string {
         $formats = ['b' => 0, 'kb' => 1, 'mb' => 2];
         $result = $bytes / pow(1024, floor($formats[strtolower($format)]));

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2409,12 +2409,12 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
     }
 
      /**
-     * returns 2d array of new graders after rotating sections set up
-     * for all access grading and limited access graders gradeables,
-     * top level is all graders' ids and second level is all rotating sections
-     *
-     * @return array
-     */
+      * returns 2d array of new graders after rotating sections set up
+      * for all access grading and limited access graders gradeables,
+      * top level is all graders' ids and second level is all rotating sections
+      *
+      * @return array
+      */
     public function getNewGraders() {
         $new_graders = [];
         $all_sections = $this->core->getQueries()->getAllRotatingSections();

--- a/site/app/libraries/routers/AccessControl.php
+++ b/site/app/libraries/routers/AccessControl.php
@@ -59,10 +59,14 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * ```php
  * @AccessControl(permission="grading.simple")
- * class SomeController extends AbstractController {
- *     @AccessControl(role="INSTRUCTOR")
- *     public function foo() {...}
- * }
+ * class SomeController extends AbstractController {}
+ * ```
+ *
+ * and then in the class:
+ *
+ * ```php
+ * @AccessControl(role="INSTRUCTOR")
+ * public function foo() {...}
  * ```
  *
  * @Annotation

--- a/site/app/libraries/routers/AccessControl.php
+++ b/site/app/libraries/routers/AccessControl.php
@@ -22,7 +22,7 @@ use Doctrine\Common\Annotations\Annotation;
  *      The following function is only accessible to full access graders and
  *      instructors.
  *
- *      @AccessControl(role="FULL_ACCESS_GRADER")
+ * @AccessControl(role="FULL_ACCESS_GRADER")
  *      public function foo() {...}
  *
  * Example (permission only):
@@ -31,7 +31,7 @@ use Doctrine\Common\Annotations\Annotation;
  *      with "grading.simple" permission, which is equivalent to having
  *      canI("grading.simple") being true.
  *
- *      @AccessControl(permission="grading.simple")
+ * @AccessControl(permission="grading.simple")
  *      class SomeController extends AbstractController {...}
  *
  * Example (role & permission):
@@ -39,7 +39,7 @@ use Doctrine\Common\Annotations\Annotation;
  *      The following function is only accessible to full access graders
  *      and instructors with "grading.simple" permission.
  *
- *      @AccessControl(role="FULL_ACCESS_GRADER", permission="grading.simple")
+ * @AccessControl(role="FULL_ACCESS_GRADER", permission="grading.simple")
  *      public function foo() {...}
  *
  * Note that if you use method level @AccessControl() annotation, the class
@@ -52,9 +52,9 @@ use Doctrine\Common\Annotations\Annotation;
  *      The foo() function will only consider if the user has the "instructor"
  *      role, and will NOT check the "grading.simple" permission.
  *
- *      @AccessControl(permission="grading.simple")
+ * @AccessControl(permission="grading.simple")
  *      class SomeController extends AbstractController {
- *          @AccessControl(role="INSTRUCTOR")
+ * @AccessControl(role="INSTRUCTOR")
  *          public function foo() {...}
  *      }
  *

--- a/site/app/libraries/routers/AccessControl.php
+++ b/site/app/libraries/routers/AccessControl.php
@@ -19,28 +19,33 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * Example (role only):
  *
- *      The following function is only accessible to full access graders and
- *      instructors.
+ * The following function is only accessible to full access graders and
+ * instructors.
  *
+ * ```php
  * @AccessControl(role="FULL_ACCESS_GRADER")
- *      public function foo() {...}
- *
+ * public function foo() {...}
+ * ```
  * Example (permission only):
  *
- *      All functions inside the following class is only accessible to users
- *      with "grading.simple" permission, which is equivalent to having
- *      canI("grading.simple") being true.
+ * All functions inside the following class is only accessible to users
+ * with "grading.simple" permission, which is equivalent to having
+ * canI("grading.simple") being true.
  *
+ * ```php
  * @AccessControl(permission="grading.simple")
- *      class SomeController extends AbstractController {...}
+ * class SomeController extends AbstractController {...}
+ * ```
  *
  * Example (role & permission):
  *
- *      The following function is only accessible to full access graders
- *      and instructors with "grading.simple" permission.
+ * The following function is only accessible to full access graders
+ * and instructors with "grading.simple" permission.
  *
+ * ```php
  * @AccessControl(role="FULL_ACCESS_GRADER", permission="grading.simple")
- *      public function foo() {...}
+ * public function foo() {...}
+ * ```
  *
  * Note that if you use method level @AccessControl() annotation, the class
  * level @AccessControl() annotation will not be considered at the same time.
@@ -49,14 +54,16 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * Example (class & method):
  *
- *      The foo() function will only consider if the user has the "instructor"
- *      role, and will NOT check the "grading.simple" permission.
+ * The foo() function will only consider if the user has the "instructor"
+ * role, and will NOT check the "grading.simple" permission.
  *
+ * ```php
  * @AccessControl(permission="grading.simple")
- *      class SomeController extends AbstractController {
- * @AccessControl(role="INSTRUCTOR")
- *          public function foo() {...}
- *      }
+ * class SomeController extends AbstractController {
+ *     @AccessControl(role="INSTRUCTOR")
+ *     public function foo() {...}
+ * }
+ * ```
  *
  * @Annotation
  * @Target({"CLASS", "METHOD"})

--- a/site/app/libraries/routers/FeatureFlag.php
+++ b/site/app/libraries/routers/FeatureFlag.php
@@ -8,7 +8,7 @@ namespace app\libraries\routers;
  * Use this to enable access to a given controller or
  * method of a controller. The feature flag is passed
  * as the single argument to the constructor:
- * 
+ *
  * ```php
  * @FeatureFlag('foo')
  * class Foo {}

--- a/site/app/libraries/routers/FeatureFlag.php
+++ b/site/app/libraries/routers/FeatureFlag.php
@@ -9,7 +9,7 @@ namespace app\libraries\routers;
  * method of a controller. The feature flag is passed
  * as the single argument to the constructor:
  *
- *   @FeatureFlag('foo')
+ * @FeatureFlag('foo')
  *
  * @Annotation
  * @Target({"CLASS", "METHOD"})

--- a/site/app/libraries/routers/FeatureFlag.php
+++ b/site/app/libraries/routers/FeatureFlag.php
@@ -8,8 +8,11 @@ namespace app\libraries\routers;
  * Use this to enable access to a given controller or
  * method of a controller. The feature flag is passed
  * as the single argument to the constructor:
- *
+ * 
+ * ```php
  * @FeatureFlag('foo')
+ * class Foo {}
+ * ```
  *
  * @Annotation
  * @Target({"CLASS", "METHOD"})

--- a/site/app/models/Breadcrumb.php
+++ b/site/app/models/Breadcrumb.php
@@ -23,7 +23,7 @@ use app\libraries\Core;
  * @method string getTitle()
  * @method string|null getUrl()
  * @method string|null getExternalUrl()
-*/
+ */
 class Breadcrumb extends AbstractModel {
     /** @prop string */
     protected $title;

--- a/site/app/models/Button.php
+++ b/site/app/models/Button.php
@@ -42,7 +42,7 @@ class Button extends AbstractModel {
     /** @prop @var string|null $subtitle */
     protected $subtitle;
     /** @prop @var \DateTime|null A DateTime object representing the time for this Button.  For example if this was a
-    * grade button then $date may represent the date and time grading begins or ends */
+     * grade button then $date may represent the date and time grading begins or ends */
     protected $date;
     /** @prop @var string|null $href */
     protected $href;

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -96,10 +96,10 @@ class Config extends AbstractModel {
     protected $course_json = array();
 
     /**
-    * Indicates whether a course config has been successfully loaded.
-    * @var bool
-    * @prop
-    */
+     * Indicates whether a course config has been successfully loaded.
+     * @var bool
+     * @prop
+     */
     protected $course_loaded = false;
 
     /*** MASTER CONFIG ***/

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -13,7 +13,7 @@ use app\libraries\FileUtils;
  * @method string getTitle()
  * @method string getDisplayName()
  * @method int getUserGroup()
-  */
+ */
 class Course extends AbstractModel {
 
     /** @property string $semester the semester (or term) code in which the course is taking place. */

--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -43,14 +43,14 @@ class CourseMaterial extends AbstractModel {
     }
 
      /**
-     * Determine if a course materials file can be viewed by the current user's section
-     *
-     * @param Core $core Application core
-     * @param string $path_to_file Full path to the file that we would like to check is allowed to be viewed
-     * @param user $current_user the current user
-     * @return bool Indicates if the file has been released or not
-     * @throws FileNotFoundException The course_materials_file_data.json was not found
-     */
+      * Determine if a course materials file can be viewed by the current user's section
+      *
+      * @param Core $core Application core
+      * @param string $path_to_file Full path to the file that we would like to check is allowed to be viewed
+      * @param user $current_user the current user
+      * @return bool Indicates if the file has been released or not
+      * @throws FileNotFoundException The course_materials_file_data.json was not found
+      */
     public static function isSectionAllowed(Core $core, string $path_to_file, user $current_user) {
         // Before students are allowed to view or download a course materials file we must ensure
         // it has been released.  To return true the file metadata must be found in course_materials_file_data.json

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -30,10 +30,10 @@ class OfficeHoursQueueModel extends AbstractModel {
     private $colors = array('#c98ee4','#9fcc55','#ea79a1','#4ed78e','#ef7568','#38b3eb','#e09965','#8499e3','#83cc88','#d9ab39','#4ddcc0','#b9c673','#658bfb','#76cc6c','#dc8b3d','#c9bf5d','#5499f0','#9a89f0','#e57fcf','#c0c246');
 
     /**
-    * OfficeHoursQueueModel constructor.
-    *
-    * @param Core  $core
-    */
+     * OfficeHoursQueueModel constructor.
+     *
+     * @param Core  $core
+     */
     public function __construct(Core $core, $full_history = false) {
         parent::__construct($core);
         $index = 0;

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -87,7 +87,7 @@ class Team extends AbstractModel {
     /**
      * Get registration section
      * @return integer
-    */
+     */
     public function getRegistrationSection() {
         return $this->registration_section;
     }
@@ -95,7 +95,7 @@ class Team extends AbstractModel {
     /**
      * Get rotating section
      * @return integer
-    */
+     */
     public function getRotatingSection() {
         return $this->rotating_section;
     }
@@ -103,7 +103,7 @@ class Team extends AbstractModel {
     /**
      * Get user ids of team members
      * @return string[]
-    */
+     */
     public function getMembers() {
         return $this->member_user_ids;
     }
@@ -111,7 +111,7 @@ class Team extends AbstractModel {
     /**
      * Get users of team, sorted by id
      * @return User[]
-    */
+     */
     public function getMemberUsersSorted() {
         $ret = $this->member_users;
         usort($ret, function ($a, $b) {
@@ -123,7 +123,7 @@ class Team extends AbstractModel {
     /**
      * Get user ids of those invited to the team
      * @return string[]
-    */
+     */
     public function getInvitations() {
         return $this->invited_user_ids;
     }
@@ -131,7 +131,7 @@ class Team extends AbstractModel {
     /**
      * Get string list of team members
      * @return string
-    */
+     */
     public function getMemberList() {
         return $this->member_list;
     }
@@ -139,7 +139,7 @@ class Team extends AbstractModel {
     /**
      * Get number of users in team
      * @return integer
-    */
+     */
     public function getSize() {
         return count($this->member_user_ids);
     }

--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -139,13 +139,13 @@ class Notebook extends AbstractModel {
 
 
       /**
-     * Gets a new 'notebook' which contains information about most recent submissions
-     *
-     * @return array An updated 'notebook' which has the most recent submission data entered into the
-     * 'recent_submission' key for each input item inside the notebook.  If there haven't been any submissions,
-     * then 'recent_submission' is populated with 'initial_value' if one exists, otherwise it will be
-     * blank.
-     */
+       * Gets a new 'notebook' which contains information about most recent submissions
+       *
+       * @return array An updated 'notebook' which has the most recent submission data entered into the
+       * 'recent_submission' key for each input item inside the notebook.  If there haven't been any submissions,
+       * then 'recent_submission' is populated with 'initial_value' if one exists, otherwise it will be
+       * blank.
+       */
     public function getMostRecentNotebookSubmissions(int $version, array $new_notebook): array {
         foreach ($new_notebook as $notebookKey => $notebookVal) {
             if (isset($notebookVal['type'])) {

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -57,10 +57,10 @@ class UserSpecificNotebook extends Notebook {
 
 
     /**
-    * Collect items from a notebook and replace them with the actual notebook values
-    * @param array $raw_notebook the original user created config with item sections
-    * @return array a new notebook with the item sections replaced with actual notebook questions/markdown/images etc
-    */
+     * Collect items from a notebook and replace them with the actual notebook values
+     * @param array $raw_notebook the original user created config with item sections
+     * @return array a new notebook with the item sections replaced with actual notebook questions/markdown/images etc
+     */
     private function replaceNotebookItemsWithQuestions(array $raw_notebook): array {
         $new_notebook = [];
         $seen_items = [];
@@ -102,10 +102,10 @@ class UserSpecificNotebook extends Notebook {
 
 
     /**
-    * Given a notebook item return an associated notebook question
-    * @param array $item notebook item from the user created config
-    * @return string the name of the notebook question to select
-    */
+     * Given a notebook item return an associated notebook question
+     * @param array $item notebook item from the user created config
+     * @return string the name of the notebook question to select
+     */
     private function getItemFromPool(array $item): string {
         $item_label = $item['item_label'];
         $selected = $this->getNotebookHash($item_label, count($item['from_pool']));
@@ -117,11 +117,11 @@ class UserSpecificNotebook extends Notebook {
 
 
     /**
-    * Generate a unique hash used to select a question for this student's notebook, the hash is saved under $this->hashes
-    * @param string $item_label the notebook item label in the config used
-    * @param int $from_pool_count the number of questions in the associated item pool
-    * @return int the index of the question to select
-    */
+     * Generate a unique hash used to select a question for this student's notebook, the hash is saved under $this->hashes
+     * @param string $item_label the notebook item label in the config used
+     * @param int $from_pool_count the number of questions in the associated item pool
+     * @return int the index of the question to select
+     */
     private function getNotebookHash(string $item_label, int $from_pool_count): int {
     
         $gid = $this->gradeable_id;
@@ -139,9 +139,9 @@ class UserSpecificNotebook extends Notebook {
     }
 
     /**
-    * Given an item_pool name return all associated notebook values and their testcases
-    * @param string $tgt_name the name of the item_pool to search for
-    */
+     * Given an item_pool name return all associated notebook values and their testcases
+     * @param string $tgt_name the name of the item_pool to search for
+     */
     private function searchForItemPool(string $tgt_name): array {
         $ret = ["notebook" => [], "testcases" => []];
         foreach ($this->item_pool as $item) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -725,7 +725,7 @@ class NavigationView extends AbstractView {
         ]);
     }
 
-        /**
+    /**
      * @param Gradeable $gradeable
      * @return Button|null
      */

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -106,7 +106,7 @@ class ForumThreadView extends AbstractView {
         for a specific thread, in addition to head of the threads
         that have been created after applying filter and to be
         displayed in the left panel.
-    */
+     */
 
     public function showForumThreads($user, $posts, $unviewed_posts, $threadsHead, $show_deleted, $show_merged_thread, $display_option, $max_thread, $initialPageNumber, $thread_resolve_state, $post_content_limit, $ajax = false) {
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -621,11 +621,11 @@ class HomeworkView extends AbstractView {
     }
 
      /**
-     * @param GradedGradeable $graded_gradeable
-     * @param AutoGradedVersion|null $version_instance
-     * @param bool $show_hidden
-     * @return string
-     */
+      * @param GradedGradeable $graded_gradeable
+      * @param AutoGradedVersion|null $version_instance
+      * @param bool $show_hidden
+      * @return string
+      */
     private function renderTotalScoreBox(GradedGradeable $graded_gradeable, $version_instance, bool $show_hidden): string {
         $gradeable = $graded_gradeable->getGradeable();
         $autograding_config = $gradeable->getAutogradingConfig();
@@ -745,11 +745,11 @@ class HomeworkView extends AbstractView {
     }
 
      /**
-     * @param GradedGradeable $graded_gradeable
-     * @param AutoGradedVersion|null $version_instance
-     * @param bool $show_hidden
-     * @return string
-     */
+      * @param GradedGradeable $graded_gradeable
+      * @param AutoGradedVersion|null $version_instance
+      * @param bool $show_hidden
+      * @return string
+      */
     private function renderAutogradingBox(GradedGradeable $graded_gradeable, $version_instance, bool $show_hidden): string {
         $gradeable = $graded_gradeable->getGradeable();
         $autograding_config = $gradeable->getAutogradingConfig();

--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -8,16 +8,16 @@ use app\views\AbstractView;
 class TeamView extends AbstractView {
 
     /**
-    * Show team management page
-    * @param \app\models\gradeable\Gradeable $gradeable
-    * @param \app\models\Team|null $team The team the user is on
-    * @param (\app\models\User|null)[] $members
-    * @param (\app\models\User|null)[] $seekers
-    * @param \app\models\Team[] $invites_received
-    * @param bool $seeking_partner
-    * @param bool $lock
-    * @return string
-    */
+     * Show team management page
+     * @param \app\models\gradeable\Gradeable $gradeable
+     * @param \app\models\Team|null $team The team the user is on
+     * @param (\app\models\User|null)[] $members
+     * @param (\app\models\User|null)[] $seekers
+     * @param \app\models\Team[] $invites_received
+     * @param bool $seeking_partner
+     * @param bool $lock
+     * @return string
+     */
     public function showTeamPage(Gradeable $gradeable, $team, $members, $seekers, $invites_received, bool $seeking_partner, bool $lock): string {
         $gradeable_id = $gradeable->getId();
 

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -160,7 +160,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
     
     /**
      * @runInSeparateProcess
-    */
+     */
 
     public function testModifyCourseMaterials() {
         $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -26,8 +26,6 @@
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
 
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-        <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar" />
-        <exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar" />
         <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops.Found" />
 
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We were not linting for the style of doc comments with regards to the alignment. This has lead to a number of doc comments that have inconsistent styling.

### What is the new behavior?

All PHP doc comments have been updated to use the same styling, which is the standard of how to do doc comments across languages, namely:
```php
/**
 * function desc
 * @param string foo
 */
function bar(foo);
```

where the `*` of each line aligns with the first `*` of the opening comment. Additionally, I've activated the `Squiz.Commenting.DocCommentAlignment` rules to enforce this style.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
