### PR TITLE
[Refactor:UI] Standardize markdown for notebook gradeables

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -38,7 +38,7 @@
             {# Handle if cell is short_answer #}
             {% elseif cell.type == "short_answer" %}
 
-                <div>
+                <div class="markdown">
                     {% if cell.label %}
                         {{ cell.label | markdown }}
                     {% else %}
@@ -108,7 +108,7 @@
                           class="mc"
                           {% if cell.recent_submission is defined %}data-prev_checked="{{ cell.recent_submission }}"{% endif %}>
                     {% if cell.allow_multiple == true %}
-                        <legend>
+                        <legend class="markdown">
                             {% if cell.label %}
                                 {{ cell.label | markdown }}
                             {% else %}
@@ -119,7 +119,7 @@
                         {{ _self.render_testcase_messages(cell, testcase_messages) }}
 
                         {% for idx in choices_indices %}
-                            <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
+                            <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}" class="markdown">
 
                                 <input type="checkbox" class="key_to_click" tabindex="0"
                                        name="multiple_choice_{{ num_multiple_choice }}"
@@ -131,7 +131,7 @@
                             </label>
                         {% endfor %}
                     {% else %}
-                        <legend>
+                        <legend class="markdown">
                             {% if cell.label %}
                                 {{ cell.label | markdown }}
                             {% else %}
@@ -142,7 +142,7 @@
                         {{ _self.render_testcase_messages(cell, testcase_messages) }}
 
                         {% for idx in choices_indices %}
-                            <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}">
+                            <label for="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}" class="markdown">
                                 <input type="radio" class="key_to_click" tabindex="0"
                                        name="multiple_choice_{{ num_multiple_choice }}"
                                        id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"

--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -11,10 +11,6 @@
     margin-right: 0;
 }
 
-.notebook ul {
-    padding-left: 3rem;
-}
-
 /* Push recent and clear buttons down a little bit and shrink them slightly */
 .notebook .sa-clear-reset,
 .notebook .codebox-clear-reset,
@@ -86,7 +82,6 @@ textarea.sa-box {
 }
 
 /* Add some margin for informational content that is inside <p> tags */
-.notebook li,
 .notebook p {
     margin-top: 12px;
     margin-bottom: 12px;


### PR DESCRIPTION
Partially #5884 

### What is the current behavior?
Notebook gradeables have the ability to render markdown in several different areas.  This markdown doesn't use the recently implemented markdown.css.

### What is the new behavior?
Updated the notebook gradeable submission page so that markdown areas now use markdown.css.
