### PR TITLE
[Bugfix:VCS] Fix auto repo generation for arbitrary name

### DIFF
--- a/bin/generate_repos.py
+++ b/bin/generate_repos.py
@@ -43,6 +43,7 @@ def create_folder(folder):
 
 
 parser = argparse.ArgumentParser(description="Generate git repositories for a specific course and homework")
+parser.add_argument("--non-interactive", action='store_true', default=False)
 parser.add_argument("semester", help="semester")
 parser.add_argument("course", help="course code")
 parser.add_argument("repo_name", help="repository name")
@@ -104,15 +105,15 @@ eg_table = Table('electronic_gradeable', course_metadata, autoload=True)
 select = eg_table.select().where(eg_table.c.g_id == bindparam('gradeable_id'))
 eg = course_connection.execute(select, gradeable_id=args.repo_name).fetchone()
 
-if eg is None:
+is_team = False
+if eg is not None:
+    is_team = eg.eg_team_assignment
+elif not args.non_interactive:
     print ("Warning: Semester '{}' and Course '{}' does not contain gradeable_id '{}'.".format(args.semester, args.course, args.repo_name))
     response = input ("Should we continue and make individual repositories named '"+args.repo_name+"' for each student? (y/n) ")
     if not response.lower() == 'y':
         print ("exiting");
         sys.exit()
-    is_team = False
-else:
-    is_team = eg.eg_team_assignment
 
 if not os.path.isdir(os.path.join(vcs_course, args.repo_name)):
     os.makedirs(os.path.join(vcs_course, args.repo_name), mode=0o770)

--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -149,7 +149,14 @@ class RunGenerateRepos(CourseGradeableJob):
             with open(log_file_path, "a") as output_file:
                 print ("At time: "+current_time, file=output_file)
                 output_file.flush()
-                subprocess.run(["sudo", gen_script, semester, course, gradeable], stdout=output_file, stderr=output_file)
+                subprocess.run([
+                    "sudo",
+                    gen_script,
+                    "--non-interactive",
+                    semester,
+                    course,
+                    gradeable
+                ], stdout=output_file, stderr=output_file)
         except PermissionError:
             print("error, could not open " + output_file + " for writing")
 
@@ -300,7 +307,7 @@ class BulkUpload(CourseJob):
         try:
             if is_qr:
                 bulk_qr_split.main([filename, split_path, qr_prefix, qr_suffix, log_file_path, use_ocr])
-            else: 
+            else:
                 bulk_upload_split.main([filename, split_path, num, log_file_path])
         except Exception:
             msg = "Failed to launch bulk_split subprocess!"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #5702.

Previously, the code would only work for automatically generating gradeables if the name was the gradeable_id. Even if an instructor were to specify their own name for the folder, it would still just create folders using the gradeable_id. Additionally, repos were always being created, even if the gradeable specified it was using GitHub repos.

### What is the new behavior?

This fixes it so that it will now properly use the gradeable_id for the first option, and whatever the instructor types in for the second option. It will also no longer create repos if the GitHub options are selected.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested both options, and that they created the repositories as expected.