### PR TITLE
[Bugfix:Plagiarism] Fix N/A Columns in Summary Table

### DIFF
--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -24,7 +24,7 @@ class PlagiarismView extends AbstractView {
                 $plagiarism_row['id'],
                 'delete'
             ]);
-            if (file_exists($course_path . "/lichen/ranking/" . $plagiarism_row['id'] . ".txt")) {
+            if (file_exists($course_path . "/lichen/ranking/" . $plagiarism_row['id'] . "/overall_ranking.txt")) {
                 $timestamp = date("F d Y H:i:s", filemtime($course_path . "/lichen/ranking/" . $plagiarism_row['id'] . "/overall_ranking.txt"));
                 $students = array_diff(scandir($course_path . "/lichen/concatenated/" . $plagiarism_row['id']), ['.', '..']);
                 $submissions = 0;


### PR DESCRIPTION
### What is the current behavior?
Fixes issue mentioned in https://github.com/Submitty/Submitty/issues/6568

### What is the new behavior?
The data depends on the timestamp of a file whose location has been changed due to refactoring of Lichen.
The columns now display the right information.  
![image](https://user-images.githubusercontent.com/71195502/121567227-57f3ea80-c9ec-11eb-9e4f-c3d534f884d9.png)