### PR TITLE
[Bugfix:Developer] Remove debug print statement which was triggered on every keystroke

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -33,7 +33,6 @@
                                               $(document).on(
                                                 'keydown',
                                                 function(event) {
-                                                  console.log($("#{{ block('popup_id') }}").is(":visible"))
                                                     if (event.key == "Escape" && $("#{{ block('popup_id') }}").is(":visible")) {
                                                       {{ block('close_click_action') }}
                                                     }


### PR DESCRIPTION
A debug print statement was introduced to master recently which triggers on every keystroke on many pages of the system. This PR removes that statement.