### PR TITLE
[Bugfix:Submission] use build config not complete config

### DIFF
--- a/site/app/exceptions/NotebookException.php
+++ b/site/app/exceptions/NotebookException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\exceptions;
+
+class NotebookException extends BaseException {
+
+    public function __construct($message, $code = 0, $previous = null) {
+        parent::__construct($message, [], $code, $previous);
+    }
+}

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -2,6 +2,7 @@
 
 namespace app\models\notebook;
 
+use app\exceptions\NotebookException;
 use app\models\notebook\Notebook;
 use app\libraries\Core;
 use app\libraries\Utils;
@@ -45,6 +46,13 @@ class UserSpecificNotebook extends Notebook {
 
         if ($json !== false && isset($json['item_pool'])) {
             $this->item_pool = $json['item_pool'];
+
+            // Verify that all items in the item pool have defined an 'item_name'
+            foreach ($this->item_pool as $item) {
+                if (!isset($item['item_name'])) {
+                    throw new NotebookException('An item pool item was found to be missing the required "item_name" field.  Please rebuild the gradeable.');
+                }
+            }
         }
 
         $this->gradeable_id = $gradeable_id;

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -38,8 +38,8 @@ class UserSpecificNotebook extends Notebook {
         $json = FileUtils::readJsonFile(
             FileUtils::joinPaths(
                 $core->getConfig()->getCoursePath(),
-                "config/complete_config",
-                "complete_config_" . $gradeable_id . ".json"
+                "config/build",
+                "build_" . $gradeable_id . ".json"
             )
         );
 


### PR DESCRIPTION
### What is the current behavior?
When the notebook submission page loads much of the relevant information is collected from the gradeable's complete_config json.

### What is the new behavior?
The PHP code has been rolled over to have this information instead collected from the build config json.

### Notes for PR testers
- Itempool notebooks will need to be rebuilt.  If you access the gradeable without rebuilding you should see an error message with instructions.
- Please test all different kinds of notebook gradeables to make sure they still behave the same way as before this change.
