### PR TITLE
[Bugfix:Autograding] add csci1200 container & update drmemory bin64 path

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -470,7 +470,8 @@ if not args.worker:
                           "submitty/autograding-default:latest",
                           "submitty/java:8",
                           "submitty/java:11",
-                          "submitty/python:3.6"
+                          "submitty/python:3.6",
+                          "submittyrpi/csci1200:default"
                        ]
         }
 

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -90,7 +90,7 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     // for Data Structures
     { "g++",                     "/usr/bin/g++" },
     { "clang++",                 "/usr/bin/clang++" },
-    { "drmemory",                SUBMITTY_INSTALL_DIRECTORY+"/drmemory/bin/drmemory" },
+    { "drmemory",                SUBMITTY_INSTALL_DIRECTORY+"/drmemory/bin64/drmemory" },
     { "valgrind",                "/usr/bin/valgrind" },
 
     // for Computer Organization


### PR DESCRIPTION
With https://github.com/Submitty/Tutorial/pull/32
we need to add the csci1200 container to the vagrant install....

And, the drmemory path has been wrong for a while (now we should use the bin64 version by default)

--------

this PR is work in progress

While for tutorial 02_simple_cpp the container works great..

for 05_cpp_static_analysis we are apparently missing the static analysis module from the docker container. 

and for 08_memory_debugging something is wrong with the drmemory install.  valgrind works fine, but drmemory complains about a bad system call.  I tried adding everything/all system calls to the allowed list but it still had the bad system call error.  I've seen that before and wasn't able to track down the problem.  So I'm worried that's an incorrect error message?  The new 08_memory_debugging works fine if you comment out the container.  No extra system call whitelist necessary.

maybe it's a path location problem for drmemory in the csci1200 container?

-------

Before merging this PR, we should merge 
https://github.com/Submitty/Tutorial/pull/32
and update the required minimum tutorial version number.