### PR TITLE
[Bugfix:InstructorUI] Generate Grade Summaries Crashes On Team-Only Course

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -290,7 +290,7 @@ class ReportController extends AbstractController {
                     // This user had no results, so generate results
                     $ggs = $this->mergeGradedGradeables($all_gradeables, $u, [], $team_graded_gradeables);
                     $late_days = new LateDays($this->core, $u, $ggs, $all_late_days[$u->getId()] ?? []);
-                    $results[$current_user->getId()] = $per_user_callback($u, $ggs, $late_days);
+                    $results[$u->getId()] = $per_user_callback($u, $ggs, $late_days, $all_polls);
                 }
             }
         }


### PR DESCRIPTION
### What is the current behavior?
If a course only has team-based assignments, clicking Generate Grade Summaries from the reports page will cause a crash. This is due to two reasons:

* The inner loop uses `$current_user` instead of `$u`, and `$current_user` is not the variable being iterated over, so this results in trying to invoke a method of NULL
* The `saveUserToFile` function expects an extra argument (polls), so the $per_user_callback closure passed into the call to `generateReportInternal()` expects 4 arguments. However the invocation in `generateReportInternal()` did not pass in this extra argument (`$all_polls`) so there would be an argument number mismatch even if the above point was addressed.

### What is the new behavior?
Courses containing gradeables that are all team gradeables do not cause an exception to be generated, and the individual student JSON files are correctly generated.
