### PR TITLE
[Bugfix:Submission] Reload up to 3 times on "Something went wrong"

### DIFF
--- a/site/app/templates/submission/homework/AutogradingResultsBox.twig
+++ b/site/app/templates/submission/homework/AutogradingResultsBox.twig
@@ -19,6 +19,16 @@
             <p class="red-message">
                 Something went wrong when grading this submission. Please contact your instructor about this.
             </p>
+            <script>
+                (() => {
+                    const params = new URLSearchParams(window.location.search);
+                    const loadAttempt = Number(params.get('loadAttempt') ?? '0');
+                    if (loadAttempt < 3) {
+                        params.set('loadAttempt', loadAttempt + 1);
+                        window.location.search = params.toString();
+                    }
+                })();
+            </script>
         {% else %}
             {# Has results! #}
             {% if show_incentive_message %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

There exists a minor race condition in "grading finished" detection for gradeables which becomes much more common on slow I/O setups that incorrectly causes the grading results page to display a "Something went wrong when grading this submission." message.

### What is the new behavior?

When the "Something went wrong when grading this submission." message occurs, we reload the page up to three times. If after three reloads the message is still visible, then assume something is in fact wrong with the submission and give up.

### Other information?

If Submitty is being run on a machine with fast I/O, this behavior can be tricky to reproduce. One way to simulate this behavior is to add delays after the modify the `GradingQueue::reloadQueue()` in `site/app/libraries/GradingQueue.php` (look for the `usleep` calls):

```php
    /**
     * Forces the queue state to be reloaded from the files on the disk
     */
    public function reloadQueue() {
        // Get all items in queue dir
        $queued_files = scandir($this->queue_path);
        usleep(100 * 1000);  // Add this
        $grading_dirs = scandir($this->grading_path);
        usleep(100 * 1000);  // Add this

        /* *snip* */

        foreach ($grading_dirs as $remote_dir) {
            $path = FileUtils::joinPaths($this->grading_path, $remote_dir);
            // First, we filter to directories that are neither `.` nor `..`.
            // These remote directories each correspond to an individual worker.
            if ($remote_dir !== "." && $remote_dir !== ".." && is_dir($path)) {
                $this_remote_files = scandir($path);
                usleep(100 * 1000);  // Add this
```

This will insert a 100ms delay after every `scandir` call. Make a submission to any gradeable and continuously refresh. It may take a few tries. Higher delays *usually* mean that it's easier to run into the race condition.