### PR TITLE
[Bugfix:System] Fix building clang for static analysis

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -609,10 +609,12 @@ if [ ! -d "${clangsrc}" ]; then
 
     mkdir -p ${clangsrc}
 
-    # checkout the clang sources
-    git clone --depth 1 http://llvm.org/git/llvm.git ${clangsrc}/llvm
-    git clone --depth 1 http://llvm.org/git/clang.git ${clangsrc}/llvm/tools/clang
-    git clone --depth 1 http://llvm.org/git/clang-tools-extra.git ${clangsrc}/llvm/tools/clang/tools/extra/
+    # clone the clang sources, circa Nov. 2018
+    git clone --depth 1 --branch llvmorg-7.1.0 https://github.com/llvm/llvm-project.git ${clangsrc}/source
+    cp -R ${clangsrc}/source/llvm ${clangsrc}/llvm
+    cp -R ${clangsrc}/source/clang ${clangsrc}/llvm/tools
+    cp -R ${clangsrc}/source/clang-tools-extra ${clangsrc}/llvm/tools/clang/tools/
+    mv ${clangsrc}/llvm/tools/clang/tools/clang-tools-extra ${clangsrc}/llvm/tools/clang/tools/extra
 
     # initial cmake for llvm tools (might take a bit of time)
     mkdir -p ${clangbuild}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Running a fresh `vagrant up` was failing as the `http://lvm.org/git/*` endpoints are no longer available. These endpoints were a mirror of the sub-directories of the main llvm-project which were meant to only be available as long as it took for the transition from SVN to git (started in 2018).

### What is the new behavior?

Transitions to the clone to use the current home of the project, https://github.com/llvm/llvm-project. I also pinned the clone to use the latest minor release (7.1.0) of the project for when it was originally added, which was when 7.0.0rc1 was released, as I am not certain the tools are being tested against newer versions of clang, and so might of broken on 8+.