### PR TITLE
[Bugfix:Forum] Standardize styling for markdown posts

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -32,7 +32,7 @@
 
     {% endif %}
 
-    <pre class='pre_forum'><span class="post_content pre-wrap" >{% include "forum/RenderPost.twig" with { "post_content": post_content, "render_markdown": render_markdown } only %}</span></pre>
+    <pre class='pre_forum'><span class="post_content markdown" style="white-space: normal;" >{% include "forum/RenderPost.twig" with { "post_content": post_content, "render_markdown": render_markdown } only %}</span></pre>
 
     <hr style="margin-bottom: 3px;">
 

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -32,7 +32,7 @@
 
     {% endif %}
 
-    <pre class='pre_forum'><span class="post_content markdown" style="white-space: normal;" >{% include "forum/RenderPost.twig" with { "post_content": post_content, "render_markdown": render_markdown } only %}</span></pre>
+    <pre class='pre_forum'><span class="post_content pre-wrap">{% include "forum/RenderPost.twig" with { "post_content": post_content, "render_markdown": render_markdown } only %}</span></pre>
 
     <hr style="margin-bottom: 3px;">
 

--- a/site/app/templates/forum/RenderPost.twig
+++ b/site/app/templates/forum/RenderPost.twig
@@ -1,1 +1,1 @@
-{% if render_markdown %}{{ post_content | markdown }}{% else %}{{ post_content }}{% endif %}
+{% if render_markdown %}<span class="markdown" style="white-space: normal;">{{ post_content | markdown }}</span>{% else %}{{ post_content }}{% endif %}

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -557,8 +557,8 @@
     font-size: 1.8em;
 }
 
-.post_content > p{
-    white-space: pre;
+.post_content p {
+    white-space: pre-wrap;
 }
 
 .post_content li {

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -557,6 +557,10 @@
     font-size: 1.8em;
 }
 
+.post_content > p{
+    white-space: pre;
+}
+
 .post_content li {
     white-space: normal;
 }


### PR DESCRIPTION
### What is the current behavior?
Partially #5884 
Forum posts do not inherit markdown styling rules from the new standard set of markdown styling rules.
![image](https://user-images.githubusercontent.com/28243927/119413631-05ac8d00-bcbc-11eb-8246-852c119153cb.png)
### What is the new behavior?
Forum posts inherit markdown styling rules from the new standard set of markdown styling rules.
![Screen Shot 2021-05-24 at 5 44 47 PM](https://user-images.githubusercontent.com/28243927/119412502-02b09d00-bcba-11eb-8440-6d6e159b5d20.jpg)



