### PR TITLE
[UI/UX:InstructorUI] No option gradeable config

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -231,7 +231,10 @@
     
     function dropDownArrowOnClick() {
         let options = $(this).parent().parent().find(".drop-down-options");
-        if (!$(options).is(":visible")) {
+        if ($(options).is(":visible")) {
+            $(options).hide();
+        }
+        else {
             $(options).show();
         }
     }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -1,33 +1,33 @@
 <div class="electronic_file">
 
-        <div class="option-title">
-            What are students allowed to do?
-        </div>
-        <div>
-            <fieldset>
-                <legend>View the gradeable on the course home page and download submitted files?</legend>
-                <input type="radio" id="no_student_view_after_grades" name="student_view_after_grades" value="false"
-                        {{ gradeable.isStudentView() and not gradeable.isStudentViewAfterGrades() ? 'checked' : '' }}/> <label for="no_student_view_after_grades">Yes</label>
-                <input type="radio" id="no_student_view" name="student_view" value="false"
-                        {{ not gradeable.isStudentView() ? 'checked' : '' }}/> <label for="no_student_view">No</label>
-                <input type="radio" id="yes_student_view_after_grades" name="student_view_after_grades" value="true"
-                        {{ gradeable.isStudentView() and gradeable.isStudentViewAfterGrades() ? 'checked' : '' }}/> <label for="yes_student_view_after_grades">When grades are released</label>
-                <div hidden>
-                    <input type="radio" id="yes_student_view" name="student_view" value="true"
-                        {{ gradeable.isStudentView() ? 'checked' : '' }} aria-label="student view"/>
-                </div>
-            </fieldset>
-        </div>
-
-        <div id="student_submit_view">
-            <div>
-                <fieldset><legend>Make new submissions and access all prior versions?</legend>
-                <input type="radio" id="yes_student_submit" name="student_submit" value="true"
-                        {{ gradeable.isStudentSubmit() ? 'checked' : '' }}/> <label for="yes_student_submit">Yes</label>
-                <input type="radio" id="no_student_submit" name="student_submit" value="false"
-                        {{ not gradeable.isStudentSubmit() ? 'checked' : '' }}/> <label for="no_student_submit">No</label></fieldset>
+    <div class="option-title">
+        What are students allowed to do?
+    </div>
+    <div>
+        <fieldset>
+            <legend>View the gradeable on the course home page and download submitted files?</legend>
+            <input type="radio" id="no_student_view_after_grades" name="student_view_after_grades" value="false"
+                    {{ gradeable.isStudentView() and not gradeable.isStudentViewAfterGrades() ? 'checked' : '' }}/> <label for="no_student_view_after_grades">Yes</label>
+            <input type="radio" id="no_student_view" name="student_view" value="false"
+                    {{ not gradeable.isStudentView() ? 'checked' : '' }}/> <label for="no_student_view">No</label>
+            <input type="radio" id="yes_student_view_after_grades" name="student_view_after_grades" value="true"
+                    {{ gradeable.isStudentView() and gradeable.isStudentViewAfterGrades() ? 'checked' : '' }}/> <label for="yes_student_view_after_grades">When grades are released</label>
+            <div hidden>
+                <input type="radio" id="yes_student_view" name="student_view" value="true"
+                    {{ gradeable.isStudentView() ? 'checked' : '' }} aria-label="student view"/>
             </div>
+        </fieldset>
+    </div>
+
+    <div id="student_submit_view">
+        <div>
+            <fieldset><legend>Make new submissions and access all prior versions?</legend>
+            <input type="radio" id="yes_student_submit" name="student_submit" value="true"
+                    {{ gradeable.isStudentSubmit() ? 'checked' : '' }}/> <label for="yes_student_submit">Yes</label>
+            <input type="radio" id="no_student_submit" name="student_submit" value="false"
+                    {{ not gradeable.isStudentSubmit() ? 'checked' : '' }}/> <label for="no_student_submit">No</label></fieldset>
         </div>
+    </div>
 <br><br>
 
     <div class="option-title">Choose an autograding configuration:</div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -44,14 +44,6 @@
         {% endif %}
 
     <div class="settings">
-        {#<input class="config_search ignore" type="text" id="config_search" list="path_data" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
-            autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration" />
-        <a class="fas fa-times key_to_click" id= "clear_search_button" onclick="clearButtonPress();" tabindex="0"></a>
-        <datalist id="path_data" style="display:none" >
-        {% for path in all_config_paths %}
-            <option class="path_autofill_option" data-name="{{path.0}}" data-value="{{path.1}}"  style="display:none" >{{path.0}}</option>
-        {% endfor %}
-        </datalist>#}
         <div class="drop-down" id="config-drop-down">
             <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
                 autocomplete="off" autocapitalize="off" spellcheck="false" style="" aria-label="autograding configuration">

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -67,7 +67,7 @@
         <br />
         
         {# text box with the path to the current config file, hidden but still used in js #}
-        <input style='width: 83%' id='input-provide-full-path' name='autograding_config_path'
+        <input style='width: 83%' id='input-provide-full-path' type="hidden" name='autograding_config_path'
             value="{{ gradeable.getAutogradingConfigPath() }}" class="required" placeholder="(Required)" {{'disabled'}}/>
     </div>
 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -53,8 +53,8 @@
         {% endfor %}
         </datalist>#}
         <div class="drop-down" id="config-drop-down">
-            <input class="config_search ignore drop-down-box" type="text" id="config_search" list="path_data" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
-                autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration" id="config-box"/>
+            <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
+                autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration"/>
             <a class="fas fa-times key_to_click" id= "clear_search_button" onclick="clearButtonPress();" tabindex="0"></a>
             <div class="drop-down-options" style="display: none;" id="config-options">
                 <option class="drop-down-option"> hi </option>
@@ -65,9 +65,9 @@
         </div>
         <a class="btn btn-primary" style="margin-top: 6px" href="{{ upload_config_url }}">Upload a custom autograding configuration</a>
         <br />
-
+        
         {# text box with the path to the current config file, hidden but still used in js #}
-        <input style='width: 83%' type='hidden' id='input-provide-full-path' name='autograding_config_path'
+        <input style='width: 83%' id='input-provide-full-path' name='autograding_config_path'
             value="{{ gradeable.getAutogradingConfigPath() }}" class="required" placeholder="(Required)" {{'disabled'}}/>
     </div>
 
@@ -143,6 +143,7 @@
     }
 
     function onConfigPathChange() {
+        console.log("changed!");
         data=getConfigData();
         let full_path_obj = $('#input-provide-full-path');
         let current_val = $('#config_search').val();
@@ -228,8 +229,8 @@
         $(options).hide();
         let box = $(options).parent().find(".drop-down-box");
         // set the box's value to the text of the option
-        console.log($(box).attr("id"));
         $(box).val($(this).text());
+        $(box).change();
     }
 
     $(document).ready(function() {

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -231,10 +231,7 @@
     
     function dropDownArrowOnClick() {
         let options = $(this).parent().parent().find(".drop-down-options");
-        if ($(options).is(":visible")) {
-            $(options).hide();
-        }
-        else {
+        if (!$(options).is(":visible")) {
             $(options).show();
         }
     }

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -44,15 +44,25 @@
         {% endif %}
 
     <div class="settings">
-        <input class="config_search ignore" type="text" id="config_search" list="path_data" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
+        {#<input class="config_search ignore" type="text" id="config_search" list="path_data" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
             autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration" />
         <a class="fas fa-times key_to_click" id= "clear_search_button" onclick="clearButtonPress();" tabindex="0"></a>
         <datalist id="path_data" style="display:none" >
         {% for path in all_config_paths %}
             <option class="path_autofill_option" data-name="{{path.0}}" data-value="{{path.1}}"  style="display:none" >{{path.0}}</option>
         {% endfor %}
-        </datalist>
-
+        </datalist>#}
+        <div class="drop-down" id="config-drop-down">
+            <input class="config_search ignore drop-down-box" type="text" id="config_search" list="path_data" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
+                autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration" id="config-box"/>
+            <a class="fas fa-times key_to_click" id= "clear_search_button" onclick="clearButtonPress();" tabindex="0"></a>
+            <div class="drop-down-options" style="display: none;" id="config-options">
+                <option class="drop-down-option"> hi </option>
+                {% for path in all_config_paths %}
+                    <option class="path_autofill_option drop-down-option" data-name="{{path.0}}" data-value="{{path.1}}">{{path.0}}</option>
+                {% endfor %}
+            </div>
+        </div>
         <a class="btn btn-primary" style="margin-top: 6px" href="{{ upload_config_url }}">Upload a custom autograding configuration</a>
         <br />
 
@@ -203,6 +213,25 @@
         no_due_date.change();
     }
 
+    function dropDownBoxOnClick() {
+        let options = $(this).parent().find(".drop-down-options");
+        if ($(options).is(":visible")) {
+            $(options).hide();
+        }
+        else {
+            $(options).show();
+        }
+    }
+
+    function dropDownOptionOnClick() {
+        let options = $(this).parent();
+        $(options).hide();
+        let box = $(options).parent().find(".drop-down-box");
+        // set the box's value to the text of the option
+        console.log($(box).attr("id"));
+        $(box).val($(this).text());
+    }
+
     $(document).ready(function() {
 
         // Hide PDF settings if not in use
@@ -232,5 +261,8 @@
             sub.prop('checked', true);
             sub.change();
         });
+
+        $('.drop-down-box').on("click", dropDownBoxOnClick);
+        $('.drop-down-option').on("click",dropDownOptionOnClick);
     });
 </script>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -54,10 +54,13 @@
         </datalist>#}
         <div class="drop-down" id="config-drop-down">
             <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
-                autocomplete="off" autocapitalize="off" spellcheck="false" style="width: 700px;" aria-label="autograding configuration"/>
-            <a class="fas fa-times key_to_click" id= "clear_search_button" onclick="clearButtonPress();" tabindex="0"></a>
+                autocomplete="off" autocapitalize="off" spellcheck="false" style="" aria-label="autograding configuration">
+            <div style="margin-left: -45px; position: relative; display: inline-block; width: auto;">
+                <a class="fas fa-times key_to_click" id= "clear_search_button" style="margin: 0%;" onclick="clearButtonPress();" tabindex="0"></a>
+                <a class="fas fa-chevron-down" style="padding: 0;" id= "drop-down-arrow"></a>
+            </div>
+            </input>
             <div class="drop-down-options" style="display: none;" id="config-options">
-                <option class="drop-down-option"> hi </option>
                 {% for path in all_config_paths %}
                     <option class="path_autofill_option drop-down-option" data-name="{{path.0}}" data-value="{{path.1}}">{{path.0}}</option>
                 {% endfor %}
@@ -143,10 +146,20 @@
     }
 
     function onConfigPathChange() {
-        console.log("changed!");
         data=getConfigData();
         let full_path_obj = $('#input-provide-full-path');
         let current_val = $('#config_search').val();
+
+        // Filters the autograding configs displayed based on the values in the box
+        $(".path_autofill_option").each(function() {
+            if ($(this).attr("data-name").toLowerCase().includes(current_val.toLowerCase()) ||
+                    $(this).attr("data-value").toLowerCase().includes(current_val.toLowerCase())) {
+                $(this).show();
+            }
+            else {
+                $(this).hide();
+            }
+        });
 
         //if a name is entered change to the path
 
@@ -181,6 +194,7 @@
 
     function clearButtonPress() {
         $('#config_search').val('');
+        $('.drop-down-box').trigger("input");
     }
 
     function onStudentViewChange() {
@@ -223,6 +237,16 @@
             $(options).show();
         }
     }
+    
+    function dropDownArrowOnClick() {
+        let options = $(this).parent().parent().find(".drop-down-options");
+        if ($(options).is(":visible")) {
+            $(options).hide();
+        }
+        else {
+            $(options).show();
+        }
+    }
 
     function dropDownOptionOnClick() {
         let options = $(this).parent();
@@ -230,7 +254,7 @@
         let box = $(options).parent().find(".drop-down-box");
         // set the box's value to the text of the option
         $(box).val($(this).text());
-        $(box).change();
+        $(box).trigger("input");
     }
 
     $(document).ready(function() {
@@ -252,7 +276,7 @@
 
         // Update the text box when the path config changes
         onConfigPathChange();
-        $('#config_search').change(onConfigPathChange);
+        $('#config_search').on("input", onConfigPathChange);
 
         $('input[name=student_view_after_grades]').change(function() {
             let elem = $('#yes_student_view');
@@ -264,6 +288,7 @@
         });
 
         $('.drop-down-box').on("click", dropDownBoxOnClick);
+        $('#drop-down-arrow').on("click", dropDownArrowOnClick);
         $('.drop-down-option').on("click",dropDownOptionOnClick);
     });
 </script>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -48,7 +48,7 @@
             <div class="drop-down" id="config-drop-down">
                 <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
                     autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="autograding configuration">
-                    <div style="margin-left: -45px; position: relative; display: inline-block; width: auto;">
+                    <div style="margin-left: -45px; position: absolute; display: inline-block; width: auto; transform: translate(0, 25%);">
                         <a class="fas fa-times key_to_click" id= "clear_search_button" style="margin: 0%;" onclick="clearButtonPress();" tabindex="0"></a>
                         <a class="fas fa-chevron-down" style="padding: 0;" id= "drop-down-arrow"></a>
                     </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -54,7 +54,7 @@
             </input>
             <div class="drop-down-options" style="display: none;" id="config-options">
                 {% for path in all_config_paths %}
-                    <option class="path_autofill_option drop-down-option" data-name="{{path.0}}" data-value="{{path.1}}">{{path.0}}</option>
+                    <div class="path_autofill_option drop-down-option" data-name="{{path.0}}" data-value="{{path.1}}">{{path.0}}</div>
                 {% endfor %}
             </div>
         </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -222,10 +222,7 @@
 
     function dropDownBoxOnClick() {
         let options = $(this).parent().find(".drop-down-options");
-        if ($(options).is(":visible")) {
-            $(options).hide();
-        }
-        else {
+        if (!$(options).is(":visible")) {
             $(options).show();
         }
     }
@@ -247,6 +244,13 @@
         // set the box's value to the text of the option
         $(box).val($(this).text());
         $(box).trigger("input");
+    }
+
+    function hideDropDownOptions(){
+        let options = $(".drop-down-options");
+        if ($(options).is(":visible")) {
+            $(options).hide();
+        }
     }
 
     $(document).ready(function() {
@@ -279,6 +283,10 @@
             sub.change();
         });
 
+        $('.drop-down').on("click", function(event){
+            event.stopPropagation();
+        });
+        $(document).on("click", hideDropDownOptions);
         $('.drop-down-box').on("click", dropDownBoxOnClick);
         $('#drop-down-arrow').on("click", dropDownArrowOnClick);
         $('.drop-down-option').on("click",dropDownOptionOnClick);

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -30,32 +30,34 @@
         </div>
 <br><br>
 
-        <div class="option-title">Choose an autograding configuration:</div>
-                <p> You may specify your <a target=_blank href="https://submitty.org/instructor/assignment_configuration/configuration_path#course-autograding-configuration-directory">
-                    "Course Autograding Config Directory"<i style="font-style:normal;" class="fa-question-circle"></i></a>
-                    from the Course Settings Page. </p>
-                <p> Manually type the full path to a configuration file, or select from the list below. </p>
-        <p> The dropdown list has all existing configurations that contain the current text. Hit the red X to clear current text.</p>
-        {% for error_message in repository_error_messages %}
-            <div class="config_search_error">({{error_message}})</div>
-        {% endfor %}
-        {% if not currently_valid_repository %}
-            <div class="config_search_error"> The current path is not valid, selecting Rebuild Gradeable without changing it will fail.</div>
-        {% endif %}
+    <div class="option-title">Choose an autograding configuration:</div>
+            <p> You may specify your <a target=_blank href="https://submitty.org/instructor/assignment_configuration/configuration_path#course-autograding-configuration-directory">
+                "Course Autograding Config Directory"<i style="font-style:normal;" class="fa-question-circle"></i></a>
+                from the Course Settings Page. </p>
+            <p> Manually type the full path to a configuration file, or select from the list below. </p>
+    <p> The dropdown list has all existing configurations that contain the current text. Hit the red X to clear current text.</p>
+    {% for error_message in repository_error_messages %}
+        <div class="config_search_error">({{error_message}})</div>
+    {% endfor %}
+    {% if not currently_valid_repository %}
+        <div class="config_search_error"> The current path is not valid, selecting Rebuild Gradeable without changing it will fail.</div>
+    {% endif %}
 
     <div class="settings">
-        <div class="drop-down" id="config-drop-down">
-            <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
-                autocomplete="off" autocapitalize="off" spellcheck="false" style="" aria-label="autograding configuration">
-            <div style="margin-left: -45px; position: relative; display: inline-block; width: auto;">
-                <a class="fas fa-times key_to_click" id= "clear_search_button" style="margin: 0%;" onclick="clearButtonPress();" tabindex="0"></a>
-                <a class="fas fa-chevron-down" style="padding: 0;" id= "drop-down-arrow"></a>
-            </div>
-            </input>
-            <div class="drop-down-options" style="display: none;" id="config-options">
-                {% for path in all_config_paths %}
-                    <div class="path_autofill_option drop-down-option" data-name="{{path.0}}" data-value="{{path.1}}">{{path.0}}</div>
-                {% endfor %}
+        <div>
+            <div class="drop-down" id="config-drop-down">
+                <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
+                    autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="autograding configuration">
+                    <div style="margin-left: -45px; position: relative; display: inline-block; width: auto;">
+                        <a class="fas fa-times key_to_click" id= "clear_search_button" style="margin: 0%;" onclick="clearButtonPress();" tabindex="0"></a>
+                        <a class="fas fa-chevron-down" style="padding: 0;" id= "drop-down-arrow"></a>
+                    </div>
+                </input>
+                <div class="drop-down-options" style="display: none;" id="config-options">
+                    {% for path in all_config_paths %}
+                        <div class="path_autofill_option drop-down-option" data-name="{{path.0}}" data-value="{{path.1}}">{{path.0}}</div>
+                    {% endfor %}
+                </div>
             </div>
         </div>
         <a class="btn btn-primary" style="margin-top: 6px" href="{{ upload_config_url }}">Upload a custom autograding configuration</a>
@@ -223,7 +225,7 @@
     function dropDownBoxOnClick() {
         let options = $(this).parent().find(".drop-down-options");
         if (!$(options).is(":visible")) {
-            $(options).show();
+            $(options).hide();
         }
     }
     

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -277,24 +277,29 @@ select[name="component-itempool"] {
 }
 
 #config_search{
-    width: 80%;
+    width: 100%;
 }
 
 .drop-down{
     display: inline-block;
-    width: 80%
+    width: 64%
 }
 
 .drop-down-options{
     border: 0.5px black solid;
     position: relative;
-    width: 80%;
+    width: 100%;
     max-height: 30vh;
     overflow-y: scroll;
 }
 
 .drop-down-options::-webkit-scrollbar{
     width: 0.7vh;
+}
+
+body::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 3px black;
+    box-shadow: inset 0 0 3px black;
 }
 
 .drop-down-options::-webkit-scrollbar-thumb {

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -282,7 +282,15 @@ select[name="component-itempool"] {
 
 .drop-down-options{
     border: 0.5px black solid;
-    padding: 1vh;
     position: relative;
     width: 80%;
+}
+
+.drop-down-option{
+    padding: 1vh;
+    text-overflow: ellipsis;
+}
+
+.drop-down-option:hover{
+    background-color: var(--hover-active-all-info-blue);
 }

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -315,3 +315,8 @@ body::-webkit-scrollbar-track {
 .drop-down-option:hover{
     background-color: var(--hover-active-all-info-blue);
 }
+
+[data-theme="dark"] .drop-down-options{
+    background-color: var(--standard-medium-dark-gray);
+    border: 1px solid var(--standard-focus-cornflowe-blue);
+}

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -275,3 +275,8 @@ select[name="component-itempool"] {
     margin-bottom: 15px;
     padding-right: 0;
 }
+
+.drop-down-box{
+    border: 1px black solid;
+    padding: 1vh;
+}

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -284,6 +284,17 @@ select[name="component-itempool"] {
     border: 0.5px black solid;
     position: relative;
     width: 80%;
+    max-height: 30vh;
+    overflow-y: scroll;
+}
+
+.drop-down-options::-webkit-scrollbar{
+    width: 0.7vh;
+}
+
+.drop-down-options::-webkit-scrollbar-thumb {
+    background-color: var(--hover-actionable-blue);
+    outline: 1px solid slategrey;
 }
 
 .drop-down-option{

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -276,7 +276,13 @@ select[name="component-itempool"] {
     padding-right: 0;
 }
 
-.drop-down-box{
-    border: 1px black solid;
+#config_search{
+    width: 80%;
+}
+
+.drop-down-options{
+    border: 0.5px black solid;
     padding: 1vh;
+    position: relative;
+    width: 80%;
 }

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -280,6 +280,11 @@ select[name="component-itempool"] {
     width: 80%;
 }
 
+.drop-down{
+    display: inline-block;
+    width: 80%
+}
+
 .drop-down-options{
     border: 0.5px black solid;
     position: relative;

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -320,3 +320,12 @@ body::-webkit-scrollbar-track {
     background-color: var(--standard-medium-dark-gray);
     border: 1px solid var(--standard-focus-cornflowe-blue);
 }
+
+#config_search {
+    padding-right: 45px;
+}
+
+#clear_search_button {
+    padding-right: 6px;
+    color: red;
+}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -460,12 +460,11 @@ td>a.active-sort {
 }
 
 #config_search {
-    padding-right: 20px;
+    padding-right: 45px;
 }
 
 #clear_search_button {
-    margin-left: -20px;
-    padding-right: 20px;
+    padding-right: 6px;
     color: red;
 }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -459,15 +459,6 @@ td>a.active-sort {
     font-size: 18px;
 }
 
-#config_search {
-    padding-right: 45px;
-}
-
-#clear_search_button {
-    padding-right: 6px;
-    color: red;
-}
-
 .option-alt {
     font-style: italic;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #6239
When creating a gradeable, on the "Submissions/Autograding" tab, no drop-down list with options for the gradable configuration is shown. No arrow is displayed either.

### What is the new behavior?
The bug is now fixed such that the drop-down and the arrow are accessible on both Firefox and Chrome. Switched from datalist to custom CSS classes to ensure it behaves as intended on Firefox. As such the UI will be slightly different from the previous version. For example, the option is now highlighted by blue when you hover over it.

### Other information?
![image](https://user-images.githubusercontent.com/49821332/120018916-c7fa7d80-bfb5-11eb-886d-af2fcbc23a29.png)

Drop-down menu
![image](https://user-images.githubusercontent.com/49821332/120360817-2df94480-c2d7-11eb-9d43-3fda8d4b164f.png)
