### PR TITLE
[UI/UX:Forum] Improve forum keyboard navigation

### DIFF
--- a/site/app/templates/forum/GeneratePostList.twig
+++ b/site/app/templates/forum/GeneratePostList.twig
@@ -58,9 +58,10 @@
         <input type="hidden" name="display_option" value="{{ display_option }}" />
         {% include "forum/ThreadPostForm.twig" with {
             "show_post" : true,
-            "post_content_placeholder" : "Enter your reply to all here...\nPress enter for newline or ctrl+enter to post\nPress escape to exit textbox",
+            "post_content_placeholder" : "Enter your reply to all here...\nPress enter for newline or ctrl+enter to post",
             "show_merge_thread_button" : true,
             "post_box_id" : post_box_id,
+            "first_post_id" : post_data[0].post_id,
             "attachment_script" : true,
             "thread_resolve_state": thread_resolve_state,
             "show_unresolve": show_unresolve,

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -77,6 +77,7 @@
             <i class="fab fa-markdown fa-2x"></i>
         </div>
         <a target=_blank href="https://submitty.org/student/discussion_forum#formatting-a-post-using-markdown/" aria-label="Markdown Info"><i id="markdown-info-{{ post_box_id }}" style="font-style:normal;" class="far fa-question-circle disabled"></i></a>
+        <a class="skip-btn skip-first-post" href="#{{ first_post_id }}">Skip to first post</a>
         {% include "misc/MarkdownArea.twig" with {
             "markdown_area_id" : "reply_box_" ~ post_box_id,
             "markdown_area_query" : "$('#reply_box_" ~ post_box_id ~ "')",
@@ -96,6 +97,7 @@
         } only %}
     </div>
     <a class="skip-btn" href="#thread_box_link_{{thread_id != "" ? thread_id : first_post_id}}">Back to thread list</a>
+    <a class="skip-btn" href="#{{ first_post_id }}">Skip to first post</a>
 <br/>
 {% endif %}
 
@@ -218,6 +220,16 @@
             } else {
                 $(".pinThread-checkbox").prop("checked", false);
             }
+        });
+
+        //only show skip buttons with class 'skip-first-post' if the user is navigating backwards
+        //from an input with 'post-content-reply' class
+        $('.post_content_reply').focus(function(){
+            $(this).closest('.markdown-area').prev('.skip-first-post').attr('tabindex', '0');
+        });
+
+        $(':not(.post_content_reply, .skip-first-post)').focus(function(){
+            $('.skip-first-post').attr('tabindex', '-1');
         });
     });
 

--- a/site/app/templates/misc/AccessibilityMessage.twig
+++ b/site/app/templates/misc/AccessibilityMessage.twig
@@ -1,0 +1,1 @@
+<span class="accessibility-message">Press TAB to indent. Press ESC to advance from answer area.</span>

--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -39,7 +39,8 @@
             <i style="font-style:normal;" class="fa-question-circle"></i>
         </a>
     </div>
-    <label for="{{ markdown_area_id }}" tabindex="0" class="screen-reader">{{ markdown_area_id }}</label>
+    <label for="{{ markdown_area_id }}" tabindex="-1" class="screen-reader">{{ markdown_area_id }}</label>
+    {% include "misc/AccessibilityMessage.twig" %}
     <textarea
         id="{{ markdown_area_id }}"
         class="fill-available {{ class }}"

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1955,6 +1955,12 @@ header > * {
     color: unset;
 }
 
+.accessibility-message {
+    font-size: 75%;
+    font-style: italic;
+    color: var(--standard-dark-gray);
+}
+
 @media (max-width: 541px) {
     .content {
         padding: 30px 15px;

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1961,6 +1961,10 @@ header > * {
     color: var(--standard-dark-gray);
 }
 
+[data-theme="dark"] .accessibility-message {
+    color: var(--standard-light-medium-gray);
+}
+
 @media (max-width: 541px) {
     .content {
         padding: 30px 15px;


### PR DESCRIPTION
### What is the current behavior?
Closes #5776 
* Reply boxes on the discussion forum are missing the "Press TAB to indent. Press ESC to advance from textarea" text.
* Navigating backwards (shift tab) from the bottom of the post list (reply box) there is no invisible button to go back to the first post.

### What is the new behavior?
* All areas that are using `misc/MarkdownArea.twig` have tabbing enabled in their textarea as well as the text "Press TAB to indent. Press ESC to advance from textarea" included above them.
  * A new template `misc/AccessibilityMessage.twig` has been created to hold this text.
* Navigating backwards (only backwards!) from a reply box will show an invisible button to skip to the first post in the post list. Also, this button has been added after the reply box as well by tabbing twice.
