### PR TITLE
[Refactor:UI] Standardize markdown for gradeable assignment/load message

### DIFF
--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -1,4 +1,4 @@
-<div class="content gradeable_message">
+<div class="content gradeable_message markdown">
     <div>{{ load_gradeable_message | markdown }}</div>
     </div>
     <div class="content">

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -2,7 +2,7 @@
 
 {# Display the gradeable_message if one exists at the top of the page #}
 {% if has_gradeable_message %}
-    <div class='content gradeable_message'>{{ gradeable_message | markdown }}</div>
+    <div class='content gradeable_message markdown'>{{ gradeable_message | markdown }}</div>
 {% endif %}
 
 {% if has_overridden_grades %}


### PR DESCRIPTION
Partially #5884 

### What is the current behavior?
Gradeable assignment messages and gradeable load messages do not inherit markdown styling rules from the new standard set of markdown styling rules.

### What is the new behavior?
Markdown rendered for these two spots in submitty now will be styled according to the recently implemented markdown.css.

Assignment message screenshot:
![image](https://user-images.githubusercontent.com/7605020/98713797-0e5bf800-2356-11eb-84a8-0c95a494f877.png)

