### PR TITLE
[UI/UX:InstructorUI] Add borders to Plagiarism Highlight Key

### DIFF
--- a/site/app/templates/admin/PlagiarismHighlightingKey.twig
+++ b/site/app/templates/admin/PlagiarismHighlightingKey.twig
@@ -3,12 +3,12 @@
 {% block title %}Plagiarism Highlighting Key{% endblock %}
 {% block body %}
 <div>
-    <i style="color:white;" class="fas fa-square" aria-label="White Box"></i> Unique <br />
-    <i style="color:#cccccc;" class="fas fa-square" aria-label="Gray Box"></i> Common (matches many/all students) <br />
-    <i style="color:#b5e3b5;" class="fas fa-square" aria-label="Green Box"></i> Matches instructor provided file <br />
-    <i style="color:yellow;" class="fas fa-square" aria-label="Yellow Box"></i> Matches other student(s) <br />
-    <i style="color:#ffa500;" class="fas fa-square" aria-label="Orange Box"></i> General match between selected users <br />
-    <i style="color:red;" class="fas fa-square" aria-label="Red Box"></i> Specific match between selected users <br />
+    <i style="color:white;" class="fas fa-square plag-legend" aria-label="White Box"></i> Unique <br />
+    <i style="color:#cccccc;" class="fas fa-square plag-legend" aria-label="Gray Box"></i> Common (matches many/all students) <br />
+    <i style="color:#b5e3b5;" class="fas fa-square plag-legend" aria-label="Green Box"></i> Matches instructor provided file <br />
+    <i style="color:yellow;" class="fas fa-square plag-legend" aria-label="Yellow Box"></i> Matches other student(s) <br />
+    <i style="color:#ffa500;" class="fas fa-square plag-legend" aria-label="Orange Box"></i> General match between selected users <br />
+    <i style="color:red;" class="fas fa-square plag-legend" aria-label="Red Box"></i> Specific match between selected users <br />
 </div>
 {% endblock %}
 {% block buttons %}

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -189,6 +189,10 @@ main#main.full-screen-mode .plagiarism-result-cont {
     border: 1px solid var(--text-black);
 }
 
+[data-theme="dark"] .plag-legend {
+    border: 1px solid transparent;
+}
+
 @media (max-width: 660px) {
     .nav-buttons a {
         width: 100%;

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -186,11 +186,12 @@ main#main.full-screen-mode .plagiarism-result-cont {
 }
 
 .plag-legend {
-    border: 1px solid var(--text-black);
+    text-shadow: 0 0 3px var(--text-black);
+    margin-left: 5px;
 }
 
 [data-theme="dark"] .plag-legend {
-    border: 1px solid transparent;
+    text-shadow: 0 0 3px transparent;
 }
 
 @media (max-width: 660px) {

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -185,6 +185,10 @@ main#main.full-screen-mode .plagiarism-result-cont {
     float: right;
 }
 
+.plag-legend {
+    border: 1px solid var(--text-black);
+}
+
 @media (max-width: 660px) {
     .nav-buttons a {
         width: 100%;


### PR DESCRIPTION
### What is the current behavior?
Fixes #6610 
![image](https://user-images.githubusercontent.com/28243927/122243803-66318300-ce92-11eb-8a66-8417d7dcd0e0.png)

There are no borders behind the icons in the plagiarism highlighting key, making white invisible on light mode.
### What is the new behavior?
There are now text shadows on light mode to help differentiate the icons from the background
![image](https://user-images.githubusercontent.com/28243927/122403753-9dfd0100-cf4c-11eb-80a6-d4deefdae72e.png)