### PR TITLE
[Bugfix:System] Create courses directory missing for migrator on install

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -528,6 +528,10 @@ mkdir -p ${SUBMITTY_DATA_DIR}
 
 #Set up database and copy down the tutorial repo if not in worker mode
 if [ ${WORKER} == 0 ]; then
+    # create the courses directory. This is needed for the first time we run
+    # the migrator in the INSTALL_SUBMITTY_HELPER.sh
+    mkdir -p ${SUBMITTY_DATA_DIR}/courses
+
     # create a list of valid userids and put them in /var/local/submitty/instructors
     # one way to create your list is by listing all of the userids in /home
     mkdir -p ${SUBMITTY_DATA_DIR}/instructors


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Alternative patch to fix issue pointed out in #5742 

The courses directory `/var/local/submitty/courses` does not exist on the first time `INSTALL_SUBMITTY_HELPER.sh` is run, which in turn causes the migrator to crash with an error due to it missing after the changes in #5735.

### What is the new behavior?

This creates the directory as part of `install_system.sh` before the helper is called for the first time. This will then allow the migrator to operate as expected, performing no action as there are no semesters or courses. Additionally, this does still leave in place the error condition in place.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
