### PR TITLE
[Testing:System] Fix regex for PR titles for dependabot

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -31,3 +31,6 @@ exclude=
     sbin/run_lichen_plagiarism.py,
     sbin/untrusted_canary.py,
     tests
+
+per-file-ignores =
+    .github/workflows/pr_title_tester.py:E501,W605

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -19,4 +19,4 @@ jobs:
           #
           # [<TYPE>:<MODULE>] <SUBJECT>
           #
-          regex: '^(\[SYSADMIN ACTION\])?((\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\] .{2,40}$)|(\[DevDependency\]|\[Dependency\]) .{2,70})$'
+          regex: '^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\] .{2,40}$|\[(DevDependency|Dependency)\] .{2,70})$'

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -19,4 +19,4 @@ jobs:
           #
           # [<TYPE>:<MODULE>] <SUBJECT>
           #
-          regex: '^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\]|\[DevDependency\]|\[Dependency\]) .{2,40}$'
+          regex: '^(\[SYSADMIN ACTION\])?((\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\] .{2,40}$)|(\[DevDependency\]|\[Dependency\]) .{2,70})$'

--- a/.github/workflows/pr_title_tester.py
+++ b/.github/workflows/pr_title_tester.py
@@ -2,7 +2,9 @@ import re
 
 
 # paste this from pr_title.yml
-exp = '^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\] .{2,40}$|\[(DevDependency|Dependency)\] .{2,70})$'
+exp = "^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|\
+VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|\
+RainbowGrades|System|Developer|API)\] .{2,40}$|\[(DevDependency|Dependency)\] .{2,70})$"
 
 
 # should pass
@@ -14,7 +16,8 @@ assert re.search(exp, "[SYSADMIN ACTION][Refactor:Autograding] xxxx")
 assert re.search(exp, "[DevDependency] xxxx")
 assert re.search(exp, "[Dependency] xxxx")
 assert re.search(exp, "[Bugfix:Submission] 0123456789012345678901234567890123456789")
-assert re.search(exp, "[Dependency] 0123456789012345678901234567890123456789012345678901234567890123456789")
+assert re.search(exp, "[Dependency] 012345678901234567890123456789"+
+                 "0123456789012345678901234567890123456789")
 
 # should fail
 assert not re.search(exp, "[UI//UX:API] xxxx")
@@ -25,4 +28,5 @@ assert not re.search(exp, "[Dependency:Autograding] xxxx")
 assert not re.search(exp, "[SYSADMINACTION][Refactor:Autograding] xxxx")
 assert not re.search(exp, "[DevDependency:Autograding] xxxx")
 assert not re.search(exp, "[Bugfix:Submission] 01234567890123456789012345678901234567890")
-assert not re.search(exp, "[Dependency] 01234567890123456789012345678901234567890123456789012345678901234567890")
+assert not re.search(exp, "[Dependency] 012345678901234567890123456789"+
+                     "01234567890123456789012345678901234567890")

--- a/.github/workflows/pr_title_tester.py
+++ b/.github/workflows/pr_title_tester.py
@@ -6,25 +6,23 @@ exp = '^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|
 
 
 # should pass
-assert re.search(exp,"[Refactor:Autograding] xxxx") != None
-assert re.search(exp,"[Bugfix:Submission] xxxx") != None
-assert re.search(exp,"[VPAT:InstructorUI] xxxx") != None
-assert re.search(exp,"[UI/UX:API] xxxx") != None
-assert re.search(exp,"[SYSADMIN ACTION][Refactor:Autograding] xxxx") != None
-assert re.search(exp,"[DevDependency] xxxx") != None
-assert re.search(exp,"[Dependency] xxxx") != None
-assert re.search(exp,"[Bugfix:Submission] 0123456789012345678901234567890123456789") != None
-assert re.search(exp,"[Dependency] 0123456789012345678901234567890123456789012345678901234567890123456789") != None
+assert re.search(exp, "[Refactor:Autograding] xxxx")
+assert re.search(exp, "[Bugfix:Submission] xxxx")
+assert re.search(exp, "[VPAT:InstructorUI] xxxx")
+assert re.search(exp, "[UI/UX:API] xxxx")
+assert re.search(exp, "[SYSADMIN ACTION][Refactor:Autograding] xxxx")
+assert re.search(exp, "[DevDependency] xxxx")
+assert re.search(exp, "[Dependency] xxxx")
+assert re.search(exp, "[Bugfix:Submission] 0123456789012345678901234567890123456789")
+assert re.search(exp, "[Dependency] 0123456789012345678901234567890123456789012345678901234567890123456789")
 
 # should fail
-assert re.search(exp,"[UI//UX:API] xxxx") == None
-assert re.search(exp,"[UI\/UX:API] xxxx") == None
-assert re.search(exp,"[Refactor:RainbowGrades]") == None
-assert re.search(exp,"[BugFix:TAGrading] xxxx") == None
-assert re.search(exp,"[Dependency:Autograding] xxxx") == None
-assert re.search(exp,"[SYSADMINACTION][Refactor:Autograding] xxxx") == None
-assert re.search(exp,"[DevDependency:Autograding] xxxx") == None
-assert re.search(exp,"[Dependency] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx") != None
-assert re.search(exp,"[Bugfix:Submission] 01234567890123456789012345678901234567890") == None
-assert re.search(exp,"[Dependency] 01234567890123456789012345678901234567890123456789012345678901234567890") == None
-
+assert not re.search(exp, "[UI//UX:API] xxxx")
+assert not re.search(exp, "[UI\/UX:API] xxxx")
+assert not re.search(exp, "[Refactor:RainbowGrades]")
+assert not re.search(exp, "[BugFix:TAGrading] xxxx")
+assert not re.search(exp, "[Dependency:Autograding] xxxx")
+assert not re.search(exp, "[SYSADMINACTION][Refactor:Autograding] xxxx")
+assert not re.search(exp, "[DevDependency:Autograding] xxxx")
+assert not re.search(exp, "[Bugfix:Submission] 01234567890123456789012345678901234567890")
+assert not re.search(exp, "[Dependency] 01234567890123456789012345678901234567890123456789012345678901234567890")

--- a/.github/workflows/pr_title_tester.py
+++ b/.github/workflows/pr_title_tester.py
@@ -1,0 +1,30 @@
+import re
+
+
+# paste this from pr_title.yml
+exp = '^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\] .{2,40}$|\[(DevDependency|Dependency)\] .{2,70})$'
+
+
+# should pass
+assert re.search(exp,"[Refactor:Autograding] xxxx") != None
+assert re.search(exp,"[Bugfix:Submission] xxxx") != None
+assert re.search(exp,"[VPAT:InstructorUI] xxxx") != None
+assert re.search(exp,"[UI/UX:API] xxxx") != None
+assert re.search(exp,"[SYSADMIN ACTION][Refactor:Autograding] xxxx") != None
+assert re.search(exp,"[DevDependency] xxxx") != None
+assert re.search(exp,"[Dependency] xxxx") != None
+assert re.search(exp,"[Bugfix:Submission] 0123456789012345678901234567890123456789") != None
+assert re.search(exp,"[Dependency] 0123456789012345678901234567890123456789012345678901234567890123456789") != None
+
+# should fail
+assert re.search(exp,"[UI//UX:API] xxxx") == None
+assert re.search(exp,"[UI\/UX:API] xxxx") == None
+assert re.search(exp,"[Refactor:RainbowGrades]") == None
+assert re.search(exp,"[BugFix:TAGrading] xxxx") == None
+assert re.search(exp,"[Dependency:Autograding] xxxx") == None
+assert re.search(exp,"[SYSADMINACTION][Refactor:Autograding] xxxx") == None
+assert re.search(exp,"[DevDependency:Autograding] xxxx") == None
+assert re.search(exp,"[Dependency] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx") != None
+assert re.search(exp,"[Bugfix:Submission] 01234567890123456789012345678901234567890") == None
+assert re.search(exp,"[Dependency] 01234567890123456789012345678901234567890123456789012345678901234567890") == None
+

--- a/.github/workflows/pr_title_tester.py
+++ b/.github/workflows/pr_title_tester.py
@@ -2,9 +2,7 @@ import re
 
 
 # paste this from pr_title.yml
-exp = "^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|\
-VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|\
-RainbowGrades|System|Developer|API)\] .{2,40}$|\[(DevDependency|Dependency)\] .{2,70})$"
+exp = r"^(\[SYSADMIN ACTION\])?(\[(Bugfix|Feature|Refactor|Testing|Documentation|VPAT|UI\/UX):(Submission|Autograding|Forum|Notifications|TAGrading|InstructorUI|RainbowGrades|System|Developer|API)\] .{2,40}$|\[(DevDependency|Dependency)\] .{2,70})$"
 
 
 # should pass
@@ -16,7 +14,7 @@ assert re.search(exp, "[SYSADMIN ACTION][Refactor:Autograding] xxxx")
 assert re.search(exp, "[DevDependency] xxxx")
 assert re.search(exp, "[Dependency] xxxx")
 assert re.search(exp, "[Bugfix:Submission] 0123456789012345678901234567890123456789")
-assert re.search(exp, "[Dependency] 012345678901234567890123456789"+
+assert re.search(exp, "[Dependency] 012345678901234567890123456789" +
                  "0123456789012345678901234567890123456789")
 
 # should fail
@@ -28,5 +26,5 @@ assert not re.search(exp, "[Dependency:Autograding] xxxx")
 assert not re.search(exp, "[SYSADMINACTION][Refactor:Autograding] xxxx")
 assert not re.search(exp, "[DevDependency:Autograding] xxxx")
 assert not re.search(exp, "[Bugfix:Submission] 01234567890123456789012345678901234567890")
-assert not re.search(exp, "[Dependency] 012345678901234567890123456789"+
+assert not re.search(exp, "[Dependency] 012345678901234567890123456789" +
                      "01234567890123456789012345678901234567890")


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The regex for PR titles added in #6099 is a bit too strict for dependabot which regularly generates titles that are between 50-70 characters long. This issue is shown in the failing on titles for recent dependabot PRs, like #6103.

### What is the new behavior?

Adjusts the regex so that the `[Dependency]` and `[DevDependency]` tag allow for up-to 70 characters in the title (to accommodate for our longest dependency title `@fortawesome/fontawesome-free`.

### Other Information

It does not look like dependabot surfaces ability to generate a shortened message (dropping say the `in /site` bit for us). We could maybe look into an action to deal with automatic PR title rewriting, but my feeling from discussion in #6099 is we would like to avoid that except as a last resort.