### PR TITLE
[Bugfix:InstructorUI] Delete Duplicate Timestamp Dates

### DIFF
--- a/migration/migrator/migrations/course/20210608141409_late_day_date.py
+++ b/migration/migrator/migrations/course/20210608141409_late_day_date.py
@@ -14,6 +14,8 @@ def up(config, database, semester, course):
     :param course: Code of course being migrated
     :type course: str
     """
+    database.execute("""DELETE FROM late_days T1 USING late_days T2 WHERE T1.since_timestamp < T2.since_timestamp
+    AND T1.user_id = T2.user_id AND T1.since_timestamp::date = T2.since_timestamp::date;""")
     database.execute("ALTER TABLE late_days ALTER COLUMN since_timestamp TYPE date USING since_timestamp::date;")
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently when the migration for #6603 is run, if duplicate dates exist the migration will fail.

### What is the new behavior?
Now before all the timestamps are casted to dates they will be checked for duplicates. Any duplicates will be deleted leaving only the last late day timestamp in that day.
