### PR TITLE
[Bugfix:Submission] Fix uninitialized notebook object property

### DIFF
--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -22,7 +22,7 @@ class Notebook extends AbstractModel {
     /** @prop @var array parsed notebook from the config */
     protected $notebook;
     /** @prop @var array notebook elements that can hold user input */
-    protected $inputs;
+    protected $inputs = [];
     /** @prop @var string parsed notebook from the config */
     protected $gradeable_id;
     /** @prop @var array of image names and their locations */


### PR DESCRIPTION
### What is the current behavior?
If an instructor creates and builds a notebook gradeable that has no inputs (for example all cells were markdown) then a PHP Warning is shown when viewing the submission page.

### What is the new behavior?
Resolved this issue.
