### PR TITLE
[Bugfix: TAGrading] Peer grading stats divide by 0

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -191,7 +191,8 @@ class ElectronicGraderView extends AbstractView {
             }
             foreach ($sections as $key => &$section) {
                 $non_peer_components_count = count($gradeable->getNonPeerComponents());
-                $section['graded'] = round($section['graded_components'] / ($non_peer_components_count != 0 ? $non_peer_components_count : 1), 1);
+                $non_zero_non_peer_components_count = $non_peer_components_count != 0 ? $non_peer_components_count : 1;
+                $section['graded'] = round($section['graded_components'] / $non_zero_non_peer_components_count, 1);
                 $section['total'] = $section['total_components'];
                 if ($section['total_components'] == 0) {
                     $section['percentage'] = 0;

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -190,7 +190,8 @@ class ElectronicGraderView extends AbstractView {
                 }
             }
             foreach ($sections as $key => &$section) {
-                $section['graded'] = round($section['graded_components'] / count($gradeable->getNonPeerComponents()), 1);
+                $non_peer_components_count = count($gradeable->getNonPeerComponents());
+                $section['graded'] = round($section['graded_components'] / ($non_peer_components_count != 0 ? $non_peer_components_count : 1), 1);
                 $section['total'] = $section['total_components'];
                 if ($section['total_components'] == 0) {
                     $section['percentage'] = 0;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If an instructor/full access grader goes to grade a gradeable which has only peer components, you get the following error: 
![image](https://user-images.githubusercontent.com/11095297/90836032-4980f900-e31c-11ea-85af-21fb5b8db6cc.png)

### What is the new behavior?
You do not get the above error
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
