### PR TITLE
[Feature:InstructorUI] Remove feature flag from Submini/Polls

### DIFF
--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -12,12 +12,8 @@ use app\libraries\routers\AccessControl;
 use app\libraries\DateUtils;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
-use app\libraries\routers\FeatureFlag;
 use app\libraries\PollUtils;
 
-/**
- * @FeatureFlag("polls")
- */
 class PollController extends AbstractController {
     public function __construct(Core $core) {
         parent::__construct($core);

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -74,34 +74,33 @@
         <textarea class="config-row" name="queue_message" id="queue-message">{{ fields['queue_message'] }}</textarea>
 
 
-        {% if feature_flag_enabled('polls') %}
-            <h2>Online Polls</h2>
-            <hr>
-            <div id="polls_enabled_wrapper" class="config-row checkbox-row">
-                <input type="checkbox" name="polls_enabled" id="polls-enabled" value="true" {{ fields['polls_enabled'] ? 'checked': '' }} />
-                <label for="polls-enabled">
-                    <span class="option-title">Enable Online Polls</span>
-                    <br>
-                    <span class="option-alt">Choose whether to enable online polling for this course.</span>
-                </label>
-            </div>
-
-            <label class="config-row" for="polls_pts_for_correct">
-                <span class="option-title">Points for correct</span>
+        <h2>Online Polls</h2>
+        <hr>
+        <div id="polls_enabled_wrapper" class="config-row checkbox-row">
+            <input type="checkbox" name="polls_enabled" id="polls-enabled" value="true" {{ fields['polls_enabled'] ? 'checked': '' }} />
+            <label for="polls-enabled">
+                <span class="option-title">Enable Online Polls</span>
                 <br>
-                <span class="option-alt">Number of points awarded for correctly answering a poll.</span>
-                <br>
+                <span class="option-alt">Choose whether to enable online polling for this course.</span>
             </label>
-            <input type="number" class="config-row" step="0.1" max="1.0" min="0.0" name="polls_pts_for_correct" id="polls_pts_for_correct" value="{{ fields['polls_pts_for_correct'] }}" />
+        </div>
 
-            <label class="config-row" for="polls_pts_for_incorrect">
-                <span class="option-title">Points for incorrect</span>
-                <br>
-                <span class="option-alt">Number of points awarded for incorrectly answering a poll.</span>
-                <br>
-            </label>
-            <input type="number" class="config-row" step="0.1" max="1.0" min="0.0" name="polls_pts_for_incorrect" id="polls_pts_for_incorrect" value="{{ fields['polls_pts_for_incorrect'] }}"/>
-        {% endif %}
+        <label class="config-row" for="polls_pts_for_correct">
+            <span class="option-title">Points for correct</span>
+            <br>
+            <span class="option-alt">Number of points awarded for correctly answering a poll.</span>
+            <br>
+        </label>
+        <input type="number" class="config-row" step="0.1" max="1.0" min="0.0" name="polls_pts_for_correct" id="polls_pts_for_correct" value="{{ fields['polls_pts_for_correct'] }}" />
+
+        <label class="config-row" for="polls_pts_for_incorrect">
+            <span class="option-title">Points for incorrect</span>
+            <br>
+            <span class="option-alt">Number of points awarded for incorrectly answering a poll.</span>
+            <br>
+        </label>
+        <input type="number" class="config-row" step="0.1" max="1.0" min="0.0" name="polls_pts_for_incorrect" id="polls_pts_for_incorrect" value="{{ fields['polls_pts_for_incorrect'] }}"/>
+
         <h2>Submissions</h2>
         <hr>
 


### PR DESCRIPTION
### What is the current behavior?
Currently, Submini/polling is locked behind a feature flag, making it a non-standard feature harder for instructors to use.

### What is the new behavior?
Now, the feature flag is removed since all required features (main polling features and the ability to access the response data) have been developed.