### PR TITLE
[Bugfix:Submission] Show actual submission status on calendar

### DIFF
--- a/site/app/controllers/calendar/CalendarController.php
+++ b/site/app/controllers/calendar/CalendarController.php
@@ -9,6 +9,7 @@ use app\controllers\GlobalController;
 use app\libraries\response\WebResponse;
 use app\models\CalendarInfo;
 use app\models\gradeable\GradeableList;
+use app\models\gradeable\GradeableUtils;
 use app\views\calendar\CalendarView;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -27,8 +28,8 @@ class CalendarController extends AbstractController {
      */
     public function viewCalendar(): WebResponse {
         $user = $this->core->getUser();
-        $gradeable_list = GradeableList::getAllGradeableListFromUserId($this->core, $user);
+        $gradeables_of_user = GradeableUtils::getAllGradeableListFromUserId($this->core, $user);
 
-        return new WebResponse(CalendarView::class, 'showCalendar', CalendarInfo::loadGradeableCalendarInfo($this->core, $gradeable_list));
+        return new WebResponse(CalendarView::class, 'showCalendar', CalendarInfo::loadGradeableCalendarInfo($this->core, $gradeables_of_user));
     }
 }

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -20,20 +20,20 @@ class CalendarInfo extends AbstractModel {
      * @var array<string, array<string, string|DateTime>>
      * the structure of the array is a "YYYY-mm-dd" date string as key, and value
      * contains an array with a structure of
-     * 'gradeable_id' : string   (the id of the item, reserved row and useless for now)
-     * 'title'        : string   (the title of the item which will be shown on each clickable button)
-     * 'semester'     : string   (the semester of which the item belongs)
-     * 'course'       : string   (the title of the course of which the item belongs)
-     * 'url'          : string   (the url of the clickable button)
-     * 'onclick'      : string   (the onclick js function of the clickable button)
-     * 'submission'   : string   (the timestamp of the item, shown in the popup tooltip)
-     * 'status'       : string   (the status of the gradeable, open/closed/grading..., is used to show different
+     * 'gradeable_id' => string   (the id of the item, reserved row and useless for now)
+     * 'title'        => string   (the title of the item which will be shown on each clickable button)
+     * 'semester'     => string   (the semester of which the item belongs)
+     * 'course'       => string   (the title of the course of which the item belongs)
+     * 'url'          => string   (the url of the clickable button)
+     * 'onclick'      => string   (the onclick js function of the clickable button)
+     * 'submission'   => string   (the timestamp of the item, shown in the popup tooltip)
+     * 'status'       => string   (the status of the gradeable, open/closed/grading..., is used to show different
      *                             colors of item, relation between color and integer are recorded in css)
-     * 'status_note'  : string   (a string describing this status)
-     * 'grading_open' : string   (reserved, useless for now. Can be empty)
-     * 'grading_due'  : string   (reserved, useless for now. Can be empty)
-     * 'show_due'     : bool     (whether to show the due date when mouse is hovering over),
-     * 'icon'         : string   (the icon showed before the item),
+     * 'status_note'  => string   (a string describing this status)
+     * 'grading_open' => string   (reserved, useless for now. Can be empty)
+     * 'grading_due'  => string   (reserved, useless for now. Can be empty)
+     * 'show_due'     => bool     (whether to show the due date when mouse is hovering over),
+     * 'icon'         => string   (the icon showed before the item),
      */
     private $items_by_date = [];
 
@@ -42,10 +42,10 @@ class CalendarInfo extends AbstractModel {
      * @var array<int, array>
      * the structure of the array is a integer as key, and value
      * contains an array with a structure of
-     * "title"      : string (title shown at the top of the table),
-     * "subtitle"   : string (title shown at the top of the table, if any. Can be empty),
-     * "section_id" : string (the id of the section. Will be used as the HTML id)
-     * "gradeables" : array. The structure of this array is same as the element of value of $items_by_date
+     * "title"      => string (title shown at the top of the table),
+     * "subtitle"   => string (title shown at the top of the table, if any. Can be empty),
+     * "section_id" => string (the id of the section. Will be used as the HTML id)
+     * "gradeables" => array. The structure of this array is same as the element of value of $items_by_date
      */
     private $items_by_sections = [];
 

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -17,7 +17,7 @@ use DateTime;
 class CalendarInfo extends AbstractModel {
 
     /**
-     * @var array<string, array<string, string|DateTime>>
+     * @var array<string, array<string, string|bool>>
      * the structure of the array is a "YYYY-mm-dd" date string as key, and value
      * contains an array with a structure of
      * 'gradeable_id' => string   (the id of the item, reserved row and useless for now)

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -20,17 +20,20 @@ class CalendarInfo extends AbstractModel {
      * @var array<string, array<string, string|DateTime>>
      * the structure of the array is a "YYYY-mm-dd" date string as key, and value
      * contains an array with a structure of
-     * 'gradeable_id' => string   (the id of the item, reserved row and useless for now)
-     * 'title'        => string   (the title of the item which will be shown on each clickable button)
-     * 'semester'     => string   (the semester of which the item belongs)
-     * 'course'       => string   (the title of the course of which the item belongs)
-     * 'url'          => string   (the url of the clickable button)
-     * 'submission'   => string   (the timestamp of the item, shown in the popup tooltip)
-     * 'status'       => string   (the status of the gradeable, open/closed/grading..., is used to show different
+     * 'gradeable_id' : string   (the id of the item, reserved row and useless for now)
+     * 'title'        : string   (the title of the item which will be shown on each clickable button)
+     * 'semester'     : string   (the semester of which the item belongs)
+     * 'course'       : string   (the title of the course of which the item belongs)
+     * 'url'          : string   (the url of the clickable button)
+     * 'onclick'      : string   (the onclick js function of the clickable button)
+     * 'submission'   : string   (the timestamp of the item, shown in the popup tooltip)
+     * 'status'       : string   (the status of the gradeable, open/closed/grading..., is used to show different
      *                             colors of item, relation between color and integer are recorded in css)
-     * 'status_note'  => string   (a string describing this status)
-     * 'grading_open' => string   (reserved, useless for now. Can be empty)
-     * 'grading_due'  => string   (reserved, useless for now. Can be empty)
+     * 'status_note'  : string   (a string describing this status)
+     * 'grading_open' : string   (reserved, useless for now. Can be empty)
+     * 'grading_due'  : string   (reserved, useless for now. Can be empty)
+     * 'show_due'     : bool     (whether to show the due date when mouse is hovering over),
+     * 'icon'         : string   (the icon showed before the item),
      */
     private $items_by_date = [];
 
@@ -39,10 +42,10 @@ class CalendarInfo extends AbstractModel {
      * @var array<int, array>
      * the structure of the array is a integer as key, and value
      * contains an array with a structure of
-     * "title"      => string (title shown at the top of the table),
-     * "subtitle"   => string (title shown at the top of the table, if any. Can be empty),
-     * "section_id" => string (the id of the section. Will be used as the HTML id)
-     * "gradeables" => array. The structure of this array is same as the element of value of $items_by_date
+     * "title"      : string (title shown at the top of the table),
+     * "subtitle"   : string (title shown at the top of the table, if any. Can be empty),
+     * "section_id" : string (the id of the section. Will be used as the HTML id)
+     * "gradeables" : array. The structure of this array is same as the element of value of $items_by_date
      */
     private $items_by_sections = [];
 
@@ -55,12 +58,14 @@ class CalendarInfo extends AbstractModel {
      * from a GradeableList object.
      *
      * @param Core $core
-     * @param GradeableList $gradeable_list container of gradeables in the system
+     * @param array $gradeables_of_user container of gradeables in the system
      * @return CalendarInfo
      */
-    public static function loadGradeableCalendarInfo(Core $core, GradeableList $gradeable_list): CalendarInfo {
+    public static function loadGradeableCalendarInfo(Core $core, array $gradeables_of_user): CalendarInfo {
         $info = new CalendarInfo($core);
         $date_format = $core->getConfig()->getDateTimeFormat()->getFormat('gradeable');
+
+        $gradeable_list = new GradeableList($core, $core->getUser(), $gradeables_of_user["gradeables"]);
 
         // get the gradeables from the GradeableList and group them by section
         $gradeable_list_sections = [
@@ -78,25 +83,31 @@ class CalendarInfo extends AbstractModel {
             $curr_section["section_id"] = NavigationView::gradeableSections[$section]["section_id"];
             $curr_section['gradeables'] = [];
 
-            $status_note = $curr_section["title"];
-            if ($curr_section["subtitle"] !== '') {
-                $status_note .= " ({$curr_section["subtitle"]})";
-            }
             // Iterate over the Gradeable objects in current section and summarize data
             foreach ($gradeables as $id => $gradeable) {
                 /** @var Gradeable $gradeable */
                 [$semester, $course_title, $gradeable_id] = unserialize($id);
+
+                // Get the submit button for the gradeable to retrieve the gradeable information
+                /** @var Button|null $submit_btn */
+                $submit_btn = $gradeables_of_user["submit_btns"][$id];
+
                 $currGradeable = [
                     'gradeable_id' => $gradeable_id,
                     'title' => $gradeable->getTitle(),
                     'semester' => $semester,
                     'course' => $course_title,
                     'url' => $info->core->buildUrl(['courses', $semester, $course_title, 'gradeable', $gradeable->getId()]),
+                    'onclick' => '',
                     'submission' => ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) ? $gradeable->getSubmissionDueDate()->format($date_format) : '',
                     'status' => (string) $section,
-                    'status_note' => $status_note,
+                    'status_note' => ($submit_btn === null) ? "N/A" : $submit_btn->getTitle(),
                     'grading_open' => $gradeable->getGradeStartDate() !== null ? $gradeable->getGradeStartDate()->format($date_format) : '',
                     'grading_due' => $gradeable->getGradeDueDate() !== null ? $gradeable->getGradeDueDate()->format($date_format) : '',
+                    'class' => ($submit_btn === null) ? "" : explode(' ', $submit_btn->getClass())[1],
+                    'disabled' => !($submit_btn === null) && $submit_btn->isDisabled(),
+                    'show_due' => true,
+                    'icon' => '',
                 ];
 
                 // Put gradeables in current section by their id which consists of semester, course title and gradeable id

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -87,54 +87,25 @@ class GradeableList extends AbstractModel {
         $this->now = $this->core->getDateTimeNow();
 
         foreach ($this->gradeables as $id => $gradeable) {
-            if ($gradeable->getGradeReleasedDate() <= $this->now) {
-                $this->graded_gradeables[$id] = $gradeable;
-            }
-            elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->hasDueDate()) {
-                // Filter out gradeables with no due date
-                if ($gradeable->isStudentSubmit()) {
-                    if ($gradeable->getGradeStartDate() < $this->core->getDateTimeNow() && $this->core->getUser()->accessGrading()) {
-                        // Put in 'grading' category only if user is a grader
-                        $this->grading_gradeables[$id] = $gradeable;
-                    }
-                    else {
-                        $this->open_gradeables[$id] = $gradeable;
-                    }
-                }
-                else {
-                    // If there is no due date and no student submission, it should
-                    //  automatically show up in the 'Grading' category
+            switch (self::getGradeableSection($this->core, $gradeable)) {
+                case self::FUTURE:
+                    $this->future_gradeables[$id] = $gradeable;
+                    break;
+                case self::BETA:
+                    $this->beta_gradeables[$id] = $gradeable;
+                    break;
+                case self::OPEN:
+                    $this->open_gradeables[$id] = $gradeable;
+                    break;
+                case self::CLOSED:
+                    $this->closed_gradeables[$id] = $gradeable;
+                    break;
+                case self::GRADING:
                     $this->grading_gradeables[$id] = $gradeable;
-                }
-            }
-            elseif (
-                (
-                    ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->isTaGrading())
-                    || $gradeable->getType() !== GradeableType::ELECTRONIC_FILE
-                )
-                && $gradeable->getGradeStartDate() <= $this->now
-            ) {
-                $this->grading_gradeables[$id] = $gradeable;
-            }
-            elseif (
-                $gradeable->getType() === GradeableType::ELECTRONIC_FILE
-                && $gradeable->getSubmissionOpenDate() <= $this->now
-                && $gradeable->getSubmissionDueDate() <= $this->now
-            ) {
-                $this->closed_gradeables[$id] = $gradeable;
-            }
-            elseif (
-                $gradeable->getType() === GradeableType::ELECTRONIC_FILE
-                && $gradeable->getSubmissionOpenDate() <= $this->now
-                && $gradeable->getTaViewStartDate() <= $this->now
-            ) {
-                $this->open_gradeables[$id] = $gradeable;
-            }
-            elseif ($this->core->getUser()->accessGrading() && $gradeable->getTaViewStartDate() <= $this->now) {
-                $this->beta_gradeables[$id] = $gradeable;
-            }
-            elseif ($this->core->getUser()->accessAdmin()) {
-                $this->future_gradeables[$id] = $gradeable;
+                    break;
+                case self::GRADED:
+                    $this->grading_gradeables[$id] = $gradeable;
+                    break;
             }
         }
         $sort_array = [
@@ -253,32 +224,63 @@ class GradeableList extends AbstractModel {
     }
 
     /**
-     * A static factory method to create a new GradeableList object that contains
-     * all gradeables in all courses of a single user.
-     * The method loads from the database of all courses and get all gradeables information.
-     * Only load once unless the user refreshes the page.
+     * A static function to get the section of a gradeable.
      *
      * @param Core $core
-     * @param User $user The user to filter gradeables by
-     * @return GradeableList
-     * @throws \Exception if a Gradeable failed to load from the database
+     * @param Gradeable $gradeable
+     * @return int the section number; or -1 if not categorized
      */
-    public static function getAllGradeableListFromUserId(Core $core, User $user): GradeableList {
-        $gradeables = [];
-        // Load the gradeable information for each course
-        $courses = $core->getQueries()->getCourseForUserId($user->getId());
-        foreach ($courses as $course) {
-            /** @var \app\models\Course $course */
-            $core->loadCourseConfig($course->getSemester(), $course->getTitle());
-            $core->loadCourseDatabase();
-            foreach ($core->getQueries()->getGradeableConfigs(null) as $gradeable) {
-                /** @var Gradeable $gradeable */
-                $gradeables[serialize([$course->getSemester(), $course->getTitle(), $gradeable->getId()])] = $gradeable;
-            }
-            $core->getCourseDB()->disconnect();
+    public static function getGradeableSection(Core $core, Gradeable $gradeable): int {
+        $now = $core->getDateTimeNow();
+        if ($gradeable->getGradeReleasedDate() <= $now) {
+            return self::GRADED;
         }
-
-        $core->getConfig()->setCourseLoaded(false);
-        return new GradeableList($core, $user, $gradeables);
+        elseif ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && !$gradeable->hasDueDate()) {
+            // Filter out gradeables with no due date
+            if ($gradeable->isStudentSubmit()) {
+                if ($gradeable->getGradeStartDate() < $core->getDateTimeNow() && $core->getUser()->accessGrading()) {
+                    // Put in 'grading' category only if user is a grader
+                    return self::GRADING;
+                }
+                else {
+                    return self::OPEN;
+                }
+            }
+            else {
+                // If there is no due date and no student submission, it should
+                //  automatically show up in the 'Grading' category
+                return self::GRADING;
+            }
+        }
+        elseif (
+            (
+                ($gradeable->getType() === GradeableType::ELECTRONIC_FILE && $gradeable->isTaGrading())
+                || $gradeable->getType() !== GradeableType::ELECTRONIC_FILE
+            )
+            && $gradeable->getGradeStartDate() <= $now
+        ) {
+            return self::GRADING;
+        }
+        elseif (
+            $gradeable->getType() === GradeableType::ELECTRONIC_FILE
+            && $gradeable->getSubmissionOpenDate() <= $now
+            && $gradeable->getSubmissionDueDate() <= $now
+        ) {
+            return self::CLOSED;
+        }
+        elseif (
+            $gradeable->getType() === GradeableType::ELECTRONIC_FILE
+            && $gradeable->getSubmissionOpenDate() <= $now
+            && $gradeable->getTaViewStartDate() <= $now
+        ) {
+            return self::OPEN;
+        }
+        elseif ($core->getUser()->accessGrading() && $gradeable->getTaViewStartDate() <= $now) {
+            return self::BETA;
+        }
+        elseif ($core->getUser()->accessAdmin()) {
+            return self::FUTURE;
+        }
+        return -1;
     }
 }

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -104,7 +104,7 @@ class GradeableList extends AbstractModel {
                     $this->grading_gradeables[$id] = $gradeable;
                     break;
                 case self::GRADED:
-                    $this->grading_gradeables[$id] = $gradeable;
+                    $this->graded_gradeables[$id] = $gradeable;
                     break;
             }
         }

--- a/site/app/models/gradeable/GradeableUtils.php
+++ b/site/app/models/gradeable/GradeableUtils.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace app\models\gradeable;
 
 use app\libraries\Core;

--- a/site/app/models/gradeable/GradeableUtils.php
+++ b/site/app/models/gradeable/GradeableUtils.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace app\models\gradeable;
+
+use app\libraries\Core;
+use app\models\Button;
+use app\models\Course;
+use app\models\User;
+use app\views\NavigationView;
+
+class GradeableUtils {
+    /**
+     * Get the gradeables of a specified course.
+     *
+     * @param Core $core
+     * @param Course $course
+     * @return array<string, Gradeable[]|GradedGradeable[]|Button[]>
+     * @throws \Exception
+     */
+    public static function getGradeablesFromCourse(Core $core, Course $course): array {
+        /** @var array<string, Gradeable> $gradeables */
+        $gradeables = [];
+        /** @var Gradeable[] $visible_gradeables */
+        $visible_gradeables = [];
+        /** @var array<string, GradedGradeable> $graded_gradeables */
+        $graded_gradeables = [];
+        /** @var array<string, Button> $submit_btns */
+        $submit_btns = [];
+
+        $core->loadCourseConfig($course->getSemester(), $course->getTitle());
+        $core->loadCourseDatabase();
+        foreach ($core->getQueries()->getGradeableConfigs(null) as $gradeable) {
+            /** @var Gradeable $gradeable */
+            $gradeables[serialize([$course->getSemester(), $course->getTitle(), $gradeable->getId()])] = $gradeable;
+            $visible_gradeables[] = $gradeable;
+        }
+
+        foreach ($core->getQueries()->getGradedGradeables($visible_gradeables, $core->getUser()->getId()) as $gg) {
+            /** @var GradedGradeable $gg */
+            $graded_gradeables[serialize([$course->getSemester(), $course->getTitle(), $gg->getGradeableId()])] = $gg;
+        }
+
+        foreach ($gradeables as $key => $gradeable) {
+            $can_submit_everyone = $core->getAccess()->canI('gradeable.submit.everyone', ['gradeable' => $gradeable]);
+            $graded_gradeable = array_key_exists($key, $graded_gradeables) ? $graded_gradeables[$key] : null;
+            $section = GradeableList::getGradeableSection($core, $gradeable);
+            if ($section === -1) {
+                $submit_btns[$key] = null;
+            }
+            else {
+                $submit_btns[$key] = NavigationView::getSubmitButton($core, $gradeable, $graded_gradeable, $section, $can_submit_everyone);
+            }
+        }
+
+        $core->getCourseDB()->disconnect();
+
+        return ["gradeables" => $gradeables, "graded_gradeables" => $graded_gradeables, "submit_btns" => $submit_btns];
+    }
+
+    /**
+     * A static factory method to create a new GradeableList object that contains
+     * all gradeables in all courses of a single user.
+     * The method loads from the database of all courses and get all gradeables information.
+     * Only load once unless the user refreshes the page.
+     *
+     * @param Core $core
+     * @param User $user The user to filter gradeables by
+     * @return array<string, Gradeable[]|GradedGradeable[]|Button[]>
+     * @throws \Exception if a Gradeable failed to load from the database
+     */
+    public static function getAllGradeableListFromUserId(Core $core, User $user): array {
+        $gradeables = [];
+        $graded_gradeables = [];
+        $submit_btns = [];
+
+        // Load the gradeable information for each course
+        $courses = $core->getQueries()->getCourseForUserId($user->getId());
+        foreach ($courses as $course) {
+            /** @var Course $course */
+            $gradeables_of_course = self::getGradeablesFromCourse($core, $course);
+            $gradeables = array_merge($gradeables, $gradeables_of_course["gradeables"]);
+            $graded_gradeables = array_merge($graded_gradeables, $gradeables_of_course["graded_gradeables"]);
+            $submit_btns = array_merge($submit_btns, $gradeables_of_course["submit_btns"]);
+        }
+
+        $core->getConfig()->setCourseLoaded(false);
+        return ["gradeables" => $gradeables, "graded_gradeables" => $graded_gradeables, "submit_btns" => $submit_btns];
+    }
+}

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -2,6 +2,7 @@
 
 namespace app\views;
 
+use app\libraries\Core;
 use app\models\Button;
 use app\libraries\GradeableType;
 use app\models\User;
@@ -228,8 +229,8 @@ class NavigationView extends AbstractView {
      */
     private function getButtons(Gradeable $gradeable, $graded_gradeable, int $list_section, bool $submit_everyone): array {
         $buttons = [];
-        $buttons[] = $this->hasTeamButton($gradeable) ? $this->getTeamButton($gradeable, $graded_gradeable) : null;
-        $buttons[] = $this->hasSubmitButton($gradeable) ? $this->getSubmitButton($gradeable, $graded_gradeable, $list_section, $submit_everyone) : null;
+        $buttons[] = $this->hasTeamButton($gradeable) ? NavigationView::getTeamButton($this->core, $gradeable, $graded_gradeable) : null;
+        $buttons[] = $this->hasSubmitButton($gradeable) ? NavigationView::getSubmitButton($this->core, $gradeable, $graded_gradeable, $list_section, $submit_everyone) : null;
 
         if ($this->hasGradeButton($gradeable)) {
             $buttons[] = $this->getGradeButton($gradeable, $list_section);
@@ -333,9 +334,9 @@ class NavigationView extends AbstractView {
      * @param GradedGradeable|null $graded_gradeable
      * @return Button|null
      */
-    private function getTeamButton(Gradeable $gradeable, $graded_gradeable) {
+    public static function getTeamButton(Core $core, Gradeable $gradeable, ?GradedGradeable $graded_gradeable) {
         // Team management button, only visible on team assignments
-        $date = $this->core->getDateTimeNow();
+        $date = $core->getDateTimeNow();
         $past_lock_date = $date < $gradeable->getTeamLockDate();
         $date_time = null;
 
@@ -355,9 +356,9 @@ class NavigationView extends AbstractView {
                 $team_button_type = 'btn-danger';
             }
             $team_button_text = 'CREATE TEAM';
-            $teams = $this->core->getQueries()->getTeamsByGradeableId($gradeable->getId());
+            $teams = $core->getQueries()->getTeamsByGradeableId($gradeable->getId());
             foreach ($teams as $t) {
-                if ($t->sentInvite($this->core->getUser()->getId())) {
+                if ($t->sentInvite($core->getUser()->getId())) {
                     $team_button_text = 'CREATE/JOIN TEAM';
                     break;
                 }
@@ -374,11 +375,11 @@ class NavigationView extends AbstractView {
             }
         }
 
-        return new Button($this->core, [
+        return new Button($core, [
             "title" => $team_button_text,
             "subtitle" => $date_text,
             "date" => $date_time,
-            "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'team']),
+            "href" => $core->buildCourseUrl(['gradeable', $gradeable->getId(), 'team']),
             "class" => "btn {$team_button_type} btn-nav",
             "name" => "team-btn"
         ]);
@@ -391,7 +392,7 @@ class NavigationView extends AbstractView {
      * @param bool $submit_everyone If the user can submit for another user
      * @return Button|null
      */
-    private function getSubmitButton(Gradeable $gradeable, $graded_gradeable, int $list_section, bool $submit_everyone) {
+    public static function getSubmitButton(Core $core, Gradeable $gradeable, $graded_gradeable, int $list_section, bool $submit_everyone) {
         $class = self::gradeableSections[$list_section]["button_type_submission"];
         $title = self::gradeableSections[$list_section]["prefix"];
         $date_time = null;
@@ -407,19 +408,19 @@ class NavigationView extends AbstractView {
 
         $points_percent = NAN;
 
-        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->hasLoadGradeableMessageEnabled($this->core->getUser()->getId())) {
-            $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_gradeable_message']);
+        if ($gradeable->hasAutogradingConfig() && $gradeable->getAutogradingConfig()->hasLoadGradeableMessageEnabled($core->getUser()->getId())) {
+            $href = $core->buildCourseUrl(['gradeable', $gradeable->getId(), 'load_gradeable_message']);
         }
         else {
-            $href = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]);
+            $href = $core->buildCourseUrl(['gradeable', $gradeable->getId()]);
         }
         $progress = null;
         $disabled = false;
 
         //Button types that override any other buttons
         if (!$gradeable->hasAutogradingConfig()) {
-            return new Button($this->core, [
-                "title" => "Need to run BUILD_{$this->core->getConfig()->getCourse()}.sh",
+            return new Button($core, [
+                "title" => "Need to run BUILD_{$core->getConfig()->getCourse()}.sh",
                 "disabled" => true,
                 "class" => "btn btn-default btn-nav"
             ]);
@@ -463,7 +464,7 @@ class NavigationView extends AbstractView {
             if ($gradeable->isTeamAssignment()) {
                 if (
                     $grade_ready_for_view
-                    && $this->core->getQueries()->getTeamViewedTime($graded_gradeable->getSubmitter()->getId(), $this->core->getUser()->getId()) === null
+                    && $core->getQueries()->getTeamViewedTime($graded_gradeable->getSubmitter()->getId(), $core->getUser()->getId()) === null
                 ) {
                     $class = "btn-success";
                 }
@@ -514,7 +515,7 @@ class NavigationView extends AbstractView {
             if (!$gradeable->hasDueDate()) {
                 $date_text = "";
             }
-            if (!$gradeable->isStudentSubmit() && $this->core->getUser()->accessFullGrading()) {
+            if (!$gradeable->isStudentSubmit() && $core->getUser()->accessFullGrading()) {
                 // Student isn't submitting
                 $title = "BULK UPLOAD";
                 $class = "btn-primary";
@@ -578,7 +579,7 @@ class NavigationView extends AbstractView {
             }
         }
 
-        return new Button($this->core, [
+        return new Button($core, [
             "title" => $title,
             "subtitle" => $date_text,
             "date" => $date_time,

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -164,7 +164,6 @@ h2.cal-month-title {
 
  /* each item in the day cell */
 .cal-gradeable-item {
-    color: var(--btn-text-white);
     margin:1px;
     text-decoration: none;
     white-space: normal;
@@ -184,11 +183,9 @@ h2.cal-month-title {
 
  /* each item in the day cell as a button */
 a.cal-gradeable-item {
-    color: var(--btn-text-white);
 }
 
 a.cal-gradeable-item:hover {
-    color: var(--btn-text-white);
     cursor:pointer;
 }
 
@@ -269,66 +266,18 @@ a.cal-gradeable-status-link:focus {
 
 /* OPEN TO SUBMIT */
 .cal-gradeable-status-2 {
-    background-color: var(--actionable-blue);
-}
-
-.cal-gradeable-status-2:hover {
-    background-color: var(--hover-actionable-blue);
-}
-
-.cal-gradeable-status-2:focus {
-    background-color: var(--focus-actionable-blue);
 }
 
 /* PAST DUE / LATE SUBMIT */
 .cal-gradeable-status-3 {
-    background-color: var(--danger-red);
-}
-
-.cal-gradeable-status-3:hover {
-    background-color: var(--hover-active-danger-red);
-    border: var(--hover-active-danger-red);
-}
-
-.cal-gradeable-status-3:focus {
-    background-color: var(--focus-danger-red);
-    border: var(--focus-danger-red);
 }
 
 /* CLOSED  being graded by TA/Instructor */
 a.cal-gradeable-status-4 {
-    color: var(--btn-text-black);
-    background-color: var(--btn-default-white);
-}
-
-a.cal-gradeable-status-4:hover {
-    color: var(--btn-text-black);
-    background-color: var(--btn-default-hover);
-    border: var(--btn-default-hover);
-}
-
-a.cal-gradeable-status-4:focus {
-    color: var(--btn-text-black);
-    background-color: var(--btn-default-active);
-    border: var(--btn-default-active);
 }
 
 /* GRADES AVAILABLE */
 a.cal-gradeable-status-5 {
-    color: var(--btn-text-black);
-    background-color: var(--good-green);
-}
-
-a.cal-gradeable-status-5:hover {
-    color: var(--btn-text-black);
-    background-color: var(--hover-good-green);
-    border: var(--hover-good-green);
-}
-
-a.cal-gradeable-status-5:focus {
-    color: var(--btn-text-black);
-    background-color: var(--disabled-good-green);
-    border: var(--disabled-good-green);
 }
 
 @media (max-width: 800px) {

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -79,15 +79,27 @@ function generateCalendarItem(item) {
     if (item['submission'] !== '') {
         due_string = `Due: ${item['submission']}`;
     }
+
     // Put detail in the tooltip
-    const tooltip = `Course: ${item['course']}&#10;` +
-        `Title: ${item['title']}&#10;` +
-        `Status: ${item['status_note']}&#10;` +
-        `${due_string}`;
+    let tooltip = `Course: ${item['course']}&#10;` +
+                  `Title: ${item['title']}&#10;`;
+    if (item['status_note'] !== '') {
+        tooltip += `Status: ${item['status_note']}&#10;`;
+    }
+    if (due_string !== '') {
+        tooltip += `${due_string}`;
+    }
     // Put the item in the day cell
-    return `<a class="cal-gradeable-status-${item['status']} cal-gradeable-item"
-           title="${tooltip}"
-           href="${item['url']}">
+    const link = (!item['disabled']) ? item['url'] : '';
+    const onclick = item['onclick'];
+    const icon = item['icon'];
+    const disabled = item['disabled'] ? 'disabled' : '';
+    return `<a class="btn ${item['class']} cal-gradeable-status-${item['status']} cal-gradeable-item"
+           title="${tooltip}" 
+           ${(link !== '') ? `href="${link}"` : ''} 
+           ${(onclick !== '') ? `onclick="${onclick}"` : ''} 
+           ${disabled}>
+          ${(icon !== '') ? `<i class="fas ${icon} cal-icon"></i>` : ''} 
           ${item['title']}
         </a>`;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [✅] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [✅] Tests for the changes have been added/updated (if possible)
* [✅] Documentation has been updated/added if relevant

### What is the current behavior?
Color of items on calendar is based on the due time and the actual time of user (open/due/graded).

### What is the new behavior?
Color of items on calendar is now showing the actual status of the submission, submit/resubmit/late submit/team lock/grades released but not viewed/etc.
![Snipaste_2021-05-05_16-24-39](https://user-images.githubusercontent.com/26744581/117336995-d77d1f80-ae6a-11eb-97e1-612f915784ef.png)
![Snipaste_2021-05-05_16-25-17](https://user-images.githubusercontent.com/26744581/117337015-de0b9700-ae6a-11eb-8f06-1dbda17e396b.png)

### Other information?

Some refactors on `NavigationView` that getting submission buttons function and getting team buttons function are now static.
Some refactors on `GradeableList` that getting the section a gradeable belongs is static
A new utility class `GradeableUtils` is created that will handle loading gradeables information from database.
