### PR TITLE
[Bugfix:Travis] Fix travis nginx race condition issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -281,7 +281,7 @@ jobs:
         - sudo apache2ctl -t
         - sudo service apache2 restart
         - sudo mkdir /etc/systemd/system/nginx.service.d
-        - sudo printf "[Service]\nExecStartPost=/bin/sleep 0.1\n" > /etc/systemd/system/nginx.service.d/override.conf
+        - sudo printf "[Service]\nExecStartPost=/bin/sleep 0.1\n" | sudo tee /etc/systemd/system/nginx.service.d/override.conf
         - sudo systemctl daemon-reload
         - sudo rm -rf /etc/nginx/sites-available/*
         - sudo rm -rf /etc/nginx/sites-enabled/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -280,6 +280,9 @@ jobs:
         - cat /etc/apache2/sites-available/submitty.conf
         - sudo apache2ctl -t
         - sudo service apache2 restart
+        - sudo mkdir /etc/systemd/system/nginx.service.d
+        - sudo printf "[Service]\nExecStartPost=/bin/sleep 0.1\n" > /etc/systemd/system/nginx.service.d/override.conf
+        - sudo systemctl daemon-reload
         - sudo rm -rf /etc/nginx/sites-available/*
         - sudo rm -rf /etc/nginx/sites-enabled/*
         - sudo cp -f .setup/nginx/submitty.conf /etc/nginx/sites-available/submitty.conf


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Travis currently failing due to a race condition on nginx, this manually creates the file ahead of a nginx restart

