### PR TITLE
[Refactor:System] Fix type signature for DB iter

### DIFF
--- a/site/app/libraries/database/DatabaseRowIterator.php
+++ b/site/app/libraries/database/DatabaseRowIterator.php
@@ -43,19 +43,19 @@ class DatabaseRowIterator implements \Iterator {
 
     public function next() {
         if (!$this->valid()) {
-            return null;
+            return;
         }
         $this->key++;
         $this->result = $this->statement->fetch(\PDO::FETCH_ASSOC);
         if ($this->result === false) {
             $this->valid = false;
-            return null;
+            return;
         }
         $this->result = $this->database->transformResult($this->result, $this->columns);
         if ($this->callback !== null) {
+            /** @var mixed $this->result */
             $this->result = call_user_func($this->callback, $this->result);
         }
-        return $this->result;
     }
 
     public function key() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `next` function in the DatabaseIterator class was returning values, even though the interface that it implements specifies that `next` should return `void`. This is now constituted as a bug properly by phpstan in #6128.

### What is the new behavior?

Removes the return statements, making the function now properly return `void`. No consumer of this iterator makes use of calling next to get a value (instead relying on `foreach` loops) which properly uses the `current` function to fetch the value.