### PR TITLE
[Feature:System] Remove pip2 installation

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -20,14 +20,8 @@ echo "Setting up distro: ${DISTRO} ${VERSION}"
 source ${CURRENT_DIR}/${DISTRO}/${VERSION}/setup_distro.sh
 
 # Install pip after we've installed python within the setup_distro.sh
-if [ ! -x "$(command -v pip2)" ] || [ ! -x "$(command -v pip3)" ]; then
+if [ ! -x "$(command -v pip3)" ]; then
     wget --tries=5 https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-fi
-
-if [ ! -x "$(command -v pip2)" ]; then
-    python2 /tmp/get-pip.py
-else
-    pip2 install -U pip
 fi
 
 if [ ! -x "$(command -v pip3)" ]; then


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We attempt to install the latest version of pip for python2. The latest version is no longer compatible with python2 and so leads to issues.

### What is the new behavior?

Given we no longer use python2 for anything within Submitty itself, no real reason to bother installing pip2.