### PR TITLE
[Bugfix:Travis] Fix docker-ce version conflict in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -242,7 +242,13 @@ jobs:
         - sudo mv dist/vnu.jar /usr/bin/
       before_script:
         # Remove Travis' built in docker-ce
+        - sudo apt-get update
+        - sudo apt-get upgrade -y
         - sudo apt-get purge docker-ce -y
+        - sudo apt-get autoremove -y
+        - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- install
+        - sudo usermod -aG docker $USER
+        - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- restart
         # Need to make this a full repo so that we can get the tag information
         # when we're installing
         - git fetch --unshallow

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,6 +241,8 @@ jobs:
         - unzip vnu.jar_20.3.16.zip
         - sudo mv dist/vnu.jar /usr/bin/
       before_script:
+        # Remove Travis' built in docker-ce
+        - sudo apt-get purge docker-ce -y
         # Need to make this a full repo so that we can get the tag information
         # when we're installing
         - git fetch --unshallow

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,8 +241,10 @@ jobs:
         - unzip vnu.jar_20.3.16.zip
         - sudo mv dist/vnu.jar /usr/bin/
       before_script:
+        # TODO: Remove this when travis updates.
         # Remove Travis' built in docker-ce
         - sudo apt-get purge docker-ce -y
+        # Dependency on someone's hosted script
         - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- install
         - sudo usermod -aG docker $USER
         - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- restart
@@ -330,6 +332,13 @@ jobs:
             - openjdk-8-jdk
       env: CLANG_VER="5.0.2"
       before_install:
+        # TODO: Remove this when travis updates.
+        # Remove Travis' built in docker-ce
+        - sudo apt-get purge docker-ce -y
+        # Dependency on someone's hosted script
+        - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- install
+        - sudo usermod -aG docker $USER
+        - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- restart
         - sudo update-java-alternatives --jre-headless --set java-1.8.0-openjdk-amd64
         - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/javac 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -242,10 +242,7 @@ jobs:
         - sudo mv dist/vnu.jar /usr/bin/
       before_script:
         # Remove Travis' built in docker-ce
-        - sudo apt-get update
-        - sudo apt-get upgrade -y
         - sudo apt-get purge docker-ce -y
-        - sudo apt-get autoremove -y
         - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- install
         - sudo usermod -aG docker $USER
         - curl -fsSL https://raw.githubusercontent.com/darkwizard242/devopsubuntu1804/v1.0/packer-build/mods/10-docker.sh | sudo bash -s -- restart


### PR DESCRIPTION
# WIP: Do not merge.
Current travis builds are failing with the error
```
docker.errors.APIError: 400 Client Error: Bad Request ("client version 1.39 is too new. Maximum supported API version is 1.38")
```

Related to [this issue](https://github.com/docker/docker-py/issues/2639)
