### PR TITLE
[Bugfix:Submission] check for lock for team seeking button and table

### DIFF
--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -104,15 +104,17 @@
         <br />
         <button class="btn btn-primary key_to_click" tabindex="0" onclick="location.href='{{ create_team_url }}'">Create New Team </button>
 
-        {% if seeking_partner %}
-            &nbsp;or&nbsp;<button class="btn btn-danger key_to_click" tabindex="0" onclick="location.href='{{ stop_seek_url }}'">Stop Seeking Team/Partner </button>
-        {% else %}
-            &nbsp;or&nbsp;<button class="btn btn-primary key_to_click" tabindex="0" onclick="location.href='{{ seek_url }}'">Seek Team/Partner </button>
-            <br>
+        {% if lock == false %}
+            {% if seeking_partner %}
+                &nbsp;or&nbsp;<button class="btn btn-danger key_to_click" tabindex="0" onclick="location.href='{{ stop_seek_url }}'">Stop Seeking Team/Partner </button>
+            {% else %}
+                &nbsp;or&nbsp;<button class="btn btn-primary key_to_click" tabindex="0" onclick="location.href='{{ seek_url }}'">Seek Team/Partner </button>
+                <br>
+            {% endif %}
         {% endif %}
 
         {# Set Seeking Message #}
-        {% if seeking_enabled %}
+        {% if seeking_enabled and lock == false %}
             {% if seeking_partner %}
                 <br /> 
                 <br /> 
@@ -143,43 +145,46 @@
 {% endif %}
 {# /Edit/create team box #}
 
-{# Users seeking team box #}
-<div class="content">
-    <div style="width:70%;">
-        <h3>Users Seeking Team/Partner:</h3><br />
-        {# This is a data table #}
-        <table class="table table-striped table-bordered persist-area">
-            <caption />
-            <thead class="persist thead">
-                <tr>
-                    <th style="width:4%">Index</th>
-                    <th style="width:9%">First Name</th>
-                    <th style="width:9%">Last Name</th>
-                    <th style="width:8%">User ID</th>
-                    <th style="width:30%">Email</th>
-                    {% if seeking_enabled %}
-                        <th style="width:40%">Message</th>
-                    {% endif %}
-                    
-                </tr>
-            </thead>
-            <tbody>
-                {% for user_details in seekers %}
+
+{% if lock == false or user.accessFullGrading() %}
+    {# Users seeking team box #}
+    <div class="content">
+        <div style="width:70%;">
+            <h3>Users Seeking Team/Partner:</h3><br />
+            {# This is a data table #}
+            <table class="table table-striped table-bordered persist-area">
+                <caption />
+                <thead class="persist thead">
                     <tr>
-                        <td>{{ loop.index }}</td>
-                        <td>{{ user_details.getDisplayedFirstName() }}</td>
-                        <td>{{ user_details.getDisplayedLastName() }}</td>
-                        <td>{{ user_details.getId() }}</td>
-                        <td>{{ user_details.getEmail() }}</td>
+                        <th style="width:4%">Index</th>
+                        <th style="width:9%">First Name</th>
+                        <th style="width:9%">Last Name</th>
+                        <th style="width:8%">User ID</th>
+                        <th style="width:30%">Email</th>
                         {% if seeking_enabled %}
-                            <td>{{ user_details.getSeekMessage(gradeable.getId()) }}</td>
+                            <th style="width:40%">Message</th>
                         {% endif %}
+                        
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for user_details in seekers %}
+                        <tr>
+                            <td>{{ loop.index }}</td>
+                            <td>{{ user_details.getDisplayedFirstName() }}</td>
+                            <td>{{ user_details.getDisplayedLastName() }}</td>
+                            <td>{{ user_details.getId() }}</td>
+                            <td>{{ user_details.getEmail() }}</td>
+                            {% if seeking_enabled %}
+                                <td>{{ user_details.getSeekMessage(gradeable.getId()) }}</td>
+                            {% endif %}
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     </div>
-</div>
+{% endif %}
 
 <script>
     var textarea = document.querySelector('textarea');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
A student is able to seek for a team even after the team lock date.
![image](https://user-images.githubusercontent.com/51247866/90325478-15878b80-df4a-11ea-9920-dd52a580a599.png)

### What is the new behavior?
A student wont have access to the team seeking button or the team seeking table if the lock is set. Only users will full access grading have access to the seeking table.
![image](https://user-images.githubusercontent.com/51247866/90325491-3fd94900-df4a-11ea-99e8-8113c05e7a3c.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Creating a team gradeable, locking the team creation, and observing the behavior for different users