### PR TITLE
[Bugfix:TAGrading] Fix version changes on the TA grading page

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1238,7 +1238,7 @@ class ElectronicGraderController extends AbstractController {
         // Get the graded gradeable for the submitter we are requesting
         $graded_gradeable = false;
         $id_from_anon = $this->core->getQueries()->getSubmitterIdFromAnonId($who_id);
-        if ($blind_grading || $anon_mode) {
+        if ($blind_grading !== "unblind" || $anon_mode) {
             $graded_gradeable = $this->tryGetGradedGradeable($gradeable, $id_from_anon, false);
         }
         else {


### PR DESCRIPTION
### What is the current behavior?
Changing the version of student code to be graded from the TA grading page results in a "frog robot" error. This was caused by the TA grading page improperly always assuming that grading was blind.

### What is the new behavior?
The error should now be resolved. 