### PR TITLE
[Testing:Travis] Remove unused pylint_runner pip dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ jobs:
         - pip3 install PyYAML
         - pip3 install psycopg2-binary
         - pip3 install sqlalchemy
-        - pip3 install pylint_runner
         - pip3 install python-dateutil
         - pip3 install --pre selenium
         - pip3 install pause
@@ -208,7 +207,6 @@ jobs:
         - pip3 install PyYAML
         - pip3 install psycopg2-binary
         - pip3 install sqlalchemy
-        - pip3 install pylint_runner
         - pip3 install python-dateutil
         - pip3 install jsonschema
         - pip3 install jsonref


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

A long while ago (3-4+ years ago?), we used pylint (and pylint_runner) to partially lint parts of the codebase. We have since moved to flake8.

### What is the new behavior?

Removes the unused pylint_runner dependency as we do not need it anymore.