### PR TITLE
[UI/UX:InstructorUI] Fix row header on Manage Graders page

### DIFF
--- a/site/app/templates/admin/users/GraderList.twig
+++ b/site/app/templates/admin/users/GraderList.twig
@@ -42,7 +42,7 @@
                         {% endfor %}
                     {% else %}
                         <tr class="info">
-                            <td colspan="7" style="text-align: center">No {{groups[grading_group].name|replace({'Grader':'Graders'})}}</td>
+                            <td colspan="8" style="text-align: center">No {{groups[grading_group].name|replace({'Grader':'Graders'})}}</td>
                         </tr>
                     {% endif %}
                 </tbody>


### PR DESCRIPTION
### What is the current behavior?
The category row in the table does not span all the columns when there are no graders in a category.
![image](https://user-images.githubusercontent.com/71195502/118136719-6988a900-b3d2-11eb-8b46-6a6e251d08c5.png)

### What is the new behavior?
The row now extends to the 8th column well.
![image](https://user-images.githubusercontent.com/71195502/118136804-81f8c380-b3d2-11eb-96f0-40a7936621e1.png)
