### PR TITLE
[Bugfix:System] Pin sqlalchemy version

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -139,7 +139,7 @@ jobs:
         - name: Install python libraries
           run : |
             python3 -m pip install --upgrade pip setuptools wheel
-            python3 -m pip install SQLAlchemy jsonschema jsonref pytz tzlocal
+            python3 -m pip install "SQLAlchemy<1.4.0" jsonschema jsonref pytz tzlocal
             python3 -m pip install coverage
             python3 -m pip install paramiko 
             python3 -m pip install docker 
@@ -233,7 +233,7 @@ jobs:
               sudo pip3 -V
               pip3 install cryptography
               pip3 install python-pam
-              pip3 install sqlalchemy
+              pip3 install "sqlalchemy<1.4.0"
               pip3 install selenium
               pip3 install tzlocal
               pip3 install jsonschema
@@ -253,7 +253,6 @@ jobs:
               sudo pip3 install docker
               sudo pip3 install paramiko
               sudo pip3 install tzlocal
-              sudo pip3 install sqlalchemy
               sudo pip3 install jsonref
               sudo pip3 install numpy
               sudo pip3 install opencv-python
@@ -268,7 +267,7 @@ jobs:
               sudo pip3 install psutil
               sudo pip3 install psycopg2
               sudo pip3 install python-pam
-              sudo pip3 install sqlalchemy
+              sudo pip3 install "sqlalchemy<1.4.0"
 
           - name: Get composer cache dir
             id: composer-cache

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -182,7 +182,7 @@ pip3 install -U pip
 pip3 install python-pam
 pip3 install PyYAML
 pip3 install psycopg2-binary
-pip3 install sqlalchemy
+pip3 install "sqlalchemy<1.4.0"
 pip3 install pylint
 pip3 install psutil
 pip3 install python-dateutil


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant: https://github.com/Submitty/submitty.github.io/pull/326

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Sqlalchemy changed behavior around how the `engine.has_table` function worked. This in-turn broke how the migrator was functioning.

### What is the new behavior?

Sets an upper-cap on the version of sqlalchemy that Submitty will install so that nobody is blocking as investigate how we might move off the `engine.has_table` function in a way that is backwards compatible.