### PR TITLE
[Bugfix:Submission] Datetime fix when using VCS gradeable

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -455,7 +455,9 @@ class Gradeable extends AbstractModel {
         foreach (self::date_properties as $date) {
             if (isset($dates[$date]) && $dates[$date] !== null) {
                 try {
-                    $parsedDates[$date] = DateUtils::parseDateTime($dates[$date], $this->core->getUser()->getUsableTimeZone());
+                    $user = $this->core->getUser();
+                    $time_zone = is_null($user) ? $this->core->getConfig()->getTimezone() : $user->getUsableTimeZone();
+                    $parsedDates[$date] = DateUtils::parseDateTime($dates[$date], $time_zone);
                 }
                 catch (\Exception $e) {
                     $parsedDates[$date] = null;


### PR DESCRIPTION
### What is the current behavior?
Received reports of gradeable code not working when using VCS gradeables.

### What is the new behavior?
Added check to test if $this->core->getUser() returns null and then sets time zone appropriately before continuing.