### PR TITLE
[Testing:Developer] Make cypress login tests less flaky

### DIFF
--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -2,93 +2,100 @@ import {buildUrl} from '../support/utils.js';
 
 
 describe('Test cases revolving around the logging in functionality of the site', () => {
-	it('should log in through root endpoint', () => {
-		const user = 'instructor';
-
-		//should hit the login form
-		cy.visit([]);
-		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
-
-		//fill out the login form and hit submit
-		cy.get('input[name=user_id]').type(user);
-		cy.get('input[name=password]').type(user);
-		cy.get('input[name=login]').click();
-
-		//should now be logged in as instructor and have a loggout button
-		cy.get('#logout .icon-title').should((val) => {
-			expect( val.text().trim() ).to.equal('Logout Quinn');
+	describe('Test cases where the user should succesfully login', () => {
+		afterEach(() => {
+			cy.logout();
 		});
 
-		cy.getCookies().then((cookies) => {
-			expect(cookies[2]).to.have.property('name', 'submitty_token');
-			expect(cookies[2]['value']).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+		it('should log in through root endpoint', () => {
+			const user = 'instructor';
+
+			//should hit the login form
+			cy.visit('/');
+			cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
+
+			//fill out the login form and hit submit
+			cy.get('input[name=user_id]').type(user);
+			cy.get('input[name=password]').type(user);
+			cy.get('input[name=login]').click();
+
+			//should now be logged in as instructor and have a loggout button
+			cy.get('#logout .icon-title').should((val) => {
+				expect( val.text().trim() ).to.equal('Logout Quinn');
+			});
+
+			cy.getCookies().then((cookies) => {
+				expect(cookies[2]).to.have.property('name', 'submitty_token');
+				expect(cookies[2]['value']).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+			});
 		});
-	});
 
 
-	it('should login through login endpoint', () => {
-		const user = 'instructor';
+		it('should login through login endpoint', () => {
+			const user = 'instructor';
 
-		cy.visit('authentication/login');
-		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
-		cy.get('input[name=user_id]').type(user);
-		cy.get('input[name=password]').type(user);
-		cy.get('input[name=login]').click();
+			cy.visit('authentication/login');
+			cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
+			cy.get('input[name=user_id]').type(user);
+			cy.get('input[name=password]').type(user);
+			cy.get('input[name=login]').click();
 
-		cy.get('#logout .icon-title').should((val) => {
-			expect( val.text().trim() ).to.equal('Logout Quinn');
+			cy.get('#logout .icon-title').should((val) => {
+				expect( val.text().trim() ).to.equal('Logout Quinn');
+			});
 		});
-	});
 
 
-	it('should reject bad passwords', () => {
-		cy.visit([]);
+		it('should redirect after logging in', () => {
+			//try to visit a page not logged in, then log in and see where we are
+			const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
+			const user = 'instructor';
 
-		cy.get('input[name=user_id]').type('instructor');
-		cy.get('input[name=password]').type('bad-password');
-		cy.get('input[name=login]').click();
+			cy.visit(['sample', 'gradeable', 'open_homework']);
+			cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
 
-		cy.get('#error-0').should((val) => {
-			expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+			cy.get('input[name=user_id]').type(user);
+			cy.get('input[name=password]').type(user);
+			cy.get('input[name=login]').click();
+
+			cy.url().should('eq', full_url);
 		});
-	});
 
 
-	it('should reject bad usernames', () => {
-		cy.visit([]);
+		it('should check if you can access a course', () => {
+			cy.login('pearsr');
+			cy.visit(['sample']);
 
-		cy.get('input[name=user_id]').type('bad-username');
-		cy.get('input[name=password]').type('instructor');
-		cy.get('input[name=login]').click();
-
-		cy.get('#error-0').should((val) => {
-			expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+			cy.get('.content').should('have.text', "\n    You don't have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n");
 		});
-	});
-
-
-	it('should redirect after logging in', () => {
-		//try to visit a page not logged in, then log in and see where we are
-		const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
-		const user = 'instructor';
-
-		cy.visit(['sample', 'gradeable', 'open_homework']);
-		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
-
-		cy.get('input[name=user_id]').type(user);
-		cy.get('input[name=password]').type(user);
-		cy.get('input[name=login]').click();
-
-		cy.url().should('eq', full_url);
-	});
-
-
-	it('should check if you can access a course', () => {
-		cy.login('pearsr');
-		cy.visit(['sample']);
-
-		cy.get('.content').should('have.text', "\n    You don't have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n");
 	})
 
+
+	describe('Test cases where the user should not be able to login', () => {
+		it('should reject bad passwords', () => {
+			cy.visit([]);
+
+			cy.get('input[name=user_id]').type('instructor');
+			cy.get('input[name=password]').type('bad-password');
+			cy.get('input[name=login]').click();
+
+			cy.get('#error-0').should((val) => {
+				expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+			});
+		});
+
+
+		it('should reject bad usernames', () => {
+			cy.visit([]);
+
+			cy.get('input[name=user_id]').type('bad-username');
+			cy.get('input[name=password]').type('instructor');
+			cy.get('input[name=login]').click();
+
+			cy.get('#error-0').should((val) => {
+				expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+			});
+		});
+	});
 
 });

--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -1,101 +1,88 @@
 import {buildUrl} from '../support/utils.js';
 
 
-describe('Test cases revolving around the logging in functionality of the site', () => {
-	describe('Test cases where the user should succesfully login', () => {
-		afterEach(() => {
-			cy.logout();
+describe('Test cases where the user should succesfully login', () => {
+	afterEach(() => {
+		cy.logout();
+	});
+
+	it('should log in through root endpoint', () => {
+		const user = 'instructor';
+
+		//should hit the login form
+		cy.visit('/');
+		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
+
+		cy.login();
+
+		//should now be logged in as instructor and have a loggout button
+		cy.get('#logout .icon-title').should((val) => {
+			expect( val.text().trim() ).to.equal('Logout Quinn');
 		});
 
-		it('should log in through root endpoint', () => {
-			const user = 'instructor';
-
-			//should hit the login form
-			cy.visit('/');
-			cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
-
-			//fill out the login form and hit submit
-			cy.get('input[name=user_id]').type(user);
-			cy.get('input[name=password]').type(user);
-			cy.get('input[name=login]').click();
-
-			//should now be logged in as instructor and have a loggout button
-			cy.get('#logout .icon-title').should((val) => {
-				expect( val.text().trim() ).to.equal('Logout Quinn');
-			});
-
-			cy.getCookies().then((cookies) => {
-				expect(cookies[2]).to.have.property('name', 'submitty_token');
-				expect(cookies[2]['value']).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-			});
-		});
-
-
-		it('should login through login endpoint', () => {
-			const user = 'instructor';
-
-			cy.visit('authentication/login');
-			cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
-			cy.get('input[name=user_id]').type(user);
-			cy.get('input[name=password]').type(user);
-			cy.get('input[name=login]').click();
-
-			cy.get('#logout .icon-title').should((val) => {
-				expect( val.text().trim() ).to.equal('Logout Quinn');
-			});
-		});
-
-
-		it('should redirect after logging in', () => {
-			//try to visit a page not logged in, then log in and see where we are
-			const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
-			const user = 'instructor';
-
-			cy.visit(['sample', 'gradeable', 'open_homework']);
-			cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
-
-			cy.get('input[name=user_id]').type(user);
-			cy.get('input[name=password]').type(user);
-			cy.get('input[name=login]').click();
-
-			cy.url().should('eq', full_url);
-		});
-
-
-		it('should check if you can access a course', () => {
-			cy.login('pearsr');
-			cy.visit(['sample']);
-
-			cy.get('.content').should('have.text', "\n    You don't have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n");
-		});
-	})
-
-
-	describe('Test cases where the user should not be able to login', () => {
-		it('should reject bad passwords', () => {
-			cy.visit([]);
-
-			cy.get('input[name=user_id]').type('instructor');
-			cy.get('input[name=password]').type('bad-password');
-			cy.get('input[name=login]').click();
-
-			cy.get('#error-0').should((val) => {
-				expect( val.text().trim() ).to.equal('Could not login using that user id or password');
-			});
-		});
-
-
-		it('should reject bad usernames', () => {
-			cy.visit([]);
-
-			cy.get('input[name=user_id]').type('bad-username');
-			cy.get('input[name=password]').type('instructor');
-			cy.get('input[name=login]').click();
-
-			cy.get('#error-0').should((val) => {
-				expect( val.text().trim() ).to.equal('Could not login using that user id or password');
-			});
+		cy.getCookies().then((cookies) => {
+			expect(cookies[2]).to.have.property('name', 'submitty_token');
+			expect(cookies[2]['value']).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 		});
 	});
 
+
+	it('should login through login endpoint', () => {
+		cy.visit('authentication/login');
+		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
+		cy.login();
+
+		cy.get('#logout .icon-title').should((val) => {
+			expect( val.text().trim() ).to.equal('Logout Quinn');
+		});
+	});
+
+
+	it('should redirect after logging in', () => {
+		//try to visit a page not logged in, then log in and see where we are
+		const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
+
+		cy.visit(['sample', 'gradeable', 'open_homework']);
+		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
+
+		cy.login();
+
+		cy.url().should('eq', full_url);
+	});
+
+
+	it('should check if you can access a course', () => {
+		cy.login('pearsr');
+		cy.visit(['sample']);
+
+		cy.get('.content').should('have.text', "\n    You don't have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n");
+	});
+});
+
+
+describe('Test cases where the user should not be able to login', () => {
+	it('should reject bad passwords', () => {
+		cy.visit([]);
+
+		cy.get('input[name=user_id]').type('instructor');
+		cy.get('input[name=password]').type('bad-password');
+		cy.get('input[name=login]').click();
+
+		cy.get('#error-0').should((val) => {
+			expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+		});
+	});
+
+
+	it('should reject bad usernames', () => {
+		cy.visit([]);
+
+		cy.get('input[name=user_id]').type('bad-username');
+		cy.get('input[name=password]').type('instructor');
+		cy.get('input[name=login]').click();
+
+		cy.get('#error-0').should((val) => {
+			expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+		});
+	});
 });

--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -1,88 +1,87 @@
 import {buildUrl} from '../support/utils.js';
 
+describe('Test cases revolving around the logging in functionality of the site', () => {
+    describe('Test cases where the user should succesfully login', () => {
+        afterEach(() => {
+            cy.logout();
+        });
 
-describe('Test cases where the user should succesfully login', () => {
-	afterEach(() => {
-		cy.logout();
-	});
+        it('should log in through root endpoint', () => {
+            //should hit the login form
+            cy.visit('/');
+            cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
 
-	it('should log in through root endpoint', () => {
-		const user = 'instructor';
+            cy.login();
 
-		//should hit the login form
-		cy.visit('/');
-		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
+            //should now be logged in as instructor and have a loggout button
+            cy.get('#logout .icon-title').should((val) => {
+                expect( val.text().trim() ).to.equal('Logout Quinn');
+            });
 
-		cy.login();
-
-		//should now be logged in as instructor and have a loggout button
-		cy.get('#logout .icon-title').should((val) => {
-			expect( val.text().trim() ).to.equal('Logout Quinn');
-		});
-
-		cy.getCookies().then((cookies) => {
-			expect(cookies[2]).to.have.property('name', 'submitty_token');
-			expect(cookies[2]['value']).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-		});
-	});
+            cy.getCookies().then((cookies) => {
+                expect(cookies[2]).to.have.property('name', 'submitty_token');
+                expect(cookies[2]['value']).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+            });
+        });
 
 
-	it('should login through login endpoint', () => {
-		cy.visit('authentication/login');
-		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
-		cy.login();
+        it('should login through login endpoint', () => {
+            cy.visit('authentication/login');
+            cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login` );
+            cy.login();
 
-		cy.get('#logout .icon-title').should((val) => {
-			expect( val.text().trim() ).to.equal('Logout Quinn');
-		});
-	});
-
-
-	it('should redirect after logging in', () => {
-		//try to visit a page not logged in, then log in and see where we are
-		const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
-
-		cy.visit(['sample', 'gradeable', 'open_homework']);
-		cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
-
-		cy.login();
-
-		cy.url().should('eq', full_url);
-	});
+            cy.get('#logout .icon-title').should((val) => {
+                expect( val.text().trim() ).to.equal('Logout Quinn');
+            });
+        });
 
 
-	it('should check if you can access a course', () => {
-		cy.login('pearsr');
-		cy.visit(['sample']);
+        it('should redirect after logging in', () => {
+            //try to visit a page not logged in, then log in and see where we are
+            const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
 
-		cy.get('.content').should('have.text', "\n    You don't have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n");
-	});
-});
+            cy.visit(['sample', 'gradeable', 'open_homework']);
+            cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
 
+            cy.login();
 
-describe('Test cases where the user should not be able to login', () => {
-	it('should reject bad passwords', () => {
-		cy.visit([]);
-
-		cy.get('input[name=user_id]').type('instructor');
-		cy.get('input[name=password]').type('bad-password');
-		cy.get('input[name=login]').click();
-
-		cy.get('#error-0').should((val) => {
-			expect( val.text().trim() ).to.equal('Could not login using that user id or password');
-		});
-	});
+            cy.url().should('eq', full_url);
+        });
 
 
-	it('should reject bad usernames', () => {
-		cy.visit([]);
+        it('should check if you can access a course', () => {
+            cy.login('pearsr');
+            cy.visit(['sample']);
 
-		cy.get('input[name=user_id]').type('bad-username');
-		cy.get('input[name=password]').type('instructor');
-		cy.get('input[name=login]').click();
+            cy.get('.content').should('have.text', "\n    You don't have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n");
+        });
+    });
 
-		cy.get('#error-0').should((val) => {
-			expect( val.text().trim() ).to.equal('Could not login using that user id or password');
-		});
-	});
+
+    describe('Test cases where the user should not be able to login', () => {
+        it('should reject bad passwords', () => {
+            cy.visit([]);
+
+            cy.get('input[name=user_id]').type('instructor');
+            cy.get('input[name=password]').type('bad-password');
+            cy.get('input[name=login]').click();
+
+            cy.get('#error-0').should((val) => {
+                expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+            });
+        });
+
+
+        it('should reject bad usernames', () => {
+            cy.visit([]);
+
+            cy.get('input[name=user_id]').type('bad-username');
+            cy.get('input[name=password]').type('instructor');
+            cy.get('input[name=login]').click();
+
+            cy.get('#error-0').should((val) => {
+                expect( val.text().trim() ).to.equal('Could not login using that user id or password');
+            });
+        });
+    });
 });

--- a/site/cypress/support/commands.js
+++ b/site/cypress/support/commands.js
@@ -38,6 +38,13 @@ Cypress.Commands.add("login", (username="instructor") => {
 	cy.get('input[name=login]').click();
 });
 
+/**
+* Log out of Submitty, assumes a user is already logged in
+*/
+Cypress.Commands.add("logout", () => {
+	cy.get('#logout > .flex-line > .icon-title').click();
+});
+
 
 /**
 * Visit a url either by an array of parts or a completed url E.g:

--- a/site/cypress/support/commands.js
+++ b/site/cypress/support/commands.js
@@ -27,12 +27,11 @@ import {buildUrl} from './utils.js';
 //These functions can be called like "cy.login(...)" and will yeild a result
 
 /**
-* Log into Submitty, assumes no one is logged in already
+* Log into Submitty, assumes no one is logged in already and at login page
 *
 * @param {String} [username=instructor] - username & password of who to log in as
 */
 Cypress.Commands.add("login", (username="instructor") => { 
-	cy.visit('/');
 	cy.get('input[name=user_id]').type(username);
 	cy.get('input[name=password]').type(username);
 	cy.get('input[name=login]').click();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:


* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Cypress is supposed to clear each session between tests however sometimes a test fails because the user is still logged in between tests.

### What is the new behavior?
Group tests by whether a user is supposed to successfully login or not and now explicitly log out of Submitty after each test that can log in.

