### PR TITLE
[Bugfix:Notebook] Remove stray 1 above randomized cells

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -94,7 +94,6 @@
 
             {# Handle if cell is multiple choice #}
             {% elseif cell.type == "multiple_choice" %}
-                {{ cell.randomize_order }}
                 {% if cell.randomize_order == true %}
                     {% set choices_indices = numberUtils.getRandomIndices(cell.choices|length, student_id, gradeable_id ) %}
                 {% else %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

For cells that had the `random_order` option enabled, a `1` would appear above it. This represents the boolean true for `random_order`, and looks like it was used for debugging from #5380.

![Screenshot 2020-06-06 15 07 32](https://user-images.githubusercontent.com/1845314/83952551-48bee780-a842-11ea-8766-35601e33b7d8.png)

### What is the new behavior?

The `1` no longer appears.