### PR TITLE
[Feature:Autograding] more control over autograding penalties

### DIFF
--- a/autograder/autograder/insert_database_version_data.py
+++ b/autograder/autograder/insert_database_version_data.py
@@ -46,13 +46,13 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
 
     if 'automatic_grading_total' in results.keys():
         automatic_grading_total = results["automatic_grading_total"]
-        nonhidden_automatic_grading_total = results["nonhidden_automatic_grading_total"]
+        # nonhidden_automatic_grading_total = results["nonhidden_automatic_grading_total"]
 
-        #hidden_diff    = automatic_grading_total - hidden_ec - hidden_non_ec
+        # hidden_diff    = automatic_grading_total - hidden_ec - hidden_non_ec
         nonhidden_diff = nonhidden_automatic_grading_total - non_hidden_ec - non_hidden_non_ec
 
         non_hidden_non_ec += nonhidden_diff
-        #hidden_non_ec += hidden_diff
+        # hidden_non_ec += hidden_diff
 
     db_name = f"submitty_{semester}_{course}"
 

--- a/autograder/autograder/insert_database_version_data.py
+++ b/autograder/autograder/insert_database_version_data.py
@@ -45,8 +45,8 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
     submission_time = results['submission_time']
 
     if 'automatic_grading_total' in results.keys():
-        automatic_grading_total = results["automatic_grading_total"]
-        # nonhidden_automatic_grading_total = results["nonhidden_automatic_grading_total"]
+        # automatic_grading_total = results["automatic_grading_total"]
+        nonhidden_automatic_grading_total = results["nonhidden_automatic_grading_total"]
 
         # hidden_diff    = automatic_grading_total - hidden_ec - hidden_non_ec
         nonhidden_diff = nonhidden_automatic_grading_total - non_hidden_ec - non_hidden_non_ec
@@ -216,7 +216,8 @@ def get_result_details(data_dir, semester, course, g_id, who_id, version):
             if 'automatic_grading_total' in result_json:
                 result_details['automatic_grading_total'] = result_json['automatic_grading_total']
             if 'nonhidden_automatic_grading_total' in result_json:
-                result_details['nonhidden_automatic_grading_total'] = result_json['nonhidden_automatic_grading_total']
+                result_details['nonhidden_automatic_grading_total'] =
+                    result_json['nonhidden_automatic_grading_total']
 
     if os.path.isfile(os.path.join(result_dir, "history.json")):
         with open(os.path.join(result_dir, "history.json")) as result_file:

--- a/autograder/autograder/insert_database_version_data.py
+++ b/autograder/autograder/insert_database_version_data.py
@@ -30,6 +30,7 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
 
     testcases = get_testcases(config, semester, course, gradeable_id)
     results = get_result_details(data_dir, semester, course, gradeable_id, who_id, version)
+
     if len(testcases) != len(results['testcases']):
         print(f"ERROR!  mismatched # of testcases {len(testcases)} != {len(results['testcases'])}")
     for i in range(len(testcases)):
@@ -42,6 +43,16 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
         else:
             non_hidden_non_ec += results['testcases'][i]['points']
     submission_time = results['submission_time']
+
+    if 'automatic_grading_total' in results.keys():
+        automatic_grading_total = results["automatic_grading_total"]
+        nonhidden_automatic_grading_total = results["nonhidden_automatic_grading_total"]
+
+        #hidden_diff    = automatic_grading_total - hidden_ec - hidden_non_ec
+        nonhidden_diff = nonhidden_automatic_grading_total - non_hidden_ec - non_hidden_non_ec
+
+        non_hidden_non_ec += nonhidden_diff
+        #hidden_non_ec += hidden_diff
 
     db_name = f"submitty_{semester}_{course}"
 
@@ -192,6 +203,7 @@ def get_result_details(data_dir, semester, course, g_id, who_id, version):
     :param version:
     :return:
     """
+
     result_details = {'testcases': [], 'submission_time': None}
     result_dir = os.path.join(data_dir, "courses", semester, course, "results", g_id, who_id,
                               str(version))
@@ -201,6 +213,10 @@ def get_result_details(data_dir, semester, course, g_id, who_id, version):
             if 'testcases' in result_json and result_json['testcases'] is not None:
                 for testcase in result_json['testcases']:
                     result_details['testcases'].append({'points': testcase['points_awarded']})
+            if 'automatic_grading_total' in result_json:
+                result_details['automatic_grading_total'] = result_json['automatic_grading_total']
+            if 'nonhidden_automatic_grading_total' in result_json:
+                result_details['nonhidden_automatic_grading_total'] = result_json['nonhidden_automatic_grading_total']
 
     if os.path.isfile(os.path.join(result_dir, "history.json")):
         with open(os.path.join(result_dir, "history.json")) as result_file:

--- a/autograder/autograder/insert_database_version_data.py
+++ b/autograder/autograder/insert_database_version_data.py
@@ -216,8 +216,8 @@ def get_result_details(data_dir, semester, course, g_id, who_id, version):
             if 'automatic_grading_total' in result_json:
                 result_details['automatic_grading_total'] = result_json['automatic_grading_total']
             if 'nonhidden_automatic_grading_total' in result_json:
-                result_details['nonhidden_automatic_grading_total'] =
-                    result_json['nonhidden_automatic_grading_total']
+                result_details['nonhidden_automatic_grading_total'] = \
+                   result_json['nonhidden_automatic_grading_total']
 
     if os.path.isfile(os.path.join(result_dir, "history.json")):
         with open(os.path.join(result_dir, "history.json")) as result_file:

--- a/grading/main_validator.cpp
+++ b/grading/main_validator.cpp
@@ -304,6 +304,7 @@ void ValidateATestCase(nlohmann::json config_json, int which_testcase,
                        int &automated_points_possible,
                        int &nonhidden_automated_points_awarded,
                        int &nonhidden_automated_points_possible,
+                       int &max_penalty_possible,
                        nlohmann::json &all_testcases,
                        std::ofstream& gradefile,
                        const std::string& username) {
@@ -382,6 +383,9 @@ void ValidateATestCase(nlohmann::json config_json, int which_testcase,
         nonhidden_automated_points_possible += possible_points;
       }
     }
+    if (possible_points < 0) {
+      max_penalty_possible += possible_points;
+    }
 
     // EXPORT TO results.json and grade.txt
     WriteToResultsJSON(
@@ -420,7 +424,8 @@ int validateTestCases(const std::string &hw_id, const std::string &rcsid, int su
   int automated_points_possible = 0;
   int nonhidden_automated_points_awarded = 0;
   int nonhidden_automated_points_possible = 0;
-
+  int max_penalty_possible = 0;
+  
   std::stringstream testcase_json;
   nlohmann::json all_testcases;
 
@@ -441,6 +446,7 @@ int validateTestCases(const std::string &hw_id, const std::string &rcsid, int su
                       automated_points_possible,
                       nonhidden_automated_points_awarded,
                       nonhidden_automated_points_possible,
+                      max_penalty_possible,
                       all_testcases,
                       gradefile,
                       rcsid);
@@ -450,7 +456,7 @@ int validateTestCases(const std::string &hw_id, const std::string &rcsid, int su
   int AUTO_POINTS         = grading_parameters.value("AUTO_POINTS",automated_points_possible);
   assert (AUTO_POINTS == automated_points_possible);
   int EXTRA_CREDIT_POINTS = grading_parameters.value("EXTRA_CREDIT_POINTS",0);
-  int PENALTY_POINTS = grading_parameters.value("PENALTY_POINTS",0);
+  int PENALTY_POINTS = grading_parameters.value("PENALTY_POINTS",max_penalty_possible);
 
   // clamp total to zero (no negative total!)
   automated_points_awarded = std::max(PENALTY_POINTS,automated_points_awarded);

--- a/grading/main_validator.cpp
+++ b/grading/main_validator.cpp
@@ -450,16 +450,19 @@ int validateTestCases(const std::string &hw_id, const std::string &rcsid, int su
   int AUTO_POINTS         = grading_parameters.value("AUTO_POINTS",automated_points_possible);
   assert (AUTO_POINTS == automated_points_possible);
   int EXTRA_CREDIT_POINTS = grading_parameters.value("EXTRA_CREDIT_POINTS",0);
+  int PENALTY_POINTS = grading_parameters.value("PENALTY_POINTS",0);
+
+  // clamp total to zero (no negative total!)
+  automated_points_awarded = std::max(PENALTY_POINTS,automated_points_awarded);
+  nonhidden_automated_points_awarded = std::max(PENALTY_POINTS,nonhidden_automated_points_awarded);
 
   // Generate results.json
   nlohmann::json sj;
   sj["testcases"] = all_testcases;
+  sj["automatic_grading_total"] = automated_points_awarded;
+  sj["nonhidden_automatic_grading_total"] = nonhidden_automated_points_awarded;
   std::ofstream json_file("results.json");
   json_file << sj.dump(4);
-
-  // clamp total to zero (no negative total!)
-  automated_points_awarded = std::max(0,automated_points_awarded);
-  nonhidden_automated_points_awarded = std::max(0,nonhidden_automated_points_awarded);
 
   // final line of results_grade.txt
   gradefile << std::setw(64) << std::left << "Automatic grading total:"

--- a/more_autograding_examples/cpp_hidden_tests/config/config.json
+++ b/more_autograding_examples/cpp_hidden_tests/config/config.json
@@ -1,7 +1,8 @@
 {
     "grading_parameters" : {
         "AUTO_POINTS" : 14,
-        "EXTRA_CREDIT_POINTS" : 4
+        "EXTRA_CREDIT_POINTS" : 4,
+        "PENALTY_POINTS" : 0  // lower clamp to zero points
     },
 
     "assignment_message" : "You are allowed 3 no penalty submissions.  You will lose 1 point for each 2 submissions beyond these non-penalty submissions.  The maximum penalty is -5 points.",

--- a/more_autograding_examples/notebook_time_limit/config/config.json
+++ b/more_autograding_examples/notebook_time_limit/config/config.json
@@ -1,4 +1,13 @@
 {
+
+    "load_gradeable_message" : {
+        "message" : "# This gradeable is TIMED  \n\
+After clicking continue, the quiz will start and you will have 10 minutes to complete the quiz.\n\
+        * Leaving the page does not stop the timer.\n\
+        * If you submit your answers more than 10 minutes after your first page access, you will lose 1 point per minute over the limit.",
+        "first_time_only" : false //true
+    },
+
     "assignment_message" : "#Welcome to a Timed Notebook Gradeable  \n\
   \n\
 Here's a short list of instructions:  \n\
@@ -14,12 +23,13 @@ Here's a short list of instructions:  \n\
         "submission_to_validation" : [ "*.txt", "*.png", ".user_assignment_access.json" ],
         "work_to_details" : [ "*.txt", "*.png", "test*/*.txt", "test*/*_diff.json" ]
     },
-    "load_gradeable_message" : {
-        "message" : "After clicking continue, the quiz will start and you will have 10 minutes to complete the quiz.\n\
-        * Leaving the page does not stop the timer.\n\
-        * If you submit your answers more than 10 minutes after your first page access, you will lose 1 point per minute over the limit.",
-        "first_time_only" : true
+
+    "grading_parameters" : {
+        "AUTO_POINTS" : 30,        // normal max positive points
+        "EXTRA_CEDIT_POINTS" : 0,  // additional extra credit
+        "PENALTY_POINTS" : -10     // lower clamp
     },
+
     "notebook" : [
         {
             "type": "markdown",

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1579,7 +1579,16 @@ class ElectronicGraderController extends AbstractController {
         $gradeable = $graded_gradeable->getGradeable();
 
         // If there is autograding, also send that information TODO: this should be restricted to non-peer
-        if ($gradeable->getAutogradingConfig()->anyPoints()) {
+        if (count($gradeable->getAutogradingConfig()->getTestCases()) > 1) {
+            // NOTE/REDESIGN FIXME: We might have autograding that is
+            // penalty only.  The available positive autograding
+            // points might be zero.  Testing for autograding > 1 is
+            // ignoring the submission limit test case... but this is
+            // also imperfect.  We want to render the column if any
+            // student has received the penalty.  But if no one has
+            // received the penalty maybe we omit it?  (expensive?/confusing?)
+            // See also note in ElectronicGraderView.php
+            // if ($gradeable->getAutogradingConfig()->anyPoints()) {
             $response_data['auto_grading_total'] = $gradeable->getAutogradingConfig()->getTotalNonExtraCredit();
 
             // Furthermore, if the user has a grade, send that information

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -457,7 +457,16 @@ HTML;
             if ($gradeable->isTaGrading()) {
                 $columns[]     = ["width" => "8%",  "title" => "Graded Questions", "function" => "graded_questions"];
             }
-            if ($gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() !== 0) {
+            // NOTE/REDESIGN FIXME: We might have autograding that is
+            // penalty only.  The available positive autograding
+            // points might be zero.  Testing for autograding > 1 is
+            // ignoring the submission limit test case... but this is
+            // also imperfect.  We want to render the column if any
+            // student has received the penalty.  But if no one has
+            // received the penalty maybe we omit it?  (expensive?/confusing?)
+            // See also note in ElectronicGradeController.php
+            if (count($gradeable->getAutogradingConfig()->getTestCases()) > 1) {
+                //if ($gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() !== 0) {
                 $columns[]     = ["width" => "15%", "title" => "Autograding",      "function" => "autograding_peer"];
                 $columns[]     = ["width" => "20%", "title" => "Manual Grading",          "function" => "grading_peer"];
                 $columns[]     = ["width" => "15%", "title" => "Total",            "function" => "total_peer"];
@@ -491,7 +500,9 @@ HTML;
                 $columns[]     = ["width" => "15%", "title" => "First Name",       "function" => "user_first", "sort_type" => "first"];
                 $columns[]     = ["width" => "15%", "title" => "Last Name",        "function" => "user_last", "sort_type" => "last"];
             }
-            if ($gradeable->getAutogradingConfig()->getTotalNonExtraCredit() !== 0) {
+            // NOTE/REDESIGN FIXME: Same note as above.
+            if (count($gradeable->getAutogradingConfig()->getTestCases()) > 1) {
+                //if ($gradeable->getAutogradingConfig()->getTotalNonExtraCredit() !== 0) {
                 $columns[]     = ["width" => "9%",  "title" => "Autograding",      "function" => "autograding"];
                 if ($gradeable->isTaGrading()) {
                     $columns[]     = ["width" => "8%",  "title" => "Graded Questions", "function" => "graded_questions"];

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_alternate
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_alternate
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 28,
+    "nonhidden_automatic_grading_total": 28,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_buggy
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 22,
+    "nonhidden_automatic_grading_total": 22,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_correct
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_correct
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 30,
+    "nonhidden_automatic_grading_total": 30,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_does_not_compile
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_does_not_compile
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/c_failure_messages/validation/results.json_hello_world
+++ b/tests/integrationTests/tests/c_failure_messages/validation/results.json_hello_world
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_c
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_c
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_cpp
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_cpp
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_python2
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_python2
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/choice_of_language/validation/results.json_python3
+++ b/tests/integrationTests/tests/choice_of_language/validation/results.json_python3
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_buggy_custom/validation/results.json_correct
+++ b/tests/integrationTests/tests/cpp_buggy_custom/validation/results.json_correct
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_allCorrect
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_allCorrect
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 25,
+    "nonhidden_automatic_grading_total": 25,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_columnSpacingOff
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_columnSpacingOff
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 15,
+    "nonhidden_automatic_grading_total": 15,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_extraLinesAtEnd
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_extraLinesAtEnd
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 13,
+    "nonhidden_automatic_grading_total": 13,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_extraSpacesAtEnd
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_extraSpacesAtEnd
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 9,
+    "nonhidden_automatic_grading_total": 9,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_frontSpacingOff
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_frontSpacingOff
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 12,
+    "nonhidden_automatic_grading_total": 12,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_lineOrderOff
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_lineOrderOff
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 9,
+    "nonhidden_automatic_grading_total": 9,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_spacingOff
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_spacingOff
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 8,
+    "nonhidden_automatic_grading_total": 8,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_cats/validation/results.json_spellingOff
+++ b/tests/integrationTests/tests/cpp_cats/validation/results.json_spellingOff
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_custom/validation/results.json_all_bugs
+++ b/tests/integrationTests/tests/cpp_custom/validation/results.json_all_bugs
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_custom/validation/results.json_correct
+++ b/tests/integrationTests/tests/cpp_custom/validation/results.json_correct
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 20,
+    "nonhidden_automatic_grading_total": 20,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_custom/validation/results.json_missing_label
+++ b/tests/integrationTests/tests/cpp_custom/validation/results.json_missing_label
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 15,
+    "nonhidden_automatic_grading_total": 15,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_custom/validation/results.json_not_random
+++ b/tests/integrationTests/tests/cpp_custom/validation/results.json_not_random
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 18,
+    "nonhidden_automatic_grading_total": 18,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_custom/validation/results.json_wrong_num
+++ b/tests/integrationTests/tests/cpp_custom/validation/results.json_wrong_num
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 17,
+    "nonhidden_automatic_grading_total": 17,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_custom/validation/results.json_wrong_total
+++ b/tests/integrationTests/tests/cpp_custom/validation/results.json_wrong_total
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 11,
+    "nonhidden_automatic_grading_total": 11,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_penalty5_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_penalty5_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/buggy_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 4,
+    "nonhidden_automatic_grading_total": 4,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_penalty1_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_penalty1_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 17,
+    "nonhidden_automatic_grading_total": 11,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_penalty2_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_penalty2_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 16,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_penalty5_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_penalty5_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 13,
+    "nonhidden_automatic_grading_total": 7,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/correct_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 18,
+    "nonhidden_automatic_grading_total": 12,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/hardcoded_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/hardcoded_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 12,
+    "nonhidden_automatic_grading_total": 12,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_hidden_tests/validation/noerrorchecking_results.json
+++ b/tests/integrationTests/tests/cpp_hidden_tests/validation/noerrorchecking_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 8,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/cpp_provided_code/validation/results.json_solution
+++ b/tests/integrationTests/tests/cpp_provided_code/validation/results.json_solution
@@ -1,5 +1,7 @@
 {
-    "testcases": [
+     "automatic_grading_total": 7,
+     "nonhidden_automatic_grading_total": 7,
+     "testcases": [
         {
             "points_awarded": 2,
             "test_name": "Test 1 Compilation"

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/buggy_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/buggy_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 15,
+    "nonhidden_automatic_grading_total": 15,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/compile_error_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/compile_error_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/extra_credit_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/extra_credit_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 24,
+    "nonhidden_automatic_grading_total": 24,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/full_credit_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/full_credit_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 22,
+    "nonhidden_automatic_grading_total": 22,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/missing_README_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/missing_README_results.json
@@ -1,4 +1,6 @@
 {
+     "automatic_grading_total": 20,
+    "nonhidden_automatic_grading_total": 20,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/cpp_simple_lab/validation/warning_results.json
+++ b/tests/integrationTests/tests/cpp_simple_lab/validation/warning_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 22,
+    "nonhidden_automatic_grading_total": 22,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/input_output_subdirectories/validation/results.json_buggy
+++ b/tests/integrationTests/tests/input_output_subdirectories/validation/results.json_buggy
@@ -1,5 +1,7 @@
 {
-    "testcases": [
+     "automatic_grading_total": 7,
+     "nonhidden_automatic_grading_total": 7,
+     "testcases": [
         {
             "points_awarded": 3,
             "test_name": "Test 1 Compilation"

--- a/tests/integrationTests/tests/input_output_subdirectories/validation/results.json_correct
+++ b/tests/integrationTests/tests/input_output_subdirectories/validation/results.json_correct
@@ -1,5 +1,7 @@
 {
-    "testcases": [
+     "automatic_grading_total": 18,
+     "nonhidden_automatic_grading_total": 18,
+     "testcases": [
         {
             "points_awarded": 3,
             "test_name": "Test 1 Compilation"

--- a/tests/integrationTests/tests/minimal_code_editing/validation/add_delete_lines_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/add_delete_lines_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/curly_brace_placement_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/curly_brace_placement_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/edits_neighboring_lines_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/edits_neighboring_lines_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/extra_spaces_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/extra_spaces_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/fancy_hello_world_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/fancy_hello_world_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/four_space_indent_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/four_space_indent_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 4,
+    "nonhidden_automatic_grading_total": 4,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/noise_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/noise_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/minimal_code_editing/validation/tabs_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/tabs_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/pdf_word_count/validation/just_right_results.json
+++ b/tests/integrationTests/tests/pdf_word_count/validation/just_right_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/pdf_word_count/validation/too_few_results.json
+++ b/tests/integrationTests/tests/pdf_word_count/validation/too_few_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/pdf_word_count/validation/too_many_results.json
+++ b/tests/integrationTests/tests/pdf_word_count/validation/too_many_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_all_bugs
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_all_bugs
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_correct
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_correct
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 20,
+    "nonhidden_automatic_grading_total": 20,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_missing_label
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_missing_label
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_not_random
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_not_random
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 18,
+    "nonhidden_automatic_grading_total": 18,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_wrong_num
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_wrong_num
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 14,
+    "nonhidden_automatic_grading_total": 14,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_wrong_total
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_wrong_total
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_buggy
+++ b/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 4,
+    "nonhidden_automatic_grading_total": 4,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_buggy2
+++ b/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_buggy2
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 3,
+    "nonhidden_automatic_grading_total": 3,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_buggy3
+++ b/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_buggy3
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_correct
+++ b/tests/integrationTests/tests/python_multipart_static_analysis/validation/results.json_correct
@@ -1,5 +1,7 @@
 {
-   "testcases": [
+    "automatic_grading_total": 9,
+    "nonhidden_automatic_grading_total": 9,
+    "testcases": [
         {
             "autochecks": [
                 {

--- a/tests/integrationTests/tests/python_simple_homework/validation/results.json_buggy
+++ b/tests/integrationTests/tests/python_simple_homework/validation/results.json_buggy
@@ -1,5 +1,7 @@
 {
-"testcases": [
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,     
+    "testcases": [
 		{
 			"test_name": "Test 1 Lab 1 Checkpoint 1",
 			"autochecks": [

--- a/tests/integrationTests/tests/python_simple_homework/validation/results.json_buggy2
+++ b/tests/integrationTests/tests/python_simple_homework/validation/results.json_buggy2
@@ -1,5 +1,7 @@
 {
-"testcases": [
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
+    "testcases": [
 		{
 			"test_name": "Test 1 Lab 1 Checkpoint 1",
 			"autochecks": [

--- a/tests/integrationTests/tests/python_simple_homework/validation/results.json_correct
+++ b/tests/integrationTests/tests/python_simple_homework/validation/results.json_correct
@@ -1,5 +1,7 @@
 {
-"testcases": [
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
+    "testcases": [
 		{
 			"test_name": "Test 1 Lab 1 Checkpoint 1",
 			"autochecks": [

--- a/tests/integrationTests/tests/python_simple_homework/validation/results.json_infinite_loop_time_cutoff
+++ b/tests/integrationTests/tests/python_simple_homework/validation/results.json_infinite_loop_time_cutoff
@@ -1,5 +1,7 @@
 {
-"testcases": [
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
+    "testcases": [
 		{
 			"test_name": "Test 1 Lab 1 Checkpoint 1",
 			"autochecks": [

--- a/tests/integrationTests/tests/python_simple_homework/validation/results.json_infinite_loop_too_much_output
+++ b/tests/integrationTests/tests/python_simple_homework/validation/results.json_infinite_loop_too_much_output
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/python_simple_homework/validation/results.json_syntax_error
+++ b/tests/integrationTests/tests/python_simple_homework/validation/results.json_syntax_error
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_01_simple_python/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_01_simple_python/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_01_simple_python/validation/results.json_solution
+++ b/tests/integrationTests/tests/tutorial_01_simple_python/validation/results.json_solution
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_02_simple_cpp/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_02_simple_cpp/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/tutorial_02_simple_cpp/validation/results.json_solution
+++ b/tests/integrationTests/tests/tutorial_02_simple_cpp/validation/results.json_solution
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 20,
+    "nonhidden_automatic_grading_total": 20,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy
@@ -1,6 +1,6 @@
 {
-    "automatic_grading_total": 0,
-    "nonhidden_automatic_grading_total": 0,
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy2
+++ b/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy2
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy2
+++ b/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_buggy2
@@ -1,6 +1,6 @@
 {
-    "automatic_grading_total": 1,
-    "nonhidden_automatic_grading_total": 1,
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_solution
+++ b/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_solution
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_wrong
+++ b/tests/integrationTests/tests/tutorial_03_multipart/validation/results.json_wrong
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 3,
+    "nonhidden_automatic_grading_total": 3,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_buggy2
+++ b/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_buggy2
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_buggy3
+++ b/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_buggy3
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_correct
+++ b/tests/integrationTests/tests/tutorial_04_python_static_analysis/validation/results.json_correct
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 4,
+    "nonhidden_automatic_grading_total": 4,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_06_loop_types/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_06_loop_types/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_06_loop_types/validation/results.json_solution
+++ b/tests/integrationTests/tests/tutorial_06_loop_types/validation/results.json_solution
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_07_loop_depth/validation/results.json_buggy
+++ b/tests/integrationTests/tests/tutorial_07_loop_depth/validation/results.json_buggy
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 0,
+    "nonhidden_automatic_grading_total": 0,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_07_loop_depth/validation/results.json_solution
+++ b/tests/integrationTests/tests/tutorial_07_loop_depth/validation/results.json_solution
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_09_java_testing/validation/buggy_results.json
+++ b/tests/integrationTests/tests/tutorial_09_java_testing/validation/buggy_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 12,
+    "nonhidden_automatic_grading_total": 12,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_09_java_testing/validation/correct_results.json
+++ b/tests/integrationTests/tests/tutorial_09_java_testing/validation/correct_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 20,
+    "nonhidden_automatic_grading_total": 20,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_09_java_testing/validation/does_not_compile_results.json
+++ b/tests/integrationTests/tests/tutorial_09_java_testing/validation/does_not_compile_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 1,
+    "nonhidden_automatic_grading_total": 1,
     "testcases": [
         {
             "autochecks": [

--- a/tests/integrationTests/tests/tutorial_09_java_testing/validation/still_buggy_results.json
+++ b/tests/integrationTests/tests/tutorial_09_java_testing/validation/still_buggy_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 8,
+    "nonhidden_automatic_grading_total": 8,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_10_java_coverage/validation/buggy_coverage_results.json
+++ b/tests/integrationTests/tests/tutorial_10_java_coverage/validation/buggy_coverage_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 9,
+    "nonhidden_automatic_grading_total": 9,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_10_java_coverage/validation/buggy_no_coverage_results.json
+++ b/tests/integrationTests/tests/tutorial_10_java_coverage/validation/buggy_no_coverage_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 11,
+    "nonhidden_automatic_grading_total": 11,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_10_java_coverage/validation/correct_no_coverage_results.json
+++ b/tests/integrationTests/tests/tutorial_10_java_coverage/validation/correct_no_coverage_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 11,
+    "nonhidden_automatic_grading_total": 11,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_10_java_coverage/validation/correct_results.json
+++ b/tests/integrationTests/tests/tutorial_10_java_coverage/validation/correct_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 20,
+    "nonhidden_automatic_grading_total": 20,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_11_resources/validation/buggy_results.json
+++ b/tests/integrationTests/tests/tutorial_11_resources/validation/buggy_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 5,
+    "nonhidden_automatic_grading_total": 5,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/tutorial_11_resources/validation/solution_results.json
+++ b/tests/integrationTests/tests/tutorial_11_resources/validation/solution_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 9,
+    "nonhidden_automatic_grading_total": 9,
     "testcases": [
         {
             "points_awarded": 5,

--- a/tests/integrationTests/tests/tutorial_12_system_calls/validation/no_fork_results.json
+++ b/tests/integrationTests/tests/tutorial_12_system_calls/validation/no_fork_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_12_system_calls/validation/parallel_fork_results.json
+++ b/tests/integrationTests/tests/tutorial_12_system_calls/validation/parallel_fork_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_12_system_calls/validation/serial_fork_results.json
+++ b/tests/integrationTests/tests/tutorial_12_system_calls/validation/serial_fork_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 10,
+    "nonhidden_automatic_grading_total": 10,
     "testcases": [
         {
             "points_awarded": 2,

--- a/tests/integrationTests/tests/tutorial_12_system_calls/validation/tree_fork_results.json
+++ b/tests/integrationTests/tests/tutorial_12_system_calls/validation/tree_fork_results.json
@@ -1,4 +1,6 @@
 {
+    "automatic_grading_total": 2,
+    "nonhidden_automatic_grading_total": 2,
     "testcases": [
         {
             "points_awarded": 2,


### PR DESCRIPTION

* negative total autograding and penalty autograding is now handled properly.

* results.json now includes fields for the cumulative hidden & nonhidden autograding totals.

* autograding now respects an optional field PENALTY_POINTS to do a lower bound clamp on the autograding total.   (by default, if omitted, the autograding penalty will not be clamped.)

* ta grading now displays autograding if there is more than 1 test case, even if its only penalty point test cases.  (Note: this is unsatisfactory.  the default submission limit test case
