### PR TITLE
[Bugfix:Autograding] Run make_generated_output after validating make exit code

### DIFF
--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -176,9 +176,6 @@ function build_homework {
     # quit (don't continue on to build other homeworks) if there is a compile error
     make -j 8  > $hw_build_path/log_make_output.txt 2>&1
 
-    # generate queue file for generated_output
-    $SUBMITTY_INSTALL_DIR/bin/make_generated_output.py $hw_source $assignment $semester $course
-
     # capture exit code of make
     make_res=$?
     chmod -f 660 $hw_build_path/log_make_output.txt
@@ -191,6 +188,9 @@ function build_homework {
         popd > /dev/null
         exit 1
     fi
+    
+    # generate queue file for generated_output
+    $SUBMITTY_INSTALL_DIR/bin/make_generated_output.py $hw_source $assignment $semester $course
 
     fix_permissions $hw_config $hw_bin_path $hw_build_path $course_dir $assignment $course_group
     popd > /dev/null


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Running make_generated_output.py is run before we validate the make exit code, making the if statement a bit misleading on what's failing. The statement was introduced in #4335 above the make line, and then moved directly below it in #4867.

### What is the new behavior?

Running `make_generated_output.py` is now done after we check the make exit code to ensure that we're not attempting to generate output for a homework which we could not build the config of.