### PR TITLE
[Bugfix:InstructorUI] Fix undefined index warning when sending seating emails

### DIFF
--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -3,7 +3,6 @@
 namespace app\models;
 
 use app\libraries\Core;
-use app\libraries\Utils;
 
 /**
  * Class Email
@@ -32,7 +31,7 @@ class Email extends AbstractModel {
    * @param array $details
    */
 
-    public function __construct(Core $core, $details = []) {
+    public function __construct(Core $core, array $details = []) {
         parent::__construct($core);
         if (count($details) == 0) {
             return;
@@ -48,21 +47,24 @@ class Email extends AbstractModel {
     }
 
     //inject course label into subject
-    private function formatSubject($subject) {
+    private function formatSubject(string $subject): string {
         $course = $this->core->getConfig()->getCourse();
         return "[Submitty $course]: " . $subject;
     }
 
     //inject a "do not reply" note in the footer of the body
     //also adds author and a relevant url if one exists
-    private function formatBody($body, $relevant_url = null, $author = false) {
-        $body .= "\n\n";
-        $anon = (isset($_POST["Anon"]) && $_POST["Anon"] === "Anon") ? 1 : 0;
-        if (!($anon) && $author) {
-            $body .= "Author: " . $this->core->getUser()->getDisplayedFirstName() . " " . $this->core->getUser()->getDisplayedLastName()[0] . ".\n";
+    private function formatBody(string $body, ?string $relevant_url = null, bool $author = false): string {
+        $extra = [];
+        if (!(isset($_POST["Anon"]) && $_POST["Anon"] === "Anon") && $author) {
+            $extra[] = "Author: " . $this->core->getUser()->getDisplayedFirstName() . " " . $this->core->getUser()->getDisplayedLastName()[0] . ".";
         }
         if (!is_null($relevant_url)) {
-            $body .= "Click here for more info: " . $relevant_url;
+            $extra[] = "Click here for more info: " . $relevant_url;
+        }
+
+        if (count($extra) > 0) {
+            $body .= "\n\n" . implode("\n", $extra);
         }
         return $body . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
     }

--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -40,13 +40,11 @@ class Email extends AbstractModel {
         $this->setUserId($details["to_user_id"]);
         $this->setSubject($this->formatSubject($details["subject"]));
 
-        $relevant_url = null;
-        if (array_key_exists("relevant_url", $details)) {
-            $relevant_url = $details["relevant_url"];
-        }
-
-        $author = $details["author"];
-        $this->setBody($this->formatBody($details["body"], $relevant_url, $author));
+        $this->setBody($this->formatBody(
+            $details["body"],
+            $details['relevant_url'] ?? null,
+            $details['author'] ?? false
+        ));
     }
 
     //inject course label into subject

--- a/site/tests/app/models/EmailTester.php
+++ b/site/tests/app/models/EmailTester.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\app\models;
+
+use app\libraries\Core;
+use app\models\Config;
+use app\models\Email;
+use app\models\User;
+
+class EmailTester extends \PHPUnit\Framework\TestCase {
+    private $footer = "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.\nPlease refer to the course syllabus for contact information for your teaching staff.";
+    /** @var Core */
+    private $core;
+
+    public function setUp(): void {
+        $this->core = new Core();
+        $config = new Config($this->core);
+        $config->setCourse('csci1100');
+        $user = new User($this->core, [
+            'user_id' => 'test',
+            'user_firstname' => 'Tester',
+            'user_preferred_firstname' => 'Test',
+            'user_lastname' => 'Person',
+            'user_email' => null
+        ]);
+        $this->core->setUser($user);
+        $this->core->setConfig($config);
+    }
+
+    public function tearDown(): void {
+        unset($_POST['Anon']);
+    }
+
+    public function testBasic(): void {
+        $email = new Email($this->core, [
+            'to_user_id' => 'person',
+            'subject' => 'some email',
+            'body' => 'email body',
+        ]);
+
+        $this->assertSame('person', $email->getUserId());
+        $this->assertSame('[Submitty csci1100]: some email', $email->getSubject());
+        $this->assertSame('email body' . $this->footer, $email->getBody());
+    }
+
+    public function testRelevantUrl(): void {
+        $email = new Email($this->core, [
+            'to_user_id' => 'person',
+            'subject' => 'some email',
+            'body' => "email body",
+            'relevant_url' => 'http://example.com'
+        ]);
+
+        $this->assertSame('person', $email->getUserId());
+        $this->assertSame('[Submitty csci1100]: some email', $email->getSubject());
+        $this->assertSame(
+            "email body\n\nClick here for more info: http://example.com" . $this->footer,
+            $email->getBody()
+        );
+    }
+
+    public function testAuthor(): void {
+        $email = new Email($this->core, [
+            'to_user_id' => 'person',
+            'subject' => 'some email',
+            'body' => "email body",
+            'author' => true
+        ]);
+
+        $this->assertSame('person', $email->getUserId());
+        $this->assertSame('[Submitty csci1100]: some email', $email->getSubject());
+        $this->assertSame(
+            "email body\n\nAuthor: Test P." . $this->footer,
+            $email->getBody()
+        );
+    }
+
+    public function testAuthorAnonymous(): void {
+        $_POST['Anon'] = 'Anon';
+        $email = new Email($this->core, [
+            'to_user_id' => 'person',
+            'subject' => 'some email',
+            'body' => "email body",
+            'author' => true
+        ]);
+
+        $this->assertSame('person', $email->getUserId());
+        $this->assertSame('[Submitty csci1100]: some email', $email->getSubject());
+        $this->assertSame(
+            "email body" . $this->footer,
+            $email->getBody()
+        );
+    }
+
+    public function testAllDetails(): void {
+        $email = new Email($this->core, [
+            'to_user_id' => 'person',
+            'subject' => 'some email',
+            'body' => "email body",
+            'relevant_url' => 'http://example.com',
+            'author' => true
+        ]);
+
+        $this->assertSame('person', $email->getUserId());
+        $this->assertSame('[Submitty csci1100]: some email', $email->getSubject());
+        $this->assertSame(
+            "email body\n\nAuthor: Test P.\nClick here for more info: http://example.com" . $this->footer,
+            $email->getBody()
+        );
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The EmailRoomSeatingController generates undefined index warnings as `author` is not defined there, and there is no `isset` type checking on author when it was added in #4959. Sending emails about the room seating still works due to PHP implicitly converting the undefined index to a falsey value.

### What is the new behavior?

This refactors it so that `author` is now properly optional on the `$details` array, defaulting to false when it does not exist. I got rid of the default arguments to the `formatBody` function as there's never a case right now where we should be using those defaults (as we're always calling the function now with three defined variables).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

I rewrote `formatBody` so that the amount of spacing would be always consistent with two `\n` between the body and next bit and two `\n` between the relevant url / author (if exists) and footer. Right now, you could have a case where you would have four `\n` between body and footer if no author or relevant url, and then three `\n` between the author and footer if no relevant url is defined.