### PR TITLE
[Bugfix:Forum] View posts by users fixed on stats page

### DIFF
--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -73,7 +73,7 @@
             for(var i=0;i<posts.length;i++){
                 var post_string = posts[i];
                 post_string = escapeSpecialChars(post_string);
-                var thread_title = thread_titles[i]["title"];
+                var thread_title = thread_titles[i];
                 thread_title = escapeSpecialChars(thread_title);
                 $(this).parent().parent().parent().append('<tr id="'+ids[i]+'"><td></td><td>'+timestamps[i]+'</td><td style = "cursor:pointer;" data-type = "thread" data-thread_id="'+thread_ids[i]+'"><pre class="pre_forum" style="white-space: pre-wrap;">'+thread_title+'</pre></td><td colspan = "2" style = "cursor:pointer;" align = "left" data-type = "post" data-thread_id="'+thread_ids[i]+'"><pre class="pre_forum" style="white-space: pre-wrap;">'+post_string+'</pre></td></tr> ');
 


### PR DESCRIPTION
On the Stats page, on clicking the **"Expand"** button, the posts were not displayed, instead it would display errors in the console. There was a tiny error in the `forum.js` file wherein a line was accessing the `thread_titles` variable as if it were a _key-value array_, whereas it was a _numerically indexed array_.

### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #5810 . On clicking the "Expand" button, the user's posts don't show up, instead errors are displayed on the browser's console.

### What is the new behavior?
On clicking the "Expand" button, the user's posts are displayed.