### PR TITLE
[UI/UX:Plagiarism] Add "No Content" Message

### DIFF
--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -5,26 +5,29 @@
            href="{{ new_plagiarism_config_link }}"
         >+ Configure New Gradeable for Plagiarism Detection</a>
     </div>
-
-    <div class="plag-table-cont">
-        <table class="table table-bordered">
-            <thead>
-                <tr>
-                    <th>Gradeable</th>
-                    <th></th>
-                    <th>Last Run</th>
-                    <th>Submissions</th>
-                    <th>Students Matched</th>
-                    <th>Nightly<br/>Re-run</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for row in plagiarism_results_info %}
-                    {{ _self.renderPlagiarismRow(row) }}
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+    {% if plagiarism_results_info|length > 0 %}
+        <div class="plag-table-cont">
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th>Gradeable</th>
+                        <th></th>
+                        <th>Last Run</th>
+                        <th>Submissions</th>
+                        <th>Students Matched</th>
+                        <th>Nightly<br/>Re-run</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in plagiarism_results_info %}
+                        {{ _self.renderPlagiarismRow(row) }}
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        <div class="plag-table-no-cont">No gradeables configured to display...</div>
+    {% endif %}
 </div>
 <script>
     checkRefreshLichenMainPage("{{ refreshLichenMainPageLink }}");

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -101,6 +101,11 @@ input[type=text]:invalid {
     margin: 0 20px 0 0;
 }
 
+.plag-table-no-cont {
+    padding-top: 20px;
+    padding-left: 5px;
+}
+
 main#main.full-screen-mode {
     position: absolute;
     top: 0;


### PR DESCRIPTION
### What is the current behavior?
In the Plagiarism  Results page, if no gradeables have been configured, a table with one row containing the column headers is displayed with no additional explanation.
![image](https://user-images.githubusercontent.com/71195502/121365047-4fc17f80-c906-11eb-9a76-53888088b93f.png)

### What is the new behavior?
If there is no information to display yet, the table is not created
![image](https://user-images.githubusercontent.com/71195502/121365350-91eac100-c906-11eb-80b3-c72f0d43f889.png)
