### PR TITLE
[Testing:SubmittyUtils] Add testcases for schema validation

### DIFF
--- a/python_submitty_utils/tests/data/complete_configs/choice_of_language.json
+++ b/python_submitty_utils/tests/data/complete_configs/choice_of_language.json
@@ -1,0 +1,407 @@
+{
+    "assignment_message": "Please submit your assignment in one of 4 languages.  Only submit to a single bucket.",
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class",
+            "test03/p3.out",
+            "test05/p4.out"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt",
+            "test03/p3.out",
+            "test05/p4.out"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "**/*.py",
+            "**/*.pdf"
+        ],
+        "submission_to_validation": [
+            "**/README.txt",
+            "input_*.txt",
+            "**/*.pdf"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "**/README.txt",
+            "input_*.txt",
+            "test*/input_*.txt",
+            "**/dispatched_actions.txt",
+            "test01/STDOUT.txt",
+            "test01/STDERR.txt",
+            "test02/STDOUT.txt",
+            "test02/STDERR.txt",
+            "test03/STDERR.txt",
+            "test03/STDOUT.txt",
+            "test04/STDOUT.txt",
+            "test04/STDERR.txt",
+            "test05/STDERR.txt",
+            "test05/STDOUT.txt",
+            "test06/STDOUT.txt",
+            "test06/STDERR.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "one_part_only": true,
+    "part_names": [
+        "Python 2",
+        "Python 3",
+        "C",
+        "C++"
+    ],
+    "publish_actions": false,
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python2 part1/*.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Python 2 Testing",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "output.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 part2/*.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Python 3 Testing",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "output.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "clang -Wall -o p3.out -- part3/*.c"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "p3.out",
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "C Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "p3.out",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./p3.out"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 3,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "C Testing",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "output.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "clang++ -Wall -o p4.out -- part4/*.cpp"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "p4.out",
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "C++ Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "p4.out",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./p4.out"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 3,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "C++ Testing",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "output.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/cpp_hidden_tests.json
+++ b/python_submitty_utils/tests/data/complete_configs/cpp_hidden_tests.json
@@ -1,0 +1,577 @@
+{
+    "assignment_message": "You are allowed 3 no penalty submissions.  You will lose 1 point for each 2 submissions beyond these non-penalty submissions.  The maximum penalty is -5 points.",
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class",
+            "test01/a.out"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt",
+            "test01/a.out"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "**/*.py",
+            "**/*.pdf"
+        ],
+        "submission_to_validation": [
+            "**/README.txt",
+            "input_*.txt",
+            "**/*.pdf"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "**/README.txt",
+            "input_*.txt",
+            "test*/input_*.txt",
+            "**/dispatched_actions.txt",
+            "test01/STDERR.txt",
+            "test01/STDOUT.txt",
+            "test02/STDOUT.txt",
+            "test02/STDERR.txt",
+            "test03/STDOUT.txt",
+            "test03/STDERR.txt",
+            "test04/STDOUT.txt",
+            "test04/STDERR.txt",
+            "test05/STDOUT.txt",
+            "test05/STDERR.txt",
+            "test06/STDOUT.txt",
+            "test06/STDERR.txt",
+            "test07/STDOUT.txt",
+            "test07/STDERR.txt",
+            "test08/STDOUT.txt",
+            "test08/STDERR.txt",
+            "test09/STDOUT.txt",
+            "test09/STDERR.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "grading_parameters": {
+        "AUTO_POINTS": 14,
+        "EXTRA_CREDIT_POINTS": 4
+    },
+    "publish_actions": false,
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "clang++ -Wall -o a.out *.cpp"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "a.out",
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "a.out",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 1"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Frame Size 1",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "frame_1.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 5"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Frame Size 5",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "frame_5.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 10"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Frame Size 10",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "frame_10.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 13"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "hidden": true,
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Frame Size 13",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "frame_13.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 0"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Error Checking: Frame Size 0",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.5,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 1,
+                    "expected_file": "error_nonpositive.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out -10"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "hidden": true,
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Error Checking: Frame Size Negative",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.5,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 1,
+                    "expected_file": "error_nonpositive.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "extra_credit": true,
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Error Checking: No Arguments",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.5,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 1,
+                    "expected_file": "error_arguments.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 1 2 3"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "extra_credit": true,
+            "hidden": true,
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Error Checking: Too Many Arguments",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.5,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 1,
+                    "expected_file": "error_arguments.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "max_submissions": 3,
+            "penalty": -0.5,
+            "points": -5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck",
+            "use_router": false
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/minimal_code_editing.json
+++ b/python_submitty_utils/tests/data/complete_configs/minimal_code_editing.json
@@ -1,0 +1,114 @@
+{
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "*.cpp"
+        ],
+        "submission_to_validation": [
+            "**/README.txt",
+            "input_*.txt",
+            "**/*.pdf"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "**/README.txt",
+            "input_*.txt",
+            "test*/input_*.txt",
+            "**/dispatched_actions.txt",
+            "test01/STDOUT.txt",
+            "test01/STDERR.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "publish_actions": false,
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "cat *.cpp"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Reasonable Code Changes",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "expected_file": "fancy_hello_world.cpp",
+                    "ignore_line_endings": true,
+                    "max_char_changes": 125,
+                    "method": "diff",
+                    "min_char_changes": 75,
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/notebook_basic.json
+++ b/python_submitty_utils/tests/data/complete_configs/notebook_basic.json
@@ -1,0 +1,779 @@
+{
+    "assignment_message": "#Welcome To My Favorite Notebook Gradeable\n  \n  This message will appear in a blue box at the top of the page.",
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class",
+            "test08/cpp_prime.out"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt",
+            "test08/cpp_prime.out"
+        ],
+        "submission_to_compilation": [
+            "*.txt",
+            "*.cpp",
+            "*.py"
+        ],
+        "submission_to_runner": [
+            "*.txt",
+            "*.out",
+            "*.py"
+        ],
+        "submission_to_validation": [
+            "*.txt",
+            "*.png"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "*.txt",
+            "*.png",
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "test01/math_1.txt",
+            "test02/math_2.txt",
+            "test03/math_3.txt",
+            "test04/math_4.txt",
+            "test05/animal_1.txt",
+            "test06/animal_2.txt",
+            "test07/animal_3.txt",
+            "test08/STDERR.txt",
+            "test08/STDOUT.txt",
+            "test09/STDOUT.txt",
+            "test09/STDERR.txt",
+            "test10/STDOUT.txt",
+            "test10/STDERR.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "hide_submitted_files": true,
+    "notebook": [
+        {
+            "markdown_string": "#Instructions\n  \n  Here's a short list of instructions:\n  * This is an open-book quiz.\n  * You have 20 minutes to submit your answers.\n",
+            "type": "markdown"
+        },
+        {
+            "markdown_string": "#Let's do Math!",
+            "type": "markdown"
+        },
+        {
+            "markdown_string": "###What is `2 + 2`?",
+            "type": "markdown"
+        },
+        {
+            "choices": [
+                {
+                    "description": "`2`",
+                    "value": "a"
+                },
+                {
+                    "description": "`3`",
+                    "value": "b"
+                },
+                {
+                    "description": "`4`",
+                    "value": "c"
+                },
+                {
+                    "description": "`5`",
+                    "value": "d"
+                },
+                {
+                    "description": "*none of the above*",
+                    "value": "e"
+                }
+            ],
+            "filename": "math_1.txt",
+            "testcase_ref": "math_1",
+            "type": "multiple_choice"
+        },
+        {
+            "markdown_string": "###What is `3 + 3`?",
+            "type": "markdown"
+        },
+        {
+            "choices": [
+                {
+                    "description": "`3`",
+                    "value": "a"
+                },
+                {
+                    "description": "`4`",
+                    "value": "b"
+                },
+                {
+                    "description": "`5`",
+                    "value": "c"
+                },
+                {
+                    "description": "`6`",
+                    "value": "d"
+                },
+                {
+                    "description": "*none of the above*",
+                    "value": "e"
+                }
+            ],
+            "filename": "math_2.txt",
+            "testcase_ref": "math_2",
+            "type": "multiple_choice"
+        },
+        {
+            "markdown_string": "###Select *all* statements that are true:",
+            "type": "markdown"
+        },
+        {
+            "allow_multiple": true,
+            "choices": [
+                {
+                    "description": "`1 + 1 = 2`",
+                    "value": "a"
+                },
+                {
+                    "description": "`4 - 2 = 3`",
+                    "value": "b"
+                },
+                {
+                    "description": "`2 * 2 = 4`",
+                    "value": "c"
+                },
+                {
+                    "description": "`6 / 2 = 4`",
+                    "value": "d"
+                }
+            ],
+            "filename": "math_3.txt",
+            "testcase_ref": "math_3",
+            "type": "multiple_choice"
+        },
+        {
+            "markdown_string": "###Select *all* numbers that are powers of 2:",
+            "type": "markdown"
+        },
+        {
+            "allow_multiple": true,
+            "choices": [
+                {
+                    "description": "`4`",
+                    "value": "4"
+                },
+                {
+                    "description": "`24`",
+                    "value": "24"
+                },
+                {
+                    "description": "`32`",
+                    "value": "32"
+                },
+                {
+                    "description": "`96`",
+                    "value": "96"
+                },
+                {
+                    "description": "`128`",
+                    "value": "128"
+                },
+                {
+                    "description": "`524`",
+                    "value": "524"
+                }
+            ],
+            "filename": "math_4.txt",
+            "randomize_order": true,
+            "testcase_ref": "math_4",
+            "type": "multiple_choice"
+        },
+        {
+            "markdown_string": "#At the Zoo!",
+            "type": "markdown"
+        },
+        {
+            "alt_text": "Animal 1",
+            "height": 213,
+            "image": "panda.png",
+            "type": "image",
+            "width": 320
+        },
+        {
+            "markdown_string": "What is the type of the above animal?",
+            "type": "markdown"
+        },
+        {
+            "filename": "animal_1.txt",
+            "testcase_ref": "animal_1",
+            "type": "short_answer"
+        },
+        {
+            "alt_text": "Animal 2",
+            "height": 219,
+            "image": "pig.png",
+            "type": "image",
+            "width": 300
+        },
+        {
+            "markdown_string": "What is the type of the above animal?",
+            "type": "markdown"
+        },
+        {
+            "filename": "animal_2.txt",
+            "initial_value": "hint, I say OINK",
+            "testcase_ref": "animal_2",
+            "type": "short_answer"
+        },
+        {
+            "alt_text": "Animal 3",
+            "height": 240,
+            "image": "zebra.png",
+            "type": "image",
+            "width": 286
+        },
+        {
+            "markdown_string": "What is the type of the above animal?",
+            "type": "markdown"
+        },
+        {
+            "filename": "animal_3.txt",
+            "testcase_ref": "animal_3",
+            "type": "short_answer"
+        },
+        {
+            "markdown_string": "#Story Time!\n  *Note: the problems in this section will not be auto-graded*",
+            "type": "markdown"
+        },
+        {
+            "markdown_string": "###Who is your favorite author?",
+            "type": "markdown"
+        },
+        {
+            "filename": "author.txt",
+            "type": "short_answer"
+        },
+        {
+            "markdown_string": "###Write a haiku:\n  Wikipedia: [Haiku in English](https://en.wikipedia.org/wiki/Haiku_in_English)",
+            "type": "markdown"
+        },
+        {
+            "filename": "haiku.txt",
+            "initial_value": "5\n7\n5",
+            "rows": 3,
+            "type": "short_answer"
+        },
+        {
+            "markdown_string": "#Hour of Code!",
+            "type": "markdown"
+        },
+        {
+            "markdown_string": "###Finish the C++ code below to print all prime numbers less than 100.",
+            "testcase_ref": "cpp_prime_compilation",
+            "type": "markdown"
+        },
+        {
+            "filename": "cpp_codebox.cpp",
+            "initial_value": "#include <iostream>\nint main() {\n  for (int i = 2; i < 100; i++) {\n\n\n\n    std::cout << i << std::endl;\n  }\n}",
+            "programming_language": "cpp",
+            "rows": 10,
+            "testcase_ref": "cpp_prime_testing",
+            "type": "short_answer"
+        },
+        {
+            "markdown_string": "###Finish the Python code below to print all prime numbers less than 100.",
+            "type": "markdown"
+        },
+        {
+            "filename": "python_codebox.py",
+            "initial_value": "for i in range(2, 100):\n\n\n\n    print(i)",
+            "programming_language": "python",
+            "testcase_ref": "python_prime",
+            "type": "short_answer"
+        }
+    ],
+    "publish_actions": false,
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 3,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "math_1",
+            "timestamped_stdout": false,
+            "title": "Math 1",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "math_1.txt",
+                    "deduction": 1.0,
+                    "expected_file": "math_1_answer.txt",
+                    "failure_message": "Incorrect Answer",
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 3,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "math_2",
+            "timestamped_stdout": false,
+            "title": "Math 2",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "math_2.txt",
+                    "deduction": 1.0,
+                    "expected_file": "math_2_answer.txt",
+                    "failure_message": "Incorrect Answer",
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 3,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "math_3",
+            "timestamped_stdout": false,
+            "title": "Math 3",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "math_3.txt",
+                    "deduction": 1.0,
+                    "expected_file": "math_3_answer.txt",
+                    "failure_message": "Incorrect Answer",
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "math_4",
+            "timestamped_stdout": false,
+            "title": "Math 4",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "math_4.txt",
+                    "comparison": "byLine",
+                    "deduction": 1.0,
+                    "expected_file": "math_4_answer.txt",
+                    "lineSwapOk": true,
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "animal_1",
+            "timestamped_stdout": false,
+            "title": "Animal 1",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "animal_1.txt",
+                    "deduction": 1.0,
+                    "expected_file": "animal_1_answer.txt",
+                    "failure_message": "Incorrect Answer (note: make sure your answer is lowercase)",
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "animal_2",
+            "timestamped_stdout": false,
+            "title": "Animal 2",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "animal_2.txt",
+                    "deduction": 1.0,
+                    "expected_file": "animal_2_answer.txt",
+                    "failure_message": "Incorrect Answer (note: make sure your answer is lowercase)",
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "animal_3",
+            "timestamped_stdout": false,
+            "title": "Animal 3",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "animal_3.txt",
+                    "deduction": 1.0,
+                    "expected_file": "animal_3_answer.txt",
+                    "failure_message": "Incorrect Answer (note: make sure your answer is lowercase)",
+                    "method": "diff",
+                    "show_actual": "never",
+                    "show_expected": "never",
+                    "show_message": "always"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "clang++ -Wall -o cpp_prime.out cpp_codebox.cpp"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "cpp_prime.out",
+            "points": 1,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "prime_cpp_compilation",
+            "timestamped_stdout": false,
+            "title": "C++ Code for Primes -- Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "cpp_prime.out",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./cpp_prime.out"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 4,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "prime_cpp_testing",
+            "timestamped_stdout": false,
+            "title": "C++ Code for Primes -- Testing",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1,
+                    "expected_file": "prime_answer.txt",
+                    "failure_message": "Incorrect Answer/Output",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.5,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 ./python_codebox.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "testcase_label": "prime_python",
+            "timestamped_stdout": false,
+            "title": "Python Code for Primes",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1,
+                    "expected_file": "prime_answer.txt",
+                    "failure_message": "Incorrect Answer/Output",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/notebook_itempool_random.json
+++ b/python_submitty_utils/tests/data/complete_configs/notebook_itempool_random.json
@@ -1,0 +1,583 @@
+{
+    "assignment_message": "#Welcome To My Favorite Notebook Gradeable\n  \n  This message will appear in a blue box at the top of the page.",
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt"
+        ],
+        "submission_to_compilation": [
+            "*.txt",
+            "*.cpp",
+            "*.py"
+        ],
+        "submission_to_runner": [
+            "*.txt",
+            "*.out",
+            "*.py"
+        ],
+        "submission_to_validation": [
+            "*.txt",
+            "*.png"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "*.txt",
+            "*.png",
+            "test*/*.txt",
+            "test*/*_diff.json"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "hide_submitted_files": true,
+    "item_pool": [
+        {
+            "item_name": "math_1",
+            "notebook": [
+                {
+                    "markdown_string": "###What is `2 + 2`?",
+                    "type": "markdown"
+                },
+                {
+                    "choices": [
+                        {
+                            "description": "`2`",
+                            "value": "a"
+                        },
+                        {
+                            "description": "`3`",
+                            "value": "b"
+                        },
+                        {
+                            "description": "`4`",
+                            "value": "c"
+                        },
+                        {
+                            "description": "`5`",
+                            "value": "d"
+                        },
+                        {
+                            "description": "*none of the above*",
+                            "value": "e"
+                        }
+                    ],
+                    "filename": "math_1.txt",
+                    "testcase_ref": "math_1",
+                    "type": "multiple_choice"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "math_1",
+                    "title": "Math 1",
+                    "validation": [
+                        {
+                            "actual_file": "math_1.txt",
+                            "expected_file": "math_1_answer.txt",
+                            "failure_message": "Incorrect Answer",
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "math_2",
+            "notebook": [
+                {
+                    "markdown_string": "###What is `3 + 3`?",
+                    "type": "markdown"
+                },
+                {
+                    "choices": [
+                        {
+                            "description": "`3`",
+                            "value": "a"
+                        },
+                        {
+                            "description": "`4`",
+                            "value": "b"
+                        },
+                        {
+                            "description": "`5`",
+                            "value": "c"
+                        },
+                        {
+                            "description": "`6`",
+                            "value": "d"
+                        },
+                        {
+                            "description": "*none of the above*",
+                            "value": "e"
+                        }
+                    ],
+                    "filename": "math_2.txt",
+                    "testcase_ref": "math_2",
+                    "type": "multiple_choice"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "math_2",
+                    "title": "Math 2",
+                    "validation": [
+                        {
+                            "actual_file": "math_2.txt",
+                            "expected_file": "math_2_answer.txt",
+                            "failure_message": "Incorrect Answer",
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "math_3",
+            "notebook": [
+                {
+                    "markdown_string": "###Select *all* statements that are true:",
+                    "type": "markdown"
+                },
+                {
+                    "allow_multiple": true,
+                    "choices": [
+                        {
+                            "description": "`1 + 1 = 2`",
+                            "value": "a"
+                        },
+                        {
+                            "description": "`4 - 2 = 3`",
+                            "value": "b"
+                        },
+                        {
+                            "description": "`2 * 2 = 4`",
+                            "value": "c"
+                        },
+                        {
+                            "description": "`6 / 2 = 4`",
+                            "value": "d"
+                        }
+                    ],
+                    "filename": "math_3.txt",
+                    "testcase_ref": "math_3",
+                    "type": "multiple_choice"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "math_3",
+                    "title": "Math 3",
+                    "validation": [
+                        {
+                            "actual_file": "math_3.txt",
+                            "expected_file": "math_3_answer.txt",
+                            "failure_message": "Incorrect Answer",
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "math_4",
+            "notebook": [
+                {
+                    "markdown_string": "###Select *all* numbers that are powers of 2:",
+                    "type": "markdown"
+                },
+                {
+                    "allow_multiple": true,
+                    "choices": [
+                        {
+                            "description": "`4`",
+                            "value": "4"
+                        },
+                        {
+                            "description": "`24`",
+                            "value": "24"
+                        },
+                        {
+                            "description": "`32`",
+                            "value": "32"
+                        },
+                        {
+                            "description": "`96`",
+                            "value": "96"
+                        },
+                        {
+                            "description": "`128`",
+                            "value": "128"
+                        },
+                        {
+                            "description": "`524`",
+                            "value": "524"
+                        }
+                    ],
+                    "filename": "math_4.txt",
+                    "randomize_order": true,
+                    "testcase_ref": "math_4",
+                    "type": "multiple_choice"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "math_4",
+                    "title": "Math 4",
+                    "validation": [
+                        {
+                            "actual_file": "math_4.txt",
+                            "comparison": "byLine",
+                            "expected_file": "math_4_answer.txt",
+                            "lineSwapOk": true,
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "animal_1",
+            "notebook": [
+                {
+                    "alt_text": "Animal 1",
+                    "height": 213,
+                    "image": "panda.png",
+                    "type": "image",
+                    "width": 320
+                },
+                {
+                    "markdown_string": "What is the type of the above animal?",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "animal_1.txt",
+                    "testcase_ref": "animal_1",
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "animal_1",
+                    "title": "Animal 1",
+                    "validation": [
+                        {
+                            "actual_file": "animal_1.txt",
+                            "expected_file": "animal_1_answer.txt",
+                            "failure_message": "Incorrect Answer (note: make sure your answer is lowercase)",
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "animal_2",
+            "notebook": [
+                {
+                    "alt_text": "Animal 2",
+                    "height": 219,
+                    "image": "pig.png",
+                    "type": "image",
+                    "width": 300
+                },
+                {
+                    "markdown_string": "What is the type of the above animal?",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "animal_2.txt",
+                    "initial_value": "hint, I say OINK",
+                    "testcase_ref": "animal_2",
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "animal_2",
+                    "title": "Animal 2",
+                    "validation": [
+                        {
+                            "actual_file": "animal_2.txt",
+                            "expected_file": "animal_2_answer.txt",
+                            "failure_message": "Incorrect Answer (note: make sure your answer is lowercase)",
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "animal_3",
+            "notebook": [
+                {
+                    "alt_text": "Animal 3",
+                    "height": 240,
+                    "image": "zebra.png",
+                    "type": "image",
+                    "width": 286
+                },
+                {
+                    "markdown_string": "What is the type of the above animal?",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "animal_3.txt",
+                    "testcase_ref": "animal_3",
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": [
+                {
+                    "testcase_label": "animal_3",
+                    "title": "Animal 3",
+                    "validation": [
+                        {
+                            "actual_file": "animal_3.txt",
+                            "expected_file": "animal_3_answer.txt",
+                            "failure_message": "Incorrect Answer (note: make sure your answer is lowercase)",
+                            "method": "diff",
+                            "show_actual": "never",
+                            "show_expected": "never"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "author",
+            "notebook": [
+                {
+                    "markdown_string": "###Who is your favorite author?",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "author.txt",
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": []
+        },
+        {
+            "item_name": "haiku",
+            "notebook": [
+                {
+                    "markdown_string": "###Write a haiku:\n  Wikipedia: [Haiku in English](https://en.wikipedia.org/wiki/Haiku_in_English)",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "haiku.txt",
+                    "initial_value": "5\n7\n5",
+                    "rows": 3,
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": []
+        },
+        {
+            "item_name": "cpp_code",
+            "notebook": [
+                {
+                    "markdown_string": "###Finish the C++ code below to print all prime numbers less than 100.",
+                    "testcase_ref": "cpp_prime_compilation",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "cpp_codebox.cpp",
+                    "initial_value": "#include <iostream>\nint main() {\n  for (int i = 2; i < 100; i++) {\n\n\n\n    std::cout << i << std::endl;\n  }\n}",
+                    "programming_language": "cpp",
+                    "rows": 10,
+                    "testcase_ref": "cpp_prime_testing",
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": [
+                {
+                    "command": "clang++ -Wall -o cpp_prime.out cpp_codebox.cpp",
+                    "executable_name": "cpp_prime.out",
+                    "points": 1,
+                    "testcase_label": "prime_cpp_compilation",
+                    "title": "C++ Code for Primes -- Compilation",
+                    "type": "Compilation"
+                },
+                {
+                    "command": "./cpp_prime.out",
+                    "points": 4,
+                    "testcase_label": "prime_cpp_testing",
+                    "title": "C++ Code for Primes -- Testing",
+                    "validation": [
+                        {
+                            "actual_file": "STDOUT.txt",
+                            "deduction": 1,
+                            "expected_file": "prime_answer.txt",
+                            "failure_message": "Incorrect Answer/Output",
+                            "method": "diff",
+                            "show_message": "on_failure"
+                        },
+                        {
+                            "actual_file": "STDERR.txt",
+                            "deduction": 0.5,
+                            "description": "Standard Error (STDERR.txt)",
+                            "method": "warnIfNotEmpty"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "item_name": "python_code",
+            "notebook": [
+                {
+                    "markdown_string": "###Finish the Python code below to print all prime numbers less than 100.",
+                    "type": "markdown"
+                },
+                {
+                    "filename": "python_codebox.py",
+                    "initial_value": "for i in range(2, 100):\n\n\n\n    print(i)",
+                    "programming_language": "python",
+                    "testcase_ref": "python_prime",
+                    "type": "short_answer"
+                }
+            ],
+            "testcases": [
+                {
+                    "command": "python3 ./python_codebox.py",
+                    "testcase_label": "prime_python",
+                    "title": "Python Code for Primes",
+                    "validation": [
+                        {
+                            "actual_file": "STDOUT.txt",
+                            "deduction": 1,
+                            "expected_file": "prime_answer.txt",
+                            "failure_message": "Incorrect Answer/Output",
+                            "method": "diff",
+                            "show_message": "on_failure"
+                        },
+                        {
+                            "actual_file": "STDERR.txt",
+                            "deduction": 0,
+                            "description": "Standard Error (STDERR.txt)",
+                            "method": "warnIfNotEmpty"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "notebook": [
+        {
+            "markdown_string": "#Instructions\n  \n  Here's a short list of instructions:\n  * This is an open-book quiz.\n  * You have 20 minutes to submit your answers.\n",
+            "type": "markdown"
+        },
+        {
+            "markdown_string": "#Let's do Math!",
+            "type": "markdown"
+        },
+        {
+            "from_pool": [
+                "math_1",
+                "math_2",
+                "math_3"
+            ],
+            "item_label": "",
+            "points": 3,
+            "type": "item"
+        },
+        {
+            "from_pool": [
+                "math_4"
+            ],
+            "item_label": "",
+            "points": 5,
+            "type": "item"
+        },
+        {
+            "markdown_string": "#At the Zoo!",
+            "type": "markdown"
+        },
+        {
+            "from_pool": [
+                "animal_1",
+                "animal_2",
+                "animal_3"
+            ],
+            "item_label": "",
+            "points": 2,
+            "type": "item"
+        },
+        {
+            "from_pool": [
+                "animal_1",
+                "animal_2",
+                "animal_3"
+            ],
+            "item_label": "",
+            "points": 2,
+            "type": "item"
+        },
+        {
+            "markdown_string": "#Story Time!\n  *Note: the problems in this section will not be auto-graded*",
+            "type": "markdown"
+        },
+        {
+            "from_pool": [
+                "author"
+            ],
+            "item_label": "",
+            "type": "item"
+        },
+        {
+            "from_pool": [
+                "haiku"
+            ],
+            "item_label": "",
+            "type": "item"
+        },
+        {
+            "markdown_string": "#Hour of Code!",
+            "type": "markdown"
+        },
+        {
+            "from_pool": [
+                "cpp_code",
+                "python_code"
+            ],
+            "item_label": "",
+            "points": 5,
+            "type": "item"
+        }
+    ],
+    "publish_actions": false,
+    "testcases": [
+        {
+            "max_submissions": 20,
+            "penalty": 0,
+            "points": 0,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/python_multipart_static_analysis.json
+++ b/python_submitty_utils/tests/data/complete_configs/python_multipart_static_analysis.json
@@ -1,0 +1,387 @@
+{
+    "assignment_message": "Submit each part of your homework to the right bucket or you will not receive credit.",
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "**/*.py",
+            "**/*.pdf"
+        ],
+        "submission_to_validation": [
+            "part2/*.txt"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "**/README.txt",
+            "input_*.txt",
+            "test*/input_*.txt",
+            "**/dispatched_actions.txt",
+            "test01/STDOUT_0.txt",
+            "test01/STDOUT_1.txt",
+            "test01/STDERR_0.txt",
+            "test01/STDERR_1.txt",
+            "test02/part2/*.txt",
+            "test03/STDOUT_0.txt",
+            "test03/STDOUT_1.txt",
+            "test03/STDOUT_2.txt",
+            "test03/STDOUT_3.txt",
+            "test03/STDERR_0.txt",
+            "test03/STDERR_1.txt",
+            "test03/STDERR_2.txt",
+            "test03/STDERR_3.txt",
+            "test04/STDOUT_0.txt",
+            "test04/STDOUT_1.txt",
+            "test04/STDERR_0.txt",
+            "test04/STDERR_1.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "part_names": [
+        "Problem 1: Temperature",
+        "Problem 2: Variables",
+        "Problem 3: Area & Volume",
+        "Problem 4: Count Odd"
+    ],
+    "publish_actions": false,
+    "resource_limits": {
+        "RLIMIT_AS": "RLIM_INFINITY",
+        "RLIMIT_CPU": 60,
+        "RLIMIT_NPROC": 100,
+        "RLIMIT_SIGPENDING": 100
+    },
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 part1/*.py",
+                        "submitty_count call -l python print part1/*.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Convert Temperature",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT_0.txt",
+                    "deduction": 0.5,
+                    "description": "Program Output",
+                    "expected_file": "p1_out.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDOUT_1.txt",
+                    "comparison": "ge",
+                    "deduction": 0.5,
+                    "description": "Number of print statements",
+                    "failure_message": "Looks like you forgot the 'print' statement.",
+                    "method": "intComparison",
+                    "show_actual": "never",
+                    "show_message": "on_failure",
+                    "term": 1
+                },
+                {
+                    "actual_file": "STDERR_0.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_0.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR_1.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_1.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 1,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Legal Variable Names",
+            "type": "FileCheck",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "part2/*.txt",
+                    "deduction": 1.0,
+                    "description": "Program Output",
+                    "expected_file": "p2_out.txt",
+                    "failure_message": "Incorrect Answer",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "never",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 part3/*.py",
+                        "submitty_count token -l python Equal part3/*.py",
+                        "submitty_count token -l python Asterisk part3/*.py",
+                        "submitty_count token -l python Plus part3/*.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 4,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Volume and Area",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT_0.txt",
+                    "deduction": 0.25,
+                    "description": "Program Output",
+                    "expected_file": "p3_out.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDOUT_1.txt",
+                    "comparison": "ge",
+                    "deduction": 0.25,
+                    "description": "Number of assignments",
+                    "failure_message": "Re-read the problem instructions.",
+                    "method": "intComparison",
+                    "show_actual": "never",
+                    "show_message": "on_failure",
+                    "term": 5
+                },
+                {
+                    "actual_file": "STDOUT_2.txt",
+                    "comparison": "ge",
+                    "deduction": 0.25,
+                    "description": "Number of multiplications",
+                    "failure_message": "Re-read the problem instructions.",
+                    "method": "intComparison",
+                    "show_actual": "never",
+                    "show_message": "on_failure",
+                    "term": 7
+                },
+                {
+                    "actual_file": "STDOUT_3.txt",
+                    "comparison": "ge",
+                    "deduction": 0.25,
+                    "description": "Number of additions",
+                    "failure_message": "Re-read the problem instructions.",
+                    "method": "intComparison",
+                    "show_actual": "never",
+                    "show_message": "on_failure",
+                    "term": 2
+                },
+                {
+                    "actual_file": "STDERR_0.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_0.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR_1.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_1.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR_2.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_2.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR_3.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_3.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 part4/*.py",
+                        "submitty_count token -l python While part4/*.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Count Odd",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT_0.txt",
+                    "deduction": 0.5,
+                    "description": "Program Output",
+                    "expected_file": "p4_out.txt",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDOUT_1.txt",
+                    "comparison": "ge",
+                    "deduction": 0.5,
+                    "description": "Number of while loops",
+                    "failure_message": "Re-read the problem instructions.",
+                    "method": "intComparison",
+                    "show_actual": "never",
+                    "show_message": "on_failure",
+                    "term": 1
+                },
+                {
+                    "actual_file": "STDERR_0.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_0.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR_1.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR_1.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/tutorial_10_java_coverage.json
+++ b/python_submitty_utils/tests/data/complete_configs/tutorial_10_java_coverage.json
@@ -1,0 +1,327 @@
+{
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class",
+            "test01/hw0/Factorial.class",
+            "test02/hw0/test/FactorialTest.class"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt",
+            "test01/hw0/Factorial.class",
+            "test02/hw0/test/FactorialTest.class"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "**/*.py",
+            "**/*.pdf"
+        ],
+        "submission_to_validation": [
+            "**/README.txt",
+            "input_*.txt",
+            "**/*.pdf"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "**/*.csv",
+            "test01/STDERR.txt",
+            "test01/STDOUT.txt",
+            "test02/STDERR.txt",
+            "test02/STDOUT.txt",
+            "test03/STDOUT_0.txt",
+            "test03/STDOUT_1.txt",
+            "test03/jacoco_report.csv",
+            "test03/STDERR_0.txt",
+            "test03/STDERR_1.txt",
+            "test04/STDOUT.txt",
+            "test04/STDERR.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "publish_actions": false,
+    "resource_limits": {
+        "RLIMIT_AS": "RLIM_INFINITY",
+        "RLIMIT_CPU": 60,
+        "RLIMIT_NPROC": 100
+    },
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "javac -cp submitty_junit.jar hw0/Factorial.java"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "hw0/Factorial.class",
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Class Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "jvm_memory": true,
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "hw0/Factorial.class",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "javac -cp submitty_junit.jar:. hw0/test/*Test.java"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "hw0/test/FactorialTest.class",
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Student and Instructor JUnit Test Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "jvm_memory": true,
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "hw0/test/FactorialTest.class",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "java -noverify -javaagent:submitty_jacocoagent.jar=destfile=coverage.exec -cp submitty_junit.jar:submitty_hamcrest.jar:submitty_junit/:. TestRunner hw0",
+                        "java -jar submitty_jacococli.jar report coverage.exec --classfiles hw0 --csv jacoco_report.csv"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 10,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "JaCoCo - Running Student JUnit Tests in hw0/tests/ and Generating Coverage Report for Student Tests",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT_0.txt",
+                    "deduction": 0.5,
+                    "description": "TestRunner output",
+                    "method": "MultipleJUnitTestGrader",
+                    "show_actual": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDOUT_1.txt",
+                    "deduction": 0,
+                    "description": "JaCoCo report generation output",
+                    "method": "errorIfEmpty",
+                    "show_actual": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "jacoco_report.csv",
+                    "deduction": 0.5,
+                    "description": "JaCoCo coverage report",
+                    "instruction_coverage_threshold": 90,
+                    "method": "JaCoCoCoverageReportGrader",
+                    "package": "hw0",
+                    "show_actual": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR_0.txt",
+                    "deduction": 0.0,
+                    "description": "syntax error output from running java",
+                    "jvm_memory": true,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDERR_1.txt",
+                    "deduction": 0.0,
+                    "description": "syntax error output from running java",
+                    "jvm_memory": true,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "java -noverify -cp submitty_junit.jar:submitty_hamcrest.jar:. org.junit.runner.JUnitCore hw0.test.FactorialTest"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 6,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "JaCoCo - Instructor JUnit Tests",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 1.0,
+                    "description": "JUnit output",
+                    "method": "JUnitTestGrader",
+                    "num_tests": 4,
+                    "show_actual": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "syntax error output from running java",
+                    "jvm_memory": true,
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/tutorial_12_system_calls.json
+++ b/python_submitty_utils/tests/data/complete_configs/tutorial_12_system_calls.json
@@ -1,0 +1,241 @@
+{
+    "allow_system_calls": [
+        "ALLOW_SYSTEM_CALL_CATEGORY_COMMUNICATIONS_AND_NETWORKING_INTERPROCESS_COMMUNICATION",
+        "ALLOW_SYSTEM_CALL_CATEGORY_PROCESS_CONTROL_NEW_PROCESS_THREAD"
+    ],
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class",
+            "test01/a.out"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt",
+            "test01/a.out"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "**/*.py",
+            "**/*.pdf"
+        ],
+        "submission_to_validation": [
+            "**/README.txt",
+            "input_*.txt",
+            "**/*.pdf"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "**/README.txt",
+            "input_*.txt",
+            "test*/input_*.txt",
+            "**/dispatched_actions.txt",
+            "test01/STDERR.txt",
+            "test01/STDOUT.txt",
+            "test02/STDOUT.txt",
+            "test02/STDERR.txt",
+            "test03/STDOUT.txt",
+            "test03/STDERR.txt"
+        ]
+    },
+    "autograding_method": "jailed_sandbox",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": false
+    },
+    "publish_actions": false,
+    "resource_limits": {
+        "RLIMIT_CPU": 10,
+        "RLIMIT_NPROC": 20
+    },
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "/usr/bin/gcc -Wall -o a.out *.c"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "executable_name": "a.out",
+            "points": 2,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Compilation",
+            "type": "Compilation",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Compilation Errors and/or Warnings",
+                    "method": "errorIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "a.out",
+                    "deduction": 1.0,
+                    "description": "Create Executable",
+                    "method": "fileExists",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 10"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 4,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "./a.out 10",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "data": [
+                        "ALL DONE! 10 successful forks"
+                    ],
+                    "deduction": 1,
+                    "description": "Standard Output (STDOUT)",
+                    "method": "searchToken",
+                    "show_actual": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "./a.out 30"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [],
+            "points": 4,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "./a.out 30",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "STDOUT.txt",
+                    "data": [
+                        "ALL DONE! 30 successful forks"
+                    ],
+                    "deduction": 1,
+                    "description": "Standard Output (STDOUT)",
+                    "method": "searchToken",
+                    "show_actual": "always",
+                    "show_message": "always"
+                },
+                {
+                    "actual_file": "STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": false,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/data/complete_configs/tutorial_16_docker_network_python.json
+++ b/python_submitty_utils/tests/data/complete_configs/tutorial_16_docker_network_python.json
@@ -1,0 +1,947 @@
+{
+    "autograding": {
+        "compilation_to_runner": [
+            "**/*.out",
+            "**/*.class"
+        ],
+        "compilation_to_validation": [
+            "test*/STDOUT*.txt",
+            "test*/STDERR*.txt"
+        ],
+        "submission_to_compilation": [
+            "**/*.cpp",
+            "**/*.cxx",
+            "**/*.c",
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.hxx",
+            "**/*.java"
+        ],
+        "submission_to_runner": [
+            "**/*.py",
+            "**/*.pdf"
+        ],
+        "submission_to_validation": [
+            "**/README.txt",
+            "input_*.txt",
+            "**/*.pdf"
+        ],
+        "use_checkout_subdirectory": "",
+        "work_to_details": [
+            "test*/*.txt",
+            "test*/*_diff.json",
+            "**/README.txt",
+            "input_*.txt",
+            "test*/input_*.txt",
+            "**/dispatched_actions.txt",
+            "test01/alpha/STDOUT.txt",
+            "test01/beta/STDOUT.txt",
+            "test01/charlie/STDOUT.txt",
+            "test01/charlie/STDOUT.txt",
+            "test01/alpha/STDERR.txt",
+            "test01/beta/STDERR.txt",
+            "test01/charlie/STDERR.txt",
+            "test01/client/STDOUT.txt",
+            "test01/client/STDERR.txt",
+            "test02/alpha/STDOUT.txt",
+            "test02/beta/STDOUT.txt",
+            "test02/charlie/STDOUT.txt",
+            "test02/router/sequence_diagram.txt",
+            "test02/alpha/STDERR.txt",
+            "test02/beta/STDERR.txt",
+            "test02/charlie/STDERR.txt",
+            "test02/client/STDOUT.txt",
+            "test02/client/STDERR.txt",
+            "test02/router/STDOUT.txt",
+            "test02/router/STDERR.txt",
+            "test03/alpha/STDOUT.txt",
+            "test03/beta/STDOUT.txt",
+            "test03/charlie/STDOUT.txt",
+            "test03/router/sequence_diagram.txt",
+            "test03/alpha/STDERR.txt",
+            "test03/beta/STDERR.txt",
+            "test03/charlie/STDERR.txt",
+            "test03/client/STDOUT.txt",
+            "test03/client/STDERR.txt",
+            "test03/router/STDOUT.txt",
+            "test03/router/STDERR.txt",
+            "test04/alpha/STDOUT.txt",
+            "test04/beta/STDOUT.txt",
+            "test04/charlie/STDOUT.txt",
+            "test04/delta/STDOUT.txt",
+            "test04/router/sequence_diagram.txt",
+            "test04/alpha/STDERR.txt",
+            "test04/beta/STDERR.txt",
+            "test04/charlie/STDERR.txt",
+            "test04/delta/STDERR.txt",
+            "test04/client/STDOUT.txt",
+            "test04/client/STDERR.txt",
+            "test04/router/STDOUT.txt",
+            "test04/router/STDERR.txt"
+        ]
+    },
+    "autograding_method": "docker",
+    "container_options": {
+        "container_image": "submitty/autograding-default:latest",
+        "number_of_ports": 1,
+        "single_port_per_container": false,
+        "use_router": true
+    },
+    "publish_actions": true,
+    "resource_limits": {
+        "RLIMIT_DATA": 2000000000,
+        "RLIMIT_NPROC": 100,
+        "RLIMIT_STACK": 10000000
+    },
+    "testcases": [
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "alpha",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "beta",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "beta",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "charlie",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "beta"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 client.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "client",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [
+                {
+                    "action": "delay",
+                    "seconds": 3
+                },
+                {
+                    "action": "stdin",
+                    "containers": [
+                        "client"
+                    ],
+                    "string": "alpha-beta:charlie\n"
+                },
+                {
+                    "action": "delay",
+                    "seconds": 5
+                },
+                {
+                    "action": "stop",
+                    "containers": [
+                        "alpha",
+                        "beta",
+                        "charlie",
+                        "client"
+                    ]
+                }
+            ],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": false,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Simple Testcase, No Router",
+            "use_router": false,
+            "validation": [
+                {
+                    "actual_file": "alpha/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "alpha_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "beta_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "charlie_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "charlie_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "alpha/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (alpha/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (beta/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (charlie/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (client/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (client/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "alpha",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "beta",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "beta",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "charlie",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "beta"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 client.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "client",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 -u submitty_router.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "router",
+                    "import_default_router": true,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [
+                {
+                    "action": "delay",
+                    "seconds": 3
+                },
+                {
+                    "action": "stdin",
+                    "containers": [
+                        "client"
+                    ],
+                    "string": "alpha-beta:charlie\n"
+                },
+                {
+                    "action": "delay",
+                    "seconds": 5
+                },
+                {
+                    "action": "stop",
+                    "containers": [
+                        "alpha",
+                        "beta",
+                        "charlie",
+                        "client"
+                    ]
+                }
+            ],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": true,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Simple Testcase, With Router",
+            "use_router": true,
+            "validation": [
+                {
+                    "actual_file": "alpha/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "alpha_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "beta_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "charlie_simple.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/sequence_diagram.txt",
+                    "deduction": 0,
+                    "points": 0,
+                    "sequence_diagram": true,
+                    "show_actual": "always",
+                    "show_message": "always",
+                    "title": "Sequence Diagram Text File",
+                    "type": "FileCheck"
+                },
+                {
+                    "actual_file": "alpha/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (alpha/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (beta/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (charlie/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (client/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (client/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (router/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "alpha",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "beta",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "beta",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "charlie",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "beta"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 client.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "client",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 -u submitty_router.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "router",
+                    "import_default_router": true,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [
+                {
+                    "action": "delay",
+                    "seconds": 3
+                },
+                {
+                    "action": "stdin",
+                    "containers": [
+                        "client"
+                    ],
+                    "string": "alpha-beta:charlie:alpha:beta:charlie\n"
+                },
+                {
+                    "action": "delay",
+                    "seconds": 5
+                },
+                {
+                    "action": "stop",
+                    "containers": [
+                        "alpha",
+                        "beta",
+                        "charlie",
+                        "client"
+                    ]
+                }
+            ],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": true,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Moderate Testcase, With Router",
+            "use_router": true,
+            "validation": [
+                {
+                    "actual_file": "alpha/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "alpha_moderate.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "beta_moderate.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "charlie_moderate.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/sequence_diagram.txt",
+                    "deduction": 0,
+                    "points": 0,
+                    "sequence_diagram": true,
+                    "show_actual": "always",
+                    "show_message": "always",
+                    "title": "Sequence Diagram Text File",
+                    "type": "FileCheck"
+                },
+                {
+                    "actual_file": "alpha/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (alpha/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (beta/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (charlie/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (client/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (client/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (router/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "containers": [
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "alpha",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "beta",
+                        "charlie",
+                        "delta"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "beta",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "charlie",
+                        "delta"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "charlie",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "beta",
+                        "delta"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 server.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "delta",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [
+                        "alpha",
+                        "beta",
+                        "charlie"
+                    ],
+                    "server": false
+                },
+                {
+                    "commands": [
+                        "python3 client.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "client",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                },
+                {
+                    "actual_file": "router/sequence_diagram.txt",
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container5",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "points": 0,
+                    "sequence_diagram": true,
+                    "server": false,
+                    "title": "Sequence Diagram Text File",
+                    "type": "FileCheck"
+                },
+                {
+                    "commands": [
+                        "python3 -u submitty_router.py"
+                    ],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "router",
+                    "import_default_router": true,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "dispatcher_actions": [
+                {
+                    "action": "delay",
+                    "seconds": 3
+                },
+                {
+                    "action": "stdin",
+                    "containers": [
+                        "client"
+                    ],
+                    "string": "beta-alpha:charlie:delta:beta:charlie:alpha:beta:delta:charlie:alpha\n"
+                },
+                {
+                    "action": "delay",
+                    "seconds": 5
+                },
+                {
+                    "action": "stop",
+                    "containers": [
+                        "alpha",
+                        "beta",
+                        "charlie",
+                        "delta",
+                        "client"
+                    ]
+                }
+            ],
+            "points": 5,
+            "pre_commands": [],
+            "publish_actions": true,
+            "single_port_per_container": false,
+            "solution_containers": [
+                {
+                    "commands": [],
+                    "container_image": "submitty/autograding-default:latest",
+                    "container_name": "container0",
+                    "number_of_ports": 1,
+                    "outgoing_connections": [],
+                    "server": false
+                }
+            ],
+            "timestamped_stdout": false,
+            "title": "Large Testcase, With Router",
+            "use_router": true,
+            "validation": [
+                {
+                    "actual_file": "alpha/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "alpha_large.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "beta_large.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "charlie_large.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "delta/STDOUT.txt",
+                    "deduction": 0.5,
+                    "expected_file": "delta_large.txt",
+                    "failure_message": "ERROR: Your code did not match the expected output.",
+                    "method": "diff",
+                    "show_actual": "always",
+                    "show_expected": "always",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/sequence_diagram.txt",
+                    "deduction": 0,
+                    "points": 0,
+                    "sequence_diagram": true,
+                    "show_actual": "always",
+                    "show_message": "always",
+                    "title": "Sequence Diagram Text File",
+                    "type": "FileCheck"
+                },
+                {
+                    "actual_file": "alpha/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (alpha/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "beta/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (beta/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "charlie/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (charlie/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "delta/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (delta/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (client/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "client/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (client/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/STDOUT.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Output (router/STDOUT.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                },
+                {
+                    "actual_file": "router/STDERR.txt",
+                    "deduction": 0.0,
+                    "description": "Standard Error (router/STDERR.txt)",
+                    "method": "warnIfNotEmpty",
+                    "show_actual": "on_failure",
+                    "show_message": "on_failure"
+                }
+            ]
+        },
+        {
+            "max_submissions": 20,
+            "penalty": -0.1,
+            "points": -5,
+            "publish_actions": true,
+            "timestamped_stdout": false,
+            "title": "Submission Limit",
+            "type": "FileCheck"
+        }
+    ],
+    "timestamped_stdout": false
+}

--- a/python_submitty_utils/tests/test_submitty_schema_validator.py
+++ b/python_submitty_utils/tests/test_submitty_schema_validator.py
@@ -1,0 +1,37 @@
+from io import StringIO
+from pathlib import Path
+import sys
+from unittest import TestCase
+
+from submitty_utils import submitty_schema_validator as validator
+
+SCHEMA_PATH = Path(
+    Path(__file__).resolve().parent.parent.parent,
+    'bin',
+    'json_schemas',
+    'complete_config_schema.json'
+)
+CONFIGS_DIR = Path(__file__).resolve().parent / 'data' / 'complete_configs'
+
+
+class TestSubmittySchemaValidator(TestCase):
+    def setUp(self):
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
+
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+    def test_valid_schemas(self):
+        for entry in CONFIGS_DIR.iterdir():
+            with self.subTest(f'Validating {entry.name}'):
+                if entry.name == 'tutorial_16_docker_network_python.json':
+                    # cannot currently pass, see #5531
+                    continue
+
+                validator.validate_complete_config_schema_using_filenames(
+                    str(entry),
+                    str(SCHEMA_PATH)
+                )
+                self.assertTrue(True)

--- a/python_submitty_utils/tests/test_submitty_schema_validator.py
+++ b/python_submitty_utils/tests/test_submitty_schema_validator.py
@@ -26,7 +26,7 @@ class TestSubmittySchemaValidator(TestCase):
     def test_valid_schemas(self):
         for entry in CONFIGS_DIR.iterdir():
             with self.subTest(f'Validating {entry.name}'):
-                if entry.name == 'tutorial_16_docker_network_python.json':
+                if entry.name == 'tutorial_16_docker_network_python.json' or 'notebook' in entry.name:
                     # cannot currently pass, see #5531
                     continue
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We do not perform unit tests for the schema validator within submitty_utils python package, doing it indirectly within the integration test suite.

### What is the new behavior?

Adds some basic testing of the schema validation function. Currently, we do not do any validation of docker networks as our own tutorial for it fails validation (see #5531).