### PR TITLE
[Bugfix:Notifications] Increase websocket reconnect interval

### DIFF
--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -26,7 +26,8 @@
 class WebSocketClient {
     constructor() {
         this.number = 0;
-        this.autoReconnectInterval = 5 * 1000;
+        // 10 seconds + a random number of seconds between 0 and 10
+        this.autoReconnectInterval = (10 + (Math.random() * 11)) * 1000;
         this.onopen = null;
         this.onmessage = null;
         // We do string replacement here so that http -> ws, https -> wss.


### PR DESCRIPTION
Increased the websocket reconnect interval from exactly 5 seconds to 10-20 seconds. This should help to decrease load when the webserver is unresponsive.