### PR TITLE
[Bugfix:TAGrading] Histogram Bucket Size Bug

### DIFF
--- a/site/app/templates/grading/electronic/ta_status/StatusAutogradingHistogram.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusAutogradingHistogram.twig
@@ -3,7 +3,7 @@
 <div id="autograding-score-histogram" class="page-content">
     <br>
     <input style='width: auto' type='text' id='bucket-size-auto' name='bucket-val' value="" placeholder="Enter bucket size" />
-    <input name = "sub-auto" class="btn btn-primary key_to_click" tabindex="0" id="submit_bucket_auto" type="submit" value="Submit Bucket Size for Auto" onclick="createNewBuckets(rangeA,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA)"/>
+    <input name = "sub-auto" class="btn btn-primary key_to_click" tabindex="0" id="submit_bucket_auto" value="Submit Bucket Size for Auto" onclick="createNewBuckets(rangeA,buckets,xValue,yValue,xBuckets,mode,modeCount,maxA,minA)"/>
     <div id="myDiv3"><!-- Plotly chart will be drawn inside this DIV --></div>
     <script>
         var buckets = new Map();

--- a/site/app/templates/grading/electronic/ta_status/StatusOverallHistogram.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusOverallHistogram.twig
@@ -3,7 +3,7 @@
 
     <br>
     <input style='width: auto' type='text' id='bucket-size-total' name='bucket-val' value="" aria-label="Enter bucket size" placeholder="Enter bucket size" />
-    <input name="sub-tot" class="btn btn-primary key_to_click" tabindex="0" id="submit_bucket" type="submit" value="Submit Bucket Size for Total" onclick="createNewBuckets(rangeT,betterBuckets,xValueT,yValue,xBuckets,mode,modeCount,maxT,minT)"/>
+    <input name="sub-tot" class="btn btn-primary key_to_click" tabindex="0" id="submit_bucket" value="Submit Bucket Size for Total" onclick="createNewBuckets(rangeT,betterBuckets,xValueT,yValue,xBuckets,mode,modeCount,maxT,minT)"/>
 
     <div id="myDiv"><!-- Plotly chart will be drawn inside this DIV --></div>
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
When a TA or instructor looks at stats on the histogram tabs and clicks on the "Submit Bucket Size" button, it results in an "Invalid CSRF Token" error

### What is the new behavior?
The bucket size now changes without the error

![image](https://user-images.githubusercontent.com/51247866/101867056-53876b80-3b48-11eb-8198-f95c537df8ad.png)
![image](https://user-images.githubusercontent.com/51247866/101867126-6f8b0d00-3b48-11eb-8fa2-ca45580105f0.png)


### Other information?
Not a breaking change, the type for the button was removed in order to prevent a page refresh
