### PR TITLE
[Bugfix:TAGrading] Fix Mobile Scrolling on PDF Edit

### DIFF
--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -188,7 +188,7 @@ function renderPDFToolbar() {
         document.getElementById("size_selector").addEventListener('click', sizeMenuToggle);
         document.addEventListener('colorchange', changeColor);
         let init_color = localStorage.getItem('main_color');
-        setColor(init_color ? init_color : "#000000");
+        setColor(init_color ? init_color : '#000000');
     }
 
     function colorMenuToggle(e){

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -59,6 +59,7 @@ function renderPDFToolbar() {
                     PDFAnnotate.UI.enableEraser();
                     break;
                 case 'cursor':
+                    currentTool = 'cursor';
                     PDFAnnotate.UI.enableEdit();
                     break;
                 case 'clear':
@@ -187,7 +188,7 @@ function renderPDFToolbar() {
         document.getElementById("size_selector").addEventListener('click', sizeMenuToggle);
         document.addEventListener('colorchange', changeColor);
         let init_color = localStorage.getItem('main_color');
-        setColor(init_color);
+        setColor(init_color ? init_color : "#000000");
     }
 
     function colorMenuToggle(e){

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -57,6 +57,7 @@ function renderPDFToolbar() {
                 case 'eraser':
                     currentTool = 'eraser';
                     PDFAnnotate.UI.enableEraser();
+                    PDFAnnotate.UI.disableEdit();
                     break;
                 case 'cursor':
                     currentTool = 'cursor';

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -189,7 +189,7 @@ function renderPDFToolbar() {
         document.getElementById("size_selector").addEventListener('click', sizeMenuToggle);
         document.addEventListener('colorchange', changeColor);
         let init_color = localStorage.getItem('main_color');
-        setColor(init_color ? init_color : '#000000');
+        setColor(init_color || '#000000');
     }
 
     function colorMenuToggle(e){

--- a/site/public/js/pdf/PDFInitToolbar.js
+++ b/site/public/js/pdf/PDFInitToolbar.js
@@ -57,7 +57,6 @@ function renderPDFToolbar() {
                 case 'eraser':
                     currentTool = 'eraser';
                     PDFAnnotate.UI.enableEraser();
-                    PDFAnnotate.UI.disableEdit();
                     break;
                 case 'cursor':
                     currentTool = 'cursor';


### PR DESCRIPTION
### What is the current behavior?
Closes #5348
On mobile, if you switch to the pencil tool and then back to the cursor, you will be unable to scroll. This makes your only option of scrolling to use the eraser tool which can be inconvenient.

### What is the new behavior?
* The cursor tool always allows scrolling of the page.
* Black is selected as the pen color in the toolbar the first time you go on the page (as opposed to a transparent box if ```localStorage.main_color``` is empty)

### Other information?
I believe this closes #5348 since the rest of the interface seems to work well on mobile.
Tested on iPad Pro with Apple Pencil
