### PR TITLE
[Feature:TAGrading] Allow peer graders to download submission zip files

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -290,9 +290,10 @@ class MiscController extends AbstractController {
 
         // TODO: Zip file anonymization is currently done based on access level (students==peers)
         // When single/double blind grading is merged, this will need to be updated.
-        if($this->core->getUser()->getGroup() === User::GROUP_STUDENT){
+        if ($this->core->getUser()->getGroup() === User::GROUP_STUDENT) {
             $zip_file_name = $gradeable_id . "_" . $anon_id . "_v" . $version . ".zip";
-        } else {
+        }
+        else {
             $zip_file_name = $gradeable_id . "_" . $user_id . "_v" . $version . ".zip";
         }
 

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -10,6 +10,7 @@ use app\libraries\routers\AccessControl;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use app\models\User;
 
 class MiscController extends AbstractController {
 
@@ -222,6 +223,8 @@ class MiscController extends AbstractController {
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/download_zip")
      */
     public function downloadSubmissionZip($gradeable_id, $user_id, $version, $is_anon, $origin = null) {
+
+        $anon_id = $user_id;
         if ($is_anon === "true") {
             $user_id = $this->core->getQueries()->getUserFromAnon($user_id)[$user_id];
         }
@@ -275,7 +278,6 @@ class MiscController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl());
         }
 
-        $zip_file_name = $gradeable_id . "_" . $user_id . "_" . date("m-d-Y") . ".zip";
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         $temp_dir = "/tmp";
@@ -285,6 +287,14 @@ class MiscController extends AbstractController {
         $gradeable_path = $this->core->getConfig()->getCoursePath();
         $active_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();
         $version = $version ?? $active_version;
+
+        // TODO: Zip file anonymization is currently done based on access level (students==peers)
+        // When single/double blind grading is merged, this will need to be updated.
+        if($this->core->getUser()->getGroup() === User::GROUP_STUDENT){
+            $zip_file_name = $gradeable_id . "_" . $anon_id . "_v" . $version . ".zip";
+        } else {
+            $zip_file_name = $gradeable_id . "_" . $user_id . "_v" . $version . ".zip";
+        }
 
         $zip = new \ZipArchive();
         $zip->open($zip_name, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -33,9 +33,7 @@
                     $('#' + currentCodeStyleRadio).prop('checked', true);
                 });
             </script>
-            {% if not student_grader %}
-                <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, true)">Download Zip File</button>
-            {% endif %}
+            <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
 
             <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
             <br />


### PR DESCRIPTION
This PR:
1. Makes the `Download Zip File` button accessible to peer graders on the TA grading page
2. Renames downloaded zip files to include version downloaded rather than timestamp downloaded
3. Anonymizes the name of zip files downloaded by peers: `{gradeable_id}_{anon_id}_{version}.zip`