### PR TITLE
[Bugfix:Plagiarism] Fix reloading issue

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -859,10 +859,6 @@ class PlagiarismController extends AbstractController {
     }
 
     /**
-     * Check if the results folder exists for a given gradeable and version results.json
-     * in the results/ directory. If the file exists, we output a string that the calling
-     * JS checks for to initiate a page refresh (so as to go from "in-grading" to done
-     *
      * @Route("/courses/{_semester}/{_course}/plagiarism/check_refresh")
      */
     public function checkRefreshLichenMainPage() {
@@ -873,13 +869,12 @@ class PlagiarismController extends AbstractController {
 
         $gradeable_ids_titles = $this->core->getQueries()->getAllGradeablesIdsAndTitles();
 
+        $gradeables_in_progress = 0;
         foreach ($gradeable_ids_titles as $gradeable_id_title) {
             if (file_exists("/var/local/submitty/daemon_job_queue/lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json") || file_exists("/var/local/submitty/daemon_job_queue/PROCESSING_lichen__" . $semester . "__" . $course . "__" . $gradeable_id_title['g_id'] . ".json")) {
-                $this->core->getOutput()->renderString("REFRESH_ME");
-                return;
+                $gradeables_in_progress++;
             }
         }
-
-        $this->core->getOutput()->renderString("NO_REFRESH");
+        echo $gradeables_in_progress;
     }
 }

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -45,29 +45,29 @@
     function checkRefreshLichenMainPage(url, semester, course) {
         // refresh time for lichen main page
         let refresh_time = 1000;
-        setTimeout(function() {
+        setInterval(function() {
             check_lichen_jobs(url, semester, course);
         }, refresh_time);
     }
 
-    let last_data = "{{ refresh_page }}";
+    let waiting_gradeables = -1;
 
     function check_lichen_jobs(url, semester, course) {
         $.get(url,
             function(data) {
-                if(data === "NO_REFRESH" && last_data === "REFRESH_ME"){
-                    last_data = "DONE_REFRESH";
+                if (waiting_gradeables === -1 || (data === waiting_gradeables && data !== 0)) {
+                    waiting_gradeables = data;
+                }
+                else {
                     // We can't just reload because we need to get rid of the REFRESH_ME part of the URL
                     window.location.href = buildCourseUrl(['plagiarism']);
-                }
-                else if (last_data !== "DONE_REFRESH") {
-                    checkRefreshLichenMainPage(url, semester, course);
                 }
             }
         );
     }
-
-    checkRefreshLichenMainPage("{{ refreshLichenMainPageLink }}");
+    {% if refresh_page == "REFRESH_ME" %}
+        checkRefreshLichenMainPage("{{ refreshLichenMainPageLink }}");
+    {% endif %}
 </script>
 
 {% include('plagiarism/DeletePlagiarismResultsAndConfig.twig') %}

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -44,27 +44,23 @@
 
     function checkRefreshLichenMainPage(url, semester, course) {
         // refresh time for lichen main page
-        var refresh_time = 5000;
+        let refresh_time = 1000;
         setTimeout(function() {
             check_lichen_jobs(url, semester, course);
         }, refresh_time);
     }
 
+    let last_data = "{{ refresh_page }}";
+
     function check_lichen_jobs(url, semester, course) {
         $.get(url,
             function(data) {
-                var last_data = localStorage.getItem("last_data");
-                if (data === "REFRESH_ME") {
-                    last_data= "REFRESH_ME";
-                    localStorage.setItem("last_data", last_data);
+                if(data === "NO_REFRESH" && last_data === "REFRESH_ME"){
+                    last_data = "DONE_REFRESH";
+                    // We can't just reload because we need to get rid of the REFRESH_ME part of the URL
                     window.location.href = buildCourseUrl(['plagiarism']);
                 }
-                else if(data === "NO_REFRESH" && last_data === "REFRESH_ME"){
-                    last_data= "NO_REFRESH";
-                    localStorage.setItem("last_data", last_data);
-                    window.location.href = buildCourseUrl(['plagiarism']);
-                }
-                else {
+                else if (last_data !== "DONE_REFRESH") {
                     checkRefreshLichenMainPage(url, semester, course);
                 }
             }
@@ -73,13 +69,6 @@
 
     checkRefreshLichenMainPage("{{ refreshLichenMainPageLink }}");
 </script>
-
-{# refresh page ensures atleast one refresh of lichen mainpage when delete, rerun, edit or new configuration is saved #}
-{% if refresh_page == "REFRESH_ME" %}
-    <script>
-        localStorage.setItem("last_data", "REFRESH_ME");
-    </script>
-{% endif %}
 
 {% include('plagiarism/DeletePlagiarismResultsAndConfig.twig') %}
 


### PR DESCRIPTION
### What is the current behavior?
The plagiarism main page currently refreshes every 5 seconds when waiting for a run to finish.  This can be annoying to instructors who are trying to view the run log or interact with the page in other ways.

### What is the new behavior?
This PR makes the page only refresh when all of the outstanding runs are complete.  JS runs behind the scenes to check for changes and reload as appropriate.