### PR TITLE
[Refactor:PHP] Fix static analysis error in CascadingIterator

### DIFF
--- a/site/app/libraries/CascadingIterator.php
+++ b/site/app/libraries/CascadingIterator.php
@@ -13,7 +13,7 @@ namespace app\libraries;
 class CascadingIterator implements \Iterator {
 
     /** @var \Iterator[] */
-    private $iterators = [];
+    private $iterators;
     /** @var int */
     private $iterator_key = 0;
     /** @var int  */
@@ -21,7 +21,7 @@ class CascadingIterator implements \Iterator {
 
     /**
      * MultiIterator constructor.
-     * @param \Iterator[] $iterators
+     * @param \Iterator ...$iterators
      */
     public function __construct(...$iterators) {
         $this->iterators = $iterators;

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -296,11 +296,6 @@ parameters:
 			path: app/controllers/student/SubmissionController.php
 
 		-
-			message: "#^PHPDoc tag @param for parameter \\$iterators with type array\\<Iterator\\> is not subtype of native type array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: app/libraries/CascadingIterator.php
-
-		-
 			message: "#^PHPDoc tag @param has invalid value \\(\\$course\\)\\: Unexpected token \"\\$course\", expected type at offset 484$#"
 			count: 1
 			path: app/libraries/Core.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There was an ignored phpstan static analysis error in CascadingIterator. This error was renamed in a recent phpstan version causing #5504 to fail.

### What is the new behavior?

The static analysis error is fixed. Once merged, #5504 should pass.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
