### PR TITLE
[Bugfix:installation] Fix initial vagrant up & vagrant provision

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -62,12 +62,12 @@ fi
 if [ ${VAGRANT} == 1 ]; then
     # Ubuntu/Debian share this stuff, CentOS does not
     if [ -d /etc/update-motd.d ]; then
-        chmod -x /etc/update-motd.d/*
-        chmod +x /etc/update-motd.d/00-header
+        chmod a-x /etc/update-motd.d/*
     fi
     if [ -f /usr/share/landscape/landscape-sysinfo.wrapper ]; then
         chmod -x /usr/share/landscape/landscape-sysinfo.wrapper
     fi
+
 
     # ${x^^} gives capitalized string
     DISTRO_LINE=$(printf "##  RUNNING: %-44s ##" "${DISTRO^^} ${VERSION^^}")
@@ -75,6 +75,7 @@ if [ ${VAGRANT} == 1 ]; then
     CGI_LINE=$(printf "##    %-51s ##" "${SUBMISSION_URL}/cgi-bin (cgi-bin scripts)")
     GIT_LINE=$(printf "##    %-51s ##" "${SUBMISSION_URL}/git (git)")
     DATABASE_LINE=$(printf "##    %-51s ##" "localhost:${DATABASE_PORT}")
+  
     # Set our cool MOTD to help people get started
     echo -e "
  _______  __   __  _______  __   __  ___   _______  _______  __   __
@@ -118,5 +119,4 @@ ${DATABASE_LINE}
 ##  Happy developing!                                     ##
 ############################################################
 " > /etc/motd
-    chmod 644 /etc/motd
 fi

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -236,7 +236,7 @@ fi
 if [ ${VAGRANT} == 1 ]; then
     # We only might build analysis tools from source while using vagrant
     echo "Installing stack (haskell)"
-    curl -sSL https://get.haskellstack.org/ | sh
+    curl -sSL https://get.haskellstack.org/ | sh -s - -f
 fi
 
 #################################################################
@@ -308,8 +308,6 @@ if [ ${WORKER} == 0 ]; then
 
     #add cgi user to docker group in order to use the Docker python sdk
     usermod -a -G "docker" ${CGI_USER}
-    echo -e "\n# set by the .setup/install_system.sh script\numask 027" >> /home/${PHP_USER}/.profile
-    echo -e "\n# set by the .setup/install_system.sh script\numask 027" >> /home/${CGI_USER}/.profile
 fi
 
 if ! cut -d ':' -f 1 /etc/passwd | grep -q ${DAEMON_USER} ; then
@@ -443,8 +441,8 @@ if [ ${WORKER} == 0 ]; then
         fi
 
         # remove default sites which would cause server to mess up
-        rm /etc/apache2/sites*/000-default.conf
-        rm /etc/apache2/sites*/default-ssl.conf
+        rm /etc/apache2/sites*/000-default.conf || true
+        rm /etc/apache2/sites*/default-ssl.conf || true
 
         cp ${SUBMITTY_REPOSITORY}/.setup/apache/submitty.conf /etc/apache2/sites-available/submitty.conf
 
@@ -493,10 +491,10 @@ EOF
     # NGINX SETUP
     #################
     # remove default site which would cause server to mess up
-    rm /etc/nginx/sites*/default
+    rm /etc/nginx/sites*/default || true
     cp ${SUBMITTY_REPOSITORY}/.setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf
     chmod 644 /etc/nginx/sites-available/submitty.conf
-    ln -s /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf
+    ln -sf /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf
 
 
     #################################################################
@@ -573,7 +571,9 @@ if [ ${WORKER} == 0 ]; then
 
         # Set the listen address to be global so that we can access the guest DB from the host
         sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/${PG_VERSION}/main/postgresql.conf
+        service postgresql start
         service postgresql restart
+        pg_lsclusters | cat
     fi
 fi
 

--- a/.setup/vagrant/pg_hba.conf
+++ b/.setup/vagrant/pg_hba.conf
@@ -4,7 +4,7 @@
 # hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
 
 # Database administrative login by Unix domain socket
-local   all             postgres                                peer
+local   all             postgres                                trust
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 # "local" is for Unix domain socket connections only


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
A fresh vagrant up appears to be broken, doing a `vagrant reload --reload` breaks and leaves a broken vm.

### What is the new behavior?
Attempts to fix this
Main issue with a fresh vagrant up,
postgresql would fail to perform peer authentication, not sure why but set it to trust any localhost account

vagrant provision would crash with
setting the motd file permissions
trying to install haskell stack if it already exists
removing files that don't exist
creating a symlink thats already there

### Other information?
need to test if this actually fixes vagrant provision, will do that later but should fix the vagrant up issue
