### PR TITLE
[Bugfix:System] Stop install system from clobbering submitty conf files

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -484,8 +484,8 @@ EOF
         fi
     fi
 
-    cp ${SUBMITTY_REPOSITORY}/.setup/php-fpm/pool.d/submitty.conf /etc/php/${PHP_VERSION}/fpm/pool.d/submitty.conf
-    cp ${SUBMITTY_REPOSITORY}/.setup/apache/www-data /etc/apache2/suexec/www-data
+    cp -n ${SUBMITTY_REPOSITORY}/.setup/php-fpm/pool.d/submitty.conf /etc/php/${PHP_VERSION}/fpm/pool.d/submitty.conf
+    cp -n ${SUBMITTY_REPOSITORY}/.setup/apache/www-data /etc/apache2/suexec/www-data
     chmod 0640 /etc/apache2/suexec/www-data
 
 
@@ -494,7 +494,7 @@ EOF
     #################
     # remove default site which would cause server to mess up
     rm -f /etc/nginx/sites*/default
-    cp ${SUBMITTY_REPOSITORY}/.setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf
+    cp -n ${SUBMITTY_REPOSITORY}/.setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf
     chmod 644 /etc/nginx/sites-available/submitty.conf
     rm -f /etc/nginx/sites-enabled/submitty.conf
     ln -s /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf


### PR DESCRIPTION
On repeated calls to `install_system`, `php-fpm/pool.d/submitty.conf`, `apache2/suexec/www-data`, and `nginx/sites-available/submitty.conf` were being reset to their default state. This PR prevents this clobbering from happening.

I am opening this PR as a draft because  are a number of `sed` operations which are taken against `php/${PHP_VERSION}/fpm/php.ini` to replace default values with higher/submitty recommended ones. Because this is basically doing find/replace on low default values to increase them, I did not add special handling of the seds (e.g. do not perform them if a `fpm/php.ini` already exists). However, one of the sed operations does wipe out the `disable_functions` list and replace it with Submitty defaults.