### PR TITLE
[Feature:Submission] Show due dates in user/server timezone on submission page

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -20,7 +20,20 @@
             {% endif %}
         </h1>
         {% if has_due_date %}
-            <h2>Due: {{ due_date|date(date_time_format) }}</h2>
+            {% set diff_time_zone = server_time_zone_string != user_time_zone_string %}
+
+            <div id="gradeable-info-due-dates">
+                <h2>
+                    Due: {{ due_date|date(date_time_format) }}
+                    {% if diff_time_zone %}
+                        <i>(Local Time)</i>
+                    {% endif %}
+                </h2>
+
+                {% if diff_time_zone %}
+                    <h2>{{ due_date|date(date_time_format, server_time_zone_string) }} <i>(Server Time)</i></h2>
+                {% endif %}
+            </div>
         {% endif %}
         <div class="loading-bar-wrapper">
             <span>Upload progress: <span id="loading-bar-percentage"></span></span>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -432,6 +432,8 @@ class HomeworkView extends AbstractView {
             'gradeable_url' => $gradeable->getInstructionsUrl(),
             'due_date' => $gradeable->getSubmissionDueDate(),
             'date_time_format' => $this->core->getConfig()->getDateTimeFormat()->getFormat('gradeable'),
+            'server_time_zone_string' => $this->core->getConfig()->getTimezone()->getName(),
+            'user_time_zone_string' => $this->core->getUser()->getUsableTimeZone()->getName(),
             'part_names' => $gradeable->getAutogradingConfig()->getPartNames(),
             'one_part_only' => $gradeable->getAutogradingConfig()->getOnePartOnly(),
             'is_vcs' => $gradeable->isVcs(),

--- a/site/public/css/submitbox.css
+++ b/site/public/css/submitbox.css
@@ -1,12 +1,15 @@
 #gradeable-info {
     display: flex;
     justify-content: space-between;
-    align-items: center;
     flex-wrap: wrap;
 }
 
 #gradeable-info > * {
     margin: 0;
+}
+
+#gradeable-info-due-dates {
+    text-align: right;
 }
 
 #submission-form > * {


### PR DESCRIPTION
Closes #5888 

### What is the current behavior?
When a user navigates to the submission page for a gradeable they will see the due date formatted for their local time zone.  Despite including a time zone identifier this was still confusing for some users.

### What is the new behavior?
On the submission page, if a user has their timezone set differently than the server timezone, they will see the due date formatted in both their local time and the servers time.

If a user has their timezone set to the same timezone as the server, they will see no changes on this page.

![image](https://user-images.githubusercontent.com/7605020/94041842-c62e4980-fd98-11ea-8749-36205ac155f1.png)
