### PR TITLE
[Testing:Developer] Do not fail fast vagrant CI

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -16,6 +16,7 @@ jobs:
             port: 1501
           - image: ubuntu-20.04
             port: 1511
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

If one job in the vagrant CI fails, the other job will be immediately killed. Usually one of the builds failing is due to spurious Ubuntu mirror problems than anything, and would still be useful to have the other job run to completion so we have a signal of "the CI failed, but it was just one job, and so probably just spurious error".

### What is the new behavior?

Do not fail fast the CI build, so that if one build fails, the other will keep on going until success or failure on its own.
