### PR TITLE
[Bugfix:Submission] Fix PHP error on no testcase for itempool item

### DIFF
--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -74,7 +74,8 @@ class UserSpecificNotebook extends Notebook {
                 $item_data = $this->searchForItemPool($tgt_item);
                 if (count($item_data['notebook']) > 0) {
                     $new_notebook = array_merge($new_notebook, $item_data['notebook']);
-                    $tests = array_merge($tests, $item_data['testcases']);
+                    $test_cases = $item_data['testcases'] ?? [];
+                    $tests = array_merge($tests, $test_cases);
                 }
 
                 //record if we potentially grabbed the same question
@@ -147,7 +148,8 @@ class UserSpecificNotebook extends Notebook {
         foreach ($this->item_pool as $item) {
             if ($item['item_name'] === $tgt_name) {
                 $ret["notebook"] = array_merge($ret["notebook"], $item["notebook"]);
-                $ret["testcases"] = array_merge($ret["testcases"], $item["testcases"]);
+                $test_cases = $item["testcases"] ?? [];
+                $ret["testcases"] = array_merge($ret["testcases"], $test_cases);
             }
         }
 


### PR DESCRIPTION
Closes #5597

### What is the current behavior?
If an instructor creates an notebook itempool gradeable but doesn't define a `testcases` array inside each `item` block then the build process completes successfully but PHP throws an error when attempting to view the submission page for the gradeable.

### What is the new behavior?
The PHP error have been resolved.

### Other information?
Tested by removing `testcases` fields from some itempool items in the development course 'notebook itempool' gradeable, rebuilding and testing.
