### PR TITLE
[Bugfix:Submission] Make codemirror wrap for plain text inputs

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -71,6 +71,10 @@
                         config_{{ num_codeboxes }}.mode = '{{ cell.codemirror_mode }}';
                     }
 
+                    if('{{ cell.programming_language }}' === '' && {{ cell.rows }} > 0) {
+                        config_{{ num_codeboxes }}.lineWrapping = true;
+                    }
+
                     if ({{ cell.rows }} > 0) {
                         var editor_{{ num_codeboxes }} = getLargeCodeMirror(document.getElementById("codebox_{{ num_codeboxes }}"), config_{{ num_codeboxes }});
                         editor_{{ num_codeboxes }}.setSize(null, rowsToPixels({{ cell.rows }}));

--- a/site/public/css/notebook-builder.css
+++ b/site/public/css/notebook-builder.css
@@ -90,6 +90,10 @@
     margin-right: 15px;
 }
 
+.short-answer-widget .initial-value-div {
+    max-width: 1000px;
+}
+
 .short-answer-widget .initial-value-msg {
     margin-bottom: 10px;
 }
@@ -97,11 +101,6 @@
 .short-answer-widget hr {
     width: 90%;
     align-self: center;
-}
-
-.short-answer-widget .initial-value-div textarea {
-    width: 100%;
-    min-height: 75px;
 }
 
 .short-answer-widget i {

--- a/site/public/js/notebook_builder/widgets/short-answer-widget.js
+++ b/site/public/js/notebook_builder/widgets/short-answer-widget.js
@@ -54,7 +54,7 @@ class ShortAnswerWidget extends Widget {
     }
 
     /**
-     * Attach event handlers to appropriate elements and handle loading textarea / codemirror boxes.
+     * Attach event handlers to appropriate elements and handle loading codemirror boxes.
      *
      * @param {HTMLDivElement} interactive_area
      */
@@ -80,7 +80,8 @@ class ShortAnswerWidget extends Widget {
 
             const codebox_config = {
                 value: this.state.initial_value ? this.state.initial_value : '',
-                theme: 'eclipse'
+                theme: 'eclipse',
+                lineWrapping: answer_type_selector.value === 'Default' && this.state.rows
             };
 
             if (answer_type_selector.value !== 'Default') {


### PR DESCRIPTION
Closes #5885

### What is the current behavior?
Codemirror boxes used on the notebook gradeable submission page and notebook builder will not wrap text, instead they will show a horizontal scroll bar.

### What is the new behavior?
- Large style codemirror boxes in these two areas have been changed so that if they are collecting plain text, long sentences will now automatically wrap to the next line instead of creating a horizontal scroll bar.
- When collecting code there will NOT be wrapping.
- Inside notebook builder adding wrapping required setting a fixed width of 1000px on the element containing the codemirror.  This may be a small visual change for some users.
