### PR TITLE
[Bugfix:TAGrading] Added cookie to remember anonymous mode

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1488,7 +1488,7 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map,$anon_mode_cookie);
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -811,12 +811,10 @@ class ElectronicGraderController extends AbstractController {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
             $this->core->redirect($this->core->buildCourseUrl());
         }
+        $anon_mode = false;
         if (array_key_exists('anon_mode', $_COOKIE)) {
             if ($_COOKIE['anon_mode'] === 'on') {
                 $anon_mode = true;
-            }
-            else {
-                $anon_mode = false;
             }
         }
         //Checks to see if the Grader has access to all users in the course,

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -879,7 +879,6 @@ class ElectronicGraderController extends AbstractController {
                 }
             }
         }
-
         $show_all_sections_button = $can_show_all;
         $show_edit_teams = $this->core->getAccess()->canI("grading.electronic.show_edit_teams") && $gradeable->isTeamAssignment();
         $show_import_teams_button = $show_edit_teams && (count($all_teams) > count($empty_teams));
@@ -1489,7 +1488,7 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map);
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map,$anon_mode_cookie);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -811,8 +811,9 @@ class ElectronicGraderController extends AbstractController {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
             $this->core->redirect($this->core->buildCourseUrl());
         }
-        if(array_key_exists('anon_mode', $_COOKIE)){
-            if($_COOKIE['anon_mode'] === 'on'){
+        
+        if (array_key_exists('anon_mode', $_COOKIE)) {
+            if ($_COOKIE['anon_mode'] === 'on') {
                 $anon_mode = true;
             }
         }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -811,7 +811,6 @@ class ElectronicGraderController extends AbstractController {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
             $this->core->redirect($this->core->buildCourseUrl());
         }
-
         if (array_key_exists('anon_mode', $_COOKIE)) {
             if ($_COOKIE['anon_mode'] === 'on') {
                 $anon_mode = true;

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -811,12 +811,7 @@ class ElectronicGraderController extends AbstractController {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
             $this->core->redirect($this->core->buildCourseUrl());
         }
-        $anon_mode = false;
-        if (array_key_exists('anon_mode', $_COOKIE)) {
-            if ($_COOKIE['anon_mode'] === 'on') {
-                $anon_mode = true;
-            }
-        }
+        $anon_mode = isset($_COOKIE['anon_mode']) && $_COOKIE['anon_mode'] === 'on';
         //Checks to see if the Grader has access to all users in the course,
         //Will only show the sections that they are graders for if not TA or Instructor
         $can_show_all = $this->core->getAccess()->canI("grading.electronic.details.show_all");

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -811,7 +811,7 @@ class ElectronicGraderController extends AbstractController {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
             $this->core->redirect($this->core->buildCourseUrl());
         }
-        
+
         if (array_key_exists('anon_mode', $_COOKIE)) {
             if ($_COOKIE['anon_mode'] === 'on') {
                 $anon_mode = true;

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -789,7 +789,7 @@ class ElectronicGraderController extends AbstractController {
      * Shows the list of submitters
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grading/details")
      */
-    public function showDetails($gradeable_id, $view = null, $sort = "id", $direction = "ASC", $anon_mode = false) {
+    public function showDetails($gradeable_id, $view = null, $sort = "id", $direction = "ASC") {
         // Default is viewing your sections
         // Limited grader does not have "View All" option
         // If nothing to grade, Instructor will see all sections
@@ -814,6 +814,9 @@ class ElectronicGraderController extends AbstractController {
         if (array_key_exists('anon_mode', $_COOKIE)) {
             if ($_COOKIE['anon_mode'] === 'on') {
                 $anon_mode = true;
+            }
+            else {
+                $anon_mode = false;
             }
         }
         //Checks to see if the Grader has access to all users in the course,

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -811,7 +811,11 @@ class ElectronicGraderController extends AbstractController {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
             $this->core->redirect($this->core->buildCourseUrl());
         }
-
+        if(array_key_exists('anon_mode', $_COOKIE)){
+            if($_COOKIE['anon_mode'] === 'on'){
+                $anon_mode = true;
+            }
+        }
         //Checks to see if the Grader has access to all users in the course,
         //Will only show the sections that they are graders for if not TA or Instructor
         $can_show_all = $this->core->getAccess()->canI("grading.electronic.details.show_all");

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -688,12 +688,12 @@
 {# /Column functions #}
 <script type = "text/javascript">
     function changeAnon() {
-        const status = '{{ anon_mode_cookie }}';
-        if (status === 'off') {
-            document.cookie = 'anon_mode=on;';
+        const status = '{{ anon_mode }}';
+        if (status) {
+            document.cookie = 'anon_mode=off;';
         }
         else {
-            document.cookie = 'anon_mode=off;';
+            document.cookie = 'anon_mode=on;';
         }
         location.reload();
     }

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -686,19 +686,16 @@
 {% endmacro %}
 
 {# /Column functions #}
-
-<script type="text/javascript">
-
+<script type = "text/javascript">
     function changeAnon() {
-        var status = '{{ anon_mode_cookie }}';
-
+        const status = '{{ anon_mode_cookie }}';
         if (status === 'off') {
-            document.cookie = "anon_mode=on;";
+            document.cookie = 'anon_mode=on;';
         }
         else {
-            document.cookie = "anon_mode=off;";
+            document.cookie = 'anon_mode=off;';
         }
         location.reload();
     }
-
 </script>
+

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -688,7 +688,7 @@
 {# /Column functions #}
 <script>
     function changeAnon() {
-        const status = '{{ anon_mode }}';
+        const status = {{ anon_mode ? 1 : 0}};
         if (status) {
             document.cookie = 'anon_mode=off;';
         }

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -1,7 +1,4 @@
 {% import _self as self %} {# Required to use macros in same template #}
-{% if anon_mode_cookie == 'on' %}
-    <h1>anon mode on</h1>
-{% endif %}
 <div class="content">
     {#
         Default is viewing your sections
@@ -50,8 +47,8 @@
                     {{ sort == 'random' ? "Default Order" : "Random Order" }}
                 </a>
                 {% if toggle_anon_button %}
-                <a class="btn btn-default"
-                   href="{{ toggle_anon_mode_url }}" onclick="changeAnon()">
+                <a class="btn btn-default" id="toggle-anon-button"
+                   href="" onclick="changeAnon()">
                     {{ anon_mode ? "Disable Anon Mode" : "Enable Anon Mode" }}
                 </a>
                 {% endif %}
@@ -691,10 +688,11 @@
 {# /Column functions #}
 
 <script type="text/javascript">
+
     function changeAnon() {
         var status = '{{ anon_mode_cookie }}';
 
-        if (status == 'off') {
+        if (status === 'off') {
             document.cookie = "anon_mode=on;";
         }
         else {
@@ -702,4 +700,5 @@
         }
         location.reload();
     }
+
 </script>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -686,7 +686,7 @@
 {% endmacro %}
 
 {# /Column functions #}
-<script type = "text/javascript">
+<script>
     function changeAnon() {
         const status = '{{ anon_mode }}';
         if (status) {

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -1,5 +1,7 @@
 {% import _self as self %} {# Required to use macros in same template #}
-
+{% if anon_mode_cookie == 'on' %}
+    <h1>anon mode on</h1>
+{% endif %}
 <div class="content">
     {#
         Default is viewing your sections
@@ -49,7 +51,7 @@
                 </a>
                 {% if toggle_anon_button %}
                 <a class="btn btn-default"
-                   href="{{ toggle_anon_mode_url }}">
+                   href="{{ toggle_anon_mode_url }}" onclick="changeAnon()">
                     {{ anon_mode ? "Disable Anon Mode" : "Enable Anon Mode" }}
                 </a>
                 {% endif %}
@@ -687,3 +689,17 @@
 {% endmacro %}
 
 {# /Column functions #}
+
+<script type="text/javascript">
+    function changeAnon() {
+        var status = '{{ anon_mode_cookie }}';
+
+        if (status == 'off') {
+            document.cookie = "anon_mode=on;";
+        }
+        else {
+            document.cookie = "anon_mode=off;";
+        }
+        location.reload();
+    }
+</script>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -443,12 +443,6 @@ HTML;
         if ($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
             $peer = true;
         }
-        if(array_key_exists('anon_mode', $_COOKIE)){
-            if($_COOKIE['anon_mode'] === 'on'){
-                $anon_mode = true;
-            }
-        }
-
         //Each table column is represented as an array with the following entries:
         // width => how wide the column should be on the page, <td width=X>
         // title => displayed title in the table header
@@ -522,7 +516,7 @@ HTML;
             else {
                 $columns[]     = ["width" => "2%",  "title" => "",                 "function" => "index"];
                 $columns[]     = ["width" => "8%", "title" => "Section",          "function" => "section"];
-                if (($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2) || $anon_mode) {
+                if ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2) {
                     $columns[]         = ["width" => "43%", "title" => "Student",          "function" => "user_id_anon"];
                 }
                 else {
@@ -826,8 +820,6 @@ HTML;
                 http_build_query(['view' => $view_all ? null : 'all', 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => $anon_mode]),
             "order_toggle_url" => $details_base_url . '?' .
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort === 'random' ? null : 'random', 'anon_mode' => $anon_mode]),
-            "toggle_anon_mode_url" => $details_base_url . '?' .
-                http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => !$anon_mode]),
             "sort" => $sort,
             "direction" => $direction
         ]);

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -806,6 +806,7 @@ HTML;
             "team_gradeable_view_history" => $team_gradeable_view_history,
             "view_all" => $view_all,
             "anon_mode" => $anon_mode,
+            "anon_mode_cookie" => array_key_exists('anon_mode', $_COOKIE) ? $_COOKIE['anon_mode'] : 'off',
             "toggle_anon_button" => ($this->core->getUser()->getGroup() == User::GROUP_INSTRUCTOR || $this->core->getUser()->getGroup() == User::GROUP_FULL_ACCESS_GRADER),
             "show_all_sections_button" => $show_all_sections_button,
             "show_import_teams_button" => $show_import_teams_button,
@@ -1098,7 +1099,6 @@ HTML;
         if ($peer && $this->core->getUser()->getGroup() == 4) {
             $i_am_a_peer = true;
         }
-
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "progress" => $progress,
             "peer_gradeable" => $peer,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -443,6 +443,11 @@ HTML;
         if ($gradeable->isPeerGrading() && $this->core->getUser()->getGroup() == User::GROUP_STUDENT) {
             $peer = true;
         }
+        if(array_key_exists('anon_mode', $_COOKIE)){
+            if($_COOKIE['anon_mode'] === 'on'){
+                $anon_mode = true;
+            }
+        }
 
         //Each table column is represented as an array with the following entries:
         // width => how wide the column should be on the page, <td width=X>
@@ -517,7 +522,7 @@ HTML;
             else {
                 $columns[]     = ["width" => "2%",  "title" => "",                 "function" => "index"];
                 $columns[]     = ["width" => "8%", "title" => "Section",          "function" => "section"];
-                if ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2) {
+                if (($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2) || $anon_mode) {
                     $columns[]         = ["width" => "43%", "title" => "Student",          "function" => "user_id_anon"];
                 }
                 else {
@@ -796,7 +801,6 @@ HTML;
         $this->core->getOutput()->addInternalJs('collapsible-panels.js');
 
         $this->core->getOutput()->enableMobileViewport();
-
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/Details.twig", [
             "gradeable" => $gradeable,
             "sections" => $sections,
@@ -824,6 +828,8 @@ HTML;
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort === 'random' ? null : 'random', 'anon_mode' => $anon_mode]),
             "toggle_anon_mode_url" => $details_base_url . '?' .
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => !$anon_mode]),
+            "anon_mode_url" => $details_base_url . '?' .
+                http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => 1]),
             "sort" => $sort,
             "direction" => $direction
         ]);

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -804,7 +804,6 @@ HTML;
             "team_gradeable_view_history" => $team_gradeable_view_history,
             "view_all" => $view_all,
             "anon_mode" => $anon_mode,
-            "anon_mode_cookie" => array_key_exists('anon_mode', $_COOKIE) ? $_COOKIE['anon_mode'] : 'off',
             "toggle_anon_button" => ($this->core->getUser()->getGroup() == User::GROUP_INSTRUCTOR || $this->core->getUser()->getGroup() == User::GROUP_FULL_ACCESS_GRADER),
             "show_all_sections_button" => $show_all_sections_button,
             "show_import_teams_button" => $show_import_teams_button,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -828,8 +828,6 @@ HTML;
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort === 'random' ? null : 'random', 'anon_mode' => $anon_mode]),
             "toggle_anon_mode_url" => $details_base_url . '?' .
                 http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => !$anon_mode]),
-            "anon_mode_url" => $details_base_url . '?' .
-                http_build_query(['view' => $view_all ? 'all' : null, 'sort' => $sort, 'direction' => $sort === 'random' ? null : $direction, 'anon_mode' => 1]),
             "sort" => $sort,
             "direction" => $direction
         ]);

--- a/site/public/js/details.js
+++ b/site/public/js/details.js
@@ -22,4 +22,3 @@ $(document).ready(() => {
 });
 
 
-

--- a/site/public/js/details.js
+++ b/site/public/js/details.js
@@ -21,3 +21,5 @@ $(document).ready(() => {
     document.head.appendChild(style);
 });
 
+
+


### PR DESCRIPTION

### What is the current behavior?
If a TA enables anonymous mode for a gradeable and then leaves the page, when they come back anonymous mode if off again. Anonymous mode is determined in the url eg. (anon_mode=1 or anon_mode=0).
<img width="865" alt="pr4_2" src="https://user-images.githubusercontent.com/66340271/119196769-b6185800-ba54-11eb-9cc7-f87c665297c6.PNG">
<img width="914" alt="pr4_3" src="https://user-images.githubusercontent.com/66340271/119196777-ba447580-ba54-11eb-9df1-d985f24bc7a3.PNG">

### What is the new behavior?
A cookie is set when a TA enables anonymous mode so anonymous mode will always be turned on for that gradeable until they turn it off. The url is no longer used to convey information about anonymous mode.
<img width="916" alt="pr4_1" src="https://user-images.githubusercontent.com/66340271/119196784-bdd7fc80-ba54-11eb-9950-c2297e813052.PNG">

### Other information?
I tested by  messing around with the gradeables in the sample course and toggling anonymous mode on and off. It worked for every assignment. 
