### PR TITLE
[Bugfix:System] Do not write package-lock on install

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -151,7 +151,7 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
         chmod 640 ${SUBMITTY_INSTALL_DIR}/site/package-lock.json
     fi
 
-    su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm install --loglevel=error"
+    su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm install --loglevel=error --no-save"
 
     NODE_FOLDER=${SUBMITTY_INSTALL_DIR}/site/node_modules
     VENDOR_FOLDER=${SUBMITTY_INSTALL_DIR}/site/public/vendor


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

npm@7 modifies the package-lock.json file on installation by default, even if it's just modifying the last-modified timestamp on the file. This messes up the installer such that it would then always detect a change in the package-lock.json file, and so always run `npm install` and then always do the full chmod / chown process over the directories, which is a bit costly on time.

### What is the new behavior?

We add the `--no-save` flag to `npm install` which changes its behavior to never modify the package-lock.json file on installation. This avoids the issue above so that the `package-lock.json` file should always match what was copied in from the git repo, and avoid the unnecessary and timely npm install / chmod / chown steps if they're not necessary.