### PR TITLE
[BugFix:Forum] Clear autosave data for empty forum reply boxes

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1931,15 +1931,19 @@ function autosaveKeyFor(replyBox) {
 
 function saveReplyBoxToLocal(replyBox) {
     const inputBox = $(replyBox).find("textarea.thread_post_content");
-    if (autosaveEnabled && inputBox.val()) {
-        const anonCheckbox = $(replyBox).find("input.thread-anon-checkbox");
-        const post = inputBox.val();
-        const isAnonymous = anonCheckbox.prop("checked");
-        localStorage.setItem(autosaveKeyFor(replyBox), JSON.stringify({
-            timestamp: Date.now(),
-            post,
-            isAnonymous
-        }));
+    if (autosaveEnabled) {
+        if (inputBox.val()) {
+            const anonCheckbox = $(replyBox).find("input.thread-anon-checkbox");
+            const post = inputBox.val();
+            const isAnonymous = anonCheckbox.prop("checked");
+            localStorage.setItem(autosaveKeyFor(replyBox), JSON.stringify({
+                timestamp: Date.now(),
+                post,
+                isAnonymous
+            }));
+        } else {
+            localStorage.removeItem(autosaveKeyFor(replyBox));
+        }
     }
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?

In the forum, if you type some text into a reply box, and the contents of the box are autosaved, and later you decide to clear out the text of that box, the old contents of the box will be shown the next time the page loads as the autosave data for that text box is not overwritten (due to a check to avoid polluting `localStorage` with a bunch of empty text box data).

### What is the new behavior?

When a forum reply box's data is about to be saved, if the reply box is empty, then its autosave data will be cleared from `localStorage` and a refresh will result in the reply box staying empty as intended.

### Other information?

Tested on Chrome.