### PR TITLE
[Bugfix:TAGrading] download submission zip

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -221,8 +221,8 @@ class MiscController extends AbstractController {
     /**
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/download_zip")
      */
-    public function downloadSubmissionZip($gradeable_id, $user_id, $is_anon, $version = null, $origin = null) {
-        if ($is_anon) {
+    public function downloadSubmissionZip($gradeable_id, $user_id, $version, $is_anon, $origin = null) {
+        if ($is_anon === "true") {
             $user_id = $this->core->getQueries()->getUserFromAnon($user_id)[$user_id];
         }
         $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -29,7 +29,7 @@
             </script>
 
             {% if not peer %}
-                <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, true)">Download Zip File</button>
+                <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
             {% endif %}
 
             <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -976,8 +976,8 @@ function downloadStudentAnnotations(url, path, dir) {
     //window.location = buildCourseUrl(['download']) + `?dir=${dir}&path=${path}`;
 }
 
-function downloadSubmissionZip(grade_id, user_id, version = null, origin = null) {
-    window.location = buildCourseUrl(['gradeable', grade_id, 'download_zip']) + `?dir=submissions&user_id=${user_id}&version=${version}&origin=${origin}`;
+function downloadSubmissionZip(grade_id, user_id, version, origin = null, is_anon = false) {
+    window.location = buildCourseUrl(['gradeable', grade_id, 'download_zip']) + `?dir=submissions&user_id=${user_id}&version=${version}&origin=${origin}&is_anon=${is_anon}`;
     return false;
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Attempting to click "Download Zip" of a student's submission causes the server to throw an exception. This is due to a missing `is_anon` parameter on the download_zip route.

### What is the new behavior?

The download zip button works as expected. #5412 added a new required parameter, `is_anon`, to the download_zip path (though implementation was such that most of the links except for the one instance where `is_anon == true` were broken). #5241 reverted the JS function to no longer use the `is_anon` parameter in the JS code, but not in the controller, which then caused exception to be thrown. The `is_anon` parameter is re-added, though at the end of the parameter list instead of the middle as most usages of the function do not use it.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I made version non-optional as it's always provided (or should be) to the method, and it will not work without a version provided.

No new tests were added as there's not a great way to test downloading a file through selenium.