### PR TITLE
[UI/UX:SubminiPolls] Fix poll edit buttons in dark mode

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -168,7 +168,7 @@
                     <i class="fa fa-lg fa-chevron-down move-arrow down"></i>
                 </div>
                 <div class="move-btn delete-btn">
-                    <i class="fa fa-lg fa-trash delete"></i>
+                    <i class="fa fa-lg fa-trash"></i>
                 </div>
                 <br/>
             </div>

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -113,7 +113,7 @@
                             <i class="fa fa-lg fa-chevron-up"></i>
                         </div>
                         <div class="move-btn down-btn">
-                            <i class="fa fa-lg fa-chevron-down move-arrow down"></i>
+                            <i class="fa fa-lg fa-chevron-down"></i>
                         </div>
                         <div class="move-btn delete-btn">
                             <i class="fa fa-lg fa-trash delete"></i>

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -110,7 +110,7 @@
                         <textarea aria-label="Reponse text" class="poll_response" name="response_{{response}}"style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                         rows="10" cols="30">{{poll.getResponseString(response)}}</textarea>
                         <div class="move-btn up-btn">
-                            <i class="fa fa-lg fa-chevron-up move-arrow up"></i>
+                            <i class="fa fa-lg fa-chevron-up"></i>
                         </div>
                         <div class="move-btn down-btn">
                             <i class="fa fa-lg fa-chevron-down move-arrow down"></i>

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -110,10 +110,10 @@
                         <textarea aria-label="Reponse text" class="poll_response" name="response_{{response}}"style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                         rows="10" cols="30">{{poll.getResponseString(response)}}</textarea>
                         <div class="move-btn up-btn">
-                            <i class="move-arrow up"></i>
+                            <i class="fa fa-lg fa-chevron-up move-arrow up"></i>
                         </div>
                         <div class="move-btn down-btn">
-                            <i class="move-arrow down"></i>
+                            <i class="fa fa-lg fa-chevron-down move-arrow down"></i>
                         </div>
                         <div class="move-btn delete-btn">
                             <i class="fa fa-lg fa-trash delete"></i>
@@ -162,10 +162,10 @@
                 <textarea aria-label="Response text" class="poll_response" name="response_${count}" placeholder="Enter response here..." style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                 rows="10" cols="30"></textarea>
                 <div class="move-btn up-btn">
-                    <i class="move-arrow up"></i>
+                    <i class="fa fa-lg fa-chevron-up move-arrow up"></i>
                 </div>
                 <div class="move-btn down-btn">
-                    <i class="move-arrow down"></i>
+                    <i class="fa fa-lg fa-chevron-down move-arrow down"></i>
                 </div>
                 <div class="move-btn delete-btn">
                     <i class="fa fa-lg fa-trash delete"></i>

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -162,10 +162,10 @@
                 <textarea aria-label="Response text" class="poll_response" name="response_${count}" placeholder="Enter response here..." style="resize: none; min-height: 50px; max-height: 300px; height: 50px; width: 80%;"
                 rows="10" cols="30"></textarea>
                 <div class="move-btn up-btn">
-                    <i class="fa fa-lg fa-chevron-up move-arrow up"></i>
+                    <i class="fa fa-lg fa-chevron-up"></i>
                 </div>
                 <div class="move-btn down-btn">
-                    <i class="fa fa-lg fa-chevron-down move-arrow down"></i>
+                    <i class="fa fa-lg fa-chevron-down"></i>
                 </div>
                 <div class="move-btn delete-btn">
                     <i class="fa fa-lg fa-trash"></i>

--- a/site/public/css/polls.css
+++ b/site/public/css/polls.css
@@ -21,22 +21,14 @@
     float: right;
 }
 
-.move-arrow {
-    border: solid black;
-    border-width: 0 5px 5px 0;
-    display: inline-block;
-    padding: 8px;
-}
-
 .move-btn {
     background: transparent;
-    padding: 5px 10px 10px 10px !important;
+    padding: 10px;
     display: inline-block;
-    border: black;
+    border: var(--text-black);
     border-style: solid;
     border-radius: 5px;
-    width: 50px;
-    height: 50px;
+    cursor: pointer;
 }
 
 .dropdown-btn .right {
@@ -44,12 +36,12 @@
     -webkit-transform: rotate(-45deg);
 }
 
-.dropdown-btn .down, .move-btn .down {
+.dropdown-btn .down{
     transform: rotate(45deg);
     -webkit-transform: rotate(45deg);
 }
 
-.dropdown-btn .up, .move-btn .up {
+.dropdown-btn .up{
     transform: rotate(-135deg);
     -webkit-transform: rotate(-135deg);
 }
@@ -59,38 +51,10 @@
     -webkit-transform: rotate(135deg);
 }
 
-.move-btn.delete-btn {
-    position: relative;
-    top: -5px;
-}
-
-.move-arrow.up {
-    position: relative;
-    top: 10px;
-    left: 2px;
-}
-
-.move-arrow.down {
-    position: relative;
-    top: 1px;
-    left: 2px;
-}
-
-.delete {
-    position: relative;
-    top: 7px;
-    left: 2px;
-}
-
 .radio p {
     display: inline;
 }
 
 .active {
-    background:var(--always-default-white);
-}
-
-a.fas {
-    font-size: 18px;
-    padding-right: 10px;
+    background: var(--always-default-white);
 }


### PR DESCRIPTION
### What is the current behavior?
Fixes #6444

### What is the new behavior?
Makes the border around buttons on the edit polls UI turn white in dark mode.  This update also switches the arrows to proper icons.