### PR TITLE
[UI/UX:TAGrading] Fix spacing issue between panels

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -375,7 +375,7 @@ progress::-webkit-progress-value {
 
 .panels-container {
     height: calc(100% - 140px);
-    margin: 0 6px;
+    margin: 0;
     background: var(--standard-medium-gray);
 }
 

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -157,11 +157,9 @@ button > i.fas:hover {
 .ta-navlink-cont {
     position: relative;
     margin-right: 4px;
-    margin-top: 4px;
     border: 2px solid black;
     border-radius: 5px;
     box-shadow: 2px 2px 4px;
-    box-sizing: border-box;
 }
 
 #prev-student-navlink i,
@@ -374,7 +372,6 @@ progress::-webkit-progress-value {
 /* Grading Panels CSS */
 
 .panels-container {
-    height: calc(100% - 140px);
     margin: 0;
     background: var(--standard-medium-gray);
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -137,13 +137,13 @@ $(function () {
   if(localStorage.getItem('notebook-setting-file-submission-expand') == 'true') {
     let notebookPanel = $('#notebook-view');
     if(notebookPanel.length != 0) {
-      let notebookItems = notebookPanel.find('.openAllFilesubmissions'); 
+      let notebookItems = notebookPanel.find('.openAllFilesubmissions');
       for(var i = 0; i < notebookItems.length; i++) {
         notebookItems[i].onclick();
       }
     }
   }
-  
+
 
   // Remove the select options which are open
   function hidePanelPositionSelect() {
@@ -233,7 +233,7 @@ function notebookScrollSave() {
         element = element.next();
       }
     }
-    
+
     if (element.length !== 0) {
       if (element.attr('data-item-ref') === undefined) {
         localStorage.setItem('ta-grading-notebook-view-scroll-id', element.attr('data-non-item-ref'));
@@ -406,7 +406,7 @@ function adjustGradingPanelHeader () {
   }
   // From the complete content remove the height occupied by navigation-bar and panel-header element
   // 6 is used for adding some space in the bottom
-  document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight() +6) + "px)";
+  document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight()) + "px)";
 }
 
 function onAjaxInit() {}
@@ -1330,8 +1330,8 @@ function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submiss
       let forceFull = url_file.substring(url_file.length - 3) === "pdf" ? 500 : -1;
       let targetHeight = iframe.hasClass("full_panel") ? 1200 : 500;
       let frameHtml = `
-        <iframe id="${iframeId}" onload="resizeFrame('${iframeId}', ${targetHeight}, ${forceFull});" 
-                src="${display_file_url}?dir=${encodeURIComponent(directory)}&file=${encodeURIComponent(html_file)}&path=${encodeURIComponent(url_file)}&ta_grading=true" 
+        <iframe id="${iframeId}" onload="resizeFrame('${iframeId}', ${targetHeight}, ${forceFull});"
+                src="${display_file_url}?dir=${encodeURIComponent(directory)}&file=${encodeURIComponent(html_file)}&path=${encodeURIComponent(url_file)}&ta_grading=true"
                 width="95%">
         </iframe>
       `;

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -405,7 +405,6 @@ function adjustGradingPanelHeader () {
     navBarBox.removeClass('mobile-view');
   }
   // From the complete content remove the height occupied by navigation-bar and panel-header element
-  // 6 is used for adding some space in the bottom
   document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight()) + "px)";
 }
 


### PR DESCRIPTION
### What is the current behavior?
An extra margin is added when the TA grading interface is split into two panes.
![before](https://user-images.githubusercontent.com/16820599/118019518-14438d80-b327-11eb-9499-28d76b96d893.png)

### What is the new behavior?
Fixes the gap around the edges of the grading interface when split into two panes.
![after](https://user-images.githubusercontent.com/16820599/118019425-fa09af80-b326-11eb-953d-1d4f27541579.png)


### Other information:
Fixes #6398
