### PR TITLE
[UI/UX:InstructorUI] Fix contrast on Gradebook in Dark Mode

### DIFF
--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -18,6 +18,7 @@ class ReportView extends AbstractView {
 
     public function showFullGradebook($grade_file) {
         $this->core->getOutput()->addBreadcrumb('Gradebook');
+        $this->core->getOutput()->addInternalCss('rainbow-grades.css');
 
         $display_rainbow_grades_summary = $this->core->getConfig()->displayRainbowGradesSummary();
 


### PR DESCRIPTION
### What is the current behavior?
Currently, in dark mode, the text in most table cells is white. This makes some cells very hard or impossible to read.

### What is the new behavior?
The text in the cells is always black (since the other colors of the rainbow grades summary don't change, neither should the text).