### PR TITLE
[Bugfix:TAGrading] Submission file half line bug

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -35,7 +35,7 @@
             </span>
             <br />
             {# Files #}
-            <div class="inner-container" id="file-container" style="padding-top: 10px;">
+            <div class="inner-container open" id="file-container" style="padding-top: 10px;">
                 {{ self.display_files(self, submissions, "s", 0, "submissions") }}
                 {% if has_vcs_files %} {# if there are checkout files, then display folder, otherwise don't #}
                     {{ self.display_files(self, checkout, "c", 0, "checkout") }}

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1112,7 +1112,7 @@ function openAll(click_class, class_modifier) {
   $("."+click_class + class_modifier).each(function(){
     // Check that the file is not a PDF before clicking on it
     //console.log($(this).attr('id'));
-    if ($(this).parent().parent().parent().hasClass("open") || $(this).parent().hasClass("open")){
+    if ($(this).parent().parent().parent().hasClass("open")){
       let innerText = Object.values($(this))[0].innerText;
       if (innerText.slice(-4) !== ".pdf") {
         $(this).click();

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1315,6 +1315,8 @@ function newEditPeerComponentsForm() {
 
 function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submission") {
   let iframe = $('#file_viewer_' + num);
+  if (!$(iframe).parent().parent().hasClass("open"))
+    return false;
   let display_file_url = buildCourseUrl(['display_file']);
   if (!iframe.hasClass('open') || iframe.hasClass('full_panel')) {
     let iframeId = "file_viewer_" + num + "_iframe";

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1111,9 +1111,12 @@ function checkOpenComponentMark(index) {
 function openAll(click_class, class_modifier) {
   $("."+click_class + class_modifier).each(function(){
     // Check that the file is not a PDF before clicking on it
-    let innerText = Object.values($(this))[0].innerText;
-    if (innerText.slice(-4) !== ".pdf") {
-      $(this).click();
+    //console.log($(this).attr('id'));
+    if ($(this).parent().parent().parent().hasClass("open") || $(this).parent().hasClass("open")){
+      let innerText = Object.values($(this))[0].innerText;
+      if (innerText.slice(-4) !== ".pdf") {
+        $(this).click();
+      }
     }
   });
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1315,8 +1315,9 @@ function newEditPeerComponentsForm() {
 
 function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submission") {
   let iframe = $('#file_viewer_' + num);
-  if (!$(iframe).parent().parent().hasClass("open"))
+  if (!$(iframe).parent().parent().hasClass("open")){
     return false;
+  }
   let display_file_url = buildCourseUrl(['display_file']);
   if (!iframe.hasClass('open') || iframe.hasClass('full_panel')) {
     let iframeId = "file_viewer_" + num + "_iframe";

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1315,9 +1315,6 @@ function newEditPeerComponentsForm() {
 
 function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submission") {
   let iframe = $('#file_viewer_' + num);
-  if (!$(iframe).parent().parent().hasClass("open")){
-    return false;
-  }
   let display_file_url = buildCourseUrl(['display_file']);
   if (!iframe.hasClass('open') || iframe.hasClass('full_panel')) {
     let iframeId = "file_viewer_" + num + "_iframe";
@@ -1342,6 +1339,8 @@ function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submiss
       });
     }
     else {
+      if (!iframe.parent().parent().hasClass("open"))
+        return false;
       let forceFull = url_file.substring(url_file.length - 3) === "pdf" ? 500 : -1;
       let targetHeight = iframe.hasClass("full_panel") ? 1200 : 500;
       let frameHtml = `


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #4525 

It was possible to produce a bug where when viewing the files submitted by a student in a gradeable, the frame for the file only shows half of a line.  The bug is also not fixable on the client's side without reloading the page or editing the html elements. The steps to produce this is the following:
 1. Go to the grading interface as a TA for a student
 2. Open the files panel in any panel viewing mode
 3. Open the Submissions folder
 4. Click the Open/Close Submissions button
 5. Open the Submissions folder again
 6. Each file is now displayed with only half a line of display
![image](https://user-images.githubusercontent.com/49821332/119723192-2ea75c00-be3b-11eb-8a5c-c69f1c48c4aa.png)


### What is the new behavior?
The bug is fixed and following the above steps does not automatically open the files when you open the submissions folder a second time.
When you open the Submissions folder a second time:
![image](https://user-images.githubusercontent.com/49821332/119723576-9a89c480-be3b-11eb-9e9f-6ccb488ae69f.png)
When you open each file inside the folder:
![image](https://user-images.githubusercontent.com/49821332/119723625-a9707700-be3b-11eb-958e-10047d024345.png)
