### PR TITLE
[BugFix: TAGrading] Revise custom Peer marks

### DIFF
--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -56,7 +56,7 @@ Required inputs:
 {% block extra_mark_rows %}
     {# Custom mark (only display in non-edit mode #}
     {% set f_mark = component.marks|first %}
-    {% if not edit_marks_enabled %}
+    {% if not edit_marks_enabled core.getUser().getGroup() < 4%}
         <div class="custom-mark-container mark-container row"
              data-mark_id="0">
             <span class="mark-selector-container">

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -56,7 +56,7 @@ Required inputs:
 {% block extra_mark_rows %}
     {# Custom mark (only display in non-edit mode #}
     {% set f_mark = component.marks|first %}
-    {% if not edit_marks_enabled core.getUser().getGroup() < 4%}
+    {% if not edit_marks_enabled and core.getUser().getGroup() < 4%}
         <div class="custom-mark-container mark-container row"
              data-mark_id="0">
             <span class="mark-selector-container">


### PR DESCRIPTION
closes #5328 
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
With peer grading, peers can write custom text in the component nor assign custom points. Peers should not be able to add or edit common marks.
### What is the new behavior?
With peer grading, peers should not be allowed to write custom text in the component nor assign custom points. Peers should not be able to add or edit common marks.

