### PR TITLE
[Bugfix:Autograding] empty gradeable access log

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1236,9 +1236,14 @@ def history_short_circuit_helper(
     if os.path.exists(user_assignment_access_path):
         with open(user_assignment_access_path) as fd:
             obj = json.load(fd, object_pairs_hook=collections.OrderedDict)
-        first_access = obj[0]['timestamp']
-        first_access_dt = dateutils.read_submitty_date(first_access)
-        access_duration = int((submit_timestamp - first_access_dt).total_seconds())
+        if len(obj) == 0:
+            # this can happen if the student never clicks on the page and the
+            # instructor makes a submission for the student
+            pass
+        else:
+            first_access = obj[0]['timestamp']
+            first_access_dt = dateutils.read_submitty_date(first_access)
+            access_duration = int((submit_timestamp - first_access_dt).total_seconds())
 
     return {
         'gradeable_deadline': gradeable_deadline,

--- a/more_autograding_examples/notebook_time_limit/config/custom_validation_code/timelimit.py
+++ b/more_autograding_examples/notebook_time_limit/config/custom_validation_code/timelimit.py
@@ -65,7 +65,14 @@ def do_the_grading():
   if os.path.exists(my_access_file):
     with open(my_access_file) as access_file:
       access = json.load(access_file)
-      first_access_timestamp_string = access[0]["timestamp"]
+      if len(access) == 0:
+        # this can happen if the student never clicks on the page and the
+        # instructor makes a submission for the student
+        return_result(score=0,
+                      message="ERROR!  empty access file for this student",
+                      status='failure')
+      else:
+        first_access_timestamp_string = access[0]["timestamp"]
   else:
     return_result(score=0,
                   message="ERROR!  access file does not exist",


### PR DESCRIPTION
If a student never accesses a gradeable page, but an instructor makes the submission for them,
there will be no information in the access log, and the .user_assignment_access.json for that
submission will be an empty array.

Previously this was crashing autograding, and jobs were getting stuck in the queue.

Now we gracefully ignore this situation in autograding.

Our sample autograder for the timelimit (which uses the access log) now also checks for this situation.
Currently the student with no access receives no penalty for time.  (This decision may need to be 
revisited/revised.)

Fixes #5935 