### PR TITLE
[Bugfix:TAGrading] Fix CodeMirror bugs

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -244,6 +244,7 @@
 
             tgts = nb.querySelectorAll('.CodeMirror');
             for(let x of tgts){
+                x.CodeMirror.setOption("readOnly", true);
                 x.CodeMirror.refresh();
             }
 

--- a/site/public/js/ta-grading-v2.js
+++ b/site/public/js/ta-grading-v2.js
@@ -563,7 +563,8 @@ function setPanelsVisibilities (ele, forceVisible=null, position=null) {
       $("#" + panel.str).toggle(eleVisibility);
       $(panel.icon).toggleClass('icon-selected', eleVisibility);
       $(id_str).toggleClass('active', eleVisibility);
-
+      $("#" + panel.str).find(".CodeMirror").each(function() {this.CodeMirror.refresh()});
+      
       if (taLayoutDet.numOfPanelsEnabled > 1 && !isMobileView) {
         checkForTwoPanelLayoutChange(eleVisibility, panel.str, position);
       } else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
If you quickly spam paste right after a CodeMirror box is clicked, you can sometimes paste data into the box.
If the notebook panel was not in your layout and you add it to your layout, the CodeMirror boxes will be blank until it is clicked on.

### What is the new behavior?
Works on #5971 
CodeMirror boxes should now be fully readonly in grader view.
CodeMirror box data will now be refreshed on adding the notebook panel into your layout.

### Other information?
Tested before and after making changes to make sure issue was fixed.
Tested CodeMirror boxes in a notebook_itempool_random gradeable to make sure they still worked.
