### PR TITLE
[Bugfix:RainbowGrades] Fixes the accumulation of horizontal lines after reordering items while customising Rainbow Grades

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -122,8 +122,7 @@
                                     <div style="margin-top:10px">
                                         <ol style="list-style-type: none;" id="gradeables-list-{{ bucket }}">
                                             {% for gradeable in gradeables %}
-                                                <li><hr /></li>
-                                                <li class="gradeable-li">
+                                                <li class="gradeable-li pt-1" style="border-top: 1px solid #FFFFFF;">
                                                     <input type="text"
                                                            aria-label="{{gradeable["title"]}} max score"
                                                            value="{{ gradeable["max_score"] }}"


### PR DESCRIPTION
# Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #5908 . After reordering items while customising rainbow grades, horizontal lines would get accumulated, since each `<hr>` tag was in its own `<li>` tag, not linked to its "parent" `<li>` tag. Solved this problem by removing the `<hr>` tag altogether and giving each `<li>` tag a top-border.

### What is the new behavior?
The `<hr>` tags don't get accumulated anymore.
