### PR TITLE
[Bugfix:System] Fix setup script for pip install

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -182,10 +182,11 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 #install DLL for zbar
 apt-get install libzbar0 --yes
 
-pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/system_requirements.txt
+pip install --upgrade pip
+pip3 install -r ${CURRENT_DIR}/.setup/pip/system_requirements.txt
 
 if [ ${VAGRANT} == 1 ]; then
-    pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/vagrant_requirements.txt
+    pip3 install -r ${CURRENT_DIR}/.setup/pip/vagrant_requirements.txt
 fi
 
 #################################################################

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -182,10 +182,10 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 #install DLL for zbar
 apt-get install libzbar0 --yes
 
-pip3 install -r ${CURRENT_DIR}/.setup/pip/system_requirements.txt
+pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/system_requirements.txt
 
 if [ ${VAGRANT} == 1 ]; then
-    pip3 install -r ${CURRENT_DIR}/.setup/pip/vagrant_requirements.txt
+    pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/vagrant_requirements.txt
 fi
 
 #################################################################

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -183,10 +183,10 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 apt-get install libzbar0 --yes
 
 pip install --upgrade pip
-pip3 install -r ${CURRENT_DIR}/.setup/pip/system_requirements.txt
+pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/system_requirements.txt
 
 if [ ${VAGRANT} == 1 ]; then
-    pip3 install -r ${CURRENT_DIR}/.setup/pip/vagrant_requirements.txt
+    pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/vagrant_requirements.txt
 fi
 
 #################################################################

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -182,7 +182,7 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 #install DLL for zbar
 apt-get install libzbar0 --yes
 
-pip install --upgrade pip
+pip3 install --upgrade pip
 pip3 install -r ${SUBMITTY_REPOSITORY}/.setup/pip/system_requirements.txt
 
 if [ ${VAGRANT} == 1 ]; then

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -27,7 +27,7 @@ opencv-python==3.4.9.33
 pytz==2021.1 # Submitty-util specific.
 
 python-pam==1.8.4
-PyYAML==3.12
+PyYAML==5.3.1
 psycopg2-binary==2.8.6
 sqlalchemy==1.3.24
 pylint==2.8.1

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -27,7 +27,7 @@ opencv-python==3.4.9.33
 pytz==2021.1 # Submitty-util specific.
 
 python-pam==1.8.4
-PyYAML==5.3.1
+PyYAML
 psycopg2-binary==2.8.6
 sqlalchemy==1.3.24
 pylint==2.8.1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### This PR is urgent as this fixes the issue relating to setting up vagrant. 

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Vagrant up does not work on a fresh install.

The path to `system_requirements.txt` and `vagrant_requirements.txt` is incorrect in the setup script `install_system.sh`.
This bug is introduced by #6399.

Furthermore, there is a problem with install PyYAML that vagrant up will trigger. The details are discussed in #6565, this PR implements a temporary fix so that vagrant up will succeed. 

The scheduled `vagrant up` CI [fails](https://github.com/Submitty/Submitty/actions/runs/916847036) due to this issue.

### What is the new behavior?
This PR replaces the faulty requirements path with a correct one. 
This PR un-pined the version for PyYAML, this is a temporary fix, more discussion is in #6399.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This PR works as a manual trigger of `vagrant up` CI succeed in setting up python dependencies in [system_requirements](https://github.com/wusatosi/Submitty/runs/2771372918?check_suite_focus=true#step:3:4027) and [vagrant_requirments](https://github.com/wusatosi/Submitty/runs/2771372918?check_suite_focus=true#step:3:4056).
