### PR TITLE
[Bugfix:Developer] Do not autostart ubuntu-20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432  # database
   end
 
-  config.vm.define 'ubuntu-20.04', primary: false do |ubuntu|
+  config.vm.define 'ubuntu-20.04', autostart: false do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-20.04'
     ubuntu.vm.network 'forwarded_port', guest: 1511, host: 1511   # site
     ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `ubuntu-20.04` autostarts on `vagrant up` that causes an error on port collisions for websockets between the two boxes.

### What is the new behavior?

`ubuntu-20.04` no longer auto-starts.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
