### PR TITLE
[Bugfix:Submission] Clean invite rcsid on team invite

### DIFF
--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -524,7 +524,7 @@ class TeamController extends AbstractController {
      * @param string $invite_id
      * @return string
      */
-    private static function cleanInviteId(string $invite_id) {
+    private static function cleanInviteId(string $invite_id): string {
         return trim(strtolower($invite_id));
     }
 }

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -168,13 +168,13 @@ class TeamController extends AbstractController {
         $invite_id = self::cleanInviteId($_POST['invite_id']);
         $invited_user = $this->core->getQueries()->getUserById($invite_id);
 
-        if (empty($invited_user)) {
+        if ($invited_user === null) {
             // If a student with this id does not exist in the course...
             $this->core->addErrorMessage("User {$invite_id} does not exist");
             $this->core->redirect($return_url);
         }
 
-        if (empty($invited_user->getRegistrationSection())) {
+        if ($invited_user->getRegistrationSection() === null) {
             // If a student with this id is in the null section...
             // (make this look the same as a non-existant student so as not to
             // reveal information about dropped students)
@@ -520,7 +520,7 @@ class TeamController extends AbstractController {
     }
 
     /**
-     * Get cleaned invite RCSID
+     * Get clean user_id invite
      * @param string $invite_id
      * @return string
      */

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -165,14 +165,16 @@ class TeamController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
-        $invite_id = $_POST['invite_id'];
-        if ($this->core->getQueries()->getUserByID($invite_id) === null) {
+        $invite_id = self::cleanInviteId($_POST['invite_id']);
+        $user = $this->core->getQueries()->getUserById($invite_id);
+
+        if (empty($user)) {
             // If a student with this id does not exist in the course...
             $this->core->addErrorMessage("User {$invite_id} does not exist");
             $this->core->redirect($return_url);
         }
 
-        if ($this->core->getQueries()->getUserByID($invite_id)->getRegistrationSection() === null) {
+        if (empty($user->getRegistrationSection())) {
             // If a student with this id is in the null section...
             // (make this look the same as a non-existant student so as not to
             // reveal information about dropped students)
@@ -515,5 +517,14 @@ class TeamController extends AbstractController {
         $lock = $date->format('Y-m-d H:i:s') > $gradeable->getTeamLockDate()->format('Y-m-d H:i:s');
         $this->core->getOutput()->addBreadcrumb("Manage Team For: {$gradeable->getTitle()}");
         $this->core->getOutput()->renderOutput(['submission', 'Team'], 'showTeamPage', $gradeable, $team, $members, $seekers, $invites_received, $seeking_partner, $lock);
+    }
+
+    /**
+     * Get cleaned invite RCSID
+     * @param string $invite_id
+     * @return string
+     */
+    private static function cleanInviteId(string $invite_id) {
+        return trim(strtolower($invite_id));
     }
 }

--- a/site/app/controllers/student/TeamController.php
+++ b/site/app/controllers/student/TeamController.php
@@ -166,15 +166,15 @@ class TeamController extends AbstractController {
         }
 
         $invite_id = self::cleanInviteId($_POST['invite_id']);
-        $user = $this->core->getQueries()->getUserById($invite_id);
+        $invited_user = $this->core->getQueries()->getUserById($invite_id);
 
-        if (empty($user)) {
+        if (empty($invited_user)) {
             // If a student with this id does not exist in the course...
             $this->core->addErrorMessage("User {$invite_id} does not exist");
             $this->core->redirect($return_url);
         }
 
-        if (empty($user->getRegistrationSection())) {
+        if (empty($invited_user->getRegistrationSection())) {
             // If a student with this id is in the null section...
             // (make this look the same as a non-existant student so as not to
             // reveal information about dropped students)

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -7,6 +7,7 @@ use app\controllers\student\TeamController;
 use app\models\gradeable\Gradeable;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
+use ReflectionObject;
 
 class TeamControllerTester extends BaseUnitTest {
 
@@ -84,5 +85,23 @@ class TeamControllerTester extends BaseUnitTest {
         }
 
         return $gradeable;
+    }
+
+    /** @dataProvider provideTestCleanInviteId */
+    public function testCleanInviteId(string $raw, string $expectation) {
+        $controller = new ReflectionObject(new TeamController($this->core));
+        $clean_invite_method = $controller->getMethod('cleanInviteId');
+        $clean_invite_method->setAccessible(true);
+
+        $clean_invite_id = $clean_invite_method->invoke(null, $raw);
+        $this->assertEquals($clean_invite_id, $expectation);
+    }
+
+    public function provideTestCleanInviteId(): array {
+        return [
+            'assert removes whitespace' => ['      rcsid    ', 'rcsid'],
+            'assert converts all chars to lowercase' => ['      RcSiD    ', 'rcsid'],
+            'assert keeps numbers' => ['rcsid1', 'rcsid1'],
+        ];
     }
 }

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -90,10 +90,10 @@ class TeamControllerTester extends BaseUnitTest {
     /** @dataProvider provideTestCleanInviteId */
     public function testCleanInviteId(string $raw, string $expectation) {
         $controller = new ReflectionObject(new TeamController($this->core));
-        $clean_invite_method = $controller->getMethod('cleanInviteId');
-        $clean_invite_method->setAccessible(true);
+        $clean_invite_id_method = $controller->getMethod('cleanInviteId');
+        $clean_invite_id_method->setAccessible(true);
 
-        $clean_invite_id = $clean_invite_method->invoke(null, $raw);
+        $clean_invite_id = $clean_invite_id_method->invoke(null, $raw);
         $this->assertEquals($clean_invite_id, $expectation);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
On team invite, the RCSID must be all lower case and must not have spaces around the input.

Results in errors like this:
![Screen Shot 2020-09-08 at 8 25 02 PM](https://user-images.githubusercontent.com/11034221/92540060-759fe380-f211-11ea-809a-fc24724027ee.jpg)

### What is the new behavior?
Cleans the input so now the issue in the screenshot shouldn't occur.
Would lookup `shomsj` that exists; instead of `Shomsj` that doesn't.

### Other information?
_Is this a breaking change?_
Nope

_How did you test_
`./site/tests/app/controllers/student/TeamControllerTester.php`