### PR TITLE
[UI/UX:SubminiPolls] Make chevrons more visible in dark mode

### DIFF
--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -10,7 +10,7 @@
     <hr>
 
     <div class="dropdown-wrapper">
-        <div onclick='updateDropdownStates($(this).find(".dropdown-arrow").hasClass("down"), "today_polls_dropdown", "{{ base_url }}")' class="dropdown-bar">
+        <div class="dropdown-bar">
             <h2> Today's Polls </h2>
             <div class="dropdown-btn">
                 <i class="fa fa-chevron-down"></i>
@@ -73,7 +73,7 @@
     <hr>
 
     <div class="dropdown-wrapper">
-        <div onclick='updateDropdownStates($(this).find(".dropdown-arrow").hasClass("down"), "old_polls_dropdown", "{{ base_url }}")' class="dropdown-bar">
+        <div class="dropdown-bar">
             <h2> Old Polls </h2>
             <div class="dropdown-btn">
                 <i class="fa fa-chevron-down"></i>
@@ -138,7 +138,7 @@
     <hr>
 
     <div class="dropdown-wrapper">
-        <div onclick='updateDropdownStates($(this).find(".dropdown-arrow").hasClass("down"), "future_polls_dropdown", "{{ base_url }}")' class="dropdown-bar">
+        <div class="dropdown-bar">
             <h2> Future Polls </h2>
             <div class="dropdown-btn">
                 <i class="fa fa-chevron-down"></i>

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -13,7 +13,7 @@
         <div onclick='updateDropdownStates($(this).find(".dropdown-arrow").hasClass("down"), "today_polls_dropdown", "{{ base_url }}")' class="dropdown-bar">
             <h2> Today's Polls </h2>
             <div class="dropdown-btn">
-                <i class="dropdown-arrow{{dropdown_states['today'] ? ' down' : ' right'}}"></i>
+                <i class="fa fa-chevron-down"></i>
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">
@@ -76,7 +76,7 @@
         <div onclick='updateDropdownStates($(this).find(".dropdown-arrow").hasClass("down"), "old_polls_dropdown", "{{ base_url }}")' class="dropdown-bar">
             <h2> Old Polls </h2>
             <div class="dropdown-btn">
-                <i class="dropdown-arrow{{dropdown_states['old'] ? ' down' : ' right'}}"></i>
+                <i class="fa fa-chevron-down"></i>
             </div>
         </div>
         <table id="older-table" class="table table-striped" style="width:100%;{{ dropdown_states['old'] ? '' : ' display: none;'}}">
@@ -141,7 +141,7 @@
         <div onclick='updateDropdownStates($(this).find(".dropdown-arrow").hasClass("down"), "future_polls_dropdown", "{{ base_url }}")' class="dropdown-bar">
             <h2> Future Polls </h2>
             <div class="dropdown-btn">
-                <i class="dropdown-arrow{{dropdown_states['future'] ? ' down' : ' right'}}"></i>
+                <i class="fa fa-chevron-down"></i>
             </div>
         </div>
         <table id="future-table" class="table table-striped" style="width:100%;{{ dropdown_states['future'] ? '' : ' display: none;'}}">

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -13,7 +13,7 @@
         <div  onclick="updateDropdownStates($(this).find('.dropdown-arrow').hasClass('down'), 'today_polls_dropdown', '{{ base_url }}')" class="dropdown-bar">
             <h2> Today's Polls </h2>
             <div class="dropdown-btn">
-                <i class="dropdown-arrow{{dropdown_states['today'] ? ' down' : ' right'}} fa fa-chevron-right"></i>
+                <i class="dropdown-arrow{{dropdown_states['today'] ? ' down'}} fa fa-chevron-right"></i>
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -10,10 +10,10 @@
     <hr>
 
     <div class="dropdown-wrapper">
-        <div class="dropdown-bar">
+        <div  onclick="updateDropdownStates($(this).find('.dropdown-arrow').hasClass('down'), 'today_polls_dropdown', '{{ base_url }}')" class="dropdown-bar">
             <h2> Today's Polls </h2>
             <div class="dropdown-btn">
-                <i class="fa fa-chevron-down"></i>
+                <i class="dropdown-arrow{{dropdown_states['today'] ? ' down' : ' right'}} fa fa-chevron-right"></i>
             </div>
         </div>
         <table id="today-table" class="table table-striped" style="width:100%;{{ dropdown_states['today'] ? '' : ' display: none;'}}">
@@ -73,10 +73,10 @@
     <hr>
 
     <div class="dropdown-wrapper">
-        <div class="dropdown-bar">
+        <div onclick="updateDropdownStates($(this).find('.dropdown-arrow').hasClass('down'), 'old_polls_dropdown', '{{ base_url }}')" class="dropdown-bar">
             <h2> Old Polls </h2>
             <div class="dropdown-btn">
-                <i class="fa fa-chevron-down"></i>
+                <i class="dropdown-arrow{{dropdown_states['old'] ? ' down' : ' right'}} fa fa-chevron-right"></i>
             </div>
         </div>
         <table id="older-table" class="table table-striped" style="width:100%;{{ dropdown_states['old'] ? '' : ' display: none;'}}">
@@ -138,10 +138,10 @@
     <hr>
 
     <div class="dropdown-wrapper">
-        <div class="dropdown-bar">
+        <div onclick="updateDropdownStates($(this).find('.dropdown-arrow').hasClass('down'), 'future_polls_dropdown', '{{ base_url }}')" class="dropdown-bar">
             <h2> Future Polls </h2>
             <div class="dropdown-btn">
-                <i class="fa fa-chevron-down"></i>
+                <i class="dropdown-arrow{{dropdown_states['future'] ? ' down' : ' right'}} fa fa-chevron-right"></i>
             </div>
         </div>
         <table id="future-table" class="table table-striped" style="width:100%;{{ dropdown_states['future'] ? '' : ' display: none;'}}">

--- a/site/app/templates/polls/AllPollsPageStudent.twig
+++ b/site/app/templates/polls/AllPollsPageStudent.twig
@@ -1,12 +1,12 @@
 <div class="content">
     <h1> Polls </h1>
-    <br/> <br/>
+    <hr/>
 
     <div class="dropdown-wrapper">
         <div class="dropdown-bar">
             <h2> Today's Polls </h2>
             <div class="dropdown-btn">
-                <i class="dropdown-arrow down"></i>
+                <i class="fa fa-chevron-down"></i>
             </div>
         </div>
         <table class="table table-striped" style="width:100%;">
@@ -54,7 +54,7 @@
         <div class="dropdown-bar">
             <h2> Older Polls </h2>
              <div class="dropdown-btn">
-                <i class="dropdown-arrow down"></i>
+                 <i class="fa fa-chevron-down"></i>
             </div>
         </div>
         <table class="table table-striped" style="width:100%;">

--- a/site/public/css/polls.css
+++ b/site/public/css/polls.css
@@ -13,7 +13,7 @@
 }
 
 .dropdown-btn .down{
-    transform: rotate(-90deg);
+    transform: rotate(90deg);
 }
 
 .move-btn {

--- a/site/public/css/polls.css
+++ b/site/public/css/polls.css
@@ -1,24 +1,19 @@
 .dropdown-wrapper h2 {
     display: inline;
-    margin: 0px;
+    margin: 0;
 }
 
 .dropdown-bar {
-    padding: 0px 0px 20px 0px;
-}
-
-.dropdown-arrow {
-    border: solid black;
-    border-width: 0 5px 5px 0;
-    display: inline-block;
-    padding: 8px;
+    padding: 0 0 20px 0;
 }
 
 .dropdown-btn {
-    background: transparent;
-    border: none !important;
-    padding: 4px 0px 0px 0px !important;
     float: right;
+    font-size: 31px;
+}
+
+.dropdown-btn .down{
+    transform: rotate(-90deg);
 }
 
 .move-btn {
@@ -29,26 +24,6 @@
     border-style: solid;
     border-radius: 5px;
     cursor: pointer;
-}
-
-.dropdown-btn .right {
-    transform: rotate(-45deg);
-    -webkit-transform: rotate(-45deg);
-}
-
-.dropdown-btn .down{
-    transform: rotate(45deg);
-    -webkit-transform: rotate(45deg);
-}
-
-.dropdown-btn .up{
-    transform: rotate(-135deg);
-    -webkit-transform: rotate(-135deg);
-}
-
-.dropdown-btn .left {
-    transform: rotate(135deg);
-    -webkit-transform: rotate(135deg);
 }
 
 .radio p {

--- a/site/public/js/polls-dropdown.js
+++ b/site/public/js/polls-dropdown.js
@@ -1,6 +1,6 @@
 $(document).ready(() => {
     $('.dropdown-bar').on('click', function() {
         $(this).siblings('table').toggle();
-        $(this).find('i').toggleClass('down right');
+        $(this).find('i').toggleClass('down');
     });
 });


### PR DESCRIPTION
### What is the current behavior?
The chevrons on the polls page are hard to see in dark mode.

![](https://user-images.githubusercontent.com/71195502/118712877-4ead9e80-b7ef-11eb-9d5f-4de3c5faca56.png)


### What is the new behavior?
Fixes #6452

![Untitled](https://user-images.githubusercontent.com/16820599/119499187-755e5e80-bd34-11eb-9923-7e2751ada540.png)
