### PR TITLE
[Feature:InstructorUI] Add additional notebook builder error checking

### DIFF
--- a/site/app/controllers/admin/NotebookBuilderController.php
+++ b/site/app/controllers/admin/NotebookBuilderController.php
@@ -20,8 +20,7 @@ class NotebookBuilderController extends AbstractController {
     /** @var string The groupname of the linux group who should own notebook builder files */
     private $expected_group;
 
-    public function __construct(\app\libraries\Core $core)
-    {
+    public function __construct(\app\libraries\Core $core) {
         parent::__construct($core);
 
         $this->expected_owner = $this->core->getConfig()->getPhpUser();

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -625,7 +625,7 @@ class FileUtils {
      * @param string $path Absolute path to file or directory
      * @param string|null $expected_owner Expected owner name of the file, or null to omit this check
      * @param string|null $expected_group Expected group name owner of the file, or null to omit this check
-     * @return array Empty array if no errors were detected or an error containing one or more error message strings if
+     * @return array Empty array if no errors were detected or an array containing one or more error message strings if
      *               errors were detected.
      */
     public static function checkForPermissionErrors(string $path, ?string $expected_owner, ?string $expected_group): array {

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -670,4 +670,30 @@ class FileUtils {
 
         return $results;
     }
+
+    /**
+     * Recursively traverse a directory structure starting at $dir.  The passed in $results array will be populated
+     * with the absolute path to each file or sub-directory.
+     *
+     * NOTE: Sub-directories are treated like files, and thus will be included as their own entries in the array.
+     *
+     * Credit:
+     * https://stackoverflow.com/questions/24783862/list-all-the-files-and-folders-in-a-directory-with-php-recursive-function
+     *
+     * @param string $dir The starting directory (not included in results)
+     * @param array $results An array passed by reference which will be populated
+     */
+    public static function getDirContents(string $dir, &$results = array()): void {
+        $files = scandir($dir);
+
+        foreach ($files as $key => $value) {
+            $path = realpath($dir . DIRECTORY_SEPARATOR . $value);
+            if (!is_dir($path)) {
+                $results[] = $path;
+            } else if ($value != "." && $value != "..") {
+                self::getDirContents($path, $results);
+                $results[] = $path;
+            }
+        }
+    }
 }

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -683,14 +683,15 @@ class FileUtils {
      * @param string $dir The starting directory (not included in results)
      * @param array $results An array passed by reference which will be populated
      */
-    public static function getDirContents(string $dir, &$results = array()): void {
+    public static function getDirContents(string $dir, &$results = []): void {
         $files = scandir($dir);
 
         foreach ($files as $key => $value) {
             $path = realpath($dir . DIRECTORY_SEPARATOR . $value);
             if (!is_dir($path)) {
                 $results[] = $path;
-            } else if ($value != "." && $value != "..") {
+            }
+            elseif ($value != "." && $value != "..") {
                 self::getDirContents($path, $results);
                 $results[] = $path;
             }

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -77,6 +77,7 @@ use app\libraries\FileUtils;
  * @method string getQueueAnnouncementMessage()
  * @method string getSubmittyInstallPath()
  * @method bool isDuckBannerEnabled()
+ * @method string getPhpUser()
  */
 
 class Config extends AbstractModel {
@@ -274,6 +275,9 @@ class Config extends AbstractModel {
     /** @prop @var DateTimeFormat */
     protected $date_time_format;
 
+    /** @prop @var string */
+    protected $php_user;
+
     /**
      * Config constructor.
      *
@@ -430,8 +434,12 @@ class Config extends AbstractModel {
         $this->latest_commit = $version_json['short_installed_commit'];
 
         $users_json = FileUtils::readJsonFile(FileUtils::joinPaths($this->config_path, 'submitty_users.json'));
-        if ($users_json !== false && isset($users_json['verified_submitty_admin_user'])) {
-            $this->verified_submitty_admin_user = $users_json['verified_submitty_admin_user'];
+        if ($users_json !== false) {
+            if (isset($users_json['verified_submitty_admin_user'])) {
+                $this->verified_submitty_admin_user = $users_json['verified_submitty_admin_user'];
+            }
+
+            $this->php_user = $users_json['php_user'];
         }
     }
 

--- a/site/public/js/notebook_builder/notebook-builder-utils.js
+++ b/site/public/js/notebook_builder/notebook-builder-utils.js
@@ -25,8 +25,12 @@ async function uploadFile(file, g_id, directory) {
         console.log(`Successfully uploaded ${file.name}.`);
     }
     else {
-        displayErrorMessage(`An error occurred uploading ${file.name}.`);
+        displayErrorMessage(`An error occurred uploading ${file.name}.  Check browser developer console for details.`);
         console.error(result.message);
+
+        if (result.data && Array.isArray(result.data)) {
+            result.data.forEach(msg => console.error(msg));
+        }
     }
 }
 

--- a/site/public/js/notebook_builder/widgets/form-options-widget.js
+++ b/site/public/js/notebook_builder/widgets/form-options-widget.js
@@ -83,6 +83,10 @@ class FormOptionsWidget extends Widget {
             }
             else {
                 this.appendStatusMessage(result.message);
+
+                if (result.data && Array.isArray(result.data)) {
+                    result.data.forEach(msg => this.appendStatusMessage(msg));
+                }
             }
         };
 

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -318,6 +318,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'latest_commit' => 'd150131c',
             'latest_tag' => 'v19.07.00',
             'verified_submitty_admin_user' => null,
+            'php_user' => null,
             'queue_enabled' => true,
             'queue_contact_info' => true,
             'queue_message' => '',


### PR DESCRIPTION
### What is the current behavior?
There is currently an issue with notebook builder not being able to correctly save/edit files in our production environment.

### What is the new behavior?
This PR adds additional error checking any time a notebook builder file is saved / edited / uploaded.  Error messages are now more verbose which will hopefully allow us to perform a more thorough debugging.

### Other information?
Tested by changing file permissions/ownership.  I used a PHP debugger to pause script execution, allowing me to manually change settings after file generation but before error checks ran.