### PR TITLE
[Bugfix:System] Fix variable collision in install script

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -6,18 +6,19 @@ if [[ "$UID" -ne "0" ]] ; then
     exit
 fi
 
-SOURCE="${BASH_SOURCE[0]}"
-CURRENT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+# Note: This script is source by install_system.sh and so caution should be used on naming variables
+# to ensure there is no collision.
+SETUP_DISTRO_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
 VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 
-if [ ! -d ${CURRENT_DIR}/${DISTRO}/${VERSION} ]; then
+if [ ! -d ${SETUP_DISTRO_DIR}/${DISTRO}/${VERSION} ]; then
     (>&2 echo "Unknown distro: ${DISTRO} ${VERSION}")
     exit 1
 fi
 
 echo "Setting up distro: ${DISTRO} ${VERSION}"
-source ${CURRENT_DIR}/${DISTRO}/${VERSION}/setup_distro.sh
+source ${SETUP_DISTRO_DIR}/${DISTRO}/${VERSION}/setup_distro.sh
 
 # Read through our arguments to get "extra" packages to install for our distro
 # ${@} are populated by whatever calls install_system.sh which then sources this
@@ -26,9 +27,9 @@ IFS=',' read -ra ADDR <<< "${@}"
 if [ ${#ADDR[@]} ]; then
     echo "Installing extra packages..."
     for i in "${ADDR[@]}"; do
-        if [ -f ${CURRENT_DIR}/${DISTRO}/${VERSION}/${i}.sh ]; then
-            echo "Running ${CURRENT_DIR}/${DISTRO}/${VERSION}/${i}.sh"
-            source ${CURRENT_DIR}/${DISTRO}/${VERSION}/${i}.sh
+        if [ -f ${SETUP_DISTRO_DIR}/${DISTRO}/${VERSION}/${i}.sh ]; then
+            echo "Running ${SETUP_DISTRO_DIR}/${DISTRO}/${VERSION}/${i}.sh"
+            source ${SETUP_DISTRO_DIR}/${DISTRO}/${VERSION}/${i}.sh
         else
             echo "Could not find ${i}.sh for ${DISTRO} ${VERSION}"
         fi


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `setup_distro.sh` script, as it's sourced by `install_system.sh`, was overwriting the value of `CURRENT_DIR` that's set in the latter, which would lead to surprising behavior on trying to use it.

### What is the new behavior?

This fixes this collision by giving the variable a new name within the `setup_distro.sh` script, and also adding a note about the potential of this collision. While a better strategy would be to move away from sourcing these files, we do currently utilize a number of variables set here and in the specific distro file during installation.