### PR TITLE
[Feature:System] Restart web servers by default when installing

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -60,6 +60,7 @@ if [[ "$#" -ge 1 && "$1" != "test" && "$1" != "clean" && "$1" != "test_rainbow"
     echo -e "   ./INSTALL_SUBMITTY.sh"
     echo -e "   ./INSTALL_SUBMITTY.sh clean"
     echo -e "   ./INSTALL_SUBMITTY.sh clean test"
+    echo -e "   ./INSTALL_SUBMITTY.sh clean skip_web_restart"
     echo -e "   ./INSTALL_SUBMITTY.sh clear test  <test_case_1>"
     echo -e "   ./INSTALL_SUBMITTY.sh clear test  <test_case_1> ... <test_case_n>"
     echo -e "   ./INSTALL_SUBMITTY.sh test"
@@ -726,7 +727,7 @@ fi
 
 # Restart php-fpm and apache
 if [ "${WORKER}" == 0 ]; then
-    if [[ "$#" == 0 || ("$#" -ge 1 && $1 != "skip_web_restart") ]]; then
+    if [[ "$#" == 0 || ("$#" == 1 && $1 != "skip_web_restart") || ("$#" -ge 2  && ($1 != "skip_web_restart" && $2 != "skip_web_restart")) ]]; then
         PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
         echo -n "restarting php${PHP_VERSION}-fpm..."
         systemctl restart php${PHP_VERSION}-fpm

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -55,7 +55,7 @@ fi
 
 # check optional argument
 if [[ "$#" -ge 1 && "$1" != "test" && "$1" != "clean" && "$1" != "test_rainbow"
-       && "$1" != "restart_web" && "$1" != "disable_shipper_worker" ]]; then
+       && "$1" != "skip_web_restart" && "$1" != "disable_shipper_worker" ]]; then
     echo -e "Usage:"
     echo -e "   ./INSTALL_SUBMITTY.sh"
     echo -e "   ./INSTALL_SUBMITTY.sh clean"
@@ -66,7 +66,7 @@ if [[ "$#" -ge 1 && "$1" != "test" && "$1" != "clean" && "$1" != "test_rainbow"
     echo -e "   ./INSTALL_SUBMITTY.sh test  <test_case_1>"
     echo -e "   ./INSTALL_SUBMITTY.sh test  <test_case_1> ... <test_case_n>"
     echo -e "   ./INSTALL_SUBMITTY.sh test_rainbow"
-    echo -e "   ./INSTALL_SUBMITTY.sh restart_web"
+    echo -e "   ./INSTALL_SUBMITTY.sh skip_web_restart"
     echo -e "   ./INSTALL_SUBMITTY.sh disable_shipper_worker"
     exit 1
 fi
@@ -726,7 +726,7 @@ fi
 
 # Restart php-fpm and apache
 if [ "${WORKER}" == 0 ]; then
-    if [[ "$#" -ge 1 && $1 == "restart_web" ]]; then
+    if [[ "$#" == 0 || ("$#" -ge 1 && $1 != "skip_web_restart") ]]; then
         PHP_VERSION=$(php -r 'print PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')
         echo -n "restarting php${PHP_VERSION}-fpm..."
         systemctl restart php${PHP_VERSION}-fpm

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -700,7 +700,7 @@ if [ ${WORKER} == 0 ]; then
 fi
 
 echo Beginning Install Submitty Script
-bash ${SUBMITTY_INSTALL_DIR}/.setup/INSTALL_SUBMITTY.sh clean
+bash ${SUBMITTY_INSTALL_DIR}/.setup/INSTALL_SUBMITTY.sh clean skip_web_restart
 
 
 # (re)start the submitty grading scheduler daemon

--- a/.setup/travis/setup.sh
+++ b/.setup/travis/setup.sh
@@ -93,7 +93,7 @@ usermod -a -G travis submitty_daemon
 # necessary to pass config path as submitty_repository is a symlink
 python3 ${SUBMITTY_REPOSITORY}/migration/run_migrator.py -e master -e system migrate --initial
 
-bash ${SUBMITTY_INSTALL_DIR}/.setup/INSTALL_SUBMITTY.sh clean
+bash ${SUBMITTY_INSTALL_DIR}/.setup/INSTALL_SUBMITTY.sh clean skip_web_restart
 
 systemctl start submitty_autograding_shipper
 systemctl start submitty_autograding_worker


### PR DESCRIPTION
Previously, when running `INSTALL_SUBMITTY.sh`, web services (e.g. apache, nginx, php) did not restart unless the `restart_web` option was specified. This PR updates the system so that web services are restarted by default, and adds the `skip_web_restart` option to avoid restarting web services.