### PR TITLE
[Bugfix:Autograding] Properly clean up stale containers

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -324,6 +324,8 @@ def cleanup_stale_containers(user_id_of_runner, my_log_function):
     for old_network in old_networks:
         old_network.remove()
 
+    client.close()
+
 
 def prepare_directory_for_autograding(config, working_directory, user_id_of_runner, autograding_zip_file, submission_zip_file, is_test_environment):
     """

--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -299,32 +299,33 @@ def lock_down_folder_permissions(top_dir):
 def cleanup_stale_containers(user_id_of_runner, my_log_function):
     # Remove any docker containers left over from past runs.
     client = docker.from_env(timeout=60)
+    try:
 
-    old_containers = []
-    for c in client.containers.list(all=True):
-        if user_id_of_runner in c.name:
-            my_log_function(f'Removing stale container {c.name}')
-            old_containers.append(c)
+        old_containers = []
+        for c in client.containers.list(all=True):
+            if user_id_of_runner in c.name:
+                my_log_function(f'Removing stale container {c.name}')
+                old_containers.append(c)
 
-    if len(old_containers) > 0:
-        print('REMOVING STALE CONTAINERS')
+        if len(old_containers) > 0:
+            print('REMOVING STALE CONTAINERS')
 
-    for old_container in old_containers:
-        old_container.remove(force=True)
+        for old_container in old_containers:
+            old_container.remove(force=True)
 
-    old_networks = []
-    for n in client.networks.list():
-        if user_id_of_runner in n.name:
-            my_log_function(f'Removing stale network {n.name}')
-            old_networks.append(n)
+        old_networks = []
+        for n in client.networks.list():
+            if user_id_of_runner in n.name:
+                my_log_function(f'Removing stale network {n.name}')
+                old_networks.append(n)
 
-    if len(old_networks) > 0:
-        print('REMOVING STALE NETWORKS')
+        if len(old_networks) > 0:
+            print('REMOVING STALE NETWORKS')
 
-    for old_network in old_networks:
-        old_network.remove()
-
-    client.close()
+        for old_network in old_networks:
+            old_network.remove()
+    finally:
+        client.close()
 
 
 def prepare_directory_for_autograding(config, working_directory, user_id_of_runner, autograding_zip_file, submission_zip_file, is_test_environment):

--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -296,13 +296,14 @@ def lock_down_folder_permissions(top_dir):
     # Chmod a directory to take away group and other rwx.
     os.chmod(top_dir,os.stat(top_dir).st_mode & ~stat.S_IRGRP & ~stat.S_IWGRP & ~stat.S_IXGRP & ~stat.S_IROTH & ~stat.S_IWOTH & ~stat.S_IXOTH)
 
-def cleanup_stale_containers(user_id_of_runner):
+def cleanup_stale_containers(user_id_of_runner, my_log_function):
     # Remove any docker containers left over from past runs.
     client = docker.from_env(timeout=60)
 
     old_containers = []
     for c in client.containers.list(all=True):
         if user_id_of_runner in c.name:
+            my_log_function(f'Removing stale container {c.name}')
             old_containers.append(c)
 
     if len(old_containers) > 0:
@@ -314,6 +315,7 @@ def cleanup_stale_containers(user_id_of_runner):
     old_networks = []
     for n in client.networks.list():
         if user_id_of_runner in n.name:
+            my_log_function(f'Removing stale network {n.name}')
             old_networks.append(n)
 
     if len(old_networks) > 0:
@@ -352,8 +354,6 @@ def prepare_directory_for_autograding(config, working_directory, user_id_of_runn
 
     os.mkdir(tmp_work)
     os.mkdir(tmp_work_test_input)
-
-    cleanup_stale_containers(user_id_of_runner)
 
     # Unzip the autograding and submission folders
     unzip_this_file(autograding_zip_file,tmp_autograding)

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -801,7 +801,8 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                 autograding_utils.cleanup_stale_containers(self.untrusted_user, self.log_message)
             except Exception:
                 self.log_stack_trace(traceback.format_exc())
-                return -1
+                # Linter hates this line (return in a finally), but the workaround just adds noise
+                return -1  # noqa: B012
 
         try:
             self.create_containers(containers, script, arguments)

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -797,7 +797,11 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             self.log_message("ERROR: Could not verify execution mode status.")
             return
         finally:
-            autograding_utils.cleanup_stale_containers(self.untrusted_user)
+            try:
+                autograding_utils.cleanup_stale_containers(self.untrusted_user, self.log_message)
+            except Exception:
+                self.log_stack_trace(traceback.format_exc())
+                return -1
 
         try:
             self.create_containers(containers, script, arguments)

--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -451,7 +451,16 @@ def grade_from_zip(
 
     # Remove the tmp directory.
     shutil.rmtree(working_directory)
-    autograding_utils.cleanup_stale_containers(which_untrusted)
+    try:
+        autograding_utils.cleanup_stale_containers(which_untrusted, config.logger.log_message)
+    except Exception:
+        config.logger.log_stack_trace(
+            traceback.format_exc(),
+            job_id=queue_obj['job_id'],
+            is_batch=queue_obj["regrade"],
+            which_untrusted=which_untrusted,
+            jobname=item_name
+        )
     return my_results_zip_file
 
 


### PR DESCRIPTION
Moves the `cleanup_stale_containers` function to use the `docker` package for python, hopefully making it less flaky. 
