### PR TITLE
[Bugfix:TAGrading] Fix invalid closing p tag

### DIFF
--- a/site/app/templates/grading/electronic/ta_status/StatusData.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusData.twig
@@ -156,7 +156,7 @@
 		                            {% else %}
 		                                <p style="padding-left:3.7em">
 		                            {% endif %}
-		                            {{ grader }} (count {{ data['count'] }} - avg {{ data['avg'] }} - stddev {{ data['std_dev'] }}) </p1>
+		                            {{ grader }} (count {{ data['count'] }} - avg {{ data['avg'] }} - stddev {{ data['std_dev'] }}) </p>
 		                        {% endfor%}
                             </div>
                         {% endfor %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?

#6083 (and originally #5979) has a broken closing `</p>` tag for showing the statistic. The page displays correctly only because browsers are being forgiving for the invalid HTML and automatically inserting the closing `</p>` tags appropriately, but this behavior is browser specific and not guaranteed.

### What is the new behavior?

Uses the appropriate closing `</p>` tag.