### PR TITLE
[Bugfix:TAGrading] Notebook image width scaling

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1177,16 +1177,22 @@ function openFrame(url, id, filename, ta_grading_interpret=false) {
 }
 
 function resizeFrame(id, max_height = 500, force_height=-1) {
+    let img = undefined;
+    img = $("iframe#" + id).contents().find("img");
     if($("iframe#" + id).contents().find("html").length !== 0) {
         $("iframe#" + id).contents().find("html").css("height", "inherit");
-        var img = $("iframe#" + id).contents().find("img");
+        img = $("iframe#" + id).contents().find("img");
         if(img) {
+            img.removeAttr("width");
+            img.removeAttr("height");
+            img.css("width", "");
+            img.css("height", "");
             img.css("max-width", "100%");
         }
         var height = parseInt($("iframe#" + id).contents().find("body").css('height').slice(0,-2));
     } else { //Handling issue with FireFox and jQuery not being able to access iframe contents for PDF reader
         var height = max_height;
-    }    
+    }
     if (force_height != -1) {
         document.getElementById(id).height = force_height + "px";
     } else if (height >= max_height) {
@@ -1194,6 +1200,17 @@ function resizeFrame(id, max_height = 500, force_height=-1) {
     }
     else {
         document.getElementById(id).height = (height+18) + "px";
+    }
+    //Workarounds for FireFox changing height/width of img sometime after this code runs
+    if(img) {
+        const observer = new ResizeObserver(function(mutationsList, observer) {
+            img.removeAttr("width");
+            img.removeAttr("height");
+            img.css("width", "");
+            img.css("height", "");
+            observer.disconnect();
+        })
+        observer.observe(img[0]);
     }
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1177,15 +1177,19 @@ function openFrame(url, id, filename, ta_grading_interpret=false) {
 }
 
 function resizeFrame(id, max_height = 500, force_height=-1) {
-    $("iframe#" + id).contents().find("html").css("height", "inherit");
-    var img = $("iframe#" + id).contents().find("img");
-    if(img) {
-        img.css("max-width", "100%");
-    }
-    var height = parseInt($("iframe#" + id).contents().find("body").css('height').slice(0,-2));
+    if($("iframe#" + id).contents().find("html").length !== 0) {
+        $("iframe#" + id).contents().find("html").css("height", "inherit");
+        var img = $("iframe#" + id).contents().find("img");
+        if(img) {
+            img.css("max-width", "100%");
+        }
+        var height = parseInt($("iframe#" + id).contents().find("body").css('height').slice(0,-2));
+    } else { //Handling issue with FireFox and jQuery not being able to access iframe contents for PDF reader
+        var height = max_height;
+    }    
     if (force_height != -1) {
         document.getElementById(id).height = force_height + "px";
-    } else if (height > max_height) {
+    } else if (height >= max_height) {
         document.getElementById(id).height= max_height + "px";
     }
     else {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1178,6 +1178,10 @@ function openFrame(url, id, filename, ta_grading_interpret=false) {
 
 function resizeFrame(id, max_height = 500, force_height=-1) {
     $("iframe#" + id).contents().find("html").css("height", "inherit");
+    var img = $("iframe#" + id).contents().find("img");
+    if(img) {
+        img.css("max-width", "100%");
+    }
     var height = parseInt($("iframe#" + id).contents().find("body").css('height').slice(0,-2));
     if (force_height != -1) {
         document.getElementById(id).height = force_height + "px";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Images in TA grading under "Submissions and Results Browser" and "Notebook" panels (+student notebook) that are from openFrame (file submission) are full size; large images will result in scroll bars.

### What is the new behavior?
Fixes #6383 
Images now have a max width of the parent container (no more horizontal bars)