### PR TITLE
[Bugfix:SubminiPolls] Turn off Autocomplete for Poll Date

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -32,7 +32,7 @@
 
             <label for="poll-date">
                 Expected release date:
-                <input id="poll-date" class="poll-date"  name="release_date" type="text" size="10" value="{{ poll.getReleaseDate() }}"/>
+                <input id="poll-date" class="poll-date" name="release_date" autocomplete="off" type="text" size="10" value="{{ poll.getReleaseDate() }}"/>
             </label>
             <br/>
 
@@ -95,7 +95,7 @@
 
             <label for="poll-date">
                 Expected release date:
-                <input id="poll-date" class="poll-date" name="release_date" type="text" size="10" value="{{ poll.getReleaseDate() }}"/>
+                <input id="poll-date" class="poll-date" name="release_date" autocomplete="off" type="text" size="10" value="{{ poll.getReleaseDate() }}"/>
             </label>
             <br/>
             <hr>


### PR DESCRIPTION
### What is the current behavior?
Addresses comment in https://github.com/Submitty/Submitty/issues/6036
The "set release date" field in the instructor's New Poll/Edit Poll page shows a dropdown over the calendar popup that makes it impossible to interact with the calendar.
![dates_before](https://user-images.githubusercontent.com/71195502/118869506-77976780-b8b3-11eb-99cc-eef3c700bc52.png)

### What is the new behavior?
The dropdown for autocomplete is disabled.

### Other information?
Tested on Windows/Chrome,Firefox
