### PR TITLE
[BugFix: InstructorUI] Re-add office hours queue auto refreshing while sockets are disabled

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -228,5 +228,7 @@
       });
   }
 
+  setTimeout("location.reload(true)", 30000);
+
 </script>
 </div>


### PR DESCRIPTION
### What is the current behavior?
Websockets no longer work so there is no auto refresh option

### What is the new behavior?
The queue for both mentors and students will refresh every 30 seconds
