### PR TITLE
[Testing:PHP] Simplify and add tests to DateUtilsTester

### DIFF
--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -33,6 +33,7 @@ use app\libraries\FileUtils;
  * @method string getConfigPath()
  * @method string getAuthentication()
  * @method \DateTimeZone getTimezone()
+ * @method setTimezone(\DateTimeZone $timezone)
  * @method string getUploadMessage()
  * @method array getHiddenDetails()
  * @method string getCourseJsonPath()

--- a/site/tests/app/libraries/DateUtilsTester.php
+++ b/site/tests/app/libraries/DateUtilsTester.php
@@ -5,9 +5,10 @@ namespace tests\app\libraries;
 use app\libraries\Core;
 use app\libraries\DateUtils;
 use app\models\Config;
+use app\models\User;
 
 class DateUtilsTester extends \PHPUnit\Framework\TestCase {
-    public function dayDiffData() {
+    public function dayDiffProvider(): array {
         return [
             [1, "Now", "Tomorrow"],
             [0, "2017-01-12 19:10:53.000000", "2017-01-12 19:10:53.000000"],
@@ -25,17 +26,13 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @param string $expected
-     * @param string $date1
-     * @param string $date2
-     *
-     * @dataProvider dayDiffData
+     * @dataProvider dayDiffProvider
      */
-    public function testCalculateDayDiff($expected, $date1, $date2) {
+    public function testCalculateDayDiff(int $expected, string $date1, string $date2): void {
         $this->assertEquals($expected, DateUtils::calculateDayDiff($date1, $date2));
     }
 
-    public function validateTimestampData(): array {
+    public function validateTimestampProvider(): array {
         return [
             ['01-25-2019', true],
             ['02-29-2020', true],
@@ -53,13 +50,13 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @dataProvider validateTimestampData
+     * @dataProvider validateTimestampProvider
      */
     public function testValidateTimestamp(string $expected, bool $valid): void {
         $this->assertTrue(DateUtils::validateTimestamp($expected) === $valid);
     }
 
-    public function validateTimestampForFormatData(): array {
+    public function validateTimestampFormatProvider(): array {
         return [
             // valid formats
             ['m-d-Y', '02-29-2020', true],
@@ -77,32 +74,48 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @dataProvider validateTimestampForFormatData
+     * @dataProvider validateTimestampFormatProvider
      */
     public function testValidateTimestampForFormat(string $format, string $timestamp, bool $valid): void {
         $this->assertTrue(DateUtils::validateTimestampForFormat($format, $timestamp) === $valid);
     }
 
-    public function testParseDateTimeInvalidType() {
+    public function testParseDateTimeInvalidType(): void {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Passed object was not a DateTime object or a date string');
         DateUtils::parseDateTime(false, new \DateTimeZone('America/New_York'));
     }
 
-    public function testParseDateTimeInvalidFormat() {
+    public function testParseDateTimeInvalidFormat(): void {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid DateTime Format');
         DateUtils::parseDateTime('this is an invalid date', new \DateTimeZone('America/New_York'));
     }
 
-    public function testParseDateTimeString() {
-        $timezone = new \DateTimeZone("Etc/GMT+5");
-        $datetime = DateUtils::parseDateTime('01/20/2019T13:24:55Z', $timezone);
-        $this->assertEquals("20/01/2019T08:24:55", $datetime->format('d/m/Y\TH:i:s'));
+    public function parseDateTimeProvider(): array {
+        return [
+            ['01/20/2019T13:24:55Z', 'Etc/GMT+5', 'd/m/Y\TH:i:s', '20/01/2019T08:24:55'],
+            // max time value
+            ['9999/12/31T13:24:55Z', 'Etc/GMT-5', 'd/m/Y\TH:i:s', '01/02/9999T00:00:00'],
+            // test timezones with DST
+            ['2020-06-01 12:00:00-04', 'America/New_York', 'Y-m-d H:i:s', '2020-06-01 12:00:00'],
+            ['2020-12-01 12:00:00-05', 'America/New_York', 'Y-m-d H:i:s', '2020-12-01 12:00:00'],
+            ['2020-06-01 12:00:00-04', 'America/Los_Angeles', 'Y-m-d H:i:s', '2020-06-01 09:00:00'],
+            ['2020-12-01 12:00:00-05', 'America/Los_Angeles', 'Y-m-d H:i:s', '2020-12-01 09:00:00'],
+        ];
+    }
+
+    /**
+     * @dataProvider parseDateTimeProvider
+     */
+    public function testParseDateTimeString(string $input, string $timezoneString, string $format, string $expected): void {
+        $timezone = new \DateTimeZone($timezoneString);
+        $datetime = DateUtils::parseDateTime($input, $timezone);
+        $this->assertEquals($expected, $datetime->format($format));
         $this->assertEquals($timezone, $datetime->getTimezone());
     }
 
-    public function testParseDateTimeDifferentTimezone() {
+    public function testParseDateTimeDifferentTimezone(): void {
         $timezone = new \DateTimeZone('Etc/GMT-5');
         $datetime = DateUtils::parseDateTime(
             new \DateTime('01/20/2019T13:24:55Z', new \DateTimeZone('UTC')),
@@ -112,7 +125,7 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($timezone, $datetime->getTimezone());
     }
 
-    public function testParseDateTimeMaxString() {
+    public function testParseDateTimeMaxString(): void {
         $timezone = new \DateTimeZone('Etc/GMT-5');
         $datetime = DateUtils::parseDateTime(
             new \DateTime('9999/12/31T13:24:55Z', $timezone),
@@ -122,14 +135,14 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($timezone, $datetime->getTimezone());
     }
 
-    public function testDateTimeToString() {
+    public function testDateTimeToString(): void {
         $actual = DateUtils::dateTimeToString(
             new \DateTime('01/20/2019T13:24:55', new \DateTimeZone('Etc/GMT+5'))
         );
         $this->assertEquals('2019-01-20 13:24:55-0500', $actual);
     }
 
-    public function testDateTimeToStringNoOffset() {
+    public function testDateTimeToStringNoOffset(): void {
         $actual = DateUtils::dateTimeToString(
             new \DateTime('01/20/2019T13:24:55', new \DateTimeZone('Etc/GMT+5')),
             false
@@ -137,96 +150,7 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('2019-01-20 13:24:55', $actual);
     }
 
-    /**
-     * Time stamp with -04 offset into America/New_York
-     * Date format: YYYY-MM-DD HH:MM:SS
-     *
-     * Time stamp: 2020-06-01 12:00:00-04
-     * UTC time: 2020-06-01 16:00:00
-     *
-     * Expected: 2020-06-01 12:00:00
-     */
-    public function testParseDateTimeNYOne() {
-        $format = 'Y-m-d H:i:s';
-        $time_zone = new \DateTimeZone('America/New_York');
-
-        $time_stamp = '2020-06-01 12:00:00-04';
-        $date_time = DateUtils::parseDateTime($time_stamp, $time_zone);
-
-        $expected_string = '2020-06-01 12:00:00';
-        $captured_string = $date_time->format($format);
-
-        $this->assertEquals($expected_string, $captured_string);
-    }
-
-    /**
-     * Time stamp with -05 offset into America/New_York
-     * Date format: YYYY-MM-DD HH:MM:SS
-     *
-     * Time stamp: 2020-12-01 12:00:00-05
-     * UTC time: 2020-12-01 17:00:00
-     *
-     * Expected: 2020-12-01 12:00:00
-     */
-    public function testParseDateTimeNYTwo() {
-        $format = 'Y-m-d H:i:s';
-        $time_zone = new \DateTimeZone('America/New_York');
-
-        $time_stamp = '2020-12-01 12:00:00-05';
-        $date_time = DateUtils::parseDateTime($time_stamp, $time_zone);
-
-        $expected_string = '2020-12-01 12:00:00';
-        $captured_string = $date_time->format($format);
-
-        $this->assertEquals($expected_string, $captured_string);
-    }
-
-    /**
-     * Time stamp with -04 offset into America/Los_Angeles
-     * Date format: YYYY-MM-DD HH:MM:SS
-     *
-     * Time stamp: 2020-06-01 12:00:00-04
-     * UTC time: 2020-06-01 16:00:00
-     *
-     * Expected: 2020-06-01 09:00:00
-     */
-    public function testParseDateTimeLAOne() {
-        $format = 'Y-m-d H:i:s';
-        $time_zone = new \DateTimeZone('America/Los_Angeles');
-
-        $time_stamp = '2020-06-01 12:00:00-04';
-        $date_time = DateUtils::parseDateTime($time_stamp, $time_zone);
-
-        $expected_string = '2020-06-01 09:00:00';
-        $captured_string = $date_time->format($format);
-
-        $this->assertEquals($expected_string, $captured_string);
-    }
-
-    /**
-     * Time stamp with -05 offset into America/Los_Angeles
-     * Date format: YYYY-MM-DD HH:MM:SS
-     *
-     * Time stamp: 2020-12-01 12:00:00-05
-     * UTC time: 2020-12-01 17:00:00
-     *
-     * Expected: 2020-12-01 09:00:00
-     */
-    public function testParseDateTimeLATwo() {
-        $format = 'Y-m-d H:i:s';
-        $time_zone = new \DateTimeZone('America/Los_Angeles');
-
-        $time_stamp = '2020-12-01 12:00:00-05';
-        $date_time = DateUtils::parseDateTime($time_stamp, $time_zone);
-
-        $expected_string = '2020-12-01 09:00:00';
-        $captured_string = $date_time->format($format);
-
-        $this->assertEquals($expected_string, $captured_string);
-    }
-
-
-    public function testGetServerTime() {
+    public function testGetServerTime(): void {
         $core = new Core();
         $config = new Config($core);
         $core->setConfig($config);
@@ -237,5 +161,59 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertRegExp("/^([0-9]|1[0-9]|2[0-3])$/", $time['hour']);
         $this->assertRegExp("/[0-5][0-9]/", $time['minute']);
         $this->assertRegExp("/[0-5][0-9]/", $time['second']);
+    }
+
+    public function testGetAvailableTimeZones(): void {
+        $timezones = DateUtils::getAvailableTimeZones();
+        $this->assertIsArray($timezones);
+        $this->assertNotEmpty($timezones);
+        $this->assertSame('NOT_SET/NOT_SET', $timezones[0]);
+        $this->assertNotContains('UTC', $timezones);
+    }
+
+    public function utcOffsetProvider(): array {
+        // we cannot test a timezone with DST here as offset will shift through the year
+        return [
+            ['NOT_SET/NOT_SET', 'NOT SET'],
+            ['UTC', '+00:00'],
+            ['Antarctica/Mawson', '+05:00'],
+            ['Pacific/Honolulu', '-10:00'],
+        ];
+    }
+
+    /**
+     * @dataProvider utcOffsetProvider
+     */
+    public function testGetUTCOffset(string $timezone, string $expected): void {
+        $this->assertSame($expected, DateUtils::getUTCOffset($timezone));
+    }
+
+    public function convertTimeStampProvider(): array {
+        return [
+            ['NOT_SET/NOT_SET', '2020-06-12 12:55:00', 'Y-m-d H:i:s', '2020-06-12 12:55:00'],
+            ['NOT_SET/NOT_SET', '2020-06-12 12:55:00Z+01:00', 'Y-m-d H:i:s', '2020-06-12 08:55:00'],
+            ['NOT_SET/NOT_SET', '2020-12-12 12:55:00Z+01:00', 'H:i:s Y-m-d', '07:55:00 2020-12-12'],
+            ['America/Los_Angeles', '2020-06-12 12:55:00', 'Y-m-d H:i:s', '2020-06-12 12:55:00'],
+            ['America/Los_Angeles', '2020-06-12T12:55:00Z+01:00', 'Y-m-d H:i:s', '2020-06-12 05:55:00'],
+            ['America/Los_Angeles', '2020-12-12T12:55:00Z+01:00', 'H:i:sP Y-m-d', '04:55:00-08:00 2020-12-12'],
+        ];
+    }
+
+    /**
+     * @dataProvider convertTimeStampProvider
+     */
+    public function testConvertTimeStamp(string $timezone, string $timestamp, string $format, string $expected): void {
+        $core = new Core();
+        $config = new Config($core);
+        $config->setTimezone(new \DateTimeZone('America/New_York'));
+        $core->setConfig(new Config($core));
+        $user = new User($core, [
+            'user_id' => 'test',
+            'user_firstname' => 'test',
+            'user_lastname' => 'person',
+            'user_email' => null,
+            'time_zone' => $timezone,
+        ]);
+        $this->assertSame($expected, DateUtils::convertTimeStamp($user, $timestamp, $format));
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Couple of the functions added in #5400, #5473 did not have tests. Some of the tests added in #5473 could be simplified using data providers (https://submitty.org/developer/testing/php_unit_tests#parameterized-php-unit-tests).

### What is the new behavior?

All functions are now tested, and use data providers as makes sense, namely condensing the four testcases in #5473. 