### PR TITLE
[Testing:Git] Fix hardcoded semester for git test

### DIFF
--- a/tests/git_test.sh
+++ b/tests/git_test.sh
@@ -43,7 +43,7 @@ test_git student student
 EXIT_CODE=0
 git clone http://student:student@localhost/git/${SEMESTER}/sample/open_homework/instructor > /tmp/submitty_git/git_stdout 2> /tmp/submitty_git/git_stderr || EXIT_CODE=$?
 test ${EXIT_CODE} -ne 0
-test "$(echo -e "Cloning into 'instructor'...\nfatal: Authentication failed for 'http://localhost/git/s20/sample/open_homework/instructor/'")" = "$(</tmp/submitty_git/git_stderr)"
+test "$(echo -e "Cloning into 'instructor'...\nfatal: Authentication failed for 'http://localhost/git/${SEMESTER}/sample/open_homework/instructor/'")" = "$(</tmp/submitty_git/git_stderr)"
 
 cleanup
 popd


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The git test hardcodes `s20` in the expected output. It now fails as July 1st marks the start of `f20` for generated courses.

### What is the new behavior?

The git test now uses a dynamically generated semester for the output, so that it does not fail when the semester rolls over to the next one.