### PR TITLE
[Bugfix:TAGrading] Add unique constraint to gradeable_data

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -1225,6 +1225,14 @@ ALTER TABLE ONLY public.electronic_gradeable
 
 
 --
+-- Name: gradeable_data g_id_gd_team_id_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_data
+    ADD CONSTRAINT g_id_gd_team_id_unique UNIQUE (g_id, gd_team_id);
+
+
+--
 -- Name: grade_override grade_override_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 

--- a/migration/migrator/migrations/course/20210521231204_team_id_constraint.py
+++ b/migration/migrator/migrations/course/20210521231204_team_id_constraint.py
@@ -1,0 +1,15 @@
+"""There was already a unique key constraint between user_id and g_id
+in the gradeable_data table, but not between team_id and g_id, which
+means we could have multiple grades for a team despite only allowing
+one grade per individual.
+"""
+
+
+def up(config, database, semester, course):
+    database.execute("ALTER TABLE public.gradeable_data DROP CONSTRAINT g_id_gd_team_id_unique;");
+    database.execute("ALTER TABLE ONLY public.gradeable_data ADD CONSTRAINT g_id_gd_team_id_unique UNIQUE (g_id, gd_team_id);");
+    pass
+
+
+def down(config, database, semester, course):
+    pass


### PR DESCRIPTION
Closes #2371 

There was already a unique key constraint between user_id and g_id in the gradeable_data table, but not between team_id and g_id, which means we could have multiple grades for a team despite only allowingone grade per individual.
