### PR TITLE
[Feature:InstructorUI] Communicate schema warnings to webUI

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1231,7 +1231,7 @@ class AdminGradeableController extends AbstractController {
     /**
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/build_log", methods={"GET"})
      */
-    public function ajaxGetBuildLogs($gradeable_id) {
+    public function getBuildLogs(string $gradeable_id): JsonResponse {
         $build_script_output_file = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'build_script_output.txt');
         $build_script_output = is_file($build_script_output_file) ? htmlentities(file_get_contents($build_script_output_file)) : null;
         $cmake_out_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'build', $gradeable_id, 'log_cmake_output.txt');
@@ -1239,13 +1239,13 @@ class AdminGradeableController extends AbstractController {
         $make_out_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'build', $gradeable_id, 'log_make_output.txt');
         $make_output = is_file($make_out_dir) ? htmlentities(file_get_contents($make_out_dir)) : null;
 
-        $this->core->getOutput()->renderJsonSuccess([$build_script_output,$cmake_output,$make_output]);
+        return JsonResponse::getSuccessResponse([$build_script_output,$cmake_output,$make_output]);
     }
 
     /**
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/build_status", methods={"GET"})
      */
-    public function getBuildStatusOfGradeable($gradeable_id) {
+    public function getBuildStatusOfGradeable(string $gradeable_id): void {
         $queued_filename = $this->core->getConfig()->getSemester() . '__' . $this->core->getConfig()->getCourse() . '__' . $gradeable_id . '.json';
         $rebuilding_filename = 'PROCESSING_' . $this->core->getConfig()->getSemester() . '__' . $this->core->getConfig()->getCourse() . '__' . $gradeable_id . '.json';
         $queued_path = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), 'daemon_job_queue', $queued_filename);
@@ -1260,6 +1260,18 @@ class AdminGradeableController extends AbstractController {
         else {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
             $status = $gradeable->hasAutogradingConfig();
+
+            // Check for schema validation errors and return a different status if needed.
+            if ($status) {
+                $logs = $this->getBuildLogs($gradeable_id);
+
+                $needle = 'The submitty configuration validator detected the above error in your config.';
+                $haystack = $logs->json['data'][0];
+
+                if (strpos($haystack, $needle) !== false) {
+                    $status = 'warnings';
+                }
+            }
         }
         clearstatcache();
         $this->core->getOutput()->renderJsonSuccess($status);

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -281,6 +281,9 @@ function ajaxCheckBuildStatus() {
                 $('.config_search_error').hide();
                 setTimeout(ajaxCheckBuildStatus,1000);
             }
+            else if (response['data'] == 'warnings') {
+                $('#rebuild-status').html('Gradeable built with warnings');
+            }
             else if (response['data'] == true) {
                 $('#rebuild-status').html('Gradeable build complete');
             }


### PR DESCRIPTION
Closes #5733 

### What is the current behavior?
On the 'Submissions/Autograding' tab of the edit gradeables page a small box indicates the build status of the gradeable.  If a gradeable is successfully build it will show `Build Status: Gradeable build complete` even if the schema validator gave warnings.

### What is the new behavior?
If the schema validator generated warnings during the gradeable build process the message will now show `Build Status: Gradeable built with warnings`.
