### PR TITLE
[UI/UX:TAGrading] Adjust hover animation for drag bars

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -475,7 +475,7 @@ progress::-webkit-progress-value {
     transition: all 0.1s;
 }
 
-.two-panel-drag-bar:hover:after{
+.two-panel-drag-bar:hover:after {
   width: 9px;
 }
 

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -457,7 +457,7 @@ progress::-webkit-progress-value {
     background-color: var(--submitty-logo-blue);
 }
 
-.panel-item-section-drag-bar:hover:after {
+.panel-item-section-drag-bar:hover:after, .panel-item-section-drag-bar:active:after {
   height: 9px;
 }
 
@@ -475,7 +475,7 @@ progress::-webkit-progress-value {
     transition: all 0.1s;
 }
 
-.two-panel-drag-bar:hover:after {
+.two-panel-drag-bar:hover:after, .two-panel-drag-bar:active:after  {
   width: 9px;
 }
 

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -453,8 +453,12 @@ progress::-webkit-progress-value {
     left: 50%;
     transform: translate(-50%, -50%);
     border-radius: 50px;
-    background: var(--submitty-logo-blue);
-    transition: all 0.5s;
+    transition: all 0.1s;
+    background-color: var(--submitty-logo-blue);
+}
+
+.panel-item-section-drag-bar:hover:after {
+  height: 9px;
 }
 
 .two-panel-drag-bar:after {
@@ -468,12 +472,11 @@ progress::-webkit-progress-value {
     transform: translate(-50%, -50%);
     border-radius: 50px;
     background: var(--submitty-logo-blue);
-    transition: all 0.5s;
+    transition: all 0.1s;
 }
 
-.two-panel-drag-bar:hover:after,
-.panel-item-section-drag-bar:hover:after {
-    filter: blur(3px);
+.two-panel-drag-bar:hover:after{
+  width: 9px;
 }
 
 #regrade_inner_info .inner-container {

--- a/site/public/js/resizable-panels.js
+++ b/site/public/js/resizable-panels.js
@@ -81,7 +81,6 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
         document.body.style.userSelect = 'none';
         document.body.style.pointerEvents = 'none';
         // Add blurry effect on drag-bar
-        dragbar.style.filter = 'blur(5px)';
 
         // Callback function
         if (typeof callback === 'function') {

--- a/site/public/js/resizable-panels.js
+++ b/site/public/js/resizable-panels.js
@@ -80,7 +80,6 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
         // Disable text selection when dragging
         document.body.style.userSelect = 'none';
         document.body.style.pointerEvents = 'none';
-        // Add blurry effect on drag-bar
 
         // Callback function
         if (typeof callback === 'function') {

--- a/site/public/js/resizable-panels.js
+++ b/site/public/js/resizable-panels.js
@@ -37,6 +37,12 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
         panelHeight = panelEle.getBoundingClientRect().height;
         panelWidth = panelEle.getBoundingClientRect().width;
 
+        document.documentElement.style.setProperty(
+            'cursor',
+            dragBarSel === '.two-panel-drag-bar' ? 'col-resize' : 'ns-resize',
+            'important',
+        );
+
         // Attach the listeners to `document`
         document.addEventListener('mousemove', mouseMoveHandler);
         document.addEventListener('mouseup', mouseUpHandler);
@@ -46,8 +52,7 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
 
     const mouseUpHandler = () => {
         // remove the dragging CSS props to go back to initial styling
-        dragbar.style.removeProperty('cursor');
-        document.body.style.removeProperty('cursor');
+        document.documentElement.style.removeProperty('cursor');
         document.body.style.removeProperty('user-select');
         document.body.style.removeProperty('pointer-events');
         dragbar.style.removeProperty('filter');
@@ -75,8 +80,6 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
             panelEle.style.width = `${updateValue}%`;
         }
 
-        // consistent mouse pointer during dragging
-        document.body.style.cursor = 'col-resize';
         // Disable text selection when dragging
         document.body.style.userSelect = 'none';
         document.body.style.pointerEvents = 'none';


### PR DESCRIPTION
### What is the current behavior?
The drag bars between panes in the TA grading interface currently blur when hovered over.  The animation is slow and looks strange.

### What is the new behavior?
This PR changes the animation to make the drag bars change in size.  The animation is faster and more subtle but also clearly indicates to the user that they are able to be dragged.
