### PR TITLE
[UI/UX:InstructorUI] Off-Center Error Banner

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -443,7 +443,6 @@ HTML;
         if ($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
             $peer = true;
         }
-
         //Each table column is represented as an array with the following entries:
         // width => how wide the column should be on the page, <td width=X>
         // title => displayed title in the table header
@@ -796,7 +795,6 @@ HTML;
         $this->core->getOutput()->addInternalJs('collapsible-panels.js');
 
         $this->core->getOutput()->enableMobileViewport();
-
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/Details.twig", [
             "gradeable" => $gradeable,
             "sections" => $sections,
@@ -821,8 +819,6 @@ HTML;
                 http_build_query(['view' => $view_all ? null : 'all', 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => $anon_mode]),
             "order_toggle_url" => $details_base_url . '?' .
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort === 'random' ? null : 'random', 'anon_mode' => $anon_mode]),
-            "toggle_anon_mode_url" => $details_base_url . '?' .
-                http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => !$anon_mode]),
             "sort" => $sort,
             "direction" => $direction
         ]);
@@ -918,6 +914,7 @@ HTML;
 
             $return .= <<<HTML
                 <div class="panels-container">
+                    <h3 id="panel-instructions">Click above to select a panel for display</h3>
                     <div class="two-panel-cont">
                          <div class="two-panel-item two-panel-left active">
                             <div class="panel-item-section left-top"></div>
@@ -1098,7 +1095,6 @@ HTML;
         if ($peer && $this->core->getUser()->getGroup() == 4) {
             $i_am_a_peer = true;
         }
-
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "progress" => $progress,
             "peer_gradeable" => $peer,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -443,6 +443,7 @@ HTML;
         if ($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
             $peer = true;
         }
+
         //Each table column is represented as an array with the following entries:
         // width => how wide the column should be on the page, <td width=X>
         // title => displayed title in the table header
@@ -795,6 +796,7 @@ HTML;
         $this->core->getOutput()->addInternalJs('collapsible-panels.js');
 
         $this->core->getOutput()->enableMobileViewport();
+
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/Details.twig", [
             "gradeable" => $gradeable,
             "sections" => $sections,
@@ -819,6 +821,8 @@ HTML;
                 http_build_query(['view' => $view_all ? null : 'all', 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => $anon_mode]),
             "order_toggle_url" => $details_base_url . '?' .
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort === 'random' ? null : 'random', 'anon_mode' => $anon_mode]),
+            "toggle_anon_mode_url" => $details_base_url . '?' .
+                http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => !$anon_mode]),
             "sort" => $sort,
             "direction" => $direction
         ]);
@@ -914,7 +918,6 @@ HTML;
 
             $return .= <<<HTML
                 <div class="panels-container">
-                    <h3 id="panel-instructions">Click above to select a panel for display</h3>
                     <div class="two-panel-cont">
                          <div class="two-panel-item two-panel-left active">
                             <div class="panel-item-section left-top"></div>
@@ -1095,6 +1098,7 @@ HTML;
         if ($peer && $this->core->getUser()->getGroup() == 4) {
             $i_am_a_peer = true;
         }
+
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "progress" => $progress,
             "peer_gradeable" => $peer,

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -546,10 +546,11 @@ progress::-webkit-progress-value {
     width: 400px;
     height: 25px;
     top: 2px;
-    margin: auto;
+    left: 120px;
     padding-top:3px;
     padding-bottom:3px;
     text-align: center;
+    vertical-align: middle;
     line-height: 25px;
     font-weight:    bold;
     background-color: var(--badge-backgroud-red);

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -204,7 +204,6 @@ progress::-webkit-progress-value {
 
 .panel-header-box {
     display: flex;
-    margin: auto;
 }
 
 .grade-panel {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -204,6 +204,7 @@ progress::-webkit-progress-value {
 
 .panel-header-box {
     display: flex;
+    margin: auto;
 }
 
 .grade-panel {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -546,11 +546,10 @@ progress::-webkit-progress-value {
     width: 400px;
     height: 25px;
     top: 2px;
-    left: 120px;
+    margin: auto;
     padding-top:3px;
     padding-bottom:3px;
     text-align: center;
-    vertical-align: middle;
     line-height: 25px;
     font-weight:    bold;
     background-color: var(--badge-backgroud-red);

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -543,8 +543,9 @@ progress::-webkit-progress-value {
     border: solid 6px var(--important-post);
     position:relative;
     display: block;
-    width: 400px;
-    height: 25px;
+    width: fit-content;
+    padding: 0.5vh 0.5vw 0.5vh 0.5vw;
+    height: fit-content;
     top: 2px;
     margin: auto;
     padding-top:3px;


### PR DESCRIPTION
Fixes #6397 
Keeps the error message banner aligned in the middle for all views options. Header panel is also aligned now.

Also made the banner automatically size to fit the content, and also adding padding to the banner.

### What is the current behavior?
![image](https://user-images.githubusercontent.com/49821332/118155757-91820780-b3e6-11eb-971b-bc4bf92ff61f.png)
![image](https://user-images.githubusercontent.com/49821332/119374824-0fb49880-bc88-11eb-8452-1200b9fae8a3.png)


### What is the new behavior?
![image](https://user-images.githubusercontent.com/49821332/119846381-15a0b880-bed8-11eb-86a0-3165f40cf6ae.png)

Automatically sizing the banner to fit the content
![image](https://user-images.githubusercontent.com/49821332/119846509-32d58700-bed8-11eb-949a-3d1473e9e20f.png)


