### PR TITLE
[Bugfix:Forum] Fix Attachment Button not Toggling 

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -101,7 +101,7 @@
 			{% if thread_exists and not is_full_threads_page %}
 	          	<li class="divider"></li>
 	          	<li title="Click to toggle all post attachments" class='dropdown-item' role="menuitem">
-	          		<a href="#" class="key_to_click" tabindex="0" onclick="loadAllInlineImages()">
+	          		<a href="#" id="toggle-attachments-button" class="key_to_click show-all" tabindex="0" onclick="loadAllInlineImages()">
    						Attachments <span class="attachment-badge badge">{{ total_attachments }}</span>
    					</a>
 				</li>

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1735,17 +1735,15 @@ function loadAllInlineImages() {
   $(".attachment-btn").each(function () {
     $(this).click();
   });
-  $(".attachment-well").each(function () {
-    $(this).show();
-  });
 }
 
 function loadInlineImages(encoded_data) {
   var data = JSON.parse(encoded_data);
   var attachment_well = $("#"+data[data.length-1]);
 
-  if (attachment_well.is(':visible'))
+  if (attachment_well.is(':visible')){
     attachment_well.hide();
+  }
   else {
     attachment_well.show();
   }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1732,9 +1732,34 @@ function loadThreadHandler(){
 }
 
 function loadAllInlineImages() {
-  $(".attachment-btn").each(function () {
+  const toggleButton = $('#toggle-attachments-button');
+
+  const allShown = $('.attachment-well').filter(function(){ return $(this).is(':visible') }).length === $('.attachment-well').length;
+  //if the button were to show them all but they have all been individually shown,
+  //we should hide them all
+  if (allShown && toggleButton.hasClass('show-all')) {
+    toggleButton.removeClass('show-all');
+  }
+
+  const allHidden = $('.attachment-well').filter(function(){ return !($(this).is(':visible')) }).length === $('.attachment-well').length;
+  //if the button were to hide them all but they have all been individually hidden,
+  //we should show them all
+  if (allHidden && !(toggleButton.hasClass('show-all'))) {
+    toggleButton.addClass('show-all');
+  }
+
+  $('.attachment-btn').each(function (i) {
     $(this).click();
+
+    //overwrite individual button click behavior to decide if it should be shown/hidden
+    if(toggleButton.hasClass('show-all')){
+      $('.attachment-well').eq(i).show();
+    } else {
+      $('.attachment-well').eq(i).hide();
+    }
   });
+
+  toggleButton.toggleClass('show-all');
 }
 
 function loadInlineImages(encoded_data) {


### PR DESCRIPTION
### What is the current behavior?
Fixes #6445 
Currently, the Attachments dropdown button in discussion forum threads can only be used to open all attachments.

### What is the new behavior?
The Attachments drop down button toggles between showing and hiding all attachments. It keeps track of whether it has shown or hidden all last time, so if all are hidden and one is individually shown, then pressing the toggle will show all, not hide one and show the others.

### Other information?
When testing this PR, specifically try combinations such as showing/hiding all and then individually toggling an attachment and make sure they never get unlinked (clicking the Attachments button shows some and hides others, etc). 
