### PR TITLE
[UI/UX:InstructorUI] Fix Invalid Contrast on Admin Gradeable

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -18,6 +18,18 @@ input.readonly.peerstudents {
     width: 200px;
 }
 
+input[type=text]:invalid {
+    background-color: var(--alert-invalid-entry-pink);
+}
+
+[data-theme="dark"] input[type=text]:invalid {
+    background-color: var(--alert-danger-red);
+}
+
+[data-theme="dark"] input[type=text]:invalid::placeholder {
+    color: var(--alert-invalid-entry-pink);
+}
+
 select {
     margin-top:7px;
     width: -webkit-fill-available;

--- a/site/public/css/userform.css
+++ b/site/public/css/userform.css
@@ -31,9 +31,13 @@ input[type=text]:valid {
  }
 
 input[type=text]:invalid {
+    background-color: var(--alert-invalid-entry-pink);
+}
+
+[data-theme="dark"] input[type=text]:invalid {
     background-color: var(--alert-danger-red);
 }
 
-input[type=text]:invalid::placeholder {
+[data-theme="dark"] input[type=text]:invalid::placeholder {
     color: var(--alert-invalid-entry-pink);
 }

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -15,7 +15,7 @@ function updateErrorMessage() {
 function setError(name, err) {
     $('[name="' + name + '"]').each(function (i, elem) {
         elem.title = err;
-        elem.style.backgroundColor = '#FDD';
+        elem.setCustomValidity("Invalid field.");
     });
     errors[name] = err;
 }
@@ -23,7 +23,7 @@ function setError(name, err) {
 function clearError(name, update) {
     $('[name="' + name + '"]').each(function (i, elem) {
         elem.title = '';
-        elem.style.backgroundColor = '';
+        elem.setCustomValidity('');
 
         // Update the value if provided
         if(update !== undefined) {
@@ -212,7 +212,7 @@ $(document).ready(function () {
                         clearError(key, response_data[key]);
                     }
                 }
-                // Clear errors by just removing red background
+                // Clear errors by setting custom validity to ''
                 for (let key in data) {
                     if (data.hasOwnProperty(key)) {
                         clearError(key);


### PR DESCRIPTION
### What is the current behavior?
Fixes #6499 
Same solution as #6454 
Currently, the contrast for invalid fields on the instructor create/edit gradeable page has poor contrast.

![image](https://user-images.githubusercontent.com/28243927/119554862-30095380-bd6b-11eb-80d9-472e9853bed7.png)

### What is the new behavior?
- Contrast is improved.
- Invalid fields are now marked with invalid selector to improve accessibility.
- Fixes a bug introduced in #6454 where dark mode styling was applied in light mode.

![image](https://user-images.githubusercontent.com/28243927/119555235-a017d980-bd6b-11eb-96fb-815ce5a319ef.png)
