### PR TITLE
[Bugfix:InstructorUI] Fix Anonymized Option Gradeables

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -234,6 +234,7 @@ class AdminGradeableController extends AbstractController {
             'regrade_allowed' => $gradeable->isRegradeAllowed(),
             'regrade_enabled' => $this->core->getConfig()->isRegradeEnabled(),
             'forum_enabled' => $this->core->getConfig()->isForumEnabled(),
+            'electronic' => $gradeable->getType() === GradeableType::ELECTRONIC_FILE,
             // Non-Gradeable-model data
             'gradeable_section_history' => $gradeable_section_history,
             'num_rotating_sections' => $num_rotating_sections,

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableGraders.twig
@@ -68,6 +68,7 @@ Form
         {{ (gradeable.getGraderAssignmentMethod() == 0) ? 'checked' : '' }}> <label for="rotating_section">Rotating Section</label>
 </fieldset>
 <br />
+{% if electronic %}
 <fieldset>
     <legend>
         How should grading be anonymized for limited access graders?
@@ -79,6 +80,7 @@ Form
         {{ (gradeable.getLimitedAccessBlind() == 2 or action == "new") ? 'checked' : '' }}><label for="blind_limited_access_grading">Blinded Grading</label>
 
 </fieldset>
+{% endif %}
 
 {% if peer %}
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
When creating a checkpoint or numeric gradeable, once you go into Grader Assignment there is an option to set Limited Access graders as blinded or unblinded. No matter which option you pick it never gets a value set.
Closes #6231 

### What is the new behavior?
Only electronic gradeables should be able to have this option so for a checkpoint or numeric gradeable this option is never shown the the instructor.
