### PR TITLE
[Bugfix:Migrator] Use default postgres port to connect if config is missing port

### DIFF
--- a/migration/migrator/db.py
+++ b/migration/migrator/db.py
@@ -63,7 +63,7 @@ class Database:
             connection_string += '{}:{}@{}/{}'.format(
                 params['database_user'],
                 params['database_password'],
-                f"{host}:{params['database_port']}" if not Path(host).exists() else '',
+                f"{host}:{params.get('database_port', 5432)}" if not Path(host).exists() else '',
                 params['dbname']
             )
 

--- a/migration/tests/test_db.py
+++ b/migration/tests/test_db.py
@@ -44,7 +44,18 @@ class TestDb(unittest.TestCase):
         params = {
             'database_driver': 'psql',
             'database_host': 'localhost',
-            'database_port': 5432,
+            'database_port': 15432,
+            'database_user': 'user',
+            'database_password': 'password',
+            'dbname': 'test'
+        }
+        string = migrator.db.Database.get_connection_string(params)
+        self.assertEqual('postgresql+psycopg2://user:password@localhost:15432/test', string)
+
+    def test_get_connection_string_postgresql_no_port(self):
+        params = {
+            'database_driver': 'psql',
+            'database_host': 'localhost',
             'database_user': 'user',
             'database_password': 'password',
             'dbname': 'test'
@@ -52,7 +63,7 @@ class TestDb(unittest.TestCase):
         string = migrator.db.Database.get_connection_string(params)
         self.assertEqual('postgresql+psycopg2://user:password@localhost:5432/test', string)
 
-    def test_get_connection_string_postgresql_str_host(self):
+    def test_get_connection_string_postgresql_path_host(self):
         try:
             host = tempfile.mkdtemp()
             params = {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

#5616 introduced having the ability to set database port. As part of this, a migration was created to add this new field to the `database.json` file. However, if someone with an existing Submitty installation was not using a unix socket for migrator, it would cause migrator to crash before it was able to update that file with the new database port field.

### What is the new behavior?

This sets it so that if `database_port` is not set, it will use the default one for postgresql (5432) to run the migrations. Given that the only conditions in which this field should not be set and Submitty functions prior to #5616 when using something like `localhost` was that postgresql must be on the default port, this should work fine.

All other usages of port should not need this as they are only used after the migrator has run.