### PR TITLE
[Bugfix:SubminiPolls] polls dir for new course/install

### DIFF
--- a/migration/migrator/migrations/course/20210513192238_polls_directory_bugfix.py
+++ b/migration/migrator/migrations/course/20210513192238_polls_directory_bugfix.py
@@ -2,7 +2,7 @@ import shutil
 from pathlib import Path
 
 
-def up(config):
+def up(config, database, semester, course):
     """
     Run up migration.
 
@@ -21,7 +21,7 @@ def up(config):
 
 
 
-def down(config):
+def down(config, database, semester, course):
     """
     Run down migration (rollback).
 

--- a/migration/migrator/migrations/system/20210513192238_polls_directory_bugfix.py
+++ b/migration/migrator/migrations/system/20210513192238_polls_directory_bugfix.py
@@ -1,0 +1,31 @@
+import shutil
+from pathlib import Path
+
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    
+    course_dir = Path(config.submitty['submitty_data_dir'], 'courses', semester, course, 'uploads')
+    polls_dir = Path(course_dir, 'polls')
+    polls_dir.mkdir(mode=0o750, exist_ok=True)
+    php_user = config.submitty_users['php_user']
+    # get course group
+    course_group_id = course_dir.stat().st_gid
+    # set the owner/group/permissions
+    shutil.chown(polls_dir, php_user, course_group_id)
+
+
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    pass

--- a/sbin/create_course.sh
+++ b/sbin/create_course.sh
@@ -227,6 +227,7 @@ create_and_set  u=rwx,g=rwxs,o=   $instructor  $ta_www_group   $course_dir/custo
 #               drwxr-s---       $DAEMON_USER     ta_www_group    checkout/
 #               drwxr-s---       $DAEMON_USER     ta_www_group    uploads/
 #               drwxr-s---       $PHP_USER        ta_www_group    uploads/bulk_pdf/
+#               drwxr-s---       $PHP_USER        ta_www_group    uploads/polls/
 #               drwxrws---       $DAEMON_USER     ta_www_group    uploads/split_pdf/
 #               drwxr-s---       $PHP_USER        ta_www_group    uploads/student_images/
 #               drwxr-s---       $PHP_USER        ta_www_group    uploads/student_images/tmp
@@ -246,6 +247,7 @@ create_and_set  u=rwx,g=rxs,o=   $DAEMON_USER     $ta_www_group   $course_dir/re
 create_and_set  u=rwx,g=rxs,o=   $DAEMON_USER     $ta_www_group   $course_dir/checkout
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads/bulk_pdf
+create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads/polls
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads/student_images
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads/student_images/tmp
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/uploads/course_materials


### PR DESCRIPTION
PR #6180 included a migration to add the uploads/polls directory for existing courses, but missed adding this directory for new courses (and new installations).
