### PR TITLE
[VPAT:Forum] Improve New Post Background in Dark Mode

### DIFF
--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -26,9 +26,6 @@
                         {% if thread.merged_thread_id != -1 %}
                             <i class="fas fa-link thread-merged" title="Thread Merged" aria-label="Thread Merged"></i>
                         {% endif %}
-                        {% if "new_thread" in thread.class %}
-                            <i class="fas fa-exclamation thread-unread"></i>
-                        {% endif %}
 
                         {% if thread.status != 0 %}
                             <i class="fa {{ thread.fa_icon }} {{ thread.fa_class }} thread-status"

--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -26,6 +26,9 @@
                         {% if thread.merged_thread_id != -1 %}
                             <i class="fas fa-link thread-merged" title="Thread Merged" aria-label="Thread Merged"></i>
                         {% endif %}
+                        {% if "new_thread" in thread.class %}
+                            <i class="fas fa-exclamation thread-unread"></i>
+                        {% endif %}
 
                         {% if thread.status != 0 %}
                             <i class="fa {{ thread.fa_icon }} {{ thread.fa_class }} thread-status"

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -149,6 +149,7 @@
     /*discussion forum*/
     --viewed-discussion-post-blue: #e8f0f7;
     --deleted-discussion-post-grey: #dcdcdc;
+    --viewed-content: #e8f0f7;
     --important-post: #ffd700; /*is also for star color*/
     --attachment-box-color: #f5f5f5;
     --file-upload-table-hover: #d1d1d1;
@@ -356,6 +357,7 @@
       /*discussion forum*/
       --viewed-discussion-post-blue: #e8f0f7;
       --deleted-discussion-post-grey: #dcdcdc;
+      --viewed-content: #292a2b;
       --important-post: #ffd700; /*is also for star color*/
       --attachment-box-color: #4a4a4a;
       --file-upload-table-hover: #4a4a4a;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -149,7 +149,6 @@
     /*discussion forum*/
     --viewed-discussion-post-blue: #e8f0f7;
     --deleted-discussion-post-grey: #dcdcdc;
-    --viewed-content: #e8f0f7;
     --important-post: #ffd700; /*is also for star color*/
     --attachment-box-color: #f5f5f5;
     --file-upload-table-hover: #d1d1d1;
@@ -195,7 +194,7 @@
     --grading-note: #777;
     --file-browser-blue: #2627ee;
     --extra-credit-blue: #0a6495;
-
+    --viewed-content: #e8f0f7;
 
 
 }
@@ -357,7 +356,6 @@
       /*discussion forum*/
       --viewed-discussion-post-blue: #e8f0f7;
       --deleted-discussion-post-grey: #dcdcdc;
-      --viewed-content: #292a2b;
       --important-post: #ffd700; /*is also for star color*/
       --attachment-box-color: #4a4a4a;
       --file-upload-table-hover: #4a4a4a;
@@ -403,4 +401,5 @@
       --grading-note: #A8A8A8;
       --file-browser-blue: #ffffff;
       --extra-credit-blue: #2DACF0;
+      --viewed-content: #292a2b;
 }

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -406,5 +406,5 @@
       --grading-note: #A8A8A8;
       --file-browser-blue: #ffffff;
       --extra-credit-blue: #2DACF0;
-      --viewed-content: #292a2b;
+      --viewed-content: #50535a;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -569,11 +569,6 @@
     font-size: 1.8em;
 }
 
-.thread-unread {
-    color: var(--submitty-logo-blue);
-    font-size: 2.0em;
-}
-
 .post_content p {
     white-space: pre-wrap;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -569,6 +569,11 @@
     font-size: 1.8em;
 }
 
+.thread-unread {
+    color: var(--submitty-logo-blue);
+    font-size: 2.0em;
+}
+
 .post_content li {
     white-space: normal;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -638,3 +638,38 @@
 .thread-left-cont {
     flex: 3;
 }
+
+.viewed_post{
+    background-color: var(--default-white);
+}
+
+/* TODO: MAKE THIS CASCADE */
+.deleted {
+    background-color: var(--deleted-discussion-post-grey);
+}
+
+.deleted.active {
+    background-color: var(--deleted-discussion-post-grey);
+}
+
+.new_post {
+    background-color: var(--viewed-content);
+}
+
+.important {
+    /* THIS IS WHERE THE BACKGROUND COLOR FOR POSTS IS */
+    border-style: solid;
+    border-width: 4px;
+    border-color: var(--important-post); /* gold */
+}
+
+.active {
+    background-color: var(--default-white);
+    /*    color: #4a4a4a;*/
+    border: 4px solid var(--submitty-logo-blue);
+}
+
+.new_thread{
+    background-color: var(--viewed-content);
+    color: var(--text-black)
+}

--- a/site/public/css/notebook-builder.css
+++ b/site/public/css/notebook-builder.css
@@ -2,8 +2,8 @@
  * Styles common to multiple notebook builder widgets
  */
 .notebook-builder-widget {
-    border: 3px solid var(--viewed_content);
-    background-color: var(--viewed_content);
+    border: 3px solid var(--viewed-content);
+    background-color: var(--viewed-content);
     border-radius: 25px;
     margin-top: 10px;
     margin-bottom: 10px;

--- a/site/public/css/rainbow-customization.css
+++ b/site/public/css/rainbow-customization.css
@@ -1,6 +1,6 @@
 .customization_item
 {
-    border: 2px solid var(--viewed_content);
+    border: 2px solid var(--viewed-content);
     padding: 5px;
     padding-left: 20px;
     margin-top: 10px;
@@ -156,7 +156,7 @@
 hr
 {
     margin: 7px 10px;
-    border-top: 1px solid var(--viewed_content);
+    border-top: 1px solid var(--viewed-content);
 }
 
 .rg_info_message

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1,14 +1,6 @@
 @import url("reset.css");
 @import url("google/inconsolata.css");
 
-:root {
-    --viewed_content: #e8f0f7;
-}
-
-[data-theme="dark"] {
-    --viewed_content: #313335;
-}
-
 a, a:hover, a:link, a:visited {
     cursor: pointer;
 }
@@ -600,41 +592,6 @@ td>a.active-sort {
   padding: 6px;
   color: var(--text-black);
   background-color: var(--standard-light-gray);
-}
-
-.viewed_post{
-    background-color: var(--default-white);
-}
-
-/* TODO: MAKE THIS CASCADE */
-.deleted {
-    background-color: var(--deleted-discussion-post-grey);
-}
-
-.deleted.active {
-    background-color: var(--deleted-discussion-post-grey);
-}
-
-.new_post {
-    background-color: var(--viewed_content);
-}
-
-.important {
-    /* THIS IS WHERE THE BACKGROUND COLOR FOR POSTS IS */
-    border-style: solid;
-    border-width: 4px;
-    border-color: var(--important-post); /* gold */
-}
-
-.active {
-    background-color: var(--default-white);
-    /*    color: #4a4a4a;*/
-    border: 4px solid var(--submitty-logo-blue);
-}
-
-.new_thread{
-    background-color: var(--viewed_content);
-    color: var(--text-black)
 }
 
 .box-title > h4 {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #6543 
Currently, in dark mode new/unread posts/threads are marked by a background color that is barely different from the main site background color.

![Screen Shot 2021-06-01 at 10 30 37 AM](https://user-images.githubusercontent.com/28243927/120344071-3f3a5500-c2c7-11eb-9ba6-1cf95d9eb69c.jpg)

### What is the new behavior?
* The viewed-content color has been adjusted to give better contrast in dark mode

![Screen Shot 2021-06-01 at 10 29 09 AM](https://user-images.githubusercontent.com/28243927/120344090-43ff0900-c2c7-11eb-9948-2d8b1a6f4fc1.jpg)
