### PR TITLE
[Bugfix:TAGrading] Peer grading ta and student notes shown

### DIFF
--- a/site/app/templates/grading/electronic/GradingPanelHeader.twig
+++ b/site/app/templates/grading/electronic/GradingPanelHeader.twig
@@ -90,7 +90,7 @@
             {{ self.renderPanelPositionSelector('discussion_browser') }}
             </span>
         {% endif %}
-        {% if isRegradePanel %}
+        {% if isRegradePanel and not student_grader %}
             <span class="grade-panel" id="regrade_info_btn">
                 <button title="Show/Hide Grade Inquiry Information (Press X)"
                         class="invisible-btn key_to_click"

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -40,6 +40,7 @@
                     </div>
                 </div>
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id}}" data-can_verify="{{ can_verify }}" hidden></div>
+                <div id="student-grader" is-student-grader="{{ student_grader }}" hidden></div>
                 <div class="inner-container" id="grading-box">
                     {% if has_active_version %}
                         <script>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1121,7 +1121,8 @@ HTML;
             'isStudentInfoPanel' => $isStudentInfoPanel,
             'isDiscussionPanel' => $isDiscussionPanel,
             'isRegradePanel' => $isRegradePanel,
-            'is_notebook' => $is_notebook
+            'is_notebook' => $is_notebook,
+            "student_grader" => $this->core->getUser()->getGroup() == User::GROUP_STUDENT,
         ]);
     }
 
@@ -1438,26 +1439,28 @@ HTML;
      */
     public function renderSolutionTaNotesPanel($gradeable, $solution_array, $submitter_itempool_map) {
         $this->core->getOutput()->addInternalJs('solution-ta-notes.js');
-
+        $is_student = $this->core->getUser()->getGroup() == User::GROUP_STUDENT;
         $r_components = $gradeable->getComponents();
         $solution_components = [];
         foreach ($r_components as $key => $value) {
-            $id = $value->getId();
-            $solution_components[] = [
-                'id' => $id,
-                'title' => $value->getTitle(),
-                'is_first_edit' => !isset($solution_array[$id]),
-                'author' => isset($solution_array[$id]) ? $solution_array[$id]['author'] : '',
-                'solution_notes' => isset($solution_array[$id]) ? $solution_array[$id]['solution_notes'] : '',
-                'edited_at' => isset($solution_array[$id])
-                    ? DateUtils::convertTimeStamp(
-                        $this->core->getUser(),
-                        $solution_array[$id]['edited_at'],
-                        $this->core->getConfig()->getDateTimeFormat()->getFormat('solution_ta_notes')
-                    ) : null,
-                'is_itempool_linked' => $value->getIsItempoolLinked(),
-                'itempool_item' => $value->getItempool() === "" ? "" : $submitter_itempool_map[$value->getItempool()]
-            ];
+            if ($value->isPeer() || !$is_student){
+                $id = $value->getId();
+                $solution_components[] = [
+                    'id' => $id,
+                    'title' => $value->getTitle(),
+                    'is_first_edit' => !isset($solution_array[$id]),
+                    'author' => isset($solution_array[$id]) ? $solution_array[$id]['author'] : '',
+                    'solution_notes' => isset($solution_array[$id]) ? $solution_array[$id]['solution_notes'] : '',
+                    'edited_at' => isset($solution_array[$id])
+                        ? DateUtils::convertTimeStamp(
+                            $this->core->getUser(),
+                            $solution_array[$id]['edited_at'],
+                            $this->core->getConfig()->getDateTimeFormat()->getFormat('solution_ta_notes')
+                        ) : null,
+                    'is_itempool_linked' => $value->getIsItempoolLinked(),
+                    'itempool_item' => $value->getItempool() === "" ? "" : $submitter_itempool_map[$value->getItempool()]
+                ];
+            }
         }
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/SolutionTaNotesPanel.twig", [
             'gradeable_id' => $gradeable->getId(),

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1443,7 +1443,7 @@ HTML;
         $r_components = $gradeable->getComponents();
         $solution_components = [];
         foreach ($r_components as $key => $value) {
-            if ($value->isPeer() || !$is_student){
+            if ($value->isPeer() || !$is_student) {
                 $id = $value->getId();
                 $solution_components[] = [
                     'id' => $id,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1424,6 +1424,7 @@ HTML;
                 "has_active_version" => $has_active_version,
                 "version_conflict" => $version_conflict,
                 "show_silent_edit" => $show_silent_edit,
+                "student_grader" => $this->core->getUser()->getGroup() == User::GROUP_STUDENT,
                 "grader_id" => $this->core->getUser()->getId(),
                 "display_version" => $display_version,
             ]);

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -546,10 +546,11 @@ progress::-webkit-progress-value {
     width: 400px;
     height: 25px;
     top: 2px;
-    margin: auto;
+    left: 120px;
     padding-top:3px;
     padding-bottom:3px;
     text-align: center;
+    vertical-align: middle;
     line-height: 25px;
     font-weight:    bold;
     background-color: var(--badge-backgroud-red);

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -546,11 +546,10 @@ progress::-webkit-progress-value {
     width: 400px;
     height: 25px;
     top: 2px;
-    left: 120px;
+    margin: auto;
     padding-top:3px;
     padding-bottom:3px;
     text-align: center;
-    vertical-align: middle;
     line-height: 25px;
     font-weight:    bold;
     background-color: var(--badge-backgroud-red);

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -195,10 +195,15 @@ function renderPeerGradeable(grader_id, gradeable, graded_gradeable, grading_dis
  * @param {boolean} componentVersionConflict
  * @returns {Promise<string>} the html for the graded component
  */
-function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict) {
+function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict, student_grader) {
     return new Promise(function (resolve, reject) {
         // Make sure we prep the graded component before rendering
         graded_component = prepGradedComponent(component, graded_component);
+        if (student_grader){
+            component.ta_comment = "";
+        } else {
+            component.student_comment = "";
+        }
         // TODO: i don't think this is async
         resolve(Twig.twig({ref: "GradingComponent"}).render({
             'component': component,

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -189,19 +189,19 @@ function renderPeerGradeable(grader_id, gradeable, graded_gradeable, grading_dis
  * @param {Object} graded_component
  * @param {boolean} grading_disabled
  * @param {boolean} canVerifyGraders
- * @param {number} precision
- * @param {boolean} editable True to render with edit mode enabled
- * @param {boolean} showMarkList True to display the mark list unhidden
  * @param {boolean} componentVersionConflict
- * @param {boolean} is_student False if the grader is a TA, True if peer grader
+ * @param {Array} displayParam Parameters affecting what is displayed, [precision: precision of decimals displayed, editable: True to render with edit mode enabled, showMarkList True to display the mark list unhidden, is_student False if the grader is a TA, True if peer grader]
  * @returns {Promise<string>} the html for the graded component
  */
-function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict, is_student) {
-    
+function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, componentVersionConflict, displayParam) {
+    let precision = displayParam[0];
+    let editable = displayParam[1];
+    let showMarkList = displayParam[2];
+    let isStudent = displayParam[3];
     return new Promise(function (resolve, reject) {
         // Make sure we prep the graded component before rendering
         graded_component = prepGradedComponent(component, graded_component);
-        if (is_student){
+        if (isStudent){
             component.ta_comment = "";
         } else {
             component.student_comment = "";

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -195,11 +195,12 @@ function renderPeerGradeable(grader_id, gradeable, graded_gradeable, grading_dis
  * @param {boolean} componentVersionConflict
  * @returns {Promise<string>} the html for the graded component
  */
-function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict, student_grader) {
+function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict, is_student) {
+    
     return new Promise(function (resolve, reject) {
         // Make sure we prep the graded component before rendering
         graded_component = prepGradedComponent(component, graded_component);
-        if (student_grader){
+        if (is_student){
             component.ta_comment = "";
         } else {
             component.student_comment = "";
@@ -367,4 +368,12 @@ function renderConflictMarks(conflict_marks) {
             decimal_precision: DECIMAL_PRECISION
         }));
     })
+}
+
+/**
+ * 
+ * @return {boolean}
+ */
+function isStudentGrader(){
+    return $("#student-grader").attr("is-student-grader"); 
 }

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -189,19 +189,19 @@ function renderPeerGradeable(grader_id, gradeable, graded_gradeable, grading_dis
  * @param {Object} graded_component
  * @param {boolean} grading_disabled
  * @param {boolean} canVerifyGraders
+ * @param {number} precision
+ * @param {boolean} editable True to render with edit mode enabled
+ * @param {boolean} showMarkList True to display the mark list unhidden
  * @param {boolean} componentVersionConflict
- * @param {Array} displayParam Parameters affecting what is displayed, [precision: precision of decimals displayed, editable: True to render with edit mode enabled, showMarkList True to display the mark list unhidden, is_student False if the grader is a TA, True if peer grader]
+ * @param {boolean} is_student False if the grader is a TA, True if peer grader
  * @returns {Promise<string>} the html for the graded component
  */
-function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, componentVersionConflict, displayParam) {
-    let precision = displayParam[0];
-    let editable = displayParam[1];
-    let showMarkList = displayParam[2];
-    let isStudent = displayParam[3];
+function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict, is_student) {
+    
     return new Promise(function (resolve, reject) {
         // Make sure we prep the graded component before rendering
         graded_component = prepGradedComponent(component, graded_component);
-        if (isStudent){
+        if (is_student){
             component.ta_comment = "";
         } else {
             component.student_comment = "";

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -193,6 +193,7 @@ function renderPeerGradeable(grader_id, gradeable, graded_gradeable, grading_dis
  * @param {boolean} editable True to render with edit mode enabled
  * @param {boolean} showMarkList True to display the mark list unhidden
  * @param {boolean} componentVersionConflict
+ * @param {boolean} is_student False if the grader is a TA, True if peer grader
  * @returns {Promise<string>} the html for the graded component
  */
 function renderGradingComponent(grader_id, component, graded_component, grading_disabled, canVerifyGraders, precision, editable, showMarkList, componentVersionConflict, is_student) {

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -3126,9 +3126,7 @@ function injectInstructorEditComponentHeader(component, showMarkList) {
  */
 function injectGradingComponent(component, graded_component, editable, showMarkList) {
     student_grader = $("#student-grader").attr("is-student-grader"); 
-    precision = getPointPrecision();
-    displayParam = [precision, editable, showMarkList, student_grader];
-    return renderGradingComponent(getGraderId(), component, graded_component, isGradingDisabled(), canVerifyGraders(), getComponentVersionConflict(graded_component), displayParam)
+    return renderGradingComponent(getGraderId(), component, graded_component, isGradingDisabled(), canVerifyGraders(), getPointPrecision(), editable, showMarkList, getComponentVersionConflict(graded_component), student_grader)
         .then(function (elements) {
             setComponentContents(component.id, elements);
         })

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -3125,7 +3125,8 @@ function injectInstructorEditComponentHeader(component, showMarkList) {
  * @return {Promise}
  */
 function injectGradingComponent(component, graded_component, editable, showMarkList) {
-    return renderGradingComponent(getGraderId(), component, graded_component, isGradingDisabled(), canVerifyGraders(), getPointPrecision(), editable, showMarkList, getComponentVersionConflict(graded_component))
+    student_grader = $("#student-grader").attr("is-student-grader"); 
+    return renderGradingComponent(getGraderId(), component, graded_component, isGradingDisabled(), canVerifyGraders(), getPointPrecision(), editable, showMarkList, getComponentVersionConflict(graded_component), student_grader)
         .then(function (elements) {
             setComponentContents(component.id, elements);
         })

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -3126,7 +3126,9 @@ function injectInstructorEditComponentHeader(component, showMarkList) {
  */
 function injectGradingComponent(component, graded_component, editable, showMarkList) {
     student_grader = $("#student-grader").attr("is-student-grader"); 
-    return renderGradingComponent(getGraderId(), component, graded_component, isGradingDisabled(), canVerifyGraders(), getPointPrecision(), editable, showMarkList, getComponentVersionConflict(graded_component), student_grader)
+    precision = getPointPrecision();
+    displayParam = [precision, editable, showMarkList, student_grader];
+    return renderGradingComponent(getGraderId(), component, graded_component, isGradingDisabled(), canVerifyGraders(), getComponentVersionConflict(graded_component), displayParam)
         .then(function (elements) {
             setComponentContents(component.id, elements);
         })


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #6366
Currently when peer grading is enabled for a gradable and there are both student components and ta components, a peer grader is able to see both the student components and the ta components in the solution/ta notes panel. In addition, peer graders have access to the grading inquiry panel through the grading inquiry button at the top. In the rubric panel, the peer grader and ta also sees both comments to the students and ta's.

### What is the new behavior?
The peer graders no longer sees the grading inquiry button, comments in the grading rubric panel now shows to different user groups accordingly. The peer graders also no longer sees ta components in the  solution/ta notes panel.

In TA's point of view 
![image](https://user-images.githubusercontent.com/49821332/118297938-cd7fa000-b4ac-11eb-8171-c1935665ff05.png)
where TA only is a TA component

In the peer grader's point of view for the same gradeable
![image](https://user-images.githubusercontent.com/49821332/118298155-1b94a380-b4ad-11eb-86c1-f4c8c7cc7503.png)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I tested by created a non peer component for the gradeable Closed Peer Team Homework and assigning the user student to grade a team for the assignment and checking to see what the student has access to on their page, and then I did the same for the user ta2.
