### PR TITLE
[Refactor:System] Remove unused network vagrant setting

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,13 +51,9 @@ Vagrant.configure(2) do |config|
   # Our primary development target, this is what RPI uses as of Fall 2018
   config.vm.define 'ubuntu-18.04', primary: true do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-18.04'
-    # TODO: remove the private_network after some time and everyone has
-    # safely transitioned to the new forwarded port
-    ubuntu.vm.network 'private_network', ip: '192.168.56.111'
     ubuntu.vm.network 'forwarded_port', guest: 1501, host: 1501   # site
     ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432  # database
-
   end
 
   config.vm.provider 'virtualbox' do |vb|


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We had previously been using the private network `192.168.56.111` to access Submitty, however, we had previously consolidated to just using `localhost:port` instead of the IP address. It was intended to then phase out these IP addresses over time.

### What is the new behavior?

The IP address has actually been broken for a while and totally unusable, so safe to just remove seeing as how no one has complained about it.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Docs PR: Submitty/submitty.github.io#320
