### PR TITLE
[Feature:System] Improve migrator DB error output

### DIFF
--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -81,9 +81,12 @@ def status(args):
                     continue
                 print_status(database, environment, loop_args)
                 database.close()
-            except OperationalError:
+            except OperationalError as exc:
                 print(
-                    'Could not get database for migrations for {}'.format(environment)
+                    'Could not get database for migrations for {}:\n  {}'.format(
+                        environment,
+                        str(exc).split("\n")[0]
+                    )
                 )
         else:
             course_dir = Path(args.config.submitty['submitty_data_dir'], 'courses')
@@ -204,13 +207,15 @@ def handle_migration(args):
     for environment in get_environments(args.environments):
         if environment in ['master', 'system']:
             loop_args = deepcopy(args)
-            loop_args.config.database['dbname'] = 'submitty'
+            loop_args.config.database['dbname'] = 'submitty1'
             try:
                 database = db.Database(loop_args.config.database, environment)
-            except OperationalError:
+            except OperationalError as exc:
                 raise SystemExit(
-                    'Submitty Database Migration Error:  '
-                    'Database does not exist for {}'.format(environment)
+                    'Submitty Database Migration Error for {}:\n  {}'.format(
+                        environment,
+                        str(exc).split("\n")[0]
+                    )
                 )
             migrate_environment(
                 database,

--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -207,7 +207,7 @@ def handle_migration(args):
     for environment in get_environments(args.environments):
         if environment in ['master', 'system']:
             loop_args = deepcopy(args)
-            loop_args.config.database['dbname'] = 'submitty1'
+            loop_args.config.database['dbname'] = 'submitty'
             try:
                 database = db.Database(loop_args.config.database, environment)
             except OperationalError as exc:

--- a/migration/tests/test_handle_migration.py
+++ b/migration/tests/test_handle_migration.py
@@ -62,10 +62,10 @@ class TestHandleMigration(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as context, \
                 patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = OperationalError('test', None, None)
+            mock_class.side_effect = OperationalError('test', None, "No Database")
             main.handle_migration(args)
         self.assertEqual(
-            "Submitty Database Migration Error:  Database does not exist for master",
+            "Submitty Database Migration Error for master:\n  (builtins.str) No Database",
             str(context.exception)
         )
 
@@ -77,10 +77,10 @@ class TestHandleMigration(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as context, \
                 patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = OperationalError('test', None, None)
+            mock_class.side_effect = OperationalError('test', None, "No Database")
             main.handle_migration(args)
         self.assertEqual(
-            "Submitty Database Migration Error:  Database does not exist for system",
+            "Submitty Database Migration Error for system:\n  (builtins.str) No Database",
             str(context.exception)
         )
 
@@ -119,11 +119,11 @@ class TestHandleMigration(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as context, \
                 patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = OperationalError('test', None, None)
+            mock_class.side_effect = OperationalError('test', None, "No Database")
             main.handle_migration(args)
 
         self.assertEqual(
-            "Submitty Database Migration Error:  Database does not exist for master",
+            "Submitty Database Migration Error for master:\n  (builtins.str) No Database",
             str(context.exception)
         )
 

--- a/migration/tests/test_status.py
+++ b/migration/tests/test_status.py
@@ -60,10 +60,10 @@ class TestStatus(unittest.TestCase):
         self.args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = OperationalError('test', None, None)
+            mock_class.side_effect = OperationalError('test', None, "No Database")
             main.status(self.args)
         self.assertEqual(
-            "Could not get database for migrations for master\n",
+            "Could not get database for migrations for master:\n  (builtins.str) No Database\n",
             sys.stdout.getvalue()
         )
 
@@ -73,10 +73,10 @@ class TestStatus(unittest.TestCase):
         self.args.config.database = dict()
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = OperationalError('test', None, None)
+            mock_class.side_effect = OperationalError('test', None, "No Database")
             main.status(self.args)
         self.assertEqual(
-            "Could not get database for migrations for system\n",
+            "Could not get database for migrations for system:\n  (builtins.str) No Database\n",
             sys.stdout.getvalue()
         )
 
@@ -107,10 +107,12 @@ class TestStatus(unittest.TestCase):
         Path(self.dir, 'courses', 'f19', 'csci1100').mkdir(parents=True)
 
         with patch.object(migrator.db, 'Database') as mock_class:
-            mock_class.side_effect = OperationalError('test', None, None)
+            mock_class.side_effect = OperationalError('test', None, "No Database")
             main.status(self.args)
-        expected = """Could not get database for migrations for master
-Could not get database for migrations for system
+        expected = """Could not get database for migrations for master:
+  (builtins.str) No Database
+Could not get database for migrations for system:
+  (builtins.str) No Database
 Could not get the status for the migrations for f19.csci1100
 """
         self.assertEqual(expected, sys.stdout.getvalue())


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Related to #6210.

Right now, if we have issues connecting to the master database, we throw a generic looking exception message. This makes it harder to debug as it's unclear if it couldn't find the database, user does not have access, etc.

### What is the new behavior?

The exception message from sqlachemy is printed out to the user. This will contain appropriate error message such as `password authentication failed for "submitty_dbuser"`and the like to make it easier to debug.