### PR TITLE
[Bugfix:TAGrading] fixed autogrow

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -102,8 +102,6 @@ aside {
     flex: 1 1 0%;
 }
 
-
-
 .active {
     border: unset;
 }

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -279,39 +279,6 @@ progress::-webkit-progress-value {
     background: #962e2e;
 }
 
-#overall-comment-ta {
-    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
-    display: grid;
-}
-#overall-comment-ta::after {
-    /* Note the weird space! Needed to preventy jumpy behavior */
-    content: attr(data-replicated-value) " ";
-
-    /* This is how textarea text behaves */
-    white-space: pre-wrap;
-
-    /* Hidden from view, clicks, and screen readers */
-    visibility: hidden;
-}
-#overall-comment-ta > textarea {
-    /* You could leave this, but after a user resizes, then it ruins the auto sizing */
-    resize: none;
-
-    /* Firefox shows scrollbar on growth, you can hide like this. */
-    overflow: hidden;
-}
-#overall-comment-ta> textarea,
-#overall-comment-ta::after {
-    /* Identical styling required!! */
-    border: 1px solid black;
-    padding: 0.5rem;
-    font: inherit;
-
-    /* Place on top of each other */
-    grid-area: 1 / 1 / 2 / 2;
-}
-
-
 #grading_rubric_btn {
     border: 2px solid #249c63;
 }

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -102,6 +102,8 @@ aside {
     flex: 1 1 0%;
 }
 
+
+
 .active {
     border: unset;
 }
@@ -276,6 +278,39 @@ progress::-webkit-progress-value {
 #autograding_results_select option:focus {
     background: #962e2e;
 }
+
+#overall-comment-ta {
+    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+    display: grid;
+}
+#overall-comment-ta::after {
+    /* Note the weird space! Needed to preventy jumpy behavior */
+    content: attr(data-replicated-value) " ";
+
+    /* This is how textarea text behaves */
+    white-space: pre-wrap;
+
+    /* Hidden from view, clicks, and screen readers */
+    visibility: hidden;
+}
+#overall-comment-ta > textarea {
+    /* You could leave this, but after a user resizes, then it ruins the auto sizing */
+    resize: none;
+
+    /* Firefox shows scrollbar on growth, you can hide like this. */
+    overflow: hidden;
+}
+#overall-comment-ta> textarea,
+#overall-comment-ta::after {
+    /* Identical styling required!! */
+    border: 1px solid black;
+    padding: 0.5rem;
+    font: inherit;
+
+    /* Place on top of each other */
+    grid-area: 1 / 1 / 2 / 2;
+}
+
 
 #grading_rubric_btn {
     border: 2px solid #249c63;

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -32,10 +32,8 @@ Required Parameters:
                 rows="5"
                 data-previous-comment="{{overall_comment["logged_in_user"]["comment"]|escape }}"
                 class="general-comment-entry noscroll key_to_click" tabindex="0"
-                onkeyup="auto_grow(this)"
                 onchange="{{ grading_disabled ? '' : 'onChangeOverallComment()'}}"
                 placeholder="Overall message for student about the gradeable...">{{overall_comment["logged_in_user"]["comment"]|escape }}</textarea>
-
         {% for user, comment in overall_comment["other_graders"] %}
             <textarea disabled
                     id="overall-comment-{{user | escape }}"

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -32,6 +32,7 @@ Required Parameters:
                 rows="5"
                 data-previous-comment="{{overall_comment["logged_in_user"]["comment"]|escape }}"
                 class="general-comment-entry noscroll key_to_click" tabindex="0"
+                onkeydown="auto_grow(this)"
                 onchange="{{ grading_disabled ? '' : 'onChangeOverallComment()'}}"
                 placeholder="Overall message for student about the gradeable...">{{overall_comment["logged_in_user"]["comment"]|escape }}</textarea>
         {% for user, comment in overall_comment["other_graders"] %}


### PR DESCRIPTION

### What is the current behavior?
When typing a long comment in the 'overall comment' section of the TA grading rubric, the comment box autogrows on keyup which causes a glitch that makes it nearly impossible to see what you are typing when you reach a 12-15 line comment.

https://user-images.githubusercontent.com/66340271/119516555-d9891e80-bd44-11eb-8b6c-652c86f626ce.mp4


### What is the new behavior?
Now the box just grows when you need a new line so there are no glitches and no matter how long of a comment it is, you will always be able to see what you're typing.
fixes #3633 

https://user-images.githubusercontent.com/66340271/119519187-3980c480-bd47-11eb-8519-403580c834e2.mp4


### Other information?
After a lot of tweaks the best fix turned out to be changing onkeyup to onkeydown. 
This change works perfectly on chrome, perfect on edge but is slightly glitchy on Firefox. You can still see what you're typing 
it just isn't as smooth as chrome or edge but it wasn't as smooth before either. If you are trying to recreate this error just type a super long comment.