### PR TITLE
[UI/UX:System] Improve Breadcrumb UI

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -138,9 +138,9 @@
                     <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}
-                              <div class="centered-icon">
-                                <i class="fas fa-angle-right"></i>
-                              </div>
+                                <span class="centered-icon">
+                                    <i class="fas fa-angle-right"></i>
+                                </span>
                             {% endif %}
                             <div class="breadcrumb">
                                 {% if b.getUrl() is not empty and not loop.last %}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -138,7 +138,9 @@
                     <div id="breadcrumbs">
                         {% for b in breadcrumbs %}
                             {% if loop.index0 > 0 %}
-                                <span>&gt;</span> {# span required to give conditional rendering #}
+                              <div class="centered-icon">
+                                <i class="fas fa-angle-right"></i>
+                              </div>
                             {% endif %}
                             <div class="breadcrumb">
                                 {% if b.getUrl() is not empty and not loop.last %}

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -70,6 +70,10 @@ nav a > i.f {
     display: none;
 }
 
+.centered-icon {
+  line-height: inherit;
+}
+
 .external-breadcrumb {
     padding-left: 7px;
 }

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -65,9 +65,9 @@ class TestSidebar(BaseTestCase):
                                 .find_elements(By.TAG_NAME, 'h1')[0].text)
             if(self.driver.find_element(By.ID, 'breadcrumbs')
                and len(self.driver.find_element(By.ID, 'breadcrumbs')
-                       .find_elements(By.TAG_NAME, 'div')) > 2):
+                       .find_elements(By.TAG_NAME, 'span')) > 2):
                 heading_text.append(self.driver.find_element(By.ID, 'breadcrumbs')
-                                    .find_elements(By.TAG_NAME, 'div')[2].text)
+                                    .find_elements(By.TAG_NAME, 'span')[2].text)
             self.assertIn(expected_text, heading_text)
             current_idx += 1
 

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -65,9 +65,9 @@ class TestSidebar(BaseTestCase):
                                 .find_elements(By.TAG_NAME, 'h1')[0].text)
             if(self.driver.find_element(By.ID, 'breadcrumbs')
                and len(self.driver.find_element(By.ID, 'breadcrumbs')
-                       .find_elements(By.TAG_NAME, 'span')) > 2):
+                       .find_elements(By.TAG_NAME, 'div')) > 2):
                 heading_text.append(self.driver.find_element(By.ID, 'breadcrumbs')
-                                    .find_elements(By.TAG_NAME, 'span')[2].text)
+                                    .find_elements(By.TAG_NAME, 'div')[2].text)
             self.assertIn(expected_text, heading_text)
             current_idx += 1
 


### PR DESCRIPTION
This update changes the breadcrumb separator to a proper icon instead of the original ">" character.  This update also adds the .centered-icon class to the global CSS file since centering FA icons is a common task which I don't believe has been added elsewhere in the CSS thus far.

### What is the current behavior?
The ">" character is currently inserted between locations in the breadcrumb path.
![](https://user-images.githubusercontent.com/16820599/117836828-edae2580-b246-11eb-82a4-ba3bb609bd62.png)


### What is the new behavior?
Inserts a small angle between locations in the breadcrumb path.  The icon looks somewhat cleaner than a text-based navigation cue.
![](https://user-images.githubusercontent.com/16820599/117837003-12a29880-b247-11eb-8dd3-6fb31b7e97ee.png)
