### PR TITLE
[TAGrading:Bugfix] Navigation buttons to prev/next student fixed

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -981,6 +981,7 @@ class ElectronicGraderController extends AbstractController {
         $team = $gradeable->isTeamAssignment();
         // If $who_id is empty string then this request came from the TA grading interface navigation buttons
         // We must decide who to display prev/next and assign them to $who_id
+        $order_all_sections = null;
         if ($who_id === '') {
             $order_grading_sections = new GradingOrder($this->core, $gradeable, $this->core->getUser());
             $order_grading_sections->sort($sort, $direction);

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1005,9 +1005,10 @@ class ElectronicGraderController extends AbstractController {
             if ($from_graded_gradeable === false) {
                  $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']));
             }
-            
+
             // Get the user ID of the user we were viewing on the TA grading interface
             $from_id = $from_graded_gradeable->getSubmitter();
+
             // Determine the student to go to based on the button that was pressed
             // For full access graders, pressing the single arrow should navigate to the next submission, regardless
             // of if that submission is in their assigned section
@@ -1036,6 +1037,7 @@ class ElectronicGraderController extends AbstractController {
             elseif ($to === 'next' && $to_ungraded === 'true') {
                 $goToStudent = $order_grading_sections->getNextUngradedSubmitter($from_id, $component_id);
             }
+
             // Reassign who_id
             if (!is_null($goToStudent)) {
                 $who_id = $peer ? $goToStudent->getAnonId() :   $goToStudent->getId();
@@ -1062,6 +1064,7 @@ class ElectronicGraderController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])  . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => 'all']));
             $peer = false;
         }
+
         $gradeableUrl = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'status']);
         $this->core->getOutput()->addBreadcrumb("{$gradeable->getTitle()} Grading", $gradeableUrl);
         $indexUrl = $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']);

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -171,11 +171,6 @@ parameters:
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-
-			message: "#^Variable \\$order_all_sections might not be defined\\.$#"
-			count: 2
-			path: app/controllers/grading/ElectronicGraderController.php
-
-		-
 			message: "#^Variable \\$goToStudent might not be defined\\.$#"
 			count: 1
 			path: app/controllers/grading/ElectronicGraderController.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When grading a student, the next, prev, next ungraded and prev ungraded buttons will redirect to the grade detail page.
### What is the new behavior?
The next, prev, next ungraded and prev ungraded buttons will redirect to the proper student
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
