### PR TITLE
[Refactor:System] unbuffer vagrant output when updating workers

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -825,20 +825,24 @@ fi
 ################################################################################################################
 ################################################################################################################
 # confirm permissions on the repository (to allow push updates from primary to worker)
-echo "Preparing to update Submitty installation on worker machines"
 if [ "${WORKER}" == 1 ]; then
     # the supervisor user/group must have write access on the worker machine
+    echo -e -n "Update/confirm worker repository permissions"
     chgrp -R ${SUPERVISOR_USER} ${SUBMITTY_REPOSITORY}
     chmod -R g+rw ${SUBMITTY_REPOSITORY}
 else
     if [ ${VAGRANT} == 0 ]; then
         # in order to update the submitty source files on the worker machines
         # the DAEMON_USER/DAEMON_GROUP must have read access to the repo on the primary machine
+        echo -e -n "Update/confirm primary repository permissions"
         chgrp -R ${DAEMON_GID} ${SUBMITTY_REPOSITORY}
         chmod -R g+r ${SUBMITTY_REPOSITORY}
     fi
 
     # Update any foreign worker machines
-    echo -e -n "Updating worker machines\n\n"
-    sudo -H -u ${DAEMON_USER} ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils/update_and_install_workers.py
+    echo -e -n "Update workers and install autograding docker images on primary and worker machines"
+    # note: unbuffer the output (python3 -u), since installing docker images takes a while
+    #       and we'd like to watch the progress
+    sudo -H -u ${DAEMON_USER} python3 -u ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils/update_and_install_workers.py
+    echo -e -n "Done updating workers and installing docker images\n\n"
 fi

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,10 @@
 # If you don't want any submissions to be automatically generated for the courses created
 # by vagrant, you'll want to specify NO_SUBMISSIONS flag.
 
+# Don't buffer output.
+$stdout.sync = true
+$stderr.sync = true
+
 extra_command = ''
 if ENV.has_key?('NO_SUBMISSIONS')
     extra_command << '--no_submissions '

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -u
 
 import os
 from os import path
@@ -34,8 +34,6 @@ def install_worker(user, host):
 # ==================================================================================
 # Tells a worker to update it's docker container dependencies
 def update_docker_images(user, host, worker, autograding_workers, autograding_containers):
-    
-    print('updating docker images')
     images_to_update = set()
     worker_requirements = autograding_workers[worker]['capabilities']
 
@@ -153,6 +151,9 @@ if __name__ == "__main__":
     submitty_repository = submitty_config['submitty_repository']
 
     for worker, stats in autograding_workers.items():
+
+        print(f"Update machine: {worker}")
+
         user = stats['username']
         host = stats['address']
         enabled = stats['enabled']
@@ -179,3 +180,5 @@ if __name__ == "__main__":
 
         # Install new docker containers for everyone.
         update_docker_images(user, host, worker, autograding_workers, autograding_containers)
+
+        print (f"finished updating machine: {worker}")


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
Numerous developers reported hangs while "updating workers" on a "vagrant up".
It was unclear what step was hanging or failing.
But a likely culprit was pulling docker images to the primary machine.

### What is the new behavior?
Now the output to the updating workers script should be unbuffered.
Also, some print statements are adjusted to make clear that docker images on the primary machine are also being updated.
