### PR TITLE
[Bugfix:InstructorUI] Add late days instead of overwriting

### DIFF
--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -98,9 +98,7 @@ class LateController extends AbstractController {
 
             $date_time = DateUtils::parseDateTime($_POST['datestamp'], $this->core->getUser()->getUsableTimeZone());
 
-
-            $existing_user = $this->core->getQueries()->getLateDaysForUserOnTimestamp($_POST['user_id'], $date_time);
-            if (isset($existing_user)) {
+            if ($this->core->getQueries()->getLateDaysForUserOnTimestamp($_POST['user_id'], $date_time) !== null) {
                 $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days'] + $existing_user->getAllowedLateDays());
             }
             else { // The user doesn't have any late days yet so we just assign them the number of late days specified.

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -107,7 +107,7 @@ class LateController extends AbstractController {
                 $user_timestamp = DateUtils::parseDateTime($user->getSinceTimestamp(), $this->core->getUser()->getUsableTimeZone());
                 if ($user->getId() == $_POST['user_id'] && $user_timestamp == $date_time) {
                     $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days'] + $user->getAllowedLateDays());
-                    $exists = True;
+                    $exists = true;
                     break;
                 }
             }

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -98,7 +98,24 @@ class LateController extends AbstractController {
 
             $date_time = DateUtils::parseDateTime($_POST['datestamp'], $this->core->getUser()->getUsableTimeZone());
 
-            $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days']);
+            // This is by all means an ugly hack but this same process is completed elsewhere while loading this page
+            // and there is no way to get a specific user by ID and get the number of late days at the same time.
+            // Ultimately, the performance difference is rather negligible since only instructors load this page.
+            $users = $this->core->getQueries()->getUsersWithLateDays();
+            $exists = false;
+            foreach ($users as $user) {
+                $user_timestamp = DateUtils::parseDateTime($user->getSinceTimestamp(), $this->core->getUser()->getUsableTimeZone());
+                if ($user->getId() == $_POST['user_id'] && $user_timestamp == $date_time) {
+                    $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days'] + $user->getAllowedLateDays());
+                    $exists = True;
+                    break;
+                }
+            }
+            // The user doesn't have any late days yet so we just assign them the number of late days.
+            if (!$exists) {
+                $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days']);
+            }
+
             $this->core->addSuccessMessage("Late days have been updated");
             return $this->getLateDays();
         }

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -98,7 +98,8 @@ class LateController extends AbstractController {
 
             $date_time = DateUtils::parseDateTime($_POST['datestamp'], $this->core->getUser()->getUsableTimeZone());
 
-            if ($this->core->getQueries()->getLateDaysForUserOnTimestamp($_POST['user_id'], $date_time) !== null) {
+            $existing_user = $this->core->getQueries()->getLateDaysForUserOnTimestamp($_POST['user_id'], $date_time);
+            if ($existing_user !== null) {
                 $this->core->getQueries()->updateLateDays($_POST['user_id'], $date_time, $_POST['late_days'] + $existing_user->getAllowedLateDays());
             }
             else { // The user doesn't have any late days yet so we just assign them the number of late days specified.

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3241,6 +3241,34 @@ ORDER BY gt.{$section_key}",
     }
 
     /**
+     * Gets the number of late days for a specific user at a specified time
+     *
+     * @param string $user_id
+     * @param \DateTime $since_timestamp
+     * @return SimpleLateUser|null
+     */
+    public function getLateDaysForUserOnTimestamp(string $user_id, \DateTime $since_timestamp): ?SimpleLateUser {
+        $this->course_db->query(
+            "
+        SELECT u.user_id, user_firstname, user_preferred_firstname,
+          user_lastname, user_preferred_lastname, allowed_late_days, since_timestamp
+        FROM users AS u
+        FULL OUTER JOIN late_days AS l
+          ON u.user_id=l.user_id
+        WHERE allowed_late_days IS NOT NULL
+          AND u.user_id = ?
+          AND since_timestamp = ?
+        ORDER BY
+          user_email ASC, since_timestamp DESC;",
+            [$user_id, $since_timestamp]
+        );
+
+        return $this->course_db->getRowCount() === 1
+            ? new SimpleLateUser($this->core, $this->course_db->row())
+            : null;
+    }
+
+    /**
      * Return an array of users with extensions
      *
      * @param  string $gradeable_id

--- a/site/app/templates/admin/LateDays.twig
+++ b/site/app/templates/admin/LateDays.twig
@@ -18,7 +18,7 @@
                 <input class="option-input" type="text" name="datestamp" id="datestamp">
             </label>
             <label for="late_days">
-                Late Days:
+                Additional Late Days:
                 <input class="option-input" type="text" name="late_days" id="late_days">
             </label>
             <div>


### PR DESCRIPTION
### What is the current behavior?
When attempting to add late days to a student, the current behavior is to overwrite the number of late days with the number of late days entered.

### What is the new behavior?
This update clarifies that the number of late days is the number of *additional* late days and fixes the bug which resulted in the late days being overwritten each time.

### Other information?
Fixes #6377
