### PR TITLE
[UI/UX:TAGrading] Add padding to TA grading panels

### DIFF
--- a/site/app/templates/grading/electronic/StudentInformationPanel.twig
+++ b/site/app/templates/grading/electronic/StudentInformationPanel.twig
@@ -39,11 +39,11 @@
                         Submitted: {{ submission_time|date("m/d/Y H:i:s T") }}<br/>
                     </b>
                 </div>
-				<div style="padding-left:10px; padding-right:10px;">
-					{% for table in tables %}
-					    {{ table|raw }}
-					{% endfor %}
-				</div>
+                <div style="padding-left:10px; padding-right:10px;">
+                        {% for table in tables %}
+                            {{ table|raw }}
+                        {% endfor %}
+                </div>
             </div>
         </div>
     </div>

--- a/site/app/templates/grading/electronic/StudentInformationPanel.twig
+++ b/site/app/templates/grading/electronic/StudentInformationPanel.twig
@@ -22,7 +22,7 @@
                         <br/>
                     {% endif %}
                 </div>
-                <div>
+                <div style="padding-left:10px;">
                     <b>
                         {% if team_assignment %}
                             Team:<br/>
@@ -39,9 +39,11 @@
                         Submitted: {{ submission_time|date("m/d/Y H:i:s T") }}<br/>
                     </b>
                 </div>
-                {% for table in tables %}
-                    {{ table|raw }}
-                {% endfor %}
+				<div style="padding-left:10px; padding-right:10px;">
+					{% for table in tables %}
+					    {{ table|raw }}
+					{% endfor %}
+				</div>
             </div>
         </div>
     </div>

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -3,37 +3,39 @@
 <div id="submission_browser" class="rubric_panel" data-gradeable-id="{{gradeable_id}}" data-anon-submitter-id="{{anon_submitter_id}}">
     <div >
         <div id="directory_view">
-            <span class="grading_label">Submissions and Results Browser</span>
-            <button class="btn btn-default expand-button" data-linked-type="submissions" data-clicked-state="wasntClicked" id="toggleSubmissionButton">Open/Close Submissions</button>
+            <span style="line-height: 40px;">
+                <span class="grading_label">Submissions and Results Browser</span>
+                <button class="btn btn-default expand-button" data-linked-type="submissions" data-clicked-state="wasntClicked" id="toggleSubmissionButton">Open/Close Submissions</button>
 
-            {# check if there are vcs files, if yes display the toggle button, else don't display it #}
-            {% if has_vcs_files %}
-                <button class="btn btn-default expand-button" data-linked-type="checkout" data-clicked-state="wasntClicked"  id="togglCheckoutButton">Open/Close Checkout</button>
-            {% endif %}
+                {# check if there are vcs files, if yes display the toggle button, else don't display it #}
+                {% if has_vcs_files %}
+                    <button class="btn btn-default expand-button" data-linked-type="checkout" data-clicked-state="wasntClicked"  id="togglCheckoutButton">Open/Close Checkout</button>
+                {% endif %}
 
-            <button class="btn btn-default expand-button" data-linked-type="results" data-clicked-state="wasntClicked"  id="toggleResultButton">Open/Close Results</button>
+                <button class="btn btn-default expand-button" data-linked-type="results" data-clicked-state="wasntClicked"  id="toggleResultButton">Open/Close Results</button>
 
-            <script>
-                $(document).ready(function(){
-                    //note the commented out code here along with the code where files are displayed that is commented out
-                    //is intended to allow open and close to change dynamically on click
-                    //the problem is currently if you click the submissions folder then the text won't change b/c it's being double clicked effectively.
-                    $(".expand-button").on('click', function(){
-                        openAll( 'openable-element-', $(this).data('linked-type'))
-                    })
+                <script>
+                    $(document).ready(function(){
+                        //note the commented out code here along with the code where files are displayed that is commented out
+                        //is intended to allow open and close to change dynamically on click
+                        //the problem is currently if you click the submissions folder then the text won't change b/c it's being double clicked effectively.
+                        $(".expand-button").on('click', function(){
+                            openAll( 'openable-element-', $(this).data('linked-type'))
+                        })
 
-                    var currentCodeStyle = localStorage.getItem('theme');
-                    var currentCodeStyleRadio = (currentCodeStyle == null || currentCodeStyle == "light") ? "style_light" : "style_dark";
-                    $('#' + currentCodeStyleRadio).parent().addClass('active');
-                    $('#' + currentCodeStyleRadio).prop('checked', true);
-                });
-            </script>
-            <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
+                        var currentCodeStyle = localStorage.getItem('theme');
+                        var currentCodeStyleRadio = (currentCodeStyle == null || currentCodeStyle == "light") ? "style_light" : "style_dark";
+                        $('#' + currentCodeStyleRadio).parent().addClass('active');
+                        $('#' + currentCodeStyleRadio).prop('checked', true);
+                    });
+                </script>
+                <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
 
-            <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
+                <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
+            </span>
             <br />
             {# Files #}
-            <div class="inner-container" id="file-container">
+            <div class="inner-container" id="file-container" style="padding-top: 10px;">
                 {{ self.display_files(self, submissions, "s", 0, "submissions") }}
                 {% if has_vcs_files %} {# if there are checkout files, then display folder, otherwise don't #}
                     {{ self.display_files(self, checkout, "c", 0, "checkout") }}

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -1243,6 +1243,7 @@ tr.is_publish {
     position:relative;
     float:left;
     width:100%;
+    padding-left: 10px;
 }
 
 #file-view {


### PR DESCRIPTION
### What is the current behavior?
The "student info" and "student submission/result browser" panels in the TA Grading interface are missing some padding, and the buttons in the submission panel overlap when they are force to wrap around
![padding_before](https://user-images.githubusercontent.com/71195502/118863688-34d29100-b8ad-11eb-8388-594415c1ba5e.png)


### What is the new behavior?
Padding added to the panels in the TA Grading interface. Works in all configurations of the page
![padding_after](https://user-images.githubusercontent.com/71195502/118863724-3e5bf900-b8ad-11eb-8d89-650b23221e51.png)
