### PR TITLE
Fix Twig Error On Team Grading Index

### DIFF
--- a/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
+++ b/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
@@ -2,6 +2,12 @@
 {% block popup_id %}randomize-button-warning{% endblock %}
 {% block title %}WARNING: Grading may be in progress!{% endblock %}
 {% block body %}
+    <style>
+        .randomize_cancel_btn{
+            float: left;
+        }
+    </style>
+    
     <p> Updating the sections for this gradeable will change the submissions assigned to each grader.<br />
         If grading has begun, this may interupt or redistribute grade submissions.<br /><br /><br />
         Are you sure you want to continue? <br /><br />
@@ -15,9 +21,3 @@
     {{ block('close_button') }}
     <a style="float: right;" class="btn btn-primary" href="{{ randomize_team_rotating_sections_url }}"> Randomly Re-Assign Teams to Rotating Sections </a>
 {% endblock %}
-
-<style>
-  .randomize_cancel_btn{
-    float: left;
-  }
-</style>

--- a/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
+++ b/site/app/templates/grading/electronic/RandomizeButtonWarning.twig
@@ -2,12 +2,6 @@
 {% block popup_id %}randomize-button-warning{% endblock %}
 {% block title %}WARNING: Grading may be in progress!{% endblock %}
 {% block body %}
-    <style>
-        .randomize_cancel_btn{
-            float: left;
-        }
-    </style>
-    
     <p> Updating the sections for this gradeable will change the submissions assigned to each grader.<br />
         If grading has begun, this may interupt or redistribute grade submissions.<br /><br /><br />
         Are you sure you want to continue? <br /><br />

--- a/site/public/css/details.css
+++ b/site/public/css/details.css
@@ -277,3 +277,7 @@
         display: contents !important;
     }
 }
+
+.randomize_cancel_btn{
+    float: left;
+}


### PR DESCRIPTION
### What is the current behavior?

Crash is due to a refactor in #5778 which moved to having a generic popup template and having specific popup templates extend the generic - code cannot be outside the scope of a block if the template is extending another template.

Closes #5876 

### What is the new behavior?

Visually behavior is correct. I'm not sure if this is the best approach, I added the style to an existing block instead of defining a new block in the `generic/Popup.twig` . It does mean jamming a `<style>` tag in a div, which may technically not be valid HTML (though I imagine all browsers will support it - my limiting testing seemed to work).