### PR TITLE
[UI/UX: InstructorUI] Increase size of contact info box for office hours queue

### DIFF
--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -62,3 +62,8 @@ th{
   background: var(--standard-light-gray);
   padding: .75rem;
 }
+
+#contact_info {
+    width: 620px;
+}
+


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The box for putting in contact info is currently quite small, and it doesn't fit a Webex meeting link:
<img width="656" alt="Screen Shot 2020-10-16 at 12 25 11 AM" src="https://user-images.githubusercontent.com/36799217/96213534-39b21980-0f47-11eb-8635-003197ce6def.png">

### What is the new behavior?
The box is now big enough to fit both a group meeting link for labs and a personal room meeting link for office hours:
<img width="1021" alt="Screen Shot 2020-10-16 at 12 22 44 AM" src="https://user-images.githubusercontent.com/36799217/96213665-8e559480-0f47-11eb-8782-76a6284b9251.png">
<img width="1096" alt="Screen Shot 2020-10-16 at 12 23 39 AM" src="https://user-images.githubusercontent.com/36799217/96213671-91e91b80-0f47-11eb-8cf4-7add385dae22.png">
