### PR TITLE
[BugFix:TAGrading] Add Fix for StopLights for Peer View

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -82,7 +82,7 @@ class ElectronicGraderController extends AbstractController {
         if ($graded_gradeable === false) {
             return;
         }
-
+ 
         // get the requested version
         $version_instance = $this->tryGetVersion($graded_gradeable->getAutoGradedGradeable(), $version);
         if ($version_instance === false) {

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -332,10 +332,23 @@
     <td class="td-graded-questions">
         <span>
             {%- for index in 0..info.graded_groups|length-1 -%}
-                {%  if graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0  %}
-                    <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-NULL"></i>
-                {% else %}
-                    <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-{{- info.graded_groups[index] -}}"></i>
+            {% if core.getUser().getGroup() < 4 %}
+                    {%  if graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0%}
+                        <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-NULL"></i>
+                    {% else %}
+                        <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-{{- info.graded_groups[index] -}}"></i>
+                    {% endif %}
+                {% endif %}
+            {% if core.getUser().getGroup() == 4 %}
+                    {%  if graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0  %}
+                        <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-NULL"></i>
+                    {% else %}
+                        {%  if info.graded_groups[index] < 4   %}
+                            <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle hideHighlights"></i>
+                        {% else %}
+                             <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-{{- info.graded_groups[index] -}}"></i>
+                        {% endif %}
+                    {% endif %}
                 {% endif %}
             {%- endfor -%}
         </span>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1492,6 +1492,9 @@ end of styles used in the admin gradeable page
     color: var(--standard-vibrant-green) /* green */
 }
 
+.hideHighlights{
+    display:none;
+}
 /* color for double graded */
 .grader-double {
     color: var(--standard-vibrant-dark-blue)  /* dark blue */


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
"Stoplights" for non-peer components from peers on the grading index page can be viewed by students

### What is the new behavior?
"Stoplights" for non-peer components from peers on the grading index page are hidden to students.
### Other information?
