### PR TITLE
[UI/UX:SubminiPolls] Improve summary page UI

### DIFF
--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -17,13 +17,17 @@
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">
-            <col style="width: 20%">
-            <col style="width: 20%">
-            <col style="width: 20%">
-            <col style="width: 20%">
-            <col style="width: 20%">
+			<col style="width: 5%">
+			<col style="width: 5%">
+			<col style="width: 45%">
+            <col style="width: 10%">
+            <col style="width: 10%">
+            <col style="width: 10%">
+            <col style="width: 15%">
             <thead>
                 <tr>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
                     <th scope="col"></th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
@@ -34,11 +38,15 @@
             <tbody>
                 {% for poll in todays_polls %}
                     <tr>
-                        <td align="left">
-                            <a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
-                                <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
-                            </a>
-                            <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}","{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+						<td>
+							<a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
+								<input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
+							</a>
+						</td>
+						<td>
+							<a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}","{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+						</td>
+						<td align="left">
                             {{ poll.getName() }}
                         </td>
                         <td>
@@ -72,15 +80,19 @@
             </div>
         </div>
         <table id="older-table" class="table table-striped" style="width:100%;{{ dropdown_states['old'] ? '' : ' display: none;'}}">
-            <col style="width: 20%">
-            <col style="width: 20%">
+			<col style="width: 5%">
+			<col style="width: 5%">
+			<col style="width: 30%">
             <col style="width: 15%">
-            <col style="width: 15%">
-            <col style="width: 15%">
+            <col style="width: 10%">
+            <col style="width: 10%">
+            <col style="width: 10%">
             <col style="width: 15%">
             <thead>
                 <tr>
                     <th scope="col"></th>
+					<th scope="col"></th>
+					<th scope="col"></th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
@@ -91,11 +103,15 @@
             <tbody>
                 {% for poll in older_polls %}
                     <tr>
-                        <td align="left"> 
-                            <a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
-                                <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
-                            </a>
-                            <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+						<td>
+							<a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
+								<input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
+							</a>
+						</td>
+						<td>
+							<a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+						</td>	
+						<td align="left"> 
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() }} </td>
@@ -129,12 +145,16 @@
             </div>
         </div>
         <table id="future-table" class="table table-striped" style="width:100%;{{ dropdown_states['future'] ? '' : ' display: none;'}}">
-            <col style="width: 25%">
-            <col style="width: 25%">
-            <col style="width: 25%">
-            <col style="width: 25%">
+            <col style="width: 5%">
+            <col style="width: 5%">
+            <col style="width: 50%">
+            <col style="width: 15%">
+            <col style="width: 10%">
+            <col style="width: 15%">
             <thead>
                 <tr>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
                     <th scope="col"></th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Responses</th>
@@ -144,11 +164,15 @@
             <tbody>
                 {% for poll in future_polls %}
                     <tr>
-                        <td align="left">
-                            <a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
-                                <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
-                            </a>
-                            <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+						<td>
+							<a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
+								<input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
+							</a>
+						</td>
+						<td>
+							<a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+						</td>
+						<td align="left">
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() }} </td>

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -26,13 +26,13 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <td scope="col"></td>
-                    <td scope="col"></td>
-                    <td scope="col"></td>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
                     <th scope="col">Responses</th>
-                    <td scope="col"></td>
+                    <th scope="col"></th>
                 </tr>
             </thead>
             <tbody>
@@ -90,14 +90,14 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <td scope="col"></td>
-                    <td scope="col"></td>
-                    <td scope="col"></td>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
                     <th scope="col">Responses</th>
-                    <td scope="col"></td>
+                    <th scope="col"></th>
                 </tr>
             </thead>
             <tbody>
@@ -153,12 +153,12 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <td scope="col"></td>
-                    <td scope="col"></td>
-                    <td scope="col"></td>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Responses</th>
-                    <td scope="col"></td>
+                    <th scope="col"></th>
                 </tr>
             </thead>
             <tbody>

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -17,9 +17,9 @@
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">
-	    <col style="width: 5%">
-	    <col style="width: 5%">
-	    <col style="width: 45%">
+            <col style="width: 5%">
+            <col style="width: 5%">
+            <col style="width: 45%">
             <col style="width: 10%">
             <col style="width: 10%">
             <col style="width: 10%">

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -26,13 +26,13 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
+                    <td scope="col"></td>
+                    <td scope="col"></td>
+                    <td scope="col"></td>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
                     <th scope="col">Responses</th>
-                    <th scope="col"></th>
+                    <td scope="col"></td>
                 </tr>
             </thead>
             <tbody>
@@ -90,14 +90,14 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
+                    <td scope="col"></td>
+                    <td scope="col"></td>
+                    <td scope="col"></td>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
                     <th scope="col">Responses</th>
-                    <th scope="col"></th>
+                    <td scope="col"></td>
                 </tr>
             </thead>
             <tbody>
@@ -153,12 +153,12 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
+                    <td scope="col"></td>
+                    <td scope="col"></td>
+                    <td scope="col"></td>
                     <th scope="col">Date Released</th>
                     <th scope="col">Responses</th>
-                    <th scope="col"></th>
+                    <td scope="col"></td>
                 </tr>
             </thead>
             <tbody>

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -17,9 +17,9 @@
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">
-			<col style="width: 5%">
-			<col style="width: 5%">
-			<col style="width: 45%">
+	    <col style="width: 5%">
+	    <col style="width: 5%">
+	    <col style="width: 45%">
             <col style="width: 10%">
             <col style="width: 10%">
             <col style="width: 10%">
@@ -38,15 +38,15 @@
             <tbody>
                 {% for poll in todays_polls %}
                     <tr>
-						<td>
-							<a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
-								<input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
-							</a>
-						</td>
-						<td>
-							<a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}","{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
-						</td>
-						<td align="left">
+                        <td>
+                                <a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
+                                        <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
+                                </a>
+                        </td>
+                        <td>
+                                <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}","{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+                        </td>
+                        <td align="left">
                             {{ poll.getName() }}
                         </td>
                         <td>
@@ -80,9 +80,9 @@
             </div>
         </div>
         <table id="older-table" class="table table-striped" style="width:100%;{{ dropdown_states['old'] ? '' : ' display: none;'}}">
-			<col style="width: 5%">
-			<col style="width: 5%">
-			<col style="width: 30%">
+            <col style="width: 5%">
+            <col style="width: 5%">
+            <col style="width: 30%">
             <col style="width: 15%">
             <col style="width: 10%">
             <col style="width: 10%">
@@ -91,8 +91,8 @@
             <thead>
                 <tr>
                     <th scope="col"></th>
-					<th scope="col"></th>
-					<th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
@@ -103,15 +103,15 @@
             <tbody>
                 {% for poll in older_polls %}
                     <tr>
-						<td>
-							<a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
-								<input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
-							</a>
-						</td>
-						<td>
-							<a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
-						</td>	
-						<td align="left"> 
+                        <td>
+                                <a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
+                                        <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
+                                </a>
+                        </td>
+                        <td>
+                                <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+                        </td>	
+                        <td align="left"> 
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() }} </td>
@@ -164,15 +164,15 @@
             <tbody>
                 {% for poll in future_polls %}
                     <tr>
-						<td>
-							<a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
-								<input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
-							</a>
-						</td>
-						<td>
-							<a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
-						</td>
-						<td align="left">
+                        <td>
+                                <a class="fas fa-pencil-alt black-btn" tabindex="0" href="{{base_url}}/editPoll/{{ poll.getId() }}" title="edit poll {{ poll.getName() }}" aria-label="edit poll {{ poll.getId() }}">
+                                        <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>
+                                </a>
+                        </td>
+                        <td>
+                                <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
+                        </td>
+                        <td align="left">
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() }} </td>

--- a/site/app/templates/polls/AllPollsPageStudent.twig
+++ b/site/app/templates/polls/AllPollsPageStudent.twig
@@ -10,9 +10,9 @@
             </div>
         </div>
         <table class="table table-striped" style="width:100%;">
-                <col style="width: 33%">
-                <col style="width: 33%">
-                <col style="width: 33%">
+                <col style="width: 40%">
+                <col style="width: 35%">
+                <col style="width: 25%">
             <thead>
                 <tr>
                     <th scope="col">Name</th>
@@ -23,8 +23,8 @@
             <tbody>
                 {% for poll in todays_polls %}
                     <tr>
-                        <td> {{ poll.getName() }} </td>
-                        <td> {{ poll.getUserResponse(user_id) is same as(null)? "No Response" : poll.getResponseString(poll.getUserResponse(user_id)) | markdown}} </td>
+                        <td align="left"> {{ poll.getName() }} </td>
+                        <td align="left"> {{ poll.getUserResponse(user_id) is same as(null)? "No Response" : poll.getResponseString(poll.getUserResponse(user_id)) | markdown}} </td>
                         <td>
                             <a href="{{ base_url }}/viewPoll/{{ poll.getId() }}">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
@@ -58,9 +58,9 @@
             </div>
         </div>
         <table class="table table-striped" style="width:100%;">
-            <col style="width: 33%">
-            <col style="width: 33%">
-            <col style="width: 33%">
+            <col style="width: 40%">
+            <col style="width: 35%">
+            <col style="width: 25%">
             <thead>
                 <tr>
                     <th scope="col">Name</th>
@@ -71,8 +71,8 @@
             <tbody>
                 {% for poll in older_polls %}
                     <tr>
-                        <td> {{ poll.getName() }} </td>
-                        <td> {{ poll.getUserResponse(user_id) is same as(null) ? "No Response" : poll.getResponseString(poll.getUserResponse(user_id)) | markdown}} </td>
+                        <td align="left"> {{ poll.getName() }} </td>
+                        <td align="left"> {{ poll.getUserResponse(user_id) is same as(null) ? "No Response" : poll.getResponseString(poll.getUserResponse(user_id)) | markdown}} </td>
                         <td>
                             <a href="{{ base_url }}/viewPoll/{{ poll.getId() }}">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -222,7 +222,7 @@ table tr.table-header {
     border-top: 1px solid var(--standard-light-gray);
 }
 
-.table tr {
+.table tr, .table td[scope="col"] {
     border-top: 1px solid #ddd;
 }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -222,7 +222,7 @@ table tr.table-header {
     border-top: 1px solid var(--standard-light-gray);
 }
 
-.table tr, .table td[scope="col"] {
+.table tr {
     border-top: 1px solid #ddd;
 }
 


### PR DESCRIPTION
Addresses issue https://github.com/Submitty/Submitty/issues/6036

### What is the current behavior?
The student view has the titles centered, while the instructor's are left justified. The titles in the instructor's page are forced to wrap earlier than necessary around the "edit" and "delete" icons.
![before](https://user-images.githubusercontent.com/71195502/118549243-2e1b1100-b729-11eb-9554-8d04f6321fef.png)
![past_student_view](https://user-images.githubusercontent.com/71195502/118549367-5c98ec00-b729-11eb-8452-810582932a58.png)

### What is the new behavior?
Titles have been left-aligned and the widths of the columns have been adjusted. The titles in the instructor's page no longer wrap around unnecessarily.
![after](https://user-images.githubusercontent.com/71195502/118549259-32dfc500-b729-11eb-9cff-193fccbba966.png)
![student_page](https://user-images.githubusercontent.com/71195502/118549390-64589080-b729-11eb-9e16-e5e3fd0c7849.png)


