### PR TITLE
[UI/UX:Submission] Fix low contrast short answer fields

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -68,7 +68,11 @@
                 <script>
                     const config_{{ num_codeboxes }} = {};
 
-                    config_{{ num_codeboxes }}.theme = 'eclipse';
+                    var theme = localStorage.getItem("theme");
+                    if(theme == null && window.matchMedia("(prefers-color-scheme: dark)").matches){
+                        theme = "dark";
+                    }
+                    config_{{ num_codeboxes }}.theme = (theme == null || theme === "light") ? "eclipse" : "monokai";
 
                     if ('{{ cell.programming_language }}') {
                         config_{{ num_codeboxes }}.lineNumbers = true;


### PR DESCRIPTION
### What is the current behavior?
Fixes #6485 
Currently, short answer fields in notebook gradeables don't change their text's theme based on the site's theme. This leads to low contrast black text on dark backgrounds.

![image](https://user-images.githubusercontent.com/28243927/119362650-eccfb780-bc7a-11eb-9d82-c7c7a9fb40ff.png)
![image](https://user-images.githubusercontent.com/28243927/119362546-d0337f80-bc7a-11eb-9e8c-6d50ae38ed45.png)
![image](https://user-images.githubusercontent.com/28243927/119362562-d590ca00-bc7a-11eb-90a1-19d16f25a0c9.png)


### What is the new behavior?
The text now uses Eclipse theme for light mode, and Monokai for dark/black mode.

![image](https://user-images.githubusercontent.com/28243927/119362691-f822e300-bc7a-11eb-8d18-c3e2d6cc3d9c.png)
![image](https://user-images.githubusercontent.com/28243927/119362795-1557b180-bc7b-11eb-8a5d-424b739b0524.png)
![image](https://user-images.githubusercontent.com/28243927/119362848-27d1eb00-bc7b-11eb-892d-36aab4384485.png)