### PR TITLE
[Bugfix:InstructorUI] Prevent access to course materials before they are released

### DIFF
--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -3,6 +3,7 @@
 namespace app\models;
 
 use app\exceptions\FileNotFoundException;
+use app\exceptions\MalformedDataException;
 use app\libraries\Core;
 
 class CourseMaterial extends AbstractModel {
@@ -35,7 +36,12 @@ class CourseMaterial extends AbstractModel {
         }
         else {
             $current_time = new \DateTime('now');
-            $release_time = \DateTime::createFromFormat('Y-m-d H:i:s', $meta_data->$path_to_file->release_datetime);
+            $release_time = new \DateTime($meta_data->$path_to_file->release_datetime);
+
+            // Ensure release time obtained from file was parsed correctly into a DateTime object
+            if ($release_time === false) {
+                throw new MalformedDataException("An error occurred parsing the file's release time data.");
+            }
 
             // If current time is greater than release time return true, else return false
             return $current_time > $release_time;


### PR DESCRIPTION
### What is the current behavior?
Students may access course materials prior to the course materials release date, provided they obtain a url to the file.

### What is the new behavior?
This behavior has been corrected and students may no longer access course materials that haven't yet been released.

### Other information?
This bug was the result of PHP being unable to correctly parse the release time string into a DateTime object.  When this condition occurs instead of throwing an exception the DateTime library will simply return `false`.  The `false` was then used in a comparison causing `true` to always be returned.

The parsing bug has been resolved.  Additionally the return type is now checked so that if a parsing error occurs an exception is now thrown.