### PR TITLE
[Bugfix:System] detect websocket server is down

### DIFF
--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -510,6 +510,10 @@ class OfficeHoursQueueController extends AbstractController {
         );
     }
 
+    /**
+     * this function opens a WebSocket client and sends a message with the corresponding update
+     * @param array $msg_array
+     */
     private function sendSocketMessage($msg_array) {
         $msg_array['user_id'] = $this->core->getUser()->getId();
         $msg_array['page'] = $this->core->getConfig()->getCourse() . "-office_hours_queue";
@@ -518,7 +522,7 @@ class OfficeHoursQueueController extends AbstractController {
             $client->send($msg_array);
         }
         catch (WebSocket\ConnectionException $e) {
-            $this->core->addNoticeMessage("WebSocket Server is down, Page won't load dynamically.");
+            $this->core->addNoticeMessage("WebSocket Server is down, page won't load dynamically.");
         }
     }
 }

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -512,7 +512,12 @@ class OfficeHoursQueueController extends AbstractController {
     private function sendSocketMessage($msg_array) {
         $msg_array['user_id'] = $this->core->getUser()->getId();
         $msg_array['page'] = $this->core->getConfig()->getCourse() . "-office_hours_queue";
-        $client = new Client($this->core);
-        $client->send($msg_array);
+        try {
+            $client = new Client($this->core);
+            $client->send($msg_array);
+        }
+        catch (\Websocket\ConnectionException $e) {
+            $this->core->addNoticeMessage("WebSocket Server is down, Page won't load dynamically.");
+        }
     }
 }

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -11,6 +11,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use app\models\OfficeHoursQueueModel;
 use app\libraries\routers\AccessControl;
 use app\libraries\socket\Client;
+use WebSocket;
 
 /**
  * Class OfficeHoursQueueController
@@ -516,7 +517,7 @@ class OfficeHoursQueueController extends AbstractController {
             $client = new Client($this->core);
             $client->send($msg_array);
         }
-        catch (\Websocket\ConnectionException $e) {
+        catch (WebSocket\ConnectionException $e) {
             $this->core->addNoticeMessage("WebSocket Server is down, Page won't load dynamically.");
         }
     }

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -514,7 +514,7 @@ class OfficeHoursQueueController extends AbstractController {
      * this function opens a WebSocket client and sends a message with the corresponding update
      * @param array $msg_array
      */
-    private function sendSocketMessage($msg_array) {
+    private function sendSocketMessage(array $msg_array): void {
         $msg_array['user_id'] = $this->core->getUser()->getId();
         $msg_array['page'] = $this->core->getConfig()->getCourse() . "-office_hours_queue";
         try {

--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -213,7 +213,7 @@ class Server implements MessageComponentInterface {
 
         $msg = json_decode($msgString, true);
 
-        if ($msg["type"] === "new_connection") {
+        if ($msg["type"] === "new_connection" && isset($msg['page'])) {
             if (!array_key_exists($msg['page'], $this->clients)) {
                 $this->clients[$msg['page']] = new \SplObjectStorage();
             }

--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -213,16 +213,21 @@ class Server implements MessageComponentInterface {
 
         $msg = json_decode($msgString, true);
 
-        if ($msg["type"] === "new_connection" && isset($msg['page'])) {
-            if (!array_key_exists($msg['page'], $this->clients)) {
-                $this->clients[$msg['page']] = new \SplObjectStorage();
-            }
-            $this->clients[$msg['page']]->attach($from);
-            $this->setSocketClientPage($msg['page'], $from);
+        if ($msg["type"] === "new_connection") {
+            if (isset($msg['page'])) {
+                if (!array_key_exists($msg['page'], $this->clients)) {
+                    $this->clients[$msg['page']] = new \SplObjectStorage();
+                }
+                $this->clients[$msg['page']]->attach($from);
+                $this->setSocketClientPage($msg['page'], $from);
 
-            if ($this->core->getConfig()->isDebug()) {
-                $course_page = explode('-', $this->getSocketClientPage($from));
-                echo "New connection --> user_id: '" . $this->getSocketUserID($from) . "' - course: '" . $course_page[0] . "' - page: '" . $course_page[1] . "'\n";
+                if ($this->core->getConfig()->isDebug()) {
+                    $course_page = explode('-', $this->getSocketClientPage($from));
+                    echo "New connection --> user_id: '" . $this->getSocketUserID($from) . "' - course: '" . $course_page[0] . "' - page: '" . $course_page[1] . "'\n";
+                }
+            }
+            else {
+                $from->close();
             }
         }
         elseif (isset($msg['user_id'])) {

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -40,7 +40,7 @@ class WebSocketClient {
             if (this.onopen) {
                 this.onopen();
             }
-            const course = window.courseUrl.split('/').pop();
+            const course = document.body.dataset.courseUrl.split('/').pop();
             this.client.send(JSON.stringify({'type': 'new_connection', 'page': `${course}-${page}`}));
         };
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)


### What is the current behavior?
If the socket server is down for any reason, some pages as office hours queue produce an unwanted behavior that users should handle manually.

![image](https://user-images.githubusercontent.com/30902406/90441884-01729400-e0da-11ea-9226-0c20eaac9cf1.png)


### What is the new behavior?
Users' actions are completed successfully as they should but they get a notice message that the server socket is down and the page won't dynamically load.

![socketserverdown](https://user-images.githubusercontent.com/30902406/90441998-2ff06f00-e0da-11ea-8b02-3d3f379c84a6.gif)

### Other Infromation
In order to test this you have to stop the websocket server so it doesn't accept connections running `systemctl stop submitty_websocket_server` on your vagrant machine.