### PR TITLE
[SYSADMIN ACTION][Feature:System] nginx to process websocket requests

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -734,6 +734,9 @@ if [ "${WORKER}" == 0 ]; then
         echo -n "restarting apache2..."
         systemctl restart apache2
         echo "done"
+        echo -n "restarting nginx..."
+        systemctl restart nginx
+        echo "done"
     fi
 fi
 
@@ -743,7 +746,7 @@ systemctl daemon-reload
 
 # restart the socket & jobs handler daemons
 for i in "${RESTART_DAEMONS[@]}"; do
-    systemctl start ${i}
+    systemctl restart ${i}
     set +e
     systemctl is-active --quiet ${i}
     is_active_after=$?

--- a/.setup/apache/submitty.conf
+++ b/.setup/apache/submitty.conf
@@ -110,13 +110,6 @@
     <Proxy "fcgi://localhost/" enablereuse=on max=20>
     </Proxy>
 
-    # Define proxy for websocket interface. The server itself should only be
-    # listening on 127.0.0.1 (localhost) to prevent arbitrary outside world
-    # connections. Doing it this way also allows the WebSocket to piggy-back
-    # off of apache's SSL configuration (if set-up) without having to do
-    # any thing extra in the server configuration.
-    ProxyPass "/ws"  "ws://127.0.0.1:41983/"
-
     # These directives block any requests going to things that start
     # with a "." or "#" or end with a "~", as these are generally either
     # private files or tmp files that regular web users do not need to

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -485,6 +485,18 @@ EOF
     cp ${SUBMITTY_REPOSITORY}/.setup/apache/www-data /etc/apache2/suexec/www-data
     chmod 0640 /etc/apache2/suexec/www-data
 
+
+    #################################################################
+    # NGINX SETUP
+    #################
+    sudo apt-get install -qqy nginx
+    # remove default site which would cause server to mess up
+    rm /etc/nginx/sites*/default
+    cp ${SUBMITTY_REPOSITORY}/.setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf
+    chmod 644 /etc/nginx/sites-available/submitty.conf
+    ln -s /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf
+
+
     #################################################################
     # PHP SETUP
     #################
@@ -810,6 +822,7 @@ su -c 'docker tag submitty/autograding-default:latest ubuntu:custom' ${DAEMON_US
 ###################
 if [ ${WORKER} == 0 ]; then
     service apache2 restart
+    service nginx restart
     service php${PHP_VERSION}-fpm restart
     service postgresql restart
 fi

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -429,6 +429,9 @@ if [ ${WORKER} == 0 ]; then
 
     a2enmod include actions cgi suexec authnz_external headers ssl proxy_fcgi rewrite proxy_http proxy_wstunnel
 
+    # Install nginx to serve websocket connections
+    sudo apt-get install -qqy nginx
+
     # A real user will have to do these steps themselves for a non-vagrant setup as to do it in here would require
     # asking the user questions as well as searching the filesystem for certificates, etc.
     if [ ${VAGRANT} == 1 ]; then
@@ -489,7 +492,6 @@ EOF
     #################################################################
     # NGINX SETUP
     #################
-    sudo apt-get install -qqy nginx
     # remove default site which would cause server to mess up
     rm /etc/nginx/sites*/default
     cp ${SUBMITTY_REPOSITORY}/.setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf

--- a/.setup/nginx/submitty.conf
+++ b/.setup/nginx/submitty.conf
@@ -1,0 +1,18 @@
+server {
+        listen 8443 default_server;
+        listen [::]:8443 default_server;
+        server_name _;
+
+        location / {
+        return 404;
+        }
+
+        location /ws {
+               proxy_pass http://127.0.0.1:41983/; #Yes, http is proper here for nginx web socket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+        }
+
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,7 @@ jobs:
             - libapache2-mod-authnz-external
             - libapache2-mod-authz-unixgroup
             - libapache2-mod-wsgi-py3
+            - nginx
             - build-essential
             - automake
             - cmake
@@ -277,6 +278,12 @@ jobs:
         - cat /etc/apache2/sites-available/submitty.conf
         - sudo apache2ctl -t
         - sudo service apache2 restart
+        - sudo rm -rf /etc/nginx/sites-available/*
+        - sudo rm -rf /etc/nginx/sites-enabled/*
+        - sudo cp -f .setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf
+        - sudo chmod 644 /etc/nginx/sites-available/submitty.conf
+        - sudo ln -s /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf
+        - sudo service nginx restart
       script:
         - echo "Authentication Method => $(sudo jq -r ".authentication_method" /usr/local/submitty/config/database.json)"
         - TEST_URL="http://localhost" python3 -m unittest discover -v --start-directory tests

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure(2) do |config|
     # safely transitioned to the new forwarded port
     ubuntu.vm.network 'private_network', ip: '192.168.56.111'
     ubuntu.vm.network 'forwarded_port', guest: 1501, host: 1501   # site
+    ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432  # database
 
   end

--- a/migration/migrator/migrations/system/20200911180000_ngnix_setup.py
+++ b/migration/migrator/migrations/system/20200911180000_ngnix_setup.py
@@ -1,0 +1,14 @@
+"""Migration for the Submitty system."""
+import os
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    os.system("apt-get install -qqy nginx")
+
+def down(config):
+    pass

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -29,9 +29,11 @@ class WebSocketClient {
         this.autoReconnectInterval = 5 * 1000;
         this.onopen = null;
         this.onmessage = null;
-        let ws_url = document.body.dataset.baseUrl.replace('http', 'ws');
-        ws_url = ws_url.substring(0, ws_url.lastIndexOf(':'));
-        this.url = `${ws_url}:8443/ws/`;
+        // We do string replacement here so that http -> ws, https -> wss.
+        let my_url = new URL(document.body.dataset.baseUrl.replace('http', 'ws'));
+        my_url.port = 8334;
+        my_url.pathname = "ws";
+        this.url = my_url.href;
     }
 
     open(page) {

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -31,7 +31,7 @@ class WebSocketClient {
         this.onmessage = null;
         // We do string replacement here so that http -> ws, https -> wss.
         let my_url = new URL(document.body.dataset.baseUrl.replace('http', 'ws'));
-        my_url.port = 8334;
+        my_url.port = 8443;
         my_url.pathname = "ws";
         this.url = my_url.href;
     }

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -29,7 +29,9 @@ class WebSocketClient {
         this.autoReconnectInterval = 5 * 1000;
         this.onopen = null;
         this.onmessage = null;
-        this.url = `${document.body.dataset.baseUrl.replace('http', 'ws')}ws/`;
+        let ws_url = document.body.dataset.baseUrl.replace('http', 'ws');
+        ws_url = ws_url.substring(0, ws_url.lastIndexOf(':'));
+        this.url = `${ws_url}:8443/ws/`;
     }
 
     open(page) {

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -30,9 +30,9 @@ class WebSocketClient {
         this.onopen = null;
         this.onmessage = null;
         // We do string replacement here so that http -> ws, https -> wss.
-        let my_url = new URL(document.body.dataset.baseUrl.replace('http', 'ws'));
+        const my_url = new URL(document.body.dataset.baseUrl.replace('http', 'ws'));
         my_url.port = 8443;
-        my_url.pathname = "ws";
+        my_url.pathname = 'ws';
         this.url = my_url.href;
     }
 

--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -6,6 +6,7 @@ import unittest
 import json
 
 from urllib.parse import urlencode
+from urllib.parse import urlparse
 
 from selenium import webdriver
 from websocket import create_connection
@@ -224,7 +225,15 @@ class BaseTestCase(unittest.TestCase):
 
     def enable_websockets(self):
         submitty_session_cookie = self.driver.get_cookie('submitty_session')
-        self.ws = create_connection(self.test_url.replace('http', 'ws') + '/ws', cookie = submitty_session_cookie['name'] +'='+ submitty_session_cookie['value'], header={"User-Agent": "python-socket-client"})
+        address = self.test_url.replace('http', 'ws') + '/ws'
+        parsed = urlparse(address)
+        netloc = parsed.netloc
+        if ':' in netloc:
+            netloc = netloc.split(':', 1)[0]
+        netloc += ':8443'
+        address = parsed._replace(netloc=netloc).geturl()
+
+        self.ws = create_connection(address, cookie = submitty_session_cookie['name'] +'='+ submitty_session_cookie['value'], header={"User-Agent": "python-socket-client"})
         new_connection_msg = json.dumps({'type': 'new_connection', 'page': self.semester + '-sample-' + self.socket_page})
         self.ws.send(new_connection_msg)
 


### PR DESCRIPTION
Updates submitty to use `nginx` to handle websocket requests. Requires sysadmin action on production servers, or a fresh `vagrant up` for development machines. 

For use on a production system, a sysadmin must:
1. Install this code,  which includes a migration will install `nginx`.
2. Remove the default `nginx` site, `/etc/nginx/sites-available/default`, if desired.
3. Copy the default nginx `submitty.conf` file from `{SUBMITTY_REPO}/.setup/submitty.conf` to `/etc/nginx/sites-available`.
4. If desired, update `submitty.conf` to use ssl (example configuration below)
5. Create a symlink for `submitty.conf` from `sites-available` to `sites-enabled` 
`ln -s /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf`
6. If migrating from a previous version of submitty, remove any existing websocket proxying, e.g., `ProxyPass "/ws"  "ws://127.0.0.1:41983/"`
7. Websockets are served over port `8443`. It may be necessary to create a firewall exception.
8. Restart `nginx` and `submitty_websocket_server` using `systemctl restart`

to combine the existing cert chain in to a pem that nginx can use
```
cp submitty.cer submitty.pem
cat chain.cer >> submitty.pem 
```

Example `submitty.conf` which uses ssl
```
server {
        # SSL configuration
        listen 8443 ssl default_server;
        listen [::]:8443 ssl default_server;

	#dont show OS or version identity
	server_tokens off; 

        ssl on;
        ssl_certificate /etc/apache2/ssl/submitty-demo.pem;
   	ssl_certificate_key /etc/apache2/ssl/submitty-demo.key;
   	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   	ssl_prefer_server_ciphers on;
   	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:AES128-SHA:RC4-SHA;
        ssl_session_cache shared:SSL:10m;

        server_name _;

        location / {
		return 404;
        }

        location /ws {
               proxy_pass http://127.0.0.1:41983/; #Yes, http is proper here for nginx web socket
    		proxy_http_version 1.1;
    		proxy_set_header Upgrade $http_upgrade;
    		proxy_set_header Connection "Upgrade";
    		proxy_set_header Host $host;
        }

}
```


Complete version installation notes will also be posted here:
https://submitty.org/sysadmin/version_notes/v20.09.00