### PR TITLE
[UI/UX:Submission] Allow codeboxes to be manually resized

### DIFF
--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -107,6 +107,7 @@ img {
     border: 1px solid var(--standard-light-gray) !important;
     border-radius: 4px !important;
     vertical-align: middle !important;
+    resize: both;
 }
 
 /* Fixes Safari spacing issue */


### PR DESCRIPTION
### What is the current behavior?
Codeboxes on the notebook gradeable submission page may not be manually resized by the user.

### What is the new behavior?
Codeboxes may now be manually resized by the user by grabbing the bottom right corner and dragging, just like a `<textarea>`.

