### PR TITLE
[Refactor:PHP] Replace deprecated twig class

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -342,7 +342,7 @@ HTML;
         try {
             return $this->twig->render($filename, $context);
         }
-        catch (\Twig_Error $e) {
+        catch (\Twig\Error\Error $e) {
             throw new OutputException("{$e->getMessage()} in {$e->getFile()}:{$e->getLine()}");
         }
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

`\Twig_Error` was deprecated at some point in the past.

### What is the new behavior?

Replaces it with the supported `\Twig\Error\Error`.
