### PR TITLE
[Bugfix:SubminiPolls] Add Correct Response Requirement

### DIFF
--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -152,6 +152,12 @@ class PollController extends AbstractController {
                 $answers[] = $_POST["option_id_" . $i];
             }
         }
+        if (count($answers) == 0) {
+            $this->core->addErrorMessage("Polls must have at least one correct response");
+            return MultiResponse::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildCourseUrl(['polls']))
+            );
+        }
         $this->core->getQueries()->addNewPoll($_POST["name"], $_POST["question"], $responses, $answers, $_POST["release_date"], $orders);
 
         return MultiResponse::RedirectOnlyResponse(
@@ -345,6 +351,12 @@ class PollController extends AbstractController {
             if (isset($_POST["is_correct_" . $i]) && $_POST["is_correct_" . $i] == "on") {
                 $answers[] = $_POST["option_id_" . $i];
             }
+        }
+        if (count($answers) == 0) {
+            $this->core->addErrorMessage("Polls must have at least one correct response");
+            return MultiResponse::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildCourseUrl(['polls']))
+            );
         }
         $this->core->getQueries()->editPoll($_POST["poll_id"], $_POST["name"], $_POST["question"], $responses, $answers, $_POST["release_date"], $orders);
 

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -154,9 +154,7 @@ class PollController extends AbstractController {
         }
         if (count($answers) == 0) {
             $this->core->addErrorMessage("Polls must have at least one correct response");
-            return MultiResponse::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['polls']))
-            );
+            new RedirectResponse($this->core->buildCourseUrl(['polls']));
         }
         $this->core->getQueries()->addNewPoll($_POST["name"], $_POST["question"], $responses, $answers, $_POST["release_date"], $orders);
 
@@ -354,9 +352,7 @@ class PollController extends AbstractController {
         }
         if (count($answers) == 0) {
             $this->core->addErrorMessage("Polls must have at least one correct response");
-            return MultiResponse::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['polls']))
-            );
+            new RedirectResponse($this->core->buildCourseUrl(['polls']));
         }
         $this->core->getQueries()->editPoll($_POST["poll_id"], $_POST["name"], $_POST["question"], $responses, $answers, $_POST["release_date"], $orders);
 

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -85,7 +85,7 @@
                     <div id="response_{{response}}_wrapper">
                         <input type="hidden" class="order order-{{index}}" name="order_{{response}}" value="{{index}}"/>
                         <input type="hidden" class="option_id" name="option_id_{{response}}" value="{{response}}"/>
-                        <input aria-label="Is correct" class="correct_box" type=checkbox name="is_correct_{{response}}" {{ poll.isCorrect(response) ? "checked": "" }}>
+                        <input aria-label="Is correct" class="correct-box" type=checkbox name="is_correct_{{response}}" {{ poll.isCorrect(response) ? "checked": "" }}>
                         <textarea aria-label="Reponse text" class="poll_response" name="response_{{response}}"style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                         rows="10" cols="30">{{poll.getResponseString(response)}}</textarea>
                         <div class="move-btn up-btn">
@@ -137,7 +137,7 @@
             <div id="response_${count}_wrapper">
                 <input type="hidden" class="order order-${count}" name="order_${count}" value="${count}"/>
                 <input type="hidden" class="option_id" name="option_id_${count}" value="${first_free_id}"/>
-                <input aria-label="Is correct" class="correct_box" type=checkbox name="is_correct_${count}">
+                <input aria-label="Is correct" class="correct-box" type=checkbox name="is_correct_${count}">
                 <textarea aria-label="Response text" class="poll_response" name="response_${count}" placeholder="Enter response here..." style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                 rows="10" cols="30"></textarea>
                 <div class="move-btn up-btn">
@@ -210,23 +210,23 @@
     }
 
     function submitErrorChecks() {
-        if ($("#poll-name").val().length == 0) {
+        if ($("#poll-name").val().length === 0) {
             $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#empty-name-error").show();
-        } else if ($("#poll-question").val().length == 0) {
+        } else if ($("#poll-question").val().length === 0) {
             $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#empty-question-error").show();
-        } else if ($("#poll-date").val().length == 0) {
+        } else if ($("#poll-date").val().length === 0) {
             $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#empty-date-error").show()
-        } else if (parseInt($("#response-count").val()) == 0) {
+        } else if (parseInt($("#response-count").val()) === 0) {
             $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#response-count-error").show();
-        } else if ($(".correct_box:checked").length == 0) {
+        } else if ($(".correct-box:checked").length === 0) {
             $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#correct-response-count-error").show();

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -85,7 +85,7 @@
                     <div id="response_{{response}}_wrapper">
                         <input type="hidden" class="order order-{{index}}" name="order_{{response}}" value="{{index}}"/>
                         <input type="hidden" class="option_id" name="option_id_{{response}}" value="{{response}}"/>
-                        <input aria-label="Is correct" type=checkbox name="is_correct_{{response}}" {{ poll.isCorrect(response) ? "checked": "" }}>
+                        <input aria-label="Is correct" class="correct_box" type=checkbox name="is_correct_{{response}}" {{ poll.isCorrect(response) ? "checked": "" }}>
                         <textarea aria-label="Reponse text" class="poll_response" name="response_{{response}}"style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                         rows="10" cols="30">{{poll.getResponseString(response)}}</textarea>
                         <div class="move-btn up-btn">

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -44,6 +44,7 @@
             <span id="empty-question-error" class="red-message polls-submit-error" hidden>Please make sure question is filled in.<br/></span>
             <span id="empty-date-error" class="red-message polls-submit-error" hidden>Please make sure release date is filled in.<br/></span>
             <span id="response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one response option.<br/></span>
+            <span id="correct-response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one correct response.<br/></span>
             <button type="submit" id="poll-form-submit" class="btn btn-primary" disabled>Add Poll</button>
         </form>
     {% else %}
@@ -110,6 +111,7 @@
             <span id="empty-question-error" class="red-message polls-submit-error" hidden>Please make sure question is filled in.<br/></span>
             <span id="empty-date-error" class="red-message polls-submit-error" hidden>Please make sure release date is filled in.<br/></span>
             <span id="response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one response option.<br/></span>
+            <span id="correct-response-count-error" class="red-message polls-submit-error" hidden>Please make sure to add at least one correct response.<br/></span>
             <button type="submit" id="poll-form-submit" class="btn btn-primary">Submit Changes</button>
         </form>
     {% endif %}
@@ -135,7 +137,7 @@
             <div id="response_${count}_wrapper">
                 <input type="hidden" class="order order-${count}" name="order_${count}" value="${count}"/>
                 <input type="hidden" class="option_id" name="option_id_${count}" value="${first_free_id}"/>
-                <input aria-label="Is correct" type=checkbox name="is_correct_${count}">
+                <input aria-label="Is correct" class="correct_box" type=checkbox name="is_correct_${count}">
                 <textarea aria-label="Response text" class="poll_response" name="response_${count}" placeholder="Enter response here..." style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                 rows="10" cols="30"></textarea>
                 <div class="move-btn up-btn">
@@ -224,6 +226,10 @@
             $("#poll-form-submit").prop("disabled", true);
             $(".polls-submit-error").hide();
             $("#response-count-error").show();
+        } else if ($(".correct_box:checked").length == 0) {
+            $("#poll-form-submit").prop("disabled", true);
+            $(".polls-submit-error").hide();
+            $("#correct-response-count-error").show();
         } else {
             $("#poll-form-submit").prop("disabled", false);
             $(".polls-submit-error").hide();


### PR DESCRIPTION
### What is the current behavior?
Closes #6177
Currently, polls are able to be submitted if there are no correct responses.

### What is the new behavior?
Now, each poll is required to have at least 1 correct response.
