### PR TITLE
[Testing:PHP] Add tests for optional round parameter in Utils::formatBytes

### DIFF
--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -642,6 +642,26 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($expected, Utils::formatBytes($format, $bytes));
     }
 
+    public function formatBytesRoundingProvider() {
+        return [
+            ['b', 0, '0B'],
+            ['b', 1000, '1000B'],
+            ['kb', 999, '1KB'],
+            ['kb', 1023, '1KB'],
+            ['kb', 500, '0KB'],
+            ['kb', 1049999, '1025KB'],
+            ['mb', 1, '0MB'],
+            ['mb', 5000123, '5MB'],
+        ];
+    }
+
+    /**
+     * @dataProvider formatBytesRoundingProvider
+     */
+    public function testFormatBytesRounding($format, $bytes, $expected) {
+        $this->assertEquals($expected, Utils::formatBytes($format, $bytes, true));
+    }
+
     public function testMbStrSplitRegularString() {
         $this->assertEquals(str_split('abcdef'), Utils::mb_str_split('abcdef'));
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The Docker UI caused a changed to the formatBytes to properly display docker image sizes that were human-readable,
in order to get it merged quickly the test was not added in that PR.

### What is the new behavior?
Adds test for optional parameter.


