### PR TITLE
[Bugfix:Plagiarism] Fix sequence length error checking

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -296,7 +296,7 @@ class PlagiarismController extends AbstractController {
             $this->core->redirect($return_url);
         }
 
-        if (isset($_POST['sequence_length']) && $_POST['sequence_length'] !== '' && is_numeric($_POST['sequence_length']) && $_POST['sequence_length'] > 0) {
+        if (isset($_POST['sequence_length']) && $_POST['sequence_length'] !== '' && is_numeric($_POST['sequence_length']) && $_POST['sequence_length'] >= 2) {
             $sequence_length = $_POST['sequence_length'];
         }
         else {

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -300,7 +300,7 @@ class PlagiarismController extends AbstractController {
             $sequence_length = $_POST['sequence_length'];
         }
         else {
-            $this->core->addErrorMessage("Invalid input provided for sequence length");
+            $this->core->addErrorMessage("Invalid input provided for sequence length. The minimum allowed threshold value is 2");
             $this->core->redirect($return_url);
         }
 


### PR DESCRIPTION
### What is the current behavior?
It is currently possible to trigger an assertion failure in `compare_matches.cpp` from the UI by setting a sequence length of 1.

### What is the new behavior?
This PR changes the minimum allowable sequence length to 2 to bring the PHP into alignment with the C++ backend.

Fixes part of #6568
