### PR TITLE
[Bugfix:InstructorUI] Fix Alerts Unable to be Closed

### DIFF
--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -337,13 +337,13 @@
                     try {
                         var json = JSON.parse(data);
                         if(json['status'] == 'fail') {
-                            var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close key_to_click" tabindex="0" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
+                            displayErrorMessage(json['message']);
                         }
                         else {
-                            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close key_to_click" tabindex="0" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['data'] + '</div>';
+                            displaySuccessMessage(json['data']);
                         }
                     } catch(err) {
-                        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close key_to_click" tabindex="0" onclick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
+                        displayErrorMessage('Error parsing data. Please try again.');
                     }
                     $('#notification-settings').css('display', 'none');
                     $('#messages').empty();

--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -346,8 +346,6 @@
                         displayErrorMessage('Error parsing data. Please try again.');
                     }
                     $('#notification-settings').css('display', 'none');
-                    $('#messages').empty();
-                    $('#messages').append(message);
                 }
             });
         });

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -175,13 +175,11 @@ function publishFormWithAttachments(form, test_category, error_message, is_threa
                 var json = JSON.parse(data);
 
                 if(json["status"] === 'fail') {
-                    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json["message"] + '</div>';
-                    $('#messages').append(message);
+                    displayErrorMessage(json['message']);
                     return;
                 }
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             // Now that we've successfully submitted the form, clear autosave data
@@ -206,8 +204,7 @@ function publishFormWithAttachments(form, test_category, error_message, is_threa
             window.location.href = json['data']['next_page'];
         },
         error: function(){
-            var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + error_message + '</div>';
-            $('#messages').append(message);
+            displayErrorMessage(error_message);
             return;
         }
     });
@@ -286,8 +283,7 @@ function socketNewOrEditPostHandler(post_id, reply_level, post_box_id=null, edit
         uploadImageAttachments('#'+ post_id + '-reply .upload_attachment_box')
 
       } catch (error) {
-        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing new post. Please refresh the page.</div>';
-        $('#messages').append(message);
+        displayErrorMessage('Error parsing new post. Please refresh the page.');
         return;
       }
     }
@@ -351,8 +347,7 @@ function socketNewOrEditThreadHandler(thread_id, edit=false){
         if ($('data#current-thread').val() != thread_id)
           $('[data-thread_id="' + thread_id + '"] .thread_box').removeClass("active");
       } catch(err) {
-        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing new thread. Please refresh the page.</div>';
-        $('#messages').append(message);
+        displayErrorMessage('Error parsing new thread. Please refresh the page.');
         return;
       }
     },
@@ -650,20 +645,17 @@ function changeThreadStatus(thread_id) {
             try {
                 var json = JSON.parse(data);
             } catch(err) {
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail') {
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
 
             window.socketClient.send({'type': "resolve_thread", 'thread_id': thread_id});
             window.location.reload();
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Thread marked as resolved.</div>';
-            $('#messages').append(message);
+            displaySuccessMessage('Thread marked as resolved.');
         },
         error: function() {
             window.alert('Something went wrong when trying to mark this thread as resolved. Please try again.');
@@ -688,13 +680,11 @@ function modifyOrSplitPost(e) {
         var json = JSON.parse(response);
       }
       catch (e) {
-        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please refresh the page.</div>';
-        $('#messages').append(message);
+        displayErrorMessage('Error parsing data. Please try again.');
         return;
       }
       if(json['status'] === 'fail'){
-        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-        $('#messages').append(message);
+        displayErrorMessage(json['message']);
         return;
       }
 
@@ -739,13 +729,11 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             try {
                 var json = JSON.parse(data);
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
             json = json['data'];
@@ -1147,13 +1135,11 @@ function showSplit(post_id) {
       try {
         var json = JSON.parse(data);
       } catch (err) {
-        var message = '<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-        $('#messages').append(message);
+        displayErrorMessage('Error parsing data. Please try again.');
         return;
       }
       if(json['status'] === 'fail'){
-        var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-        $('#messages').append(message);
+        displayErrorMessage(json['message']);
         return;
       }
       json = json['data'];
@@ -1205,13 +1191,11 @@ function showHistory(post_id) {
             try {
                 var json = JSON.parse(data);
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
             $("#popup-post-history").show();
@@ -1267,17 +1251,14 @@ function addNewCategory(csrf_token){
             try {
                 var json = JSON.parse(data);
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully created category "'+ escapeSpecialChars(newCategory) +'".</div>';
-            $('#messages').append(message);
+            displaySuccessMessage(`Successfully created category ${escapeSpecialChars(newCategory)}.`);
             $('#new_category_text').val("");
             // Create new item in #ui-category-list using dummy category
             var category_id = json['data']['new_id'];
@@ -1315,17 +1296,14 @@ function deleteCategory(category_id, category_desc, csrf_token){
             try {
                 var json = JSON.parse(data);
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully deleted category "'+ escapeSpecialChars(category_desc) +'"</div>';
-            $('#messages').append(message);
+            displaySuccessMessage(`Successfully deleted category ${escapeSpecialChars(category_desc)}.`);
             $('#categorylistitem-'+category_id).remove();
             refreshCategories();
         },
@@ -1355,17 +1333,14 @@ function editCategory(category_id, category_desc, category_color, csrf_token) {
             try {
                 var json = JSON.parse(data);
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully updated!</div>';
-            $('#messages').append(message);
+            displaySuccessMessage(`Successfully updated category "${category_desc}"!`);
             setTimeout(function() {removeMessagePopup('theid');}, 1000);
             if(category_color !== null) {
                 $("#categorylistitem-"+category_id).css("color",category_color);
@@ -1477,17 +1452,14 @@ function reorderCategories(csrf_token) {
             try {
                 var json = JSON.parse(data);
             } catch (err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again').
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Successfully reordered categories.';
-            $('#messages').append(message);
+            displaySuccessMessage('Successfully reordered categories.');
             setTimeout(function() {removeMessagePopup('theid');}, 1000);
             refreshCategories();
         },
@@ -1525,13 +1497,11 @@ function deletePostToggle(isDeletion, thread_id, post_id, author, time, csrf_tok
                 try {
                     var json = JSON.parse(data);
                 } catch (err){
-                    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                    $('#messages').append(message);
+                    displayErrorMessage('Error parsing data. Please try again').
                     return;
                 }
                 if(json['status'] === 'fail'){
-                    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                    $('#messages').append(message);
+                    displayErrorMessage(json['message']);
                     return;
                 }
                 var new_url = "";
@@ -1696,13 +1666,11 @@ function loadThreadHandler(){
                 try {
                     var json = JSON.parse(data);
                 } catch (err){
-                    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                    $('#messages').append(message);
+                    displayErrorMessage('Error parsing data. Please try again').
                     return;
                 }
                 if(json['status'] === 'fail'){
-                    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                    $('#messages').append(message);
+                    displayErrorMessage(json['message']);
                     return;
                 }
                 if (typeof json.data.merged !== 'undefined') {
@@ -1946,14 +1914,12 @@ function updateSelectedThreadContent(selected_thread_first_post_id){
             try {
                 var json = JSON.parse(data);
             } catch(err) {
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again. Error is ' + err +'</div>';
-                $('#messages').append(message);
+                displayErrorMessage(`Error parsing data. Please try again. Error is ${err}`);
                 return;
             }
 
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1284,7 +1284,7 @@ function displaySuccessMessage(message) {
  */
 function displayMessage(message, type) {
     const id = `${type}-js-${messages}`;
-    message = `<div id="${id}" class="inner-message alert alert-${type}"><span><i class="fas fa-${type === 'error' ? 'times' : 'check'}-circle"></i>${message.replace(/(?:\r\n|\r|\n)/g, '<br />')}</span><a class="fas fa-times" onClick="removeMessagePopup('${type}-js-${messages}');"></a></div>`;
+    message = `<div id="${id}" class="inner-message alert alert-${type}"><span><i style="margin-right:3px;" class="fas fa-${type === 'error' ? 'times' : 'check'}-circle"></i>${message.replace(/(?:\r\n|\r|\n)/g, '<br />')}</span><a class="fas fa-times" onClick="removeMessagePopup('${type}-js-${messages}');"></a></div>`;
     $('#messages').append(message);
     $('#messages').fadeIn('slow');
     if (type === 'success') {
@@ -1347,21 +1347,18 @@ function updateGradeOverride(data) {
             try {
                 var json = JSON.parse(data);
             } catch(err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
             refreshOnResponseOverriddenGrades(json);
             $('#user_id').val(this.defaultValue);
             $('#marks').val(this.defaultValue);
             $('#comment').val(this.defaultValue);
-            var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Updated overridden Grades for ' + json['data']['gradeable_id'] + '.</div>';
-            $('#messages').append(message);
+            displaySuccessMessage(`Updated overridden Grades for ${json['data']['gradeable_id']}`);
         },
         error: function() {
             window.alert("Something went wrong. Please try again.");
@@ -1378,13 +1375,11 @@ function loadOverriddenGrades(g_id) {
             try {
                 var json = JSON.parse(data);
             } catch(err){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>Error parsing data. Please try again.</div>';
-                $('#messages').append(message);
+                displayErrorMessage('Error parsing data. Please try again.');
                 return;
             }
             if(json['status'] === 'fail'){
-                var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                $('#messages').append(message);
+                displayErrorMessage(json['message']);
                 return;
             }
             refreshOnResponseOverriddenGrades(json);
@@ -1430,12 +1425,10 @@ function deleteOverriddenGrades(user_id, g_id) {
             success: function(data) {
                 var json = JSON.parse(data);
                 if(json['status'] === 'fail'){
-                    var message ='<div class="inner-message alert alert-error" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-times-circle"></i>' + json['message'] + '</div>';
-                    $('#messages').append(message);
+                    displayErrorMessage(json['message']);
                     return;
                 }
-                var message ='<div class="inner-message alert alert-success" style="position: fixed;top: 40px;left: 50%;width: 40%;margin-left: -20%;" id="theid"><a class="fas fa-times message-close" onClick="removeMessagePopup(\'theid\');"></a><i class="fas fa-check-circle"></i>Overridden Grades deleted .</div>';
-                $('#messages').append(message);
+                displaySuccessMessage('Overridden Grades deleted.');
                 refreshOnResponseOverriddenGrades(json);
             },
             error: function() {


### PR DESCRIPTION
### What is the current behavior?
Fixes #6526
Currently, alerts from the grade override page, forum, and notification settings page are unable to be closed and have improper styling.
![image](https://user-images.githubusercontent.com/28243927/120025962-68a16b00-bfbf-11eb-9a61-b7bca393c999.png)
![image](https://user-images.githubusercontent.com/28243927/120025975-6ccd8880-bfbf-11eb-9931-9808ecf281f1.png)
![image](https://user-images.githubusercontent.com/28243927/120026034-7d7dfe80-bfbf-11eb-9285-3e045acd778c.png)

### What is the new behavior?
The alerts have been updated to match the behavior and styling of alerts on the rest of the site.
![image](https://user-images.githubusercontent.com/28243927/120026216-c0d86d00-bfbf-11eb-942b-9383e33c594a.png)
![image](https://user-images.githubusercontent.com/28243927/120026275-d77ec400-bfbf-11eb-9317-5fdff7ee5818.png)
![image](https://user-images.githubusercontent.com/28243927/120026187-b5854180-bfbf-11eb-91c7-4f4da83ccef8.png)

