### PR TITLE
[Bugfix:System] Add missing java8 to ubuntu-20.04

### DIFF
--- a/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
@@ -65,7 +65,7 @@ apt-get install -qqy scrot
 
 apt-get install -qqy clang autoconf automake autotools-dev diffstat finger gdb \
 p7zip-full patchutils libpq-dev unzip valgrind zip libboost-all-dev gcc g++ \
-g++-multilib jq libseccomp-dev libseccomp2 seccomp flex bison poppler-utils
+g++-multilib jq libseccomp-dev libseccomp2 seccomp junit flex bison poppler-utils
 
 apt-get install -qqy ninja-build
 
@@ -79,6 +79,11 @@ apt-get install -qqy cmake
 
 # for Lichen (Plagiarism Detection)
 apt-get install -qqy python-clang-6.0
+
+# Install OpenJDK8 Non-Interactively
+echo "installing java8"
+apt-get install -qqy openjdk-8-jdk
+update-java-alternatives --set java-1.8.0-openjdk-amd64
 
 # Install Image Magick for image comparison, etc.
 apt-get install -qqy imagemagick


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Java 8 was missing from the install for Ubuntu 20.04.

### What is the new behavior?

Java 8 is present. Given that we still want this for local testing purposes for the integration suite, re-adding this here.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
