### PR TITLE
[Bugfix:TAGrading] Fix auto open button not working

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -309,6 +309,7 @@ function initializeTaLayout() {
   }
   updateLayoutDimensions();
   updatePanelOptions();
+  readCookies();
 }
 
 function updateLayoutDimensions() {
@@ -432,6 +433,7 @@ function readCookies(){
   };
 
   if (autoscroll == "on") {
+    $('#autoscroll_id')[0].checked = true;
     let files_array = JSON.parse(files);
     files_array.forEach(function(element) {
       let file_path = element.split('#$SPLIT#$');


### PR DESCRIPTION
### What is the current behavior?
Fixes #6509 
Checking the auto open checkbox on the TA Grading page has no effect when moving between students.

### What is the new behavior?
The auto open checkbox now works and reopens folders that were open on the previous student.