### PR TITLE
[Bugfix:Vagrant] Call partial reset as part of recreate sample courses

### DIFF
--- a/.setup/bin/recreate_sample_courses.sh
+++ b/.setup/bin/recreate_sample_courses.sh
@@ -35,7 +35,7 @@ fi
 # GIT_CHECKOUT/Submitty/.setup/bin -> GIT_CHECKOUT/Submitty
 cd ../../
 
-# python3 ./.setup/bin/partial_reset.py
+python3 ./.setup/bin/partial_reset.py
 python3 ./.setup/bin/setup_sample_courses.py ${EXTRA}
 
 PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Prior change to this script commented out to the call to `partial_reset.py` as it was done during testing, but that it was not un-uncommented out after I was done testing.

### What is the new behavior?

Removes the comment, and so `partial_reset.py` is now properly run again as part of the `recreate_sample_sources.sh` script.