### PR TITLE
[Bugfix:System] Fix pip install on vagrant up

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -182,10 +182,10 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 #install DLL for zbar
 apt-get install libzbar0 --yes
 
-pip3 install -r ${CURRENT_DIR}/.setup/pip/system_requirements.txt
+pip3 install -r ${CURRENT_DIR}/pip/system_requirements.txt
 
 if [ ${VAGRANT} == 1 ]; then
-    pip3 install -r ${CURRENT_DIR}/.setup/pip/vagrant_requirements.txt
+    pip3 install -r ${CURRENT_DIR}/pip/vagrant_requirements.txt
 fi
 
 #################################################################

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -55,5 +55,6 @@ pyzbar==0.1.8
 pdf2image==1.14.0
 numpy==1.19.5
 
-#python libraries for OCR for digit recognition
-onnxruntime==1.7.0
+# python libraries for OCR for digit recognition
+# newer versions are not supported on 18.04
+onnxruntime==1.3.0


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

There was a bug introduced in #6399 where an invalid version of onnxruntime was used for Ubuntu 18.04 and an improper path was used for referencing the pip requirements file.

### What is the new behavior?

This PR fixes the path reference to the pip requirements file, as well as pins `onnxruntime` to a version that is supported on Ubuntu 18.04 and 20.04. Newer versions look to require something that's not available out of the box on 18.04, but did not look too deeply into this. On dropping support for Ubuntu 18.04, we can look to upgrade the dependency.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Manually ran the `vagrant up` action to ensure this fixes things: https://github.com/Submitty/Submitty/actions/runs/922053172
