### PR TITLE
[Refactor:Router] Simplify check for invalid course redirect

### DIFF
--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -284,15 +284,19 @@ class WebRouter {
                 new RedirectResponse($this->core->buildCourseUrl(['no_access']))
             );
         }
+        elseif (
+            $logged_in
+            && Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')
+            && $this->parameters['_method'] !== 'logout'
+        ) {
+            return MultiResponse::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildUrl(['home']))
+            );
+        }
 
         if (!$this->core->getConfig()->isCourseLoaded() && !Utils::endsWith($this->parameters['_controller'], 'MiscController')) {
             if ($logged_in) {
-                if (
-                    $this->parameters['_method'] !== 'logout'
-                    && !Utils::endsWith($this->parameters['_controller'], 'HomePageController')
-                    && !Utils::endsWith($this->parameters['_controller'], 'UserProfileController')
-                    && !Utils::endsWith($this->parameters['_controller'], 'DockerInterfaceController')
-                ) {
+                if (isset($this->parameters['_semester']) && isset($this->parameters['_course'])) {
                     return MultiResponse::RedirectOnlyResponse(
                         new RedirectResponse($this->core->buildUrl(['home']))
                     );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The prior behavior here was that if we attempted to load a route, but it did not allow us to load a course, but was not one of our "top level" routes, we would redirect to the home page. Due to it being that the course path started at `/{_semester}/{_course}`, it meant we had to iterate each top-level controller individually to catch for them, due to how the routing might fall through in certain cases.

### What is the new behavior?

Given that courses are now sequestered under the unique `/courses/{_semester}/{_course}`, we can simplify this check to just check on if `_semester` and `_course` are set meaning we attempted to load a course that did not exist, while not worrying about colliding with our top-level routes. This then simplifies adding new top-level routes (like in #5337 or #5353) as it will no longer require editing this if statement each time a new controller is introduced.