### PR TITLE
[Bugfix:Migrator] Exit with failure if DB not found

### DIFF
--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -208,8 +208,10 @@ def handle_migration(args):
             try:
                 database = db.Database(loop_args.config.database, environment)
             except OperationalError:
-                print('Database does not exist for {}'.format(environment))
-                continue
+                raise SystemExit(
+                    'Submitty Database Migration Error:  '
+                    'Database does not exist for {}'.format(environment)
+                )
             migrate_environment(
                 database,
                 environment,
@@ -221,8 +223,9 @@ def handle_migration(args):
         if environment == 'course':
             course_dir = Path(args.config.submitty['submitty_data_dir'], 'courses')
             if not course_dir.exists():
-                print("Could not find courses directory: {}".format(course_dir))
-                continue
+                raise SystemExit(
+                    f"Migrator Error:  Could not find courses directory: {course_dir}"
+                )
             for semester in sorted(os.listdir(str(course_dir))):
                 courses = sorted(os.listdir(os.path.join(str(course_dir), semester)))
                 for course in courses:
@@ -247,9 +250,11 @@ def handle_migration(args):
                         )
                         database.close()
                     except OperationalError:
-                        print("Submitty Database Migration Warning:  "
-                              "Database does not exist for "
-                              "semester={} course={}".format(semester, course))
+                        raise SystemExit(
+                            "Submitty Database Migration Error:  "
+                            "Database does not exist for "
+                            "semester={} course={}".format(semester, course)
+                        )
     for missing_migration in all_missing_migrations:
         if missing_migration.exists():
             missing_migration.unlink()

--- a/migration/tests/test_handle_migration.py
+++ b/migration/tests/test_handle_migration.py
@@ -44,12 +44,14 @@ class TestHandleMigration(unittest.TestCase):
         args.config.submitty = {
             'submitty_data_dir': self.dir
         }
-        main.handle_migration(args)
+
+        with self.assertRaises(SystemExit) as context:
+            main.handle_migration(args)
         self.assertEqual(
-            "Could not find courses directory: {}\n".format(
+            "Migrator Error:  Could not find courses directory: {}".format(
                 str(Path(self.dir, 'courses'))
             ),
-            sys.stdout.getvalue()
+            str(context.exception)
         )
 
     def test_migration_no_db_master(self):
@@ -58,12 +60,13 @@ class TestHandleMigration(unittest.TestCase):
         args.config = SimpleNamespace()
         args.config.database = dict()
 
-        with patch.object(migrator.db, 'Database') as mock_class:
+        with self.assertRaises(SystemExit) as context, \
+                patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
             main.handle_migration(args)
         self.assertEqual(
-            "Database does not exist for master\n",
-            sys.stdout.getvalue()
+            "Submitty Database Migration Error:  Database does not exist for master",
+            str(context.exception)
         )
 
     def test_migration_no_db_system(self):
@@ -72,12 +75,13 @@ class TestHandleMigration(unittest.TestCase):
         args.config = SimpleNamespace()
         args.config.database = dict()
 
-        with patch.object(migrator.db, 'Database') as mock_class:
+        with self.assertRaises(SystemExit) as context, \
+                patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
             main.handle_migration(args)
         self.assertEqual(
-            "Database does not exist for system\n",
-            sys.stdout.getvalue()
+            "Submitty Database Migration Error:  Database does not exist for system",
+            str(context.exception)
         )
 
     def test_migration_no_db_course(self):
@@ -90,12 +94,13 @@ class TestHandleMigration(unittest.TestCase):
         args.config.submitty['submitty_data_dir'] = Path(self.dir)
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
-        with patch.object(migrator.db, 'Database') as mock_class:
+        with self.assertRaises(SystemExit) as context, \
+                patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
             main.handle_migration(args)
         self.assertEqual(
-            "Submitty Database Migration Warning:  Database does not exist for semester=f19 course=csci1100\n",
-            sys.stdout.getvalue()
+            "Submitty Database Migration Error:  Database does not exist for semester=f19 course=csci1100",
+            str(context.exception)
         )
 
     def test_migration_no_db_all(self):
@@ -108,14 +113,15 @@ class TestHandleMigration(unittest.TestCase):
         args.config.submitty['submitty_data_dir'] = Path(self.dir)
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
-        with patch.object(migrator.db, 'Database') as mock_class:
+        with self.assertRaises(SystemExit) as context, \
+                patch.object(migrator.db, 'Database') as mock_class:
             mock_class.side_effect = OperationalError('test', None, None)
             main.handle_migration(args)
-        expected = """Database does not exist for master
-Database does not exist for system
-Submitty Database Migration Warning:  Database does not exist for semester=f19 course=csci1100
-"""
-        self.assertEqual(expected, sys.stdout.getvalue())
+
+        self.assertEqual(
+            "Submitty Database Migration Error:  Database does not exist for master",
+            str(context.exception)
+        )
 
     @patch('migrator.main.migrate_environment')
     def test_migration_master(self, mock_method):


### PR DESCRIPTION
Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>

### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #5728 

If the database or courses directory were not found, it would print out a warning message, but keep running. This meant that `.setup/INSTALL_SUBMITTY_HELPER.sh` would then proceed as normal, which would put us into a potentially buggy / undefined state.

### What is the new behavior?

More explicitly cause the migrator to crash if it cannot find the database. There should never be a point where the database does not exist under normal circumstances, even on fresh install.