### PR TITLE
[TAGrading:Bugfix] Download Zip Downloading Hidden Peer Files

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -338,14 +338,6 @@ class MiscController extends AbstractController {
 
         // create a new zipstream object
         $zip_stream = new \ZipStream\ZipStream($zip_file_name, $options);
-        
-        if ($gradeable->isGradeByRegistration()) {
-            $section = $graded_gradeable->getSubmitter()->getRegistrationSection();
-        }
-        else {
-            $section = $graded_gradeable->getSubmitter()->getRotatingSection();
-        }
-
         foreach ($folder_names as $folder_name) {
             $path = FileUtils::joinPaths($gradeable_path, $folder_name, $gradeable->getId(), $graded_gradeable->getSubmitter()->getId(), $version);
             if (is_dir($path)) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If an instructor uses wildcards to designate files hidden to peer graders, the peer graders can download the files using the Download Zip files button

### What is the new behavior?
The Download Zip files now only includes files which the peer has access to (will not allow for hidden files)
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
