### PR TITLE
[Bugfix:InstructorUI] Fixed timezone issues on office hours queue

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -706,14 +706,14 @@ CREATE TABLE public.queue (
     queue_code text NOT NULL,
     user_id text NOT NULL,
     name text NOT NULL,
-    time_in timestamp without time zone NOT NULL,
-    time_help_start timestamp without time zone,
-    time_out timestamp without time zone,
+    time_in timestamp with time zone NOT NULL,
+    time_out timestamp with time zone,
     added_by text NOT NULL,
     help_started_by text,
     removed_by text,
     contact_info text,
-    last_time_in_queue timestamp with time zone
+    last_time_in_queue timestamp with time zone,
+    time_help_start timestamp with time zone
 );
 
 

--- a/migration/migrator/migrations/course/20200712221345_fix_queue_timezones.py
+++ b/migration/migrator/migrations/course/20200712221345_fix_queue_timezones.py
@@ -1,0 +1,37 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+
+    database.execute("ALTER TABLE queue ALTER COLUMN time_in TYPE timestamp with time zone;");
+    database.execute("ALTER TABLE queue ALTER COLUMN time_help_start TYPE timestamp with time zone;");
+    database.execute("ALTER TABLE queue ALTER COLUMN time_out TYPE timestamp with time zone;");
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    
+    database.execute("ALTER TABLE queue ALTER COLUMN time_in TYPE timestamp;");
+    database.execute("ALTER TABLE queue ALTER COLUMN time_help_start TYPE timestamp;");
+    database.execute("ALTER TABLE queue ALTER COLUMN time_out TYPE timestamp;");

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -168,7 +168,7 @@ class DatabaseQueries {
      */
     public function getSimilarNumericIdMatches(string $id_string): array {
         $this->course_db->query("
-            SELECT user_numeric_id from users where 
+            SELECT user_numeric_id from users where
             cast(user_numeric_id as text)
             like ?
         ", [$id_string]);
@@ -2535,7 +2535,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
     public function updateTeamRegistrationSection($team_id, $section) {
         $this->course_db->query("UPDATE gradeable_teams SET registration_section=? WHERE team_id=?", [$section, $team_id]);
     }
-    
+
     /**
      * Set team $team_id's anon_id
      *
@@ -3247,7 +3247,7 @@ SQL;
     public function removePeerAssignmentsForGrader($gradeable_id, $grader_id) {
         $this->course_db->query("DELETE FROM peer_assign WHERE g_id = ? AND grader_id = ?", [$gradeable_id, $grader_id]);
     }
-    
+
     /**
      * Bulk Uploads Peer Grading Assignments
      *
@@ -3256,7 +3256,7 @@ SQL;
     public function insertBulkPeerGradingAssignment($values) {
         $this->course_db->query("INSERT INTO peer_assign(grader_id, user_id, g_id) VALUES " . $values);
     }
-    
+
 
     /**
      * Removes all peer grading pairs from a given assignment
@@ -3647,7 +3647,7 @@ AND gc_id IN (
         }
         return $return;
     }
-    
+
     public function getTeamAnonId($team_id) {
         $params = (is_array($team_id)) ? $team_id : [$team_id];
 
@@ -3671,7 +3671,7 @@ AND gc_id IN (
         }
         return $return;
     }
-    
+
     public function getTeamIdFromAnonId($anon_id) {
         $params = is_array($anon_id) ? $anon_id : [$anon_id];
 
@@ -4329,7 +4329,7 @@ AND gc_id IN (
 
         return $users;
     }
-    
+
     public function getUsersOrTeamsById(array $ids) {
         $users = $this->getUsersById($ids);
         if (empty($users)) {
@@ -5482,7 +5482,7 @@ AND gc_id IN (
     }
 
     public function getPastQueue() {
-        $this->course_db->query("SELECT ROW_NUMBER() OVER(order by time_out DESC, time_in DESC),* FROM queue where time_in > CURRENT_DATE AND current_state IN ('done') order by ROW_NUMBER");
+        $this->course_db->query("SELECT ROW_NUMBER() OVER(order by time_out DESC, time_in DESC),* FROM queue where time_in > ? AND current_state IN ('done') order by ROW_NUMBER", array($this->core->getDateTimeNow()->format('Y-m-d')));
         return $this->course_db->rows();
     }
 
@@ -5569,7 +5569,7 @@ AND gc_id IN (
                 TRIM(?),
                 ?,
                 ?,
-                current_timestamp,
+                ?,
                 NULL,
                 NULL,
                 ?,
@@ -5577,7 +5577,7 @@ AND gc_id IN (
                 NULL,
                 ?,
                 ?
-            )", [$queue_code,$user_id,$name,$user_id,$contact_info,$last_time_in_queue]);
+            )", [$queue_code,$user_id,$name,$this->core->getDateTimeNow(),$user_id,$contact_info,$last_time_in_queue]);
     }
 
     public function removeUserFromQueue($user_id, $remove_type, $queue_code) {
@@ -5601,7 +5601,7 @@ AND gc_id IN (
             return false;
         }
 
-        $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = ?, time_out = current_timestamp, removed_by = ? WHERE user_id = ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) AND current_state IN ('waiting','being_helped')", [$remove_type,$this->core->getUser()->getId(), $user_id, $queue_code]);
+        $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = ?, time_out = ?, removed_by = ? WHERE user_id = ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) AND current_state IN ('waiting','being_helped')", [$remove_type,$this->core->getDateTimeNow(),$this->core->getUser()->getId(), $user_id, $queue_code]);
     }
 
     public function startHelpUser($user_id, $queue_code) {
@@ -5610,7 +5610,7 @@ AND gc_id IN (
             $this->core->addErrorMessage("User not in queue");
             return false;
         }
-        $this->course_db->query("UPDATE queue SET current_state = 'being_helped', time_help_start = current_timestamp, help_started_by = ? WHERE user_id = ? and UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting')", [$this->core->getUser()->getId(), $user_id, $queue_code]);
+        $this->course_db->query("UPDATE queue SET current_state = 'being_helped', time_help_start = ?, help_started_by = ? WHERE user_id = ? and UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting')", [$this->core->getDateTimeNow(), $this->core->getUser()->getId(), $user_id, $queue_code]);
     }
 
     public function finishHelpUser($user_id, $queue_code, $remove_type) {
@@ -5620,11 +5620,11 @@ AND gc_id IN (
             return false;
         }
 
-        $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = ?, time_out = current_timestamp, removed_by = ? WHERE user_id = ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('being_helped')", [$remove_type,$this->core->getUser()->getId(), $user_id, $queue_code]);
+        $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = ?, time_out = ?, removed_by = ? WHERE user_id = ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('being_helped')", [$remove_type,$this->core->getDateTimeNow(),$this->core->getUser()->getId(), $user_id, $queue_code]);
     }
 
     public function emptyQueue($queue_code) {
-        $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = 'emptied', removed_by = ?, time_out = current_timestamp where current_state IN ('waiting','being_helped') and UPPER(TRIM(queue_code)) = UPPER(TRIM(?))", [$this->core->getUser()->getId(), $queue_code]);
+        $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = 'emptied', removed_by = ?, time_out = ? where current_state IN ('waiting','being_helped') and UPPER(TRIM(queue_code)) = UPPER(TRIM(?))", [$this->core->getUser()->getId(),$this->core->getDateTimeNow(), $queue_code]);
     }
 
     public function getQueueFromEntryId($entry_id) {
@@ -5702,12 +5702,15 @@ AND gc_id IN (
     }
 
     public function getNumberAheadInQueueThisWeek($queue_code, $time_in) {
-        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < CURRENT_DATE - interval '4' day AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", [$queue_code, $time_in]);
+        $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d');
+        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", array($day_threshold, $queue_code, $time_in));
         return $this->course_db->rows()[0]['count'];
     }
 
     public function getNumberAheadInQueueToday($queue_code, $time_in) {
-        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < CURRENT_DATE AND last_time_in_queue > CURRENT_DATE - interval '4' day AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", [$queue_code, $time_in]);
+        $current_date = $this->core->getDateTimeNow()->format('Y-m-d');
+        $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d');
+        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND last_time_in_queue > ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", array($current_date, $day_threshold, $queue_code, $time_in));
         return $this->course_db->rows()[0]['count'];
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5482,7 +5482,7 @@ AND gc_id IN (
     }
 
     public function getPastQueue() {
-        $this->course_db->query("SELECT ROW_NUMBER() OVER(order by time_out DESC, time_in DESC),* FROM queue where time_in > ? AND current_state IN ('done') order by ROW_NUMBER", [$this->core->getDateTimeNow()->format('Y-m-d')]);
+        $this->course_db->query("SELECT ROW_NUMBER() OVER(order by time_out DESC, time_in DESC),* FROM queue where time_in > ? AND current_state IN ('done') order by ROW_NUMBER", [$this->core->getDateTimeNow()->format('Y-m-d 00:00:00O')]);
         return $this->course_db->rows();
     }
 
@@ -5702,14 +5702,14 @@ AND gc_id IN (
     }
 
     public function getNumberAheadInQueueThisWeek($queue_code, $time_in) {
-        $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d');
+        $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d 00:00:00O');
         $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", [$day_threshold, $queue_code, $time_in]);
         return $this->course_db->rows()[0]['count'];
     }
 
     public function getNumberAheadInQueueToday($queue_code, $time_in) {
-        $current_date = $this->core->getDateTimeNow()->format('Y-m-d');
-        $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d');
+        $current_date = $this->core->getDateTimeNow()->format('Y-m-d 00:00:00O');
+        $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d 00:00:00O');
         $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND last_time_in_queue > ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", [$current_date, $day_threshold, $queue_code, $time_in]);
         return $this->course_db->rows()[0]['count'];
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5482,7 +5482,7 @@ AND gc_id IN (
     }
 
     public function getPastQueue() {
-        $this->course_db->query("SELECT ROW_NUMBER() OVER(order by time_out DESC, time_in DESC),* FROM queue where time_in > ? AND current_state IN ('done') order by ROW_NUMBER", array($this->core->getDateTimeNow()->format('Y-m-d')));
+        $this->course_db->query("SELECT ROW_NUMBER() OVER(order by time_out DESC, time_in DESC),* FROM queue where time_in > ? AND current_state IN ('done') order by ROW_NUMBER", [$this->core->getDateTimeNow()->format('Y-m-d')]);
         return $this->course_db->rows();
     }
 
@@ -5703,14 +5703,14 @@ AND gc_id IN (
 
     public function getNumberAheadInQueueThisWeek($queue_code, $time_in) {
         $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d');
-        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", array($day_threshold, $queue_code, $time_in));
+        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", [$day_threshold, $queue_code, $time_in]);
         return $this->course_db->rows()[0]['count'];
     }
 
     public function getNumberAheadInQueueToday($queue_code, $time_in) {
         $current_date = $this->core->getDateTimeNow()->format('Y-m-d');
         $day_threshold = $this->core->getDateTimeNow()->modify('-4 day')->format('Y-m-d');
-        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND last_time_in_queue > ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", array($current_date, $day_threshold, $queue_code, $time_in));
+        $this->course_db->query("SELECT count(*) from queue where last_time_in_queue < ? AND last_time_in_queue > ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('waiting') and time_in < ?", [$current_date, $day_threshold, $queue_code, $time_in]);
         return $this->course_db->rows()[0]['count'];
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The office hours queue does not store timezones with the times
The times for the office hours queue comes from the sql database time

### What is the new behavior?

All office hours queue times now store a timezone as well
The times in the office hours queue not correctly get times based on the submitty config file so that the sql database time should not matter anymore 

Fixes office hours queue parts of #2808
Closes  #4702

