### PR TITLE
[Feature:SubminiPolls] Update sidebar to reflect new name

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -166,7 +166,7 @@ class GlobalController extends AbstractController {
         if ($this->core->getConfig()->isPollsEnabled()) {
             $sidebar_buttons[] = new Button($this->core, [
                 "href" => $this->core->buildCourseUrl(['polls']),
-                "title" => "Polls",
+                "title" => "Submini Polls",
                 "class" => "nav-row",
                 "id" => "nav-sidebar-polls",
                 "icon" => "fa-question-circle"


### PR DESCRIPTION
### What is the current behavior?
Currently, Submini Polls are just labelled as "Polls". This lacks crucial branding.

### What is the new behavior?
Now, we are using the properly branded name "Submini Polls". This will help Submini Polls in its mission to overtake iClickers forever.
