### PR TITLE
[Bugfix:InstructorUI] RG WebUI bugfix

### DIFF
--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -166,8 +166,8 @@ function getGradeableBuckets()
 
             // Extract each independent gradeable in the bucket
             var ids = [];
-            var selector = '#gradeables-list-' + type + ' li';
-            $(selector).each(function() {
+            var selector = `#gradeables-list-${type}`;
+            $(selector).children('.gradeable-li').each(function() {
 
                 var gradeable = {};
 


### PR DESCRIPTION
Fixes an issue on the rainbow grades webUI page where users saw ```Status: TypeError: $(...).find(...)[0] is undefined``` when attempting to save their selections.
