### PR TITLE
[Bugfix: InstructorUI] Fix student view of polls not showing answer correctly

### DIFF
--- a/site/app/templates/polls/AllPollsPageStudent.twig
+++ b/site/app/templates/polls/AllPollsPageStudent.twig
@@ -23,7 +23,7 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                             <input type="hidden" name="poll_id" value="{{ poll.getID() }}"/>
                             {% if poll.isOpen() %}
-                                {% if poll.getUserResponse(user_id) == null %}
+                                {% if poll.getUserResponse(user_id) is same as(null) %}
                                     <button type="submit" class="btn btn-success"> Answer
                                 {% else %}
                                     <button type="submit" class="btn btn-success"> Edit Answer
@@ -57,7 +57,7 @@
             {% for poll in older_polls %}
                 <tr>
                     <td> {{ poll.getName() }} </td>
-                    <td> {{ poll.getUserResponse(user_id) == null ? "No Response" : poll.getResponseString(poll.getUserResponse(user_id)) | markdown}} </td>
+                    <td> {{ poll.getUserResponse(user_id) is same as(null) ? "No Response" : poll.getResponseString(poll.getUserResponse(user_id)) | markdown}} </td>
                     <td>
                         <form method="post" action="{{ base_url }}/viewPoll">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>

--- a/site/app/templates/polls/PollPageStudent.twig
+++ b/site/app/templates/polls/PollPageStudent.twig
@@ -11,13 +11,13 @@
             </legend>
             <label class="radio" for="answer-no-response">
                 {% if poll.isOpen() %}
-                    {% if poll.getUserResponse(user_id) == null %}
+                    {% if poll.getUserResponse(user_id) is same as(null) %}
                         <input type="radio" value="-1" name="answer" id="answer-no-response" checked/>
                     {% else %}
                         <input type="radio" value="-1" name="answer" id="answer-no-response"/>
                     {% endif %}
                 {% else %}
-                    {% if poll.getUserResponse(user_id) == null %}
+                    {% if poll.getUserResponse(user_id) is same as(null) %}
                         <input type="radio" value="-1" name="answer" id="answer-no-response" checked disabled/>
                     {% else %}
                         <input type="radio" value="-1" name="answer" id="answer-no-response" disabled/>


### PR DESCRIPTION
### What is the current behavior?
Under some circumstances, an incorrect null check causes a student's view of polls to show that they have not submitted a response in either the answer column showing "No Response" or the answer column erroneously labelled "Answer" as opposed to "Edit Answer."

### What is the new behavior?
Now both the answer column and the answer column will update correctly if the student has already responded to the poll.