### PR TITLE
[Feature:Developer] Add dependabot configuration file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+- package-ecosystem: composer
+  directory: "/site"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  versioning-strategy: increase
+  commit-message:
+    prefix: "[Dependency]"
+    prefix-development: "[DevDependency]"
+    include: "scope"
+- package-ecosystem: npm
+  directory: "/site"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  commit-message:
+    prefix: "[Dependency]"
+    prefix-development: "[DevDependency]"
+    include: "scope"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Dependabot currently uses a prefix of `chore(dep)` or `chore(dev-dep)` for new PRs. This will fail the PR check added in #6099.

### What is the new behavior?
This PR aims to prefix the to use `[Dependency]` and `[DevDevendency]`. This should hopefully get us PRs that pass the validation in #6099.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Documentation for the config file can be found [here](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates). Most of the file was automatically generated from the dependabot website, with my addition being the `commit-message` bit. I suspect we may have issues where it'll generate PRs with a semi-colon between the prefix and the scope, and so may need to go upstream in that case.

Testing was done by validating the schema through [dependabot's online validator](https://dependabot.com/docs/config-file/validator/), which says it "Looks good 👍 ".