### PR TITLE
[Bugfix:Plagiarism] Fix bug when re-running plagiarism

### DIFF
--- a/sbin/run_lichen_plagiarism.py
+++ b/sbin/run_lichen_plagiarism.py
@@ -61,9 +61,8 @@ def main():
         log_json = open(log_path, 'w+')
 
     start_time = time.time()
-    if (previous_hash == None or (previous_hash != config_hash and config_regex_changed)):
-        concat_res = subprocess.call(['/usr/local/submitty/Lichen/bin/concatenate_all.py', config_path ])
-        tok_res = subprocess.call(['/usr/local/submitty/Lichen/bin/tokenize_all.py', config_path ])
+    concat_res = subprocess.call(['/usr/local/submitty/Lichen/bin/concatenate_all.py', config_path ])
+    tok_res = subprocess.call(['/usr/local/submitty/Lichen/bin/tokenize_all.py', config_path ])
     hash_res = subprocess.call(['/usr/local/submitty/Lichen/bin/hash_all.py', config_path ])
     compare_res = subprocess.call(['/usr/local/submitty/Lichen/bin/compare_hashes.out', config_path ])
     end_time = time.time()

--- a/sbin/run_lichen_plagiarism.py
+++ b/sbin/run_lichen_plagiarism.py
@@ -32,15 +32,17 @@ def main():
     course = sys.argv[2]
     gradeable = sys.argv[3]
     config_hash = ""
-    config_regex_changed = ""
     config_path = "/var/local/submitty/courses/"+ semester + "/" +course+ "/lichen/config/lichen_"+ semester+"_"+ course+ "_" +gradeable+".json"
     log_path = f"/var/local/submitty/courses/{semester}/{course}/lichen/logs/{gradeable}/run_results.json"
-    log_json = None
+    log_json = open(log_path, 'w+')
     rank_path = f"/var/local/submitty/courses/{semester}/{course}/lichen/ranking/{gradeable}.txt"
     matches_path = f"/var/local/submitty/courses/{semester}/{course}/lichen/matches/{gradeable}"
     hashes_path = f"/var/local/submitty/courses/{semester}/{course}/lichen/hashes/{gradeable}"
+
+    # Remove ranking from previous run
     if os.path.exists(rank_path):
         os.remove(rank_path)
+
     # Clear hashes/matches from previous run...
     if os.path.isdir(matches_path):
         rmtree(matches_path)
@@ -52,13 +54,6 @@ def main():
     with open(config_path, 'r') as j:
         json_data = json.load(j)
         config_hash = "" if 'hash' not in json_data else json_data['hash']
-        config_regex_changed = "" if 'regex_updated' not in json_data else json_data['regex_updated']
-    previous_hash = None
-    try:
-        log_json = open(log_path, 'r+')
-        previous_hash = json.load(log_json)['config_hash']
-    except:
-        log_json = open(log_path, 'w+')
 
     start_time = time.time()
     concat_res = subprocess.call(['/usr/local/submitty/Lichen/bin/concatenate_all.py', config_path ])


### PR DESCRIPTION
### What is the current behavior?
Currently, an error occurs in the lichen run log when re-running plagiarism detection on an existing gradeable.  The gradeable disappears from the list of configured gradeables but is unable to be reconfigured.  From the client side, it appears to simply disappear altogether.  This is due to an error in `sbin/run_lichen_plagiarism.py` which causes some files to be deleted and some to not be deleted.

The code currently has logic which attempts to not rehash files when re-running a gradeable.  This logic is partially broken and incomplete.

### What is the new behavior?
This PR removes unnecessary, buggy, logic from `sbin/run_lichen_plagiarism.py`.  When re-running plagiarism, the code now hashes and concatenates all of the submissions again, all the time.  Concatenating and hashing take less than 2% of the total running time on most test cases so there is no performance difference.