### PR TITLE
[UI/UX:Plagiarism] Make due date more visible

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -169,7 +169,9 @@ class PlagiarismController extends AbstractController {
         foreach ($gradeable_ids_titles as $i => $gradeable_id_title) {
             if (!in_array($gradeable_id_title['g_id'], $gradeable_with_submission) || file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/config/lichen_" . $semester . "_" . $course . "_" . $gradeable_id_title['g_id'] . ".json")) {
                 unset($gradeable_ids_titles[$i]);
+                continue;
             }
+            $gradeable_ids_titles[$i]['g_grade_due_date'] = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id'])->format('F d Y H:i:s');;
         }
 
         $prior_term_gradeables = $this->getGradeablesFromPriorTerm();

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -174,6 +174,10 @@ class PlagiarismController extends AbstractController {
             $gradeable_ids_titles[$i]['g_grade_due_date'] = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id'])->format('F d Y H:i:s');;
         }
 
+        usort($gradeable_ids_titles, function ($a, $b) {
+            return $a['g_grade_due_date'] > $b['g_grade_due_date'];
+        });
+
         $prior_term_gradeables = $this->getGradeablesFromPriorTerm();
         $this->core->getOutput()->renderOutput(['admin', 'Plagiarism'], 'configureGradeableForPlagiarismForm', 'new', $gradeable_ids_titles, $prior_term_gradeables, null, null);
     }

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -4,6 +4,7 @@ namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
 use app\libraries\FileUtils;
+use app\libraries\DateUtils;
 use app\libraries\plagiarism\PlagiarismUtils;
 use app\libraries\routers\AccessControl;
 use app\libraries\routers\FeatureFlag;
@@ -76,6 +77,11 @@ class PlagiarismController extends AbstractController {
         foreach ($gradeables_with_plagiarism_result as $i => $gradeable_id_title) {
             if (!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id_title['g_id'] . ".txt") && !file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") && !file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
                 unset($gradeables_with_plagiarism_result[$i]);
+                continue;
+            }
+            $duedate = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id']);
+            if (isset($duedate)) {
+                $gradeables_with_plagiarism_result[$i]['g_grade_due_date'] = $duedate;
             }
         }
 

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -79,10 +79,7 @@ class PlagiarismController extends AbstractController {
                 unset($gradeables_with_plagiarism_result[$i]);
                 continue;
             }
-            $duedate = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id']);
-            if (isset($duedate)) {
-                $gradeables_with_plagiarism_result[$i]['g_grade_due_date'] = $duedate;
-            }
+            $gradeables_with_plagiarism_result[$i]['g_grade_due_date'] = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id']);
         }
 
         usort($gradeables_with_plagiarism_result, function ($a, $b) {

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -171,7 +171,8 @@ class PlagiarismController extends AbstractController {
                 unset($gradeable_ids_titles[$i]);
                 continue;
             }
-            $gradeable_ids_titles[$i]['g_grade_due_date'] = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id'])->format('F d Y H:i:s');;
+            $duedate = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id']);
+            $gradeable_ids_titles[$i]['g_grade_due_date'] = $duedate->format('F d Y H:i:s');
         }
 
         usort($gradeable_ids_titles, function ($a, $b) {

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -85,7 +85,7 @@ class PlagiarismController extends AbstractController {
             }
         }
 
-        usort($gradeables_with_plagiarism_result, function($a, $b) {
+        usort($gradeables_with_plagiarism_result, function ($a, $b) {
             return $a['g_grade_due_date'] > $b['g_grade_due_date'];
         });
 

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -85,6 +85,10 @@ class PlagiarismController extends AbstractController {
             }
         }
 
+        usort($gradeables_with_plagiarism_result, function($a, $b) {
+            return $a['g_grade_due_date'] > $b['g_grade_due_date'];
+        });
+
         $nightly_rerun_info_file = "/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/nightly_rerun.json";
         if (!file_exists($nightly_rerun_info_file)) {
             $nightly_rerun_info = [];

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2634,6 +2634,17 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
         return $this->course_db->rows();
     }
 
+    /**
+     * Gets the date for a specified gradeable
+     *
+     * @param $id
+     * @return \DateTime
+     */
+    public function getDateForGradeableById($id) {
+        $this->course_db->query("SELECT g_grade_due_date FROM gradeable WHERE g_id=?", [$id]);
+        return new \DateTime($this->course_db->rows()[0]['g_grade_due_date']);
+    }
+
     public function getAllGradeablesIds() {
         $this->course_db->query("SELECT g_id FROM gradeable ORDER BY g_id");
         return $this->course_db->rows();

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2637,7 +2637,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
     /**
      * Gets the date for a specified gradeable
      *
-     * @param $id
+     * @param string $id
      * @return \DateTime
      */
     public function getDateForGradeableById($id) {

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -6,11 +6,23 @@
         >+ Configure New Gradeable for Plagiarism Detection</a>
     </div>
 
-    <div class="sub plag-table-cont">
-        <table class="plag-table">
-            {% for row in plagiarism_results_info %}
-                {{ _self.renderPlagiarismRow(row) }}
-            {% endfor %}
+    <div class="plag-table-cont">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Gradeable</th>
+                    <th></th>
+                    <th>Last Run</th>
+                    <th>Submissions</th>
+                    <th>Students<br/>Matched</th>
+                    <th>Nightly<br/>Re-run</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in plagiarism_results_info %}
+                    {{ _self.renderPlagiarismRow(row) }}
+                {% endfor %}
+            </tbody>
         </table>
     </div>
 </div>
@@ -28,32 +40,7 @@
 {% include('plagiarism/DeletePlagiarismResultsAndConfig.twig') %}
 
 {% macro renderPlagiarismRow(row) %}
-    {% if row['in_queue'] %}
-        <tr>
-            <td>{{ row['title'] }}
-            </td>
-            <td colspan=3>
-                {% if row['processing'] %}
-                    <i>Running</i>
-                {% else %}
-                    <i>In queue</i>
-                {% endif %}
-            </td>
-            <td>
-                Last run: {{ row['timestamp'] }}
-            </td>
-            <td>
-                {{ row['students'] }} students, {{ row['submissions'] }} submissions
-            </td>
-            <td>
-                <label>
-                    <input type="checkbox" {{ row['nightly_rerun_status'] }}>
-                    Nightly Re-run
-                </label>
-            </td>
-        </tr>
-    {% else %}
-        <tr>
+    <tr>
         {% if row['ranking_available'] %}
             <td>
                 <a href="{{ row['gradeable_link'] }}">{{ row['title'] }}</a>
@@ -61,11 +48,19 @@
         {% else %}
             <td>{{ row['title'] }}</td>
         {% endif %}
+        {% if row['in_queue'] %}
+            <td colspan=4>
+                {% if row['processing'] %}
+                    <i>Running</i>
+                {% else %}
+                    <i>In queue</i>
+                {% endif %}
+            </td>
+        {% else %}
             <td>
                 <span class="plag-action-btn-cont">
                     <a href="{{ row['edit_plagiarism_link'] }}"
-                       aria-label="Edit {{ row['title'] }}"
-                    >
+                       aria-label="Edit {{ row['title'] }}">
                         <i class="fas fa-pencil-alt"></i>
                     </a>
                     <a href="{{ row['rerun_plagiarism_link'] }}"
@@ -81,7 +76,7 @@
                 </span>
             </td>
             <td>
-                Last run: {{ row['timestamp'] }}
+                {{ row['timestamp'] }}
             </td>
             <td>
                 {{ row['students'] }} students, {{ row['submissions'] }} submissions
@@ -89,14 +84,11 @@
             <td>
                 {{ row['matches_and_topmatch'] }}
             </td>
-            <td>
-                <label>
-                    <input type="checkbox"
-                           onclick='window.location.href = {{ row['nightly_rerun_link'] }};'
-                           {{ row['nightly_rerun_status'] }}>
-                    Nightly Re-run
-                </label>
-            </td>
-        </tr>
     {% endif %}
+        <td>
+            <input type="checkbox"
+                   onclick='window.location.href = {{ row['nightly_rerun_link'] }};'
+                   {{ row['nightly_rerun_status'] }}>
+        </td>
+    </tr>
 {% endmacro %}

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -48,7 +48,7 @@
                 {{ row['title'] }}
             {% endif %}
             <br/>
-            {{ row['duedate'] }}
+            Due: {{ row['duedate'] }}
         </td>
         {% if row['in_queue'] %}
             <td colspan=4>

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -14,7 +14,7 @@
                     <th></th>
                     <th>Last Run</th>
                     <th>Submissions</th>
-                    <th>Students<br/>Matched</th>
+                    <th>Students Matched</th>
                     <th>Nightly<br/>Re-run</th>
                 </tr>
             </thead>

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -86,7 +86,7 @@
             <td>
                 {{ row['matches_and_topmatch'] }}
             </td>
-    {% endif %}
+        {% endif %}
         <td>
             <input type="checkbox"
                    onclick='window.location.href = {{ row['nightly_rerun_link'] }};'

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -41,13 +41,15 @@
 
 {% macro renderPlagiarismRow(row) %}
     <tr>
-        {% if row['ranking_available'] %}
-            <td>
+        <td>
+            {% if row['ranking_available'] %}
                 <a href="{{ row['gradeable_link'] }}">{{ row['title'] }}</a>
-            </td>
-        {% else %}
-            <td>{{ row['title'] }}</td>
-        {% endif %}
+            {% else %}
+                {{ row['title'] }}
+            {% endif %}
+            <br/>
+            {{ row['duedate'] }}
+        </td>
         {% if row['in_queue'] %}
             <td colspan=4>
                 {% if row['processing'] %}

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -13,7 +13,7 @@
                     {% if new_or_edit == "new" %}
                         <select name="gradeable_id">
                             {% for gradeable_id_title in gradeable_ids_titles %}
-                                <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }} | Due {{ gradeable_id_title['g_grade_due_date'] }}</option>
+                                <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }} (Due {{ gradeable_id_title['g_grade_due_date'] }})</option>
                             {% endfor %}
                         </select>
                     {% else %}

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -13,7 +13,7 @@
                     {% if new_or_edit == "new" %}
                         <select name="gradeable_id">
                             {% for gradeable_id_title in gradeable_ids_titles %}
-                                <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }}</option>
+                                <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }} | Due {{ gradeable_id_title['g_grade_due_date'] }}</option>
                             {% endfor %}
                         </select>
                     {% else %}

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -17,6 +17,7 @@ class PlagiarismView extends AbstractView {
             $plagiarism_row = [];
             $plagiarism_row['title'] = $gradeable['g_title'];
             $plagiarism_row['id'] = $gradeable['g_id'];
+            $plagiarism_row['duedate'] = $gradeable['g_grade_due_date']->format('F d Y H:i:s'); // TODO: think about the format of this date.  Using the format of the last run date for now.
             $plagiarism_row['delete_form_action'] = $this->core->buildCourseUrl([
                 'plagiarism',
                 'gradeable',
@@ -24,7 +25,7 @@ class PlagiarismView extends AbstractView {
                 'delete'
             ]);
             if (file_exists($course_path . "/lichen/ranking/" . $plagiarism_row['id'] . ".txt")) {
-                $timestamp = date("F d Y H:i:s.", filemtime($course_path . "/lichen/ranking/" . $plagiarism_row['id'] . ".txt"));
+                $timestamp = date("F d Y H:i:s", filemtime($course_path . "/lichen/ranking/" . $plagiarism_row['id'] . ".txt"));
                 $students = array_diff(scandir($course_path . "/lichen/concatenated/" . $plagiarism_row['id']), ['.', '..']);
                 $submissions = 0;
                 foreach ($students as $student) {

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -7,11 +7,6 @@
     margin-top: 24px;
 }
 
-.sub table {
-    border-collapse: separate;
-    border-spacing: 15px 10px;
-}
-
 td .plag-action-btn-cont {
     display: flex;
 }
@@ -189,25 +184,6 @@ main#main.full-screen-mode .plagiarism-result-cont {
         width: 100%;
     }
 
-    .plag-table {
-        width: 100%;
-    }
-
-    .plag-table tbody {
-        display: block;
-    }
-
-    .plag-table tbody tr {
-       display: flex;
-       flex-direction: column;
-       border-bottom: 1px solid;
-       padding: 15px 0;
-    }
-
-    .plag-table tbody tr td {
-        padding: 2px 8px;
-        margin: 2px 0;
-    }
     #users_with_plagiarism.plag-flex a,
     #users_with_plagiarism.plag-flex span {
         flex-grow: 1;


### PR DESCRIPTION
### What is the current behavior?
Closes #2618

### What is the new behavior?
This pull request:
- Changes the interface of the Lichen homepage to feature a table with more distinct rows
- Adds the due date under each gradeable on the Lichen homepage
- Sorts the gradeables on the Lichen homepage by due date
- Adds the due date for each gradeable on the gradeable configuration page
- Sorts the list in the gradeable configuration page by due date


Before:
![before](https://user-images.githubusercontent.com/16820599/118877619-a82fcf00-b8bc-11eb-8ab6-ffd2c63f24dd.png)

After:
![after](https://user-images.githubusercontent.com/16820599/118877644-acf48300-b8bc-11eb-88a8-7cd8e6be7605.png)


