### PR TITLE
[Bugfix:Submission] validate single uploaded files

### DIFF
--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -540,25 +540,21 @@ class FileUtils {
      *            'success','size' => 100, 'is_zip' => false, 'success' => true)
      * if $files is null returns failed => no files sent to validate
      */
-    public static function validateUploadedFiles($files) {
+    public static function validateUploadedFiles(array $files): array {
         if (empty($files)) {
             return ["failed" => "No files sent to validate"];
         }
 
-        $ret = [];
-        $num_files = count($files['name']);
-        $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
+        $validator = function ($file) {
+            $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
+            $name = $file['name'];
+            $tmp_name = $file['tmp_name'];
 
-        for ($i = 0; $i < $num_files; $i++) {
-            //extract the values from each file
-            $name = $files['name'][$i];
-            $tmp_name = $files['tmp_name'][$i];
             $type = mime_content_type($tmp_name);
-
             $zip_status = FileUtils::getZipFileStatus($tmp_name);
             $errors = [];
-            if ($files['error'][$i] !== UPLOAD_ERR_OK) {
-                $errors[] = ErrorMessages::uploadErrors($files['error'][$i]);
+            if ($file['error'] !== UPLOAD_ERR_OK) {
+                $errors[] = ErrorMessages::uploadErrors($file['error']);
             }
 
             //check if its a zip file
@@ -580,7 +576,7 @@ class FileUtils {
             }
 
             //for zip files use the size of the contents in case it gets extracted
-            $size = $is_zip ? FileUtils::getZipSize($tmp_name) : $files['size'][$i];
+            $size = $is_zip ? FileUtils::getZipSize($tmp_name) : $file['size'];
 
             //manually check against set size limit
             //incase the max POST size is greater than max file size
@@ -598,7 +594,7 @@ class FileUtils {
                 $success = false;
             }
 
-            $ret[] = [
+            return [
                 'name' => $name,
                 'type' => $type,
                 'error' => $success ? "No error." : implode(" ", $errors),
@@ -606,6 +602,27 @@ class FileUtils {
                 'is_zip' => $is_zip,
                 'success' => $success,
             ];
+        };
+
+        $ret = [];
+        if (!is_array($files['name'])) {
+            $ret[] = $validator($files);
+        }
+        else {
+            $num_files = count($files['name']);
+
+            for ($i = 0; $i < $num_files; $i++) {
+                //construct single file from uploaded file array
+                $file = [
+                    'name' => $files['name'][$i],
+                    'type' => $files['type'][$i],
+                    'tmp_name' => $files['tmp_name'][$i],
+                    'error' => $files['error'][$i],
+                    'size' => $files['size'][$i]
+                ];
+
+                $ret[] = $validator($file);
+            }
         }
 
         return $ret;

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -761,7 +761,7 @@ STRING;
         $zip->close();
 
         $this->buildSingleFakeFile('tes<>t2.zip');
-        $stat = FileUtils::validateUploadedFiles($_FILES["tes<>t2.zip"]);
+        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
         $this->assertCount(1, $stat);
         $this->assertEquals(
             $stat[0],

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -472,6 +472,7 @@ STRING;
         $this->assertTrue(FileUtils::recursiveRmdir($base_dir));
     }
 
+    //Creates a tmp file and adds it to a file array in the $_FILES variables
     private function buildFakeFile($filename, $part = 1, $err = 0, $size = 100) {
         $file_path = FileUtils::joinpaths($this->path, $filename);
 
@@ -492,13 +493,34 @@ STRING;
         $_FILES["files{$part}"]['error'][] = $err;
     }
 
+    //Create a tmp file and sets $_FILES to it
+    private function buildSingleFakeFile($filename, $err = 0, $size = 100) {
+        $_FILES = [];
+        $file_path = FileUtils::joinpaths($this->path, $filename);
+
+        //zip files will already exist
+        if (!file_exists($file_path)) {
+            file_put_contents($file_path, str_repeat(' ', $size));
+        }
+
+        $_FILES["file"]['name'] = $filename;
+        $_FILES["file"]['type'] = mime_content_type($file_path);
+        $_FILES["file"]['size'] = filesize($file_path);
+
+        $tmpname = FileUtils::joinPaths($this->path, Utils::generateRandomString() . $filename);
+
+        copy($file_path, $tmpname);
+
+        $_FILES["file"]['tmp_name'] = $tmpname;
+        $_FILES["file"]['error'] = $err;
+    }
+
     public function testvalidateUploadedFilesGood() {
         FileUtils::createDir($this->path);
         $this->buildFakeFile('foo.txt');
         $this->buildFakeFile('foo2.txt');
 
         $stat = FileUtils::validateUploadedFiles($_FILES["files1"]);
-
         $this->assertCount(2, $stat);
         $this->assertEquals(
             $stat[0],
@@ -514,6 +536,21 @@ STRING;
         $this->assertEquals(
             $stat[1],
             ['name' => 'foo2.txt',
+             'type' => 'text/plain',
+             'error' => 'No error.',
+             'size' => 100,
+             'is_zip' => false,
+             'success' => true
+            ]
+        );
+
+        $this->buildSingleFakeFile('foo3.txt');
+        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
+
+        $this->assertCount(1, $stat);
+        $this->assertEquals(
+            $stat[0],
+            ['name' => 'foo3.txt',
              'type' => 'text/plain',
              'error' => 'No error.',
              'size' => 100,
@@ -599,6 +636,20 @@ STRING;
              'success' => false
              ]
         );
+
+        $this->buildSingleFakeFile('\?<>2.txt');
+        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
+        $this->assertCount(1, $stat);
+        $this->assertEquals(
+            $stat[0],
+            ['name' => '\?<>2.txt',
+             'type' => 'text/plain',
+             'error' => 'Invalid filename',
+             'size' => 100,
+             'is_zip' => false,
+             'success' => false
+             ]
+        );
     }
 
     public function testvalidateUploadedFilesBig() {
@@ -630,7 +681,7 @@ STRING;
              'size' =>  Utils::returnBytes(ini_get('upload_max_filesize')),
              'is_zip' => false,
              'success' => true
-             ]
+            ]
         );
     }
 
@@ -665,6 +716,24 @@ STRING;
              'success' => true
             ]
         );
+
+        $zip = new \ZipArchive();
+        $zip->open(FileUtils::joinPaths($this->path, 'test2.zip'), \ZipArchive::CREATE);
+        $zip->addFromString('testfile', "file test");
+        $zip->close();
+        $this->buildSingleFakeFile('test2.zip');
+        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
+        $this->assertCount(1, $stat);
+        $this->assertEquals(
+            $stat[0],
+            ['name' => 'test2.zip',
+             'type' => 'application/zip',
+             'error' => 'No error.',
+             'size' => 9,
+             'is_zip' => true,
+             'success' => true
+            ]
+        );
     }
 
     public function testvalidateUploadedFilesZipBad() {
@@ -688,6 +757,39 @@ STRING;
              'success' => false
             ],
             $stat[0]
+        );
+
+        $this->buildSingleFakeFile('tes<>t2.zip');
+        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
+        $this->assertCount(1, $stat);
+        $this->assertEquals(
+            $stat[0],
+            ['name' => 'test2.zip',
+             'type' => 'application/zip',
+             'error' => 'No error.',
+             'size' => 9,
+             'is_zip' => true,
+             'success' => true
+            ]
+        );
+
+        $zip = new \ZipArchive();
+        $zip->open(FileUtils::joinPaths($this->path, 'tes<>t2.zip'), \ZipArchive::CREATE);
+        $zip->addFromString('testfile', "file test");
+        $zip->close();
+
+        $this->buildSingleFakeFile('tes<>t2.zip');
+        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
+        $this->assertCount(1, $stat);
+        $this->assertEquals(
+            $stat[0],
+            ['name' => 'test2.zip',
+             'type' => 'application/zip',
+             'error' => 'No error.',
+             'size' => 9,
+             'is_zip' => true,
+             'success' => true
+            ]
         );
     }
 

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -686,10 +686,6 @@ STRING;
     }
 
     public function testvalidateUploadedFilesFail() {
-        $stat = FileUtils::validateUploadedFiles(null);
-        $this->assertArrayHasKey("failed", $stat);
-        $this->assertEquals($stat["failed"], "No files sent to validate");
-
         $stat = FileUtils::validateUploadedFiles([]);
         $this->assertArrayHasKey("failed", $stat);
         $this->assertEquals($stat["failed"], "No files sent to validate");
@@ -759,33 +755,19 @@ STRING;
             $stat[0]
         );
 
-        $this->buildSingleFakeFile('tes<>t2.zip');
-        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
-        $this->assertCount(1, $stat);
-        $this->assertEquals(
-            $stat[0],
-            ['name' => 'test2.zip',
-             'type' => 'application/zip',
-             'error' => 'No error.',
-             'size' => 9,
-             'is_zip' => true,
-             'success' => true
-            ]
-        );
-
         $zip = new \ZipArchive();
         $zip->open(FileUtils::joinPaths($this->path, 'tes<>t2.zip'), \ZipArchive::CREATE);
         $zip->addFromString('testfile', "file test");
         $zip->close();
 
         $this->buildSingleFakeFile('tes<>t2.zip');
-        $stat = FileUtils::validateUploadedFiles($_FILES["file"]);
+        $stat = FileUtils::validateUploadedFiles($_FILES["tes<>t2.zip"]);
         $this->assertCount(1, $stat);
         $this->assertEquals(
             $stat[0],
-            ['name' => 'test2.zip',
+            ['name' => 'tes<>t2.zip',
              'type' => 'application/zip',
-             'error' => 'No error.',
+             'error' => 'Invalid filename',
              'size' => 9,
              'is_zip' => true,
              'success' => true

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -770,7 +770,7 @@ STRING;
              'error' => 'Invalid filename',
              'size' => 9,
              'is_zip' => true,
-             'success' => true
+             'success' => false
             ]
         );
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently the library function `validateUploadedFiles` expects the `$_FILES` variable to contain a file array which is what most of our uploads handle since users typically can upload multiple files. However, when the client is restricted to a single file upload, PHP changes the structure of `$_FILES`

### What is the new behavior?
`validateUploadedFiles` can now handle both file arrays and single files uploaded.

For multiple files the structure looks like:
```
'upload_name' => 
'name' => ['name1, name2, ... ]
'type' => ['type1, type2, ...]
etc
```

but single files have:
```
'upload_name' =>
'name' => 'name',
'type' => 'type'
etc
```
