### PR TITLE
[Feature:instructorui] Add pause button to office hours queue

### DIFF
--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -193,6 +193,25 @@ class OfficeHoursQueueController extends AbstractController {
     }
 
     /**
+     * @Route("/courses/{_semester}/{_course}/office_hours_queue/togglePause", methods={"POST"})
+     * @return MultiResponse
+     */
+    public function setQueuePauseState() {
+        if (empty($_POST['pause_state'])) {
+            $this->core->addErrorMessage("Missing pause state");
+            return MultiResponse::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
+            );
+        }
+
+        $this->core->getQueries()->setQueuePauseState($_POST['pause_state'] === 'true');
+        $this->core->addSuccessMessage($_POST['pause_state'] === 'true' ? "Place paused" : "Place unpaused");
+        return MultiResponse::RedirectOnlyResponse(
+            new RedirectResponse($this->core->buildCourseUrl(['office_hours_queue']))
+        );
+    }
+
+    /**
      * @Route("/courses/{_semester}/{_course}/office_hours_queue/{queue_code}/restore", methods={"POST"})
      * @AccessControl(role="LIMITED_ACCESS_GRADER")
      * @return MultiResponse

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5628,6 +5628,10 @@ AND gc_id IN (
         $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = ?, time_out = ?, removed_by = ? WHERE user_id = ? AND UPPER(TRIM(queue_code)) = UPPER(TRIM(?)) and current_state IN ('being_helped')", [$remove_type,$this->core->getDateTimeNow(),$this->core->getUser()->getId(), $user_id, $queue_code]);
     }
 
+    public function setQueuePauseState($new_state) {
+        $this->course_db->query("UPDATE queue SET paused = ? WHERE current_state = 'waiting' AND user_id = ?", [$new_state, $this->core->getUser()->getId()]);
+    }
+
     public function emptyQueue($queue_code) {
         $this->course_db->query("UPDATE queue SET current_state = 'done', removal_type = 'emptied', removed_by = ?, time_out = ? where current_state IN ('waiting','being_helped') and UPPER(TRIM(queue_code)) = UPPER(TRIM(?))", [$this->core->getUser()->getId(),$this->core->getDateTimeNow(), $queue_code]);
     }

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -161,6 +161,10 @@ class OfficeHoursQueueModel extends AbstractModel {
         return $this->current_queue_state['queue_code'];
     }
 
+    public function isCurrentlyPaused() {
+        return $this->current_queue_state['paused'];
+    }
+
     public function getCurrentQueueStatus() {
         return $this->current_queue_state['current_state'];
     }

--- a/site/app/templates/officeHoursQueue/CurrentQueue.twig
+++ b/site/app/templates/officeHoursQueue/CurrentQueue.twig
@@ -19,10 +19,14 @@
 
           {% if entry['current_state'] == 'waiting' %}
             <td>
-              <form method="post" action="{{base_url}}/{{entry['queue_code']}}/startHelp">
+              <form method="post" action="{{base_url}}/{{entry['queue_code']}}/startHelp" {% if entry['paused'] %}onsubmit="return confirm('Are you sure you want to start helping this student? This student is currently paused.');"{% endif %}>
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                 <input type="hidden" name="user_id" value="{{entry['user_id']}}"/>
-                {% if viewer.firstTimeInQueueThisWeek(entry['last_time_in_queue']) %}
+                {% if entry['paused'] %}
+                  <button type="submit" class="btn btn-primary help_btn" title="Student paused">
+                    <i class="fas fa-pause"></i>
+                    Help</button>
+                {% elseif viewer.firstTimeInQueueThisWeek(entry['last_time_in_queue']) %}
                   <button type="submit" class="btn btn-primary help_btn" title="First time in this queue this week">
                     <i class="fas fa-star"></i>
                     Help</button>

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -73,6 +73,19 @@
       <input type="hidden" name="queue_code" value="{{ viewer.getCurrentQueueCode() }}"/>
       <button id="leave_queue" type="submit" class="btn btn-danger">Leave Queue</button>
     </form>
+    <br>
+    <p>The pause button is meant for short breaks such as going to the bathroom and not to hold your place until you have a question.</p>
+    <form method="post" action="{{base_url}}/togglePause">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
+      <input type="hidden" name="pause_state" value="{{ viewer.isCurrentlyPaused()?'false':'true' }}"/>
+      <button id="pause_user" type="submit" class="btn btn-primary">
+        {% if viewer.isCurrentlyPaused() %}
+          Unpause place in queue
+        {% else %}
+          Pause place in queue
+        {% endif %}
+      </button>
+    </form>
   </div>
 {% else %}
   <div id="queue_status">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When the office hours queue is long a student may be waiting for a long period of time to get help. In the unlucky situation where say they need to go to the bathroom right as they are next in the queue, they may get called on and then lose their spot in line because they were unable to respond 

### What is the new behavior?
This pr adds the ability for students to let mentors know they will be away for a few min through a pause button.

Student view:
![image](https://user-images.githubusercontent.com/18558130/89449382-fb1e0880-d726-11ea-9d87-5ce7c5709837.png)

Grader view:
![image](https://user-images.githubusercontent.com/18558130/89449417-0709ca80-d727-11ea-8e50-3f6e56ebd7db.png)
If you try and help that student, it will warn you making sure your really want to help the student even though they are paused
![image](https://user-images.githubusercontent.com/18558130/89449512-2f91c480-d727-11ea-986c-a1a1222b0fbd.png)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
There is a chance that a student could abuse this system and stay paused until they have a question, currently the way we talked about dealing with that is to just remove students from the queue that are paused for longer than a reasonable amount of time
