### PR TITLE
[Testing:System] Remove scope from dependabot message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
   commit-message:
     prefix: "[Dependency]"
     prefix-development: "[DevDependency]"
-    include: "scope"  
 - package-ecosystem: npm
   directory: "/site"
   schedule:
@@ -24,4 +23,3 @@ updates:
   commit-message:
     prefix: "[Dependency]"
     prefix-development: "[DevDependency]"
-    include: "scope"  


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Dependabot PR titles are currently `[Development](deps): ...` where we want to remove the `(deps)` part.

### What is the new behavior?

This removes the `(dep)` part. While the documentation is poor on what the `includes` parameter does, listing:

> include: "scope" specifies that any prefix is followed by a list of the dependencies updated in the commit.

Looking at the source code seems to confirm that removing this should remove the `(deps)` part of the message.