### PR TITLE
[Bugfix:HelpQueue] Fix JS error on opening page as student

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -13,7 +13,10 @@
   var timers = []; //keep track of the current running timers on the page
 
   //Runs the function that gets and fills in the old filter settings
-  filterQueues();
+  {% if viewer.isGrader() %}
+    filterQueues();
+  {% endif %}
+
   //Unide the checkboxes now that they have been set
   $(".page_loading").removeClass("page_loading");
 
@@ -203,15 +206,17 @@
       window.socketClient.open('office_hours_queue');
   }
 
-  window.isAudibleAlertEnabled = false;
+  {% if viewer.isGrader() %}
+    window.isAudibleAlertEnabled = false;
 
-  try {
-      window.notificationSound = new NotificationSound();
-      document.querySelector('.disable-audible').style.display = 'none';
-      document.querySelector('.enable-audible').style.display = 'inline-block';
-  } catch (e) {
-      console.error(e);
-  }
+    try {
+        window.notificationSound = new NotificationSound();
+        document.querySelector('.disable-audible').style.display = 'none';
+        document.querySelector('.enable-audible').style.display = 'inline-block';
+    } catch (e) {
+        console.error(e);
+    }
+  {% endif %}
 
   function toggleAudibleAlert() {
       if (window.isAudibleAlertEnabled) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #6349 

On loading the Office Hours queue page as a student, there are two possible JS errors that are thrown. The first is the one mentioned in the above issue. The second is building a binding to the notification alert on/off button. Both of these errors are a result of the elements not existing for students.

### What is the new behavior?

Wraps the code with a twig if statement such that the code is only triggered for a grader. This isn't necessarily the cleanest solution, which would be breaking the JS into its own file and only loading what is needed for a student vs grader, but quickest to fix the bug, and have the page cleanly load.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
