### PR TITLE
[Feature:System] Move python-pip to be managed by apt-get

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -19,21 +19,6 @@ fi
 echo "Setting up distro: ${DISTRO} ${VERSION}"
 source ${CURRENT_DIR}/${DISTRO}/${VERSION}/setup_distro.sh
 
-# Install pip after we've installed python within the setup_distro.sh
-if [ ! -x "$(command -v pip3)" ]; then
-    wget --tries=5 https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-fi
-
-if [ ! -x "$(command -v pip3)" ]; then
-    python3 /tmp/get-pip.py
-else
-    pip3 install -U pip
-fi
-
-if [ -f /tmp/get-pip.py ]; then
-    rm -f /tmp/get-pip.py
-fi
-
 # Read through our arguments to get "extra" packages to install for our distro
 # ${@} are populated by whatever calls install_system.sh which then sources this
 # script.

--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -19,7 +19,7 @@ fi
 apt-get -qqy update
 
 apt-get install -qqy apt-transport-https ca-certificates curl software-properties-common
-apt-get install -qqy python python-dev python3 python3-dev libpython3.6
+apt-get install -qqy python python-dev python3 python3-dev libpython3.6 python3-pip
 
 ############################
 # NTP: Network Time Protocol

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -178,7 +178,6 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 # PYTHON PACKAGE SETUP
 #########################
 
-pip3 install -U pip
 pip3 install python-pam
 pip3 install PyYAML
 pip3 install psycopg2-binary


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Right now, as part of the installation process, we install the latest version of `pip`. While this is nice from the standpoint of having the latest and greatest, it's not so great in that it often falls behind in version anyway as upgrading through `pip` itself is a greater burden than using the mechanisms of `apt-get`.

### What is the new behavior?

This replaces the installation of `pip` from the pip website to use `python3-pip` instead. As we also do not do anything with python2 anymore, we do not have to worry about collisions here within the base installation.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is not a breaking change per-se, but may warrant writing a release doc to indicate this change, as well as how one could apply this to an existing machine:

```
sudo python3 -m pip uninstall pip
sudo apt-get install python3-pip
```
