### PR TITLE
[Feature:TAGrading] Cached late days for more stats

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -293,6 +293,41 @@ CREATE TABLE public.gradeable (
 
 
 --
+-- Name: gradeable_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.gradeable_access (
+    id integer NOT NULL,
+    g_id character varying(255) NOT NULL,
+    user_id character varying(255),
+    team_id character varying(255),
+    accessor_id character varying(255),
+    "timestamp" timestamp with time zone NOT NULL,
+    CONSTRAINT access_team_id_check CHECK (((user_id IS NOT NULL) OR (team_id IS NOT NULL)))
+);
+
+
+--
+-- Name: gradeable_access_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.gradeable_access_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: gradeable_access_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.gradeable_access_id_seq OWNED BY public.gradeable_access.id;
+
+
+--
 -- Name: gradeable_component; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -475,20 +510,6 @@ CREATE TABLE public.gradeable_teams (
     rotating_section integer
 );
 
-
---
--- Name: gradeable_access; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.gradeable_access (
-    id SERIAL NOT NULL PRIMARY KEY,
-    g_id character varying(255) NOT NULL ,
-    user_id character varying(255),
-    team_id character varying(255),
-    accessor_id character varying(255),
-    "timestamp" timestamp with time zone NOT NULL,
-    CONSTRAINT access_team_id_check CHECK (((user_id IS NOT NULL) OR (team_id IS NOT NULL)))
-);
 
 --
 -- Name: grading_registration; Type: TABLE; Schema: public; Owner: -
@@ -1064,6 +1085,13 @@ ALTER TABLE ONLY public.categories_list ALTER COLUMN category_id SET DEFAULT nex
 
 
 --
+-- Name: gradeable_access id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_access ALTER COLUMN id SET DEFAULT nextval('public.gradeable_access_id_seq'::regclass);
+
+
+--
 -- Name: gradeable_component gc_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1200,6 +1228,14 @@ ALTER TABLE ONLY public.electronic_gradeable
 
 ALTER TABLE ONLY public.grade_override
     ADD CONSTRAINT grade_override_pkey PRIMARY KEY (user_id, g_id);
+
+
+--
+-- Name: gradeable_access gradeable_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_access
+    ADD CONSTRAINT gradeable_access_pkey PRIMARY KEY (id);
 
 
 --
@@ -1650,6 +1686,38 @@ ALTER TABLE ONLY public.grade_override
 
 ALTER TABLE ONLY public.grade_override
     ADD CONSTRAINT grade_override_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON UPDATE CASCADE;
+
+
+--
+-- Name: gradeable_access gradeable_access_fk0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_access
+    ADD CONSTRAINT gradeable_access_fk0 FOREIGN KEY (g_id) REFERENCES public.gradeable(g_id) ON DELETE CASCADE;
+
+
+--
+-- Name: gradeable_access gradeable_access_fk1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_access
+    ADD CONSTRAINT gradeable_access_fk1 FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+
+--
+-- Name: gradeable_access gradeable_access_fk2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_access
+    ADD CONSTRAINT gradeable_access_fk2 FOREIGN KEY (team_id) REFERENCES public.gradeable_teams(team_id);
+
+
+--
+-- Name: gradeable_access gradeable_access_fk3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_access
+    ADD CONSTRAINT gradeable_access_fk3 FOREIGN KEY (accessor_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
 
 
 --
@@ -2172,30 +2240,6 @@ ALTER TABLE ONLY public.viewed_responses
     ADD CONSTRAINT viewed_responses_fk1 FOREIGN KEY (user_id) REFERENCES public.users(user_id);
 
 
---
--- Name: gradeable_access gradeable_access_fk0; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-ALTER TABLE ONLY public.gradeable_access
-    ADD CONSTRAINT gradeable_access_fk0 FOREIGN KEY (g_id) REFERENCES public.gradeable(g_id) ON DELETE CASCADE;
-
-
---
--- Name: gradeable_access gradeable_access_fk1; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-ALTER TABLE ONLY public.gradeable_access
-    ADD CONSTRAINT gradeable_access_fk1 FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
-
---
--- Name: gradeable_access gradeable_access_fk2; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-ALTER TABLE ONLY public.gradeable_access
-    ADD CONSTRAINT gradeable_access_fk2 FOREIGN KEY (team_id) REFERENCES public.gradeable_teams(team_id);
-
---
--- Name: gradeable_access gradeable_access_fk2; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-ALTER TABLE ONLY public.gradeable_access
-    ADD CONSTRAINT gradeable_access_fk3 FOREIGN KEY (accessor_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
 --
 -- PostgreSQL database dump complete
 --

--- a/migration/migrator/migrations/course/20201221204041_add_status_column.py
+++ b/migration/migrator/migrations/course/20201221204041_add_status_column.py
@@ -1,0 +1,35 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('ALTER TABLE IF EXISTS electronic_gradeable_version ADD COLUMN IF NOT EXISTS late_day_status int;')
+    pass
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('ALTER TABLE IF EXISTS electronic_gradeable_version DROP COLUMN IF EXISTS late_day_status;')
+    pass

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -8,6 +8,7 @@ use app\libraries\DateUtils;
 use app\libraries\GradeableType;
 use app\models\gradeable\Gradeable;
 use app\models\gradeable\Component;
+use app\models\gradeable\LateDays;
 use app\models\gradeable\Mark;
 use app\libraries\FileUtils;
 use app\libraries\response\JsonResponse;
@@ -1010,11 +1011,6 @@ class AdminGradeableController extends AbstractController {
         }
     }
 
-    /**
-     * Recalculate the late day information for every user in each grading section
-     *
-     * @param $gradeable
-     */
     private function recalculateCachedLateDays($gradeable) {
         $sections = $gradeable->getAllGradingSections();
 

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -45,6 +45,10 @@ class LateController extends AbstractController {
         );
     }
 
+    public function reccacheLateDays($user_id) {
+        LateDays::cacheLateDayInfoForUser($this->core, $this->submitter->getId());
+    }
+
     /**
      * @param $csv_option string csv_option_overwrite_all or csv_option_preserve_higher
      *
@@ -97,6 +101,7 @@ class LateController extends AbstractController {
             $date_time = DateUtils::parseDateTime($_POST['datestamp'], $this->core->getUser()->getUsableTimeZone());
 
             $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days']);
+            $this->reccacheLateDays($_POST['user_id']);
             $this->core->addSuccessMessage("Late days have been updated");
             return $this->getLateDays();
         }
@@ -125,6 +130,7 @@ class LateController extends AbstractController {
             );
         }
         $this->core->getQueries()->deleteLateDays($_POST['user_id'], $_POST['datestamp']);
+        $this->reccacheLateDays($_POST['user_id']);
         $this->core->addSuccessMessage("Late days entry removed");
 
         return $this->getLateDays();
@@ -238,6 +244,7 @@ class LateController extends AbstractController {
             }
             else {
                 $this->core->getQueries()->updateExtensions($_POST['user_id'], $_POST['g_id'], $late_days);
+                $this->reccacheLateDays($_POST['user_id']);
                 $this->core->addSuccessMessage("Extensions have been updated");
                 return MultiResponse::JsonOnlyResponse(JsonResponse::getSuccessResponse());
             }

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -4,12 +4,12 @@ namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
 use app\libraries\DateUtils;
-use app\models\gradeable\LateDays;
 use app\libraries\routers\AccessControl;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\JsonResponse;
 use app\libraries\response\WebResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use app\models\gradeable\LateDays;
 
 /**
  * Class LateController
@@ -216,6 +216,7 @@ class LateController extends AbstractController {
             if ($team != null && $team->getSize() > 1) {
                 if ($option == 0) {
                     $this->core->getQueries()->updateExtensions($_POST['user_id'], $_POST['g_id'], $late_days);
+                    $this->reccacheLateDays($_POST['user_id']);
                     $this->core->addSuccessMessage("Extensions have been updated");
                     return MultiResponse::JsonOnlyResponse(JsonResponse::getSuccessResponse());
                 }
@@ -223,6 +224,7 @@ class LateController extends AbstractController {
                     $team_member_ids = explode(", ", $team->getMemberList());
                     for ($i = 0; $i < count($team_member_ids); $i++) {
                         $this->core->getQueries()->updateExtensions($team_member_ids[$i], $_POST['g_id'], $late_days);
+                        $this->reccacheLateDays($team_member_ids[$i]);
                     }
                     $this->core->addSuccessMessage("Extensions have been updated");
                     return MultiResponse::JsonOnlyResponse(JsonResponse::getSuccessResponse());

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -4,6 +4,7 @@ namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
 use app\libraries\DateUtils;
+use app\models\gradeable\LateDays;
 use app\libraries\routers\AccessControl;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\JsonResponse;
@@ -46,7 +47,7 @@ class LateController extends AbstractController {
     }
 
     public function reccacheLateDays($user_id) {
-        app\models\gradeable\LateDays::cacheLateDayInfoForUser($this->core, $user_id);
+        LateDays::cacheLateDayInfoForUser($this->core, $user_id);
     }
 
     /**

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -46,7 +46,7 @@ class LateController extends AbstractController {
     }
 
     public function reccacheLateDays($user_id) {
-        LateDays::cacheLateDayInfoForUser($this->core, $this->submitter->getId());
+        app\models\gradeable\LateDays::cacheLateDayInfoForUser($this->core, $user_id);
     }
 
     /**

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -841,6 +841,11 @@ class SubmissionController extends AbstractController {
         return $this->uploadResult("Successfully deleted this PDF.");
     }
 
+    public function updateLateDays($user_id) {
+        // $user = $this->core->getQueries()->getUserById($user_id);
+        // $late_days = LateDays::fromUser($this->core, $user);
+    }
+
     /**
      * Function for uploading a submission to the server. This should be called via AJAX, saving the result
      * to the json_buffer of the Output object, returning a true or false on whether or not it suceeded or not.
@@ -1448,6 +1453,8 @@ class SubmissionController extends AbstractController {
         else {
             $message = "Successfully uploaded version {$new_version} for {$gradeable->getTitle()} for {$who_id}";
         }
+
+        $this->updateLateDays($user_id);
 
         return $this->uploadResult($message);
     }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -14,6 +14,7 @@ use app\libraries\response\RedirectResponse;
 use app\libraries\response\MultiResponse;
 use app\libraries\routers\AccessControl;
 use app\libraries\Utils;
+use app\models\gradeable\LateDays;
 use app\models\gradeable\Gradeable;
 use app\models\gradeable\GradedGradeable;
 use Symfony\Component\Routing\Annotation\Route;
@@ -842,7 +843,7 @@ class SubmissionController extends AbstractController {
     }
 
     public function reccacheLateDays($user_id) {
-        LateDays::cacheLateDayInfoForUser($this->core, $this->submitter->getId());
+        LateDays::cacheLateDayInfoForUser($this->core, $user_id);
     }
 
     /**

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3153,24 +3153,17 @@ ORDER BY gt.{$section_key}",
     }
 
     public function cacheLateDayInfo($submitter_id, $g_id, $status, $is_team) {
-        $u_or_t = "u";
-        $users_or_teams = "users";
         $user_or_team_id = "user_id";
         if ($is_team) {
-            $u_or_t = "t";
-            $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
         }
 
         $this->course_db->query(
             "
         UPDATE electronic_gradeable_version SET late_day_status = ? 
-        FROM electronic_gradeable_version
-        LEFT JOIN 
-            {$users_or_teams} AS {$u_or_t}
-        ON {$user_or_team_id}=?
+        WHERE {$user_or_team_id}=?
         AND g_id=?",
-            [$submitter_id, $g_id]
+            [$status, $submitter_id, $g_id]
         );
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3152,6 +3152,28 @@ ORDER BY gt.{$section_key}",
         return $return;
     }
 
+    public function cacheLateDayInfo($submitter_id, $g_id, $status, $is_team) {
+        $u_or_t = "u";
+        $users_or_teams = "users";
+        $user_or_team_id = "user_id";
+        if ($is_team) {
+            $u_or_t = "t";
+            $users_or_teams = "gradeable_teams";
+            $user_or_team_id = "team_id";
+        }
+
+        $this->course_db->query(
+            "
+        UPDATE electronic_gradeable_version SET late_day_status = ? 
+        FROM electronic_gradeable_version
+        LEFT JOIN 
+            {$users_or_teams} AS {$u_or_t}
+        ON {$user_or_team_id}=?
+        AND g_id=?",
+            [$submitter_id, $g_id]
+        );
+    }
+
     /**
      * Return an array of users with late days
      *
@@ -6472,6 +6494,7 @@ AND gc_id IN (
 
               /* Active Submission Version */
               egv.active_version,
+              egv.late_day_status,
 
               /* Grade inquiry data */
              rr.array_grade_inquiries,
@@ -6635,7 +6658,8 @@ AND gc_id IN (
                 $gradeable,
                 new Submitter($this->core, $submitter),
                 [
-                    'late_day_exceptions' => $late_day_exceptions
+                    'late_day_exceptions' => $late_day_exceptions,
+                    'late_day_status' => $row['late_day_status']
                 ]
             );
             $ta_graded_gradeable = null;

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -39,6 +39,9 @@ class GradedGradeable extends AbstractModel {
     /** @prop @var array The late day exceptions indexed by user id */
     protected $late_day_exceptions = [];
 
+    /** @prop @var int Late Day Info STatus */
+    protected $late_day_status = null;
+
     /** @prop @var bool|null|SimpleGradeOverriddenUser Does this graded gradeable have overridden grades */
     protected $overridden_grades = false;
 
@@ -67,6 +70,15 @@ class GradedGradeable extends AbstractModel {
         $this->submitter = $submitter;
 
         $this->late_day_exceptions = $details['late_day_exceptions'] ?? [];
+        $this->late_day_status = $details['late_day_status'] ?? null;
+    }
+
+    /**
+     * Gets if the submitter submitted on time
+     * @return bool
+     */
+    public function isOnTimeSubmission() {
+        return $late_day_status == LateDayInfo::STATUS_GOOD || $late_day_status == LateDayInfo::STATUS_LATE;
     }
 
     /**

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -85,7 +85,6 @@ class GradedGradeable extends AbstractModel {
 
         // If there is no info cached, treat it as a normal gradeable
         if (!$this->hasLateDayInfoCached()) {
-            var_dump($this->submitter->getId());
             LateDays::cacheLateDayInfoForUser($this->core, $this->submitter->getId());
             return true;
         }

--- a/site/app/models/gradeable/GradedGradeable.php
+++ b/site/app/models/gradeable/GradedGradeable.php
@@ -78,7 +78,27 @@ class GradedGradeable extends AbstractModel {
      * @return bool
      */
     public function isOnTimeSubmission() {
-        return $late_day_status == LateDayInfo::STATUS_GOOD || $late_day_status == LateDayInfo::STATUS_LATE;
+        // if there is no submission, ignore
+        if (!$this->hasSubmission()) {
+            return true;
+        }
+
+        // If there is no info cached, treat it as a normal gradeable
+        if (!$this->hasLateDayInfoCached()) {
+            var_dump($this->submitter->getId());
+            LateDays::cacheLateDayInfoForUser($this->core, $this->submitter->getId());
+            return true;
+        }
+
+        return $this->late_day_status == LateDayInfo::STATUS_GOOD || $this->late_day_status == LateDayInfo::STATUS_LATE;
+    }
+
+    /**
+     * Gets if the submitter submitted on time
+     * @return bool
+     */
+    public function hasLateDayInfoCached() {
+        return $this->late_day_status != null;
     }
 
     /**

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -259,7 +259,6 @@ class LateDays extends AbstractModel {
     public static function cacheLateDayInfoForUser(Core $core, $user_id) {
         $user = $core->getQueries()->getUserById($user_id);
         $ld = LateDays::fromUser($core, $user);
-        //$ld->clearCachedLateData();
         $ld->cacheLateDay();
     }
 
@@ -272,13 +271,6 @@ class LateDays extends AbstractModel {
         foreach ($this->late_day_info as $g_id => $info) {
             $this->core->getQueries()->cacheLateDayInfo($this->user->getId(), $g_id, $clear ? null : $info->getStatus(), $info->getGradedGradeable()->getGradeable()->isTeamAssignment());
         }
-    }
-
-    /**
-     * Clear the cached late day information for this user
-     */
-    public function clearCachedLateData() {
-        //$this->core->getQueries()->clearCachedLateDayInfo($this->user->getId());
     }
 
     /**

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -253,8 +253,8 @@ class LateDays extends AbstractModel {
     /**
      * Create late day information then cahce it
      *
-     * @param $core
-     * @param $user_id
+     * @param $core Core to construct the late day object
+     * @param $user_id User getting late day information recalculated
      */
     public static function cacheLateDayInfoForUser(Core $core, $user_id) {
         $user = $core->getQueries()->getUserById($user_id);

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -253,6 +253,7 @@ class LateDays extends AbstractModel {
     /**
      * Create late day information then cahce it
      *
+     * @param $core
      * @param $user_id
      */
     public static function cacheLateDayInfoForUser(Core $core, $user_id) {

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -64,6 +64,8 @@ class LateDays extends AbstractModel {
             );
             $this->late_day_info[$graded_gradeable->getGradeableId()] = $info;
         }
+
+        $this->cacheLateDayInfo();
     }
 
     /**
@@ -248,6 +250,16 @@ class LateDays extends AbstractModel {
         }
 
         return $late_days_remaining;
+    }
+
+    public function cacheLateDayInfo() {
+        foreach ($late_day_info as $g_id => $info) {
+            $this->core->getQueries()->cacheLateDayInfo(
+                $user->getId(), 
+                $g_id, 
+                $info->getStatus(), 
+                $info->getGradedGradeable()->getGradeable()->isTeamAssignment());
+        }
     }
 
     /**

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -64,8 +64,6 @@ class LateDays extends AbstractModel {
             );
             $this->late_day_info[$graded_gradeable->getGradeableId()] = $info;
         }
-
-        $this->cacheLateDayInfo();
     }
 
     /**
@@ -252,13 +250,23 @@ class LateDays extends AbstractModel {
         return $late_days_remaining;
     }
 
-    public function cacheLateDayInfo() {
-        foreach ($late_day_info as $g_id => $info) {
-            $this->core->getQueries()->cacheLateDayInfo(
-                $user->getId(), 
-                $g_id, 
-                $info->getStatus(), 
-                $info->getGradedGradeable()->getGradeable()->isTeamAssignment());
+    /**
+     * Create late day information then cahce it
+     *
+     * @param $user_id
+     */
+    public static function cacheLateDayInfoForUser(Core $core, $user_id) {
+        $user = $core->getQueries()->getUserById($user_id);
+        $ld = LateDays::fromUser($core, $user);
+        $ld->cacheLateDay();
+    }
+
+    /**
+     * Cache the late day information for this user
+     */
+    public function cacheLateDay() {
+        foreach ($this->late_day_info as $g_id => $info) {
+            $this->core->getQueries()->cacheLateDayInfo($this->user->getId(), $g_id, $info->getStatus(), $info->getGradedGradeable()->getGradeable()->isTeamAssignment());
         }
     }
 

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -258,16 +258,24 @@ class LateDays extends AbstractModel {
     public static function cacheLateDayInfoForUser(Core $core, $user_id) {
         $user = $core->getQueries()->getUserById($user_id);
         $ld = LateDays::fromUser($core, $user);
+        //$ld->clearCachedLateData();
         $ld->cacheLateDay();
     }
 
     /**
      * Cache the late day information for this user
      */
-    public function cacheLateDay() {
+    public function cacheLateDay($clear = false) {
         foreach ($this->late_day_info as $g_id => $info) {
-            $this->core->getQueries()->cacheLateDayInfo($this->user->getId(), $g_id, $info->getStatus(), $info->getGradedGradeable()->getGradeable()->isTeamAssignment());
+            $this->core->getQueries()->cacheLateDayInfo($this->user->getId(), $g_id, $clear ? null : $info->getStatus(), $info->getGradedGradeable()->getGradeable()->isTeamAssignment());
         }
+    }
+
+    /**
+     * Clear the cached late day information for this user
+     */
+    public function clearCachedLateData() {
+        //$this->core->getQueries()->clearCachedLateDayInfo($this->user->getId());
     }
 
     /**

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -251,10 +251,10 @@ class LateDays extends AbstractModel {
     }
 
     /**
-     * Create late day information then cahce it
+     * Create late day information then cache it
      *
-     * @param $core Core to construct the late day object
-     * @param $user_id User getting late day information recalculated
+     * @param Core $core Core to construct the late day object
+     * @param string $user_id User getting late day information recalculated
      */
     public static function cacheLateDayInfoForUser(Core $core, $user_id) {
         $user = $core->getQueries()->getUserById($user_id);
@@ -265,6 +265,8 @@ class LateDays extends AbstractModel {
 
     /**
      * Cache the late day information for this user
+     *
+     * @param bool $clear true if we are clearing the contents of the cache
      */
     public function cacheLateDay($clear = false) {
         foreach ($this->late_day_info as $g_id => $info) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
All late days are currently calculated with context. This means that we generate the late day information every single time per user. We calculate it by running through every single graded gradable a user is being graded for and subtracting any late days if we see a late submission. This works well, but it means we can't show cool stats on the TAGrading page because its to expensive to do for every student at once :(
 
### What is the new behavior?
When there is a late day recalculation trigger, the late day values are calculated and then cached within the database in order for easy access. This means we can customize the TA status and grading index page a lot more.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
All "triggers" I accounted for:
-submit a gradeable
-gradeable version change
-drop submission
-late day addition (late days allowed page)
-late day change (gradeable admin page)
-gradeable due date change
-extension

This PR is in order to finish https://github.com/Submitty/Submitty/pull/5631. This PR will use the caching system in order to add more stats and visual assistance to the TAs
