### PR TITLE
[Bugfix:SubmittyUtils] Fix parse_datetime not handling dates and times without timezone

### DIFF
--- a/python_submitty_utils/tests/test_dateutils.py
+++ b/python_submitty_utils/tests/test_dateutils.py
@@ -1,0 +1,117 @@
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase
+from unittest.mock import patch
+
+from pytz import timezone as pytz_timezone
+
+from submitty_utils import dateutils
+
+
+class TestDateUtils(TestCase):
+    @patch(
+        "submitty_utils.dateutils.get_current_time",
+        return_value=pytz_timezone('America/New_York').localize(datetime(
+            2016, 10, 14, 22, 11, 32, 0
+        ))
+    )
+    @patch(
+        "submitty_utils.dateutils.get_timezone",
+        return_value=pytz_timezone('America/New_York')
+    )
+    def test_parse_datetime(self, current_time, get_timezone):
+        testcases = (
+            (
+                '2016-10-14 22:11:32+0200',
+                datetime(
+                    2016, 10, 14, 22, 11, 32, 0, timezone(timedelta(hours=2))
+                )
+            ),
+            (
+                '2016-10-14 22:11:32',
+                datetime(
+                    2016, 10, 14, 22, 11, 32, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '2016-10-14',
+                datetime(
+                    2016, 10, 14, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '+1 days',
+                datetime(
+                    2016, 10, 15, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '+3 day',
+                datetime(
+                    2016, 10, 17, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '+0 days',
+                datetime(
+                    2016, 10, 14, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '-1 days',
+                datetime(
+                    2016, 10, 13, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '-10 day',
+                datetime(
+                    2016, 10, 4, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                '+1 day at 10:30:00',
+                datetime(
+                    2016, 10, 15, 10, 30, 0, 0, timezone(timedelta(hours=-4))
+                )
+            ),
+            (
+                datetime(
+                    2016, 10, 4, 23, 59, 59, 0, timezone(timedelta(hours=+1))
+                ),
+                datetime(
+                    2016, 10, 4, 23, 59, 59, 0, timezone(timedelta(hours=+1))
+                )
+            ),
+            (
+                datetime(
+                    2016, 10, 4, 23, 59, 59, 0
+                ),
+                datetime(
+                    2016, 10, 4, 23, 59, 59, 0, timezone(timedelta(hours=-4))
+                )
+            )
+        )
+
+        for testcase in testcases:
+            with self.subTest(str(testcase[0])):
+                self.assertEqual(
+                    testcase[1],
+                    dateutils.parse_datetime(testcase[0])
+                )
+
+    def test_parse_datetime_invalid_type(self):
+        with self.assertRaises(TypeError) as cm:
+            dateutils.parse_datetime(10)
+        self.assertEqual(
+            "Invalid type, expected str, got <class 'int'>",
+            str(cm.exception)
+        )
+
+    def test_parse_datetime_invalid_format(self):
+        with self.assertRaises(ValueError) as cm:
+            dateutils.parse_datetime('invalid datetime')
+
+        self.assertEqual(
+            'Invalid string for date parsing: invalid datetime',
+            str(cm.exception)
+        )


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The dateutils.parse_datetime function is documented as handling a string of the format "2018-10-23", but attempting to do so would throw an exception. This is due to #1232 breaking the regex to recognize that format.

### What is the new behavior?

Fixes the function to allow that style of date. It also expands allowed formats to allow "2018-10-23 10:23:20" again (without timezone), but will attach the local timezone to it.