### PR TITLE
[Feature:TAGrading] Prev/next student by (active) inquiry

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1248,10 +1248,9 @@ class ElectronicGraderController extends AbstractController {
         $gradeable_version = null,
         $sort = "id",
         $direction = "ASC",
-        $to_ungraded = null,
         $component_id = "-1",
         $anon_mode = false,
-        $to_same_itempool = false
+        $filter = 'default'
     ) {
         if (empty($this->core->getQueries()->getTeamsById([$who_id])) && $this->core->getQueries()->getUserById($who_id) == null) {
             $anon_mode = true;
@@ -1307,16 +1306,16 @@ class ElectronicGraderController extends AbstractController {
             // of if that submission is in their assigned section
             // Limited access graders should only be able to navigate to submissions in their assigned sections
             if ($to === 'prev' && $this->core->getUser()->accessFullGrading()) {
-                $goToStudent = $order_all_sections->getPrevSubmitter($from_id, $to_ungraded === 'true', is_numeric($component_id) ? $component_id : -1, $to_same_itempool === "true");
+                $goToStudent = $order_all_sections->getPrevSubmitter($from_id, is_numeric($component_id) ? $component_id : -1, $filter);
             }
             elseif ($to === 'prev') {
-                $goToStudent = $order_grading_sections->getPrevSubmitter($from_id, $to_ungraded === 'true', is_numeric($component_id) ? $component_id : -1, $to_same_itempool === "true");
+                $goToStudent = $order_grading_sections->getPrevSubmitter($from_id, is_numeric($component_id) ? $component_id : -1, $filter);
             }
             elseif ($to === 'next' && $this->core->getUser()->accessFullGrading()) {
-                $goToStudent = $order_all_sections->getNextSubmitter($from_id, $to_ungraded === 'true', is_numeric($component_id) ? $component_id : -1, $to_same_itempool === "true");
+                $goToStudent = $order_all_sections->getNextSubmitter($from_id, is_numeric($component_id) ? $component_id : -1, $filter);
             }
             elseif ($to === 'next') {
-                $goToStudent = $order_grading_sections->getNextSubmitter($from_id, $to_ungraded === 'true', is_numeric($component_id) ? $component_id : -1, $to_same_itempool === "true");
+                $goToStudent = $order_grading_sections->getNextSubmitter($from_id, is_numeric($component_id) ? $component_id : -1, $filter);
             }
             // Reassign who_id
             if (!is_null($goToStudent)) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4303,6 +4303,24 @@ AND gc_id IN (
         return ($this->course_db->getRowCount() > 0) ? $this->course_db->row()['status'] : 0;
     }
 
+    public function getRegradeRequestsUsers(string $gradeable_id, bool $ungraded_only = false, int $component_id = -1) {
+        $parameters = [];
+        $parameters[] = $gradeable_id;
+        $ungraded_query = "";
+        if($ungraded_only) {
+            $ungraded_query = "AND status = ? ";
+            $parameters[] = RegradeRequest::STATUS_ACTIVE;
+        }
+        $component_query = "";
+        if($component_id !== -1) {
+            $component_query = "AND gc_id = ? ";
+            $parameters[] = $component_id;
+        }
+        
+        $this->course_db->query("SELECT user_id FROM regrade_requests WHERE g_id = ? " . $ungraded_query . $component_query, $parameters);
+        return $this->rowsToArray($this->course_db->rows());
+    }
+
 
     /**
      * insert a new grade inquiry for a submitter

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4313,7 +4313,7 @@ AND gc_id IN (
         }
         $component_query = "";
         if($component_id !== -1) {
-            $component_query = "AND gc_id = ? ";
+            $component_query = "AND (gc_id IS NULL OR gc_id = ?) ";
             $parameters[] = $component_id;
         }
         

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4307,16 +4307,16 @@ AND gc_id IN (
         $parameters = [];
         $parameters[] = $gradeable_id;
         $ungraded_query = "";
-        if($ungraded_only) {
+        if ($ungraded_only) {
             $ungraded_query = "AND status = ? ";
             $parameters[] = RegradeRequest::STATUS_ACTIVE;
         }
         $component_query = "";
-        if($component_id !== -1) {
+        if ($component_id !== -1) {
             $component_query = "AND (gc_id IS NULL OR gc_id = ?) ";
             $parameters[] = $component_id;
         }
-        
+
         $this->course_db->query("SELECT user_id FROM regrade_requests WHERE g_id = ? " . $ungraded_query . $component_query, $parameters);
         return $this->rowsToArray($this->course_db->rows());
     }

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -2,7 +2,6 @@
 
 namespace app\models;
 
-use app\exceptions\DatabaseException;
 use app\libraries\Core;
 use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\Submitter;

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -193,7 +193,7 @@ class GradingOrder extends AbstractModel {
      * @param string $filter The filter to use when checking submitters
      * @return Submitter|null Previous submitter to grade
      */
-    public function getPrevSubmitter(Submitter $submitter,  int $component_id = -1, string $filter = 'default'): ?Submitter {
+    public function getPrevSubmitter(Submitter $submitter, int $component_id = -1, string $filter = 'default'): ?Submitter {
         return $this->getPrevSubmitterMatching($submitter, $this->getFilterFunction($submitter, $component_id, $filter));
     }
 
@@ -224,14 +224,14 @@ class GradingOrder extends AbstractModel {
      * Queries the database to populate $this->grade_inquiry_users
      * @param bool $ungraded If it should only find active grade inquiries
      * @param int $component_id The component ID in the gradeable
-     * @return void 
+     * @return void
      */
     private function initUsersGradeInquiry(bool $ungraded, int $component_id) {
         if (is_null($this->grade_inquiry_users)) {
             $this->grade_inquiry_users = $this->core->getQueries()->getRegradeRequestsUsers($this->gradeable->getId(), $ungraded, $component_id);
         }
     }
-    
+
     /**
      * Given the selected filter, returns a function that can be used to filter students in getSubmitterMatching
      * @param Submitter $submitter Current grading submitter
@@ -240,38 +240,38 @@ class GradingOrder extends AbstractModel {
      * @return callable Args: (Submitter) Returns: bool, true if the submitter should be included
      */
     private function getFilterFunction(Submitter $submitter, int $component_id, string $filter) {
-        if($filter === 'default') {
+        if ($filter === 'default') {
             return function (Submitter $sub) {
                 return $this->getHasSubmission($sub);
             };
         }
-        elseif($filter === 'ungraded') {
+        elseif ($filter === 'ungraded') {
             $this->initUsersNotFullyGraded($component_id);
 
-            return function(Submitter $sub) {
+            return function (Submitter $sub) {
                 return in_array($sub->getId(), $this->not_fully_graded) && $this->getHasSubmission($sub);
             };
         }
-        elseif($filter === 'itempool') {
-            if($component_id !== -1 && $this->getItempoolIndicesForSubmitter($submitter, $component_id)) {
+        elseif ($filter === 'itempool') {
+            if ($component_id !== -1 && $this->getItempoolIndicesForSubmitter($submitter, $component_id)) {
                 return function (Submitter $sub) {
                     return $this->getHasSubmission($sub) && $this->isSameItempool($sub);
                 };
             }
             return $this->getFilterFunction($submitter, $component_id, 'default');
         }
-        elseif($filter === 'ungraded-itempool') {
+        elseif ($filter === 'ungraded-itempool') {
             $this->initUsersNotFullyGraded($component_id);
 
-            if($component_id !== -1 && $this->getItempoolIndicesForSubmitter($submitter, $component_id)) {
+            if ($component_id !== -1 && $this->getItempoolIndicesForSubmitter($submitter, $component_id)) {
                 return function (Submitter $sub) {
                     return in_array($sub->getId(), $this->not_fully_graded) && $this->getHasSubmission($sub) && $this->isSameItempool($sub);
                 };
             }
             return $this->getFilterFunction($submitter, $component_id, 'ungraded');
         }
-        elseif($filter === 'inquiry') {
-            if($this->core->getConfig()->isRegradeEnabled()) {
+        elseif ($filter === 'inquiry') {
+            if ($this->core->getConfig()->isRegradeEnabled()) {
                 $this->initUsersGradeInquiry(false, $component_id);
 
                 return function (Submitter $sub) {
@@ -279,8 +279,8 @@ class GradingOrder extends AbstractModel {
                 };
             }
         }
-        elseif($filter === 'active-inquiry') {
-            if($this->core->getConfig()->isRegradeEnabled()) {
+        elseif ($filter === 'active-inquiry') {
+            if ($this->core->getConfig()->isRegradeEnabled()) {
                 $this->initUsersGradeInquiry(true, $component_id);
 
                 return function (Submitter $sub) {
@@ -291,7 +291,6 @@ class GradingOrder extends AbstractModel {
         return function (Submitter $sub) {
             return $this->getHasSubmission($sub);
         };
-
     }
 
     /**

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -271,18 +271,22 @@ class GradingOrder extends AbstractModel {
             return $this->getFilterFunction($submitter, $component_id, 'ungraded');
         }
         elseif($filter === 'inquiry') {
-            $this->initUsersGradeInquiry(false, $component_id);
+            if($this->core->getConfig()->isRegradeEnabled()) {
+                $this->initUsersGradeInquiry(false, $component_id);
 
-            return function (Submitter $sub) {
-                return in_array($sub->getId(), $this->grade_inquiry_users) && $this->getHasSubmission($sub);
-            };
+                return function (Submitter $sub) {
+                    return in_array($sub->getId(), $this->grade_inquiry_users) && $this->getHasSubmission($sub);
+                };
+            }
         }
         elseif($filter === 'active-inquiry') {
-            $this->initUsersGradeInquiry(true, $component_id);
+            if($this->core->getConfig()->isRegradeEnabled()) {
+                $this->initUsersGradeInquiry(true, $component_id);
 
-            return function (Submitter $sub) {
-                return in_array($sub->getId(), $this->grade_inquiry_users) && $this->getHasSubmission($sub);
-            };
+                return function (Submitter $sub) {
+                    return in_array($sub->getId(), $this->grade_inquiry_users) && $this->getHasSubmission($sub);
+                };
+            }
         }
         return function (Submitter $sub) {
             return $this->getHasSubmission($sub);

--- a/site/public/js/ta-grading-keymap.js
+++ b/site/public/js/ta-grading-keymap.js
@@ -24,7 +24,9 @@ let settingsData = [
                     "Prev/Next Student": "default",
                     "Prev/Next Ungraded Student": "ungraded",
                     "Prev/Next Itempool Student": "itempool",
-                    "Prev/Next Ungraded Itempool Student": "ungraded-itempool"
+                    "Prev/Next Ungraded Itempool Student": "ungraded-itempool",
+                    "Prev/Next Grade Inquiry": "inquiry",
+                    "Prev/Next Active Grade Inquiry": "active-inquiry",
                 }, 
                 default: "Prev/Next Student"
             }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -219,6 +219,26 @@ function changeStudentArrowTooltips(data) {
         $('#next-student-navlink').find("i").first().attr("title", "Next ungraded student (item " + $('#component-' + component_id).attr('data-itempool_id') + "; " + $("#component-" + component_id).find(".component-title").text().trim() + ")");
       }
       break;
+    case "inquiry":
+      component_id = getFirstOpenComponentId();
+      if(component_id === NO_COMPONENT_ID) {
+        $('#prev-student-navlink').find("i").first().attr("title", "Previous student with inquiry");
+        $('#next-student-navlink').find("i").first().attr("title", "Next student with inquiry");
+      } else {
+        $('#prev-student-navlink').find("i").first().attr("title", "Previous student with inquiry (" + $("#component-" + component_id).find(".component-title").text().trim() + ")");
+        $('#next-student-navlink').find("i").first().attr("title", "Next student with inquiry (" + $("#component-" + component_id).find(".component-title").text().trim() + ")");
+      }
+      break;
+    case "active-inquiry":
+      component_id = getFirstOpenComponentId();
+      if(component_id === NO_COMPONENT_ID) {
+        $('#prev-student-navlink').find("i").first().attr("title", "Previous student with active inquiry");
+        $('#next-student-navlink').find("i").first().attr("title", "Next student with active inquiry");
+      } else {
+        $('#prev-student-navlink').find("i").first().attr("title", "Previous student with active inquiry (" + $("#component-" + component_id).find(".component-title").text().trim() + ")");
+        $('#next-student-navlink').find("i").first().attr("title", "Next student with active inquiry (" + $("#component-" + component_id).find(".component-title").text().trim() + ")");
+      }
+      break;
     default:
       $('#prev-student-navlink').find("i").first().attr("title", "Previous student");
       $('#next-student-navlink').find("i").first().attr("title", "Next student");

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -572,34 +572,29 @@ function gotoMainPage() {
 
 function gotoPrevStudent() {
 
+  let filter = localStorage.getItem("general-setting-arrow-function") || "default";
+
   let selector = "#prev-student";
-  let window_location = $(selector)[0].dataset.href;
+  let window_location = $(selector)[0].dataset.href + "&filter=" + filter;
 
-  let switchType = localStorage.getItem("general-setting-arrow-function") || "default";
-
-  switch(switchType) {
+  switch(filter) {
     case "ungraded":
-      window_location += "&to_ungraded=true";
-      window_location += "&to_same_itempool=false";
       window_location += "&component_id=" + getFirstOpenComponentId();
       break;
     case "itempool":
-      window_location += "&to_ungraded=false";
-      window_location += "&to_same_itempool=true";
       window_location += "&component_id=" + getFirstOpenComponentId(true);
       break;
     case "ungraded-itempool":
-      window_location += "&to_ungraded=true";
-      window_location += "&to_same_itempool=true";
       component_id = getFirstOpenComponentId(true);
       if(component_id === NO_COMPONENT_ID) {
         component_id = getFirstOpenComponentId();
       }
-      window_location += "&component_id=" + component_id;
       break;
-    default:
-      window_location += "&to_ungraded=false";
-      window_location += "&to_same_itempool=false";
+    case "inquiry":
+      window_location += "&component_id=" + getFirstOpenComponentId();
+      break;
+    case "ungraded-inquiry":
+      window_location += "&component_id=" + getFirstOpenComponentId();
       break;
   }
 
@@ -619,36 +614,29 @@ function gotoPrevStudent() {
 
 function gotoNextStudent() {
 
+  let filter = localStorage.getItem("general-setting-arrow-function") || "default";
+
   let selector = "#next-student";
-  let window_location = $(selector)[0].dataset.href;
+  let window_location = $(selector)[0].dataset.href + "&filter=" + filter;
 
-  let switchType = localStorage.getItem("general-setting-arrow-function") || "default";
-
-  let component_id = NO_COMPONENT_ID;
-
-  switch(switchType) {
+  switch(filter) {
     case "ungraded":
-      window_location += "&to_ungraded=true";
-      window_location += "&to_same_itempool=false";
       window_location += "&component_id=" + getFirstOpenComponentId();
       break;
     case "itempool":
-      window_location += "&to_ungraded=false";
-      window_location += "&to_same_itempool=true";
       window_location += "&component_id=" + getFirstOpenComponentId(true);
       break;
     case "ungraded-itempool":
-      window_location += "&to_ungraded=true";
-      window_location += "&to_same_itempool=true";
       component_id = getFirstOpenComponentId(true);
       if(component_id === NO_COMPONENT_ID) {
         component_id = getFirstOpenComponentId();
       }
-      window_location += "&component_id=" + component_id;
       break;
-    default:
-      window_location += "&to_ungraded=false";
-      window_location += "&to_same_itempool=false";
+    case "inquiry":
+      window_location += "&component_id=" + getFirstOpenComponentId();
+      break;
+    case "ungraded-inquiry":
+      window_location += "&component_id=" + getFirstOpenComponentId();
       break;
   }
 

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -593,7 +593,7 @@ function gotoPrevStudent() {
     case "inquiry":
       window_location += "&component_id=" + getFirstOpenComponentId();
       break;
-    case "ungraded-inquiry":
+    case "active-inquiry":
       window_location += "&component_id=" + getFirstOpenComponentId();
       break;
   }
@@ -635,7 +635,7 @@ function gotoNextStudent() {
     case "inquiry":
       window_location += "&component_id=" + getFirstOpenComponentId();
       break;
-    case "ungraded-inquiry":
+    case "active-inquiry":
       window_location += "&component_id=" + getFirstOpenComponentId();
       break;
   }


### PR DESCRIPTION
### What is the current behavior?
No prev/next inquiry option for switching between students in TA grading.

### What is the new behavior?
Closes #4765 
Prev/next inquiry and active inquiry options added for switching between students in TA grading.
If a component is open, the prev/next student for inquiries is found based on the component id (searches for unlinked regrade requests and regrade requests with the specified component id). Otherwise, it will just find the prev/next student with a grade inquiry.
Refactored filtering to make it easier to add more filters in the future.
