### PR TITLE
[Bugfix:Testing] Fix Eslint lint:fix script not actually running fix

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -32,6 +32,6 @@
   },
   "scripts": {
     "lint": "eslint \"public/js/**/*.js\"",
-    "lint:fix": "eslint \"public/js/**/*.js\""
+    "lint:fix": "eslint \"public/js/**/*.js\" --fix"
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The command to run eslint auto fix was not passing the `--fix` paramater when calling `eslint` so it wasn't doing anything

### What is the new behavior?
`npm run lint:fix` correctly begins the eslint run script

