### PR TITLE
[Refactor:Router] Mark MultiResponse::only* deprecated

### DIFF
--- a/site/app/libraries/response/MultiResponse.php
+++ b/site/app/libraries/response/MultiResponse.php
@@ -35,6 +35,8 @@ class MultiResponse implements ResponseInterface {
     }
 
     /**
+     * @deprecated should not be used, just return WebResponse directly
+     *
      * @param WebResponse $web_response
      * @return MultiResponse
      */
@@ -43,6 +45,8 @@ class MultiResponse implements ResponseInterface {
     }
 
     /**
+     * @deprecated should not be used, just return JsonResponse directly
+     *
      * @param JsonResponse $json_response
      * @return MultiResponse
      */
@@ -51,6 +55,8 @@ class MultiResponse implements ResponseInterface {
     }
 
     /**
+     * @deprecated should not be used, just return RedirectResponse directly
+     *
      * @param RedirectResponse $redirect_response
      * @return MultiResponse
      */


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The methods are used, and without any indication within the codebase they should be ignored (though https://submitty.org/developer/router#what-is-the-responseinterface-object-is-it-required discusses what to return). #5206 discusses the rationale for this.

### What is the new behavior?

Adds a `@deprecated` tag to these functions, with an expectation that they will be removed from the codebase in follow-up PRs.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

@shailpatels Since there's the push to have two pages on the subject, please update https://submitty.org/developer/development_instructions/router-response#the-multiresponse-object and following sections to fit this defined behavior 