### PR TITLE
[Bugfix:Submission] Fix Penalty Badges Not Showing

### DIFF
--- a/site/app/templates/functions/Badge.twig
+++ b/site/app/templates/functions/Badge.twig
@@ -62,7 +62,11 @@
         {% if extra_credit %}
             +{{ earned }}
         {% elseif earned < 0 %}
-            &minus;{{ earned|abs }} / {{ max }}
+            {% if max != 0 %}
+                &minus;{{ earned|abs }} / {{ max }}
+            {% else %}
+                &minus;{{ earned|abs }}
+            {% endif %}
         {% else %}
             {{ earned }} / {{ max }}
         {% endif %}

--- a/site/app/templates/functions/Badge.twig
+++ b/site/app/templates/functions/Badge.twig
@@ -81,16 +81,14 @@
         {% elseif max > 0 %}
             {# Normal case always shows #}
             true
-        {% elseif max < 0 %}
+        {% else %}
             {# Negaitve points only show if you got it #}
             {% if earned < 0 %}
                 true
             {% else %}
+                {# Otherwise it's worth <= 0 points and no points were earned, so don't show #}
                 false
             {% endif %}
-        {% else %}
-            {# Otherwise it's worth zero points, don't show #}
-            false
         {% endif %}
     {%- endapply -%}
 {%- endmacro -%}

--- a/site/app/templates/functions/Badge.twig
+++ b/site/app/templates/functions/Badge.twig
@@ -86,7 +86,7 @@
             {% if earned < 0 %}
                 true
             {% else %}
-                {# Otherwise it's worth <= 0 points and no points were earned, so don't show #}
+                {# Otherwise it's worth <= 0 points and no penalty points were earned, so don't show #}
                 false
             {% endif %}
         {% endif %}


### PR DESCRIPTION
### What is the current behavior?
Fixes #4631 
Currently, components that have only penalty points will not have their badge shown even if the student has earned the penalty points. For a rubric like this:
![image](https://user-images.githubusercontent.com/28243927/122652717-2080ee80-d10e-11eb-9941-aacb6baaf400.png)
The result is this on the student's end:
![image](https://user-images.githubusercontent.com/28243927/122652695-0c3cf180-d10e-11eb-8b4f-1a184de1c678.png)

### What is the new behavior?
Badges from penalty only components now show if the student has earned the penalty points. All other badges remain the same.
![image](https://user-images.githubusercontent.com/28243927/122652656-e0ba0700-d10d-11eb-9105-f64204ba4b6c.png)
