### PR TITLE
[Bugfix:Submission] Resize Sequence Diagrams

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2058,7 +2058,7 @@ header > * {
     z-index: 999; /* Specify a stack order in case you're using a different order for other elements */
     cursor: pointer; /* Add a pointer on hover */
   }
-  
+
   @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
@@ -2085,4 +2085,8 @@ header > * {
   }
   .custom-file-input:active::before {
     background: -webkit-linear-gradient(top, #e3e3e3, #f9f9f9);
+  }
+
+  .mermaid-element {
+    width: 100%;
   }


### PR DESCRIPTION
Sequence diagrams sizes were never explicitly set. A previous change caused them to be rendered at very small scales. This PR explicitly sets sequence diagram sizes to 100% of their container's width.