### PR TITLE
[Documentation:Developer] Update build status icon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="http://submitty.org/images/submitty_logo.png" alt="Submitty Logo" width="500px"/>
 </p>
 
-[![Build Status](https://travis-ci.com/Submitty/Submitty.svg?branch=master)](https://travis-ci.com/Submitty/Submitty)
+[[![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="http://submitty.org/images/submitty_logo.png" alt="Submitty Logo" width="500px"/>
 </p>
 
-[![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)
+[![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="http://submitty.org/images/submitty_logo.png" alt="Submitty Logo" width="500px"/>
 </p>
 
-[[![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)
+[![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)
 
 # Usage
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

README had build icon from Travis, which we no longer use.

### What is the new behavior?

README has build icon for GitHub actions.
