### PR TITLE
[UI/UX:InstructorUI] Add scrollbar to SQL toolbox table

### DIFF
--- a/site/public/css/sql-toolbox.css
+++ b/site/public/css/sql-toolbox.css
@@ -2,3 +2,7 @@
     width: 100%;
     height: 300px;
 }
+
+#query-results {
+    overflow-x: auto;
+}


### PR DESCRIPTION
### What is the current behavior?
Closes https://github.com/Submitty/Submitty/issues/6373

### What is the new behavior?
The horizontal scroll bar fits to the box container that surrounds the output table instead of the scroll bar fitting to the whole page. 
Screenshot (cut because the page is long):
![sqltable](https://user-images.githubusercontent.com/71195502/118880130-81bf6300-b8bf-11eb-9d75-bff9fd6b1f5f.png)

