### PR TITLE
[UI/UX:Submission] Show graded version worker information

### DIFF
--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -291,6 +291,7 @@ def prepare_autograding_and_submission_zip(
     obj["regrade"] = is_batch_job
     obj["waittime"] = waittime
     obj["job_id"] = job_id
+    obj["which_machine"] = which_machine
 
     with open(os.path.join(tmp_submission, "queue_file.json"), 'w') as outfile:
         json.dump(obj, outfile, sort_keys=True, indent=4, separators=(',', ': '))

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -110,6 +110,7 @@ def unzip_queue_file(zipfilename):
 # ==================================================================================
 def prepare_autograding_and_submission_zip(
     config,
+    machine_name: str,
     which_machine,
     which_untrusted,
     next_directory,
@@ -291,7 +292,7 @@ def prepare_autograding_and_submission_zip(
     obj["regrade"] = is_batch_job
     obj["waittime"] = waittime
     obj["job_id"] = job_id
-    obj["which_machine"] = which_machine
+    obj["which_machine"] = machine_name
 
     with open(os.path.join(tmp_submission, "queue_file.json"), 'w') as outfile:
         json.dump(obj, outfile, sort_keys=True, indent=4, separators=(',', ': '))

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1359,6 +1359,7 @@ def try_short_circuit(config: dict, queue_file: str) -> bool:
     queue_obj['gradingtime'] = grading_time
     queue_obj['grade_result'] = autograde_result_msg
     queue_obj['which_untrusted'] = '(short-circuited)'
+    queue_obj['which_machine'] = '(short-circuited)'
 
     # Save the augmented queue object
     with open(queue_file_json_path, 'w') as fd:

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -360,8 +360,10 @@ def prepare_job(
 
     # prepare the zip files
     try:
+        machine_name = my_name[:my_name.rfind('_')]
         zips = packer_unpacker.prepare_autograding_and_submission_zip(
             config,
+            machine_name,
             which_machine,
             which_untrusted,
             next_directory,

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -22,6 +22,7 @@ use app\models\AbstractModel;
  * @method float getHiddenExtraCredit()
  * @method \DateTime getSubmissionTime()
  * @method bool isAutogradingComplete()
+ * @method string getAutograderMachine()
  */
 class AutoGradedVersion extends AbstractModel {
     /** @var GradedGradeable Reference to the GradedGradeable */
@@ -40,6 +41,8 @@ class AutoGradedVersion extends AbstractModel {
     protected $submission_time = null;
     /** @prop @var bool If the autograding has complete for this version */
     protected $autograding_complete = false;
+    /** @prop @var string The name of the worker machine that graded this version. */
+    protected $autograder_machine = null;
 
     /** @prop @var AutoGradedTestcase[] The testcases for this version indexed by testcase id (lazy loaded)  */
     private $graded_testcases = null;
@@ -229,6 +232,11 @@ class AutoGradedVersion extends AbstractModel {
             // Couldn't find the file, so grading hasn't happened yet...
             $this->graded_testcases = [];
             return;
+        }
+
+        $queue_file = FileUtils::readJsonFile(FileUtils::joinPaths($results_path, 'queue_file.json'));
+        if ($queue_file !== false && array_key_exists('which_machine', $queue_file)) {
+            $this->autograder_machine = $queue_file['which_machine'];
         }
 
         // Load the historical results (for early submission incentive)

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -53,17 +53,14 @@
                     <span>Grading time:</span>
                     <span>{{ grade_time }} seconds</span>
                 </span>
-                {% if autograder_machine is not null %}
-                    <span class="flex-row">
-                        <span>Graded on machine:</span>
+                <span class="flex-row">
+                    <span>Graded on machine:</span>
+                    {% if autograder_machine is not null %}
                         <span>{{ autograder_machine }}</span>
-                    </span>
-                {% else %}
-                    <span class="flex-row">
-                        <span>Graded on machine:</span>
+                    {% else %}
                         <span>(unknown)</span>
-                    </span>
-                {% endif %}
+                    {% endif %}
+                </span>
                 {% if num_autogrades == 1 %}
                     <span class="flex-row">
                         <span>Queue wait time:</span>

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -54,11 +54,12 @@
                     <span>{{ grade_time }} seconds</span>
                 </span>
                 <span class="flex-row">
-                    <span>Graded on machine:</span>
-                    {% if autograder_machine is not null %}
-                        <span>{{ autograder_machine }}</span>
+                    {% if autograder_machine is null %}
+                       {# unknown machine -- backwards compatible #}
+                    {% elseif autograder_machine == '(short-circuited)' %}
+                       {# short-circuited -- simple grading w/o worker machine #}
                     {% else %}
-                        <span>(unknown)</span>
+                       <span>Graded on machine:</span><span>{{ autograder_machine }}</span>
                     {% endif %}
                 </span>
                 {% if num_autogrades == 1 %}

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -53,6 +53,17 @@
                     <span>Grading time:</span>
                     <span>{{ grade_time }} seconds</span>
                 </span>
+                {% if autograder_machine is not null %}
+                    <span class="flex-row">
+                        <span>Graded on machine:</span>
+                        <span>{{ autograder_machine }}</span>
+                    </span>
+                {% else %}
+                    <span class="flex-row">
+                        <span>Graded on machine:</span>
+                        <span>(unknown)</span>
+                    </span>
+                {% endif %}
                 {% if num_autogrades == 1 %}
                     <span class="flex-row">
                         <span>Queue wait time:</span>

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -945,6 +945,7 @@ class HomeworkView extends AbstractView {
                 'num_autogrades' => $version_instance->getHistoryCount(),
                 'files' => array_merge($files['submissions'], $files['checkout']),
                 'display_version_days_late' => $version_instance->getDaysLate(),
+                'autograder_machine' => $version_instance->getAutograderMachine(),
             ]);
 
             if ($history !== null) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?

Currently, no information is given by Submitty as to which worker machine has graded a gradeable. This can make debugging worker setups with many different worker hardware configurations difficult, as sometimes bugs may manifest on one worker but not another (e.g. a graphics assignment being graded differently on different workers due to worker hardware).

### What is the new behavior?

A gradeable's version information box now displays the name of the worker that graded that specific version alongside other information such as queue wait time, first access timestamp, etc. There are three different output cases:

* Output in most cases:
![image](https://user-images.githubusercontent.com/9640304/106532378-17c0b080-64be-11eb-8ef1-6f566bffacef.png)


* Output on a graded version which does not have associated worker machine information (e.g., it was graded before this information was added to the stored queue file):
![image](https://user-images.githubusercontent.com/9640304/106532409-24450900-64be-11eb-9b55-2a504c5544e0.png)


* Output on a graded version that has been short-circuited by the autograder:
![image](https://user-images.githubusercontent.com/9640304/106532192-b698dd00-64bd-11eb-8dcf-fe6a41af4533.png)

