### PR TITLE
[Bugfix:Plagiarism] Fix plagiarism view results for teams

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -815,8 +815,8 @@ class PlagiarismController extends AbstractController {
             array_push($temp, $item[1]);
             array_push($temp, $item[2]);
             if (!$this->core->getQueries()->getGradeableConfig($gradeable_id)->isTeamAssignment()) {
-                array_push($temp, $this->core->getQueries()->getUserById($ranking[1])->getDisplayedFirstName());
-                array_push($temp, $this->core->getQueries()->getUserById($ranking[1])->getDisplayedLastName());
+                array_push($temp, $this->core->getQueries()->getUserById($item[1])->getDisplayedFirstName());
+                array_push($temp, $this->core->getQueries()->getUserById($item[1])->getDisplayedLastName());
             }
             else {
                 array_push($temp, "");

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -237,7 +237,8 @@ class PlagiarismController extends AbstractController {
     public function showPlagiarismResult($gradeable_id) {
         $semester = $this->core->getConfig()->getSemester();
         $course = $this->core->getConfig()->getCourse();
-        $gradeable_title = ($this->core->getQueries()->getGradeableConfig($gradeable_id))->getTitle();
+        $gradeable_config = $this->core->getQueries()->getGradeableConfig($gradeable_id);
+        $gradeable_title = $gradeable_config->getTitle();
 
         $rankings = $this->getOverallRankings($gradeable_id);
         if ($rankings === null) {
@@ -250,8 +251,14 @@ class PlagiarismController extends AbstractController {
         }
 
         foreach ($rankings as $i => $ranking) {
-            array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedFirstName());
-            array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedLastName());
+            if (!$gradeable_config->isTeamAssignment()) {
+                array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedFirstName());
+                array_push($rankings[$i], $this->core->getQueries()->getUserById($ranking[1])->getDisplayedLastName());
+            }
+            else {
+                array_push($rankings[$i], "");
+                array_push($rankings[$i], "");
+            }
         }
 
         $this->core->getOutput()->renderOutput(['admin', 'Plagiarism'], 'showPlagiarismResult', $semester, $course, $gradeable_id, $gradeable_title, $rankings);
@@ -807,8 +814,14 @@ class PlagiarismController extends AbstractController {
             $temp = [];
             array_push($temp, $item[1]);
             array_push($temp, $item[2]);
-            array_push($temp, $this->core->getQueries()->getUserById($item[1])->getDisplayedFirstName());
-            array_push($temp, $this->core->getQueries()->getUserById($item[1])->getDisplayedLastName());
+            if (!$this->core->getQueries()->getGradeableConfig($gradeable_id)->isTeamAssignment()) {
+                array_push($temp, $this->core->getQueries()->getUserById($ranking[1])->getDisplayedFirstName());
+                array_push($temp, $this->core->getQueries()->getUserById($ranking[1])->getDisplayedLastName());
+            }
+            else {
+                array_push($temp, "");
+                array_push($temp, "");
+            }
             array_push($temp, $item[0]);
             array_push($return, $temp);
         }

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -121,10 +121,10 @@ class PlagiarismView extends AbstractView {
         $language["plaintext"] = "selected";
         $threshold = 5;
         $sequence_length = 4;
-        $prior_term_gradeables_number = $saved_config['prev_term_gradeables'] ? count($saved_config['prev_term_gradeables']) + 1 : 1;
+        //$prior_term_gradeables_number = $saved_config['prev_term_gradeables'] ? count($saved_config['prev_term_gradeables']) + 1 : 1;
         $prior_terms = false;
         $ignore_submissions = false;
-        $ignore_submission_number = $saved_config['ignore_submissions'] ? count($saved_config['ignore_submissions']) + 1 : 1;
+        //$ignore_submission_number = $saved_config['ignore_submissions'] ? count($saved_config['ignore_submissions']) + 1 : 1;
 
 
         // Values which are in saved configuration
@@ -154,8 +154,8 @@ class PlagiarismView extends AbstractView {
             "new_or_edit" => $new_or_edit,
             "form_action_link" => $this->core->buildCourseUrl(['plagiarism', 'configuration', 'new']) . "?new_or_edit={$new_or_edit}&gradeable_id={$gradeable_id}",
             "csrf_token" => $this->core->getCsrfToken(),
-            "ignore_submission_number" => $ignore_submission_number,
-            "prior_term_gradeables_number" => $prior_term_gradeables_number,
+            //"ignore_submission_number" => $ignore_submission_number,
+            //"prior_term_gradeables_number" => $prior_term_gradeables_number,
             "provided_code" => $provided_code,
             "gradeable_ids_titles" => $gradeable_ids_titles,
             "title" => $title,

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -146,7 +146,7 @@ class PlagiarismView extends AbstractView {
             $language[$saved_config['language']] = "selected";
             $threshold = (int) $saved_config['threshold'];
             $sequence_length = (int) $saved_config['sequence_length'];
-            $prior_terms = $prior_term_gradeables_number > 1;
+            $prior_terms = false; // $prior_term_gradeables_number > 1;
             $ignore_submissions = count($saved_config['ignore_submissions']) > 0;
         }
 


### PR DESCRIPTION
### What is the current behavior?
Viewing the results of a plagiarism detection run on a team gradeable induces errors which are not dealt with gracefully. The plagiarism backend attempts to grab the first and last name that correspond to the the student_id from the Lichen output files, so when the id correspond to a team instead of a student, the page breaks.

### What is the new behavior?
The backend was modified to not query the student first and last name for team gradeables, and for now, the dropdown menu displaying the top matched submissions does not display the names of the students in the teams, but only the team id.
![image](https://user-images.githubusercontent.com/71195502/122994295-4d373f00-d376-11eb-8540-6f1f5dd66bea.png)
