### PR TITLE
[Feature: InstructorUI] Adding logging for office hours queue

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -229,6 +229,7 @@ if [ "${WORKER}" == 0 ]; then
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/rainbow_grades
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/psql
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/preferred_names
+    mkdir -p ${SUBMITTY_DATA_DIR}/logs/office_hours_queue
 fi
 # ------------------------------------------------------------------------
 
@@ -268,6 +269,7 @@ if [ "${WORKER}" == 0 ]; then
     # Folder g+w permission needed to permit DAEMON_GROUP to remove expired Postgresql logs.
     chmod  g+w                                        ${SUBMITTY_DATA_DIR}/logs/psql
     chown  -R ${DAEMON_USER}:${DAEMON_GROUP}          ${SUBMITTY_DATA_DIR}/logs/preferred_names
+    chown  -R ${PHP_USER}:${COURSE_BUILDERS_GROUP}    ${SUBMITTY_DATA_DIR}/logs/office_hours_queue
 
     # php needs to be able to read containers config
     chown ${PHP_USER}:${DAEMONPHP_GROUP} ${SUBMITTY_INSTALL_DIR}/config/autograding_containers.json

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -222,6 +222,30 @@ class Logger {
         static::logMessage('ta_grading', $log_message);
     }
 
+
+    /**
+     * This logs the activity of a queue when it is
+     * 1. Opened
+     * 2. Closed
+     * 3. Emptied
+     * 4. Created
+     * Timestamp | Course Semester | Course Name | Queue Name | Action | User Agent
+     *
+     * where action is either OPENED, CLOSED, EMPTIED, CREATED
+     *
+     * @param $course_semester the current semester
+     * @param $course the course name
+     * @param $queue_name the name of the queue
+     * @param $queue_action the action performed
+     */
+    public static function logQueueActivity($course_semester, $course, $queue_name, $queue_action) {
+        $log_message[] = $course_semester;
+        $log_message[] = $course;
+        $log_message[] = $queue_name;
+        $log_message[] = $queue_action;
+        static::logMessage('office_hours_queue', $log_message);
+    }
+
     private static function logMessage($folder, $log_message) {
         $filename = static::getFilename();
         array_unshift($log_message, static::getTimestamp());

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -233,10 +233,10 @@ class Logger {
      *
      * where action is either OPENED, CLOSED, EMPTIED, CREATED
      *
-     * @param $course_semester the current semester
-     * @param $course the course name
-     * @param $queue_name the name of the queue
-     * @param $queue_action the action performed
+     * @param string $course_semester The current semester
+     * @param string $course The course name
+     * @param string $queue_name The name of the queue
+     * @param string $queue_action The action performed
      */
     public static function logQueueActivity($course_semester, $course, $queue_name, $queue_action) {
         $log_message[] = $course_semester;


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #5454 

### What is the new behavior?
Upon queue open, close, empty, or creation, a message is logged to /var/local/submitty/logs/office_hours_queue/file.log
A new file is created each day, like how existing logs work.
Each time a queue does an action, a line is written containing:
Timestamp | Course Semester | Course Name | Queue Name | {OPENED | CLOSED | EMPTIED | CREATED} | User Agent