### PR TITLE
[Documentation:Developer] Add install line to plugin error message

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ bash ${GIT_PATH}/.setup/vagrant/setup_vagrant.sh #{extra_command} 2>&1 | tee ${G
 SCRIPT
 
 unless Vagrant.has_plugin?('vagrant-vbguest')
-  raise 'vagrant-vbguest is not installed!'
+  raise 'vagrant-vbguest is not installed! To install, run: vagrant plugin install vagrant-vbguest'
 end
 
 Vagrant.configure(2) do |config|


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When you run `vagrant up` without having the vbguest plugin installed, it prints a short error message about missing it. On hitting it, I knew I needed to do `vagrant plugin install`, but could never remember if it was `vagrant plugin install vbguest` or `vagrant plugin install vagrant-vbguest`, necessitating looking into the docs to get the proper install line.

### What is the new behavior?

This includes the install line in the error output to give an immediate actionable step for a developer. This install line has been stable ever since we added this plugin years back, and so this does not introduce any maintenance overhead to keep it up-to-date.