### PR TITLE
[Feature:InstructorUI] Restrict access to course materials by user

### DIFF
--- a/site/app/models/CourseMaterial.php
+++ b/site/app/models/CourseMaterial.php
@@ -48,6 +48,24 @@ class CourseMaterial extends AbstractModel {
         }
     }
 
+    /**
+     * Determine if a user is allowed to access a course materials file based on the file's user_allow_list.
+     *
+     * @param string $user_id A user_id, for example 'student' or 'aphacker'
+     * @param array $json Course materials metadata as loaded from the course materials metadata json
+     *                    This array must be loaded by FileUtils::readJsonFile() to be in the expected format!
+     * @param string $path_to_file Absolute path to the file in question
+     * @return bool True if user is allowed to access the file, or if user_allow_list is not in use
+     *              False if the given user was not found in the user_allow_list for this file
+     */
+    public static function isUserAllowedByAllowList(string $user_id, array $json, string $path_to_file): bool {
+        if (array_key_exists('user_allow_list', $json[$path_to_file])) {
+            return in_array($user_id, $json[$path_to_file]['user_allow_list']);
+        }
+
+        return true;
+    }
+
      /**
       * Determine if a course materials file can be viewed by the current user's section
       *

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -43,30 +43,34 @@
         </ul>
     {% endif %}
     <div class="inner-container" id="file-container">
-        {{ self.display_files(self, submissions, fileReleaseDates, "s", 0, "submissions", userGroup, uploadFolderPath, inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, "") }}
+        {{ self.display_files(self, submissions, fileReleaseDates, "s", 0, "submissions", userGroup, uploadFolderPath, inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, "", authorized_by_allow_list) }}
 
     </div>
 </div>
 
-{% macro display_files(self, files, fileReleaseDates, id, indent, title, userGroup, folderPath, inDir, display_file_url,user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir) %}
+{% macro display_files(self, files, fileReleaseDates, id, indent, title, userGroup, folderPath, inDir, display_file_url,user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir, authorized_by_allow_list) %}
     {# Files on top #}
     {% for dir, path in files %}
         {% if path is not iterable %}
-            {{ self.display_file(self, dir, fileReleaseDates, path, id ~ "f" ~ loop.index, indent, title, userGroup, inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir ~ "/" ~ dir) }}
+            {{ self.display_file(self, dir, fileReleaseDates, path, id ~ "f" ~ loop.index, indent, title, userGroup, inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir ~ "/" ~ dir, authorized_by_allow_list) }}
         {% else %}
-            {{ self.display_dir(self, dir, fileReleaseDates, path, id ~ "d" ~ loop.index, indent, title, userGroup, folderPath ~ '/' ~ dir,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir ~ "/" ~ dir) }}
+            {{ self.display_dir(self, dir, fileReleaseDates, path, id ~ "d" ~ loop.index, indent, title, userGroup, folderPath ~ '/' ~ dir,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir ~ "/" ~ dir, authorized_by_allow_list) }}
         {% endif %}
     {% endfor %}
 {% endmacro %}
 
 
-{% macro display_file(self, dir, fileReleaseDates, path, id, indent, title, userGroup, inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir) %}
+{% macro display_file(self, dir, fileReleaseDates, path, id, indent, title, userGroup, inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir, authorized_by_allow_list) %}
     {% set this_file_section = file_sections[path] %}
     {% set this_hide_from_students = hide_from_students[path] %}
     {% set this_external_link = external_link[path] %}
 
     {% set greater_than_student = userGroup < 4 %}
-    {% set visible_to_student = this_hide_from_students == 'off' and (this_file_section is null or user_section in this_file_section) %}
+    {% set visible_to_student =
+        this_hide_from_students == 'off' and
+        (this_file_section is null or user_section in this_file_section) and
+        authorized_by_allow_list[path]
+    %}
 
     {% if greater_than_student or visible_to_student %}
     <div class="file-container">
@@ -146,9 +150,9 @@
     {% endif %}
 {% endmacro %}
 
-{% macro display_dir(self, dir, fileReleaseDates, contents, id, indent, title, userGroup, folderPath,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir) %}
+{% macro display_dir(self, dir, fileReleaseDates, contents, id, indent, title, userGroup, folderPath,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir, authorized_by_allow_list) %}
     {% if indent == 0 %}
-        {{ self.display_files(self, contents, fileReleaseDates, id, indent + 1, title, userGroup, folderPath,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir) }}
+        {{ self.display_files(self, contents, fileReleaseDates, id, indent + 1, title, userGroup, folderPath,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir, authorized_by_allow_list) }}
     {% else %}
     <div class="folder-container">
 
@@ -176,7 +180,7 @@
 
             {# Recurse #}
 
-            {{ self.display_files(self, contents, fileReleaseDates, id, indent + 1, title, userGroup, folderPath,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir) }}
+            {{ self.display_files(self, contents, fileReleaseDates, id, indent + 1, title, userGroup, folderPath,inDir, display_file_url, user_section, file_sections, hide_from_students, external_link, priorities, recursiveDir, authorized_by_allow_list) }}
 
         </div>
     </div>


### PR DESCRIPTION
### What is the current behavior?
There is no ability to restrict access to course materials on a user-by-user basis.

### What is the new behavior?
This PR begins to implement this behavior.  A user interface for this feature will be added in a later PR.

To test simply add a 'user_allow_list' array to a desired file in the `course_materials_file_data.json` as illustrated below.

![image](https://user-images.githubusercontent.com/7605020/98864687-450a3f00-2438-11eb-95bf-d03a31a1e642.png)

**Note:** Using the instructor facing website interface of course materials to edit any files will likely clobber custom made edits to `course_materials_file_data.json`. 

Adding a 'user_allow_list' to a file will restrict access and visibility of that file to *only* those users in the allow list, or users that have a higher access level than students (for example instructors).
