### PR TITLE
[Testing:JS] Add curly rule to eslint rule set

### DIFF
--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -19,6 +19,7 @@
         "block-spacing": ["error"],
         "brace-style": ["error", "stroustrup"],
         "comma-dangle": ["error", "always-multiline"],
+        "curly" : ["error"],
         "default-param-last": ["error"],
         "eol-last": ["error"],
         "indent": ["error", 4, {"SwitchCase": 1}],
@@ -32,7 +33,6 @@
         "quotes": ["error", "single"],
         "semi": ["error", "always"],
         "semi-style": ["error", "last"],
-        "template-curly-spacing": ["error", "never"],
-        "curly" : ["error"]
+        "template-curly-spacing": ["error", "never"]
     }
 }

--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -32,6 +32,7 @@
         "quotes": ["error", "single"],
         "semi": ["error", "always"],
         "semi-style": ["error", "last"],
-        "template-curly-spacing": ["error", "never"]
+        "template-curly-spacing": ["error", "never"],
+        "curly" : ["error"]
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
     https://github.com/Submitty/submitty.github.io/pull/284

### What is the new behavior?
Eslinting now checks to make sure block statements (if, while, for) use curly braces even if the block is only one line 
e.g:
```
if ( foo )
   bar():
```

is no longer allowed.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
