### PR TITLE
[UI/UX:InstructorUI] Collection of Contrast Fixes

### DIFF
--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -496,8 +496,9 @@ input[type="button"].btn-block {
 }
 
 .alert-danger a,
-.alert-error a {
-    color: var(--alert-danger-red);
+.alert-error a,
+.alert-success a {
+    color: inherit;
 }
 
 .alert-danger h4,

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -495,6 +495,11 @@ input[type="button"].btn-block {
     border-color: var(--alert-border-danger-red);
 }
 
+.alert-danger a,
+.alert-error a {
+    color: var(--alert-danger-red);
+}
+
 .alert-danger h4,
 .alert-error h4 {
     color: var(--gray-red);

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -67,7 +67,7 @@
     --standard-light-medium-gray: #bbbbbb;
     --standard-medium-gray: #888888;
     --standard-medium-dark-gray: #666666;
-    --standard-dark-gray: #5555555;
+    --standard-dark-gray: #555555;
     --standard-deep-dark-gray: #2e2e2e;
 
     --standard-gray-black: #111111;
@@ -274,7 +274,7 @@
       --standard-light-medium-gray: #bbbbbb;
       --standard-medium-gray: #A3A3A3;
       --standard-medium-dark-gray: #666666;
-      --standard-dark-gray: #5555555;
+      --standard-dark-gray: #555555;
       --standard-deep-dark-gray: #2e2e2e;
 
       --standard-gray-black: #111111;

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -20,38 +20,6 @@ th{
     display: none;
 }
 
-/*
-  This will hide elements on phones. This is useful for extra content that
-  is not normally needed such as a user id
-*/
-@media only screen and (max-width: 479px) {
-
-    /* Put this on elements you dont need on mobile */
-    .mobile-hide {
-        display: none !important;
-    }
-
-    .finish_helping_btn{
-      white-space: normal;
-      width: 5rem;
-    }
-
-    .filter_settings_btn{
-      width: 4rem;
-    }
-
-    .content{
-      padding: 20px;
-    }
-}
-
-/* Put this on elements you dont need on desktop */
-@media only screen and (min-width: 480px) {
-    .desktop-hide {
-        display: none !important;
-    }
-}
-
 .current_queue_row, a > i.fas{
   color: var(--btn-text-black);
 }
@@ -64,8 +32,12 @@ th{
 }
 
 #announcement {
-  background: var(--standard-light-gray);
+  background-color: var(--standard-light-gray);
   padding: .75rem;
+}
+
+[data-theme="dark"] #announcement {
+  background-color: var(--standard-dark-gray);
 }
 
 #contact_info {
@@ -80,4 +52,36 @@ th{
 .filter-buttons:hover, .filter-buttons:focus{
     opacity: 0.8;
     filter: alpha(opacity=80);
+}
+
+/*
+  This will hide elements on phones. This is useful for extra content that
+  is not normally needed such as a user id
+*/
+@media only screen and (max-width: 479px) {
+
+  /* Put this on elements you dont need on mobile */
+  .mobile-hide {
+      display: none !important;
+  }
+
+  .finish_helping_btn{
+    white-space: normal;
+    width: 5rem;
+  }
+
+  .filter_settings_btn{
+    width: 4rem;
+  }
+
+  .content{
+    padding: 20px;
+  }
+}
+
+/* Put this on elements you dont need on desktop */
+@media only screen and (min-width: 480px) {
+  .desktop-hide {
+      display: none !important;
+  }
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -123,6 +123,27 @@ input[type="color"] {
     width: auto;
 }
 
+[data-theme="dark"]
+select,
+textarea,
+input[type="text"],
+input[type="password"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="date"],
+input[type="month"],
+input[type="time"],
+input[type="week"],
+input[type="number"],
+input[type="email"],
+input[type="url"],
+input[type="search"],
+input[type="tel"],
+input[type="color"] {
+    color: var(--text-black);
+}
+
+
 input.readonly {
     background-color: var(--standard-pale-gray);
     cursor: not-allowed;
@@ -1485,11 +1506,11 @@ end of styles used in the admin gradeable page
     border-right: none;
 }
 
-.ta-grading-setting-list tr:nth-child(even) {
+.ta-grading-setting-list tr:nth-child(odd) {
     background-color: var(--standard-hover-light-gray);
 }
 
-.ta-grading-setting-list tr:nth-child(odd) {
+.ta-grading-setting-list tr:nth-child(even) {
     background-color: var(--default-white);
 }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1486,7 +1486,11 @@ end of styles used in the admin gradeable page
 }
 
 .ta-grading-setting-list tr:nth-child(even) {
-    background-color: var(--standard-pale-gray);
+    background-color: var(--standard-hover-light-gray);
+}
+
+.ta-grading-setting-list tr:nth-child(odd) {
+    background-color: var(--default-white);
 }
 
 .ta-grading-setting-list td {


### PR DESCRIPTION
### What is the current behavior?
Fixes #6512 
Contrast issues currently exist in the following places:
* _(DARK MODE)_ Hotkey Settings menu found on the Grade page of a Lab (checkpoint) gradeable.

![image](https://user-images.githubusercontent.com/28243927/119710347-3f040a80-be2c-11eb-9c52-b60c2034b141.png)
* _(DARK MODE)_ Office Hours Announcement

![image](https://user-images.githubusercontent.com/28243927/119710213-1b40c480-be2c-11eb-8dd1-79a2f772764e.png)
* _(DARK MODE)_ Closing X button on any alert-error or alert-success (ex. Go to Late Days page as instructor and submit data to see).

![image](https://user-images.githubusercontent.com/28243927/119710795-c9e50500-be2c-11eb-8ebd-6fa7259713d5.png)
![image](https://user-images.githubusercontent.com/28243927/119710702-a9b54600-be2c-11eb-869b-65f1e6b72b0e.png)

* The ```--standard-dark-gray``` color is broken

### What is the new behavior?
* _(DARK MODE)_ Hotkey Settings Menu contrast is fixed.

![image](https://user-images.githubusercontent.com/28243927/119711520-a3739980-be2d-11eb-9ada-616dffd664dc.png)

* _(DARK MODE)_ Office Hours Announcement contrast has been improved to a 7:1 ratio

![image](https://user-images.githubusercontent.com/28243927/119711676-cb62fd00-be2d-11eb-80cc-d5618e9324be.png)
* Closing X button color now matches alert type (red for errors, green for success) in all site themes

![image](https://user-images.githubusercontent.com/28243927/119711830-f64d5100-be2d-11eb-9b55-2389fb216bd5.png)
![image](https://user-images.githubusercontent.com/28243927/119711894-06fdc700-be2e-11eb-926c-4d62678e5e26.png)


* The ```--standard-dark-gray``` color is fixed. Some places that previously used this color incorrectly had their colors changed to the actual color they were displaying.