### PR TITLE
[SECURITY][Bugfix:TAGrading] Prevent loading of SVG+XML files

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -134,7 +134,7 @@ class MiscController extends AbstractController {
         $file_type = FileUtils::getContentType($file_name);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
-        if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
+        if ($mime_type === "application/pdf" || (Utils::startsWith($mime_type, "image/") && $mime_type !== "image/svg+xml")) {
             header("Content-type: " . $mime_type);
             header('Content-Disposition: inline; filename="' . $file_name . '"');
             readfile($corrected_name);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Closes #5266 

### What is the new behavior?
Prevents loading of a SVG+XML file while TAGrading
