### PR TITLE
[UI/UX:Submission] Make Version Conflict State Clearer

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionBox.twig
+++ b/site/app/templates/submission/homework/CurrentVersionBox.twig
@@ -75,7 +75,7 @@
                 {% elseif active_version > 0 %}
                     <p class="red-message">
                         {% if after_ta_open %}
-                            Warning: TA grading has already begun and your grade will automatically be set to zero if the active <br />
+                            Warning: TA grading has already begun and your grade will automatically be set to zero if the active
                             submission version does not match the version graded by instructor or teaching assistant.
                         {% else %}
                             Note: This version of your assignment will not be graded the instructor/TAs. <br />

--- a/site/app/templates/submission/homework/CurrentVersionBox.twig
+++ b/site/app/templates/submission/homework/CurrentVersionBox.twig
@@ -74,8 +74,13 @@
                     </p>
                 {% elseif active_version > 0 %}
                     <p class="red-message">
-                        Note: This version of your assignment will not be graded the instructor/TAs. <br />
-                        Click the button "Grade This Version" if you would like to specify that this version of your homework should be graded.
+                        {% if after_ta_open %}
+                            Warning: TA grading has already begun and your grade will automatically be set to zero if the active <br />
+                            submission version does not match the version graded by instructor or teaching assistant.
+                        {% else %}
+                            Note: This version of your assignment will not be graded the instructor/TAs. <br />
+                            Click the button "Grade This Version" if you would like to specify that this version of your homework should be graded.
+                        {% endif %}
                     </p>
                 {% else %}
                     <p class="red-message">

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1007,7 +1007,8 @@ class HomeworkView extends AbstractView {
             'can_see_all_versions' => $this->core->getUser()->accessGrading() || $gradeable->isStudentSubmit(),
             'active_same_as_graded' => $active_same_as_graded,
             'csrf_token' => $this->core->getCsrfToken(),
-            'date_time_format' => $this->core->getConfig()->getDateTimeFormat()->getFormat('gradeable_with_seconds')
+            'date_time_format' => $this->core->getConfig()->getDateTimeFormat()->getFormat('gradeable_with_seconds'),
+            'after_ta_open' => $gradeable->getGradeStartDate() < $this->core->getDateTimeNow()
         ]);
 
         $this->core->getOutput()->addInternalJs('confetti.js');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently a non-clear message is shown before a student decides to change their version on Submitty.
Closes #5262 

### What is the new behavior?
Now a clearer message is shown after TA grading has begun to warn them their grade will be set to a zero.
