### PR TITLE
[Bugfix:InstructorUI] Undefined var on saving component pages

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2094,7 +2094,7 @@ class ElectronicGraderController extends AbstractController {
 
     public function saveComponentPages(Gradeable $gradeable, array $pages) {
         foreach ($gradeable->getComponents() as $component) {
-            if (!isset($orders[$component->getId()])) {
+            if (!isset($pages[$component->getId()])) {
                 throw new \InvalidArgumentException('Missing component id in pages array');
             }
             $page = $pages[$component->getId()];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Undefined variable when attempting to save all component pages at once. I am somewhat guessing this is a dead code path.

### What is the new behavior?

The used variable is now defined. Given the usage on like 2100 of `$pages[$component->getId()]`, this gives credence that this is the right change.
