### PR TITLE
[Bugfix:TAGrading] save components before redirecting to main grading page

### DIFF
--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -8,7 +8,8 @@
         <a href="javascript:gotoPrevStudent();" data-href="{{ prev_student_url }}" id="prev-student"><i title="Previous student" class="fas fa-caret-left icon-header"></i></a>
 
         {# Back to list button #}
-        <a href="{{ home_url }}"><i title="Go to the main page" class="fas fa-home icon-header" ></i></a>
+        <a href="javascript:gotoMainPage();" data-href="{{ home_url }}"
+        id="main-page"><i title="Go to the main page" class="fas fa-home icon-header icon-streched" ></i></a>
 
         {# Next buttons #}
         <a href="javascript:gotoNextStudent();" data-href="{{ next_student_url }}" id="next-student"><i title="Next student" class="fas fa-caret-right icon-header"></i></a>

--- a/site/app/templates/grading/electronic/NavigationBarV2.twig
+++ b/site/app/templates/grading/electronic/NavigationBarV2.twig
@@ -3,7 +3,12 @@
         <div class="grading_toolbar">
             {# Back to list button #}
             <span class="ta-navlink-cont">
-                <a href="{{ home_url }}"><i title="Go to the main page" class="fas fa-home icon-header icon-streched" ></i></a>
+                <a href="javascript:gotoMainPage();"
+                   data-href="{{ home_url }}"
+                   id="main-page"
+                >
+                    <i title="Go to the main page" class="fas fa-home icon-header icon-streched" ></i>
+                </a>
             </span>
 
             {# Nav buttons (Prev + Next)#}

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -330,6 +330,29 @@ function updateCookies(){
 
 //-----------------------------------------------------------------------------
 // Student navigation
+function gotoMainPage() {
+
+  let selector;
+  let window_location;
+
+  selector = "#main-page";
+  window_location = $(selector)[0].dataset.href
+
+  console.log(window_location);
+  if (getGradeableId() !== '') {
+    closeAllComponents(true).then(function () {
+      window.location = window_location;
+    }).catch(function () {
+      if (confirm("Could not save open component, go to main page anyway?")) {
+        window.location = window_location;
+      }
+    });
+  }
+  else {
+    window.location = window_location;
+  }
+}
+
 function gotoPrevStudent(to_ungraded = false) {
 
   let selector;

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -332,11 +332,9 @@ function updateCookies(){
 // Student navigation
 function gotoMainPage() {
 
-  let selector;
   let window_location;
 
-  selector = "#main-page";
-  window_location = $(selector)[0].dataset.href
+  window_location = $("#main-page")[0].dataset.href
 
   console.log(window_location);
   if (getGradeableId() !== '') {

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -332,11 +332,8 @@ function updateCookies(){
 // Student navigation
 function gotoMainPage() {
 
-  let window_location;
+  let window_location = $("#main-page")[0].dataset.href
 
-  window_location = $("#main-page")[0].dataset.href
-
-  console.log(window_location);
   if (getGradeableId() !== '') {
     closeAllComponents(true).then(function () {
       window.location = window_location;

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -361,11 +361,9 @@ function updateCookies(){
 // Student navigation
 function gotoMainPage() {
 
-  let selector;
   let window_location;
 
-  selector = "#main-page";
-  window_location = $(selector)[0].dataset.href
+  window_location = $("#main-page")[0].dataset.href
 
   if (getGradeableId() !== '') {
     closeAllComponents(true).then(function () {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -361,9 +361,7 @@ function updateCookies(){
 // Student navigation
 function gotoMainPage() {
 
-  let window_location;
-
-  window_location = $("#main-page")[0].dataset.href
+  let window_location = $("#main-page")[0].dataset.href
 
   if (getGradeableId() !== '') {
     closeAllComponents(true).then(function () {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -359,6 +359,28 @@ function updateCookies(){
 
 //-----------------------------------------------------------------------------
 // Student navigation
+function gotoMainPage() {
+
+  let selector;
+  let window_location;
+
+  selector = "#main-page";
+  window_location = $(selector)[0].dataset.href
+
+  if (getGradeableId() !== '') {
+    closeAllComponents(true).then(function () {
+      window.location = window_location;
+    }).catch(function () {
+      if (confirm("Could not save open component, go to main page anyway?")) {
+        window.location = window_location;
+      }
+    });
+  }
+  else {
+    window.location = window_location;
+  }
+}
+
 function gotoPrevStudent(to_ungraded = false) {
 
     var selector;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #5190- If a TA is grading a component and clicks on the home button to go to the main page, none of the changes are fixed, unlike the next and previous buttons.

### What is the new behavior?
The home page button now behaves like the next and previous buttons and saves the components before redirecting

### Other information?
<!-- Is this a breaking change? --> 
<!-- How did you test --> 
Create complex gradable components and make sure they save
Used windows with chrome and firefox