### PR TITLE
[Bugfix:TAGrading] fixed anonymous mode for peer gradeables

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -451,14 +451,14 @@ HTML;
         if ($peer || $anon_mode) {
             $columns[]         = ["width" => "5%",  "title" => "",                 "function" => "index"];
             if ($gradeable->isTeamAssignment()) {
-                if ($gradeable->getPeerBlind() === Gradeable::DOUBLE_BLIND_GRADING) {
+                if ($gradeable->getPeerBlind() === Gradeable::DOUBLE_BLIND_GRADING || $anon_mode) {
                     $columns[] = ["width" => "30%", "title" => "Team Members",     "function" => "team_members_anon"];
                 }
                 else {
                     $columns[] = ["width" => "32%", "title" => "Team Members",     "function" => "team_members"];
                 }
             }
-            elseif ($gradeable->getPeerBlind() !== Gradeable::DOUBLE_BLIND_GRADING) {
+            elseif ($gradeable->getPeerBlind() !== Gradeable::DOUBLE_BLIND_GRADING && !$anon_mode) {
                 $columns[]         = ["width" => "30%", "title" => "Student",          "function" => "user_id"];
             }
             else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
Currently If an instructor configures a peer gradeable to be an unblinded or single blinded grading assignment, when a TA is on the student details page of the grading interface and they click enable anonymous mode, the format of the page changes but the names are still displayed instead of hashes.

### What is the new behavior?
Anonymous mode works as expected for all peer gradeables.

### Other information?
How to test:
On master,
As an instructor configure or edit a peer gradeable to be unblind or single blind
log in as a TA and switch toggle anonymous mode.
See error

On peer-anon-bug branch,
As an instructor configure or edit a peer gradeable to be unblind or single blind
log in as a TA and switch toggle anonymous mode.
See results
