### PR TITLE
[Bugfix:Plagiarism] Fix plagiarism not displaying files

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -604,6 +604,7 @@ class PlagiarismController extends AbstractController {
                 $tokens_user_2 = json_decode(file_get_contents($file_path), true);
             }
             while (!$matches->isEmpty()) {
+                /** @var \app\libraries\plagiarism\Interval $match */
                 $match = $matches->peek();
                 $s_pos = $match->getStart();
                 $e_pos = $match->getEnd();

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -619,8 +619,8 @@ class PlagiarismController extends AbstractController {
                     $segment_info["{$start_line}_{$start_pos}"] = [];
                     $orange_color = false;
                 foreach ($match->getUsers() as $i => $other) {
-                    $segment_info["{$start_line}_{$start_pos}"][] = $other->getUid() . "_" . $other->getVid();
-                    if ($other->getUid() == $user_id_2) {
+                    $segment_info["{$start_line}_{$start_pos}"][] = $other->getUserId() . "_" . $other->getVersion();
+                    if ($other->getUserId() == $user_id_2) {
                         $orange_color = true;
                         if ($codebox == "2" && $user_id_2 != "") {
                             foreach ($other->getMatchingPositions() as $pos) {


### PR DESCRIPTION
### What is the current behavior?
Currently, if you enter a gradeable on the plagiarism detection interface and select User 1, an error pops up saying that the file cannot be found.

### What is the new behavior?
This change fixes a typo which resulted in the page not being displayed properly.
