### PR TITLE
[Testing:Developer] Fix PR title workflow using wrong branch

### DIFF
--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -17,4 +17,4 @@ jobs:
       #
       # [<TYPE>:<MODULE>] <SUBJECT>
       #
-      - uses: submitty/action-pr-title@master
+      - uses: submitty/action-pr-title@main


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

I changed the primary branch of the `pr-title-action` repository from `master` to `main`. This broke the workflow here as it still referred to master.

### What is the new behavior?

It now points at main.