### PR TITLE
[Bugfix:Submission] Fix CSV uploading issues with new lines

### DIFF
--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -280,6 +280,8 @@ class LateController extends AbstractController {
                 "error" => "Invalid mimetype, must start with 'text/', got '{$mime_type}'"
             ];
         }
+        ini_set("auto_detect_line_endings", true);
+
         $rows = file($csv_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if ($rows === false) {
             $data = null;

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -478,7 +478,7 @@ function setupNumericTextCells() {
                 reader.readAsText(f);
                 reader.onload = function(evt) {
                     var breakOut = false; //breakOut is used to break out of the function and alert the user the format is wrong
-                    var lines = (reader.result).trim().split(/\r\n|\n/);
+                    var lines = (reader.result).trim().split(/\r\n|\n|\r/);
                     var tempArray = lines[0].split(',');
                     var csvLength = tempArray.length; //gets the length of the array, all the tempArray should be the same length
                     for (var k = 0; k < lines.length && !breakOut; k++) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Uploading a CSV with only `\r` as the line ending for either late days allowed or for numeric gradeables causes it to fail; uploading a CSV with `\r\n` or `\n` as the line ending works fine.

### What is the new behavior?
Fixes #5325 
Fixes #5925 
Uploading a CSV with `\r\n`, `\n`, and `\r` all work fine for late days allowed and numeric gradeables.
