### PR TITLE
[TAGrading: Feature] Allow instructors to exempt files from peer view

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -198,6 +198,7 @@ CREATE TABLE public.electronic_gradeable (
     eg_thread_ids json DEFAULT '{}'::json NOT NULL,
     eg_has_discussion boolean DEFAULT false NOT NULL,
     eg_grade_inquiry_start_date timestamp(6) with time zone NOT NULL,
+    eg_hidden_files character varying(1024),
     CONSTRAINT eg_grade_inquiry_due_date_max CHECK ((eg_grade_inquiry_due_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
     CONSTRAINT eg_grade_inquiry_start_date_max CHECK ((eg_grade_inquiry_start_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
     CONSTRAINT eg_regrade_allowed_true CHECK (((eg_regrade_allowed IS TRUE) OR (eg_grade_inquiry_per_component_allowed IS FALSE))),
@@ -1050,12 +1051,6 @@ CREATE TABLE public.viewed_responses (
     thread_id integer NOT NULL,
     user_id character varying NOT NULL,
     "timestamp" timestamp with time zone NOT NULL
-);
-
-CREATE TABLE public.electronic_gradeable_hidden_files (
-    g_id character varying(255) NOT NULL,
-    file_wildcard character varying(255) NOT NULL,
-    lowest_access_group INTEGER NOT NULL DEFAULT 3
 );
 
 
@@ -2199,14 +2194,6 @@ ALTER TABLE ONLY public.gradeable_access
 --
 ALTER TABLE ONLY public.gradeable_access
     ADD CONSTRAINT gradeable_access_fk3 FOREIGN KEY (accessor_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
---
--- Name: gradeable_access gradeable_access_fk2; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-ALTER TABLE ONLY public.electronic_gradeable_hidden_files
-    ADD CONSTRAINT electronic_gradeable_hidden_files_pk PRIMARY KEY (g_id, file_wildcard);
-
-ALTER TABLE ONLY public.electronic_gradeable_hidden_files
-    ADD CONSTRAINT electronic_gradeable_hidden_files_fk FOREIGN KEY (g_id) REFERENCES public.electronic_gradeable(g_id) ON DELETE CASCADE;
 --
 -- PostgreSQL database dump complete
 --

--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -1055,7 +1055,7 @@ CREATE TABLE public.viewed_responses (
 CREATE TABLE public.electronic_gradeable_hidden_files (
     g_id character varying(255) NOT NULL,
     file_wildcard character varying(255) NOT NULL,
-    lowest_access_group INTEGER NOT NULL DEFAULT 3,
+    lowest_access_group INTEGER NOT NULL DEFAULT 3
 );
 
 

--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -1052,6 +1052,12 @@ CREATE TABLE public.viewed_responses (
     "timestamp" timestamp with time zone NOT NULL
 );
 
+CREATE TABLE public.electronic_gradeable_hidden_files (
+    g_id character varying(255) NOT NULL,
+    file_wildcard character varying(255) NOT NULL,
+    lowest_access_group INTEGER NOT NULL DEFAULT 3,
+);
+
 
 --
 -- Name: categories_list category_id; Type: DEFAULT; Schema: public; Owner: -
@@ -2193,9 +2199,14 @@ ALTER TABLE ONLY public.gradeable_access
 --
 ALTER TABLE ONLY public.gradeable_access
     ADD CONSTRAINT gradeable_access_fk3 FOREIGN KEY (accessor_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+--
+-- Name: gradeable_access gradeable_access_fk2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+ALTER TABLE ONLY public.electronic_gradeable_hidden_files
+    ADD CONSTRAINT electronic_gradeable_hidden_files_pk PRIMARY KEY (g_id, file_wildcard);
 
-
-
+ALTER TABLE ONLY public.electronic_gradeable_hidden_files
+    ADD CONSTRAINT electronic_gradeable_hidden_files_fk FOREIGN KEY (g_id) REFERENCES public.electronic_gradeable(g_id) ON DELETE CASCADE;
 --
 -- PostgreSQL database dump complete
 --

--- a/migration/migrator/migrations/course/20201012030252_omit_files.py
+++ b/migration/migrator/migrations/course/20201012030252_omit_files.py
@@ -1,9 +1,5 @@
 def up(config, database, semester, course):
-    database.execute("""CREATE TABLE IF NOT EXISTS electronic_gradeable_hidden_files (g_id character varying(255) NOT NULL,
-     file_wildcard character varying(255) NOT NULL, 
-     lowest_access_group INTEGER NOT NULL DEFAULT 3, 
-     CONSTRAINT electronic_gradeable_hidden_files_pk PRIMARY KEY (g_id, file_wildcard), 
-     CONSTRAINT electronic_gradeable_hidden_files_fk FOREIGN KEY (g_id) REFERENCES electronic_gradeable(g_id) ON DELETE CASCADE);""")
+    database.execute("""ALTER TABLE electronic_gradeable ADD eg_hidden_files character varying(1024);""")
 
 def down(config, database, semester, course):
-	pass
+	database.execute("""ALTER TABLE electronic_gradeable DROP COLUMN eg_hidden_files;""")

--- a/migration/migrator/migrations/course/20201012030252_omit_files.py
+++ b/migration/migrator/migrations/course/20201012030252_omit_files.py
@@ -2,5 +2,6 @@ def up(config, database, semester, course):
     database.execute("""ALTER TABLE electronic_gradeable ADD eg_hidden_files character varying(1024);""")
 
 def down(config, database, semester, course):
-	database.execute("""DROP TABLE electronic_gradeable_hidden_files;""")
-	database.execute("""ALTER TABLE electronic_gradeable DROP COLUMN eg_hidden_files;""")
+	#database.execute("""DROP TABLE electronic_gradeable_hidden_files;""")
+	#database.execute("""ALTER TABLE electronic_gradeable DROP COLUMN eg_hidden_files;""")
+	pass

--- a/migration/migrator/migrations/course/20201012030252_omit_files.py
+++ b/migration/migrator/migrations/course/20201012030252_omit_files.py
@@ -2,4 +2,5 @@ def up(config, database, semester, course):
     database.execute("""ALTER TABLE electronic_gradeable ADD eg_hidden_files character varying(1024);""")
 
 def down(config, database, semester, course):
+	database.execute("""DROP TABLE electronic_gradeable_hidden_files;""")
 	database.execute("""ALTER TABLE electronic_gradeable DROP COLUMN eg_hidden_files;""")

--- a/migration/migrator/migrations/course/20201012030252_omit_files.py
+++ b/migration/migrator/migrations/course/20201012030252_omit_files.py
@@ -1,0 +1,7 @@
+def up(config, database, semester, course):
+    database.execute("CREATE TABLE electronic_gradeable_hidden_files (g_id character varying(255) NOT NULL, file_wildcard character varying(255) NOT NULL, lowest_access_group INTEGER NOT NULL DEFAULT 3);")
+    database.execute("ALTER TABLE ONLY electronic_gradeable_hidden_files ADD CONSTRAINT electronic_gradeable_hidden_files_pk PRIMARY KEY (g_id, file_wildcard);")
+    database.execute("ALTER TABLE ONLY electronic_gradeable_hidden_files ADD CONSTRAINT electronic_gradeable_hidden_files_fk FOREIGN KEY (g_id) REFERENCES electronic_gradeable(g_id) ON DELETE CASCADE;")
+
+def down(config, database, semester, course):
+	pass

--- a/migration/migrator/migrations/course/20201012030252_omit_files.py
+++ b/migration/migrator/migrations/course/20201012030252_omit_files.py
@@ -1,7 +1,7 @@
 def up(config, database, semester, course):
     database.execute("""ALTER TABLE electronic_gradeable ADD eg_hidden_files character varying(1024);""")
+    pass
 
 def down(config, database, semester, course):
-	#database.execute("""DROP TABLE electronic_gradeable_hidden_files;""")
-	#database.execute("""ALTER TABLE electronic_gradeable DROP COLUMN eg_hidden_files;""")
+	database.execute("""ALTER TABLE electronic_gradeable DROP COLUMN eg_hidden_files;""")
 	pass

--- a/migration/migrator/migrations/course/20201012030252_omit_files.py
+++ b/migration/migrator/migrations/course/20201012030252_omit_files.py
@@ -1,7 +1,9 @@
 def up(config, database, semester, course):
-    database.execute("CREATE TABLE electronic_gradeable_hidden_files (g_id character varying(255) NOT NULL, file_wildcard character varying(255) NOT NULL, lowest_access_group INTEGER NOT NULL DEFAULT 3);")
-    database.execute("ALTER TABLE ONLY electronic_gradeable_hidden_files ADD CONSTRAINT electronic_gradeable_hidden_files_pk PRIMARY KEY (g_id, file_wildcard);")
-    database.execute("ALTER TABLE ONLY electronic_gradeable_hidden_files ADD CONSTRAINT electronic_gradeable_hidden_files_fk FOREIGN KEY (g_id) REFERENCES electronic_gradeable(g_id) ON DELETE CASCADE;")
+    database.execute("""CREATE TABLE IF NOT EXISTS electronic_gradeable_hidden_files (g_id character varying(255) NOT NULL,
+     file_wildcard character varying(255) NOT NULL, 
+     lowest_access_group INTEGER NOT NULL DEFAULT 3, 
+     CONSTRAINT electronic_gradeable_hidden_files_pk PRIMARY KEY (g_id, file_wildcard), 
+     CONSTRAINT electronic_gradeable_hidden_files_fk FOREIGN KEY (g_id) REFERENCES electronic_gradeable(g_id) ON DELETE CASCADE);""")
 
 def down(config, database, semester, course):
 	pass

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -267,7 +267,7 @@ class AdminGradeableController extends AbstractController {
             'peer' => $gradeable->isPeerGrading(),
             'peer_grader_pairs' => $this->core->getQueries()->getPeerGradingAssignment($gradeable->getId()),
             'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()]),
-            'hidden_files' => $this->core->getQueries()->getOmmitedFiles($gradeable->getId())
+            'hidden_files' => implode(",",array_keys($gradeable->getHiddenFiles()))
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
@@ -1130,11 +1130,12 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
-        if (isset($details["files_to_omit"])) {
+        if (isset($details["hidden_files"])) {
             $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
-            foreach (explode(',', $details["files_to_omit"]) as $file_name) {
-                $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
+            foreach (explode(',', $details["hidden_files"]) as $file_name) {
+                $this->core->getQueries()->insertOmittedFiles($gradeable, $file_name, 3);
             }
+            $gradeable->setHiddenFiles($details["hidden_files"]);
         }
 
         // Be strict.  Only apply database changes if there were no errors

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1130,7 +1130,7 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
-        if(isset($details["files_to_omit"])){
+        if (isset($details["files_to_omit"])) {
             $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
             foreach (explode(',', $details["files_to_omit"]) as $file_name) {
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -222,7 +222,6 @@ class AdminGradeableController extends AbstractController {
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         $this->core->getOutput()->addInternalJs('admin-gradeable-updates.js');
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
-
         $this->core->getOutput()->renderTwigOutput('admin/admin_gradeable/AdminGradeableBase.twig', [
             'gradeable' => $gradeable,
             'action' => 'edit',

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1130,14 +1130,10 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
-        echo("sdfsdf!");
         if(isset($details["files_to_omit"])){
             $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
-            echo("CHECsdfK!");
             foreach (explode(':', $details["files_to_omit"]) as $file_name) {
-                echo("CHECK!");
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
-                echo($this->core->getQueries()->getOmmitedFiles($gradeable->getId()));
             }
         }
 
@@ -1145,7 +1141,7 @@ class AdminGradeableController extends AbstractController {
         if (count($errors) !== 0) {
             throw new ValidationException('', $errors);
         }
-        #$this->core->getQueries()->updateGradeable($gradeable);
+        $this->core->getQueries()->updateGradeable($gradeable);
 
         // Only return updated properties if the changes were applied
         return $updated_properties;

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -266,7 +266,8 @@ class AdminGradeableController extends AbstractController {
             'csrf_token' => $this->core->getCsrfToken(),
             'peer' => $gradeable->isPeerGrading(),
             'peer_grader_pairs' => $this->core->getQueries()->getPeerGradingAssignment($gradeable->getId()),
-            'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()])
+            'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()]),
+            'hidden_files' => $this->core->getQueries()->getOmmitedFiles($gradeable->getId())
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
@@ -1129,11 +1130,14 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
-        
+        echo("sdfsdf!");
         if(isset($details["files_to_omit"])){
-            $this->core->getQueries()->deleteOmittedFiles($gradeable_id);
-            foreach ($details["files_to_omit"].split(":") as $file_name) {
+            $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
+            echo("CHECsdfK!");
+            foreach (explode(':', $details["files_to_omit"]) as $file_name) {
+                echo("CHECK!");
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
+                echo($this->core->getQueries()->getOmmitedFiles($gradeable->getId()));
             }
         }
 
@@ -1141,7 +1145,7 @@ class AdminGradeableController extends AbstractController {
         if (count($errors) !== 0) {
             throw new ValidationException('', $errors);
         }
-        $this->core->getQueries()->updateGradeable($gradeable);
+        #$this->core->getQueries()->updateGradeable($gradeable);
 
         // Only return updated properties if the changes were applied
         return $updated_properties;

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1129,6 +1129,13 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
+        
+        if(isset($details["files_to_omit"])){
+            $this->core->getQueries()->deleteOmittedFiles($gradeable_id)
+            foreach ($details["files_to_omit"].split(":") as $file_name) {
+                $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
+            }
+        }
 
         // Be strict.  Only apply database changes if there were no errors
         if (count($errors) !== 0) {

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -222,7 +222,6 @@ class AdminGradeableController extends AbstractController {
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         $this->core->getOutput()->addInternalJs('admin-gradeable-updates.js');
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
-
         $this->core->getOutput()->renderTwigOutput('admin/admin_gradeable/AdminGradeableBase.twig', [
             'gradeable' => $gradeable,
             'action' => 'edit',
@@ -267,7 +266,7 @@ class AdminGradeableController extends AbstractController {
             'peer' => $gradeable->isPeerGrading(),
             'peer_grader_pairs' => $this->core->getQueries()->getPeerGradingAssignment($gradeable->getId()),
             'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()]),
-            'hidden_files' => implode(",", array_keys($gradeable->getHiddenFiles()))
+            'hidden_files' => $gradeable->getHiddenFiles()
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
@@ -913,7 +912,7 @@ class AdminGradeableController extends AbstractController {
                 'peer_grading' => false,
                 'peer_grade_set' => 0,
                 'late_submission_allowed' => true,
-                'hidden_files' => []
+                'hidden_files' => ""
             ]);
         }
         else {
@@ -929,7 +928,7 @@ class AdminGradeableController extends AbstractController {
                 'peer_grade_set' => 0,
                 'late_submission_allowed' => true,
                 'has_due_date' => false,
-                'hidden_files' => []
+                'hidden_files' => ""
             ]);
         }
 
@@ -1138,7 +1137,6 @@ class AdminGradeableController extends AbstractController {
             throw new ValidationException('', $errors);
         }
         $this->core->getQueries()->updateGradeable($gradeable);
-
         // Only return updated properties if the changes were applied
         return $updated_properties;
     }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -222,6 +222,7 @@ class AdminGradeableController extends AbstractController {
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         $this->core->getOutput()->addInternalJs('admin-gradeable-updates.js');
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
+
         $this->core->getOutput()->renderTwigOutput('admin/admin_gradeable/AdminGradeableBase.twig', [
             'gradeable' => $gradeable,
             'action' => 'edit',
@@ -266,7 +267,7 @@ class AdminGradeableController extends AbstractController {
             'peer' => $gradeable->isPeerGrading(),
             'peer_grader_pairs' => $this->core->getQueries()->getPeerGradingAssignment($gradeable->getId()),
             'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()]),
-            'hidden_files' => implode(",", array_keys($this->core->getQueries()->getOmmitedFiles($gradeable->getId())))
+            'hidden_files' => implode(",", array_keys($gradeable->getHiddenFiles()))
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
@@ -911,7 +912,8 @@ class AdminGradeableController extends AbstractController {
                 // TODO: properties that aren't supported yet
                 'peer_grading' => false,
                 'peer_grade_set' => 0,
-                'late_submission_allowed' => true
+                'late_submission_allowed' => true,
+                'hidden_files' => []
             ]);
         }
         else {
@@ -927,6 +929,7 @@ class AdminGradeableController extends AbstractController {
                 'peer_grade_set' => 0,
                 'late_submission_allowed' => true,
                 'has_due_date' => false,
+                'hidden_files' => []
             ]);
         }
 
@@ -1128,13 +1131,6 @@ class AdminGradeableController extends AbstractController {
             else {
                 $updated_properties[] = 'rebuild_queued';
             }
-        }
-        if (isset($details["hidden_files"])) {
-            $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
-            foreach (explode(',', $details["hidden_files"]) as $file_name) {
-                $this->core->getQueries()->insertOmittedFiles($gradeable, $file_name, 3);
-            }
-            $gradeable->setHiddenFiles($details["hidden_files"]);
         }
 
         // Be strict.  Only apply database changes if there were no errors

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1130,9 +1130,9 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
-        if (isset($details["files_to_omit"])) {
+        if (isset($details["files-to-omit"])) {
             $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
-            foreach (explode(',', $details["files_to_omit"]) as $file_name) {
+            foreach (explode(',', $details["files-to-omit"]) as $file_name) {
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
             }
         }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1131,7 +1131,7 @@ class AdminGradeableController extends AbstractController {
         }
         
         if(isset($details["files_to_omit"])){
-            $this->core->getQueries()->deleteOmittedFiles($gradeable_id)
+            $this->core->getQueries()->deleteOmittedFiles($gradeable_id);
             foreach ($details["files_to_omit"].split(":") as $file_name) {
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
             }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1132,7 +1132,7 @@ class AdminGradeableController extends AbstractController {
         }
         if(isset($details["files_to_omit"])){
             $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
-            foreach (explode(':', $details["files_to_omit"]) as $file_name) {
+            foreach (explode(',', $details["files_to_omit"]) as $file_name) {
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
             }
         }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -266,7 +266,7 @@ class AdminGradeableController extends AbstractController {
             'peer' => $gradeable->isPeerGrading(),
             'peer_grader_pairs' => $this->core->getQueries()->getPeerGradingAssignment($gradeable->getId()),
             'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()]),
-            'hidden_files' => implode(",",array_keys($this->core->getQueries()->getOmmitedFiles($gradeable->getId())))
+            'hidden_files' => implode(",", array_keys($this->core->getQueries()->getOmmitedFiles($gradeable->getId())))
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -912,7 +912,7 @@ class AdminGradeableController extends AbstractController {
                 'peer_grading' => false,
                 'peer_grade_set' => 0,
                 'late_submission_allowed' => true,
-                'hidden_files' => ""
+                'hidden_files' => "",
                 'limited_access_blind' => 1,
                 'peer_blind' => 3
             ]);

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1130,9 +1130,9 @@ class AdminGradeableController extends AbstractController {
                 $updated_properties[] = 'rebuild_queued';
             }
         }
-        if (isset($details["files-to-omit"])) {
+        if (isset($details["files_to_omit"])) {
             $this->core->getQueries()->deleteOmittedFiles($gradeable->getId());
-            foreach (explode(',', $details["files-to-omit"]) as $file_name) {
+            foreach (explode(',', $details["files_to_omit"]) as $file_name) {
                 $this->core->getQueries()->insertOmittedFiles($gradeable->getId(), $file_name, 4);
             }
         }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -266,7 +266,7 @@ class AdminGradeableController extends AbstractController {
             'peer' => $gradeable->isPeerGrading(),
             'peer_grader_pairs' => $this->core->getQueries()->getPeerGradingAssignment($gradeable->getId()),
             'notebook_builder_url' => $this->core->buildCourseUrl(['notebook_builder', $gradeable->getId()]),
-            'hidden_files' => implode(",",array_keys($gradeable->getHiddenFiles()))
+            'hidden_files' => implode(",",array_keys($this->core->getQueries()->getOmmitedFiles($gradeable->getId())))
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -765,7 +765,7 @@ class Access {
                     else {
                         $args["gradeable"] = $this->core->getQueries()->getGradeableConfig($value);
                     }
-                    $hidden_files = $args["gradeable"]->getHiddenFiles();
+                    $hidden_files = $this->core->getQueries()->getOmmitedFiles($args["gradeable"]->getId());
                     foreach ($hidden_files as $file_regex => $lowest_access_group) {
                         if (fnmatch($file_regex, $subpart_values[count($subpart_values)-1]) and $this->core->getUser()->getGroup() > $lowest_access_group) {
                             return false;

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -747,8 +747,7 @@ class Access {
 
         //To array of [type, value]
         $subparts = array_combine($subpart_types, $subpart_values);
-
-        //So we can extract parameters from the path
+        //So we can extract parameters from the path 
         foreach ($subpart_types as $type) {
             $value = $subparts[$type];
             switch ($type) {
@@ -765,6 +764,12 @@ class Access {
                     }
                     else {
                         $args["gradeable"] = $this->core->getQueries()->getGradeableConfig($value);
+                    }
+                    $hidden_files = $this->core->getQueries()->getOmmitedFiles($args["gradeable"]->getId());
+                    foreach ($hidden_files as $file_regex => $lowest_access_group) {
+                        if (fnmatch($file_regex, $subpart_values[count($subpart_values)-1]) and $this->core->getUser()->getGroup() > $lowest_access_group) {
+                            return false;
+                        }
                     }
                     break;
                 case "submitter":

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -747,6 +747,7 @@ class Access {
 
         //To array of [type, value]
         $subparts = array_combine($subpart_types, $subpart_values);
+
         //So we can extract parameters from the path
         foreach ($subpart_types as $type) {
             $value = $subparts[$type];
@@ -765,9 +766,9 @@ class Access {
                     else {
                         $args["gradeable"] = $this->core->getQueries()->getGradeableConfig($value);
                     }
-                    $hidden_files = $this->core->getQueries()->getOmmitedFiles($args["gradeable"]->getId());
-                    foreach ($hidden_files as $file_regex => $lowest_access_group) {
-                        if (fnmatch($file_regex, $subpart_values[count($subpart_values) - 1]) && $this->core->getUser()->getGroup() > $lowest_access_group) {
+                    $hidden_files = $args["gradeable"]->getHiddenFiles();
+                    foreach ($hidden_files as $file_regex) {
+                        if (fnmatch($file_regex, $subpart_values[count($subpart_values) - 1]) && $this->core->getUser()->getGroup() > 3) {
                             return false;
                         }
                     }

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -765,7 +765,7 @@ class Access {
                     else {
                         $args["gradeable"] = $this->core->getQueries()->getGradeableConfig($value);
                     }
-                    $hidden_files = $this->core->getQueries()->getOmmitedFiles($args["gradeable"]->getId());
+                    $hidden_files = $args["gradeable"]->getHiddenFiles();
                     foreach ($hidden_files as $file_regex => $lowest_access_group) {
                         if (fnmatch($file_regex, $subpart_values[count($subpart_values)-1]) and $this->core->getUser()->getGroup() > $lowest_access_group) {
                             return false;

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -747,7 +747,7 @@ class Access {
 
         //To array of [type, value]
         $subparts = array_combine($subpart_types, $subpart_values);
-        //So we can extract parameters from the path 
+        //So we can extract parameters from the path
         foreach ($subpart_types as $type) {
             $value = $subparts[$type];
             switch ($type) {
@@ -767,7 +767,7 @@ class Access {
                     }
                     $hidden_files = $this->core->getQueries()->getOmmitedFiles($args["gradeable"]->getId());
                     foreach ($hidden_files as $file_regex => $lowest_access_group) {
-                        if (fnmatch($file_regex, $subpart_values[count($subpart_values)-1]) and $this->core->getUser()->getGroup() > $lowest_access_group) {
+                        if (fnmatch($file_regex, $subpart_values[count($subpart_values) - 1]) && $this->core->getUser()->getGroup() > $lowest_access_group) {
                             return false;
                         }
                     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1673,63 +1673,6 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         }
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
-    
-    /**
-     * Inserts a set of ommitted file wildcards for a gradeable
-     *
-     * @param  Gradeable $gradeable
-     * @param  string $file_name
-     * @param  int $lowest_allowed
-     */
-    
-    public function insertOmittedFiles(Gradeable $gradeable, string $file_name, int $lowest_allowed) {
-        $params = [$gradeable->getId(), $file_name, $lowest_allowed];
-        $this->course_db->query(
-            "
-            INSERT INTO electronic_gradeable_hidden_files (g_id, file_wildcard, lowest_access_group)
-            VALUES (?, ?, ?)
-            ",
-            $params
-        );
-    }
-    
-    /**
-     * Delete all ommitted file wildcards for a gradeable
-     *
-     * @param  string $gradeable_id
-     */
-    
-    public function deleteOmittedFiles(string $gradeable_id) {
-        $params = [$gradeable_id];
-        $this->course_db->query(
-            "
-            DELETE FROM electronic_gradeable_hidden_files WHERE g_id = ?;
-            ",
-            $params
-        );
-    }
-    
-    /**
-     * Get all ommitted file wildcards for a gradeable
-     *
-     * @param  string $gradeable_id
-     */
-    
-    public function getOmmitedFiles(string $gradeable_id) {
-        $params = [$gradeable_id];
-        $return = [];
-        $this->course_db->query(
-            "
-            SELECT file_wildcard, lowest_access_group FROM electronic_gradeable_hidden_files WHERE g_id = ?;
-            ",
-            $params
-        );
-        $return;
-        foreach ($this->course_db->rows() as $row) {
-            $return[$row["file_wildcard"]] = $row["lowest_access_group"];
-        }
-        return $return;
-    }
 
     public function getNumUsersWhoViewedGradeBySections($gradeable, $sections) {
         $table = $gradeable->isTeamAssignment() ? 'gradeable_teams' : 'users';
@@ -5182,6 +5125,7 @@ AND gc_id IN (
                     $gradeable->isGradeInquiryPerComponentAllowed(),
                     $gradeable->getDiscussionThreadId(),
                     $gradeable->isDiscussionBased(),
+                    $gradeable->getHiddenFiles(),
                     $gradeable->getId()
                 ];
                 $this->course_db->query(
@@ -5210,7 +5154,8 @@ AND gc_id IN (
                       eg_regrade_allowed=?,
                       eg_grade_inquiry_per_component_allowed=?,
                       eg_thread_ids=?,
-                      eg_has_discussion=?
+                      eg_has_discussion=?,
+                      eg_hidden_files=?
                     WHERE g_id=?",
                     $params
                 );

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1675,24 +1675,44 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     }
     
     public function insertOmittedFiles($gradeable_id, $file_name, $lowest_allowed){
-        $params = [$gradeable_id];
+        $params = [$gradeable_id, $file_name, $lowest_allowed];
         $this->course_db->query(
             "
-            INSERT INTO electronic_gradeable_hidden_files
-            VALUES ($gradeable_id, $file_name, $lowest_allowed)
+            INSERT INTO electronic_gradeable_hidden_files (g_id, file_wildcard, lowest_access_group)
+            VALUES (?, ?, ?)
             ",
             $params
         );
     }
     
     public function deleteOmittedFiles($gradeable_id){
-        $params = [$gradeable_id, $file_name, $lowest_allowed];
+        $params = [$gradeable_id];
         $this->course_db->query(
             "
-            DELETE FROM table_name WHERE g_id = $gradeable_id;
+            DELETE FROM electronic_gradeable_hidden_files WHERE g_id = ?;
             ",
             $params
         );
+    }
+    
+    public function getOmmitedFiles($gradeable_id){
+        $params = [$gradeable_id];
+        $this->course_db->query(
+            "
+            SELECT file_wildcard FROM electronic_gradeable_hidden_files WHERE g_id = ?;
+            ",
+            $params
+        );
+        $hidden_files = "";
+        foreach ($this->course_db->rows() as $row) {
+            if($hidden_files !== ""){
+                $hidden_files = $hidden_files . ":" . $row["file_wildcard"];
+            }
+            else{
+                $hidden_files = $row["file_wildcard"];
+            }
+        }
+        return ($hidden_files);
     }
 
     public function getNumUsersWhoViewedGradeBySections($gradeable, $sections) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1706,7 +1706,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         $hidden_files = "";
         foreach ($this->course_db->rows() as $row) {
             if($hidden_files !== ""){
-                $hidden_files = $hidden_files . ":" . $row["file_wildcard"];
+                $hidden_files = $hidden_files . "," . $row["file_wildcard"];
             }
             else{
                 $hidden_files = $row["file_wildcard"];

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1677,7 +1677,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     /**
      * Inserts a set of ommitted file wildcards for a gradeable
      *
-     * @param  Gradeable $gradeable_id
+     * @param  Gradeable $gradeable
      * @param  string $file_name
      * @param  int $lowest_allowed
      */

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1677,13 +1677,13 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     /**
      * Inserts a set of ommitted file wildcards for a gradeable
      *
-     * @param  string $gradeable_id
+     * @param  Gradeable $gradeable_id
      * @param  string $file_name
      * @param  int $lowest_allowed
      */
     
-    public function insertOmittedFiles(string $gradeable_id, string $file_name, int $lowest_allowed) {
-        $params = [$gradeable_id, $file_name, $lowest_allowed];
+    public function insertOmittedFiles(Gradeable $gradeable, string $file_name, int $lowest_allowed) {
+        $params = [$gradeable->getId(), $file_name, $lowest_allowed];
         $this->course_db->query(
             "
             INSERT INTO electronic_gradeable_hidden_files (g_id, file_wildcard, lowest_access_group)
@@ -1717,22 +1717,18 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
     
     public function getOmmitedFiles(string $gradeable_id) {
         $params = [$gradeable_id];
+        $return = [];
         $this->course_db->query(
             "
-            SELECT file_wildcard FROM electronic_gradeable_hidden_files WHERE g_id = ?;
+            SELECT file_wildcard, lowest_access_group FROM electronic_gradeable_hidden_files WHERE g_id = ?;
             ",
             $params
         );
-        $hidden_files = "";
+        $return;
         foreach ($this->course_db->rows() as $row) {
-            if ($hidden_files !== "") {
-                $hidden_files = $hidden_files . "," . $row["file_wildcard"];
-            }
-            else {
-                $hidden_files = $row["file_wildcard"];
-            }
+           $return[$row["file_wildcard"]] = $row["lowest_access_group"];
         }
-        return ($hidden_files);
+        return $return;
     }
 
     public function getNumUsersWhoViewedGradeBySections($gradeable, $sections) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1673,6 +1673,27 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         }
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
+    
+    public function insertOmittedFiles($gradeable_id, $file_name, $lowest_allowed){
+        $params = [$gradeable_id];
+        $this->course_db->query(
+            "
+            INSERT INTO electronic_gradeable_hidden_files
+            VALUES ($gradeable_id, $file_name, $lowest_allowed)
+            ",
+            $params
+        );
+    }
+    
+    public function deleteOmittedFiles($gradeable_id){
+        $params = [$gradeable_id, $file_name, $lowest_allowed];
+        $this->course_db->query(
+            "
+            DELETE FROM table_name WHERE g_id = $gradeable_id;
+            ",
+            $params
+        );
+    }
 
     public function getNumUsersWhoViewedGradeBySections($gradeable, $sections) {
         $table = $gradeable->isTeamAssignment() ? 'gradeable_teams' : 'users';

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4311,7 +4311,8 @@ AND gc_id IN (
                   eg_has_due_date AS has_due_date,
                   eg_late_days AS late_days,
                   eg_allow_late_submission AS late_submission_allowed,
-                  eg_precision AS precision
+                  eg_precision AS precision,
+                  eg_hidden_files as hidden_files
                 FROM electronic_gradeable
               ) AS eg ON g.g_id=eg.eg_g_id
               LEFT JOIN (
@@ -4978,7 +4979,8 @@ AND gc_id IN (
                 $gradeable->isRegradeAllowed(),
                 $gradeable->isGradeInquiryPerComponentAllowed(),
                 $gradeable->getDiscussionThreadId(),
-                $gradeable->isDiscussionBased()
+                $gradeable->isDiscussionBased(),
+                $gradeable->getHiddenFiles()
             ];
             $this->course_db->query(
                 "
@@ -5007,9 +5009,10 @@ AND gc_id IN (
                   eg_regrade_allowed,
                   eg_grade_inquiry_per_component_allowed,
                   eg_thread_ids,
-                  eg_has_discussion
+                  eg_has_discussion,
+                  eg_hidden_files
                   )
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 $params
             );
         }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1674,7 +1674,15 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
     
-    public function insertOmittedFiles($gradeable_id, $file_name, $lowest_allowed) {
+    /**
+     * Inserts a set of ommitted file wildcards for a gradeable
+     *
+     * @param  string $gradeable_id
+     * @param  string $file_name
+     * @param  int $lowest_allowed
+     */
+    
+    public function insertOmittedFiles(string $gradeable_id, string $file_name, int $lowest_allowed) {
         $params = [$gradeable_id, $file_name, $lowest_allowed];
         $this->course_db->query(
             "
@@ -1685,7 +1693,13 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         );
     }
     
-    public function deleteOmittedFiles($gradeable_id) {
+    /**
+     * Delete all ommitted file wildcards for a gradeable
+     *
+     * @param  string $gradeable_id
+     */
+    
+    public function deleteOmittedFiles(string $gradeable_id) {
         $params = [$gradeable_id];
         $this->course_db->query(
             "
@@ -1695,7 +1709,13 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         );
     }
     
-    public function getOmmitedFiles($gradeable_id) {
+    /**
+     * Get all ommitted file wildcards for a gradeable
+     *
+     * @param  string $gradeable_id
+     */
+    
+    public function getOmmitedFiles(string $gradeable_id) {
         $params = [$gradeable_id];
         $this->course_db->query(
             "

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1674,7 +1674,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
     
-    public function insertOmittedFiles($gradeable_id, $file_name, $lowest_allowed){
+    public function insertOmittedFiles($gradeable_id, $file_name, $lowest_allowed) {
         $params = [$gradeable_id, $file_name, $lowest_allowed];
         $this->course_db->query(
             "
@@ -1685,7 +1685,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         );
     }
     
-    public function deleteOmittedFiles($gradeable_id){
+    public function deleteOmittedFiles($gradeable_id) {
         $params = [$gradeable_id];
         $this->course_db->query(
             "
@@ -1695,7 +1695,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         );
     }
     
-    public function getOmmitedFiles($gradeable_id){
+    public function getOmmitedFiles($gradeable_id) {
         $params = [$gradeable_id];
         $this->course_db->query(
             "
@@ -1705,10 +1705,10 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         );
         $hidden_files = "";
         foreach ($this->course_db->rows() as $row) {
-            if($hidden_files !== ""){
+            if ($hidden_files !== "") {
                 $hidden_files = $hidden_files . "," . $row["file_wildcard"];
             }
-            else{
+            else {
                 $hidden_files = $row["file_wildcard"];
             }
         }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1726,7 +1726,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
         );
         $return;
         foreach ($this->course_db->rows() as $row) {
-           $return[$row["file_wildcard"]] = $row["lowest_access_group"];
+            $return[$row["file_wildcard"]] = $row["lowest_access_group"];
         }
         return $return;
     }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -81,8 +81,9 @@ use app\controllers\admin\AdminGradeableController;
  * @method void setDiscussionThreadId($discussion_thread_id)
  * @method int getActiveRegradeRequestCount()
  * @method void setHasDueDate($has_due_date)
+ * @method void setHiddenFiles($hidden_files)
  * @method object[] getPeerGradingPairs()
- * @method object[] getHiddenFiles()
+ * @method void setHiddenFiles()
  */
 class Gradeable extends AbstractModel {
     /* Enum range for grader_assignment_method */
@@ -2009,12 +2010,5 @@ class Gradeable extends AbstractModel {
         );
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
-    }
-    public function setHiddenFiles($files) {
-        $this->modified = true;
-        foreach (explode(',', $files) as $file_name) {
-            $this->hidden_files[$file_name] = 3;
-        }
-        $this->hidden_files = $this->core->getQueries()->getOmmitedFiles($this->id);
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -81,9 +81,9 @@ use app\controllers\admin\AdminGradeableController;
  * @method void setDiscussionThreadId($discussion_thread_id)
  * @method int getActiveRegradeRequestCount()
  * @method void setHasDueDate($has_due_date)
- * @method void setHiddenFiles($hidden_files)
  * @method object[] getPeerGradingPairs()
- * @method void setHiddenFiles()
+ * @method string getHiddenFiles()
+ * @method void setHiddenFiles($hidden_files)
  */
 class Gradeable extends AbstractModel {
     /* Enum range for grader_assignment_method */
@@ -216,7 +216,7 @@ class Gradeable extends AbstractModel {
     /** @prop @var string thread id for corresponding to discussion forum thread*/
     protected $discussion_thread_id = '';
     /** @var array are a list of hidden files and the lowest_access_group that can see those files */
-    protected $hidden_files = [];
+    protected $hidden_files = "";
     /**
      * Gradeable constructor.
      * @param Core $core
@@ -238,11 +238,6 @@ class Gradeable extends AbstractModel {
         if (array_key_exists('peer_graders_list', $details)) {
             $this->setPeerGradersList($details['peer_graders_list']);
         }
-        
-        if (array_key_exists('hidden_files', $details)) {
-            $this->setHiddenFiles($details['hidden_files']);
-        }
-
         if ($this->getType() === GradeableType::ELECTRONIC_FILE) {
             $this->setAutogradingConfigPath($details['autograding_config_path']);
             $this->setVcs($details['vcs']);
@@ -262,6 +257,7 @@ class Gradeable extends AbstractModel {
             $this->setGradeInquiryPerComponentAllowed($details['grade_inquiry_per_component_allowed']);
             $this->setDiscussionBased((bool) $details['discussion_based']);
             $this->setDiscussionThreadId($details['discussion_thread_ids']);
+            $this->setHiddenFiles($details['hidden_files']);
         }
 
         $this->setActiveRegradeRequestCount($details['active_regrade_request_count'] ?? 0);
@@ -2010,5 +2006,9 @@ class Gradeable extends AbstractModel {
         );
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
+    }
+    public function setHiddenFiles($string){
+        $this->hidden_files = $string;
+        $this->modified = true;
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2005,10 +2005,10 @@ class Gradeable extends AbstractModel {
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
     }
-    public function setFilesToOmit(){
+    public function setFilesToOmit() {
         return;
     }
-    public function getFilesToOmit(){
-        return "check";
+    public function getFilesToOmit() {
+        return;
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2006,9 +2006,9 @@ class Gradeable extends AbstractModel {
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
     }
     public function setFilesToOmit() {
-        return;
+
     }
     public function getFilesToOmit() {
-        return;
+
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -215,7 +215,7 @@ class Gradeable extends AbstractModel {
     protected $discussion_based = false;
     /** @prop @var string thread id for corresponding to discussion forum thread*/
     protected $discussion_thread_id = '';
-    /** @var array are a list of hidden files and the lowest_access_group that can see those files */
+    /** @prop @var string are a list of hidden files and the lowest_access_group that can see those files */
     protected $hidden_files = "";
     /**
      * Gradeable constructor.
@@ -2006,9 +2006,5 @@ class Gradeable extends AbstractModel {
         );
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
-    }
-    public function setHiddenFiles($string){
-        $this->hidden_files = $string;
-        $this->modified = true;
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2006,9 +2006,7 @@ class Gradeable extends AbstractModel {
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
     }
     public function setFilesToOmit() {
-
     }
     public function getFilesToOmit() {
-
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -82,6 +82,7 @@ use app\controllers\admin\AdminGradeableController;
  * @method int getActiveRegradeRequestCount()
  * @method void setHasDueDate($has_due_date)
  * @method object[] getPeerGradingPairs()
+ * @method object[] getHiddenFiles()
  */
 class Gradeable extends AbstractModel {
     /* Enum range for grader_assignment_method */
@@ -213,8 +214,8 @@ class Gradeable extends AbstractModel {
     protected $discussion_based = false;
     /** @prop @var string thread id for corresponding to discussion forum thread*/
     protected $discussion_thread_id = '';
-
-
+    /** @var array are a list of hidden files and the lowest_access_group that can see those files */
+    protected $hidden_files = [];
     /**
      * Gradeable constructor.
      * @param Core $core
@@ -235,6 +236,10 @@ class Gradeable extends AbstractModel {
         $this->setTaInstructions($details['ta_instructions']);
         if (array_key_exists('peer_graders_list', $details)) {
             $this->setPeerGradersList($details['peer_graders_list']);
+        }
+        
+        if (array_key_exists('hidden_files', $details)) {
+            $this->setHiddenFiles($details['hidden_files']);
         }
 
         if ($this->getType() === GradeableType::ELECTRONIC_FILE) {
@@ -2005,8 +2010,8 @@ class Gradeable extends AbstractModel {
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
     }
-    public function setFilesToOmit() {
-    }
-    public function getFilesToOmit() {
+    public function setHiddenFiles() {
+        $this->hidden_files = $this->core->getQueries()->getOmmitedFiles($this->getId());
+        $this->modified = true;
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2010,8 +2010,10 @@ class Gradeable extends AbstractModel {
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
     }
-    public function setHiddenFiles() {
-        $this->hidden_files = $this->core->getQueries()->getOmmitedFiles($this->getId());
+    public function setHiddenFiles($files) {
         $this->modified = true;
+        foreach (explode(',', $files) as $file_name) {
+            $this->hidden_files[$file_name] = 3;
+        }
     }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2005,4 +2005,10 @@ class Gradeable extends AbstractModel {
 
         return !(strpos($this->getAutogradingConfigPath(), $config_upload_path) === false);
     }
+    public function setFilesToOmit(){
+        return;
+    }
+    public function getFilesToOmit(){
+        return "check";
+    }
 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -257,7 +257,9 @@ class Gradeable extends AbstractModel {
             $this->setGradeInquiryPerComponentAllowed($details['grade_inquiry_per_component_allowed']);
             $this->setDiscussionBased((bool) $details['discussion_based']);
             $this->setDiscussionThreadId($details['discussion_thread_ids']);
-            $this->setHiddenFiles($details['hidden_files']);
+            if (array_key_exists('hidden_files', $details)) {
+                $this->setHiddenFiles($details['hidden_files']);
+            }
         }
 
         $this->setActiveRegradeRequestCount($details['active_regrade_request_count'] ?? 0);

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2015,5 +2015,6 @@ class Gradeable extends AbstractModel {
         foreach (explode(',', $files) as $file_name) {
             $this->hidden_files[$file_name] = 3;
         }
+        $this->hidden_files = $this->core->getQueries()->getOmmitedFiles($this->id);
     }
 }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -32,7 +32,7 @@
                     <br>
                 </div>
             </div>
-        </div> 
+        </div>
         <div class="row">
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -37,7 +37,7 @@
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>
-                    <input type="text" id="files_to_omit" name = "files_to_omit" class="auto_save" placeholder="" value = {{hidden_files}}>
+                    <input type="text" id="hidden_files" name = "hidden_files" class="auto_save" placeholder="" value = {{hidden_files}}>
             </div>
         </div> 
 </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -37,7 +37,7 @@
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>
-                    <input type="text" id="files_to_omit" name = "files_to_omit" class="auto_save" placeholder="" value = {{hidden_files}}>
+                    <input type="text" id="files-to-omit" name = "files-to-omit" class="auto_save" placeholder="" value = {{hidden_files}}>
             </div>
         </div> 
 </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -36,7 +36,7 @@
         <div class="row">
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
-                    Enter any file wildcards that should not be viewable by students <br>
+                    Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>
                     <input type="text" id="files_to_omit" name = "files_to_omit" class="auto_save" placeholder="" value = {{hidden_files}}>
             </div>
         </div> 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -33,6 +33,13 @@
                 </div>
             </div>
         </div> 
+        <div class="row">
+            <div class="card col-md-12" style="margin:0px">
+                <div class="content"style="margin:0px">
+                    Enter any file wildcards that should not be viewable by students <br>
+                    <input type="text" id="files_to_omit" placeholder="">
+            </div>
+        </div> 
 </div>
     <div id="peer_loader" class="loader hide"></div>
         <div class="table-wrapper">

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -34,6 +34,7 @@
             </div>
         </div> 
         <div class="row">
+        {{dump(hidden_files)}}
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -37,7 +37,7 @@
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>
-                    <input type="text" id="files-to-omit" name = "files-to-omit" class="auto_save" placeholder="" value = {{hidden_files}}>
+                    <input type="text" id="files_to_omit" name = "files_to_omit" class="auto_save" placeholder="" value = {{hidden_files}}>
             </div>
         </div> 
 </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -34,7 +34,6 @@
             </div>
         </div> 
         <div class="row">
-        {{dump(hidden_files)}}
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -37,7 +37,7 @@
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students <br>
-                    <input type="text" id="files_to_omit" placeholder="">
+                    <input type="text" id="files_to_omit" name = "files_to_omit" class="auto_save" placeholder="" value = {{hidden_files}}>
             </div>
         </div> 
 </div>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1186,7 +1186,7 @@ HTML;
             if ($new_files) {
                 foreach ($new_files as $file) {
                     $skipping = false;
-                    foreach ($hidden_files as $file_regex) {
+                    foreach (explode(",", $hidden_files) as $file_regex) {
                         if (fnmatch($file_regex, $file["name"]) && $this->core->getUser()->getGroup() > 3) {
                             $skipping = true;
                         }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1182,8 +1182,8 @@ HTML;
     public function renderSubmissionPanel(GradedGradeable $graded_gradeable, int $display_version, bool $showNewInterface) {
         $add_files = function (&$files, $new_files, $start_dir_name, $graded_gradeable) {
             $files[$start_dir_name] = [];
-            #$hidden_files = $this->core->getQueries()->getOmmitedFiles($graded_gradeable->getGradeable()->getId());
-            $hidden_files = $graded_gradeable->getGradeable()->getHiddenFiles();
+            $hidden_files = $this->core->getQueries()->getOmmitedFiles($graded_gradeable->getGradeable()->getId());
+            #$hidden_files = $graded_gradeable->getGradeable()->getHiddenFiles();
             if ($new_files) {
                 foreach ($new_files as $file) {
                     $skipping = false;

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1187,7 +1187,7 @@ HTML;
                 foreach ($new_files as $file) {
                     $skipping = false;
                     if($this->core->getUser()->getGroup() == User::GROUP_STUDENT){
-                        foreach (explode(':',$hidden_files) as $hidden_file) {
+                        foreach (explode(',',$hidden_files) as $hidden_file) {
                             if(fnmatch($hidden_file, $file["name"])){
                                 $skipping = true;
                             }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1188,7 +1188,7 @@ HTML;
                 foreach ($new_files as $file) {
                     $skipping = false;
                     foreach ($hidden_files as $file_regex => $lowest_access_group) {
-                        if (fnmatch($file_regex, $file["name"]) and $this->core->getUser()->getGroup() > $lowest_access_group) {
+                        if (fnmatch($file_regex, $file["name"]) && $this->core->getUser()->getGroup() > $lowest_access_group) {
                             $skipping = true;
                         }
                     }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1182,15 +1182,14 @@ HTML;
     public function renderSubmissionPanel(GradedGradeable $graded_gradeable, int $display_version, bool $showNewInterface) {
         $add_files = function (&$files, $new_files, $start_dir_name, $graded_gradeable) {
             $files[$start_dir_name] = [];
-            $hidden_files = $this->core->getQueries()->getOmmitedFiles($graded_gradeable->getGradeableId());
+            #$hidden_files = $this->core->getQueries()->getOmmitedFiles($graded_gradeable->getGradeable()->getId());
+            $hidden_files = $graded_gradeable->getGradeable()->getHiddenFiles();
             if ($new_files) {
                 foreach ($new_files as $file) {
                     $skipping = false;
-                    if ($this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
-                        foreach (explode(',', $hidden_files) as $hidden_file) {
-                            if (fnmatch($hidden_file, $file["name"])) {
-                                $skipping = true;
-                            }
+                    foreach ($hidden_files as $file_regex => $lowest_access_group) {
+                        if (fnmatch($file_regex, $file["name"]) and $this->core->getUser()->getGroup() > $lowest_access_group) {
+                            $skipping = true;
                         }
                     }
                     if (!$skipping) {

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1182,13 +1182,12 @@ HTML;
     public function renderSubmissionPanel(GradedGradeable $graded_gradeable, int $display_version, bool $showNewInterface) {
         $add_files = function (&$files, $new_files, $start_dir_name, $graded_gradeable) {
             $files[$start_dir_name] = [];
-            $hidden_files = $this->core->getQueries()->getOmmitedFiles($graded_gradeable->getGradeable()->getId());
-            #$hidden_files = $graded_gradeable->getGradeable()->getHiddenFiles();
+            $hidden_files = $graded_gradeable->getGradeable()->getHiddenFiles();
             if ($new_files) {
                 foreach ($new_files as $file) {
                     $skipping = false;
-                    foreach ($hidden_files as $file_regex => $lowest_access_group) {
-                        if (fnmatch($file_regex, $file["name"]) && $this->core->getUser()->getGroup() > $lowest_access_group) {
+                    foreach ($hidden_files as $file_regex) {
+                        if (fnmatch($file_regex, $file["name"]) && $this->core->getUser()->getGroup() > 3) {
                             $skipping = true;
                         }
                     }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1186,14 +1186,14 @@ HTML;
             if ($new_files) {
                 foreach ($new_files as $file) {
                     $skipping = false;
-                    if($this->core->getUser()->getGroup() == User::GROUP_STUDENT){
-                        foreach (explode(',',$hidden_files) as $hidden_file) {
-                            if(fnmatch($hidden_file, $file["name"])){
+                    if ($this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
+                        foreach (explode(',', $hidden_files) as $hidden_file) {
+                            if (fnmatch($hidden_file, $file["name"])) {
                                 $skipping = true;
                             }
                         }
                     }
-                    if(!$skipping){
+                    if (!$skipping) {
                         if ($start_dir_name == "submissions") {
                             $file["path"] = $this->setAnonPath($file["path"]);
                         }

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -483,7 +483,6 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
     }
         
     else{
-        console.log(p_values)
         let container = $('#container-rubric');
         if (container.length === 0) {
             alert("UPDATES DISABLED: no 'container-rubric' element!");

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -129,7 +129,12 @@ $(document).ready(function () {
         }
 
         let data = {'csrf_token': csrfToken};
-        data[this.name] = $(this).val();
+        if (this.name == 'hidden_files') {
+            data[this.name] = $(this).val().replace(", ", ",");
+        }
+        else {
+            data[this.name] = $(this).val();
+        }
         let addDataToRequest = function (i, val) {
             if (val.type === 'radio' && !$(val).is(':checked')) {
                 return;

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -130,7 +130,7 @@ $(document).ready(function () {
 
         let data = {'csrf_token': csrfToken};
         if (this.name == 'hidden_files') {
-            data[this.name] = $(this).val().replace(", ", ",");
+            data[this.name] = $(this).val().replace(/\s*,\s*/, ",");
         }
         else {
             data[this.name] = $(this).val();

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -483,6 +483,7 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
     }
         
     else{
+        console.log(p_values)
         let container = $('#container-rubric');
         if (container.length === 0) {
             alert("UPDATES DISABLED: no 'container-rubric' element!");


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
A peer grader can see all of the files a student submitted

### What is the new behavior?
On the peer matrix tab while creating/editting a gradeable, an instructor can enter wildcards. Filenames that match the attached wildcards will not be shown to the student (but will be shown instructors, Full and limited access TAs) 
![image](https://user-images.githubusercontent.com/11095297/95796149-21799a80-0cba-11eb-942b-0c6899e3c540.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
