### PR TITLE
[Bugfix:Submission] Notebook multiple choice clickable area

### DIFF
--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -79,6 +79,8 @@ textarea.sa-box {
 .mc label {
     float: left;
     clear: both;
+    display: flex;
+    align-items: center;
 }
 
 .mc input[type='checkbox'],

--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -34,11 +34,6 @@
     font-family: monospace;
 }
 
-fieldset.mc {
-    display: flex;
-    flex-direction: column;
-}
-
 /* Display notebook multiple choice descriptions on same line as radio button or checkbox */
 /* Input field is the first child */
 .mc > label > :nth-child(2)
@@ -82,9 +77,8 @@ textarea.sa-box {
 }
 
 .mc label {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+    float: left;
+    clear: both;
 }
 
 .mc input[type='checkbox'],


### PR DESCRIPTION
### What is the current behavior?
The html label for notebook multiple choice inputs occupies 100% width of the parent container.  You can activate the checkbox/radio button accidentally by clicking far right of where there is text.

### What is the new behavior?
Styling has been changed so that the html label is only as wide as the text inside of it, making it much harder to accidentally activate the checkbox/radio button.