### PR TITLE
[Bugfix:System] Add missing column to sql dump

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -684,7 +684,8 @@ CREATE TABLE public.polls (
     name text NOT NULL,
     question text NOT NULL,
     status text NOT NULL,
-    release_date date NOT NULL
+    release_date date NOT NULL,
+    image_path text
 );
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

PR #6180 did not modify the `course_tables.sql` file for the addition of its new column. This meant that new installations of Submitty would be missing the column, causing a crash on trying to use online polls.

### What is the new behavior?

This adds the column to our dump so that new installations will work properly for it.