### PR TITLE
[UI/UX:TAGrading] Make disabled radio buttons more visible

### DIFF
--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -180,3 +180,15 @@ footer .footer-separator {
 #loading-bar-percentage{
     margin-left: 10px;
 }
+
+input[type="radio"][disabled=""]:checked:before {
+    content: "";
+    display: block;
+    position: relative;
+    top: 3px;
+    left: 3px;
+    width: 7px;
+    height: 7px;
+    border-radius: 100%;
+    background: var(--standard-medium-dark-gray);
+}


### PR DESCRIPTION
### What is the current behavior?
Fixes https://github.com/Submitty/Submitty/issues/6277
Checked disabled radio buttons are hard to see in light mode, and even more so in dark mode. The original issue addressed the buttons on the Notebook/TA Grading page, but this exists on the student's View Poll page when the poll is closed and still visible.
Notebook:
![before_light](https://user-images.githubusercontent.com/71195502/118832305-828bd100-b88e-11eb-9f16-19de3c93c46e.png) ![before_dark](https://user-images.githubusercontent.com/71195502/118832342-8a4b7580-b88e-11eb-97df-631726144df4.png) 
Student View Poll:
![student_before_light](https://user-images.githubusercontent.com/71195502/118832329-86b7ee80-b88e-11eb-8a64-b287dec2fa51.png) 

### What is the new behavior?
All disabled radio buttons on Submitty will now be more visible in every color theme
Notebook:
![notebook_after_light](https://user-images.githubusercontent.com/71195502/118832649-cda5e400-b88e-11eb-8a74-20be0db04f99.png) ![notebook_after_dark](https://user-images.githubusercontent.com/71195502/118832676-d26a9800-b88e-11eb-9b3c-e732d3c0685e.png)
Student View Poll:
![after_light](https://user-images.githubusercontent.com/71195502/118832697-d72f4c00-b88e-11eb-9897-356e2cc4a0fc.png) ![after_dark](https://user-images.githubusercontent.com/71195502/118832712-d8f90f80-b88e-11eb-96ff-417cd92dc9ff.png) ![after_darkbalsk](https://user-images.githubusercontent.com/71195502/118832721-db5b6980-b88e-11eb-8fb9-99e1d61b462c.png)

### Other information?
Tested on Widnows/Chrome,Edge,Firefox. It worked well on Chrome and Edge, but was ineffective on Firefox. Needs to be tested on other browsers as well (like Safari, etc.). If any reviewer knows how to improve it, please do so :)
