### PR TITLE
[Feature:Vagrant] Add no_submissions flag to recreate_sample_courses

### DIFF
--- a/.setup/bin/recreate_sample_courses.sh
+++ b/.setup/bin/recreate_sample_courses.sh
@@ -3,6 +3,19 @@
 # Automated regeneration of sample course data
 
 ########################################################################
+EXTRA=
+
+while :; do
+    case $1 in
+        --no_submissions)
+            EXTRA="--no_submissions"
+            ;;
+        *) # No more options, so break out of the loop.
+            break
+    esac
+
+    shift
+done
 
 # If any command fails, we need to bail
 set -ev
@@ -22,8 +35,8 @@ fi
 # GIT_CHECKOUT/Submitty/.setup/bin -> GIT_CHECKOUT/Submitty
 cd ../../
 
-python3 ./.setup/bin/partial_reset.py
-python3 ./.setup/bin/setup_sample_courses.py
+# python3 ./.setup/bin/partial_reset.py
+python3 ./.setup/bin/setup_sample_courses.py ${EXTRA}
 
 PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
 service php${PHP_VERSION}-fpm restart


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant: Submitty/submitty.github.io#265

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There was no way to set similar no submissions behavior on using this script as when doing vagrant up.

### What is the new behavior?

Can now use the `--no_submissions` flag when running `recreate_sample_coures.sh` which will trigger no submissions to be made when generating the courses. This mirrors the flag named that's used within the `setup_sample_courses.py` script and so decided to go with that as opposed to using a variable similar to how `vagrant up` operates.