### PR TITLE
[Bugfix:Autograding] copy files from checkout folder

### DIFF
--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -52,7 +52,7 @@ def get_testcases(
         for item in complete_config_obj['item_pool']:
             testcase_specs += item['testcases']
 
-    is_vcs = queue_obj['vcs_checkout'],
+    is_vcs = queue_obj['vcs_checkout']
 
     # Construct the testcase objects
     for t in testcase_specs:

--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -52,6 +52,8 @@ def get_testcases(
         for item in complete_config_obj['item_pool']:
             testcase_specs += item['testcases']
 
+    is_vcs = queue_obj['vcs_checkout'],
+
     # Construct the testcase objects
     for t in testcase_specs:
         tmp_test = testcase.Testcase(
@@ -61,7 +63,7 @@ def get_testcases(
             complete_config_obj,
             t,
             which_untrusted,
-            False,
+            is_vcs,
             queue_obj["regrade"],
             queue_obj["job_id"],
             working_directory,


### PR DESCRIPTION
Properly set the `is_vcs` boolean when constructing testcase objects.