### PR TITLE
[Feature:Developer] Increase python linter's max-line-length to 100 characters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 exclude=
     .git,
     .setup/bin,


### PR DESCRIPTION
Increase flake8's `max-line-length` from 88 characters to 100.