### PR TITLE
[Refactor:Forum] Add proper bootstrap dropdown support

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -84,52 +84,32 @@
 					More
 				</button>
 				<div class="dropdown-menu">
-					<ul>
-						{% for more in more_data|slice(1) %}
-							{% if user_group <= more.required_rank %}
-								{% set onclick = (more.onclick[0]) ? 'onclick=' ~ more.onclick[1] %}
-								{% set optional_class = (more.optional_class[0]) ? 'class=' ~ more.optional_class[1] %}
-								<li class='dropdown-item' role="menuitem">
-									<a id="{{ more.id }}" title="{{ more.title }}" {{ optional_class }} href="{{ more.link }}" {{ onclick }}>{{ more.display_text }}</a>
-								</li>
-							{% endif %}
-						{% endfor %}
-						{% if core.getUser().accessGrading() %}
-							<li class="divider"></li>
-							<li title="Click to edit categories" class='dropdown-item' role="menuitem">
-								<a href="{{ manage_categories_url }}" title="Edit Forum Categories" >Edit Categories</a>
-							</li>
+					{% for more in more_data|slice(1) %}
+						{% if user_group <= more.required_rank %}
+							{% set onclick = (more.onclick[0]) ? 'onclick=' ~ more.onclick[1] %}
+							{% set optional_class = (more.optional_class[0]) ? 'class=' ~ more.optional_class[1] %}
+								<a id="{{ more.id }}" class="dropdown-item" title="{{ more.title }}" {{ optional_class }} href="{{ more.link }}" {{ onclick }}>{{ more.display_text }}</a>
 						{% endif %}
-						{% if thread_exists and not is_full_threads_page %}
-							<li class="divider"></li>
-							<li title="Click to toggle all post attachments" class='dropdown-item' role="menuitem">
-								<a href="#" id="toggle-attachments-button" class="key_to_click show-all" tabindex="0" onclick="loadAllInlineImages()">
-									Attachments <span class="attachment-badge badge">{{ total_attachments }}</span>
-								</a>
-							</li>
-							<li class="divider"></li>
-							<li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item' role="menuitem">
-								<a class="key_to_click"  onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a>
-							</li>
-							<li title="Sort posts by ascending chronological order" id="time" class='dropdown-item' role="menuitem">
-								<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a>
-							</li>
-							<li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item' role="menuitem">
-								<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological <i class="fas fa-angle-down"></i> </a>
-							</li>
-							{% if user_group <= core.getUser().accessGrading() %}
-								<li title="Sort posts by author's last name" id="alpha" class='dropdown-item' role="menuitem">
-									<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha')">Alphabetical</a>
-								</li>
-								<li title="Sort posts by author's registration section then last name" id="alpha_by_registration" class='dropdown-item' role="menuitem">
-									<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha_by_registration')">Alpha by Registration</a>
-								</li>
-								<li title="Sort posts by author's rotating section then last name" id="alpha_by_rotating" class='dropdown-item' role="menuitem">
-									<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha_by_rotating')">Alpha by Rotating</a>
-								</li>
-							{% endif %}
+					{% endfor %}
+					{% if core.getUser().accessGrading() %}
+						<div class="dropdown-divider"></div>
+						<a class="dropdown-item" href="{{ manage_categories_url }}" title="Edit Forum Categories" >Edit Categories</a>
+					{% endif %}
+					{% if thread_exists and not is_full_threads_page %}
+						<div class="dropdown-divider"></div>
+						<a class="dropdown-item" href="#" id="toggle-attachments-button" class="key_to_click show-all" tabindex="0" title="Click to toggle all post attachments" onclick="loadAllInlineImages()">
+							Attachments <span class="attachment-badge badge">{{ total_attachments }}</span>
+						</a>
+						<div class="dropdown-divider"></div>
+						<a class="key_to_click dropdown-item"  id="tree" title="Sort posts by reply hierarchy" onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a>
+						<a href="#" id="time" class="key_to_click dropdown-item" tabindex="0" title="Sort posts by ascending chronological order" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a>
+						<a href="#" id="reverse-time" class="key_to_click dropdown-item" tabindex="0" title="Sort posts by descending chronological order" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological <i class="fas fa-angle-down"></i> </a>
+						{% if user_group <= core.getUser().accessGrading() %}
+							<a href="#" id="alpha" class="key_to_click dropdown-item" tabindex="0" title="Sort posts by author's last name" onclick="changeDisplayOptions('alpha')">Alphabetical</a>
+							<a href="#" id="alpha_by_registration" class="key_to_click dropdown-item" tabindex="0" title="Sort posts by author's registration section then last name" onclick="changeDisplayOptions('alpha_by_registration')">Alpha by Registration</a>
+							<a href="#" id="alpha_by_rotating" class="key_to_click dropdown-item" tabindex="0" title="Sort posts by author's rotating section then last name" onclick="changeDisplayOptions('alpha_by_rotating')">Alpha by Rotating</a>
 						{% endif %}
-					</ul>
+					{% endif %}
 				</div>
 			</div>
 	    </div>

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -79,55 +79,59 @@
 
 	{% if show_more %}
 	    <div class="dropdown more-dropdown">
-	        <a title="More options" id="dropdownLabel" role="button" data-toggle="dropdown" class="btn btn-default dropdown-toggle" data-target="#" href="#">
-	            More <span class="caret"></span>
-	        </a>
-			<ul class="dropdown-menu multi-level" role="menu" aria-labelledby="dropdownLabel">
-			{% for more in more_data|slice(1) %}
-				{% if user_group <= more.required_rank %}
-					{% set onclick = (more.onclick[0]) ? 'onclick=' ~ more.onclick[1] %}
-					{% set optional_class = (more.optional_class[0]) ? 'class=' ~ more.optional_class[1] %}
-	          		<li class='dropdown-item' role="menuitem">
-						<a id="{{ more.id }}" title="{{ more.title }}" {{ optional_class }} href="{{ more.link }}" {{ onclick }}>{{ more.display_text }}</a>
-					</li>
-	          	{% endif %}
-	        {% endfor %}
-	        {% if core.getUser().accessGrading() %}
-                <li class="divider"></li>
-              	<li title="Click to edit categories" class='dropdown-item' role="menuitem">
-            		<a href="{{ manage_categories_url }}" title="Edit Forum Categories" >Edit Categories</a>
-				</li>
-			{% endif %}
-			{% if thread_exists and not is_full_threads_page %}
-	          	<li class="divider"></li>
-	          	<li title="Click to toggle all post attachments" class='dropdown-item' role="menuitem">
-	          		<a href="#" id="toggle-attachments-button" class="key_to_click show-all" tabindex="0" onclick="loadAllInlineImages()">
-   						Attachments <span class="attachment-badge badge">{{ total_attachments }}</span>
-   					</a>
-				</li>
-	          	<li class="divider"></li>
-              	<li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item' role="menuitem">
-				  	<a class="key_to_click"  onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a>
-				</li>
-              	<li title="Sort posts by ascending chronological order" id="time" class='dropdown-item' role="menuitem">
-					<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a>
-				</li>
-			    <li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item' role="menuitem">
-					<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological <i class="fas fa-angle-down"></i> </a>
-				</li>
-              	{% if user_group <= core.getUser().accessGrading() %}
-              		<li title="Sort posts by author's last name" id="alpha" class='dropdown-item' role="menuitem">
-						<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha')">Alphabetical</a>
-					</li>
-              		<li title="Sort posts by author's registration section then last name" id="alpha_by_registration" class='dropdown-item' role="menuitem">
-						<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha_by_registration')">Alpha by Registration</a>
-					</li>
-              		<li title="Sort posts by author's rotating section then last name" id="alpha_by_rotating" class='dropdown-item' role="menuitem">
-						<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha_by_rotating')">Alpha by Rotating</a>
-					</li>
-	            {% endif %}
-	        {% endif %}
-	        </ul>
+			<div class="btn-group">
+				<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					More
+				</button>
+				<div class="dropdown-menu">
+					<ul>
+						{% for more in more_data|slice(1) %}
+							{% if user_group <= more.required_rank %}
+								{% set onclick = (more.onclick[0]) ? 'onclick=' ~ more.onclick[1] %}
+								{% set optional_class = (more.optional_class[0]) ? 'class=' ~ more.optional_class[1] %}
+								<li class='dropdown-item' role="menuitem">
+									<a id="{{ more.id }}" title="{{ more.title }}" {{ optional_class }} href="{{ more.link }}" {{ onclick }}>{{ more.display_text }}</a>
+								</li>
+							{% endif %}
+						{% endfor %}
+						{% if core.getUser().accessGrading() %}
+							<li class="divider"></li>
+							<li title="Click to edit categories" class='dropdown-item' role="menuitem">
+								<a href="{{ manage_categories_url }}" title="Edit Forum Categories" >Edit Categories</a>
+							</li>
+						{% endif %}
+						{% if thread_exists and not is_full_threads_page %}
+							<li class="divider"></li>
+							<li title="Click to toggle all post attachments" class='dropdown-item' role="menuitem">
+								<a href="#" id="toggle-attachments-button" class="key_to_click show-all" tabindex="0" onclick="loadAllInlineImages()">
+									Attachments <span class="attachment-badge badge">{{ total_attachments }}</span>
+								</a>
+							</li>
+							<li class="divider"></li>
+							<li title="Sort posts by reply hierarchy" id="tree" class='dropdown-item' role="menuitem">
+								<a class="key_to_click"  onclick="changeDisplayOptions('tree', {{ current_thread }})" href="#">Hierarchical</a>
+							</li>
+							<li title="Sort posts by ascending chronological order" id="time" class='dropdown-item' role="menuitem">
+								<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('time', {{ current_thread }})">Chronological  <i class="fas fa-angle-up"></i> </a>
+							</li>
+							<li title="Sort posts by descending chronological order" id="reverse-time" class='dropdown-item' role="menuitem">
+								<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('reverse-time', {{ current_thread }})">Chronological <i class="fas fa-angle-down"></i> </a>
+							</li>
+							{% if user_group <= core.getUser().accessGrading() %}
+								<li title="Sort posts by author's last name" id="alpha" class='dropdown-item' role="menuitem">
+									<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha')">Alphabetical</a>
+								</li>
+								<li title="Sort posts by author's registration section then last name" id="alpha_by_registration" class='dropdown-item' role="menuitem">
+									<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha_by_registration')">Alpha by Registration</a>
+								</li>
+								<li title="Sort posts by author's rotating section then last name" id="alpha_by_rotating" class='dropdown-item' role="menuitem">
+									<a href="#" class="key_to_click" tabindex="0" onclick="changeDisplayOptions('alpha_by_rotating')">Alpha by Rotating</a>
+								</li>
+							{% endif %}
+						{% endif %}
+					</ul>
+				</div>
+			</div>
 	    </div>
 	{% endif %}
 

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -595,6 +595,341 @@ input[type="button"].btn-block {
   margin-bottom: 0;
 }
 
+.dropup,
+.dropright,
+.dropdown,
+.dropleft {
+  position: relative;
+}
+
+.dropdown-toggle::after {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0;
+  border-left: 0.3em solid transparent;
+}
+
+.dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 10rem;
+  padding: 0.5rem 0;
+  margin: 0.125rem 0 0;
+  font-size: 1rem;
+  color: #212529;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.25rem;
+}
+
+.dropdown-menu-right {
+  right: 0;
+  left: auto;
+}
+
+.dropup .dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 0.125rem;
+}
+
+.dropup .dropdown-toggle::after {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0.3em solid;
+  border-left: 0.3em solid transparent;
+}
+
+.dropup .dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+
+.dropright .dropdown-menu {
+  top: 0;
+  right: auto;
+  left: 100%;
+  margin-top: 0;
+  margin-left: 0.125rem;
+}
+
+.dropright .dropdown-toggle::after {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0;
+  border-bottom: 0.3em solid transparent;
+  border-left: 0.3em solid;
+}
+
+.dropright .dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+
+.dropright .dropdown-toggle::after {
+  vertical-align: 0;
+}
+
+.dropleft .dropdown-menu {
+  top: 0;
+  right: 100%;
+  left: auto;
+  margin-top: 0;
+  margin-right: 0.125rem;
+}
+
+.dropleft .dropdown-toggle::after {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+}
+
+.dropleft .dropdown-toggle::after {
+  display: none;
+}
+
+.dropleft .dropdown-toggle::before {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-right: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0.3em solid;
+  border-bottom: 0.3em solid transparent;
+}
+
+.dropleft .dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+
+.dropleft .dropdown-toggle::before {
+  vertical-align: 0;
+}
+
+.dropdown-menu[x-placement^="top"], .dropdown-menu[x-placement^="right"], .dropdown-menu[x-placement^="bottom"], .dropdown-menu[x-placement^="left"] {
+  right: auto;
+  bottom: auto;
+}
+
+.dropdown-divider {
+  height: 0;
+  margin: 0.5rem 0;
+  overflow: hidden;
+  border-top: 1px solid #e9ecef;
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 1.5rem;
+  clear: both;
+  font-weight: 400;
+  color: #212529;
+  text-align: inherit;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0;
+}
+
+.dropdown-item:hover, .dropdown-item:focus {
+  color: #16181b;
+  text-decoration: none;
+  background-color: #f8f9fa;
+}
+
+.dropdown-item.active, .dropdown-item:active {
+  color: #fff;
+  text-decoration: none;
+  background-color: #007bff;
+}
+
+.dropdown-item.disabled, .dropdown-item:disabled {
+  color: #6c757d;
+  background-color: transparent;
+}
+
+.dropdown-menu.show {
+  display: block;
+}
+
+.dropdown-header {
+  display: block;
+  padding: 0.5rem 1.5rem;
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  color: #6c757d;
+  white-space: nowrap;
+}
+
+.dropdown-item-text {
+  display: block;
+  padding: 0.25rem 1.5rem;
+  color: #212529;
+}
+
+.btn-group,
+.btn-group-vertical {
+  position: relative;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.btn-group > .btn,
+.btn-group-vertical > .btn {
+  position: relative;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.btn-group > .btn:hover,
+.btn-group-vertical > .btn:hover {
+  z-index: 1;
+}
+
+.btn-group > .btn:focus, .btn-group > .btn:active, .btn-group > .btn.active,
+.btn-group-vertical > .btn:focus,
+.btn-group-vertical > .btn:active,
+.btn-group-vertical > .btn.active {
+  z-index: 1;
+}
+
+.btn-group .btn + .btn,
+.btn-group .btn + .btn-group,
+.btn-group .btn-group + .btn,
+.btn-group .btn-group + .btn-group,
+.btn-group-vertical .btn + .btn,
+.btn-group-vertical .btn + .btn-group,
+.btn-group-vertical .btn-group + .btn,
+.btn-group-vertical .btn-group + .btn-group {
+  margin-left: -1px;
+}
+
+.btn-toolbar {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.btn-toolbar .input-group {
+  width: auto;
+}
+
+.btn-group > .btn:first-child {
+  margin-left: 0;
+}
+
+.btn-group > .btn:not(:last-child):not(.dropdown-toggle),
+.btn-group > .btn-group:not(:last-child) > .btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.btn-group > .btn:not(:first-child),
+.btn-group > .btn-group:not(:first-child) > .btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.dropdown-toggle-split {
+  padding-right: 0.5625rem;
+  padding-left: 0.5625rem;
+}
+
+.dropdown-toggle-split::after,
+.dropup .dropdown-toggle-split::after,
+.dropright .dropdown-toggle-split::after {
+  margin-left: 0;
+}
+
+.dropleft .dropdown-toggle-split::before {
+  margin-right: 0;
+}
+
+.btn-sm + .dropdown-toggle-split, .btn-group-sm > .btn + .dropdown-toggle-split {
+  padding-right: 0.375rem;
+  padding-left: 0.375rem;
+}
+
+.btn-lg + .dropdown-toggle-split, .btn-group-lg > .btn + .dropdown-toggle-split {
+  padding-right: 0.75rem;
+  padding-left: 0.75rem;
+}
+
+.btn-group-vertical {
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.btn-group-vertical .btn,
+.btn-group-vertical .btn-group {
+  width: 100%;
+}
+
+.btn-group-vertical > .btn + .btn,
+.btn-group-vertical > .btn + .btn-group,
+.btn-group-vertical > .btn-group + .btn,
+.btn-group-vertical > .btn-group + .btn-group {
+  margin-top: -1px;
+  margin-left: 0;
+}
+
+.btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle),
+.btn-group-vertical > .btn-group:not(:last-child) > .btn {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.btn-group-vertical > .btn:not(:first-child),
+.btn-group-vertical > .btn-group:not(:first-child) > .btn {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.btn-group-toggle > .btn,
+.btn-group-toggle > .btn-group > .btn {
+  margin-bottom: 0;
+}
+
 .btn-group-toggle > .btn input[type="radio"],
 .btn-group-toggle > .btn input[type="checkbox"],
 .btn-group-toggle > .btn-group > .btn input[type="radio"],

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -774,7 +774,7 @@ input[type="button"].btn-block {
 .dropdown-item:hover, .dropdown-item:focus {
   color: var(--standard-deep-dark-gray);
   text-decoration: none;
-  background-color: var(--standard-pale-blue-gray);
+  background-color: var(--btn-standard-pale-blue-gray);
 }
 
 .dropdown-item.active, .dropdown-item:active {

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -630,18 +630,26 @@ input[type="button"].btn-block {
   padding: 0.5rem 0;
   margin: 0.125rem 0 0;
   font-size: 1rem;
-  color: #212529;
   text-align: left;
   list-style: none;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 0.25rem;
+  background-color: var(--default-white);
+  -webkit-background-clip: padding-box;
+          background-clip: padding-box;
+  border: 1px solid var(--standard-light-gray);
+  border: 1px solid rgba(0, 0, 0, .15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+          box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
 }
 
 .dropdown-menu-right {
   right: 0;
   left: auto;
+}
+
+.dropdown-menu-left {
+  right: auto;
+  left: 0;
 }
 
 .dropup .dropdown-menu {
@@ -747,7 +755,7 @@ input[type="button"].btn-block {
   height: 0;
   margin: 0.5rem 0;
   overflow: hidden;
-  border-top: 1px solid #e9ecef;
+  border-top: 1px solid var(--standard-hover-light-gray);
 }
 
 .dropdown-item {
@@ -756,7 +764,7 @@ input[type="button"].btn-block {
   padding: 0.25rem 1.5rem;
   clear: both;
   font-weight: 400;
-  color: #212529;
+  color: var(--text-black);
   text-align: inherit;
   white-space: nowrap;
   background-color: transparent;
@@ -764,19 +772,19 @@ input[type="button"].btn-block {
 }
 
 .dropdown-item:hover, .dropdown-item:focus {
-  color: #16181b;
+  color: var(--standard-deep-dark-gray);
   text-decoration: none;
-  background-color: #f8f9fa;
+  background-color: var(--standard-pale-blue-gray);
 }
 
 .dropdown-item.active, .dropdown-item:active {
-  color: #fff;
+  color: var(--default-white);
   text-decoration: none;
-  background-color: #007bff;
+  background-color: var(--actionable-blue);
 }
 
 .dropdown-item.disabled, .dropdown-item:disabled {
-  color: #6c757d;
+  color: var(--standard-medium-dark-gray);
   background-color: transparent;
 }
 
@@ -789,14 +797,14 @@ input[type="button"].btn-block {
   padding: 0.5rem 1.5rem;
   margin-bottom: 0;
   font-size: 0.875rem;
-  color: #6c757d;
+  color: var(--standard-medium-dark-gray);
   white-space: nowrap;
 }
 
 .dropdown-item-text {
   display: block;
   padding: 0.25rem 1.5rem;
-  color: #212529;
+  color: var(--standard-deep-dark-gray);
 }
 
 .btn-group,

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -808,7 +808,44 @@ tbody.collapse.in {
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
-.dropup,
+
+.dropdown-menu ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+.dropdown-menu li a {
+  display: block;
+  padding: 3px 20px;
+  text-decoration: none;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: var(--text-black);
+  white-space: nowrap;
+}
+.dropdown-menu li > a:hover,
+.dropdown-menu li > a:focus {
+  color: var(--standard-deep-dark-gray);
+  text-decoration: none;
+  background-color: var(--btn-standard-pale-blue-gray);
+}
+  
+.dropdown-menu .disabled > a,
+.dropdown-menu .disabled > a:hover,
+.dropdown-menu .disabled > a:focus {
+  color: var(--standard-medium-gray);
+}
+.dropdown-menu .disabled > a:hover,
+.dropdown-menu .disabled > a:focus {
+  text-decoration: none;
+  cursor: not-allowed;
+  background-color: transparent;
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+
+/* .dropup,
 .dropdown {
   position: relative;
 }
@@ -959,7 +996,7 @@ tbody.collapse.in {
   bottom: 0;
   left: 0;
   z-index: 990;
-}
+} */
 
 .btn-primary {
   color: var(--default-white);

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -809,197 +809,38 @@ tbody.collapse.in {
   border-left: 4px solid transparent;
 }
 
-.dropdown-menu ul {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-}
-
-.dropdown-menu a {
+.dropdown-item {
   display: block;
   padding: 3px 20px;
   text-decoration: none;
   clear: both;
   font-weight: normal;
   line-height: 1.42857143;
-  color: var(--text-black);
+  color: var(--text-black) !important;
   white-space: nowrap;
 }
 
-.dropdown-menu a:hover,
-.dropdown-menu a:focus {
-  color: var(--standard-deep-dark-gray);
+.dropdown-item:hover,
+.dropdown-item:focus {
+  color: var(--standard-deep-dark-gray) !important;
   text-decoration: none;
   background-color: var(--btn-standard-pale-blue-gray);
 }
   
-.dropdown-menu .disabled > a,
-.dropdown-menu .disabled > a:hover,
-.dropdown-menu .disabled > a:focus {
+.dropdown-item.disabled,
+.dropdown-item.disabled:hover,
+.dropdown-item.disabled:focus {
   color: var(--standard-medium-gray);
 }
 
-.dropdown-menu .disabled > a:hover,
-.dropdown-menu .disabled > a:focus {
+.dropdown-item.disabled:hover,
+.dropdown-item.disabled:focus {
   text-decoration: none;
   cursor: not-allowed;
   background-color: transparent;
   background-image: none;
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
-
-/* .dropup,
-.dropdown {
-  position: relative;
-}
-.dropdown-toggle:focus {
-  outline: 0;
-}
-.dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 1000;
-  display: none;
-  float: left;
-  min-width: 160px;
-  padding: 5px 0;
-  margin: 2px 0 0;
-  font-size: 14px;
-  text-align: left;
-  list-style: none;
-  background-color: var(--default-white);
-  -webkit-background-clip: padding-box;
-          background-clip: padding-box;
-  border: 1px solid var(--standard-light-gray);
-  border: 1px solid rgba(0, 0, 0, .15);
-  border-radius: 4px;
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
-          box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
-}
-.dropdown-menu.pull-right {
-  right: 0;
-  left: auto;
-}
-.dropdown-menu .divider {
-  height: 1px;
-  margin: 9px 0;
-  overflow: hidden;
-  background-color: var(--standard-hover-light-gray);
-}
-.dropdown-menu > li > a {
-  display: block;
-  padding: 3px 20px;
-  text-decoration: none;
-  clear: both;
-  font-weight: normal;
-  line-height: 1.42857143;
-  color: var(--text-black);
-  white-space: nowrap;
-}
-.dropdown-menu > li > a:hover,
-.dropdown-menu > li > a:focus {
-  color: var(--standard-deep-dark-gray);
-  text-decoration: none;
-  background-color: var(--btn-standard-pale-blue-gray);
-}
-
-.dropdown-menu > .disabled > a,
-.dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
-  color: var(--standard-medium-gray);
-}
-.dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
-  text-decoration: none;
-  cursor: not-allowed;
-  background-color: transparent;
-  background-image: none;
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-}
-
-.show > .dropdown-menu,
-.open > .dropdown-menu {
-  display: block;
-}
-
-
-.dropdown-submenu {
-    position: relative;
-}
-
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: -6px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 6px 6px 6px;
-    -moz-border-radius: 0 6px 6px;
-    border-radius: 0 6px 6px 6px;
-}
-
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
-}
-
-.dropdown-submenu>a:after {
-    display: block;
-    content: " ";
-    float: right;
-    width: 0;
-    height: 0;
-    border-color: transparent;
-    border-style: solid;
-    border-width: 5px 0 5px 5px;
-    border-left-color: var(--standard-light-gray);
-    margin-top: 5px;
-    margin-right: -10px;
-}
-
-.dropdown-submenu:hover>a:after {
-    border-left-color: var(--default-white);
-}
-
-.dropdown-submenu.pull-left {
-    float: none;
-}
-
-.dropdown-submenu.pull-left>.dropdown-menu {
-    left: -100%;
-    margin-left: 10px;
-    -webkit-border-radius: 6px 0 6px 6px;
-    -moz-border-radius: 6px 0 6px 6px;
-    border-radius: 6px 0 6px 6px;
-}
-
-.show > a,
-.open > a {
-  outline: 0;
-}
-.dropdown-menu-right {
-  right: 0;
-  left: auto;
-}
-.dropdown-menu-left {
-  right: auto;
-  left: 0;
-}
-.dropdown-header {
-  display: block;
-  padding: 3px 20px;
-  font-size: 12px;
-  line-height: 1.42857143;
-  color: var(--standard-medium-gray);
-  white-space: nowrap;
-}
-.dropdown-backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 990;
-} */
 
 .btn-primary {
   color: var(--default-white);

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -814,7 +814,8 @@ tbody.collapse.in {
     margin: 0;
     padding: 0;
 }
-.dropdown-menu li a {
+
+.dropdown-menu a {
   display: block;
   padding: 3px 20px;
   text-decoration: none;
@@ -824,8 +825,9 @@ tbody.collapse.in {
   color: var(--text-black);
   white-space: nowrap;
 }
-.dropdown-menu li > a:hover,
-.dropdown-menu li > a:focus {
+
+.dropdown-menu a:hover,
+.dropdown-menu a:focus {
   color: var(--standard-deep-dark-gray);
   text-decoration: none;
   background-color: var(--btn-standard-pale-blue-gray);
@@ -836,6 +838,7 @@ tbody.collapse.in {
 .dropdown-menu .disabled > a:focus {
   color: var(--standard-medium-gray);
 }
+
 .dropdown-menu .disabled > a:hover,
 .dropdown-menu .disabled > a:focus {
   text-decoration: none;


### PR DESCRIPTION
### What is the current behavior?
Fixes #6618
Currently, the bootstrap dropdown-menu class is partially implemented in `server.css`, and has been modified greatly so it is difficult to use in other areas (can't just simply use dropdown-menu class like bootstrap docs suggests).

### What is the new behavior?
Dropdown related classes have been added to `bootstrap.css` and Submitty specific overrides have been specified in `server.css`. The only place previously using this class (More dropdown on discussion forum) has been adjusted to use the proper layout. 

Now, following [this simple format](https://getbootstrap.com/docs/4.0/components/dropdowns/#single-button-dropdowns), dropdown menus can easily be added.

Also, there is now support for split buttons and [split button dropdowns](https://getbootstrap.com/docs/4.0/components/dropdowns/#single-button-dropdowns).