### PR TITLE
[Feature:Vagrant] Remove symlinked log folder

### DIFF
--- a/.setup/bin/partial_reset.py
+++ b/.setup/bin/partial_reset.py
@@ -17,7 +17,6 @@ import shutil
 import json
 import subprocess
 
-import distro
 import yaml
 
 CURRENT_PATH = Path(__file__).resolve().parent
@@ -110,25 +109,6 @@ def main():
 
     shutil.rmtree('/var/local/submitty', True)
     Path(SUBMITTY_DATA_DIR, 'courses').mkdir(parents=True)
-
-    distro_name = distro.id()
-    distro_version = distro.lsb_release_attr('codename')
-
-    # Clean out the log files, but leave the folders intact
-    if Path(CURRENT_PATH, "..", "..", ".vagrant").is_dir():
-        repo_path = Path(
-            SUBMITTY_REPOSITORY,
-            '.vagrant',
-            distro_name,
-            distro_version,
-            'logs',
-            'submitty'
-        )
-        data_path = SUBMITTY_DATA_DIR / 'logs'
-        if repo_path.exists():
-            shutil.rmtree(str(repo_path))
-        repo_path.mkdir()
-        data_path.symlink_to(repo_path)
 
     with Path(SUBMITTY_INSTALL_DIR, 'config', 'database.json').open() as submitty_config:
         submitty_config_json = json.load(submitty_config)

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -322,16 +322,6 @@ usermod -a -G "${DAEMONCGI_GROUP}" "${DAEMON_USER}"
 
 echo -e "\n# set by the .setup/install_system.sh script\numask 027" >> /home/${DAEMON_USER}/.profile
 
-if [ ${VAGRANT} == 1 ]; then
-    # add these users so that they can write to .vagrant/logs folder
-    if [ ${WORKER} == 0 ]; then
-        usermod -a -G vagrant "${PHP_USER}"
-        usermod -a -G vagrant "${CGI_USER}"
-        usermod -a -G vagrant postgres # needed by preferred_name_logging
-    fi
-    usermod -a -G vagrant "${DAEMON_USER}"
-fi
-
 usermod -a -G docker "${DAEMON_USER}"
 
 #################################################################
@@ -689,17 +679,6 @@ if [ ${WORKER} == 0 ]; then
     else
         echo "Submitty master database already exists"
     fi
-fi
-
-if [[ ${VAGRANT} == 1 ]]; then
-    DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
-    VERSION=$(lsb_release -sc | tr '[:upper:]' '[:lower:]')
-
-    rm -rf ${SUBMITTY_DATA_DIR}/logs/
-    rm -rf ${SUBMITTY_REPOSITORY}/.vagrant/${DISTRO}/${VERSION}/logs/submitty
-
-    mkdir -p ${SUBMITTY_REPOSITORY}/.vagrant/${DISTRO}/${VERSION}/logs/submitty
-    ln -s ${SUBMITTY_REPOSITORY}/.vagrant/${DISTRO}/${VERSION}/logs/submitty ${SUBMITTY_DATA_DIR}/logs
 fi
 
 echo Beginning Install Submitty Script

--- a/.setup/vagrant/setup_vagrant.sh
+++ b/.setup/vagrant/setup_vagrant.sh
@@ -23,6 +23,6 @@ if [ $? -ne 0 ]; then
 For whatever reason, Vagrant has failed to build. If reporting
 an error to the developers, please be sure to also send the
 build log of Vagrant located at:
-.vagrant/${DISTRO}/${VERSION}/logs/vagrant.log.
+.vagrant/install_${DISTRO}_${VERSION}.log.
 "
 fi

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,8 +35,7 @@ $script = <<SCRIPT
 GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
 DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
 VERSION=$(lsb_release -sc | tr '[:upper:]' '[:lower:]')
-mkdir -p ${GIT_PATH}/.vagrant/${DISTRO}/${VERSION}/logs
-bash ${GIT_PATH}/.setup/vagrant/setup_vagrant.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/${DISTRO}/${VERSION}/logs/vagrant.log
+bash ${GIT_PATH}/.setup/vagrant/setup_vagrant.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_${DISTRO}_${VERSION}.log
 SCRIPT
 
 unless Vagrant.has_plugin?('vagrant-vbguest')
@@ -78,7 +77,7 @@ Vagrant.configure(2) do |config|
     # vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
-    
+
   config.vm.provider "vmware_desktop" do |vm|
     vm.vmx["memsize"] = "2048"
     vm.vmx["numvcpus"] = "2"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We were symlinking the log folder of Submitty to be under the shared directory. This made it easy to access the folders during development on the host machine. It had the increasingly adverse effect that it would cause services to fail on a `vagrant up` on a halted VM due to processes attempting to access the folders before the shared folder was mounted. Given that only a very few people actually utilized this feature, the services failing is more a con than a pro.

### What is the new behavior?

Removes the symlink, which should remove the point of failure for services.
