### PR TITLE
[Bugfix:InstructorUI] Change Late Day Timestamps to Dates

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -559,7 +559,7 @@ CREATE TABLE public.late_day_exceptions (
 CREATE TABLE public.late_days (
     user_id character varying(255) NOT NULL,
     allowed_late_days integer NOT NULL,
-    since_timestamp timestamp(6) with time zone NOT NULL
+    since_timestamp date NOT NULL
 );
 
 

--- a/migration/migrator/migrations/course/20210608141409_late_day_date.py
+++ b/migration/migrator/migrations/course/20210608141409_late_day_date.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE late_days ALTER COLUMN since_timestamp TYPE date USING since_timestamp::date;")
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE late_days ALTER COLUMN since_timestamp TYPE timestamptz USING since_timestamp::timestamptz;")

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -81,7 +81,7 @@ class LateController extends AbstractController {
                 );
             }
 
-            if (!isset($_POST['datestamp']) || (\DateTime::createFromFormat('Y-m-d H:i:s', $_POST['datestamp']) === false)) {
+            if (!isset($_POST['datestamp']) || (\DateTime::createFromFormat('Y-m-d', $_POST['datestamp']) === false)) {
                 $error = "Datestamp must be Y-m-d H:i:s";
                 $this->core->addErrorMessage($error);
                 return MultiResponse::JsonOnlyResponse(

--- a/site/app/models/DateTimeFormat.php
+++ b/site/app/models/DateTimeFormat.php
@@ -33,7 +33,7 @@ class DateTimeFormat extends AbstractModel {
             'solution_ta_notes' => 'j/n g:i A',
             'office_hours_queue' => 'g:i A',
             'date_time_picker' => 'Y-m-d H:i:s',
-            'late_days_allowed' => 'm/d/Y h:i:s A T',
+            'late_days_allowed' => 'm/d/Y',
             'poll' => 'm/d/Y',
         ],
         'DMY' => [

--- a/site/app/models/SimpleLateUser.php
+++ b/site/app/models/SimpleLateUser.php
@@ -26,7 +26,7 @@ class SimpleLateUser extends AbstractModel {
     protected $displayed_last_name;
     /** @prop @var string The allowed late days of the user */
     protected $allowed_late_days;
-    /** @prop @var string The day late days are put into effect */
+    /** @prop @var date The day late days are put into effect */
     protected $since_timestamp;
     /** @prop @var string The extensions of a user (allowed late days for a specific homework) */
     protected $late_day_exceptions;

--- a/site/app/models/SimpleLateUser.php
+++ b/site/app/models/SimpleLateUser.php
@@ -63,7 +63,7 @@ class SimpleLateUser extends AbstractModel {
 
         if (isset($details['allowed_late_days']) && isset($details['since_timestamp'])) {
             $this->allowed_late_days = $details['allowed_late_days'];
-            $this->since_timestamp = DateUtils::parseDateTime($details['since_timestamp'], $this->core->getUser()->getUsableTimeZone());
+            $this->since_timestamp = DateUtils::parseDateTime($details['since_timestamp'], $this->core->getDateTimeNow()->getTimezone());
         }
         if (isset($details['late_day_exceptions'])) {
             $this->late_day_exceptions = $details['late_day_exceptions'];

--- a/site/app/templates/admin/LateDays.twig
+++ b/site/app/templates/admin/LateDays.twig
@@ -105,10 +105,10 @@
             }
         )],
         allowInput: true,
-        enableTime: true,
-        enableSeconds: true,
+        enableTime: false,
+        enableSeconds: false,
         time_24hr: true,
-        dateFormat: "Y-m-d H:i:S",
+        dateFormat: "Y-m-d",
         onReady: (a, b, fp) => {
             fp.calendarContainer.firstChild.childNodes[1].firstChild.firstChild.setAttribute('aria-label', 'Month');
             fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');

--- a/site/tests/app/models/SimpleLateUserTester.php
+++ b/site/tests/app/models/SimpleLateUserTester.php
@@ -32,7 +32,7 @@ class SimpleLateUserTester extends \PHPUnit\Framework\TestCase {
         $this->core->setUser($user);
         $this->core->setConfig($config);
         $sinceDateTime = new \DateTime('now', $this->core->getUser()->getUsableTimeZone());
-        $sinceTimestamp = $sinceDateTime->format('m/d/Y h:i:s A T');
+        $sinceTimestamp = $sinceDateTime->format('m/d/Y');
         $this->userDetails = [
             'user_id' => 'id',
             'user_firstname' => 'Alexander',
@@ -97,7 +97,7 @@ class SimpleLateUserTester extends \PHPUnit\Framework\TestCase {
     public function testLateUserMethods(): void {
         $user = new SimpleLateUser($this->core, $this->userDetails);
         $sinceDateTime = new \DateTime('now', $this->core->getUser()->getUsableTimeZone());
-        $sinceTimestamp = $sinceDateTime->format('m/d/Y h:i:s A T');
+        $sinceTimestamp = $sinceDateTime->format('m/d/Y');
         $newUserDetails = [
             'user_id' => 'id_updated',
             'user_firstname' => 'Alexander_updated',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently late days are stored with a full timestamp.
Closes #6053

### What is the new behavior?
Late days are now only stored with a date. The precision down to the second is not needed for late days.

### Other information?
This does change all timestamps for late days into a date by casting it.
