### PR TITLE
[TAGrading: Bugfix] Null values not being checked in EGC and EGV

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1865,7 +1865,7 @@ class ElectronicGraderController extends AbstractController {
             return;
         }
 
-        $is_notebook_gradeable = $gradeable->getAutogradingConfig()->isNotebookGradeable();
+        $is_notebook_gradeable = ($gradeable->getAutogradingConfig() !== null) && $gradeable->getAutogradingConfig()->isNotebookGradeable();
 
         if ($is_notebook_gradeable) {
             if ($is_itempool_linked === 'true') {

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -934,8 +934,8 @@ HTML;
             );
 
             $old_files = [];
-            for ($i = 1; $i <= $notebook_model->getNumParts(); $i++) {
-                if ($display_version_instance !== null) {
+            if ($display_version_instance !== null) {
+                for ($i = 1; $i <= $notebook_model->getNumParts(); $i++) {
                     foreach ($display_version_instance->getPartFiles($i)['submissions'] as $file) {
                         $old_files[] = [
                             'name' => str_replace('\'', '\\\'', $file['name']),

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -935,12 +935,14 @@ HTML;
 
             $old_files = [];
             for ($i = 1; $i <= $notebook_model->getNumParts(); $i++) {
-                foreach ($display_version_instance->getPartFiles($i)['submissions'] as $file) {
-                    $old_files[] = [
-                        'name' => str_replace('\'', '\\\'', $file['name']),
-                        'size' => number_format($file['size'] / 1024, 2),
-                        'part' => $i
-                    ];
+                if ($display_version_instance !== null) {
+                    foreach ($display_version_instance->getPartFiles($i)['submissions'] as $file) {
+                        $old_files[] = [
+                            'name' => str_replace('\'', '\\\'', $file['name']),
+                            'size' => number_format($file['size'] / 1024, 2),
+                            'part' => $i
+                        ];
+                    }
                 }
             }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
In ElectronicGraderController and ElectronicGraderViewer, there are some situations variables are not being checked to be not null before functions are called on them. This leads to some errors in niche cases.
### What is the new behavior?
The variables are being checked as not null. This prevents the edge case errors
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
