### PR TITLE
[UI/UX:Submission] Remove h1 from notebook load message

### DIFF
--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -1,9 +1,4 @@
 <div class="content gradeable_message">
-    <header id="gradeable-info">
-        <h1>
-            Message for: {{ gradeable_name }}
-        </h1>
-    </header>
     <div>{{ load_gradeable_message | markdown }}</div>
     </div>
     <div class="content">


### PR DESCRIPTION
Leave all formatting to the markdown string configured by the instructor.