### PR TITLE
[Feature:TAGrading] Keep notebook scroll position in TA grading page

### DIFF
--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -73,6 +73,8 @@ class UserSpecificNotebook extends Notebook {
         $new_notebook = [];
         $seen_items = [];
         $tests = [];
+        
+        $item_ref = 0;
 
         foreach ($raw_notebook as $notebook_cell) {
             if (isset($notebook_cell['type']) && $notebook_cell['type'] === 'item') {
@@ -81,6 +83,10 @@ class UserSpecificNotebook extends Notebook {
 
                 $item_data = $this->searchForItemPool($tgt_item);
                 if (count($item_data['notebook']) > 0) {
+                    for($i = 0; $i < count($item_data['notebook']); $i++) {
+                        $item_data['notebook'][$i]["item_ref"] = $item_ref;
+                    }
+                    $item_ref++;
                     $new_notebook = array_merge($new_notebook, $item_data['notebook']);
                     $test_cases = $item_data['testcases'] ?? [];
                     $tests = array_merge($tests, $test_cases);

--- a/site/app/models/notebook/UserSpecificNotebook.php
+++ b/site/app/models/notebook/UserSpecificNotebook.php
@@ -73,7 +73,7 @@ class UserSpecificNotebook extends Notebook {
         $new_notebook = [];
         $seen_items = [];
         $tests = [];
-        
+
         $item_ref = 0;
 
         foreach ($raw_notebook as $notebook_cell) {
@@ -83,7 +83,7 @@ class UserSpecificNotebook extends Notebook {
 
                 $item_data = $this->searchForItemPool($tgt_item);
                 if (count($item_data['notebook']) > 0) {
-                    for($i = 0; $i < count($item_data['notebook']); $i++) {
+                    for ($i = 0; $i < count($item_data['notebook']); $i++) {
                         $item_data['notebook'][$i]["item_ref"] = $item_ref;
                     }
                     $item_ref++;

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -5,7 +5,7 @@
     {% set num_multiple_choice = 0 %}
     {% set num_file_submissions = 0 %}
     {% for cell in notebook %}
-        <div id="content_{{ loop.index0 }}" class="{{ cell.type }}">
+        <div id="content_{{ loop.index0 }}" class="{{ cell.type }}" {% if cell.item_ref is defined %}data-item-ref={{ cell.item_ref }}{% endif %}>
 
             {# Handle if cell is markdown #}
             {% if cell.type == "markdown" %}

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -4,8 +4,9 @@
     {% set num_codeboxes = 0 %}
     {% set num_multiple_choice = 0 %}
     {% set num_file_submissions = 0 %}
+    {% set data_non_item_ref = 0 %}
     {% for cell in notebook %}
-        <div id="content_{{ loop.index0 }}" class="{{ cell.type }}" {% if cell.item_ref is defined %}data-item-ref={{ cell.item_ref }}{% endif %}>
+        <div id="content_{{ loop.index0 }}" class="{{ cell.type }}" {% if cell.item_ref is defined %}data-item-ref={{ cell.item_ref }}{% else %}data-non-item-ref={{data_non_item_ref}}{% set data_non_item_ref = data_non_item_ref + 1 %}{% endif %}>
 
             {# Handle if cell is markdown #}
             {% if cell.type == "markdown" %}

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -117,8 +117,12 @@ $(function () {
       const panelId = panelSpanId.split(/(_|-)btn/)[0];
       setPanelsVisibilities(panelId, null, position);
       $('select#' + panelId + '_select').hide();
+      checkNotebookScroll();
     }
   });
+  notebookScrollLoad();
+
+  checkNotebookScroll();
 
   // Remove the select options which are open
   function hidePanelPositionSelect() {
@@ -145,6 +149,62 @@ $(function () {
   });
 
 });
+
+function checkNotebookScroll() {
+  if (taLayoutDet.currentTwoPanels.leftTop === 'notebook-view'
+    || taLayoutDet.currentTwoPanels.leftBottom === 'notebook-view'
+    || taLayoutDet.currentTwoPanels.rightTop === 'notebook-view'
+    || taLayoutDet.currentTwoPanels.rightBottom === 'notebook-view'
+    || taLayoutDet.currentOpenPanel === 'notebook-view'
+  ) {
+    $('#notebook-view').scroll(delayedNotebookSave());
+  } else {
+    $('#notebook-view').off('scroll');
+    localStorage.removeItem('ta-grading-notebook-view-scroll');
+  }
+}
+
+function delayedNotebookSave() {
+  var timer;
+  return function() {
+    timer && clearTimeout(timer);
+    timer = setTimeout(notebookScrollSave, 250);
+  }
+}
+
+function notebookScrollLoad() {
+  var notebookView = $('#notebook-view');
+  if (notebookView !== 0 && notebookView.is(":visible")) {
+    var elementID = localStorage.getItem('ta-grading-notebook-view-scroll');
+    if (elementID) {
+      var element = $('#' + elementID);
+      if(element.length !== 0) {
+        notebookView.scrollTop(element.offset().top - notebookView.offset().top + notebookView.scrollTop());
+        return;
+      }
+      //Invalid element, remove here
+      localStorage.removeItem('ta-grading-notebook-view-scroll');
+    }
+  }
+}
+
+function notebookScrollSave() {
+  var notebookView = $('#notebook-view');
+  if (notebookView.length !== 0 && notebookView.is(":visible")) {
+    var notebookTop = $('#notebook-view').offset().top;
+    var element = $('#content_0');
+    while (element.length !== 0) {
+      if (element.offset().top > notebookTop) {
+      // if(element.offset().top + element.offsetHeight() > notebookTop) {
+        break;
+      }
+      element = element.next();
+    }
+    if (element.length !== 0) {
+      localStorage.setItem('ta-grading-notebook-view-scroll', element.attr('id'));
+    }
+  }
+}
 
 // returns taLayoutDet object from LS, and if its not present returns empty object
 function getSavedTaLayoutDetails() {

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -187,7 +187,7 @@ function notebookScrollLoad() {
         }
       }
     } else {
-      element = $('#' + elementID);
+      element = $('[data-non-item-ref=' + elementID + ']');
     }
     if (element !== null) {
       if(element.length !== 0) {
@@ -213,7 +213,7 @@ function notebookScrollSave() {
     }
     if (element.length !== 0) {
       if (element.attr('data-item-ref') === undefined) {
-        localStorage.setItem('ta-grading-notebook-view-scroll-id', element.attr('id'));
+        localStorage.setItem('ta-grading-notebook-view-scroll-id', element.attr('data-non-item-ref'));
         localStorage.removeItem('ta-grading-notebook-view-scroll-item');
       } else {
         localStorage.setItem('ta-grading-notebook-view-scroll-item', element.attr('data-item-ref'));

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -160,7 +160,8 @@ function checkNotebookScroll() {
     $('#notebook-view').scroll(delayedNotebookSave());
   } else {
     $('#notebook-view').off('scroll');
-    localStorage.removeItem('ta-grading-notebook-view-scroll');
+    localStorage.removeItem('ta-grading-notebook-view-scroll-id');
+    localStorage.removeItem('ta-grading-notebook-view-scroll-item');
   }
 }
 
@@ -175,33 +176,49 @@ function delayedNotebookSave() {
 function notebookScrollLoad() {
   var notebookView = $('#notebook-view');
   if (notebookView !== 0 && notebookView.is(":visible")) {
-    var elementID = localStorage.getItem('ta-grading-notebook-view-scroll');
-    if (elementID) {
-      var element = $('#' + elementID);
+    var elementID = localStorage.getItem('ta-grading-notebook-view-scroll-id');
+    var element = null;
+    if (elementID === null) {
+      elementID = localStorage.getItem('ta-grading-notebook-view-scroll-item');
+      if (elementID !== null) {
+        element = $('[data-item-ref=' + elementID + ']');
+        if(element.length !== 0) {
+          element = element.first();
+        }
+      }
+    } else {
+      element = $('#' + elementID);
+    }
+    if (element !== null) {
       if(element.length !== 0) {
         notebookView.scrollTop(element.offset().top - notebookView.offset().top + notebookView.scrollTop());
-        return;
+      } else {
+        localStorage.removeItem('ta-grading-notebook-view-scroll-id');
+        localStorage.removeItem('ta-grading-notebook-view-scroll-item');
       }
-      //Invalid element, remove here
-      localStorage.removeItem('ta-grading-notebook-view-scroll');
     }
   }
 }
 
 function notebookScrollSave() {
   var notebookView = $('#notebook-view');
-  if (notebookView.length !== 0 && notebookView.is(":visible")) {
+  if (notebookView.length !== 0 && notebookView.is(':visible')) {
     var notebookTop = $('#notebook-view').offset().top;
     var element = $('#content_0');
     while (element.length !== 0) {
       if (element.offset().top > notebookTop) {
-      // if(element.offset().top + element.offsetHeight() > notebookTop) {
         break;
       }
       element = element.next();
     }
     if (element.length !== 0) {
-      localStorage.setItem('ta-grading-notebook-view-scroll', element.attr('id'));
+      if (element.attr('data-item-ref') === undefined) {
+        localStorage.setItem('ta-grading-notebook-view-scroll-id', element.attr('id'));
+        localStorage.removeItem('ta-grading-notebook-view-scroll-item');
+      } else {
+        localStorage.setItem('ta-grading-notebook-view-scroll-item', element.attr('data-item-ref'));
+        localStorage.removeItem('ta-grading-notebook-view-scroll-id');
+      }
     }
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
When grading inside of the new TA grading interface, when a grader goes to a different student, the scroll position in the notebook resets.

### What is the new behavior?
Fixes #5976 
When grading inside of the new TA grading interface, when a grader goes to a different student, the scroll position in the notebook goes to the same content section from the previous one (if it is a random item pool item, it will go to the top of that item as a whole).

### Other information?
Tested by going through each section and going between students to make sure it went to the correct content section in the notebook.