### PR TITLE
[Bugfix:Autograding] Fix broken docker network removal

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -313,7 +313,7 @@ def cleanup_stale_containers(user_id_of_runner, my_log_function):
         old_networks = client.networks.list(filters={"name":user_id_of_runner})
         for old_network in old_networks:
             try:
-                my_log_function(f'Removing stale network {n.name}')
+                my_log_function(f'Removing stale network {old_network.name}')
                 old_network.remove()
             except Exception:
                 my_log_function("ERROR: Could not remove docker network")


### PR DESCRIPTION
A recent PR introduced a typo when removing stale docker networks. This PR patches that bug.