### PR TITLE
[Bugfix:Submission] Notebook codebox hotfix

### DIFF
--- a/site/.eslintignore
+++ b/site/.eslintignore
@@ -1,5 +1,6 @@
 public/js/admin-gradeable-updates.js
 public/js/autosave-utils.js
+public/js/code-mirror-utils.js
 public/js/collapsible-panels.js
 public/js/confetti.js
 public/js/configuration.js

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -83,8 +83,8 @@
                             makeCodeMirrorAccessible(editor_{{ num_codeboxes }});
 
                             {% if cell.rows is defined and cell.rows > 0 %}
-                                const height = rowsToPixels({{ cell.rows }});
-                                editor_{{ num_codeboxes }}.setSize(null, height);
+                                const height_{{ num_codeboxes }} = rowsToPixels({{ cell.rows }});
+                                editor_{{ num_codeboxes }}.setSize(null, height_{{ num_codeboxes }});
                             {% endif %}
 
                             {# Populate codebox and set state of buttons initially #}


### PR DESCRIPTION

### What is the current behavior?
On the notebook submission page if there is more than one codebox with 'rows' set then they break.

### What is the new behavior?
Corrected issue where javascript variable tries to be redefined.