### PR TITLE
[UI/UX:Forum] Fix forum date error

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -754,10 +754,11 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             var anon = json.anon;
             var change_anon = json.change_anon;
             var user_id = escapeSpecialChars(json.user);
+            json.post_time = json.post_time.replace(" ", "T");
             var time = Date.parse(json.post_time);
             if(!time) {
                 // Timezone suffix ":00" might be missing
-                time = Date.parse(json.post_time+":00");
+                time = Date.parse(json.post_time+"00");
             }
             time = new Date(time);
             var categories_ids = json.categories_ids;


### PR DESCRIPTION
### What is the current behavior?
When editing posts on the discussion forum, the date format is incorrect.
![](https://user-images.githubusercontent.com/11927934/102252027-92644b00-3ed3-11eb-83b1-b2bb1c9a018d.png)


### What is the new behavior?
This change fixes the dates on the discussion forum by correcting the date format to be a proper Javascript date.
![Untitled](https://user-images.githubusercontent.com/16820599/118171164-0b22f100-b3f9-11eb-944c-e6cfa21ab5d8.png)
