### PR TITLE
[Bugfix:Autograding] add item_name to build config

### DIFF
--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -406,6 +406,7 @@ int main(int argc, char *argv[]) {
   if(config_json.find("item_pool") != config_json.end()){
     int i = 0;
     for(nlohmann::json::iterator itr = config_json["item_pool"].begin(); itr != config_json["item_pool"].end(); itr++, i++) {
+      j["item_pool"][i]["item_name"] = (*itr)["item_name"];
       j["item_pool"][i]["notebook"] = validate_notebook((*itr)["notebook"], config_json);
     }
   }


### PR DESCRIPTION
### What is the current behavior?
Configuration json found in the course build directory do not contain an `item_name` for notebook item pools.

### What is the new behavior?
This field has been added when building item pools.
