### PR TITLE
[Feature:System] Allow port for database connection

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -141,27 +141,29 @@ EMAIL_JSON = os.path.join(CONFIG_INSTALL_DIR, 'email.json')
 
 ##############################################################################
 
-defaults = {'database_host': 'localhost',
-            'database_user': 'submitty_dbuser',
-            'submission_url': '',
-            'supervisor_user': 'submitty',
-            'vcs_url': '',
-            'authentication_method': 1,
-            'institution_name' : '',
-            'username_change_text' : 'Submitty welcomes individuals of all ages, backgrounds, citizenships, disabilities, sex, education, ethnicities, family statuses, genders, gender identities, geographical locations, languages, military experience, political views, races, religions, sexual orientations, socioeconomic statuses, and work experiences. In an effort to create an inclusive environment, you may specify a preferred name to be used instead of what was provided on the registration roster.',
-            'institution_homepage' : '',
-            'timezone' : tzlocal.get_localzone().zone,
-            'submitty_admin_username': '',
-            'submitty_admin_password': '',
-            'email_user': '',
-            'email_password': '',
-            'email_sender': 'submitty@myuniversity.edu',
-            'email_reply_to': 'submitty_do_not_reply@myuniversity.edu',
-            'email_server_hostname': 'mail.myuniversity.edu',
-            'email_server_port': 25,
-            'course_code_requirements': "Please follow your school's convention for course code.",
-            'sys_admin_email': '',
-            'sys_admin_url': ''
+defaults = {
+    'database_host': 'localhost',
+    'database_port': 5432,
+    'database_user': 'submitty_dbuser',
+    'submission_url': '',
+    'supervisor_user': 'submitty',
+    'vcs_url': '',
+    'authentication_method': 1,
+    'institution_name' : '',
+    'username_change_text' : 'Submitty welcomes individuals of all ages, backgrounds, citizenships, disabilities, sex, education, ethnicities, family statuses, genders, gender identities, geographical locations, languages, military experience, political views, races, religions, sexual orientations, socioeconomic statuses, and work experiences. In an effort to create an inclusive environment, you may specify a preferred name to be used instead of what was provided on the registration roster.',
+    'institution_homepage' : '',
+    'timezone' : tzlocal.get_localzone().zone,
+    'submitty_admin_username': '',
+    'submitty_admin_password': '',
+    'email_user': '',
+    'email_password': '',
+    'email_sender': 'submitty@myuniversity.edu',
+    'email_reply_to': 'submitty_do_not_reply@myuniversity.edu',
+    'email_server_hostname': 'mail.myuniversity.edu',
+    'email_server_port': 25,
+    'course_code_requirements': "Please follow your school's convention for course code.",
+    'sys_admin_email': '',
+    'sys_admin_url': ''
 }
 
 loaded_defaults = {}
@@ -208,6 +210,12 @@ if args.worker:
 else:
     DATABASE_HOST = get_input('What is the database host?', defaults['database_host'])
     print()
+
+    if not os.path.isdir(DATABASE_HOST):
+        DATABASE_PORT = int(get_input('What is the database port?', defaults['database_port']))
+        print()
+    else:
+        DATABASE_PORT = defaults['database_port']
 
     DATABASE_USER = get_input('What is the database user/role?', defaults['database_user'])
     print()
@@ -344,6 +352,7 @@ else:
     config['php_gid'] = PHP_GID
 
     config['database_host'] = DATABASE_HOST
+    config['database_port'] = DATABASE_PORT
     config['database_user'] = DATABASE_USER
     config['database_password'] = DATABASE_PASS
     config['timezone'] = TIMEZONE
@@ -410,7 +419,7 @@ SECRETS_PHP_JSON = os.path.join(CONFIG_INSTALL_DIR, 'secrets_submitty_php.json')
 
 #Rescue the autograding_workers and _containers files if they exist.
 rescued = list()
-tmp_folder = tempfile.mkdtemp() 
+tmp_folder = tempfile.mkdtemp()
 if not args.worker:
     for full_file_name, file_name in [(WORKERS_JSON, 'autograding_workers.json'), (CONTAINERS_JSON, 'autograding_containers.json')]:
         if os.path.isfile(full_file_name):
@@ -467,7 +476,7 @@ if not args.worker:
 
         with open(CONTAINERS_JSON, 'w') as container_file:
             json.dump(container_dict, container_file, indent=4)
-    
+
     for file in [WORKERS_JSON, CONTAINERS_JSON]:
       shutil.chown(file, 'root',DAEMON_GID)
       os.chmod(file, 0o460)
@@ -481,6 +490,7 @@ if not args.worker:
     config = OrderedDict()
     config['authentication_method'] = AUTHENTICATION_METHOD
     config['database_host'] = DATABASE_HOST
+    config['database_port'] = DATABASE_PORT
     config['database_user'] = DATABASE_USER
     config['database_password'] = DATABASE_PASS
     config['debugging_enabled'] = DEBUGGING_ENABLED

--- a/bin/generate_repos.py
+++ b/bin/generate_repos.py
@@ -13,6 +13,7 @@ import sys
 import shutil
 from sqlalchemy import create_engine, MetaData, Table, bindparam
 
+from submitty_utils import db_utils
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'config')
 
 with open(os.path.join(CONFIG_PATH, 'submitty_users.json')) as open_file:
@@ -22,6 +23,7 @@ DAEMONCGI_GROUP = JSON['daemoncgi_group']
 with open(os.path.join(CONFIG_PATH, 'database.json')) as open_file:
     JSON = json.load(open_file)
 DATABASE_HOST = JSON['database_host']
+DATABASE_PORT = JSON['database_port']
 DATABASE_USER = JSON['database_user']
 DATABASE_PASS = JSON['database_password']
 
@@ -46,11 +48,13 @@ parser.add_argument("course", help="course code")
 parser.add_argument("repo_name", help="repository name")
 args = parser.parse_args()
 
-db = 'submitty'
-if os.path.isdir(DATABASE_HOST):
-    conn_string = "postgresql://{}:{}@/{}?host={}".format(DATABASE_USER, DATABASE_PASS, db, DATABASE_HOST)
-else:
-    conn_string = "postgresql://{}:{}@{}/{}".format(DATABASE_USER, DATABASE_PASS, DATABASE_HOST, db)
+conn_string = db_utils.generate_connect_string(
+    DATABASE_HOST,
+    DATABASE_PORT,
+    "submitty",
+    DATABASE_USER,
+    DATABASE_PASS,
+)
 
 engine = create_engine(conn_string)
 connection = engine.connect()
@@ -78,18 +82,19 @@ is_team = False
 # We will always pass in the name of the desired repository.
 #
 # If the repository name matches the name of an existing gradeable in
-# the course, we will check if it's a team gradeable and create 
+# the course, we will check if it's a team gradeable and create
 # individual or team repos as appropriate.
 #
 # If it's not an existing gradeable, we will ask the user for
 # confirmation, and make individual repos if requested.
 
-
-course_db = "submitty_{}_{}".format(args.semester, args.course)
-if os.path.isdir(DATABASE_HOST):
-    course_conn_string = "postgresql://{}:{}@/{}?host={}".format(DATABASE_USER, DATABASE_PASS, course_db, DATABASE_HOST)
-else:
-    course_conn_string = "postgresql://{}:{}@{}/{}".format(DATABASE_USER, DATABASE_PASS, DATABASE_HOST, course_db)
+course_conn_string = db_utils.generate_connect_string(
+    DATABASE_HOST,
+    DATABASE_PORT,
+    f"submitty_{args.semester}_{args.port}",
+    DATABASE_USER,
+    DATABASE_PASS,
+)
 
 course_engine = create_engine(course_conn_string)
 course_connection = course_engine.connect()

--- a/bin/generate_repos.py
+++ b/bin/generate_repos.py
@@ -91,7 +91,7 @@ is_team = False
 course_conn_string = db_utils.generate_connect_string(
     DATABASE_HOST,
     DATABASE_PORT,
-    f"submitty_{args.semester}_{args.port}",
+    f"submitty_{args.semester}_{args.course}",
     DATABASE_USER,
     DATABASE_PASS,
 )

--- a/migration/migrator/db.py
+++ b/migration/migrator/db.py
@@ -63,7 +63,7 @@ class Database:
             connection_string += '{}:{}@{}/{}'.format(
                 params['database_user'],
                 params['database_password'],
-                host if not Path(host).exists() else '',
+                f"{host}:{params['database_port']}" if not Path(host).exists() else '',
                 params['dbname']
             )
 

--- a/migration/migrator/migrations/system/20200701122138_database_port.py
+++ b/migration/migrator/migrations/system/20200701122138_database_port.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    tgt = Path(config.submitty['submitty_install_dir'], 'config', 'database.json')
+
+    with tgt.open() as infile:
+        data = json.load(infile)
+
+    data['database_port'] = 5432
+
+    with tgt.open('w') as outfile:
+        json.dump(data, outfile, indent=4)

--- a/migration/tests/test_db.py
+++ b/migration/tests/test_db.py
@@ -12,7 +12,7 @@ class TestDb(unittest.TestCase):
     def test_invalid_driver(self):
         with self.assertRaises(RuntimeError):
             migrator.db.Database({'database_driver': 'mysql'}, 'system')
-    
+
     def test_db(self):
         db = migrator.db.Database({'database_driver': 'sqlite'}, 'master')
         db.execute("""
@@ -44,12 +44,13 @@ class TestDb(unittest.TestCase):
         params = {
             'database_driver': 'psql',
             'database_host': 'localhost',
+            'database_port': 5432,
             'database_user': 'user',
             'database_password': 'password',
             'dbname': 'test'
         }
         string = migrator.db.Database.get_connection_string(params)
-        self.assertEqual('postgresql+psycopg2://user:password@localhost/test', string)
+        self.assertEqual('postgresql+psycopg2://user:password@localhost:5432/test', string)
 
     def test_get_connection_string_postgresql_str_host(self):
         try:

--- a/python_submitty_utils/submitty_utils/db_utils.py
+++ b/python_submitty_utils/submitty_utils/db_utils.py
@@ -1,0 +1,19 @@
+"""Utilities for interacting with databases"""
+
+
+def generate_connect_string(
+    host: str,
+    port: int,
+    db: str,
+    user: str,
+    password: str,
+) -> str:
+    conn_string = f"postgresql://{user}:{password}@"
+    if not host.startswith('/'):
+        conn_string += f"{host}:{port}"
+    conn_string += f"/{db}"
+
+    if host.startswith('/'):
+        conn_string += f"?host={host}"
+
+    return conn_string

--- a/python_submitty_utils/tests/test_db_utils.py
+++ b/python_submitty_utils/tests/test_db_utils.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from submitty_utils import db_utils
+
+
+class TestDbUtils(TestCase):
+    def test_connection_string(self):
+        self.assertEqual(
+            'postgresql://test:my_pass@127.0.0.1:1111/db_name',
+            db_utils.generate_connect_string(
+                '127.0.0.1',
+                1111,
+                'db_name',
+                'test',
+                'my_pass',
+            ))
+
+    def test_connection_string_dir(self):
+        self.assertEqual(
+            'postgresql://test:my_pass@/db_name?host=/var/run/postgresql',
+            db_utils.generate_connect_string(
+                '/var/run/postgresql',
+                5432,
+                'db_name',
+                'test',
+                'my_pass',
+            ))

--- a/sbin/adduser.py
+++ b/sbin/adduser.py
@@ -10,10 +10,13 @@ from os import path
 import subprocess
 from sqlalchemy import create_engine, MetaData, Table, bindparam
 
+from submitty_utils import db_utils
+
 CONFIG_PATH = path.join(path.dirname(path.realpath(__file__)), '..', 'config')
 with open(path.join(CONFIG_PATH, 'database.json')) as open_file:
     DATABASE_DETAILS = json.load(open_file)
 DATABASE_HOST = DATABASE_DETAILS['database_host']
+DATABASE_PORT = DATABASE_DETAILS['database_port']
 DATABASE_USER = DATABASE_DETAILS['database_user']
 DATABASE_PASS = DATABASE_DETAILS['database_password']
 AUTHENTICATION_METHOD = DATABASE_DETAILS['authentication_method']
@@ -61,13 +64,15 @@ def main():
     args = parse_args()
     user_id = args.user_id
 
-    engine_str = f"postgresql://{DATABASE_USER}:{DATABASE_PASS}@"
-    if path.isdir(DATABASE_HOST):
-        engine_str += f"/submitty?host={DATABASE_HOST}"
-    else:
-        engine_str += f"{DATABASE_HOST}/submitty"
+    conn_str = db_utils.generate_connect_string(
+        DATABASE_HOST,
+        DATABASE_PORT,
+        "submitty",
+        DATABASE_USER,
+        DATABASE_PASS,
+    )
 
-    engine = create_engine(engine_str)
+    engine = create_engine(conn_str)
     connection = engine.connect()
     metadata = MetaData(bind=engine)
     users_table = Table('users', metadata, autoload=True)

--- a/sbin/adduser_course.py
+++ b/sbin/adduser_course.py
@@ -11,10 +11,13 @@ from os import path
 import sys
 from sqlalchemy import create_engine, MetaData, Table, bindparam, and_
 
+from submitty_utils import db_utils
+
 CONFIG_PATH = path.join(path.dirname(path.realpath(__file__)), '..', 'config')
 with open(path.join(CONFIG_PATH, 'database.json')) as open_file:
     DATABASE_DETAILS = json.load(open_file)
 DATABASE_HOST = DATABASE_DETAILS['database_host']
+DATABASE_PORT = DATABASE_DETAILS['database_port']
 DATABASE_USER = DATABASE_DETAILS['database_user']
 DATABASE_PASS = DATABASE_DETAILS['database_password']
 
@@ -38,13 +41,15 @@ def main():
     course = args.course
     registration_section = args.registration_section
 
-    engine_str = f"postgresql://{DATABASE_USER}:{DATABASE_PASS}@"
-    if path.isdir(DATABASE_HOST):
-        engine_str += f"/submitty?host={DATABASE_HOST}"
-    else:
-        engine_str += f"{DATABASE_HOST}/submitty"
+    conn_str = db_utils.generate_connect_string(
+        DATABASE_HOST,
+        DATABASE_PORT,
+        "submitty",
+        DATABASE_USER,
+        DATABASE_PASS,
+    )
 
-    engine = create_engine(engine_str)
+    engine = create_engine(conn_str)
     connection = engine.connect()
     metadata = MetaData(bind=engine)
     users_table = Table('users', metadata, autoload=True)

--- a/sbin/create_course.sh
+++ b/sbin/create_course.sh
@@ -26,14 +26,20 @@ CGI_USER=$(jq -r '.cgi_user' ${CONF_DIR}/submitty_users.json)
 COURSE_BUILDERS_GROUP=$(jq -r '.course_builders_group' ${CONF_DIR}/submitty_users.json)
 
 DATABASE_HOST=$(jq -r '.database_host' ${CONF_DIR}/database.json)
+DATABASE_PORT=$(jq -r '.database_port' ${CONF_DIR}/database.json)
 DATABASE_USER=$(jq -r '.database_user' ${CONF_DIR}/database.json)
 DATABASE_PASS=$(jq -r '.database_password' ${CONF_DIR}/database.json)
 
 ########################################################################################################################
 ########################################################################################################################
 
+CONN_STRING="-h ${DATABASE_HOST} -U ${DATABASE_USER}"
+if [ -d ${DATABASE_HOST} ]; then
+    CONN_EXTRA="${CONN_STRING} -p ${DATABASE_PORT}"
+fi
+
 # Check that Submitty Master DB exists.
-PGPASSWORD=${DATABASE_PASS} psql -h ${DATABASE_HOST} -U ${DATABASE_USER} -lqt | cut -d \| -f 1 | grep -qw submitty
+PGPASSWORD=${DATABASE_PASS} psql ${CONN_STRING} -lqt | cut -d \| -f 1 | grep -qw submitty
 if [[ $? -ne "0" ]] ; then
     echo "ERROR: Submitty master database doesn't exist."
     exit
@@ -41,7 +47,7 @@ fi
 
 #Ensure that tables exist within Submitty Master DB.
 sql="SELECT count(*) FROM pg_tables WHERE schemaname='public' AND tablename IN ('terms','courses','courses_users','sessions','users');"
-table_count=`PGPASSWORD=${DATABASE_PASS} psql -h ${DATABASE_HOST} -U ${DATABASE_USER} -d submitty -tAc "${sql}"`
+table_count=`PGPASSWORD=${DATABASE_PASS} psql ${CONN_STRING} -d submitty -tAc "${sql}"`
 if [[ $table_count -ne "5" ]] ; then
     echo "ERROR: Submitty Master DB is invalid."
     exit
@@ -280,7 +286,7 @@ replace_fillin_variables ${course_dir}/config/config.json
 
 
 echo -e "Creating database ${DATABASE_NAME}\n"
-PGPASSWORD=${DATABASE_PASS} psql -h ${DATABASE_HOST} -U ${DATABASE_USER} -d postgres -c "CREATE DATABASE ${DATABASE_NAME}"
+PGPASSWORD=${DATABASE_PASS} psql ${CONN_STRING} -d postgres -c "CREATE DATABASE ${DATABASE_NAME}"
 if [[ $? -ne "0" ]] ; then
     echo "ERROR: Failed to create database ${DATABASE_NAME}"
     exit
@@ -291,7 +297,7 @@ if [[ $? -ne "0" ]] ; then
     echo "ERROR: Failed to create tables within database ${DATABASE_NAME}"
     exit
 fi
-PGPASSWORD=${DATABASE_PASS} psql -h ${DATABASE_HOST} -U ${DATABASE_USER} -d submitty -c "INSERT INTO courses (semester, course) VALUES ('${semester}', '${course}');"
+PGPASSWORD=${DATABASE_PASS} psql ${CONN_STRING} -d submitty -c "INSERT INTO courses (semester, course) VALUES ('${semester}', '${course}');"
 if [[ $? -ne "0" ]] ; then
     echo "ERROR: Failed to add this course to the master Submitty database."
     echo "HINT:  'insert or update on table \"courses\" violates foreign key constraint...'"

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -6,7 +6,6 @@ class PostgresqlDatabase extends AbstractDatabase {
     protected $host;
     protected $port;
     protected $dbname;
-    protected $unix_socket;
 
     /**
      * @inheritdoc
@@ -36,7 +35,8 @@ class PostgresqlDatabase extends AbstractDatabase {
         if ($this->host !== null) {
             $params[] = "host={$this->host}";
         }
-        if ($this->port !== null) {
+
+        if ($this->port !== null && ($this->host === null || $this->host[0] !== '/')) {
             $params[] = "port={$this->port}";
         }
 

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -284,6 +284,7 @@ class Config extends AbstractModel {
         $this->submitty_database_params = [
             'dbname' => 'submitty',
             'host' => $database_json['database_host'],
+            'port' => $database_json['database_port'],
             'username' => $database_json['database_user'],
             'password' => $database_json['database_password']
         ];

--- a/site/tests/app/controllers/admin/ConfigurationControllerTester.php
+++ b/site/tests/app/controllers/admin/ConfigurationControllerTester.php
@@ -27,7 +27,7 @@ class ConfigurationControllerTester extends \PHPUnit\Framework\TestCase {
         }
         $config_files = [
             'autograding_workers' => '{"primary":{"capabilities":["default"],"address":"localhost","username":"","num_autograding_workers":5,"enabled":true}}',
-            'database' => '{"authentication_method":"PamAuthentication","database_host":"\/var\/run\/postgresql","database_user":"submitty_dbuser","database_password":"submitty_dbuser","debugging_enabled":true}',
+            'database' => '{"authentication_method":"PamAuthentication","database_host":"\/var\/run\/postgresql","database_port":5432,"database_user":"submitty_dbuser","database_password":"submitty_dbuser","debugging_enabled":true}',
             'email' => '{"email_enabled":true,"email_user":"","email_password":"","email_sender":"submitty@vagrant","email_reply_to":"do-not-reply@vagrant","email_server_hostname":"localhost","email_server_port":25}',
             'secrets_submitty_php' => '{"session":"cGRZSDnVxdDjQwGyiq4ECnJyiZ8IQXEL1guSsJ1XlSKSEqisqvdCPhCRcYDEjpjm"}',
             'submitty_admin' => '{"submitty_admin_username":"submitty-admin","submitty_admin_password":"submitty-admin","token":"token"}',

--- a/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
+++ b/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
@@ -20,6 +20,11 @@ class PostgresqlDatabaseTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('pgsql:dbname=submitty', $database->getDSN());
     }
 
+    public function testPostgresqlUnixSocket() {
+        $database = new PostgresqlDatabase(['host' => '/var/run/postgresql', 'port' => 5432]);
+        $this->assertEquals('pgsql:host=/var/run/postgresql', $database->getDSN());
+    }
+
     public function arrayData() {
         return [
             ['{}', []],

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -56,6 +56,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $config = [
             "authentication_method" => "PamAuthentication",
             "database_host" => "/var/run/postgresql",
+            "database_port" => 5432,
             "database_user" => "submitty_dbuser",
             "database_password" => "submitty_dbpass",
             "debugging_enabled" => false,
@@ -185,6 +186,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
         $db_params = [
             'dbname' => 'submitty',
             'host' => '/var/run/postgresql',
+            'port' => 5432,
             'username' => 'submitty_dbuser',
             'password' => 'submitty_dbpass'
         ];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant: Submitty/submitty.github.io#263

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

It is not possible to use a non-standard port for postgres when using a TCP connection.

### What is the new behavior?

If not using the unix socket, CONFIGURE will now ask for a port to be specified (defaulting to 5432, postgresql's default) and it will be used for all connections when we use TCP host (e.g. localhost, ip address, etc.)