### PR TITLE
[Feature:InstructorUI] Grade summaries rotating section

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -355,6 +355,7 @@ class ReportController extends AbstractController {
         $user_data['legal_last_name'] = $user->getLegalLastName();
         $user_data['preferred_last_name'] = $user->getPreferredLastName();
         $user_data['registration_section'] = $user->getRegistrationSection();
+        $user_data['rotating_section'] = $user->getRotatingSection();
         $user_data['default_allowed_late_days'] = $this->core->getConfig()->getDefaultStudentLateDays();
         $user_data['last_update'] = date("l, F j, Y");
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
#5816: grade summaries don't include rotating section

### What is the new behavior?
 grade summaries include rotating section. This doesn't correct any behaviors with rainbow grades, just the .json files with the student summaries

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
