### PR TITLE
[Testing:PHP] Add tests for FeatureFlag class

### DIFF
--- a/site/app/libraries/routers/FeatureFlag.php
+++ b/site/app/libraries/routers/FeatureFlag.php
@@ -2,6 +2,8 @@
 
 namespace app\libraries\routers;
 
+use InvalidArgumentException;
+
 /**
  * Annotation class for @FeatureFlag().
  *
@@ -22,6 +24,9 @@ class FeatureFlag {
     private $flag;
 
     public function __construct(array $data) {
+        if (empty($data['value']) || !is_string($data['value'])) {
+            throw new InvalidArgumentException('Must have non-empty string "value" for FeatureFlag annotation');
+        }
         $this->flag = $data['value'];
     }
 

--- a/site/tests/app/libraries/routers/FeatureFlagTester.php
+++ b/site/tests/app/libraries/routers/FeatureFlagTester.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace tests\app\libraries\routers;
+
+use app\libraries\routers\FeatureFlag;
+use InvalidArgumentException;
+
+class FeatureFlagTester extends \PHPUnit\Framework\TestCase {
+    public function testFeatureFlag() {
+        $flag = new FeatureFlag(['value' => 'test_flag']);
+        $this->assertSame('test_flag', $flag->getFlag());
+    }
+
+    public function testEmptyValue() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Must have non-empty string "value" for FeatureFlag annotation');
+        new FeatureFlag([]);
+    }
+
+    public function testNonStringValue() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Must have non-empty string "value" for FeatureFlag annotation');
+        new FeatureFlag(['value' => 1]);
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The FeatureFlag annotation class did not have any direct tests.

### What is the new behavior?

Adds direct testing of the FeatureFlag class.