### PR TITLE
[Bugfix:System] Fix install_system for initial vagrant up

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -484,7 +484,7 @@ EOF
         fi
     fi
 
-    cp ${SUBMITTY_REPOSITORY}/.setup/php-fpm/pool.d/submitty.conf /etc/php/${PHP_VERSION}/fpm/pool.d/submitty.conf
+    cp -n ${SUBMITTY_REPOSITORY}/.setup/php-fpm/pool.d/submitty.conf /etc/php/${PHP_VERSION}/fpm/pool.d/submitty.conf
     cp ${SUBMITTY_REPOSITORY}/.setup/apache/www-data /etc/apache2/suexec/www-data
     chmod 0640 /etc/apache2/suexec/www-data
 

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -484,8 +484,8 @@ EOF
         fi
     fi
 
-    cp -n ${SUBMITTY_REPOSITORY}/.setup/php-fpm/pool.d/submitty.conf /etc/php/${PHP_VERSION}/fpm/pool.d/submitty.conf
-    cp -n ${SUBMITTY_REPOSITORY}/.setup/apache/www-data /etc/apache2/suexec/www-data
+    cp ${SUBMITTY_REPOSITORY}/.setup/php-fpm/pool.d/submitty.conf /etc/php/${PHP_VERSION}/fpm/pool.d/submitty.conf
+    cp ${SUBMITTY_REPOSITORY}/.setup/apache/www-data /etc/apache2/suexec/www-data
     chmod 0640 /etc/apache2/suexec/www-data
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
CGI scripts are not able to run after an initial vagrant up. This will prevent users from logging in to the sample system since it's based on pam authentication. The existing suexec config file is not updated if it already exists, this prevents apache from executing any cgi script since it thinks the docroot is located somewhere else.

Apache was most likely creating default files before the install_system script could copy the correct versions over.

### What is the new behavior?
Removes the `-n` flags so the install_system will clobber the submitty.conf and suexec/www-data with whatever is on the host system.
This should make sure those files are correct on initial up.

### Other information?
If you have this issue you might be able to skip a vagrant destroy/up with the following commands:
```bash
cp ${SUBMITTY_REPOSITORY}/.setup/apache/www-data  /etc/apache2/suexec/www-data
chmod 0640 /etc/apache2/suexec/www-data
service apache2 restart
```
