### PR TITLE
[UI/UX:Forum] Fix forum post border in dark mode

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -595,7 +595,7 @@
 }
 
 [data-theme="dark"] .post_box:not(.important) {
-    border:1px solid #bbb;
+    border: 1px solid #bbb;
 }
 
 .thread-box-full {

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -594,6 +594,10 @@
   box-shadow: none;
 }
 
+[data-theme="dark"] .post_box {
+    border:1px solid #bbb;
+}
+
 .thread-box-full {
     padding: 10px 20px;
     margin: 5px auto;

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -594,7 +594,7 @@
   box-shadow: none;
 }
 
-[data-theme="dark"] .post_box {
+[data-theme="dark"] .post_box:not(.important) {
     border:1px solid #bbb;
 }
 


### PR DESCRIPTION
### What is the current behavior?
Fixes #5874
Currently, there are no borders on discussion forum posts/threads in dark mode.

![current-dark](https://user-images.githubusercontent.com/28243927/118673984-738e1b80-b7c7-11eb-90d2-470268ba1295.jpg)
![current-dark(black)](https://user-images.githubusercontent.com/28243927/118692433-1189e200-b7d8-11eb-876a-d44bc170da1f.jpg)


### What is the new behavior?
Light gray borders have been added to each unimportant post in dark mode.

![new-dark](https://user-images.githubusercontent.com/28243927/118691493-22862380-b7d7-11eb-9e60-a175162fd5f1.jpg)
![new-dark(black)](https://user-images.githubusercontent.com/28243927/118692233-d1c2fa80-b7d7-11eb-8fd5-0446ca7c5f0a.jpg)
