### PR TITLE
[Bugfix:Vagrant] Do not chmod/chgrp on shared directory

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -27,6 +27,11 @@ set -e
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 CONF_DIR=${THIS_DIR}/../../../config
 
+VAGRANT=0
+if [ -d ${THIS_DIR}/../.vagrant ]; then
+    VAGRANT=1
+fi
+
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
 SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)
 
@@ -826,10 +831,12 @@ if [ "${WORKER}" == 1 ]; then
     chgrp -R ${SUPERVISOR_USER} ${SUBMITTY_REPOSITORY}
     chmod -R g+rw ${SUBMITTY_REPOSITORY}
 else
-    # in order to update the submitty source files on the worker machines
-    # the DAEMON_USER/DAEMON_GROUP must have read access to the repo on the primary machine
-    chgrp -R ${DAEMON_GID} ${SUBMITTY_REPOSITORY}
-    chmod -R g+r ${SUBMITTY_REPOSITORY}
+    if [ ${VAGRANT} == 0 ]; then
+        # in order to update the submitty source files on the worker machines
+        # the DAEMON_USER/DAEMON_GROUP must have read access to the repo on the primary machine
+        chgrp -R ${DAEMON_GID} ${SUBMITTY_REPOSITORY}
+        chmod -R g+r ${SUBMITTY_REPOSITORY}
+    fi
 
     # Update any foreign worker machines
     echo -e -n "Updating worker machines\n\n"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

During the installation process, the installer attempts to chgrp and chown the git repository folder for Submitty. This is to ensure that the folder has the proper permissions so that it can be copied over to the worker machines. However, on Vagrant, this step does not actually do anything to permissions or owner as the repository folder is a shared one. Additionally, in certain cases, this was causing hangs and failures on running the script for people.

### What is the new behavior?

This makes it so that the chgrp / chown will only happen on non-vagrant installations (as determined by existence of the `.vagrant` folder at the top-level of the repository.