### PR TITLE
[UI/UX:TAGrading] Fix Zip Button Contrast in Dark Mode

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -236,14 +236,14 @@ div.btn-container {
 
 #zip_link_limited {
     text-decoration:none;
-    color:white;
+    color: var(--text-black);
     padding:10px;
     padding-left:0px;
 }
 
 #zip_link_full {
     text-decoration:none;
-    color:black;
+    color: var(--text-black);
     padding:10px;
     padding-left:0px;
 }


### PR DESCRIPTION
### What is the current behavior?
Fixes #6503 
Currently, the Download Zip button text on the grading page is black.

![image](https://user-images.githubusercontent.com/28243927/119558768-d6efee80-bd6f-11eb-9acb-40c90f5fa332.png)
![image](https://user-images.githubusercontent.com/28243927/119558779-da837580-bd6f-11eb-8f3c-f11ff0606aef.png)

### What is the new behavior?
The text now adapts to the site theme.

![image](https://user-images.githubusercontent.com/28243927/119558947-0acb1400-bd70-11eb-9620-9555e7ec4664.png)
![image](https://user-images.githubusercontent.com/28243927/119558832-ec651880-bd6f-11eb-9e78-93d74bd64ac8.png)
