### PR TITLE
[Feature:SubminiPolls] Add checkbox to keep edit image

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -82,7 +82,16 @@
                 Optional Image:
             </label>
             <input type="file" id="image-file" name="image_file"/>
-            <br/><br/>
+            <br />
+            {% if poll.getImagePath() != null %}
+                Current Image: {{ poll.getImagePath() }}
+                <br/>
+                <label for="keep-image">
+                    Keep Image:
+                </label>
+                <input type="checkbox" id="keep-image" name="keep_image" checked />
+            {% endif %}
+            <br/>
 
             <label for="poll-date">
                 Expected release date:

--- a/site/app/views/PollView.php
+++ b/site/app/views/PollView.php
@@ -4,6 +4,7 @@ namespace app\views;
 
 use app\models\User;
 use app\libraries\FileUtils;
+use app\models\PollModel;
 
 class PollView extends AbstractView {
 
@@ -73,7 +74,7 @@ class PollView extends AbstractView {
           ]);
     }
 
-    public function editPoll($poll) {
+    public function editPoll(PollModel $poll) {
         $this->core->getOutput()->addBreadcrumb("Polls", $this->core->buildCourseUrl(["polls"]));
         $this->core->getOutput()->addBreadcrumb("Edit Poll");
         $this->core->getOutput()->addInternalCss('polls.css');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #6254

The edit poll form did not have a good way to preserve the previously saved image. Instructors would always have to re-upload their image every time they edited the form.

### What is the new behavior?

This adds a new checkbox to the edit poll form that if checked, will keep the previously saved image (if no new image is uploaded at the same time).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This PR also prints out the current image filepath. I debated having it actually show the image, as well as if we should print out some message in the case where you edit a poll without an image. I went with this for simplicity, but I welcome suggestions.

No currently uploaded image:
<img width="740" alt="Screen Shot 2021-03-29 at 9 07 36 AM" src="https://user-images.githubusercontent.com/1845314/112841207-39798680-906e-11eb-9711-0504b8affbb9.png">

Previously uploaded image exists:
<img width="952" alt="Screen Shot 2021-03-29 at 9 07 27 AM" src="https://user-images.githubusercontent.com/1845314/112841224-3c747700-906e-11eb-81db-01053f903d06.png">

