### PR TITLE
[Bugfix:InstructorUI] verified admin user not in course

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/__init__.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/__init__.py
@@ -23,3 +23,4 @@ QUEUE_DIR = Path(DATA_DIR, 'daemon_job_queue')
 with open(str(Path(CONFIG_PATH, 'submitty_users.json'))) as open_file:
     JSON_FILE = json.load(open_file)
 DAEMON_USER = JSON_FILE['daemon_user']
+VERIFIED_ADMIN_USER = JSON_FILE['verified_submitty_admin_user']

--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -15,7 +15,7 @@ from . import bulk_qr_split
 from . import bulk_upload_split
 from . import INSTALL_DIR, DATA_DIR
 from . import write_to_log as logger
-
+from . import VERIFIED_ADMIN_USER
 
 class AbstractJob(ABC):
     """
@@ -354,3 +354,5 @@ class CreateCourse(AbstractJob):
         with log_file_path.open("w") as output_file:
             subprocess.run(["sudo", "/usr/local/submitty/sbin/create_course.sh", semester, course, head_instructor, base_group], stdout=output_file, stderr=output_file)
             subprocess.run(["sudo", "/usr/local/submitty/sbin/adduser_course.py", head_instructor, semester, course], stdout=output_file, stderr=output_file)
+            if VERIFIED_ADMIN_USER != "":
+                subprocess.run(["sudo", "/usr/local/submitty/sbin/adduser_course.py", VERIFIED_ADMIN_USER, semester, course], stdout=output_file, stderr=output_file)

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4082,8 +4082,8 @@ AND gc_id IN (
             FROM courses_users WHERE user_id=? AND course=? AND semester=?",
             [$user_id, $course, $semester]
         );
-        return array_key_exists('is_instructor',$this->submitty_db->row())
-            && $this->submitty_db->row()['is_instructor'];
+        return count($this->submitty_db->rows()) >= 1 &&
+            $this->submitty_db->row()['is_instructor'];
     }
 
     public function getRegradeRequestStatus($user_id, $gradeable_id) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4082,7 +4082,8 @@ AND gc_id IN (
             FROM courses_users WHERE user_id=? AND course=? AND semester=?",
             [$user_id, $course, $semester]
         );
-        return $this->submitty_db->row()['is_instructor'];
+        return array_key_exists('is_instructor',$this->submitty_db->row())
+            && $this->submitty_db->row()['is_instructor'];
     }
 
     public function getRegradeRequestStatus($user_id, $gradeable_id) {


### PR DESCRIPTION
### What is the current behavior?
Previously, when an instructor makes a new course, only the instructor user is added.  The verified admin user is missing, which caused an error on the course settings page, when it attempted to check if the admin user had access for automatic rainbow grades processing.  NOTE:  The missing admin user was a separate known inconvenience.

Now the admin user (if it exists) will be added to the new course automatically.  AND we will properly handle the admin user not being in the course when we offer the option for rainbow grades nightly runs.
