### PR TITLE
[Bugfix:InstructorUI] Fix "View Queue Stats" Button

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -29,6 +29,10 @@
 
   {% if not viewer.isGrader() %}
     {% include 'officeHoursQueue/QueueStatus.twig' %}
+      <br>
+      <a id="view-stats" class="btn btn-default filter_btn" href="{{base_url}}/stats">
+          View Queue Stats
+      </a>
   {% else %}
     {% include 'officeHoursQueue/QueueButtonBar.twig' %}
     {% include 'officeHoursQueue/CurrentQueue.twig' %}

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -108,7 +108,4 @@
     </form>
   </div>
 {% endif %}
-<br>
-<a id="view-stats" class="btn btn-default filter_btn" href="{{base_url}}/stats">
-  View Queue Stats
-</a>
+


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Every time an instructor/TA makes a change to a queue (Helps/Finishes Helping/Removes), the student sees an additional "View Queue Stats" button:
![image](https://user-images.githubusercontent.com/36799217/95795079-7d8eef80-0cb7-11eb-876b-9de6a174777b.png)

### What is the new behavior?
The student only sees one "View Queue Stats" button no matter how many times the instructor/TA interacts with the queue.