### PR TITLE
[Testing:System] Remove semicolon from dependabot message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
   - dependencies
   versioning-strategy: increase
   commit-message:
-    prefix: "[Dependency]"
-    prefix-development: "[DevDependency]"
+    prefix: "[Dependency] "
+    prefix-development: "[DevDependency] "
 - package-ecosystem: npm
   directory: "/site"
   schedule:
@@ -21,5 +21,5 @@ updates:
   labels:
   - dependencies
   commit-message:
-    prefix: "[Dependency]"
-    prefix-development: "[DevDependency]"
+    prefix: "[Dependency] "
+    prefix-development: "[DevDependency] "


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Digging into the code of dependabot, namely [this section](https://github.com/dependabot/dependabot-core/blob/e566a102b15eb7876271914b07234f22b58177a0/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb#L81-L89):

```ruby
      def prefix_from_explicitly_provided_details
        prefix = explicitly_provided_prefix_string
        return if prefix.empty?

        prefix += "(#{scope})" if commit_message_options[:include_scope]
        prefix += ":" if prefix.match?(/[A-Za-z0-9\)\]]\Z/)
        prefix += " " unless prefix.end_with?(" ")
        prefix
      end
```

it looks like that if the specified prefix matches the regex, it will append a `:` to the message, which would then fail our PR title tester.

### What is the new behavior?

Appends a space which should mean that the `:` will not be appended as the regex will fail, and then the following line will also not fire leaving us with just one space between the prefix and the text body, giving us the desired format of `[Dependency] <msg>` which should then finally pass our PR title workflow and not require any manual intervention from us going forward.