### PR TITLE
[Bugfix:HelpQueue] individual queue usage stats page

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6151,7 +6151,7 @@ AND gc_id IN (
               LEFT JOIN (SELECT
                 user_id,"
                 . $this->getInnerQueueSelect() .
-               "SUM(CASE
+               ",SUM(CASE
                   WHEN removal_type IN ('removed', 'emptied', 'self') THEN 1
                   ELSE 0
                 END) AS not_helped_count


### PR DESCRIPTION
### What is the current behavior?
If you log in as an instructor and go to office hours queue => view queue stats => view student specific stats, the page doesn't load and throws an ugly error.
<img width="780" alt="pr6_1" src="https://user-images.githubusercontent.com/66340271/119668805-7b704000-be05-11eb-98c4-c40a193a4d17.PNG">

### What is the new behavior?
The page loads properly
<img width="876" alt="pr6_2" src="https://user-images.githubusercontent.com/66340271/119668991-a8245780-be05-11eb-8630-d3b25d94a24e.PNG">

### Other information?

