### PR TITLE
[UI/UX:Plagiarism] Add gradeable name to breadcrumb path

### DIFF
--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -88,7 +88,8 @@ class PlagiarismView extends AbstractView {
     }
 
     public function showPlagiarismResult($semester, $course, $gradeable_id, $gradeable_title, $rankings) {
-        $this->core->getOutput()->addBreadcrumb('Plagiarism Detection', $this->core->buildCourseUrl(['plagiarism']));
+        $this->core->getOutput()->addBreadcrumb('Plagiarism', $this->core->buildCourseUrl(['plagiarism']));
+        $this->core->getOutput()->addBreadcrumb($gradeable_title, $this->core->buildCourseUrl([$gradeable_title]));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'codemirror.css'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('codemirror', 'codemirror.js'));
         $this->core->getOutput()->addInternalJs('plagiarism.js');

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -88,8 +88,8 @@ class PlagiarismView extends AbstractView {
     }
 
     public function showPlagiarismResult($semester, $course, $gradeable_id, $gradeable_title, $rankings) {
-        $this->core->getOutput()->addBreadcrumb('Plagiarism', $this->core->buildCourseUrl(['plagiarism']));
-        $this->core->getOutput()->addBreadcrumb($gradeable_title, $this->core->buildCourseUrl([$gradeable_title]));
+        $this->core->getOutput()->addBreadcrumb('Plagiarism  Detection', $this->core->buildCourseUrl(['plagiarism']));
+        $this->core->getOutput()->addBreadcrumb($gradeable_title);
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'codemirror.css'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('codemirror', 'codemirror.js'));
         $this->core->getOutput()->addInternalJs('plagiarism.js');


### PR DESCRIPTION
### What is the current behavior?
When viewing a gradeable in Lichen, the breadcrumb path does not update to reflect the current location.  This also means that there are no ways to get back to the previous page via the UI.

### What is the new behavior?
This update adds an additional location in the breadcrumb path to make it easier to get back to the previous page.
