### PR TITLE
[Bugfix:Submission] display notebook autograding messages

### DIFF
--- a/site/app/templates/grading/electronic/NotebookPanel.twig
+++ b/site/app/templates/grading/electronic/NotebookPanel.twig
@@ -6,7 +6,7 @@
 <div id="notebook-view" class="draggable rubric_panel" style="display:none">
 	{% include 'notebook/Notebook.twig' with {
         "notebook": notebook,
-        "testcase_messages" : testcase_message,
+        "testcase_messages" : testcase_messages,
         "image_data" : image_data,
         "numberUtils" : numberUtils,
         "student_id" : student_id,

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -255,7 +255,7 @@
     {% if is_notebook %}
         {% include 'notebook/Notebook.twig' with {
             "notebook": notebook,
-            "testcase_messages" : testcase_message,
+            "testcase_messages" : testcase_messages,
             "image_data" : image_data,
             "numberUtils" : numberUtils,
             "student_id" : student_id,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
#5681 introduced a bug when displaying a twig template was changed to use the `with include` syntax causing auto-grading messages not being properly sent over to the template

### What is the new behavior?
Auto grading messages after a notebook has been graded are now properly rendered both on student notebook view and the new grading screen panel.


