### PR TITLE
[Feature:Submission] Message page before gradeable

### DIFF
--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -45,6 +45,9 @@
       "assignment_message" : {
         "type" : "string"
       },
+      "load_message" : {
+        "type" : "string"
+      },
       "required_capabilities" : {
         "type" : "string"
       },

--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -45,8 +45,15 @@
       "assignment_message" : {
         "type" : "string"
       },
-      "load_message" : {
-        "type" : "string"
+      "load_gradeable_message" : {
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          },
+          "first_time_only" : {
+            "type" : "boolean"
+          }
+        }
       },
       "required_capabilities" : {
         "type" : "string"

--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -366,6 +366,9 @@ int main(int argc, char *argv[]) {
   } else if (config_json.find("gradeable_message") != config_json.end()) {
     j["gradeable_message"] = config_json.value("gradeable_message", "");
   }
+  if (config_json.find("load_message") != config_json.end()) {
+    j["load_message"] = config_json.value("load_message", "");
+  }
   if (config_json.find("early_submission_incentive") != config_json.end()) {
     nlohmann::json early_submission_incentive = config_json.value("early_submission_incentive",nlohmann::json::object());
     nlohmann::json incentive;

--- a/grading/main_configure.cpp
+++ b/grading/main_configure.cpp
@@ -366,8 +366,12 @@ int main(int argc, char *argv[]) {
   } else if (config_json.find("gradeable_message") != config_json.end()) {
     j["gradeable_message"] = config_json.value("gradeable_message", "");
   }
-  if (config_json.find("load_message") != config_json.end()) {
-    j["load_message"] = config_json.value("load_message", "");
+  if (config_json.find("load_gradeable_message") != config_json.end()) {
+    nlohmann::json load_gradeable_message = config_json.value("load_gradeable_message", nlohmann::json::object());
+    nlohmann::json load_gradeable_message_prop;
+    load_gradeable_message_prop["message"] = load_gradeable_message.value("message", "");
+    load_gradeable_message_prop["first_time_only"] = load_gradeable_message.value("first_time_only", false);
+    j["load_gradeable_message"] = load_gradeable_message_prop;
   }
   if (config_json.find("early_submission_incentive") != config_json.end()) {
     nlohmann::json early_submission_incentive = config_json.value("early_submission_incentive",nlohmann::json::object());

--- a/more_autograding_examples/notebook_time_limit/config/config.json
+++ b/more_autograding_examples/notebook_time_limit/config/config.json
@@ -19,7 +19,7 @@ Here's a short list of instructions:  \n\
         * Leaving the page does not stop the timer.\n\
         * If you submit your answers more than 10 minutes after your first page access, you will lose 1 point per minute over the limit.",
         "first_time_only" : true
-    }
+    },
     "notebook" : [
         {
             "type": "markdown",

--- a/more_autograding_examples/notebook_time_limit/config/config.json
+++ b/more_autograding_examples/notebook_time_limit/config/config.json
@@ -14,9 +14,12 @@ Here's a short list of instructions:  \n\
         "submission_to_validation" : [ "*.txt", "*.png", ".user_assignment_access.json" ],
         "work_to_details" : [ "*.txt", "*.png", "test*/*.txt", "test*/*_diff.json" ]
     },
-    "load_message" : "After clicking continue, the quiz will start and you will have 10 minutes to complete the quiz.\n\
-* Leaving the page does not stop the timer.\n\
-* If you submit your answers more than 10 minutes after your first page access, you will lose 1 point per minute over the limit.",
+    "load_gradeable_message" : {
+        "message" : "After clicking continue, the quiz will start and you will have 10 minutes to complete the quiz.\n\
+        * Leaving the page does not stop the timer.\n\
+        * If you submit your answers more than 10 minutes after your first page access, you will lose 1 point per minute over the limit.",
+        "first_time_only" : true
+    }
     "notebook" : [
         {
             "type": "markdown",

--- a/more_autograding_examples/notebook_time_limit/config/config.json
+++ b/more_autograding_examples/notebook_time_limit/config/config.json
@@ -14,6 +14,9 @@ Here's a short list of instructions:  \n\
         "submission_to_validation" : [ "*.txt", "*.png" ],
         "work_to_details" : [ "*.txt", "*.png", "test*/*.txt", "test*/*_diff.json" ]
     },
+    "load_message" : "After clicking continue, the quiz will start and you will have 10 minutes to complete the quiz.\n\
+* Leaving the page does not stop the timer.\n\
+* If you submit your answers more than 10 minutes after your first page access, you will lose 1 point per minute over the limit.",
     "notebook" : [
         {
             "type": "markdown",

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -199,9 +199,9 @@ class SubmissionController extends AbstractController {
 
     /**
      * Function for showing a message to a user before the gradeable is loaded.
-     * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/load_message")
+     * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/load_gradeable_message")
      */
-    public function loadMessage($gradeable_id) {
+    public function loadGradeableMessage($gradeable_id) {
         $gradeable = $this->tryGetElectronicGradeable($gradeable_id);
         if ($gradeable === null) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
@@ -214,14 +214,14 @@ class SubmissionController extends AbstractController {
             return $verify_permissions;
         }
 
-        if (!$gradeable->getAutogradingConfig()->hasLoadMessage()) {
+        if (!$gradeable->getAutogradingConfig()->shouldLoadGradeableMessage($gradeable->getId(), $this->core->getUser()->getId())) {
             $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]));
         }
         else {
             $this->core->getOutput()->enableMobileViewport();
             $this->core->getOutput()->renderTwigOutput('submission/homework/LoadMessagePage.twig', [
                 "gradeable_name" => $gradeable->getTitle(),
-                "load_message" => $gradeable->getAutogradingConfig()->getLoadMessage(),
+                "load_gradeable_message" => $gradeable->getAutogradingConfig()->getLoadGradeableMessage(),
                 "button_back" => $this->core->buildCourseUrl([]),
                 "button_forward" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId()])
             ]);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -15,6 +15,7 @@ use app\libraries\response\MultiResponse;
 use app\libraries\routers\AccessControl;
 use app\libraries\Utils;
 use app\models\gradeable\Gradeable;
+use app\models\gradeable\GradedGradeable;
 use Symfony\Component\Routing\Annotation\Route;
 use app\models\notebook\UserSpecificNotebook;
 use app\models\notebook\SubmissionCodeBox;
@@ -67,7 +68,7 @@ class SubmissionController extends AbstractController {
         }
     }
 
-    private function verifyHomeworkPagePermissions($gradeable_id, &$gradeable, &$graded_gradeable) {
+    private function verifyHomeworkPagePermissions($gradeable_id, Gradeable $gradeable, $graded_gradeable) {
         if ($graded_gradeable === null && !$this->core->getUser()->accessAdmin()) {
             // FIXME if $graded_gradeable is null, the user isn't on a team, so we want to redirect
             // FIXME    to nav with an error
@@ -214,8 +215,8 @@ class SubmissionController extends AbstractController {
             return $verify_permissions;
         }
 
-        if (!$gradeable->getAutogradingConfig()->shouldLoadGradeableMessage($gradeable->getId(), $this->core->getUser()->getId())) {
-            $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]));
+        if (!$gradeable->getAutogradingConfig()->hasLoadGradeableMessageEnabled($gradeable_id, $this->core->getUser()->getId())) {
+            return new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable_id]));
         }
         else {
             $this->core->getOutput()->enableMobileViewport();
@@ -223,7 +224,7 @@ class SubmissionController extends AbstractController {
                 "gradeable_name" => $gradeable->getTitle(),
                 "load_gradeable_message" => $gradeable->getAutogradingConfig()->getLoadGradeableMessage(),
                 "button_back" => $this->core->buildCourseUrl([]),
-                "button_forward" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId()])
+                "button_forward" => $this->core->buildCourseUrl(['gradeable', $gradeable_id])
             ]);
         }
     }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -137,7 +137,7 @@ class SubmissionController extends AbstractController {
                 $team_id = $team->getId();
             }
         }
-
+        
         $this->core->getQueries()->insertGradeableAccess(
             $gradeable->getId(),
             $user_id,
@@ -199,7 +199,6 @@ class SubmissionController extends AbstractController {
 
     /**
      * Function for showing a message to a user before the gradeable is loaded.
-     * 
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/load_message")
      */
     public function loadMessage($gradeable_id) {
@@ -217,7 +216,8 @@ class SubmissionController extends AbstractController {
 
         if (!$gradeable->getAutogradingConfig()->hasLoadMessage()) {
             $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable->getId()]));
-        } else {
+        }
+        else {
             $this->core->getOutput()->enableMobileViewport();
             $this->core->getOutput()->renderTwigOutput('submission/homework/LoadMessagePage.twig', [
                 "gradeable_name" => $gradeable->getTitle(),

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -80,6 +80,7 @@ class AutogradingConfig extends AbstractModel {
     protected $load_gradeable_message = '';
     /** @prop @var @bool If the message should only be shown to the user if they haven't opened the gradeable yet */
     protected $load_gradeable_message_first_time_only = false;
+
     /* Properties accumulated from the AutogradingTestcases */
 
     /** @prop @var int Total number of non-hidden non-extra-credit ('normal') points for all test cases */
@@ -239,14 +240,6 @@ class AutogradingConfig extends AbstractModel {
      */
     public function shouldLoadGradeableMessage($gradeable_id, $user_id) {
         return $this->load_gradeable_message_enabled && (!$this->load_gradeable_message_first_time_only || count($this->core->getQueries()->getGradeableAccessUser($gradeable_id, $user_id)) === 0);
-    }
-
-    /**
-     * Gets whether this config has a load message
-     * @return bool
-     */
-    public function hasLoadGradeableMessage() {
-        return $this->load_gradeable_message_enabled;
     }
 
     /**

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -78,7 +78,7 @@ class AutogradingConfig extends AbstractModel {
     private $load_gradeable_message_enabled = false;
     /** @prop @var string The message to show to the user before letting them go to the gradeable */
     protected $load_gradeable_message = '';
-    /** @prop @var @bool If the message should only be shown to the user if they haven't opened the gradeable yet */
+    /** @prop @var bool If the message should only be shown to the user if they haven't opened the gradeable yet */
     protected $load_gradeable_message_first_time_only = false;
 
     /* Properties accumulated from the AutogradingTestcases */
@@ -238,7 +238,7 @@ class AutogradingConfig extends AbstractModel {
      * Gets whether a load message should be loaded
      * @return bool
      */
-    public function shouldLoadGradeableMessage($gradeable_id, $user_id) {
+    public function hasLoadGradeableMessageEnabled($gradeable_id, $user_id) : bool {
         return $this->load_gradeable_message_enabled && (!$this->load_gradeable_message_first_time_only || count($this->core->getQueries()->getGradeableAccessUser($gradeable_id, $user_id)) === 0);
     }
 
@@ -246,7 +246,7 @@ class AutogradingConfig extends AbstractModel {
      * Returns the load message
      * @return string
      */
-    public function getLoadGradeableMessage() {
+    public function getLoadGradeableMessage() : string {
         return $this->load_gradeable_message;
     }
 

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -73,6 +73,11 @@ class AutogradingConfig extends AbstractModel {
     /** @prop @var bool */
     protected $notebook_gradeable = false;
 
+    /* Property if load message alert is enabled */
+    /** @pro @var bool If there is a message to show on Gradeable load */
+    private $load_message_enabled = false;
+    /** @prop @var string The message to show to the user before letting them go to the gradeable */
+    protected $load_message = '';
 
     /* Properties accumulated from the AutogradingTestcases */
 
@@ -101,6 +106,11 @@ class AutogradingConfig extends AbstractModel {
         }
         elseif (isset($details['gradeable_message'])) {
             $this->gradeable_message = $details['gradeable_message'] ?? '';
+        }
+
+        if (isset($details['load_message'])) {
+            $this->load_message_enabled = true;
+            $this->load_message = $details['load_message'] ?? '';
         }
 
         // These two items default to false if they don't exist in the gradeable config.json
@@ -219,6 +229,22 @@ class AutogradingConfig extends AbstractModel {
 
     public function updateTestCases($test_cases) {
         $this->parseTestCases($test_cases);
+    }
+
+    /**
+     * Gets whether this config has a load message
+     * @return bool 
+     */
+    public function hasLoadMessage() {
+        return $this->load_message_enabled;
+    }
+
+    /**
+     * Returns the load message
+     * @return string 
+     */
+    public function getLoadMessage() {
+        return $this->load_message;
     }
 
     /**

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -233,7 +233,7 @@ class AutogradingConfig extends AbstractModel {
 
     /**
      * Gets whether this config has a load message
-     * @return bool 
+     * @return bool
      */
     public function hasLoadMessage() {
         return $this->load_message_enabled;
@@ -241,7 +241,7 @@ class AutogradingConfig extends AbstractModel {
 
     /**
      * Returns the load message
-     * @return string 
+     * @return string
      */
     public function getLoadMessage() {
         return $this->load_message;

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -238,7 +238,7 @@ class AutogradingConfig extends AbstractModel {
      * Gets whether a load message should be loaded
      * @return bool
      */
-    public function hasLoadGradeableMessageEnabled($gradeable_id, $user_id) : bool {
+    public function hasLoadGradeableMessageEnabled($gradeable_id, $user_id): bool {
         return $this->load_gradeable_message_enabled && (!$this->load_gradeable_message_first_time_only || count($this->core->getQueries()->getGradeableAccessUser($gradeable_id, $user_id)) === 0);
     }
 
@@ -246,7 +246,7 @@ class AutogradingConfig extends AbstractModel {
      * Returns the load message
      * @return string
      */
-    public function getLoadGradeableMessage() : string {
+    public function getLoadGradeableMessage(): string {
         return $this->load_gradeable_message;
     }
 

--- a/site/app/models/gradeable/AutogradingConfig.php
+++ b/site/app/models/gradeable/AutogradingConfig.php
@@ -74,11 +74,12 @@ class AutogradingConfig extends AbstractModel {
     protected $notebook_gradeable = false;
 
     /* Property if load message alert is enabled */
-    /** @pro @var bool If there is a message to show on Gradeable load */
-    private $load_message_enabled = false;
+    /** @prop @var bool If there is a message to show on Gradeable load */
+    private $load_gradeable_message_enabled = false;
     /** @prop @var string The message to show to the user before letting them go to the gradeable */
-    protected $load_message = '';
-
+    protected $load_gradeable_message = '';
+    /** @prop @var @bool If the message should only be shown to the user if they haven't opened the gradeable yet */
+    protected $load_gradeable_message_first_time_only = false;
     /* Properties accumulated from the AutogradingTestcases */
 
     /** @prop @var int Total number of non-hidden non-extra-credit ('normal') points for all test cases */
@@ -108,9 +109,10 @@ class AutogradingConfig extends AbstractModel {
             $this->gradeable_message = $details['gradeable_message'] ?? '';
         }
 
-        if (isset($details['load_message'])) {
-            $this->load_message_enabled = true;
-            $this->load_message = $details['load_message'] ?? '';
+        if (isset($details['load_gradeable_message'])) {
+            $this->load_gradeable_message_enabled = true;
+            $this->load_gradeable_message = $details['load_gradeable_message']['message'] ?? '';
+            $this->load_gradeable_message_first_time_only = $details['load_gradeable_message']['first_time_only'] ?? false;
         }
 
         // These two items default to false if they don't exist in the gradeable config.json
@@ -232,19 +234,27 @@ class AutogradingConfig extends AbstractModel {
     }
 
     /**
+     * Gets whether a load message should be loaded
+     * @return bool
+     */
+    public function shouldLoadGradeableMessage($gradeable_id, $user_id) {
+        return $this->load_gradeable_message_enabled && (!$this->load_gradeable_message_first_time_only || count($this->core->getQueries()->getGradeableAccessUser($gradeable_id, $user_id)) === 0);
+    }
+
+    /**
      * Gets whether this config has a load message
      * @return bool
      */
-    public function hasLoadMessage() {
-        return $this->load_message_enabled;
+    public function hasLoadGradeableMessage() {
+        return $this->load_gradeable_message_enabled;
     }
 
     /**
      * Returns the load message
      * @return string
      */
-    public function getLoadMessage() {
-        return $this->load_message;
+    public function getLoadGradeableMessage() {
+        return $this->load_gradeable_message;
     }
 
     /**

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -7,6 +7,6 @@
     <div>{{ load_gradeable_message | markdown }}</div>
     </div>
     <div class="content">
-    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-primary btn-lg" style="float: right">Accept, Continue to<br>'{{ gradeable_name }}'</a>
-    <a type="button" id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Cancel, Return to<br>Home Page</a>
+    <a id="continue" href="{{ button_forward }}"class="btn btn-primary btn-lg" style="float: right">Accept, Continue to<br>'{{ gradeable_name }}'</a>
+    <a id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Cancel, Return to<br>Home Page</a>
 </div>

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -7,6 +7,6 @@
     <div>{{ load_gradeable_message | markdown }}</div>
     </div>
     <div class="content">
-    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Accept, Continue to<br>'{{ gradeable_name }}'</a>
+    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-primary btn-lg" style="float: right">Accept, Continue to<br>'{{ gradeable_name }}'</a>
     <a type="button" id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Cancel, Return to<br>Home Page</a>
 </div>

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -7,6 +7,6 @@
     <span>{{ load_gradeable_message | markdown }}</span>
     </div>
     <div class="content">
-    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Continue</a>
-    <a type="button" id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Return to gradeables</a>
+    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Accept, Continue to<br>{{ gradeable_name }}</a>
+    <a type="button" id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Cancel, Return to<br>Home Page</a>
 </div>

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -7,6 +7,6 @@
     <span>{{ load_gradeable_message | markdown }}</span>
     </div>
     <div class="content">
-    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Accept, Continue to<br>{{ gradeable_name }}</a>
+    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Accept, Continue to<br>'{{ gradeable_name }}'</a>
     <a type="button" id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Cancel, Return to<br>Home Page</a>
 </div>

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -4,7 +4,7 @@
             Message for: {{ gradeable_name }}
         </h1>
     </header>
-    <span>{{ load_gradeable_message | markdown }}</span>
+    <div>{{ load_gradeable_message | markdown }}</div>
     </div>
     <div class="content">
     <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Accept, Continue to<br>'{{ gradeable_name }}'</a>

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -1,0 +1,12 @@
+<div class="content gradeable_message">
+    <header id="gradeable-info">
+        <h1>
+            Message for: {{ gradeable_name }}
+        </h1>
+    </header>
+    <span>{{ load_message | markdown }}</span>
+    </div>
+    <div class="content">
+    <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Continue</a>
+    <a type="button" id="back" href="{{ button_back }}" class="btn btn-primary btn-lg">Return to gradeables</a>
+</div>

--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -4,7 +4,7 @@
             Message for: {{ gradeable_name }}
         </h1>
     </header>
-    <span>{{ load_message | markdown }}</span>
+    <span>{{ load_gradeable_message | markdown }}</span>
     </div>
     <div class="content">
     <a type="button" id="continue" href="{{ button_forward }}"class="btn btn-danger btn-lg" style="float: right">Continue</a>

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -407,7 +407,11 @@ class NavigationView extends AbstractView {
 
         $points_percent = NAN;
 
-        $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]);
+        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->hasLoadMessage()) {
+            $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_message']);
+        } else {
+            $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]);
+        }
         $progress = null;
         $disabled = false;
 
@@ -418,6 +422,8 @@ class NavigationView extends AbstractView {
                 "disabled" => true,
                 "class" => "btn btn-default btn-nav"
             ]);
+        } else {
+
         }
 
         if ($graded_gradeable !== null) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -407,8 +407,8 @@ class NavigationView extends AbstractView {
 
         $points_percent = NAN;
 
-        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->hasLoadMessage()) {
-            $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_message']);
+        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->shouldLoadGradeableMessage($gradeable->getId(), $this->core->getUser()->getId())) {
+            $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_gradeable_message']);
         }
         else {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]);

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -409,7 +409,8 @@ class NavigationView extends AbstractView {
 
         if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->hasLoadMessage()) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_message']);
-        } else {
+        }
+        else {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]);
         }
         $progress = null;
@@ -422,8 +423,6 @@ class NavigationView extends AbstractView {
                 "disabled" => true,
                 "class" => "btn btn-default btn-nav"
             ]);
-        } else {
-
         }
 
         if ($graded_gradeable !== null) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -407,7 +407,7 @@ class NavigationView extends AbstractView {
 
         $points_percent = NAN;
 
-        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->shouldLoadGradeableMessage($gradeable->getId(), $this->core->getUser()->getId())) {
+        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->hasLoadGradeableMessageEnabled($gradeable->getId(), $this->core->getUser()->getId())) {
             $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_gradeable_message']);
         }
         else {

--- a/site/socket/index.php
+++ b/site/socket/index.php
@@ -8,7 +8,7 @@ use Ratchet\WebSocket\WsServer;
 use app\libraries\Core;
 use app\libraries\socket\Server;
 
-require_once(__DIR__.'/../vendor/autoload.php');
+require_once(__DIR__ . '/../vendor/autoload.php');
 
 $core = new Core();
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
When opening a gradeable, it always immediately opens the gradeable.

### What is the new behavior?
When opening a gradeable with the "load_gradeable_message" option in the autograding configuration for that gradeable, it will first redirect the user to a confirmation page with the contents of "message" (under "load_gradeable_message") displayed on the screen (with markdown). The user can then opt to either continue to the gradeable or can go back to the main gradeable page (or can select any of the options on the sidebar). If the option "first_time_only" (under "load_gradeable_message") is selected, then after an entry is found in the database for user access to the gradeable, the message will no longer show.

### Other information?
The "load_gradeable_message" page does not trigger a page access for the gradeable.
Tested by making sure that the "load_gradeable_message" page only replaced the default gradeable URL when "load_gradeable_message" was in the autograding config and that it only showed up when it should with first_time_only enabled.
