### PR TITLE
[UI/UX:Submission] Set max-width for rendering notebook cells on submission page

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -5,7 +5,7 @@
     {% set num_multiple_choice = 0 %}
     {% set num_file_submissions = 0 %}
     {% for cell in notebook %}
-        <div id="content_{{ loop.index0 }}">
+        <div id="content_{{ loop.index0 }}" class="{{ cell.type }}">
 
             {# Handle if cell is markdown #}
             {% if cell.type == "markdown" %}

--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -113,3 +113,10 @@ img {
 .notebook fieldset legend {
     -webkit-margin-top-collapse: separate;
 }
+
+/* Not set for images as we want to allow them to be wider than 700px */
+.notebook .multiple_choice,
+.notebook .short_answer,
+.notebook .markdown {
+    max-width: 700px;
+}


### PR DESCRIPTION
### What is the current behavior?
When rendering notebook cells on the submission page text takes up the full width of page.

### What is the new behavior?
Short-answer, multiple-choice, and markdown cells are now limited to a maximum width of 700px.  Text wider than that will wrap onto a new line.  Images are excluded, so they may appear at a width greater than 700px.
