### PR TITLE
[Bugfix:Autograding] Stop subsequent testcase failure on docker errors

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -792,8 +792,8 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             self.log_stack_trace(traceback.format_exc())
             self.log_message("ERROR: Could not verify execution mode status.")
             return
-
-        autograding_utils.cleanup_stale_containers(self.untrusted_user)
+        finally:
+            autograding_utils.cleanup_stale_containers(self.untrusted_user)
 
         try:
             self.create_containers(containers, script, arguments)

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -793,6 +793,8 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             self.log_message("ERROR: Could not verify execution mode status.")
             return
 
+        autograding_utils.cleanup_stale_containers(self.untrusted_user)
+
         try:
             self.create_containers(containers, script, arguments)
             self.network_containers(containers)

--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -440,6 +440,7 @@ def grade_from_zip(
 
     # Remove the tmp directory.
     shutil.rmtree(working_directory)
+    autograding_utils.cleanup_stale_containers(which_untrusted)
     return my_results_zip_file
 
 


### PR DESCRIPTION
At present if an error occurs as the result of a failed docker operation (e.g, container creation), any hanging containers are not cleaned up. This means that subsequent testcases fail due to docker name collisions.

This PR adds container cleanup before testcases are run, intermediately between each testcase, and after execution has finished.