### PR TITLE
[Bugfix: Notebook] Notebook header collapsing on Safari

### DIFF
--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -105,3 +105,8 @@ textarea.sa-box {
     margin-top: 0;
     margin-bottom: 0;
 }
+
+/* Fixes Safari spacing issue */
+.notebook fieldset legend {
+    -webkit-margin-top-collapse: separate;
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Notebook headers for MCQ/MSQ are collapsing on Safari.
![Screenshot 2020-08-13 at 11 48 42 AM](https://user-images.githubusercontent.com/48342617/90126088-fd9de500-dd5a-11ea-833d-96f7c9f7cce0.png)


### What is the new behavior?
Closes #5811 
Fixes Notebook header or MCQ/MSQ collapsing on Safari
![Screenshot 2020-08-13 at 11 47 08 AM](https://user-images.githubusercontent.com/48342617/90126103-0393c600-dd5b-11ea-8180-43dbc76be874.png)


### Other information?
