### PR TITLE
[Feature:TAGrading] display message if no panel is selected

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -918,7 +918,7 @@ HTML;
 
             $return .= <<<HTML
                 <div class="panels-container">
-                <h3 id="panel-instructions">Click above to select a panel for display</h3>
+                    <h3 id="panel-instructions">Click above to select a panel for display</h3>
                     <div class="two-panel-cont">
                          <div class="two-panel-item two-panel-left active">
                             <div class="panel-item-section left-top"></div>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -918,6 +918,7 @@ HTML;
 
             $return .= <<<HTML
                 <div class="panels-container">
+                <h3 id="panel-instructions">Click above to select a panel for display</h3>
                     <div class="two-panel-cont">
                          <div class="two-panel-item two-panel-left active">
                             <div class="panel-item-section left-top"></div>

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -475,9 +475,9 @@ progress::-webkit-progress-value {
 
 #panel-instructions{
     color: dimgray;
-    text-align: center;
-    position: relative;
-    padding-top: 200px;
+    display: flex;
+    justify-content: center;
+    padding-top: 20%;
 }
 
 #regrade_inner_info .inner-container {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -473,6 +473,13 @@ progress::-webkit-progress-value {
     filter: blur(3px);
 }
 
+#panel-instructions{
+    color: dimgray;
+    text-align: center;
+    position: relative;
+    padding-top: 200px;
+}
+
 #regrade_inner_info .inner-container {
     padding: 20px;
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -655,6 +655,7 @@ function checkForTwoPanelLayoutChange (isPanelAdded, panelId = null, panelPositi
 
 // Keep only those panels which are part of the two panel layout
 function setMultiPanelModeVisiblities () {
+    $("#panel-instructions").hide();
     panelElements.forEach((panel) => {
       let id_str = document.getElementById("#" + panel.str + "_btn") ? "#" + panel.str + "_btn" : "#" + panel.str + "-btn";
 
@@ -689,6 +690,11 @@ function setPanelsVisibilities (ele, forceVisible=null, position=null) {
       } else {
         // update the global variable
         taLayoutDet.currentOpenPanel = eleVisibility ? panel.str : null;
+      }
+      if( taLayoutDet.currentOpenPanel === null){
+        $("#panel-instructions").show();
+      }else{
+        $("#panel-instructions").hide();
       }
     } else if ((taLayoutDet.numOfPanelsEnabled && !isMobileView
       && taLayoutDet.currentTwoPanels.rightTop !== panel.str
@@ -759,7 +765,11 @@ function togglePanelLayoutModes(forceVal = false) {
   if (!forceVal) {
     taLayoutDet.numOfPanelsEnabled = +taLayoutDet.numOfPanelsEnabled === 3 ? 1 : +taLayoutDet.numOfPanelsEnabled + 1;
   }
-
+  if( taLayoutDet.currentOpenPanel === null){
+    $("#panel-instructions").show();
+  }else{
+    $("#panel-instructions").hide();
+  }
   if (taLayoutDet.numOfPanelsEnabled === 2 && !isMobileView) {
     twoPanelCont.addClass("active");
     $("#two-panel-exchange-btn").addClass("active");

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -691,9 +691,10 @@ function setPanelsVisibilities (ele, forceVisible=null, position=null) {
         // update the global variable
         taLayoutDet.currentOpenPanel = eleVisibility ? panel.str : null;
       }
-      if( taLayoutDet.currentOpenPanel === null){
+      if (taLayoutDet.currentOpenPanel === null) {
         $("#panel-instructions").show();
-      }else{
+      }
+      else {
         $("#panel-instructions").hide();
       }
     } else if ((taLayoutDet.numOfPanelsEnabled && !isMobileView
@@ -765,11 +766,13 @@ function togglePanelLayoutModes(forceVal = false) {
   if (!forceVal) {
     taLayoutDet.numOfPanelsEnabled = +taLayoutDet.numOfPanelsEnabled === 3 ? 1 : +taLayoutDet.numOfPanelsEnabled + 1;
   }
-  if( taLayoutDet.currentOpenPanel === null){
+  if (taLayoutDet.currentOpenPanel === null) {
     $("#panel-instructions").show();
-  }else{
+  }
+  else {
     $("#panel-instructions").hide();
   }
+
   if (taLayoutDet.numOfPanelsEnabled === 2 && !isMobileView) {
     twoPanelCont.addClass("active");
     $("#two-panel-exchange-btn").addClass("active");


### PR DESCRIPTION

### What is the current behavior?
Fixes #6368
Currently when someone opens the ta grading page for the first time, a blank grey panel is displayed with no instructions.
This could be confusing to first time users.
<img width="826" alt="pr1_1" src="https://user-images.githubusercontent.com/66340271/118861538-9ba27b00-b8aa-11eb-8b09-0e3eb17a76c3.PNG">


### What is the new behavior?
Now there is a message displayed that tells users to click on the buttons above to get a panel to display. I wasn't able to get the message to display in multiple panels but first time users will only have 1 panel displayed anyway. The message appears and disappears based on if the user has an active panel or not.
<img width="834" alt="pr1_2" src="https://user-images.githubusercontent.com/66340271/118861563-a3621f80-b8aa-11eb-9431-1a65de9b4d3d.PNG">
<img width="842" alt="pr1_3" src="https://user-images.githubusercontent.com/66340271/118861598-ae1cb480-b8aa-11eb-90f1-474e8acf67c3.PNG">
<img width="849" alt="pr1_4" src="https://user-images.githubusercontent.com/66340271/118861606-b1b03b80-b8aa-11eb-84f1-c183e80ed395.PNG">

### Other information?
Although it the message won't display in every panel, Barb told me to go ahead with this PR and then if someone else thinks they can tackle it later, they can.
