### PR TITLE
[Bugfix:InstructorUI] update RainbowGrades version

### DIFF
--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -7,7 +7,7 @@
 # SUBMITTY REPOS
 export AnalysisTools_Version=v.18.06.00
 export Lichen_Version=v20.05.00
-export RainbowGrades_Version=v20.07.00
+export RainbowGrades_Version=v20.08.00
 export Tutorial_Version=v20.07.00
 export SysadminTools_Version=v20.01.00
 


### PR DESCRIPTION
To handle average & stddev of zero length arrays.