### PR TITLE
[UI/UX: TAGrading] Show Peer Grading Reminders

### DIFF
--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -123,6 +123,24 @@
     }
 </script>
 <body onload="document.getElementById('defaultOpen').click();">
+<!-- If grader is limited access grader or student peer, Grading reminder should be displayed -->
+{% if core.getUser().getGroup() == 4 or core.getUser().getGroup() == 3%}
+<div class="content gradeable_message">
+    <h1>Your Responsibility as a Peer Grader!</h1>
+    <p>
+        You will be reviewing materials submitted by your classmates and these materials are considered confidential. Your classmate, the author of this material, is entitled to copyright protection. As such,
+        <ul>
+            <li> You may not use or share any of these materials or ideas without explicit permission from the author. </li>
+            <li>You may not retain this material -- you must delete/destroy any copies of this material after your review and grading of the work is complete. </li>
+            <li>Your instructor has configured the grading for this assignment to be [ double-blind / single-blind / unblinded ]. </li>
+            <li>You should not attempt to discover the identify of your classmate. However, the identify of the classmate may be unintentionally or unavoidably revealed. Please respect your classmate's privacy. </li>
+            <br>
+        </ul>
+        <u>Please refer to your instructor's course policies if you realize you have a conflict of interest with a peer that you have been assigned to grade.</u>
+        
+    </p>
+</div>
+{% endif %}
 <div class = "content">
     <h1>Status of {{ gradeable_title }}</h1>
 

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -123,24 +123,59 @@
     }
 </script>
 <body onload="document.getElementById('defaultOpen').click();">
-<!-- If grader is limited access grader or student peer, Grading reminder should be displayed -->
-{% if core.getUser().getGroup() == 4 or core.getUser().getGroup() == 3%}
+
+{% set double_blind = true %}
+{% set single_blind = false %}
+
+<!-- If grader is limited access or full access grader -->
+{% if core.getUser().getGroup() == 2 or core.getUser().getGroup() == 3 %}
 <div class="content gradeable_message">
-    <h1>Your Responsibility as a Peer Grader!</h1>
+    <h1>Your Responsibility as a Grader</h1>
     <p>
-        You will be reviewing materials submitted by your classmates and these materials are considered confidential. Your classmate, the author of this material, is entitled to copyright protection. As such,
-        <ul>
-            <li> You may not use or share any of these materials or ideas without explicit permission from the author. </li>
-            <li>You may not retain this material -- you must delete/destroy any copies of this material after your review and grading of the work is complete. </li>
-            <li>Your instructor has configured the grading for this assignment to be [ double-blind / single-blind / unblinded ]. </li>
-            <li>You should not attempt to discover the identify of your classmate. However, the identify of the classmate may be unintentionally or unavoidably revealed. Please respect your classmate's privacy. </li>
-            <br>
-        </ul>
-        <u>Please refer to your instructor's course policies if you realize you have a conflict of interest with a peer that you have been assigned to grade.</u>
-        
+        You will be reviewing materials submitted by students and these materials are considered confidential.<br>
+        The author of this material is entitled to copyright protection. As such,
+    <ul>
+        <li style="margin-left:30px;margin-bottom:10px;">You may not use or share any of these materials or ideas without explicit permission from the author.</li>
+        <li style="margin-left:30px;margin-bottom:10px;">You may not retain this material.<br>
+            You must delete/destroy any copies of this material after your review and grading of the work is complete.</li>
+{% if double_blind == true %}            
+        <li style="margin-left:30px;margin-bottom:10px;">Your instructor has configured the grading for this assignment to be <em>blinded</em>.<br>
+            You should not attempt to discover the identities of the students.<br>
+            However, their identities may be unintentionally or unavoidably revealed.<br>
+            Please respect the students' privacy.</li>
+{% endif %}
+    </ul>
+    </p><p>
+        Please communicate with the instructor if you realize you have a conflict of interest with a student that you have been assigned to grade.
+    </p>
+</div>
+<!-- Else if grader is a student peer grader -->
+{% elseif core.getUser().getGroup() == 4 %}
+<div class="content gradeable_message">
+    <h1>Your Responsibility as a Peer Grader</h1>
+    <p>
+        You will be reviewing materials submitted by your classmates and these materials are considered confidential.<br>
+        Your classmate, the author of this material, is entitled to copyright protection. As such,
+    <ul>
+        <li style="margin-left:30px;margin-bottom:10px;">You may not use or share any of these materials or ideas without explicit permission from the author.</li>
+        <li style="margin-left:30px;margin-bottom:10px;">You may not retain this material -- you must delete/destroy any copies of this material after your review and grading of the work is complete.</li>
+{% if double_blind == true %}            
+        <li style="margin-left:30px;margin-bottom:10px;">Your instructor has configured the grading for this assignment to be double-blind.<br>
+            You should not attempt to discover the identities of your classmates.<br>
+            However, the identities of the classmates may be unintentionally or unavoidably revealed.<br>
+            Please respect your classmates' privacy.</li>
+{% elseif single_blind == true %}
+        <li style="margin-left:30px;margin-bottom:10px;">Your instructor has configured the grading for this assignment to be single-blind.</li>
+{% else %}
+        <li style="margin-left:30px;margin-bottom:10px;">Your instructor has configured the grading for this assignment to be unblinded.</li>
+{% endif %}
+    </ul>
+    </p><p>
+        Please communicate with your instructor if you realize you have a conflict of interest with a peer that you have been assigned to grade.
     </p>
 </div>
 {% endif %}
+
 <div class = "content">
     <h1>Status of {{ gradeable_title }}</h1>
 


### PR DESCRIPTION
closes #5663 

### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Peer graders will be reviewing the materials submitted by their peers, and the process of peer grading may reveal the identity of the student. Limited access graders and peer graders are not reminded on their roles as reviewer.
### What is the new behavior?
Adds a reminder to both limited access and peer graders of their role as a reviewer.

