### PR TITLE
[Refactor:PHP] getRandomIndices now static method

### DIFF
--- a/site/app/libraries/NumberUtils.php
+++ b/site/app/libraries/NumberUtils.php
@@ -10,12 +10,12 @@ namespace app\libraries;
 class NumberUtils {
 
     /**
-     *  Gives the closest number to the `value` with respect to `precision`
+     * Gives the closest number to the `value` with respect to `precision`
      * @param float $value The number to round
      * @param float $precision The precision with calculation to be made
      * @return float The rounded result to the nearest multiple of precision
      */
-    public static function roundPointValue(float $value, float $precision) {
+    public static function roundPointValue(float $value, float $precision): float {
 
         // No $precision, no rounding
         if ($precision === 0.0) {
@@ -47,19 +47,17 @@ class NumberUtils {
 
     /**
      * @param int $array_length
-     * @param string $student_id
-     * @param string $gradeable_id
+     * @param string $seed
      * @return array the randomized indices array
      */
-    public function getRandomIndices(int $array_length, string $student_id, string $gradeable_id) {
-
+    public static function getRandomIndices(int $array_length, string $seed): array {
         // creating an array which is holding the indices to be shuffled.
         $randomizedIndices = [];
         for ($i = 0; $i < $array_length; $i++) {
             $randomizedIndices[] = $i;
         }
 
-        $hash = str_split(hash('sha256', '' . $student_id . $gradeable_id));
+        $hash = str_split(hash('sha256', $seed));
         // generating a seed value for the random function
         $seedValue = 0;
         foreach ($hash as $hashChar) {
@@ -77,13 +75,5 @@ class NumberUtils {
         }
 
         return $randomizedIndices;
-    }
-
-    /**
-     * @param array $array
-     * @return array indices for the given array
-     */
-    public function getIndices(array $array) {
-        return array_keys($array);
     }
 }

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -98,7 +98,7 @@
                 {% if cell.randomize_order == true %}
                     {% set choices_indices = numberUtils.getRandomIndices(cell.choices|length, student_id, gradeable_id ) %}
                 {% else %}
-                    {% set choices_indices = numberUtils.getIndices(cell.choices) %}
+                    {% set choices_indices = cell.choices|keys %}
                 {% endif %}
 
                 <fieldset id="mc_field_{{ num_multiple_choice }}"

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -455,7 +455,11 @@ class HomeworkView extends AbstractView {
             'students_full' => $students_full,
             'team_assignment' => $gradeable->isTeamAssignment(),
             'student_id' => $student_id,
-            'numberUtils' => $numberUtils,
+            'numberUtils' => new class () {
+                public function getRandomIndices(int $array_length, string $student_id, string $gradeable_id): array {
+                    return NumberUtils::getRandomIndices($array_length, '' . $student_id . $gradeable_id);
+                }
+            },
             'late_days_use' => $late_days_use,
             'old_files' => $old_files,
             'inputs' => $input_data,

--- a/site/tests/app/libraries/NumbersUtilsTester.php
+++ b/site/tests/app/libraries/NumbersUtilsTester.php
@@ -2,9 +2,7 @@
 
 namespace tests\app\libraries;
 
-use app\libraries\Core;
 use app\libraries\NumberUtils;
-use app\models\Config;
 use PHPUnit\Framework\TestCase;
 
 class NumbersUtilsTester extends TestCase {
@@ -13,29 +11,49 @@ class NumbersUtilsTester extends TestCase {
      */
     public function roundPointValueData() {
         return [
-            [6, 6, 0.05],
+            [6.0, 6, 0.05],
             [1.002, 1, 0.006],
             [0.996, 0.998, 0.006],
-            [21, 20, 7],
-            [24, 24, 8],
-            [15, 15, 0.5],
+            [21.0, 20, 7],
+            [24.0, 24, 8],
+            [15.0, 15, 0.5],
             [49.8, 50, 0.6],
             [50.4, 50.2, 0.6],
-            [190, 194, 10],
-            [200, 197, 10],
+            [190.0, 194, 10],
+            [200.0, 197, 10],
             [1.02, 0.992, 0.06],
-            [98, 100, 7],
+            [98.0, 100, 7],
         ];
     }
 
     /**
-     * @param string $expectedValue
-     * @param string $value
-     * @param string $precision
-     *
      * @dataProvider roundPointValueData
      */
-    public function testRoundPointValue($expectedValue, $value, $precision) {
-        $this->assertEquals($expectedValue, NumberUtils::roundPointValue($value, $precision));
+    public function testRoundPointValue(float $expectedValue, float $value, float $precision): void {
+        $this->assertSame($expectedValue, NumberUtils::roundPointValue($value, $precision));
+    }
+
+    public function testRoundPointValueZeroPrecision(): void {
+        $this->assertSame(12.134, NumberUtils::roundPointValue(12.134, 0));
+    }
+
+    public function randomIndicesData(): array {
+        return [
+            [-1, []],
+            [0, []],
+            [1, [0]],
+            [5, [2, 3, 1, 4, 0]],
+        ];
+    }
+
+    /**
+     * @dataProvider randomIndicesData
+     */
+    public function testGetRandomIndices(int $len, array $expected): void {
+        $this->assertSame($expected, NumberUtils::getRandomIndices($len, 'test'));
+    }
+
+    public function testGetRandomIndicesDifferentSeeds(): void {
+        $this->assertNotSame(NumberUtils::getRandomIndices(5, 'seed1'), NumberUtils::getRandomIndices(5, 'seed2'));
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

NumberUtils included two non-static functions, to be used within a twig template within a class instantiation of NumberUtils. One of the functions also just returns the array keys of an array.

### What is the new behavior?

Gets rid of the array keys function in favor of the builtin [`keys`](https://twig.symfony.com/doc/3.x/filters/keys.html) filter. The other function was made static, and then uses an anonymous class instantation to pass it into twig to allow it to be used the same as before. Tests were also added for the function.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
We should be trying to create and use PHP models to pass into the templates, and not passing in arrays of scalar values wherever possible, so that we might have a `notebook.getCells()` method that returns a `Cell` model, and then internal to that model, it would call NumberUtils.