### PR TITLE
[Bugfix:InstructorUI] Remove field from iclicker config

### DIFF
--- a/more_autograding_examples/iclicker_upload/config/config.json
+++ b/more_autograding_examples/iclicker_upload/config/config.json
@@ -21,7 +21,6 @@
     "testcases" : [ 
         {
             "title" : "iClicker ID",
-            "actual_file" : "input_0.txt",
             "points" : 1,
             "command" : [],
             "validation": [


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #6285

The iclicker_upload config was failing validation, due to the `actual_file` field that was under the `testcases` object.

### What is the new behavior?

The `actual_file` field was removed here as it did not belong. This field is only needed in the validators section (where it is present) and has no effect being placed at this top level.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Tested by compiling the configuration and running the complete config against our schema validator. It failed validation before this change and then passed after it.
