### PR TITLE
[Feature:Notebook] item_pool map student to problem

### DIFF
--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -1549,6 +1549,10 @@
                 "type" : "string"
               }
             },
+            "user_item_map" : {
+              "type" : "object",
+              "description" : "Mapping of username to index of 'from_pool' array. Users in this mapping, will only be shown item corresponding to the mentioned index next to their username and no hash-based randomization will be done for them."
+            },
             "points" : {
               "type" : "number",
               "description" : "The number of points that this item is worth."

--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -224,7 +224,7 @@ nlohmann::json validate_notebook(const nlohmann::json& notebook, const nlohmann:
         // Check if the indices mapped to users are in 'from_pool' array range
         for (auto i=user_item_map.begin(); i!=user_item_map.end(); i++) {
            int item_index = i.value();
-           if(item_index < 0 || item_index > in_notebook_cell_from_pool.size()) {
+           if(item_index < 0 || item_index >= in_notebook_cell_from_pool.size()) {
                std::cout << "ERROR: user (" << i.key() <<") mapped with index \"" << item_index;
                std::cout << "\" which is out of 'from_pool' array range: 0 to " << user_item_map.size() << std::endl;
                throw -1;

--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -221,6 +221,15 @@ nlohmann::json validate_notebook(const nlohmann::json& notebook, const nlohmann:
                       << (item_label.empty() ? "[no label]" : item_label) << std::endl;
           }*/
         }
+        // Check if the indices mapped to users are in 'from_pool' array range
+        for (auto i=user_item_map.begin(); i!=user_item_map.end(); i++) {
+           int item_index = i.value();
+           if(item_index < 0 || item_index > in_notebook_cell_from_pool.size()) {
+               std::cout << "ERROR: user (" << i.key() <<") mapped with index \"" << item_index;
+               std::cout << "\" which is out of 'from_pool' array range: 0 to " << user_item_map.size() << std::endl;
+               throw -1;
+           }
+        }
 
         // Write the empty string if no label provided, otherwise pass forward item_label
         out_notebook_cell["item_label"] = item_label;

--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -178,6 +178,7 @@ nlohmann::json validate_notebook(const nlohmann::json& notebook, const nlohmann:
       }
       else if(type == "item"){
         std::string item_label = in_notebook_cell.value("item_label", "");
+        nlohmann::json user_item_map = in_notebook_cell.value("user_item_map", nlohmann::json::object());
 
         // Update the complete_config if we had a blank label
         complete[i]["item_label"] = "";
@@ -223,6 +224,10 @@ nlohmann::json validate_notebook(const nlohmann::json& notebook, const nlohmann:
 
         // Write the empty string if no label provided, otherwise pass forward item_label
         out_notebook_cell["item_label"] = item_label;
+        
+        // Write the empty object if no 'mapping' provided, otherwise pass forward user_item_map
+        out_notebook_cell["user_item_map"] = user_item_map;
+                
         // Pass forward other items
         out_notebook_cell["from_pool"] = in_notebook_cell["from_pool"];
         if(in_notebook_cell.find("points") != in_notebook_cell.end()){

--- a/more_autograding_examples/notebook_itempool_random/config/config.json
+++ b/more_autograding_examples/notebook_itempool_random/config/config.json
@@ -347,10 +347,15 @@ Here's a short list of instructions:\n  \
             "markdown_string": "#Let's do Math!"
         },
         {
-            "type" : "item",
-            "item_label" : "Math Problem",
-            "from_pool" : ["math_1", "math_2", "math_3"],
-            "points" : 3
+              "type" : "item",
+              "item_label" : "Math Problem",
+              "from_pool" : ["math_1", "math_2", "math_3"],
+              "user_item_map": {
+                "instructor" : 0,
+                "student" : 1,
+                "aphacker" : 2
+              },
+              "points" : 3
         },
         {
             "type" : "item",
@@ -366,6 +371,11 @@ Here's a short list of instructions:\n  \
             "type" : "item",
             "item_label" : "Animal FIRST",
             "from_pool" : ["animal_1", "animal_2", "animal_3"],
+            "user_item_map": {
+              "instructor" : 0,
+              "student" : 1,
+              "aphacker" : 2
+            },
             "points" : 2
         },
         {
@@ -397,6 +407,11 @@ Here's a short list of instructions:\n  \
             "type" : "item",
             "item_label" : "JUST CODE",
             "from_pool" : ["cpp_code", "python_code"],
+            "user_item_map": {
+              "instructor" : 0,
+              "student" : 1,
+              "aphacker" : 0
+            },
             "points" : 5
         }
         // ===================================================

--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -79,8 +79,8 @@ class Notebook extends AbstractModel {
                 }
             }
             elseif (
-                isset($notebook_cell['type']) &&
-                $notebook_cell['type'] === 'short_answer'
+                isset($notebook_cell['type'])
+                && $notebook_cell['type'] === 'short_answer'
                 && !empty($notebook_cell['programming_language'])
                 && empty($notebook_cell['codemirror_mode'])
             ) {

--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -79,6 +79,7 @@ class Notebook extends AbstractModel {
                 }
             }
             elseif (
+                isset($notebook_cell['type']) &&
                 $notebook_cell['type'] === 'short_answer'
                 && !empty($notebook_cell['programming_language'])
                 && empty($notebook_cell['codemirror_mode'])
@@ -92,7 +93,7 @@ class Notebook extends AbstractModel {
             }
 
             // If cell is a type of input add it to the $actual_inputs array
-            if (in_array($notebook_cell['type'], ['short_answer', 'multiple_choice'])) {
+            if (isset($notebook_cell['type']) && in_array($notebook_cell['type'], ['short_answer', 'multiple_choice'])) {
                 $actual_input[] = $notebook_cell;
             }
 

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -111,7 +111,8 @@ class UserSpecificNotebook extends Notebook {
         $item_label = $item['item_label'];
         $selected = null;
         // Check if user-mapping is available or not
-        if (isset($item["user_item_map"])
+        if (
+            isset($item["user_item_map"])
             && isset($item["user_item_map"][$this->user_id])
             && $item["user_item_map"][$this->user_id] >= 0
             && $item["user_item_map"][$this->user_id] < count($item['from_pool'])

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -111,10 +111,14 @@ class UserSpecificNotebook extends Notebook {
         $item_label = $item['item_label'];
         $selected = null;
         // Check if user-mapping is available or not
-        if (isset($item["user_item_map"]) && isset($item["user_item_map"][$this->user_id])) {
+        if (isset($item["user_item_map"])
+            && isset($item["user_item_map"][$this->user_id])
+            && $item["user_item_map"][$this->user_id] >= 0
+            && $item["user_item_map"][$this->user_id] < count($item['from_pool'])
+        ) {
             $selected = $item["user_item_map"][$this->user_id];
         }
-        else {
+        if (is_null($selected)) {
             $selected = $this->getNotebookHash($item_label, count($item['from_pool']));
         }
         $item_from_pool = $item['from_pool'][$selected];

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -109,7 +109,14 @@ class UserSpecificNotebook extends Notebook {
      */
     private function getItemFromPool(array $item): string {
         $item_label = $item['item_label'];
-        $selected = $this->getNotebookHash($item_label, count($item['from_pool']));
+        $selected = null;
+        // Check if user-mapping is available or not
+        if (isset($item["user_item_map"]) && isset($item["user_item_map"][$this->user_id])) {
+            $selected = $item["user_item_map"][$this->user_id];
+        }
+        else {
+            $selected = $this->getNotebookHash($item_label, count($item['from_pool']));
+        }
         $item_from_pool = $item['from_pool'][$selected];
         $this->selected_questions[] = $item_from_pool;
 

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -142,6 +142,7 @@ class UserSpecificNotebook extends Notebook {
     /**
      * Given an item_pool name return all associated notebook values and their testcases
      * @param string $tgt_name the name of the item_pool to search for
+     * @return array
      */
     private function searchForItemPool(string $tgt_name): array {
         $ret = ["notebook" => [], "testcases" => []];

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -109,19 +109,11 @@ class UserSpecificNotebook extends Notebook {
      */
     private function getItemFromPool(array $item): string {
         $item_label = $item['item_label'];
-        $selected = null;
-        // Check if user-mapping is available or not
-        if (
-            isset($item["user_item_map"])
-            && isset($item["user_item_map"][$this->user_id])
-            && $item["user_item_map"][$this->user_id] >= 0
-            && $item["user_item_map"][$this->user_id] < count($item['from_pool'])
-        ) {
-            $selected = $item["user_item_map"][$this->user_id];
-        }
-        if (is_null($selected)) {
-            $selected = $this->getNotebookHash($item_label, count($item['from_pool']));
-        }
+        //if user-mapping is available use the mentioned index
+        $selected = $item["user_item_map"][$this->user_id] ?? null;
+        // else get the index by hashing
+        $selected = $selected ?? $this->getNotebookHash($item_label, count($item['from_pool']));
+
         $item_from_pool = $item['from_pool'][$selected];
         $this->selected_questions[] = $item_from_pool;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently, if there are multiple items that are available in `from_pool`, hashing is done to pick one of these questions.
Also, there is an unhandled `undefined key error` case ( for 'type' ) which is popping out on some gradeable.

### What is the new behavior?
Closes #5647 
Fixes undefined index error. 
Adds support for optional field `user_item_map`.  This object contains a mapping of usernames to the index of items present in the `from_pool` array. 
```
          "user_item_map": {
                "<username_0> : <index_0>,
                "<username_1> : <index_1>....
              },
```
Users in this mapping will only be shown item corresponding to the mentioned index next to their username and no hash-based randomization will be done for them.
These ensure instructors can proofread all the question before exam... see #5647 for more info

### Other information?
Added this key in item_pool_random gradeable config.json for testing :)
