### PR TITLE
[Bugfix:InstructorUI] Show message for empty results

### DIFF
--- a/site/public/js/sql-toolbox.js
+++ b/site/public/js/sql-toolbox.js
@@ -33,6 +33,15 @@ async function runSqlQuery() {
 
         const data = json.data;
 
+        if (data.length === 0) {
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.innerText = 'No rows returned';
+            row.appendChild(cell);
+            table.appendChild(row);
+            return;
+        }
+
         const header = document.createElement('thead');
         const header_row = document.createElement('tr');
         Object.keys(data[0]).forEach((col) => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

If the query does not return any results, then nothing is shown to the user at all. This can lead to confusion on if the page worked at all, or otherwise.

### What is the new behavior?

The page will now show a new message if the returned result set is empty:

<img width="1518" alt="Screen Shot 2021-05-01 at 4 30 15 PM" src="https://user-images.githubusercontent.com/1845314/116788915-c06db480-aa9b-11eb-946d-0a321540f702.png">
