### PR TITLE
[Testing] Move to pcov for coverage in GH action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
           - uses: shivammathur/setup-php@2.7.0
             with:
               extensions: imagick
+              coverage: pcov
           - name: Cache Composer
             id: composer-cache
             run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -77,7 +78,7 @@ jobs:
           - name: Install dependencies
             run: composer install --prefer-dist --dev
           - name: Run php unit tests
-            run : XDEBUG_MODE=coverage php vendor/bin/phpunit --configuration tests/phpunit.xml
+            run : php vendor/bin/phpunit --configuration tests/phpunit.xml
 
 
     python-lint:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The GH action uses [xdebug](https://xdebug.org/) profiler to handle calculating the code coverage statistics for the PHP unit tests. Due to the large amount of test doubles / mocks we use in the codebase, with the way xdebug tracks that info, it drags down running the test suite quite a bit.

### What is the new behavior?

This PR switches from xdebug to [pcov](https://github.com/krakjoe/pcov) library. While xdebug is still the best tool in profiling PHP code in general and analysis and has been around for a 10+yrs, but it brings in a lot of tooling and such to just do code coverage. pcov on the other hand is a much newer (~1yr old?) smaller library that's focused just on code coverage statistics, allowing it to run in a much smaller fraction of time, like in our case 10m44s -> 58s.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
In the `shivammathur/setup-php` action, by default it comes with xdebug enabled, but you when you specify `coverage: pcov`, it does disable / remove xdebug and so makes only pcov available.
