### PR TITLE
[Bugfix:Submission] Show autograding incentive message

### DIFF
--- a/site/app/templates/submission/homework/AutogradingResultsBox.twig
+++ b/site/app/templates/submission/homework/AutogradingResultsBox.twig
@@ -34,7 +34,7 @@
             {% if show_incentive_message %}
                 <script>
                     (function() {
-                        ('#incentive_message').show();
+                        $('#incentive_message').show();
                     })();
                 </script>
             {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
JQuery syntax was broken from a missing `$` causing broken JS syntax throwing an exception on the homework 
results page in the autograding section

### What is the new behavior?
Add `$` back so JQuery selector works again

### Other information?
