### PR TITLE
[UI/UX:TAGrading] Improve Breadcrumb UI

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -138,7 +138,9 @@
                     <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}
-                                <span>&gt;</span> {# span required to give conditional rendering #}
+                              <div class="centered-icon">
+                                <i class="fas fa-angle-right"></i>
+                              </div>
                             {% endif %}
                             <div class="breadcrumb">
                                 {% if b.getUrl() is not empty and not loop.last %}

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -375,7 +375,7 @@ progress::-webkit-progress-value {
 
 .panels-container {
     height: calc(100% - 140px);
-    margin: 0 6px;
+    margin: 0;
     background: var(--standard-medium-gray);
 }
 

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -450,8 +450,12 @@ progress::-webkit-progress-value {
     left: 50%;
     transform: translate(-50%, -50%);
     border-radius: 50px;
-    background: var(--submitty-logo-blue);
-    transition: all 0.5s;
+    transition: all 0.1s;
+    background-color: var(--submitty-logo-blue);
+}
+
+.panel-item-section-drag-bar:hover:after {
+  height: 9px;
 }
 
 .two-panel-drag-bar:after {
@@ -465,12 +469,11 @@ progress::-webkit-progress-value {
     transform: translate(-50%, -50%);
     border-radius: 50px;
     background: var(--submitty-logo-blue);
-    transition: all 0.5s;
+    transition: all 0.1s;
 }
 
-.two-panel-drag-bar:hover:after,
-.panel-item-section-drag-bar:hover:after {
-    filter: blur(3px);
+.two-panel-drag-bar:hover:after{
+  width: 9px;
 }
 
 #regrade_inner_info .inner-container {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -157,11 +157,9 @@ button > i.fas:hover {
 .ta-navlink-cont {
     position: relative;
     margin-right: 4px;
-    margin-top: 4px;
     border: 2px solid black;
     border-radius: 5px;
     box-shadow: 2px 2px 4px;
-    box-sizing: border-box;
 }
 
 #prev-student-navlink i,
@@ -374,7 +372,6 @@ progress::-webkit-progress-value {
 /* Grading Panels CSS */
 
 .panels-container {
-    height: calc(100% - 140px);
     margin: 0;
     background: var(--standard-medium-gray);
 }

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -70,6 +70,10 @@ nav a > i.f {
     display: none;
 }
 
+.centered-icon {
+  line-height: inherit;
+}
+
 .external-breadcrumb {
     padding-left: 7px;
 }

--- a/site/public/js/resizable-panels.js
+++ b/site/public/js/resizable-panels.js
@@ -81,7 +81,6 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
         document.body.style.userSelect = 'none';
         document.body.style.pointerEvents = 'none';
         // Add blurry effect on drag-bar
-        dragbar.style.filter = 'blur(5px)';
 
         // Callback function
         if (typeof callback === 'function') {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -137,13 +137,13 @@ $(function () {
   if(localStorage.getItem('notebook-setting-file-submission-expand') == 'true') {
     let notebookPanel = $('#notebook-view');
     if(notebookPanel.length != 0) {
-      let notebookItems = notebookPanel.find('.openAllFilesubmissions'); 
+      let notebookItems = notebookPanel.find('.openAllFilesubmissions');
       for(var i = 0; i < notebookItems.length; i++) {
         notebookItems[i].onclick();
       }
     }
   }
-  
+
 
   // Remove the select options which are open
   function hidePanelPositionSelect() {
@@ -233,7 +233,7 @@ function notebookScrollSave() {
         element = element.next();
       }
     }
-    
+
     if (element.length !== 0) {
       if (element.attr('data-item-ref') === undefined) {
         localStorage.setItem('ta-grading-notebook-view-scroll-id', element.attr('data-non-item-ref'));
@@ -406,7 +406,7 @@ function adjustGradingPanelHeader () {
   }
   // From the complete content remove the height occupied by navigation-bar and panel-header element
   // 6 is used for adding some space in the bottom
-  document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight() +6) + "px)";
+  document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight()) + "px)";
 }
 
 function onAjaxInit() {}
@@ -1330,8 +1330,8 @@ function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submiss
       let forceFull = url_file.substring(url_file.length - 3) === "pdf" ? 500 : -1;
       let targetHeight = iframe.hasClass("full_panel") ? 1200 : 500;
       let frameHtml = `
-        <iframe id="${iframeId}" onload="resizeFrame('${iframeId}', ${targetHeight}, ${forceFull});" 
-                src="${display_file_url}?dir=${encodeURIComponent(directory)}&file=${encodeURIComponent(html_file)}&path=${encodeURIComponent(url_file)}&ta_grading=true" 
+        <iframe id="${iframeId}" onload="resizeFrame('${iframeId}', ${targetHeight}, ${forceFull});"
+                src="${display_file_url}?dir=${encodeURIComponent(directory)}&file=${encodeURIComponent(html_file)}&path=${encodeURIComponent(url_file)}&ta_grading=true"
                 width="95%">
         </iframe>
       `;

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -405,7 +405,6 @@ function adjustGradingPanelHeader () {
     navBarBox.removeClass('mobile-view');
   }
   // From the complete content remove the height occupied by navigation-bar and panel-header element
-  // 6 is used for adding some space in the bottom
   document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight()) + "px)";
 }
 


### PR DESCRIPTION
This update changes the breadcrumb separator to a proper icon instead of the original ">" character.  This update also adds the .centered-icon class to the global CSS file since centering FA icons is a common task which I don't believe has been added elsewhere in the CSS thus far.

What it looked like before:
![before](https://user-images.githubusercontent.com/16820599/117836828-edae2580-b246-11eb-82a4-ba3bb609bd62.png)

What it looks like now:
![after](https://user-images.githubusercontent.com/16820599/117837003-12a29880-b247-11eb-8dd3-6fb31b7e97ee.png)



As an edit to this PR, I have now made two commits which fix a minor spacing issue on the grading interface.
Before spacing fix:
![before](https://user-images.githubusercontent.com/16820599/117869158-74272f00-b268-11eb-875f-2911bad87830.png)

After spacing fix:
![after](https://user-images.githubusercontent.com/16820599/117869181-7c7f6a00-b268-11eb-9483-05d9bf6712f8.png)
