### PR TITLE
[Bugfix:SubminiPolls] past polls now in ascending order

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6994,7 +6994,7 @@ AND gc_id IN (
 
     public function getFuturePolls() {
         $polls = [];
-        $this->course_db->query("SELECT * from polls where release_date > ? order by release_date DESC, name ASC", [date("Y-m-d")]);
+        $this->course_db->query("SELECT * from polls where release_date > ? order by release_date ASC, name ASC", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
         $user = $this->core->getUser()->getId();
 

--- a/site/app/models/PollModel.php
+++ b/site/app/models/PollModel.php
@@ -12,7 +12,7 @@ use app\libraries\DateUtils;
  * @method int getId()
  * @method string getName()
  * @method string getQuestion()
- ///* @method array getAnswers()
+ * @method array getAnswers()
  * @method array getUserResponses()
  * @method string|null getImagePath()
  */

--- a/site/app/models/PollModel.php
+++ b/site/app/models/PollModel.php
@@ -12,7 +12,7 @@ use app\libraries\DateUtils;
  * @method int getId()
  * @method string getName()
  * @method string getQuestion()
- * @method array getAnswers()
+ ///* @method array getAnswers()
  * @method array getUserResponses()
  * @method string|null getImagePath()
  */


### PR DESCRIPTION


### What is the current behavior?
The future polls section shows the polls with the furthest out poll at the top and the closest poll at the bottom.
<img width="808" alt="pr2_2" src="https://user-images.githubusercontent.com/66340271/119020776-a58cb280-b96c-11eb-99fa-6e9bf602d71d.PNG">

### What is the new behavior?
The future polls are now in ascending order with the closest poll appearing first.
<img width="807" alt="pr2_1" src="https://user-images.githubusercontent.com/66340271/119020791-a9203980-b96c-11eb-8529-f957d14d7b62.PNG">

### Other information?
I tested by making a ton of poles with different dates and it works perfectly.
I had to comment out @method array getAnswers() in the poll model because it was saying getAnswers was already defined.
It had no effect on anything but it got rid of the error
