### PR TITLE
[Bugfix:InstructorUI] Fix warning on deleting reg section

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -451,14 +451,16 @@ class UsersController extends AbstractController {
                 // DELETE trigger function in master DB will catch integrity violation exceptions (such as FK violations when users/graders are still enrolled in section).
                 // $num_del_sections indicates how many DELETEs were performed.  0 DELETEs means either the section didn't exist or there are users still enrolled.
                 $fp = $this->core->getConfig()->getCoursePath() . '/uploads/course_materials_file_data.json';
-                $json = file_get_contents($fp);
-                $jsonArray = json_decode($json, true);
-                foreach ($jsonArray as $key => $value) {
-                    if (isset($value['sections'])) {
-                        $sections = $value['sections'];
-                        if ($key = array_search($_POST['delete_reg_section'], $sections) !== false) {
-                            $this->core->addErrorMessage("Section {$_POST['delete_reg_section']} not removed.  This section is referenced in course materials");
-                            $this->core->redirect($return_url);
+                if (file_exists($fp)) {
+                    $json = file_get_contents($fp);
+                    $jsonArray = json_decode($json, true);
+                    foreach ($jsonArray as $key => $value) {
+                        if (isset($value['sections'])) {
+                            $sections = $value['sections'];
+                            if ($key = array_search($_POST['delete_reg_section'], $sections) !== false) {
+                                $this->core->addErrorMessage("Section {$_POST['delete_reg_section']} not removed.  This section is referenced in course materials");
+                                $this->core->redirect($return_url);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #6587 

The warning would occur on trying to delete a registration section for a course that had no course materials. This is due to the course materials JSON file missing as it gets generated on the first time a course material is added.

### What is the new behavior?

Adds a file existence check around the course materials file, checking if it exists before attempting to open and read from it.