### PR TITLE
[Documentation:Developer] Remove PR title check in template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 ### Please check if the PR fulfills these requirements:
 
-* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
 * [ ] Tests for the changes have been added/updated (if possible)
 * [ ] Documentation has been updated/added if relevant
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
As discussed in https://github.com/Submitty/Lichen/pull/35, since we now have a github action for the "PR Title Check", this manual check is not necessary anymore.

### What is the new behavior?
The Lichen PR was meant to add a PR template to the repo, and for consistency, the manual title check is removed in the main Submitty repo as well.
