### PR TITLE
[Bugfix:InstructorUI] Course materials fix hide from students option

### DIFF
--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -3,6 +3,7 @@
 namespace app\models;
 
 use app\exceptions\FileNotFoundException;
+use app\exceptions\MalformedDataException;
 use app\libraries\Core;
 
 class CourseMaterial extends AbstractModel {
@@ -35,7 +36,12 @@ class CourseMaterial extends AbstractModel {
         }
         else {
             $current_time = new \DateTime('now');
-            $release_time = \DateTime::createFromFormat('Y-m-d H:i:s', $meta_data->$path_to_file->release_datetime);
+            $release_time = new \DateTime($meta_data->$path_to_file->release_datetime);
+
+            // Ensure release time obtained from file was parsed correctly into a DateTime object
+            if ($release_time === false) {
+                throw new MalformedDataException("An error occurred parsing the file's release time data.");
+            }
 
             // If current time is greater than release time return true, else return false
             return $current_time > $release_time;

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -66,7 +66,10 @@
     {% set this_hide_from_students = hide_from_students[path] %}
     {% set this_external_link = external_link[path] %}
 
-    {% if userGroup != 4 or this_file_section is null or (this_hide_from_students == "off" and user_section in this_file_section)%}
+    {% set greater_than_student = userGroup < 4 %}
+    {% set visible_to_student = this_hide_from_students == 'off' and (this_file_section is null or user_section in this_file_section) %}
+
+    {% if greater_than_student or visible_to_student %}
     <div class="file-container">
         <div class="file-viewer">
 


### PR DESCRIPTION
### What is the current behavior?
When working with course materials as an instructor, there is a file option to 'Hide from students'.  In testing this option didn't appear to do anything.

### What is the new behavior?
This behavior has been corrected so that when this option is selected the file will not be visible to students (but will still be accessible via a link, as described in the options documentation).