### PR TITLE
[Bugfix:System] Specify nginx-full on installation

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -430,7 +430,7 @@ if [ ${WORKER} == 0 ]; then
     a2enmod include actions cgi suexec authnz_external headers ssl proxy_fcgi rewrite proxy_http proxy_wstunnel
 
     # Install nginx to serve websocket connections
-    sudo apt-get install -qqy nginx
+    sudo apt-get install -qqy nginx-full
 
     # A real user will have to do these steps themselves for a non-vagrant setup as to do it in here would require
     # asking the user questions as well as searching the filesystem for certificates, etc.

--- a/migration/migrator/migrations/system/20200911180000_ngnix_setup.py
+++ b/migration/migrator/migrations/system/20200911180000_ngnix_setup.py
@@ -8,7 +8,7 @@ def up(config):
     :param config: Object holding configuration details about Submitty
     :type config: migrator.config.Config
     """
-    os.system("apt-get install -qqy nginx")
+    os.system("apt-get install -qqy nginx-full")
 
 def down(config):
     pass


### PR DESCRIPTION
When installing nginx on our production servers using `apt-get install nginx`, we found that the command yielded differing results across machines. Upon further investigation, it seems that installing `nginx` chooses one of four different installation candidates based on OS, `nginx-core`, `nginx-full`, `nginx-light` and `nginx-extras`. This PR moves us to be explicit about the version that we want, `nginx-full`.

This PR has been tested, and it __does not__ modify or remove existing nginx submitty configurations. This PR may require the installer to run `systemctl restart nginx` and `systemctl restart submitty_websocket_server`. 