### PR TITLE
[Bugfix: Submission] Correct Powerpoint Submission Extraction

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -602,8 +602,13 @@ def zip_my_directory(path,zipfilename):
 def unzip_this_file(zipfilename,path):
     if not os.path.exists(zipfilename):
         raise RuntimeError("ERROR: zip file does not exist '", zipfilename, "'")
+    _, file_ext = os.path.splitext(zipfilename)
     zip_ref = zipfile.ZipFile(zipfilename,'r')
-    zip_ref.extractall(path)
+    if file_ext is ".pptx":
+        zip_ref.extract(path)
+    else:
+        zip_ref.extractall(path)
+
     zip_ref.close()
 
 # ==================================================================================


### PR DESCRIPTION
Fixed #5995 

Originally Submitty was extracting a .pptx file submission as if it were a zip and thus having a long list of submitted files (fonts, pictures, etc.) when there should have only been one .pptx file. Now, Submitty will extract it as only a .pptx file and not have a long list of files. Submitty only shows one file, the .pptx file, in the list of submitted files.