### PR TITLE
[Bugfix:UI/UX] gradeable ordering - date then alpha

### DIFF
--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -139,15 +139,15 @@ class GradeableList extends AbstractModel {
         foreach ($sort_array as $list => $function) {
             uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
                 if ($a->$function() == $b->$function()) {
-                    if ($a->getTitle() == $b->getTitle()) {
-                        if ($a->getId() < $b->getId()) {
+                    if (strtolower($a->getTitle()) == strtolower($b->getTitle())) {
+                        if (strtolower($a->getId()) < strtolower($b->getId())) {
                             return -1;
                         }
                         else {
                             return 1;
                         }
                     }
-                    elseif ($a->getTitle() < $b->getTitle()) {
+                    elseif (strtolower($a->getTitle()) < strtolower($b->getTitle())) {
                         return -1;
                     }
                     else {

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -139,7 +139,7 @@ class GradeableList extends AbstractModel {
         foreach ($sort_array as $list => $function) {
             uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
                 if ($a->$function() == $b->$function()) {
-                    if ($a->getId() < $b->getId()) {
+                    if ($a->getTitle() < $b->getTitle()) {
                         return -1;
                     }
                     else {

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -139,7 +139,15 @@ class GradeableList extends AbstractModel {
         foreach ($sort_array as $list => $function) {
             uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
                 if ($a->$function() == $b->$function()) {
-                    if ($a->getTitle() < $b->getTitle()) {
+                    if ($a->getTitle() == $b->getTitle()) {
+                        if ($a->getId() < $b->getId()) {
+                            return -1;
+                        }
+                        else {
+                            return 1;
+                        }
+                    }
+                    elseif ($a->getTitle() < $b->getTitle()) {
                         return -1;
                     }
                     else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The gradeables are ordered by submission due date and the tie breaker is gradeable id

### What is the new behavior?
Now the tie breaker will be the gradeable title so it looks better for the user. If for some reason the titles are the same, it will fall back on the id.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Created gradeables with the same submission date and different titles and ids.