### PR TITLE
[Bugfix:Submission] Visualize whitespace only on text

### DIFF
--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -9,7 +9,7 @@
         <iframe src="{{ check.url }}" width="95%" height="1200px" style="border: 0"></iframe>
     {% else %}
         <div class="autocheck-header">
-          {% if check.actual %}
+          {% if check.actual and check.actual.type == "text" %}
             <div class="autocheck-header-button">
                 <a id="show_char_{{ index }}_{{ loop.index0 }}" class="btn btn-default key_to_click" tabindex="0" style="float:right;" onclick="changeDiffView('container_{{ index }}_{{ loop.index0 }}', '{{ gradeable_id }}', '{{ who }}', '{{ display_version }}', '{{ index }}', '{{ loop.index0 }}', 'white_space_helper_{{ index }}')">Visualize whitespace characters</a>
             </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute) 
### What is the current behavior?
Visualize whitespace button appears on all AutoChecks with output (on actual).

### What is the new behavior?
Fixes #6182 
Visualize whitespace button only appears on AutoChecks with a type of "text" on actual.
