### PR TITLE
initial attempt to save when leaving

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -3188,3 +3188,10 @@ function addItempoolOptions(componentId) {
   select_ele.html(itempool_options);
   select_ele.val(selected_value).change();
 }
+
+$(document).ready(function(){
+    $(window).on('beforeunload', function(e){
+        closeAllComponents(true);
+    });
+}
+);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
When instructor leaves the page with an open unsaved change to the gradeable, the change is lost.

### What is the new behavior?
The gradeable changes are now saved when the instructor leaves the page with unsaved change to gradeable.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
