### PR TITLE
[Bugfix:System] Add guard on constraint drop

### DIFF
--- a/migration/migrator/migrations/course/20210521231204_team_id_constraint.py
+++ b/migration/migrator/migrations/course/20210521231204_team_id_constraint.py
@@ -6,10 +6,5 @@ one grade per individual.
 
 
 def up(config, database, semester, course):
-    database.execute("ALTER TABLE public.gradeable_data DROP CONSTRAINT g_id_gd_team_id_unique;");
+    database.execute("ALTER TABLE public.gradeable_data DROP CONSTRAINT IF EXISTS g_id_gd_team_id_unique;");
     database.execute("ALTER TABLE ONLY public.gradeable_data ADD CONSTRAINT g_id_gd_team_id_unique UNIQUE (g_id, gd_team_id);");
-    pass
-
-
-def down(config, database, semester, course):
-    pass


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The migration to add the unique constraint to gradeable_data has an issue where the `DROP CONSTRAINT` would error out if `g_id_gd_team_id_unique` did not exist.

### What is the new behavior?

We use a `IF EXISTS` to guard on the constraint drop so that the migration will not error if it does not exist.
