### PR TITLE
[Bugfix:Plagiarism] Fix disappearing gradeables bug

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -178,7 +178,10 @@ class PlagiarismController extends AbstractController {
 
         $gradeables_with_plagiarism_result = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
         foreach ($gradeables_with_plagiarism_result as $i => $gradeable_id_title) {
-            if (!file_exists("/var/local/submitty/courses/" . $semester . "/" . $course . "/lichen/ranking/" . $gradeable_id_title['g_id'] . "/overall_ranking.txt") && !file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") && !file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
+            if (!file_exists(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen", "config", "lichen_{$semester}_{$course}_{$gradeable_id_title['g_id']}.json"))
+                && !file_exists(FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "daemon_job_queue", "lichen__{$semester}__{$course}__{$gradeable_id_title['g_id']}.json"))
+                && !file_exists(FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "daemon_job_queue", "PROCESSING_lichen__{$semester}__{$course}__{$gradeable_id_title['g_id']}.json"))
+                ) {
                 unset($gradeables_with_plagiarism_result[$i]);
                 continue;
             }

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -178,10 +178,11 @@ class PlagiarismController extends AbstractController {
 
         $gradeables_with_plagiarism_result = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
         foreach ($gradeables_with_plagiarism_result as $i => $gradeable_id_title) {
-            if (!file_exists(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen", "config", "lichen_{$semester}_{$course}_{$gradeable_id_title['g_id']}.json"))
+            if (
+                !file_exists(FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "lichen", "config", "lichen_{$semester}_{$course}_{$gradeable_id_title['g_id']}.json"))
                 && !file_exists(FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "daemon_job_queue", "lichen__{$semester}__{$course}__{$gradeable_id_title['g_id']}.json"))
                 && !file_exists(FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "daemon_job_queue", "PROCESSING_lichen__{$semester}__{$course}__{$gradeable_id_title['g_id']}.json"))
-                ) {
+            ) {
                 unset($gradeables_with_plagiarism_result[$i]);
                 continue;
             }

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -53,7 +53,7 @@ class PlagiarismView extends AbstractView {
             else {
                 // no lichen job
                 $ranking_file_path = FileUtils::joinPaths($course_path, "lichen", "ranking", $plagiarism_row["id"], "overall_ranking.txt");
-                if (file_get_contents($ranking_file_path) == "") {
+                if (!file_exists($ranking_file_path) || file_get_contents($ranking_file_path) == "") {
                     $plagiarism_row['matches_and_topmatch'] = "0 students matched, N/A top match";
                 }
                 else {


### PR DESCRIPTION
### What is the current behavior?
Currently, if an error occurs while running Lichen which results in a rankings file not being generated, gradeables will disappear from the plagiarism UI and it is impossible to delete , edit, or otherwise access the configuration.  The only way to fix this issue is to manually delete the buggy output files via the command line and create a new configuration via the UI.  This behavior is due to the Plagiarism Controller looking for a rankings file instead of a configuration file to determine which rows to display in the summary table.

### What is the new behavior?
This PR changes the means of determining rows to display in the summary table such that it now depends upon the existence of a configuration file.  This allows users to properly view the erroneous run log and delete or edit configured gradeables as appropriate, all via the UI with no need to access the command line.  If an error occurs, the summary table now displays "N/A" for most fields, as appropriate.

![Untitled](https://user-images.githubusercontent.com/16820599/122941355-522ecb00-d343-11eb-9186-6c27c95d90e0.png)
