### PR TITLE
[Bugfix:TAGrading] Fix full panel view and file view height

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -74,7 +74,7 @@
 {% macro display_file(self, dir, path, id, indent, title) %}
     <div>
         <div class="file-viewer">
-            <a class='openAllFile{{ title }} openable-element-{{ title }} key_to_click' file-url="{{ path|url_encode }}" onclick='openFrame("{{ dir|e('js') }}", "{{ path|e('js') }}", "{{ id }}"); updateCookies();'>
+            <a class='openAllFile{{ title }} openable-element-{{ title }} key_to_click' file-url="{{ path|url_encode }}" onclick='openFrame("{{ dir|e('js') }}", "{{ path|e('js') }}", "{{ id }}"); updateCookies();' data-viewer_id="{{ id }}">
                 <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
                 {{ dir }}</a> &nbsp;
             <a id = 'open_file_{{ dir|url_encode }}' onclick='popOutSubmittedFile("{{ dir|url_encode }}", "{{ path|url_encode }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
@@ -88,7 +88,7 @@
 {% macro display_dir(self, dir, contents, id, indent, title) %}
     <div>
         <div class="div-viewer">
-            <a class='openAllDiv openAllDiv{{ title }} openable-element-{{ title }} key_to_click' id='{{ dir }}' onclick='openDiv("{{ id }}"); updateCookies();'>
+            <a class='openAllDiv openAllDiv{{ title }} openable-element-{{ title }} key_to_click' id='{{ dir }}' onclick='openDiv("{{ id }}"); updateCookies();' data-viewer_id="{{ id }}">
                 <span class="fas fa-folder open-all-folder" style='vertical-align:text-top;'></span>
                 {{ dir }}
             </a>

--- a/site/app/templates/misc/Code.twig
+++ b/site/app/templates/misc/Code.twig
@@ -9,8 +9,16 @@
         <script src='{{ script }}'></script>
     {% endfor %}
     <script>
-        $(document).ready(function() {
+        function iFrameInit() {
+            $('body').css("height", "auto");
+            $('.CodeMirror').height("auto");
+
+            $('.CodeMirror')[0].CodeMirror.setSize(null, null);
+
             $('body').css("height", ($('.CodeMirror').height()) + "px");
+        }
+        $(document).ready(function() {
+            iFrameInit();
         });
     </script>
 </head>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -943,11 +943,12 @@ function openFrame(url, id, filename, ta_grading_interpret=false) {
 
 function resizeFrame(id, max_height = 500, force_height=-1) {
     let img = undefined;
+    let visible = $("iframe#" + id).is(":visible");
     img = $("iframe#" + id).contents().find("img");
     if($("iframe#" + id).contents().find("html").length !== 0) {
         $("iframe#" + id).contents().find("html").css("height", "inherit");
         img = $("iframe#" + id).contents().find("img");
-        if(img) {
+        if(img.length !== 0) {
             img.removeAttr("width");
             img.removeAttr("height");
             img.css("width", "");
@@ -967,7 +968,7 @@ function resizeFrame(id, max_height = 500, force_height=-1) {
         document.getElementById(id).height = (height+18) + "px";
     }
     //Workarounds for FireFox changing height/width of img sometime after this code runs
-    if(img) {
+    if(img.length !== 0) {
         const observer = new ResizeObserver(function(mutationsList, observer) {
             img.removeAttr("width");
             img.removeAttr("height");
@@ -976,6 +977,21 @@ function resizeFrame(id, max_height = 500, force_height=-1) {
             observer.disconnect();
         })
         observer.observe(img[0]);
+    }
+    if(!visible) {
+        const observer = new IntersectionObserver(function(entries, observer) {
+            console.log("observing...");
+            if($("iframe#" + id).is(":visible")) {
+                $("iframe#" + id).removeAttr("height");
+                let iframeFunc = $("iframe#" + id)[0].contentWindow.iFrameInit;
+                if(typeof(iframeFunc) === "function") {
+                    iframeFunc();
+                }
+                observer.disconnect();
+                resizeFrame(id, max_height, force_height);
+            }
+        });
+        observer.observe($("iframe#" + id)[0]);
     }
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -980,7 +980,6 @@ function resizeFrame(id, max_height = 500, force_height=-1) {
     }
     if(!visible) {
         const observer = new IntersectionObserver(function(entries, observer) {
-            console.log("observing...");
             if($("iframe#" + id).is(":visible")) {
                 $("iframe#" + id).removeAttr("height");
                 let iframeFunc = $("iframe#" + id)[0].contentWindow.iFrameInit;

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1117,10 +1117,14 @@ function checkOpenComponentMark(index) {
 
 // expand all files in Submissions and Results section
 function openAll(click_class, class_modifier) {
-  $("."+click_class + class_modifier).each(function(){
+
+  let toClose = $("#div_viewer_" + $("." + click_class + class_modifier).attr("data-viewer_id")).hasClass("open");
+  
+  $("#submission_browser").find("." + click_class + class_modifier).each(function(){
     // Check that the file is not a PDF before clicking on it
-    //console.log($(this).attr('id'));
-    if ($(this).parent().parent().parent().hasClass("open")){
+    let viewerID = $(this).attr("data-viewer_id");
+    if(($(this).parent().hasClass("file-viewer") && $("#file_viewer_" + viewerID).hasClass("shown") === toClose) ||
+        ($(this).parent().hasClass("div-viewer") && $("#div_viewer_" + viewerID).hasClass("open") === toClose)) {
       let innerText = Object.values($(this))[0].innerText;
       if (innerText.slice(-4) !== ".pdf") {
         $(this).click();
@@ -1350,8 +1354,6 @@ function openFrame(html_file, url_file, num, pdf_full_panel=true, panel="submiss
       });
     }
     else {
-      if (!iframe.parent().parent().hasClass("open"))
-        return false;
       let forceFull = url_file.substring(url_file.length - 3) === "pdf" ? 500 : -1;
       let targetHeight = iframe.hasClass("full_panel") ? 1200 : 500;
       let frameHtml = `


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
Viewing a file using the full panel icon does not work.
When a file is rapidly clicked twice (so it finishes loading while the iframe for the file is closed), the height is very small when opened back up. 
When using the Open/Close Submissions/Results buttons, instead of opening and closing all of them it inverts the open and closed state for the most part.

### What is the new behavior?
Viewing a file using the full panel icon now works.
When a file is rapidly clicked twice, an observer observes the iframe until it is opened up again to properly resize it.
When using the Open/Close Submissions/Results buttons, it fully opens/closes the child items.
