### PR TITLE
[TAGrading: Bugfix] Anon_id and download file fix

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -30,6 +30,10 @@ class MiscController extends AbstractController {
      * Given a path that may or may not contain the anon_id instead of the user_id return the path containing the user_id
      */
     public function decodeAnonPath($path) {
+        $exploded_path = explode("/", $path);
+        if (sizeof($exploded_path) < 10){
+            return $path;
+        }
         $anon_id = explode("/", $path)[9];
         $correct_user_id = $this->core->getQueries()->getSubmitterIdFromAnonId($anon_id);
         if ($correct_user_id !== null) {
@@ -154,7 +158,6 @@ class MiscController extends AbstractController {
      * @Route("/courses/{_semester}/{_course}/read_file")
      */
     public function readFile($dir, $path, $csrf_token = null) {
-        $path = $this->decodeAnonPath($path);
         // security check
         if (!$this->core->getAccess()->canI("path.read", ["dir" => $dir, "path" => $path])) {
             $this->core->getOutput()->showError("You do not have access to this file");

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -31,7 +31,7 @@ class MiscController extends AbstractController {
      */
     public function decodeAnonPath($path) {
         $exploded_path = explode("/", $path);
-        if (sizeof($exploded_path) < 10){
+        if (count($exploded_path) < 10) {
             return $path;
         }
         $anon_id = explode("/", $path)[9];

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -27,9 +27,9 @@ class MiscController extends AbstractController {
     }
     
     /**
-    * 
-    */
-    public function decodeAnonPath($path){
+     * Given a path that may or may not contain the anon_id instead of the user_id return the path containing the user_id
+     */
+    public function decodeAnonPath($path) {
         $anon_id = explode("/", $path)[9];
         $correct_user_id = $this->core->getQueries()->getSubmitterIdFromAnonId($anon_id);
         if ($correct_user_id !== null) {

--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -113,16 +113,13 @@ class PDFController extends AbstractController {
 
         $gradeable = $this->tryGetGradeable($gradeable_id);
         if ($gradeable === false) {
-            return false;
+            return $this->core->getOutput()->renderJsonFail('Could not get gradeable');
         }
         if ($this->core->getUser()->getGroup() === User::GROUP_STUDENT) {
             if ($gradeable->isPeerGrading()) {
                 $user_ids = $this->core->getQueries()->getPeerAssignment($gradeable_id, $grader_id);
                 if (!$gradeable->isTeamAssignment()) {
                     if (!in_array($user_id, $user_ids)) {
-                        return $this->core->getOutput()->renderJsonFail('You do not have permission to grade this student');
-                    }
-                    else {
                         return $this->core->getOutput()->renderJsonFail('You do not have permission to grade this student');
                     }
                 }
@@ -144,7 +141,7 @@ class PDFController extends AbstractController {
 
         $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $user_id);
         if ($graded_gradeable === false) {
-            return false;
+            return $this->core->getOutput()->renderJsonFail('Could not get graded gradeable');
         }
 
         $active_version = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion();

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -80,7 +80,7 @@
             let directory = "";
             if (url_file.includes("submissions")) {
                 directory = "submissions";
-                url_file = getNonAnonPath(url_file, "{{anon_submitter_id}}", {{user_ids|json_encode|raw}});
+                url_file = url_file;
             }
             else if (url_file.includes("results_public")) {
                 directory = "results_public";
@@ -124,7 +124,7 @@
         var directory = "";
         if (url_file.includes("submissions")) {
             directory = "submissions";
-            url_file = getNonAnonPath(url_file, "{{anon_submitter_id}}", {{user_ids|json_encode|raw}});
+            url_file = url_file;
         }
         else if (url_file.includes("results_public")) {
             directory = "results_public";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

closes #5774

### What is the current behavior?
File paths containing the anon_id are not being properly substituted for the file path containing the user id in all cases. This leads files not being able to be downloaded/opened properly in some cases

### What is the new behavior?
Files can be opened/downloaded as normal
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
