### PR TITLE
[Refactor:UI] Standardize markdown for office hours queue

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -14,7 +14,7 @@ use Ds\Set;
 /**
  * Class Output
  *
- * We us this class to act as a wrapper around Twig as well as to hold our output
+ * We use this class to act as a wrapper around Twig as well as to hold our output
  * as we build it before final output either when we output at the end of the calling
  * class or if the application has thrown an uncaught exception
  */
@@ -145,7 +145,7 @@ HTML;
         $this->addInternalCss('bootstrap.css');
         $this->addInternalCss('diff-viewer.css');
         $this->addInternalCss('glyphicons-halflings.css');
-
+        $this->addInternalCss('markdown.css');
 
         $this->addVendorJs(FileUtils::joinPaths('jquery', 'jquery.min.js'));
         $this->addVendorJs(FileUtils::joinPaths('jquery-ui', 'jquery-ui.min.js'));

--- a/site/app/templates/officeHoursQueue/AnnouncementMsg.twig
+++ b/site/app/templates/officeHoursQueue/AnnouncementMsg.twig
@@ -1,5 +1,5 @@
 {% if viewer.getQueueAnnouncementMessage() | length > 0 %}
-    <div id="announcement">
+    <div id="announcement" class="markdown">
         <h2>Office Hours Queue Announcements:</h2>
         <p>{{viewer.getQueueAnnouncementMessage() | markdown}}</p>
     </div>

--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -1,7 +1,5 @@
 {% if viewer.getQueueMessage() | length > 0 %}
-  <div class="content gradeable_message">
-    <p>{{viewer.getQueueMessage() | markdown}}</p>
-  </div>
+  <div class="content gradeable_message markdown">{{viewer.getQueueMessage() | markdown}}</div>
 {% endif %}
 
 <div class="content">

--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -1,0 +1,32 @@
+/*
+ * This file defines a standardized set of styling rules for html elements which have been converted from
+ * markdown to html using our markdown parser.
+ *
+ * To utilize these rules simply add 'markdown' to the class attribute of the parent container which holds the
+ * converted markdown.
+ *
+ * Beware when making changes here, as your changes are likely to affect the look and feel of several pages on submitty.
+ */
+
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+    margin: 0
+}
+
+.markdown p {
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+
+.markdown ol,
+.markdown ul {
+    margin-bottom: 12px;
+}
+
+.markdown li {
+    margin-left: 25px;
+}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -351,10 +351,6 @@ td>a.active-sort {
     color: var(--always-default-white);
 }
 
-.content.gradeable_message p:not(:last-child){
-    padding-bottom: 20px;
-}
-
 .content.overridden_message {
     background-color: var(--important-post);
     color: black;


### PR DESCRIPTION
Partially #5884 

### What is the current behavior?
The styling of rendered markdown is inconsistent across submitty.

### What is the new behavior?
This PR introduces a global level `markdown.css` file and starts implementing styling rules.  The PR also has applied these rules to the office hours queue welcome message (pictured below) and office hours queue announcements (not pictured).

### Other information?
This is only the first of several PRs to standardize the look of markdown across submitty.

### Screenshot
![image](https://user-images.githubusercontent.com/7605020/97343887-6c6ce380-185e-11eb-835b-ec4dc8ee8367.png)