### PR TITLE
[Testing:Travis] Do not complete full build pipeline for draft PRs

### DIFF
--- a/.setup/travis/check_wip.py
+++ b/.setup/travis/check_wip.py
@@ -33,6 +33,10 @@ def main():
                 json = res.json()
                 print(f"Draft => {json['draft']}")
                 if json['draft'] is True:
+                    print(
+                        "Draft PR detected, build failed. Must be marked ready "
+                        "for review for this to pass."
+                    )
                     sys.exit(1)
                 title = json['title'].lower()
                 if title is None or title == 'null':

--- a/.setup/travis/check_wip.py
+++ b/.setup/travis/check_wip.py
@@ -31,6 +31,9 @@ def main():
             res = requests.get(url, headers=headers, timeout=10)
             if res.status_code == 200:
                 json = res.json()
+                print(f"Draft => {json['draft']}")
+                if json['draft'] is True:
+                    sys.exit(1)
                 title = json['title'].lower()
                 if title is None or title == 'null':
                     time.sleep(1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   include:
     # Test if the name of the PR starts with [WIP] and fail at this stage if it does
     - if: type = pull_request
-      stage: pr test for wip
+      stage: pr test for wip or draft
       language: python
       python: 3.6
       install:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

PRs that are marked as drafts, but do not have the `[WIP]` tag still go through the entire PR build process. This check was added back before GitHub supported pull requests drafts.

### What is the new behavior?

Fails PR builds if they are marked as drafts or WIP.