### PR TITLE
[Feature:TAGrading] display name of student being graded

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1236,8 +1236,6 @@ class ElectronicGraderController extends AbstractController {
         if (empty($this->core->getQueries()->getTeamsById([$who_id])) && $this->core->getQueries()->getUserById($who_id) == null) {
             $anon_mode = true;
         }
-
-
         /** @var Gradeable $gradeable */
 
         $gradeable = $this->tryGetGradeable($gradeable_id, false);
@@ -1321,7 +1319,7 @@ class ElectronicGraderController extends AbstractController {
                 }
             }
             if (is_null($who_id) || $who_id == '') {
-                    $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])  . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => 'all']));
+                $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])  . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => 'all']));
             }
         }
         // Get the graded gradeable for the submitter we are requesting

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -812,6 +812,7 @@ class ElectronicGraderController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl());
         }
         $anon_mode = isset($_COOKIE['anon_mode']) && $_COOKIE['anon_mode'] === 'on';
+
         //Checks to see if the Grader has access to all users in the course,
         //Will only show the sections that they are graders for if not TA or Instructor
         $can_show_all = $this->core->getAccess()->canI("grading.electronic.details.show_all");

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1488,7 +1488,7 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode);
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1236,6 +1236,10 @@ class ElectronicGraderController extends AbstractController {
         if (empty($this->core->getQueries()->getTeamsById([$who_id])) && $this->core->getQueries()->getUserById($who_id) == null) {
             $anon_mode = true;
         }
+        $anon_mode = false;
+        echo '<script type="text/javascript">';
+        echo ' alert("JavaScript Alert Box by PHP")';  //not showing an alert box.
+        echo '</script>';
         /** @var Gradeable $gradeable */
 
         $gradeable = $this->tryGetGradeable($gradeable_id, false);
@@ -1276,7 +1280,7 @@ class ElectronicGraderController extends AbstractController {
             }
 
             if ($from_graded_gradeable === false) {
-                 $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']));
+                $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']));
             }
 
             // Get the user ID of the user we were viewing on the TA grading interface
@@ -1319,7 +1323,7 @@ class ElectronicGraderController extends AbstractController {
                 }
             }
             if (is_null($who_id) || $who_id == '') {
-                $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])  . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => 'all']));
+                    $this->core->redirect($this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details'])  . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => 'all']));
             }
         }
         // Get the graded gradeable for the submitter we are requesting

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1478,7 +1478,7 @@ class ElectronicGraderController extends AbstractController {
             "action" => "VIEW_PAGE",
         ];
         Logger::logTAGrading($logger_params);
-
+        $anon_mode = isset($_COOKIE['anon_mode']) && $_COOKIE['anon_mode'] === 'on';
         $submitter_itempool_map = $this->getItempoolMapForSubmitter($gradeable, $graded_gradeable->getSubmitter()->getId());
         $solution_ta_notes = $this->getSolutionTaNotesForGradeable($gradeable, $submitter_itempool_map) ?? [];
 
@@ -1490,7 +1490,7 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map);
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollbackSubmission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1235,11 +1235,12 @@ class ElectronicGraderController extends AbstractController {
     public function showGrading($gradeable_id, $who_id = '', $from = "", $to = null, $gradeable_version = null, $sort = "id", $direction = "ASC", $to_ungraded = null, $component_id = "-1", $anon_mode = false) {
         if (empty($this->core->getQueries()->getTeamsById([$who_id])) && $this->core->getQueries()->getUserById($who_id) == null) {
             $anon_mode = true;
+            echo '<script type="text/javascript">';
+            echo ' alert("JavaScript Alert Box by PHP")';  //not showing an alert box.
+            echo '</script>';
         }
-        $anon_mode = false;
-        echo '<script type="text/javascript">';
-        echo ' alert("JavaScript Alert Box by PHP")';  //not showing an alert box.
-        echo '</script>';
+        ///$anon_mode = false;
+
         /** @var Gradeable $gradeable */
 
         $gradeable = $this->tryGetGradeable($gradeable_id, false);

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1235,11 +1235,8 @@ class ElectronicGraderController extends AbstractController {
     public function showGrading($gradeable_id, $who_id = '', $from = "", $to = null, $gradeable_version = null, $sort = "id", $direction = "ASC", $to_ungraded = null, $component_id = "-1", $anon_mode = false) {
         if (empty($this->core->getQueries()->getTeamsById([$who_id])) && $this->core->getQueries()->getUserById($who_id) == null) {
             $anon_mode = true;
-            echo '<script type="text/javascript">';
-            echo ' alert("JavaScript Alert Box by PHP")';  //not showing an alert box.
-            echo '</script>';
         }
-        ///$anon_mode = false;
+
 
         /** @var Gradeable $gradeable */
 

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,6 +1,6 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
     <div id="grading-panel-student-name">
-        <b>{% if not isBlind and not anon_mode and peer_blind_grading is same as('unblind') %}
+        <b>{% if not isBlind and not anon_mode and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single'))%}
                 {% if team_assignment %}
                     Team:<br/>
                     {% for team_member in submitter.getTeam().getMemberUsers() %}
@@ -106,7 +106,7 @@
     </div>
 </div>
 <script>
-    if ({{ not anon_mode and not isBlind}}) {
+    if ({{ not anon_mode and not isBlind and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single'))}}) {
         $('.navigation-box').css({'position':'relative'});
         $('.navigation-box').css({'float':'left'});
         $('.navigation-box').css({'margin-left':'20%'});

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,6 +1,6 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
     <div id="grading-panel-student-name">
-        <b>{% if not limited_access_blind and not isBlind and not anon_mode %}
+        <b>{% if not limited_access_blind and not isBlind %}
                 {% if team_assignment %}
                     Team:<br/>
                     {% for team_member in submitter.getTeam().getMemberUsers() %}

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,6 +1,6 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
     <div id="grading-panel-student-name">
-        <b>{% if not limited_access_blind and not isBlind %}
+        <b>{% if not limited_access_blind and not isBlind and not anon_mode %}
                 {% if team_assignment %}
                     Team:<br/>
                     {% for team_member in submitter.getTeam().getMemberUsers() %}

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,6 +1,6 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
     <div id="grading-panel-student-name">
-        <b>{% if not limited_access_blind %}
+        <b>{% if not limited_access_blind and not isBlind %}
                 {% if team_assignment %}
                     Team:<br/>
                     {% for team_member in submitter.getTeam().getMemberUsers() %}

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,6 +1,6 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
     <div id="grading-panel-student-name">
-        <b>{% if not isBlind and not anon_mode and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single'))%}
+        <b>{% if not isBlind and not anon_mode and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single')) %}
                 {% if team_assignment %}
                     Team:<br/>
                     {% for team_member in submitter.getTeam().getMemberUsers() %}
@@ -106,7 +106,8 @@
     </div>
 </div>
 <script>
-    if ({{ not anon_mode and not isBlind and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single'))}}) {
+    //if student/team name(s) are being displayed
+    if ({{ not anon_mode and not isBlind and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single')) }}) {
         $('.navigation-box').css({'position':'relative'});
         $('.navigation-box').css({'float':'left'});
         $('.navigation-box').css({'margin-left':'20%'});

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,6 +1,6 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
     <div id="grading-panel-student-name">
-        <b>{% if not limited_access_blind and not isBlind and not anon_mode %}
+        <b>{% if not isBlind and not anon_mode and peer_blind_grading is same as('unblind') %}
                 {% if team_assignment %}
                     Team:<br/>
                     {% for team_member in submitter.getTeam().getMemberUsers() %}
@@ -106,9 +106,9 @@
     </div>
 </div>
 <script>
-    if ({{ not anon_mode }}) {
+    if ({{ not anon_mode and not isBlind}}) {
         $('.navigation-box').css({'position':'relative'});
         $('.navigation-box').css({'float':'left'});
-        $('.navigation-box').css({'margin-left':'18%'});
+        $('.navigation-box').css({'margin-left':'20%'});
     }
 </script>

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -105,3 +105,10 @@
         </div>
     </div>
 </div>
+<script>
+    if ({{ not anon_mode }}) {
+        $('.navigation-box').css({'position':'relative'});
+        $('.navigation-box').css({'float':'left'});
+        $('.navigation-box').css({'margin-left':'18%'});
+    }
+</script>

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -1,4 +1,19 @@
 <div id="bar_wrapper" class="ta-nav-wrapper">
+    <div id="grading-panel-student-name">
+        <b>{% if not limited_access_blind %}
+                {% if team_assignment %}
+                    Team:<br/>
+                    {% for team_member in submitter.getTeam().getMemberUsers() %}
+                        &emsp;{{ team_member.getDisplayedFirstName() }} {{ team_member.getDisplayedLastName() }} ({{ team_member.getId() }})<br/>
+                    {% endfor %}
+                {% else %}
+                    Student:<br/>
+                    {{ submitter.getUser().getDisplayedFirstName() }} {{ submitter.getUser().getDisplayedLastName() }} ({{ submitter.getId() }})
+                    <br/>
+                {% endif %}
+            {% endif %}
+        </b>
+    </div>
     <div class="navigation-box">
         <div class="grading_toolbar">
             {# Back to list button #}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -901,7 +901,7 @@ HTML;
         		    <div class="content-items-container">
                     <div class="content-item content-item-right">
 HTML;
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->isPeerGrading(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2),$anon_mode,$blind_grading);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->isPeerGrading(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2), $anon_mode, $blind_grading);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1079,7 +1079,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode,$blind_grading) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if ($gradeable->getLimitedAccessBlind() == 2) {

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -909,7 +909,8 @@ HTML;
                 $isStudentInfoPanel,
                 $isDiscussionPanel,
                 $isRegradePanel,
-                $gradeable->getAutogradingConfig()->isNotebookGradeable()
+                $gradeable->getAutogradingConfig()->isNotebookGradeable(),
+                $graded_gradeable
             );
 
             $return .= <<<HTML
@@ -1079,6 +1080,7 @@ HTML;
      * @return string
      */
     public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind) {
+        $gradeable = $graded_gradeable->getGradeable();
         $home_url = $this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'details']) . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => (count($this->core->getUser()->getGradingRegistrationSections()) == 0) ? 'all' : null ]);
 
         $studentBaseUrl = $this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'grade']);
@@ -1107,7 +1109,9 @@ HTML;
             "home_url" => $home_url,
             'regrade_panel_available' => $this->core->getConfig()->isRegradeEnabled() && $this->core->getUser()->getGroup() < 4,
             'grade_inquiry_pending' => $graded_gradeable->hasActiveRegradeRequest(),
-            'discussion_based' => $graded_gradeable->getGradeable()->isDiscussionBased()
+            'discussion_based' => $graded_gradeable->getGradeable()->isDiscussionBased(),
+            'submitter' => $graded_gradeable->getSubmitter(),
+            'team_assignment' => $gradeable->isTeamAssignment()
         ]);
     }
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1081,6 +1081,10 @@ HTML;
      */
     public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind) {
         $gradeable = $graded_gradeable->getGradeable();
+        $isBlind = false;
+        if($gradeable->getLimitedAccessBlind() == 2){
+            $isBlind = true;
+        }
         $home_url = $this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'details']) . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => (count($this->core->getUser()->getGradingRegistrationSections()) == 0) ? 'all' : null ]);
 
         $studentBaseUrl = $this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'grade']);
@@ -1111,7 +1115,8 @@ HTML;
             'grade_inquiry_pending' => $graded_gradeable->hasActiveRegradeRequest(),
             'discussion_based' => $graded_gradeable->getGradeable()->isDiscussionBased(),
             'submitter' => $graded_gradeable->getSubmitter(),
-            'team_assignment' => $gradeable->isTeamAssignment()
+            'team_assignment' => $gradeable->isTeamAssignment(),
+            'isBlind' => $isBlind
         ]);
     }
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -856,7 +856,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $rollbackSubmission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $rollbackSubmission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading) {
 
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $isPeerPanel = false;
@@ -901,7 +901,7 @@ HTML;
         		    <div class="content-items-container">
                     <div class="content-item content-item-right">
 HTML;
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->isPeerGrading(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2),$anon_mode);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->isPeerGrading(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2),$anon_mode,$blind_grading);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1079,7 +1079,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode,$blind_grading) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if ($gradeable->getLimitedAccessBlind() == 2) {
@@ -1103,6 +1103,7 @@ HTML;
         }
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "anon_mode" => $anon_mode,
+            "peer_blind_grading" => $blind_grading,
             "progress" => $progress,
             "peer_gradeable" => $peer,
             "i_am_a_peer" => $i_am_a_peer,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -856,7 +856,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $rollbackSubmission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $rollbackSubmission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode) {
 
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $isPeerPanel = false;
@@ -901,7 +901,7 @@ HTML;
         		    <div class="content-items-container">
                     <div class="content-item content-item-right">
 HTML;
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->isPeerGrading(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2));
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->isPeerGrading(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2),$anon_mode);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1079,7 +1079,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if ($gradeable->getLimitedAccessBlind() == 2) {
@@ -1102,6 +1102,7 @@ HTML;
             $i_am_a_peer = true;
         }
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
+            "anon_mode" => $anon_mode,
             "progress" => $progress,
             "peer_gradeable" => $peer,
             "i_am_a_peer" => $i_am_a_peer,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -866,6 +866,7 @@ HTML;
         // WIP: Replace this logic when there is a definitive way to get my peer-ness
         // If this is a peer gradeable but I am not allowed to view the peer panel, then I must be a peer.
         if ($gradeable->isPeerGrading()) {
+            $anon_mode = false;
             if ($this->core->getUser()->getGroup() !== 4) {
                 $isPeerPanel = true;
                 $isStudentInfoPanel = true;

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1082,7 +1082,7 @@ HTML;
     public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
-        if($gradeable->getLimitedAccessBlind() == 2){
+        if ($gradeable->getLimitedAccessBlind() == 2) {
             $isBlind = true;
         }
         $home_url = $this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'details']) . '?' . http_build_query(['sort' => $sort, 'direction' => $direction, 'view' => (count($this->core->getUser()->getGradingRegistrationSections()) == 0) ? 'all' : null ]);

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -49,6 +49,12 @@ aside {
     padding: 6px 0;
 }
 
+#bar_banner{
+    position: relative;
+    float: right;
+    margin-right: 10%;
+}
+
 .navigation-box {
     margin: 0 auto;
     display: flex;

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -50,10 +50,10 @@ aside {
 }
 
 .navigation-box {
-    margin: 0 auto;
     display: flex;
     width: max-content;
     max-width: 100%;
+    margin-left: 30%;
 }
 
 .navigation-box.smaller-navbar .progress_bar {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -483,6 +483,12 @@ progress::-webkit-progress-value {
     padding-top: 20%;
 }
 
+#grading-panel-student-name{
+    position: relative;
+    float: left;
+    padding-left: 5px;
+}
+
 #regrade_inner_info .inner-container {
     padding: 20px;
 }

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -50,7 +50,7 @@ aside {
 }
 
 .navigation-box {
-    margin-left: 30%;
+    margin: 0 auto;
     display: flex;
     width: max-content;
     max-width: 100%;

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -50,10 +50,10 @@ aside {
 }
 
 .navigation-box {
+    margin-left: 30%;
     display: flex;
     width: max-content;
     max-width: 100%;
-    margin-left: 30%;
 }
 
 .navigation-box.smaller-navbar .progress_bar {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -66,10 +66,6 @@ aside {
     display: none;
 }
 
-.navigation-box.smaller-navbar #grading-panel-student-name {
-    color: black;
-}
-
 .navigation-box.smaller-navbar .progress-value {
     position: unset;
     display: block;

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -66,6 +66,10 @@ aside {
     display: none;
 }
 
+.navigation-box.smaller-navbar #grading-panel-student-name {
+    color: black;
+}
+
 .navigation-box.smaller-navbar .progress-value {
     position: unset;
     display: block;

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -743,7 +743,10 @@ function toggleFullLeftColumnMode (forceVal = false) {
   document.querySelector(newPanelsContSelector).prepend(leftPanelCont, dragBar);
 
   panelsContSelector = newPanelsContSelector;
-  $("#grading-panel-student-name").hide();
+  if(!taLayoutDet.isFullScreenMode){
+    $("#grading-panel-student-name").hide();
+  }
+
 }
 
 /**

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -725,6 +725,9 @@ function toggleFullScreenMode () {
   initializeResizablePanels(leftSelector, verticalDragBarSelector, false, saveResizedColsDimensions);
   //Save the taLayoutDetails in LS
   saveTaLayoutDetails();
+  if(taLayoutDet.isFullLeftColumnMode){
+    $("#grading-panel-student-name").toggle();
+  }
 }
 
 function toggleFullLeftColumnMode (forceVal = false) {
@@ -740,6 +743,7 @@ function toggleFullLeftColumnMode (forceVal = false) {
   document.querySelector(newPanelsContSelector).prepend(leftPanelCont, dragBar);
 
   panelsContSelector = newPanelsContSelector;
+  $("#grading-panel-student-name").hide();
 }
 
 /**
@@ -759,6 +763,9 @@ function changePanelsLayout(panelsCount, isLeftTaller, twoOnRight = false) {
   initializeResizablePanels(leftSelector, verticalDragBarSelector, false, saveResizedColsDimensions);
   initializeHorizontalTwoPanelDrag();
   togglePanelSelectorModal(false);
+  if(!taLayoutDet.isFullLeftColumnMode){
+    $("#grading-panel-student-name").show();
+  }
 }
 
 function togglePanelLayoutModes(forceVal = false) {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -224,7 +224,7 @@ function notebookScrollSave() {
     var notebookTop = $('#notebook-view').offset().top;
     var element = $('#content_0');
     if(notebookView.scrollTop() + notebookView.innerHeight() + 1 > notebookView[0].scrollHeight) {
-      element = $('[id^=content_').last();
+      element = $('[id^=content_]').last();
     } else {
       while (element.length !== 0) {
         if (element.offset().top > notebookTop) {
@@ -743,10 +743,10 @@ function toggleFullLeftColumnMode (forceVal = false) {
   document.querySelector(newPanelsContSelector).prepend(leftPanelCont, dragBar);
 
   panelsContSelector = newPanelsContSelector;
+
   if(!taLayoutDet.isFullScreenMode){
     $("#grading-panel-student-name").hide();
   }
-
 }
 
 /**

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -725,9 +725,6 @@ function toggleFullScreenMode () {
   initializeResizablePanels(leftSelector, verticalDragBarSelector, false, saveResizedColsDimensions);
   //Save the taLayoutDetails in LS
   saveTaLayoutDetails();
-  if(taLayoutDet.isFullLeftColumnMode){
-    $("#grading-panel-student-name").toggle();
-  }
 }
 
 function toggleFullLeftColumnMode (forceVal = false) {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -741,7 +741,7 @@ function toggleFullLeftColumnMode (forceVal = false) {
 
   panelsContSelector = newPanelsContSelector;
 
-  if(!taLayoutDet.isFullScreenMode){
+  if (!taLayoutDet.isFullScreenMode) {
     $("#grading-panel-student-name").hide();
   }
 }
@@ -763,7 +763,7 @@ function changePanelsLayout(panelsCount, isLeftTaller, twoOnRight = false) {
   initializeResizablePanels(leftSelector, verticalDragBarSelector, false, saveResizedColsDimensions);
   initializeHorizontalTwoPanelDrag();
   togglePanelSelectorModal(false);
-  if(!taLayoutDet.isFullLeftColumnMode){
+  if (!taLayoutDet.isFullLeftColumnMode) {
     $("#grading-panel-student-name").show();
   }
 }


### PR DESCRIPTION

### What is the current behavior?
Currently if a TA, peer or instructor is grading an assignment the only place they can see the name of the person or team they are grading is in the student info tab. For peers however, the student info tab is not available (by design) so they might have no way of knowing who they are grading. 

### What is the new behavior?
Now as long as blind grading and anonymous mode are disabled, the name/names of the student or team being graded will be displayed on the TA Grading navigation bar. For peer grading, if single or double blind grading are enabled by the instructor, the name will not be displayed. We made a design choice to make the name go away if the user chooses a panel layout where there is a full left column because it shrinks the nav bar by 50% and there is no longer room for the names to be displayed.
<img width="852" alt="pr5_1" src="https://user-images.githubusercontent.com/66340271/119550927-03ebd380-bd67-11eb-9813-6cf58693aae1.PNG">
<img width="819" alt="pr5_2" src="https://user-images.githubusercontent.com/66340271/119550943-06e6c400-bd67-11eb-9675-79ed19161b7f.PNG">

### Other information?
While this feature is mostly to help with peer grading, the names will also be displayed for TA and instructor grading.

I had to use a sort of hacky method to center the nav bar when the student name is being displayed because having another div there throws everything off and I wasn't sure what the best way to handle it is. Please make suggestions if you have them.
