### PR TITLE
[UI/UX:SubminiPolls] Fix Icons wrapping in Edit Poll

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -107,7 +107,7 @@
                         <input type="hidden" class="order order-{{index}}" name="order_{{response}}" value="{{index}}"/>
                         <input type="hidden" class="option_id" name="option_id_{{response}}" value="{{response}}"/>
                         <input aria-label="Is correct" class="correct-box" type=checkbox name="is_correct_{{response}}" {{ poll.isCorrect(response) ? "checked": "" }}>
-                        <textarea aria-label="Reponse text" class="poll_response" name="response_{{response}}"style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
+                        <textarea aria-label="Reponse text" class="poll_response" name="response_{{response}}"style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: calc(100% - 200px);"
                         rows="10" cols="30">{{poll.getResponseString(response)}}</textarea>
                         <div class="move-btn up-btn">
                             <i class="move-arrow up"></i>

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -159,7 +159,7 @@
                 <input type="hidden" class="order order-${count}" name="order_${count}" value="${count}"/>
                 <input type="hidden" class="option_id" name="option_id_${count}" value="${first_free_id}"/>
                 <input aria-label="Is correct" class="correct-box" type=checkbox name="is_correct_${count}">
-                <textarea aria-label="Response text" class="poll_response" name="response_${count}" placeholder="Enter response here..." style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
+                <textarea aria-label="Response text" class="poll_response" name="response_${count}" placeholder="Enter response here..." style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: calc(100% - 200px);"
                 rows="10" cols="30"></textarea>
                 <div class="move-btn up-btn">
                     <i class="move-arrow up"></i>


### PR DESCRIPTION
### What is the current behavior?
In the instructor's Edit Poll/New Poll page, the "up", "down" and "delete" buttons for the responses wrap around when the width of the page is decreased. 
![image](https://user-images.githubusercontent.com/71195502/118556139-85bd7a80-b731-11eb-821e-9c5054f821a2.png)


### What is the new behavior?
The text field adjusts to the width of the page and the buttons always stay on the same row to the right of the response in the Edit Poll page.
![image](https://user-images.githubusercontent.com/71195502/118557101-bbaf2e80-b732-11eb-8e30-bcb018e4bb42.png)