### PR TITLE
[Bugfix:Submission] Prevent file submission dropzones from showing labels twice

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -218,7 +218,10 @@
         {% endif %}
         <input type="submit" id="submit" class="btn btn-primary" value="Grade My Repository" />
     {% else %}
+
+    {% if is_notebook %}
         {{ renderNotebook(notebook, testcase_messages, image_data, numberUtils, student_id, gradeable_id, highest_version,max_file_uploads, old_files) }}
+    {% endif %}
 
         {# File upload boxes #}
         <div id="upload-boxes">

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -475,6 +475,7 @@ class HomeworkView extends AbstractView {
             'max_file_size' => Utils::returnBytes(ini_get('upload_max_filesize')),
             'max_post_size' => Utils::returnBytes(ini_get('post_max_size')),
             'max_file_uploads' => ini_get('max_file_uploads'),
+            'is_notebook' => $config->isNotebookGradeable()
         ]);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
If a file gets uploaded, its label will be displayed twice on the file submission zone even though it was only ever uploaded once.

### What is the new behavior?
Prevents `addLabel` function from getting called accidentally from notebook rendering code

### Other information?
fixes #5614
