### PR TITLE
[Bugfix:Forum] Prevent spamming duplicate posts

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -164,6 +164,8 @@ function publishFormWithAttachments(form, test_category, error_message, is_threa
     }
     var submit_url = form.attr('action');
 
+    form.find("[type=submit]").prop('disabled', true);
+
     $.ajax({
         url: submit_url,
         data: formData,


### PR DESCRIPTION
### What is the current behavior?
Fixes #6613 
When submitting a post or creating a thread on the discussion forum, you can create multiple duplicate posts/threads by clicking the submit button multiple times before the page reloads.

### What is the new behavior?
The Submit Reply and Publish Thread buttons will now be disabled after being clicked on once, so that the form can't be submitted multiple times.
