### PR TITLE
[Bugfix:System] Fix Ubuntu 18.04 installation

### DIFF
--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -93,6 +93,9 @@ apt-get install -qqy imagemagick
 # miscellaneous usability
 apt-get install -qqy emacs
 
+# necessary for onnxruntime to install
+apt-get install -qqy protobuf-compiler libprotoc-dev
+
 # fix networking on vagrants
 # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1768560
 # When the vagrant box comes with netplan.io 0.40+ we can remove this
@@ -126,3 +129,12 @@ apt-get -qqy autoremove
 add-apt-repository ppa:git-core/ppa -y
 apt-get install git -y
 # ------------------------------------------------------------------
+
+# necessary to install these to support the older version of pip
+# that Ubuntu-18.04
+# cryptography>=3.4 includes rust which requires additional stuff
+# to work on ubuntu-18.04, easier to pin to older version
+pip3 install cryptography==3.3.2
+# newer versions of opencv require a very length compile step
+# or newer version of pip, easier to install this older version
+pip3 install opencv-python==3.4.9.33


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Installing on Ubuntu 18.04 was failing as a couple of python dependencies relied on a much newer version of pip than what is available in the package repository. This started to happen as a result of moving to using the package repository in #6282, as well as that we do not constrain the versions of the pip packages we install.

### What is the new behavior?

This fixes the installation script by pinning back the version of packages to ones installable by the version of pip on 18.04, as well as installing an additional dependency as needed for onnx. Ubuntu 18.04 can now be installed upon, as tested by doing `vagrant up` with the default image.
