### PR TITLE
[Bugfix:TAGrading] Fix Viewing Other Comments

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2437,7 +2437,7 @@ function open_overall_comment_tab(user) {
 
     //if it is someone not the current user's comment and it hasn't been rendered yet
     if(textarea.hasClass('markdown-preview') && !textarea.find('.markdown').length){
-        const url = buildCourseUrl(['gradeable', getGradeableId(), 'grading', 'overall_comment', 'preview']);
+        const url = buildCourseUrl(['markdown', 'preview']);
         renderMarkdown($(`#overall-comment-${user}`), url, content);
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now, clicking on other grader's comments will produce a submitty page rather than their comment.
Closes #6647

### What is the new behavior?
Their comment is shown with markdown rendered.
