### PR TITLE
[Bugfix:TAGrading] fixed Anon mode bugs

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -338,7 +338,7 @@
 
 {# Graded Questions #}
 {% macro render_column_graded_questions(self, context, section, graded_gradeable, index, info, column) %}
-    <td class="td-graded-questions">
+    <td class="td-graded-questions" style="text-align: center">
         <span>
             {%- for index in 0..info.graded_groups|length-1 -%}
             {# Non-Peer View for Stoplights #}

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -114,7 +114,7 @@
                             </a>
                         </th>
                     {% else %}
-                        <th style="width:{{ column.width }}" data-col-title="{{ column.title }}">{{ column.title }}</th>
+                        <th style="width:{{ column.width }}; text-align: center" data-col-title="{{ column.title }}">{{ column.title }}</th>
                     {% endif %}
                 {% endfor %}
             </tr>
@@ -329,7 +329,7 @@
 
 {# Autograding (peer) #}
 {% macro render_column_autograding_peer(self, context, section, graded_gradeable, index, info, column) %}
-    <td>
+    <td style="text-align: center">
         {% if graded_gradeable.getAutoGradedGradeable().getHighestVersion() != 0 %}
             {{ graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance().getNonHiddenPoints() }} / {{ graded_gradeable.getGradeable.getAutogradingConfig().getTotalNonHiddenNonExtraCredit() }}
         {% endif %}

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -107,9 +107,9 @@
 </div>
 <script>
     //if student/team name(s) are being displayed
-    if ({{ not anon_mode and not isBlind and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single')) }}) {
-        $('.navigation-box').css({'position':'relative'});
-        $('.navigation-box').css({'float':'left'});
-        $('.navigation-box').css({'margin-left':'20%'});
-    }
+{#    {% if not anon_mode and not isBlind and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single')) %}#}
+{#    $('.navigation-box').css({'position':'relative'});#}
+{#    $('.navigation-box').css({'float':'left'});#}
+{#    $('.navigation-box').css({'margin-left':'20%'});#}
+{#    {% endif %}#}
 </script>

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -105,5 +105,4 @@
         </div>
     </div>
 </div>
-<script>
-</script>
+

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -106,10 +106,4 @@
     </div>
 </div>
 <script>
-    //if student/team name(s) are being displayed
-{#    {% if not anon_mode and not isBlind and (peer_blind_grading is same as('unblind') or peer_blind_grading is same as('single')) %}#}
-{#    $('.navigation-box').css({'position':'relative'});#}
-{#    $('.navigation-box').css({'float':'left'});#}
-{#    $('.navigation-box').css({'margin-left':'20%'});#}
-{#    {% endif %}#}
 </script>

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -491,9 +491,8 @@ progress::-webkit-progress-value {
 }
 
 #grading-panel-student-name{
-    position: relative;
-    float: left;
-    padding-left: 5px;
+    display: flex;
+    margin: auto;
 }
 
 #regrade_inner_info .inner-container {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -746,6 +746,12 @@ function toggleFullLeftColumnMode (forceVal = false) {
   if (!taLayoutDet.isFullScreenMode) {
     $("#grading-panel-student-name").hide();
   }
+
+  if(taLayoutDet.isFullLeftColumnMode){
+      $('.navigation-box').css({'margin-left':'10%'});
+  }else{
+      $('.navigation-box').css({'margin-left':'20%'});
+  }
 }
 
 /**

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -743,15 +743,8 @@ function toggleFullLeftColumnMode (forceVal = false) {
 
   panelsContSelector = newPanelsContSelector;
 
-  if (!taLayoutDet.isFullScreenMode) {
-    $("#grading-panel-student-name").hide();
-  }
+  $("#grading-panel-student-name").hide();
 
-  if(taLayoutDet.isFullLeftColumnMode){
-      $('.navigation-box').css({'margin-left':'10%'});
-  }else{
-      $('.navigation-box').css({'margin-left':'20%'});
-  }
 }
 
 /**


### PR DESCRIPTION

### What is the current behavior?
1. On the details page, The autograding & grading column are left justified in anon mode but centered in non-anon mode.

2. In 2 column mode, in non-anon mode, the layout seems to leave room for the student name (so the first row of buttons isn't center, it's got extra space on the left side

3. Team/student names were still displaying in 2 column mode if you enabled full screen mode.

### What is the new behavior?
1. On the details page, The autograding & grading column are now always centered.
<img width="725" alt="pr8_1" src="https://user-images.githubusercontent.com/66340271/120829786-cbe54d00-c52b-11eb-85dd-04ed4b8866d7.PNG">

2.In 2 column mode, the navbar is always centered.
<img width="847" alt="pr8_2" src="https://user-images.githubusercontent.com/66340271/120829885-e91a1b80-c52b-11eb-832d-712200153215.PNG">

3. Student/team names are never displayed in 2 column mode, regardless of full screen mode.


### Other information?
There were other issues with centering/spacing not mentioned in the issue that this PR is linked too. In order to fix all of the centering issues the only fix was to make the names appear above the navbar and not be in line with it. The div's were messing each other up and there was no good fix that could handle things like different screen size or long student names.
<img width="764" alt="pr8_3" src="https://user-images.githubusercontent.com/66340271/120830400-73fb1600-c52c-11eb-8c60-95dca112151d.PNG">
<img width="826" alt="pr8_4" src="https://user-images.githubusercontent.com/66340271/120830403-7493ac80-c52c-11eb-9c06-ea2c1bb6ce33.PNG">

