### PR TITLE
[Bugfix:Autograding] Fix pattern default in config

### DIFF
--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -1029,6 +1029,7 @@
                     "type" : "string"
                   },
                   "pattern" : {
+                    "type": "string"
                   },
                   "source" : {
                     "type" : "string"

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -846,7 +846,7 @@ void formatPreActions(nlohmann::json &testcases, nlohmann::json &whole_config) {
       assert(source_name.find("\'") == std::string::npos);
 
       if(!pre_command["pattern"].is_string()){
-         (*my_testcase)["pattern"] = "";
+         pre_command["pattern"] = "";
       }else{
         std::string pattern = pre_command["pattern"];
         //The pattern must not container .. or $


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #6286

The `test_notes_upload*` autograding examples were failing config validation due to the presence of a `pattern` field at the top level of a testcase instead of just contained within the `pre_commands` section, for example:

```json
{
    "containers": [
        {
            "commands": [
                "mv test_template.pdf student_test_template.pdf",
                "pdflatex blank_page.tex",
                "python3 separate_pages.py 2",
                "pdflatex test_template.tex"
            ],
            "container_image": "submitty/autograding-default:latest",
            "container_name": "container0",
            "number_of_ports": 1,
            "outgoing_connections": [],
            "server": false
        }
    ],
    "details": "",
    "dispatcher_actions": [],
    "extra_credit": false,
    "hidden": false,
    "pattern": "",
    "points": 1,
    "pre_commands": [
        {
            "command": "cp",
            "destination": ".",
            "option": "-R",
            "pattern": null,
            "source": "student_file.pdf",
            "testcase": "test01"
        }
    ],
    "publish_actions": false,
    "release_hidden_details": false,
    "single_port_per_container": false,
    "solution_containers": [
        {
            "commands": [],
            "container_image": "submitty/autograding-default:latest",
            "container_name": "container0",
            "number_of_ports": 1,
            "outgoing_connections": [],
            "server": false
        }
    ],
    "testcase_id": "test02",
    "testcase_label": "",
    "timestamped_stdout": false,
    "title": "Can we attach your notes page(s) to a sample test?",
    "use_router": false,
    "validation": [
    ],
    "view_testcase_message": true
}
```

We see here that it has a `pattern: ""` at the testcase level, as well as a `pattern: null` in the `pre_commands` section. The schema for the config specifies only `pattern` within the `pre_commands` section.

### What is the new behavior?

This updates the `load_config_json.cpp` file so that instead of writing out a blank string `pattern` default at testcase, it writes it out (properly) within the pre_command object. I've also updated the schema to indicate that this field should only ever be a string as indicated by the code here which writes it to be a string if it's not one.