### PR TITLE
[Bugfix:OfficeHours] Fix updating queue dynamically 

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -126,11 +126,12 @@ if ($is_api) {
 }
 else {
     $response = WebRouter::getWebResponse($request, $core);
-}
+    $request_json = isset($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === "text/json";
 
-if ($request->isXmlHttpRequest() && ($response instanceof MultiResponse)) {
-    //If its an Ajax based request, we can only send a JSON payload back
-    $response = $response->convertToJsonResponse();
+    if ($request->isXmlHttpRequest() && ($response instanceof MultiResponse) && $request_json) {
+        //convert to JSON if an ajax request asks for it
+        $response = $response->convertToJsonResponse();
+    }
 }
 
 

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -126,7 +126,7 @@ if ($is_api) {
 }
 else {
     $response = WebRouter::getWebResponse($request, $core);
-    $request_json = isset($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === "text/json";
+    $request_json = isset($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === "application/json";
 
     if ($request->isXmlHttpRequest() && ($response instanceof MultiResponse) && $request_json) {
         //convert to JSON if an ajax request asks for it

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -976,7 +976,7 @@ function handleSubmission(days_late, days_to_be_charged,late_days_allowed, versi
             return myXhr;
         },
         headers : {
-            Accept: "text/json"
+            Accept: "application/json"
         },
         contentType: false,
         type: 'POST',

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -975,6 +975,9 @@ function handleSubmission(days_late, days_to_be_charged,late_days_allowed, versi
             }
             return myXhr;
         },
+        headers : {
+            Accept: "text/json"
+        },
         contentType: false,
         type: 'POST',
         success: function(data) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
PR https://github.com/Submitty/Submitty/pull/5950 introduced a bug where the office hours queue would say "request type not supported" when the queue would dynamically update if a student entered/left.

This was because pr 5950 forced ajax requests to receive JSON responses back, but the office hours queue was using ajax to grab the new html and updating the dom via javascript, preventing a full page refresh. There were no checks of the response type so whatever was sent back was displayed to the user.

### What is the new behavior?
Since developers might be interested in receiving raw HTML from a controller in scenarios like this the router will
will now by default send back whatever the controller that was called returned. If the client wants to enforce a JSON request they can set the "accepts" headers to "text/json". I think this is a good middle ground 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
