### PR TITLE
[Feature:SubminiPolls] Poll Image Type and Size 

### DIFF
--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -163,40 +163,20 @@ class PollController extends AbstractController {
         $poll_id = $this->core->getQueries()->addNewPoll($_POST["name"], $_POST["question"], $responses, $answers, $_POST["release_date"], $orders);
         $file_path = null;
         if (isset($_FILES['image_file']) && $_FILES["image_file"]["name"] !== "") {
-            //$file = $_FILES["image_file"];
-
-            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            $errors = array();
             $maxsize = Utils::returnBytes(ini_get('upload_max_filesize'));
-            $acceptable = array(
-                'image/jpeg',
-                'image/jpg',
-                'image/gif',
-                'image/png'
-            );
-            if(($_FILES['image_file']['size'] >= $maxsize) || ($_FILES["image_file"]["size"] == 0)) {
+            $acceptable = array('image/jpeg','image/jpg','image/gif','image/png');
+            if (($_FILES['image_file']['size'] >= $maxsize) || ($_FILES["image_file"]["size"] == 0)) {
                 $this->core->addErrorMessage("File(s) uploaded too large.  Maximum size is " . ($max_size / 1024) . " kb.");
             }
-            if((!in_array($_FILES['image_file']['type'], $acceptable)) && (!empty($_FILES["image_file"]["type"]))) {
-                $this->core->addErrorMessage("Upload failed: Invalid file type. Only JPG, GIF and PNG types are accepted.");
+            elseif ((!in_array($_FILES['image_file']['type'], $acceptable)) && (!empty($_FILES["image_file"]["type"]))) {
+                $this->core->addErrorMessage("Upload failed: Invalid file type. Only JPG, JPEG, GIF and PNG types are accepted.");
             }
-            if(count($errors) === 0) {
+            else {
                 $file = $_FILES["image_file"];
                 $file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $poll_id . "_" . $_FILES["image_file"]["name"]);
                 move_uploaded_file($file["tmp_name"], $file_path);
                 $this->core->getQueries()->setPollImage($poll_id, $file_path);
-            } else {
-                foreach($errors as $error) {
-                    echo '<script>alert("'.$error.'");</script>';
-                }
-                die(); //Ensure no more processing is done
             }
-            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-            //$file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $poll_id . "_" . $_FILES["image_file"]["name"]);
-            //move_uploaded_file($file["tmp_name"], $file_path);
-            //$this->core->getQueries()->setPollImage($poll_id, $file_path);
         }
 
         return MultiResponse::RedirectOnlyResponse(
@@ -375,41 +355,23 @@ class PollController extends AbstractController {
         }
         $file_path = null;
         if (isset($_FILES['image_file']) && $_FILES["image_file"]["name"] !== "") {
-            
             $file = $_FILES["image_file"];
             $current_file_path = $poll->getImagePath();
             if ($current_file_path !== null) {
                 unlink($current_file_path);
             }
-
-            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            $errors = array();
             $maxsize = Utils::returnBytes(ini_get('upload_max_filesize'));
-            $acceptable = array(
-                'image/jpeg',
-                'image/jpg',
-                'image/gif',
-                'image/png'
-            );
-            if(($_FILES['image_file']['size'] >= $maxsize) || ($_FILES["image_file"]["size"] == 0)) {
+            $acceptable = array('image/jpeg','image/jpg','image/gif','image/png');
+            if (($_FILES['image_file']['size'] >= $maxsize) || ($_FILES["image_file"]["size"] == 0)) {
                 $this->core->addErrorMessage("File(s) uploaded too large.  Maximum size is " . ($max_size / 1024) . " kb.");
             }
-            if((!in_array($_FILES['image_file']['type'], $acceptable)) && (!empty($_FILES["image_file"]["type"]))) {
+            elseif ((!in_array($_FILES['image_file']['type'], $acceptable)) && (!empty($_FILES["image_file"]["type"]))) {
                 $this->core->addErrorMessage("Upload failed: Invalid file type. Only JPG, GIF and PNG types are accepted.");
             }
-            if(count($errors) === 0) {
+            else {
                 $file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $_POST["poll_id"] . "_" . $_FILES["image_file"]["name"]);
                 move_uploaded_file($file["tmp_name"], $file_path);
-            } else {
-                foreach($errors as $error) {
-                    echo '<script>alert("'.$error.'");</script>';
-                }
-                die(); //Ensure no more processing is done
             }
-            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-            //$file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $_POST["poll_id"] . "_" . $_FILES["image_file"]["name"]);
-            //move_uploaded_file($file["tmp_name"], $file_path);
         }
         elseif (isset($_POST['keep_image'])) {
             $file_path = $poll->getImagePath();

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -163,10 +163,40 @@ class PollController extends AbstractController {
         $poll_id = $this->core->getQueries()->addNewPoll($_POST["name"], $_POST["question"], $responses, $answers, $_POST["release_date"], $orders);
         $file_path = null;
         if (isset($_FILES['image_file']) && $_FILES["image_file"]["name"] !== "") {
-            $file = $_FILES["image_file"];
-            $file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $poll_id . "_" . $_FILES["image_file"]["name"]);
-            move_uploaded_file($file["tmp_name"], $file_path);
-            $this->core->getQueries()->setPollImage($poll_id, $file_path);
+            //$file = $_FILES["image_file"];
+
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            $errors = array();
+            $maxsize = Utils::returnBytes(ini_get('upload_max_filesize'));
+            $acceptable = array(
+                'image/jpeg',
+                'image/jpg',
+                'image/gif',
+                'image/png'
+            );
+            if(($_FILES['image_file']['size'] >= $maxsize) || ($_FILES["image_file"]["size"] == 0)) {
+                $this->core->addErrorMessage("File(s) uploaded too large.  Maximum size is " . ($max_size / 1024) . " kb.");
+            }
+            if((!in_array($_FILES['image_file']['type'], $acceptable)) && (!empty($_FILES["image_file"]["type"]))) {
+                $this->core->addErrorMessage("Upload failed: Invalid file type. Only JPG, GIF and PNG types are accepted.");
+            }
+            if(count($errors) === 0) {
+                $file = $_FILES["image_file"];
+                $file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $poll_id . "_" . $_FILES["image_file"]["name"]);
+                move_uploaded_file($file["tmp_name"], $file_path);
+                $this->core->getQueries()->setPollImage($poll_id, $file_path);
+            } else {
+                foreach($errors as $error) {
+                    echo '<script>alert("'.$error.'");</script>';
+                }
+                die(); //Ensure no more processing is done
+            }
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+            //$file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $poll_id . "_" . $_FILES["image_file"]["name"]);
+            //move_uploaded_file($file["tmp_name"], $file_path);
+            //$this->core->getQueries()->setPollImage($poll_id, $file_path);
         }
 
         return MultiResponse::RedirectOnlyResponse(
@@ -345,13 +375,41 @@ class PollController extends AbstractController {
         }
         $file_path = null;
         if (isset($_FILES['image_file']) && $_FILES["image_file"]["name"] !== "") {
+            
             $file = $_FILES["image_file"];
             $current_file_path = $poll->getImagePath();
             if ($current_file_path !== null) {
                 unlink($current_file_path);
             }
-            $file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $_POST["poll_id"] . "_" . $_FILES["image_file"]["name"]);
-            move_uploaded_file($file["tmp_name"], $file_path);
+
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            $errors = array();
+            $maxsize = Utils::returnBytes(ini_get('upload_max_filesize'));
+            $acceptable = array(
+                'image/jpeg',
+                'image/jpg',
+                'image/gif',
+                'image/png'
+            );
+            if(($_FILES['image_file']['size'] >= $maxsize) || ($_FILES["image_file"]["size"] == 0)) {
+                $this->core->addErrorMessage("File(s) uploaded too large.  Maximum size is " . ($max_size / 1024) . " kb.");
+            }
+            if((!in_array($_FILES['image_file']['type'], $acceptable)) && (!empty($_FILES["image_file"]["type"]))) {
+                $this->core->addErrorMessage("Upload failed: Invalid file type. Only JPG, GIF and PNG types are accepted.");
+            }
+            if(count($errors) === 0) {
+                $file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $_POST["poll_id"] . "_" . $_FILES["image_file"]["name"]);
+                move_uploaded_file($file["tmp_name"], $file_path);
+            } else {
+                foreach($errors as $error) {
+                    echo '<script>alert("'.$error.'");</script>';
+                }
+                die(); //Ensure no more processing is done
+            }
+            // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+            //$file_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "polls", "poll_image_" . $_POST["poll_id"] . "_" . $_FILES["image_file"]["name"]);
+            //move_uploaded_file($file["tmp_name"], $file_path);
         }
         elseif (isset($_POST['keep_image'])) {
             $file_path = $poll->getImagePath();

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -27,7 +27,7 @@
             <label for="image-file">
                 Optional Image:
             </label>
-            <input type="file" id="image-file" name="image_file"/>
+            <input type="file" id="image-file" name="image_file" accept="image/jpeg, image/jpg, image/gif, image/png"/>
             <br/><br/>
 
             <label for="poll-date">
@@ -78,10 +78,10 @@
             </label>
             <br/><br/>
 
-            <label for="image-file">
+            <label for="image-file" 
                 Optional Image:
             </label>
-            <input type="file" id="image-file" name="image_file" accept="'image/jpeg','image/jpg','image/gif','image/png'" />
+            <input type="file" id="image-file" name="image_file" accept="image/jpeg, image/jpg, image/gif, image/png" />
             <br />
             {% if poll.getImagePath() != null %}
                 Current Image: {{ poll.getImagePath() }}
@@ -89,7 +89,7 @@
                 <label for="keep-image">
                     Keep Image:
                 </label>
-                <input type="checkbox" id="keep-image" name="keep_image" accept="'image/jpeg','image/jpg','image/gif','image/png'" checked />
+                <input type="checkbox" id="keep-image" name="keep_image" checked />
             {% endif %}"<br/>
 
             <label for="poll-date">

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -90,7 +90,7 @@
                     Keep Image:
                 </label>
                 <input type="checkbox" id="keep-image" name="keep_image" checked />
-            {% endif %}"
+            {% endif %}
             <br/>
 
             <label for="poll-date">

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -81,7 +81,7 @@
             <label for="image-file">
                 Optional Image:
             </label>
-            <input type="file" id="image-file" name="image_file"/>
+            <input type="file" id="image-file" name="image_file" accept="'image/jpeg','image/jpg','image/gif','image/png'" />
             <br />
             {% if poll.getImagePath() != null %}
                 Current Image: {{ poll.getImagePath() }}
@@ -89,9 +89,8 @@
                 <label for="keep-image">
                     Keep Image:
                 </label>
-                <input type="checkbox" id="keep-image" name="keep_image" checked />
-            {% endif %}
-            <br/>
+                <input type="checkbox" id="keep-image" name="keep_image" accept="'image/jpeg','image/jpg','image/gif','image/png'" checked />
+            {% endif %}"<br/>
 
             <label for="poll-date">
                 Expected release date:

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -78,7 +78,7 @@
             </label>
             <br/><br/>
 
-            <label for="image-file" 
+            <label for="image-file">
                 Optional Image:
             </label>
             <input type="file" id="image-file" name="image_file" accept="image/jpeg, image/jpg, image/gif, image/png" />
@@ -90,7 +90,8 @@
                     Keep Image:
                 </label>
                 <input type="checkbox" id="keep-image" name="keep_image" checked />
-            {% endif %}"<br/>
+            {% endif %}"
+            <br/>
 
             <label for="poll-date">
                 Expected release date:


### PR DESCRIPTION
Fixes one of the issues listed in #5913

### What is the current behavior?
The instructor's "Add Poll" and "Edit Poll" pages accept any file type as the optional image, with no error checking. The student's "View Poll" shows images properly, but shows a generic file icon if non-image files are attached to a poll.


### What is the new behavior?
The pop-up file browser in the "Add Poll" and "Edit Poll" pages accepts only image file types (JPEG, JPG, PNG, GIF), and only files under the size limit can be attached to a poll.
