### PR TITLE
[Bugfix:TAGrading] Fix canceling ungraded component

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1833,30 +1833,30 @@ function onClickComponent(me) {
  * @param me DOM Element of the cancel button
  */
 function onCancelComponent(me) {
-  const component_id = getComponentIdFromDOMElement(me);
-  const gradeable_id = getGradeableId();
-  const anon_id = getAnonId();
-  ajaxGetGradedComponent(gradeable_id, component_id, anon_id).then((component)=>{
-    // If there is any changes made in comment of a component , prompt the TA
-    if ( component.comment !== $('#component-' + component_id).find('.mark-note-custom').val()) {
-      if(confirm( "Are you sure you want to discard all changes to the student message?")){
-        toggleComponent(component_id, false)
-          .catch(function (err) {
-            console.error(err);
-            alert('Error closing component! ' + err.message);
-          });
-      }
-    }
-    // There is no change in comment, i.e it is same as the saved comment (before)
-    else {
-      toggleComponent(component_id, false)
-        .catch(function (err) {
-          console.error(err);
-          alert('Error closing component! ' + err.message);
-        });
-    }
-  });
-
+    const component_id = getComponentIdFromDOMElement(me);
+    const gradeable_id = getGradeableId();
+    const anon_id = getAnonId();
+    ajaxGetGradedComponent(gradeable_id, component_id, anon_id).then((component) => {
+        const customMarkNote = $(`#component-${component_id}`).find('.mark-note-custom').val();
+        // If there is any changes made in comment of a component , prompt the TA
+        if ((component && component.comment !== customMarkNote) || (!component && customMarkNote !== '')) {
+            if (confirm('Are you sure you want to discard all changes to the student message?')){
+                toggleComponent(component_id, false)
+                    .catch((err) => {
+                        console.error(err);
+                        alert(`Error closing component! ${err.message}`);
+                    });
+            }
+        }
+        // There is no change in comment, i.e it is same as the saved comment (before)
+        else {
+            toggleComponent(component_id, false)
+                .catch((err) => {
+                    console.error(err);
+                    alert(`Error closing component! ${err.message}`);
+                });
+        }
+    });
 }
 
 function onCancelEditRubricComponent(me) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #6247

When an ungraded component is open, the cancel button does not work, and it throws an exception on attempting to use it.

### What is the new behavior?

The cancel button is fixed. It now properly exits out of the ungraded component, leaving it ungraded. Additionally, if the custom mark has any text in it, it will also show a confirmation on discarding changes, similar for how it works for graded components.

### Other information

On viewing the diff, it's suggested to hit the cog icon to hide whitespace changes.