### PR TITLE
[UI/UX:Submission] Invalid Polls Setup

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -2,7 +2,7 @@
     {% if not poll is defined %}
         <h1> Add a New Poll </h1>
 
-        <form method="post" action="{{base_url}}/newPoll">
+        <form id="new-poll-form" method="post" action="{{base_url}}/newPoll">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
             <input type="hidden" name="response_count" id="response-count" value="0"/>
 
@@ -40,9 +40,11 @@
             <button type="button" class="btn btn-primary" onclick="removeResponse()">-</button>
             <br/> <br/>
 
-
-
-            <button type="submit" class="btn btn-primary">Add Poll</button>
+            <span id="empty-name-error" class="red-message">Please make sure poll name is filled in.<br/></span>
+            <span id="empty-question-error" class="red-message" hidden>Please make sure question is filled in.<br/></span>
+            <span id="empty-date-error" class="red-message" hidden>Please make sure release date is filled in.<br/></span>
+            <span id="response-count-error" class="red-message" hidden>Please make sure to add at least one response option.<br/></span>
+            <button type="submit" id="new-poll-submit" class="btn btn-primary" disabled>Add Poll</button>
         </form>
     {% else %}
         <h1> Edit Poll </h1>
@@ -247,6 +249,38 @@
             $(this).parent().remove()
             count -= 1
             $("#response-count").val("" + count)
+        })
+        $("#new-poll-form").on("change click", function() {
+            if ($("#poll-name").val().length == 0) {
+                $("#new-poll-submit").prop("disabled", true);
+                $("#empty-question-error").hide();
+                $("#empty-date-error").hide();
+                $("#response-count-error").hide();
+                $("#empty-name-error").show();
+            } else if ($("#poll-question").val().length == 0) {
+                $("#new-poll-submit").prop("disabled", true);
+                $("#empty-name-error").hide();
+                $("#empty-date-error").hide();
+                $("#response-count-error").hide();
+                $("#empty-question-error").show();
+            } else if ($("#poll-date").val().length == 0) {
+                $("#new-poll-submit").prop("disabled", true);
+                $("#empty-question-error").hide();
+                $("#empty-name-error").hide();
+                $("#response-count-error").hide();
+                $("#empty-date-error").show()
+            } else if (parseInt($("#response-count").val()) == 0) {
+                $("#empty-question-error").hide();
+                $("#empty-name-error").hide();
+                $("#empty-date-error").hide();
+                $("#response-count-error").show();
+            } else {
+                $("#new-poll-submit").prop("disabled", false);
+                $("#empty-name-error").hide();
+                $("#empty-question-error").hide();
+                $("#empty-question-error").hide();
+                $("#response-count-error").hide();
+            }
         })
     });
 

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -44,12 +44,12 @@
             <span id="empty-question-error" class="red-message polls-submit-error" hidden>Please make sure question is filled in.<br/></span>
             <span id="empty-date-error" class="red-message polls-submit-error" hidden>Please make sure release date is filled in.<br/></span>
             <span id="response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one response option.<br/></span>
-            <button type="submit" id="new-poll-submit" class="btn btn-primary" disabled>Add Poll</button>
+            <button type="submit" id="poll-form-submit" class="btn btn-primary" disabled>Add Poll</button>
         </form>
     {% else %}
         <h1> Edit Poll </h1>
 
-        <form method="post" action="{{base_url}}/editPoll/submitEdits">
+        <form id="edit-poll-form" method="post" action="{{base_url}}/editPoll/submitEdits">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
             <input type="hidden" name="poll_id" value="{{ poll.getID() }}"/>
             <input type="hidden" name="response_count" id="response-count" value="{{ poll.getResponses()|length }}"/>
@@ -106,7 +106,11 @@
             <button type="button" class="btn btn-primary" onclick="removeResponse()">-</button>
             <br/> <br/>
 
-            <button type="submit" class="btn btn-primary">Submit Changes</button>
+            <span id="empty-name-error" class="red-message polls-submit-error" hidden>Please make sure poll name is filled in.<br/></span>
+            <span id="empty-question-error" class="red-message polls-submit-error" hidden>Please make sure question is filled in.<br/></span>
+            <span id="empty-date-error" class="red-message polls-submit-error" hidden>Please make sure release date is filled in.<br/></span>
+            <span id="response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one response option.<br/></span>
+            <button type="submit" id="poll-form-submit" class="btn btn-primary">Submit Changes</button>
         </form>
     {% endif %}
 </div>
@@ -205,23 +209,23 @@
 
     function submitErrorChecks() {
         if ($("#poll-name").val().length == 0) {
-            $("#new-poll-submit").prop("disabled", true);
+            $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#empty-name-error").show();
         } else if ($("#poll-question").val().length == 0) {
-            $("#new-poll-submit").prop("disabled", true);
+            $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#empty-question-error").show();
         } else if ($("#poll-date").val().length == 0) {
-            $("#new-poll-submit").prop("disabled", true);
+            $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#empty-date-error").show()
         } else if (parseInt($("#response-count").val()) == 0) {
-            $("#new-poll-submit").prop("disabled", true);
+            $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#response-count-error").show();
         } else {
-            $("#new-poll-submit").prop("disabled", false);
+            $("#poll-form-submit").prop("disabled", false);
             $(".polls-submit-error").hide();
         }
     }
@@ -274,6 +278,7 @@
             $("#response-count").val("" + count)
         })
         $("#new-poll-form").on("change click", submitErrorChecks);
+        $("#edit-poll-form").on("change click", submitErrorChecks);
     });
 
 </script>

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -40,10 +40,10 @@
             <button type="button" class="btn btn-primary" onclick="removeResponse()">-</button>
             <br/> <br/>
 
-            <span id="empty-name-error" class="red-message">Please make sure poll name is filled in.<br/></span>
-            <span id="empty-question-error" class="red-message" hidden>Please make sure question is filled in.<br/></span>
-            <span id="empty-date-error" class="red-message" hidden>Please make sure release date is filled in.<br/></span>
-            <span id="response-count-error" class="red-message" hidden>Please make sure to add at least one response option.<br/></span>
+            <span id="empty-name-error" class="red-message polls-submit-error">Please make sure poll name is filled in.<br/></span>
+            <span id="empty-question-error" class="red-message polls-submit-error" hidden>Please make sure question is filled in.<br/></span>
+            <span id="empty-date-error" class="red-message polls-submit-error" hidden>Please make sure release date is filled in.<br/></span>
+            <span id="response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one response option.<br/></span>
             <button type="submit" id="new-poll-submit" class="btn btn-primary" disabled>Add Poll</button>
         </form>
     {% else %}
@@ -203,6 +203,29 @@
         $("#response-count").val("" + count)
     }
 
+    function submitErrorChecks() {
+        if ($("#poll-name").val().length == 0) {
+            $("#new-poll-submit").prop("disabled", true);
+            $(".polls-submit-error").hide();
+            $("#empty-name-error").show();
+        } else if ($("#poll-question").val().length == 0) {
+            $("#new-poll-submit").prop("disabled", true);
+            $(".polls-submit-error").hide();
+            $("#empty-question-error").show();
+        } else if ($("#poll-date").val().length == 0) {
+            $("#new-poll-submit").prop("disabled", true);
+            $(".polls-submit-error").hide();
+            $("#empty-date-error").show()
+        } else if (parseInt($("#response-count").val()) == 0) {
+            $("#new-poll-submit").prop("disabled", true);
+            $(".polls-submit-error").hide();
+            $("#response-count-error").show();
+        } else {
+            $("#new-poll-submit").prop("disabled", false);
+            $(".polls-submit-error").hide();
+        }
+    }
+
     $(document).ready(function() {
         $(".up-btn").on("click", function() {
             let curr_pos = parseInt($($(this).siblings(".order")[0]).attr("value"))
@@ -250,38 +273,7 @@
             count -= 1
             $("#response-count").val("" + count)
         })
-        $("#new-poll-form").on("change click", function() {
-            if ($("#poll-name").val().length == 0) {
-                $("#new-poll-submit").prop("disabled", true);
-                $("#empty-question-error").hide();
-                $("#empty-date-error").hide();
-                $("#response-count-error").hide();
-                $("#empty-name-error").show();
-            } else if ($("#poll-question").val().length == 0) {
-                $("#new-poll-submit").prop("disabled", true);
-                $("#empty-name-error").hide();
-                $("#empty-date-error").hide();
-                $("#response-count-error").hide();
-                $("#empty-question-error").show();
-            } else if ($("#poll-date").val().length == 0) {
-                $("#new-poll-submit").prop("disabled", true);
-                $("#empty-question-error").hide();
-                $("#empty-name-error").hide();
-                $("#response-count-error").hide();
-                $("#empty-date-error").show()
-            } else if (parseInt($("#response-count").val()) == 0) {
-                $("#empty-question-error").hide();
-                $("#empty-name-error").hide();
-                $("#empty-date-error").hide();
-                $("#response-count-error").show();
-            } else {
-                $("#new-poll-submit").prop("disabled", false);
-                $("#empty-name-error").hide();
-                $("#empty-question-error").hide();
-                $("#empty-question-error").hide();
-                $("#response-count-error").hide();
-            }
-        })
+        $("#new-poll-form").on("change click", submitErrorChecks);
     });
 
 </script>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
One bullet of #5912 --  when an instructors submits edits or a new poll and there is a part that is an invalid setup, it will simply kick the instructor back to the all polls page, and discard their changes.

### What is the new behavior?
If there's an invalid polls setup (for either editing or creating new polls), there is now front-end error checking that will disable the submit button and add an error message above the submit button.
![screenshot](https://user-images.githubusercontent.com/43322572/98141600-cd1aa280-1e94-11eb-94bb-8821383bc41a.png)

### Other information?
Yet to do -- test on  Firefox to see if on "change" detects typing in the textboxes -- I had only developed on Safari and tested on Chrome.