### PR TITLE
[Bugfix:Submission] Don't extract Microsoft Office files as zip

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1167,7 +1167,7 @@ class SubmissionController extends AbstractController {
                 if (isset($uploaded_files[$i])) {
                     $uploaded_files[$i]["is_zip"] = [];
                     for ($j = 0; $j < $count[$i]; $j++) {
-                        if (mime_content_type($uploaded_files[$i]["tmp_name"][$j]) == "application/zip") {
+                        if (mime_content_type($uploaded_files[$i]["tmp_name"][$j]) === "application/zip" && pathinfo($uploaded_files[$i]["name"][$j], PATHINFO_EXTENSION) === "zip") {
                             if (FileUtils::checkFileInZipName($uploaded_files[$i]["tmp_name"][$j]) === false) {
                                 return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[$i]["name"][$j] . ".", false);
                             }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1167,7 +1167,7 @@ class SubmissionController extends AbstractController {
                 if (isset($uploaded_files[$i])) {
                     $uploaded_files[$i]["is_zip"] = [];
                     for ($j = 0; $j < $count[$i]; $j++) {
-                        if (mime_content_type($uploaded_files[$i]["tmp_name"][$j]) === "application/zip" && pathinfo($uploaded_files[$i]["name"][$j], PATHINFO_EXTENSION) === "zip") {
+                        if (mime_content_type($uploaded_files[$i]["tmp_name"][$j]) === "application/zip" && strtolower(pathinfo($uploaded_files[$i]["name"][$j], PATHINFO_EXTENSION)) === "zip") {
                             if (FileUtils::checkFileInZipName($uploaded_files[$i]["tmp_name"][$j]) === false) {
                                 return $this->uploadResult("Error: You may not use quotes, backslashes or angle brackets in your filename for files inside " . $uploaded_files[$i]["name"][$j] . ".", false);
                             }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?

Fixes #5995

When uploading certain Microsoft Office files, the submission controller identifies these as zip files, which, while *technically* true, is not intended behavior. This happens because the submission controller exclusively uses the MIME type of the file to determine whether it is a ZIP file or not, 

### What is the new behavior?

The submission controller now checks if the file extension is zip *in addition to* inspecting the MIME type of the file. This way, a user can be confident in knowing that their upload will only be expanded if it is a valid zip file with the zip extension.

### Other information?

Exporting a docx from Docs, a pptx from Slides, or an xlsx from Sheets will reliably trigger this bug.

This is an artifact of an [upstream bug](https://bugs.astron.com/view.php?id=46) in `libmagic`, part of the `file` utility, which was fixed in October 2018. The version of `file` included in Ubuntu 18.04 has the same bug: running `file --mime-type` on a Microsoft Office file exported from GSuite will display `application/zip`.