### PR TITLE
[Bugfix:HelpQueue] Fix changing announcement breaking student page

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -258,8 +258,7 @@
 
   function updateAnnouncement() {
       $.get("{{base_url}}/new_announcement", function(newAnnouncement) {
-          if ($('#announcement').length > 0){
-              $('#announcement').next().remove();
+          if ($('#announcement').length > 0) {
               $('#announcement').replaceWith(newAnnouncement);
           }
           else $(newAnnouncement).insertAfter($('h1').next());


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Any time an announcement is updated, all student currently viewing the queue page have some of their page elements deleted.

### What is the new behavior?
The announcement is updated without deleting anything.
Fixes #6448 

### Other information?
Tested on Chrome and Firefox
