### PR TITLE
[Feature:TAGrading] Grader stats breakdown

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -553,6 +553,7 @@ class ElectronicGraderController extends AbstractController {
             $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
             $ta_graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
             $component_averages = $this->core->getQueries()->getAverageComponentScores($gradeable_id, $section_key, $gradeable->isTeamAssignment());
+            $this->core->getQueries()->getAverageGraderScores($gradeable_id, $section_key, $gradeable->isTeamAssignment()); 
             $autograded_average = $this->core->getQueries()->getAverageAutogradedScores($gradeable_id, $section_key, $gradeable->isTeamAssignment());
             $overall_average = $this->core->getQueries()->getAverageForGradeable($gradeable_id, $section_key, $gradeable->isTeamAssignment());
             $order = new GradingOrder($this->core, $gradeable, $this->core->getUser(), true);

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -553,7 +553,6 @@ class ElectronicGraderController extends AbstractController {
             $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
             $ta_graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
             $component_averages = $this->core->getQueries()->getAverageComponentScores($gradeable_id, $section_key, $gradeable->isTeamAssignment());
-            $this->core->getQueries()->getAverageGraderScores($gradeable_id, $section_key, $gradeable->isTeamAssignment()); 
             $autograded_average = $this->core->getQueries()->getAverageAutogradedScores($gradeable_id, $section_key, $gradeable->isTeamAssignment());
             $overall_average = $this->core->getQueries()->getAverageForGradeable($gradeable_id, $section_key, $gradeable->isTeamAssignment());
             $order = new GradingOrder($this->core, $gradeable, $this->core->getUser(), true);

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -15,6 +15,7 @@ use app\libraries\Core;
  * @method int getCount()
  * @method int getActiveGradeInquiryCount()
  * @method bool getIsPeer()
+ * @method bool setGraderInfo($grader_info)
 
  */
 class SimpleStat extends AbstractModel {
@@ -36,6 +37,8 @@ class SimpleStat extends AbstractModel {
     protected $active_grade_inquiry_count = 0;
     /** @prop @var bool Does this component use peer grading*/
     protected $is_peer = null;
+    /** @prop @var array Grader information for these stats*/
+    protected $grader_info = null;
 
     public function __construct(Core $core, $details = []) {
         parent::__construct($core);

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -15,7 +15,7 @@ use app\libraries\Core;
  * @method int getCount()
  * @method int getActiveGradeInquiryCount()
  * @method bool getIsPeer()
- * @method bool setGraderInfo($grader_info)
+ * @method string[] getGraderInfo()
 
  */
 class SimpleStat extends AbstractModel {
@@ -52,6 +52,7 @@ class SimpleStat extends AbstractModel {
             $this->is_peer = $details['gc_is_peer'];
             $this->count = $details['count'];
             $this->active_grade_inquiry_count = $details['active_grade_inquiry_count'];
+            $this->grader_info = $this->core->getQueries()->getAverageGraderScores($details['g_id'], $details['gc_id'], $details['section_key'], $details['team']);
         }
         else {
             $this->component = false;

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -784,6 +784,10 @@
                                             <br/>
                                             Standard Deviation: {{ component.getStandardDeviation() }} <br/>
                                             Count: {{ component.getCount() }} <br/>
+                                            {#Graders: 
+                                            {% for grader in component.getGraders() %} 
+                                            {{ grader }} ({{ component.getGraderAvg(grader) }}) <br/>
+                                            #}
                                         </div>
                                     {% endfor %}
                                     <br/>

--- a/site/app/templates/grading/electronic/Status.twig
+++ b/site/app/templates/grading/electronic/Status.twig
@@ -784,10 +784,14 @@
                                             <br/>
                                             Standard Deviation: {{ component.getStandardDeviation() }} <br/>
                                             Count: {{ component.getCount() }} <br/>
-                                            {#Graders: 
-                                            {% for grader in component.getGraders() %} 
-                                            {{ grader }} ({{ component.getGraderAvg(grader) }}) <br/>
-                                            #}
+                                            {% for grader, data in component.getGraderInfo() %}
+                                                {% if loop.first == grader %}
+                                                    <p> Graders: 
+                                                {% else %}
+                                                    <p style="padding-left:3.7em">
+                                                {% endif %}
+                                                {{ grader }} (count {{ data['count'] }} - avg {{ data['avg'] }} - stddev {{ data['std_dev'] }}) </p1>
+                                            {% endfor%}
                                         </div>
                                     {% endfor %}
                                     <br/>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
#5975 (and #1650)- There are currently no stats for graders for a given gradeable

### What is the new behavior?
Every gradeable now has a grader breakdown for each component (count, average, and stdev).

![image](https://user-images.githubusercontent.com/51247866/97219412-5ac50680-17a0-11eb-969c-84108e7ccf28.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Created a new gradeable with different graders and matched the results with my expected output