### PR TITLE
[Dependency: System] Add websocket library for e2e forum tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -217,6 +217,7 @@ jobs:
         - pip3 install paramiko
         - pip3 install psutil
         - pip3 install docker
+        - pip3 install websocket_client
         - CHROME_VERSION=$(google-chrome --version | egrep -o -e '[0-9]+\.[0-9]+\.[0-9]+')
         - CHROME_DRIVER_VERSION=$(curl -L https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION})
         - wget https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip


### PR DESCRIPTION
### What is the current behavior?
E2E Forum tests don't test the use of websockets which will be added upon merging #5529 

### What is the new behavior?
Added the `websocket_client` python library required to test the websockets functionality in e2e test_forum file
