### PR TITLE
[Testing:Developer] Skip vbguest in CI

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+  push:
 
 jobs:
   vagrant-up:
@@ -19,7 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: vagrant plugin install vagrant-vbguest
-      - run: NO_SUBMISSIONS=1 vagrant up ${{ matrix.image }}
+      # Installing this is skipped in CI as using it was causing some corruption in
+      # attempting to mount the shared folder. The guest and host guest additions
+      # versions are close enough that we are fine without it.
+      # - run: vagrant plugin install vagrant-vbguest
+      - run: NO_SUBMISSIONS=1 SKIP_VBGUEST=1 vagrant up ${{ matrix.image }}
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:${{ matrix.port }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-  push:
 
 jobs:
   vagrant-up:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 bash ${GIT_PATH}/.setup/vagrant/setup_vagrant.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_${DISTRO}_${VERSION}.log
 SCRIPT
 
-unless Vagrant.has_plugin?('vagrant-vbguest')
+unless Vagrant.has_plugin?('vagrant-vbguest') || ENV.has_key?('SKIP_VBGUEST')
   raise 'vagrant-vbguest is not installed! To install, run: vagrant plugin install vagrant-vbguest'
 end
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The vagrant up CI job is failing due to some issue mounting the shared directory.

### What is the new behavior?

This may be related to some botched operation by vbguest when run in the context of the CI. To help here, I am adding a flag to the vagrantfile to allow skipping ensuring that vbguest is installed, and then using that in CI to skip it as well.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
