### PR TITLE
[UI/UX:InstructorUI] "no assignments posted" Message Style

### DIFF
--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -86,7 +86,7 @@
         {% endfor %}
         </div>
     {% else %}
-        <div class="container">
+        <div class="no-assignments-message">
             <p>There are currently no assignments posted.  Please check back later.</p>
         </div>
     {% endif %}

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -86,7 +86,7 @@
         {% endfor %}
         </div>
     {% else %}
-        <div class="no-assignments-message">
+        <div class="container no-assignments-message">
             <p>There are currently no assignments posted.  Please check back later.</p>
         </div>
     {% endif %}

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -23,6 +23,7 @@
 
 .no-assignments-message {
     padding-bottom: 30px;
+    padding-left: 0;
 }
 
 .course-main {

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -21,6 +21,10 @@
     border: none;
 }
 
+.no-assignments-message {
+    padding-bottom: 30px;
+}
+
 .course-main {
     display: flex;
     align-items: center;

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -23,7 +23,6 @@
 
 .no-assignments-message {
     padding-bottom: 30px;
-    padding-left: 0;
 }
 
 .course-main {


### PR DESCRIPTION
### What is the current behavior?
The "no assignments posted" message that is displayed in the Gradeables page when there are no available gradeables is missing some padding
![before_padding](https://user-images.githubusercontent.com/71195502/120194890-2f9a0e00-c1ec-11eb-843a-98c316f68a70.png)

### What is the new behavior?
Padding is added, and the message is now aligned with the "Gradeables" title.
![image](https://user-images.githubusercontent.com/71195502/120195047-53f5ea80-c1ec-11eb-952c-3f1664e3a931.png)