### PR TITLE
[Refactor:PHP] Remove useless ternary operators

### DIFF
--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -55,7 +55,7 @@ class NotificationController extends AbstractController {
      * @return MultiResponse
      */
     public function showNotifications($show_all = null) {
-        $show_all = isset($show_all) ? true : false;
+        $show_all = isset($show_all);
         $notifications = $this->core->getQueries()->getUserNotifications($this->core->getUser()->getId(), $show_all);
         return MultiResponse::webOnlyResponse(
             new WebResponse(

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -148,7 +148,7 @@ class ConfigurationController extends AbstractController {
                 ]
             )
         ) {
-            $entry = $entry === "true" ? true : false;
+            $entry = $entry === "true";
         }
         elseif ($name == "course_home_url") {
             if (!filter_var($entry, FILTER_VALIDATE_URL) && !empty($entry)) {
@@ -176,7 +176,7 @@ class ConfigurationController extends AbstractController {
                 }
             }
 
-            $entry = $entry === "true" ? true : false;
+            $entry = $entry === "true";
         }
 
         if ($name === 'forum_enabled' && $entry == 1) {

--- a/site/app/controllers/forum/ForumController2.php
+++ b/site/app/controllers/forum/ForumController2.php
@@ -750,13 +750,13 @@ class ForumController2 extends AbstractController {
         //Get post data
         $title = trim($_POST['title']);
         $thread_post_content = $_POST['thread_post_content'];
-        $anon = !empty($_POST['Anon']) ? true : false;
+        $anon = !empty($_POST['Anon']);
         $thread_status = $_POST['thread_status'];
 
 
         //Default to false
-        $announcement = !empty($_POST['Announcement']) && $this->core->getUser()->accessGrading() && $_POST['Announcement'] == 'true' ? true : false;
-        $email_announcement = !empty($_POST['EmailAnnouncement']) && $this->core->getUser()->accessFullGrading() && $_POST['EmailAnnouncement'] == 'true' ? true : false;
+        $announcement = !empty($_POST['Announcement']) && $this->core->getUser()->accessGrading() && $_POST['Announcement'] == 'true';
+        $email_announcement = !empty($_POST['EmailAnnouncement']) && $this->core->getUser()->accessFullGrading() && $_POST['EmailAnnouncement'] == 'true';
 
         $categories_ids  = [];
         foreach ($_POST["cat"] as $category_id) {
@@ -789,7 +789,7 @@ class ForumController2 extends AbstractController {
         $parent_id = $_POST['parent_id'];
         $post_content = $_POST['thread_post_content'];
         $thread_id = $_POST['thread_id'];
-        $anon = !empty($_POST['Anon']) ? true : false;
+        $anon = !empty($_POST['Anon']);
 
 
         return $this->core->getForum()->publish([

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -737,7 +737,7 @@ class ElectronicGraderController extends AbstractController {
      */
     public function adminTeamSubmit($gradeable_id) {
         $view = $_POST['view'] ?? '';
-        $new_team = ($_POST['new_team'] ?? '') === 'true' ? true : false;
+        $new_team = ($_POST['new_team'] ?? '') === 'true';
         $leader_id = $_POST['new_team_user_id'] ?? '';
         $team_id = $_POST['edit_team_team_id'] ?? '';
         $reg_section = $_POST['reg_section'] ?? 'NULL';
@@ -901,11 +901,11 @@ class ElectronicGraderController extends AbstractController {
             else {
                 $from_graded_gradeable = $this->tryGetGradedGradeable($gradeable, $from, false);
             }
-            
+
             if ($from_graded_gradeable === false) {
                  $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']));
             }
-            
+
             // Get the user ID of the user we were viewing on the TA grading interface
             $from_id = $from_graded_gradeable->getSubmitter();
 

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -183,7 +183,7 @@ class DiffViewer {
                 if (filesize($actual_file) < $size_limit) {
                     $this->actual_file_name = $actual_file;
                     $this->actual = file_get_contents($actual_file);
-                    $this->has_actual = trim($this->actual) !== "" ? true : false;
+                    $this->has_actual = trim($this->actual) !== "";
                     $this->actual = explode("\n", $this->actual);
                     $this->display_actual = true;
                 }
@@ -192,7 +192,7 @@ class DiffViewer {
                     $can_diff = false;
                     //load in the first sizelimit characters of the file (TEMP VALUE)
                     $this->actual = file_get_contents($actual_file, null, null, 0, $size_limit);
-                    $this->has_actual = trim($this->actual) !== "" ? true : false;
+                    $this->has_actual = trim($this->actual) !== "";
                     $this->actual = explode("\n", $this->actual);
                     $this->display_actual = true;
                 }
@@ -209,7 +209,7 @@ class DiffViewer {
             else {
                 if (filesize($expected_file) < $size_limit) {
                     $this->expected = file_get_contents($expected_file);
-                    $this->has_expected = trim($this->expected) !== "" ? true : false;
+                    $this->has_expected = trim($this->expected) !== "";
                     $this->expected = explode("\n", $this->expected);
                     $this->display_expected = true;
                 }
@@ -217,7 +217,7 @@ class DiffViewer {
                     $can_diff = false;
                     //load in the first sizelimit characters of the file (TEMP VALUE)
                     $this->expected = file_get_contents($expected_file, null, null, 0, $size_limit);
-                    $this->has_expected = trim($this->expected) !== "" ? true : false;
+                    $this->has_expected = trim($this->expected) !== "";
                     $this->expected = explode("\n", $this->expected);
                     $this->display_expected = true;
                 }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -566,7 +566,7 @@ WHERE status = 1"
             if ($value != 'false') {
                 $results[$key] = 'true';
             }
-            $this->core->getUser()->updateUserNotificationSettings($key, $results[$key] == 'true' ? true : false);
+            $this->core->getUser()->updateUserNotificationSettings($key, $results[$key] == 'true');
             $updates .= $key . ' = ?,';
         }
 
@@ -779,7 +779,7 @@ WHERE status = 1"
         $this->course_db->query("SELECT parent_id from posts where id=?", [$post_id]);
         $parent_id = $this->course_db->rows()[0]["parent_id"];
         $children = [$post_id];
-        $get_deleted = ($newStatus ? false : true);
+        $get_deleted = $newStatus == 0;
         $this->findChildren($post_id, $thread_id, $children, $get_deleted);
 
         if (!$newStatus) {
@@ -5087,7 +5087,7 @@ AND gc_id IN (
                 VALUES (?, ?, ?, ?, ?)
                 ON CONFLICT {$conflict_clause}
                 DO
-                    UPDATE SET 
+                    UPDATE SET
                         goc_overall_comment=?;
             ";
 
@@ -5887,7 +5887,7 @@ AND gc_id IN (
               ) AS gd ON gd.g_id=g.g_id AND gd.gd_{$submitter_type}={$submitter_type_ext}
 
               LEFT JOIN (
-                SELECT 
+                SELECT
                     json_agg(goc_grader_id) as commenter_ids,
                     json_agg(goc_overall_comment) as overall_comments,
                     g_id,

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -148,7 +148,7 @@ class PostgresqlDatabase extends AbstractDatabase {
             else {
                 $lower = strtolower($element);
                 if ($parse_bools && in_array($lower, ["true", "t", "false", "f"])) {
-                    $return[] = ($lower === "true" || $lower === "t") ? true : false;
+                    $return[] = ($lower === "true" || $lower === "t");
                 }
                 elseif ($lower == "null") {
                     $return[] = null;

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -452,10 +452,17 @@ class Config extends AbstractModel {
             $this->$key = intval($this->$key);
         }
 
-        $array = ['zero_rubric_grades', 'display_rainbow_grades_summary',
-            'display_custom_message', 'forum_enabled', 'regrade_enabled', 'seating_only_for_instructor', "queue_enabled", 'queue_contact_info'];
+        $array = [
+            'zero_rubric_grades',
+            'display_rainbow_grades_summary',
+            'display_custom_message',
+            'forum_enabled', 'regrade_enabled',
+            'seating_only_for_instructor',
+            'queue_enabled',
+            'queue_contact_info'
+        ];
         foreach ($array as $key) {
-            $this->$key = ($this->$key == true) ? true : false;
+            $this->$key = (bool) $this->$key;
         }
 
         if (!empty($this->course_json['feature_flags']) && is_array($this->course_json['feature_flags'])) {

--- a/site/tests/ruleset.xml
+++ b/site/tests/ruleset.xml
@@ -33,7 +33,6 @@
         <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod" />
         <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty" />
         <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty" />
-        <exclude name="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator.UselessTernaryOperator" />
         <exclude name="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
         <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException" />
         <exclude name="SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter" />


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Number of places used useless ternary operators. They are roughly of the form `$var === true ? true : false`, where keeping just the condition gives the same effect.

### What is the new behavior?

Removes the useless ternary operators, and adds a lint rule to prevent them.