### PR TITLE
[Bugfix:TAGrading] Expand file in full panel mode

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -85,7 +85,7 @@
                 <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
                 {{ dir }}</a> &nbsp;
             <a id = 'open_file_{{ dir }}' onclick='popOutSubmittedFile("{{ dir }}", "{{ path }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
-            <a onclick='expandFile("{{ dir }}", "{{ path }}")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></a>
+            <a onclick='viewFileFullPanel("{{ dir }}", "{{ path }}")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></a>
             <a onclick='downloadFile("{{ path }}", "{{ title }}")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
         </div>
         <div id="file_viewer_{{ id }}" style="margin-left:{{ indent * -15 }}px" data-file_name="{{ dir }}" data-file_url="{{ path }}"></div>

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1265,7 +1265,7 @@ function openFrame(html_file, url_file, num) {
     }
     // handle pdf
     if (url_file.substring(url_file.length - 3) === "pdf") {
-      openPDFEditor(html_file, url_file).then(function(){
+      viewFileFullPanel(html_file, url_file).then(function(){
         loadPDFToolbar();
       });
     }
@@ -1322,7 +1322,7 @@ function popOutSubmittedFile(html_file, url_file) {
 }
 
 
-function openPDFEditor(name, path, page_num = 0) {
+function viewFileFullPanel(name, path, page_num = 0) {
   // debugger;
   if($('#viewer').length != 0){
     $('#viewer').remove();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
PR #6158 introduced a bug where a JS function name was changed for opening PDF files, originally they were the only type of file that could be opened in a full panel (to support the PDF editor). However, that feature had been expanded to any file when the new ta grading interface was built, as a result, non pdf files would break when viewed in full panel mode.

### What is the new behavior?
The function has been renamed to reflect its real behavior and all instances have been updated. PDFs and all other files can now be viewed in full panel mode

### Other information?
