### PR TITLE
[Bugfix:Plagiarism] Display Plagiarism Config Invalid Inputs

### DIFF
--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -83,13 +83,13 @@
             <div class="plag-data-group">
                 <div class="plag-data-label">Threshold/Maximum number of students (more than this number of students with matching code will be considered common code):</div>
                 <div class="plag-data">
-                    <input type="text" name="threshold" value="{{ threshold }}" />
+                    <input type="text" name="threshold" value="{{ threshold }}" placeholder="(Required)"/>
                 </div>
             </div>
             <div class="plag-data-group">
                 <div class="plag-data-label">Sequence Length:</div>
                 <div class="plag-data">
-                    <input type="text" name="sequence_length" value="{{ sequence_length }}"/>
+                    <input type="text" name="sequence_length" value="{{ sequence_length }}" placeholder="(Required)"/>
                 </div>
             </div>
             <div class="plag-data-group">
@@ -205,5 +205,16 @@
         const ignore_submission_number = $('[name="ignore_submission_number"]', form).val();
         $('#ignore_submission_div', form).append('<br /><input type="text" name="ignore_submission_'+ ignore_submission_number +'" class="low-margin-top"/>');
         $('[name="ignore_submission_number"]', form).val(parseInt(ignore_submission_number)+1);
+    });
+
+    $('[name="threshold"], [name="sequence_length"]').change(function(){
+        if($(this).val().length === 0){
+            $(this)[0].setCustomValidity('Input is required');
+        }
+        else if(!(/^[\d]+$/g).test($(this).val())){
+            $(this)[0].setCustomValidity('Input must only contain numeric characters');
+        } else {
+            $(this)[0].setCustomValidity('');
+        }
     });
 </script>

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -40,6 +40,18 @@ input[type="text"], select {
     width: 100%;
 }
 
+input[type=text]:invalid {
+    background-color: var(--alert-invalid-entry-pink);
+}
+
+[data-theme="dark"] input[type=text]:invalid {
+    background-color: var(--alert-danger-red);
+}
+
+[data-theme="dark"] input[type=text]:invalid::placeholder {
+    color: var(--alert-invalid-entry-pink);
+}
+
 #prev_gradeable_div {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
### What is the current behavior?
Fixes #6508 
Entering invalid inputs (Threshold and Sequence length) in the plagiarism configuration screen doesn't register the inputs as invalid or change their background color. You just receive an alert that at least one of them is invalid when you submit the form.

### What is the new behavior?
* Inputs (Threshold and Sequence Length) will now be marked as invalid and have their background color changed. 
* A tooltip will appear under the field with the invalid input when trying to submit.
* Colors are contrast-friendly on all site themes
