### PR TITLE
[Refactor:Developer] Fix phpstan errors in Utils

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -9,33 +9,11 @@ use Ds\Set;
  * Class Utils
  */
 class Utils {
-    /**
-     * Recursively removes a string from any value in an array.
-     *
-     * @param string $needle
-     * @param array  $haystack
-     *
-     * @return array
-     */
-    public static function stripStringFromArray($needle, $haystack) {
-        if (!is_array($haystack) || !is_string($needle)) {
-            return null;
-        }
-        foreach ($haystack as $key => $value) {
-            if (is_array($value)) {
-                $haystack[$key] = Utils::stripStringFromArray($needle, $value);
-            }
-            else {
-                $haystack[$key] = str_replace($needle, "", $value);
-            }
-        }
-        return $haystack;
-    }
 
     /**
      * Defines a new default str_pad that's useful for things like parts of a datetime
      *
-     * @param        $string
+     * @param mixed  $string
      * @param int    $pad_width  [optional]
      * @param string $pad_string [optional]
      * @param int    $pad_type   [optional]
@@ -100,7 +78,6 @@ class Utils {
      * for associative arrays that do not have numeric keys or the keys are out of order and we can't just use indices
      * as in other languages.
      *
-     * @param $array
      * @return mixed|null
      */
     public static function getLastArrayElement(array $array) {
@@ -112,7 +89,6 @@ class Utils {
      * Gets the first element of an array. This can be used for associate arrays like the above
      * getLastArrayElement defined above.
      *
-     * @param $array
      * @return mixed|null
      */
     public static function getFirstArrayElement(array $array) {
@@ -121,8 +97,6 @@ class Utils {
         }
         return null;
     }
-
-
 
     /**
      * Checks if string $haystack begins with the string $needle, returning TRUE if it does or FALSE otherwise.

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -379,26 +379,6 @@ parameters:
 			path: app/libraries/SessionManager.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\Utils\\:\\:stripStringFromArray\\(\\) should return array but returns null\\.$#"
-			count: 1
-			path: app/libraries/Utils.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$string\\)\\: Unexpected token \"\\$string\", expected type at offset 119$#"
-			count: 1
-			path: app/libraries/Utils.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$array\\)\\: Unexpected token \"\\$array\", expected type at offset 404$#"
-			count: 1
-			path: app/libraries/Utils.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$array\\)\\: Unexpected token \"\\$array\", expected type at offset 163$#"
-			count: 1
-			path: app/libraries/Utils.php
-
-		-
 			message: "#^Access to an undefined property Ratchet\\\\ConnectionInterface\\:\\:\\$httpRequest\\.$#"
 			count: 1
 			path: app/libraries/socket/Server.php

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -88,24 +88,6 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals("&lt;test<br />\n<br />\ntest&gt;", Utils::prepareHtmlString($string));
     }
 
-    public function testStripStringFromArray() {
-        $array = [
-            "test/aa",
-            [
-                "test/test2/aa",
-                "bb"
-            ]
-        ];
-        $expected = ["/aa", ["/2/aa", "bb"]];
-        $this->assertEquals($expected, Utils::stripStringFromArray("test", $array));
-    }
-
-    public function testStripStringFromArrayNull() {
-        $this->assertNull(Utils::stripStringFromArray("test", null));
-        $this->assertNull(Utils::stripStringFromArray(null, []));
-        $this->assertNull(Utils::stripStringFromArray(1, []));
-    }
-
     public function elementDataProvider() {
         return [
             [[], null, null],


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The Utilss library class hand a handful of phpstan errors that were ignored.

### What is the new behavior?

This fixes the phpstan errors in the file. Additionally, `stripStringFromArray` was not used anywhere in the codebase so it was removed.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
