### PR TITLE
[Bugfix:TAGrading] status page in ungraded gradeables

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1545,7 +1545,7 @@ ORDER BY gc_order
             $user_or_team_id = "team_id";
         }
         $this->course_db->query("
-SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) FROM(
+SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) AS row_count FROM(
    SELECT * FROM (
       SELECT (egd.autograding_non_hidden_non_extra_credit + egd.autograding_non_hidden_extra_credit + egd.autograding_hidden_non_extra_credit + egd.autograding_hidden_extra_credit) AS score
       FROM electronic_gradeable_data AS egd
@@ -1560,7 +1560,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
    )g
 ) as individual;
           ", [$g_id]);
-        return ($this->course_db->getRowCount() > 0) ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
+        return ($this->course_db->getRowCount() > 0 && $this->course_db->rows()[0]['row_count'] > 0) ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
     }
     public function getScoresForGradeable($g_id, $section_key, $is_team) {
         $u_or_t = "u";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1560,7 +1560,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
    )g
 ) as individual;
           ", [$g_id]);
-        return $this->course_db->getRowCount() > 0 ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
+        return ($this->course_db->getRowCount() > 0) ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
     }
     public function getScoresForGradeable($g_id, $section_key, $is_team) {
         $u_or_t = "u";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1545,7 +1545,7 @@ ORDER BY gc_order
             $user_or_team_id = "team_id";
         }
         $this->course_db->query("
-SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) AS row_count FROM(
+SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_dev, 0 AS max, COUNT(*) FROM(
    SELECT * FROM (
       SELECT (egd.autograding_non_hidden_non_extra_credit + egd.autograding_non_hidden_extra_credit + egd.autograding_hidden_non_extra_credit + egd.autograding_hidden_extra_credit) AS score
       FROM electronic_gradeable_data AS egd
@@ -1560,7 +1560,7 @@ SELECT round((AVG(score)),2) AS avg_score, round(stddev_pop(score), 2) AS std_de
    )g
 ) as individual;
           ", [$g_id]);
-        return ($this->course_db->getRowCount() > 0 && $this->course_db->rows()[0]['row_count'] > 0) ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
+        return $this->course_db->getRowCount() > 0 ? new SimpleStat($this->core, $this->course_db->rows()[0]) : null;
     }
     public function getScoresForGradeable($g_id, $section_key, $is_team) {
         $u_or_t = "u";

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -111,7 +111,7 @@
                 var dataAuto = tracing(xBuckets,yValue);
                 Plotly.newPlot('myDiv3', dataAuto, layout, {displayModeBar: false,displaylogo: false});
                 bucketInputAuto.value='';
-                document.getElementById("mySmallDiv3").innerHTML='<b>Mean: </b>'+{{ autograded_average.getAverageScore() }}+'&nbsp&nbsp&nbsp&nbsp'+'<b>Mode: </b>'
+                document.getElementById("mySmallDiv3").innerHTML='<b>Mean: </b>'+{{ autograded_average.getAverageScore() | default('0') }}+'&nbsp&nbsp&nbsp&nbsp'+'<b>Mode: </b>'
                 +mode+'&nbsp&nbsp&nbsp&nbsp'+'<b>Median: </b>'+median+'&nbsp&nbsp&nbsp&nbsp'+ '<b>Maximum: </b>'+max+
                 '&nbsp&nbsp&nbsp&nbsp'+'<b>Minimum: </b>'+min+'&nbsp&nbsp&nbsp&nbsp'+'<b>Standard Deviation: </b>'+
                 {{ autograded_average.getStandardDeviation()  }}+'&nbsp&nbsp&nbsp&nbsp'+'<b>Range: </b>'+range;


### PR DESCRIPTION
Fixes the status page of ungraded gradeables. The problem would arise when `averageScore` is a null value, since there were no entries to fetch, JavaScript would emit an error. Fixed this by modifying the database query and then including another check while constructing the `SimpleStat` model.

### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #5562 . Currently, an error shows up on the console.

### What is the new behavior?
No error is shown in the console.