### PR TITLE
[Feature:InstructorUI] Display responses per poll

### DIFF
--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -12,17 +12,21 @@
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">
-            <col style="width: 20%">
-            <col style="width: 16%">
-            <col style="width: 16%">
-            <col style="width: 16%">
-            <col style="width: 16%">
-            <col style="width: 16%">
+            <col style="width: 23%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
             <thead>
                 <tr>
                     <th scope="col">Name</th>
+                    <th scope="col"></th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
+                    <th scope="col">Responses</th>
                     <th scope="col">Edit</th>
                     <th scope="col">View Results</th>
                     <th scope="col">Delete</th>
@@ -32,11 +36,15 @@
                 {% for poll in todays_polls %}
                     <tr>
                         <td> {{ poll.getName() }} </td>
+                        <td>{{ poll.getReleaseDate() }}</td>
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getID() }}_visible" aria-label="label" onclick='updatePollVisible("{{ poll.getID() }}", "{{ base_url }}")' {{ (poll.isOpen() or poll.isEnded) ? 'checked' : '' }}>
                         </td>
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getID() }}_view_results" aria-label="label" onclick='updatePollAcceptingAnswers("{{ poll.getID() }}", "{{ base_url }}")' {{ poll.isOpen ? 'checked' : ''}}>
+                        </td>
+                        <td>
+                            {{ poll.getUserResponses()|length }}
                         </td>
                         <td>
                             <a href="{{base_url}}/editPoll/{{ poll.getID() }}">
@@ -75,19 +83,22 @@
             </div>
         </div>
         <table id="older-table" class="table table-striped" style="width:100%;{{ dropdown_states['old'] ? '' : ' display: none;'}}">
-            <col style="width: 20%">
-            <col style="width: 14%">
-            <col style="width: 10%">
-            <col style="width: 15%">
-            <col style="width: 13%">
-            <col style="width: 15%">
-            <col style="width: 13%">
+            <col style="width: 23%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+
             <thead>
                 <tr>
                     <th scope="col">Name</th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
+                    <th scope="col">Responses</th>
                     <th scope="col">Edit</th>
                     <th scope="col">View Results</th>
                     <th scope="col">Delete</th>
@@ -103,6 +114,9 @@
                         </td>
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getID() }}_view_results" aria-label="label" onclick='updatePollAcceptingAnswers("{{ poll.getID() }}", "{{ base_url }}")' {{ poll.isOpen ? 'checked' : ''}}>
+                        </td>
+                        <td>
+                            {{ poll.getUserResponses()|length }}
                         </td>
                         <td>
                             <a href="{{base_url}}/editPoll/{{ poll.getID() }}">
@@ -140,15 +154,21 @@
             </div>
         </div>
         <table id="future-table" class="table table-striped" style="width:100%;{{ dropdown_states['future'] ? '' : ' display: none;'}}">
-            <col style="width: 20%">
-            <col style="width: 20%">
-            <col style="width: 20%">
-            <col style="width: 20%">
-            <col style="width: 20%">
+            <col style="width: 23%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
+            <col style="width: 11%">
             <thead>
                 <tr>
                     <th scope="col">Name</th>
                     <th scope="col">Date Released</th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col">Responses</th>
                     <th scope="col">Edit</th>
                     <th scope="col">View Results</th>
                     <th scope="col">Delete</th>
@@ -159,6 +179,11 @@
                     <tr>
                         <td> {{ poll.getName() }} </td>
                         <td> {{ poll.getReleaseDate() }} </td>
+                        <td></td>
+                        <td></td>
+                        <td>
+                            {{ poll.getUserResponses()|length }}
+                        </td>
                         <td>
                             <a href="{{base_url}}/editPoll/{{ poll.getID() }}">
                                 <input type="hidden" name="poll_id" value="{{ poll.getID() }}"/>

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -36,16 +36,14 @@
                 {% for poll in todays_polls %}
                     <tr>
                         <td> {{ poll.getName() }} </td>
-                        <td>{{ poll.getReleaseDate() }}</td>
+                        <td></td>
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getID() }}_visible" aria-label="label" onclick='updatePollVisible("{{ poll.getID() }}", "{{ base_url }}")' {{ (poll.isOpen() or poll.isEnded) ? 'checked' : '' }}>
                         </td>
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getID() }}_view_results" aria-label="label" onclick='updatePollAcceptingAnswers("{{ poll.getID() }}", "{{ base_url }}")' {{ poll.isOpen ? 'checked' : ''}}>
                         </td>
-                        <td>
-                            {{ poll.getUserResponses()|length }}
-                        </td>
+                        <td> {{ poll.getUserResponses()|length }} </td>
                         <td>
                             <a href="{{base_url}}/editPoll/{{ poll.getID() }}">
                                 <input type="hidden" name="poll_id" value="{{ poll.getID() }}"/>
@@ -115,9 +113,7 @@
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getID() }}_view_results" aria-label="label" onclick='updatePollAcceptingAnswers("{{ poll.getID() }}", "{{ base_url }}")' {{ poll.isOpen ? 'checked' : ''}}>
                         </td>
-                        <td>
-                            {{ poll.getUserResponses()|length }}
-                        </td>
+                        <td> {{ poll.getUserResponses()|length }} </td>
                         <td>
                             <a href="{{base_url}}/editPoll/{{ poll.getID() }}">
                                 <input type="hidden" name="poll_id" value="{{ poll.getID() }}"/>
@@ -181,9 +177,7 @@
                         <td> {{ poll.getReleaseDate() }} </td>
                         <td></td>
                         <td></td>
-                        <td>
-                            {{ poll.getUserResponses()|length }}
-                        </td>
+                        <td> {{ poll.getUserResponses()|length }} </td>
                         <td>
                             <a href="{{base_url}}/editPoll/{{ poll.getID() }}">
                                 <input type="hidden" name="poll_id" value="{{ poll.getID() }}"/>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
There is no easy way for the instructor to see the total number of responses per poll from the main poll page.

### What is the new behavior?
There is now a column for responses that displays the total number of responses per poll.

The spacing of columns for the main poll page has also been slightly changed to _hopefully_ be prettier :)

### Other information?

