### PR TITLE
[Dependency] Remove vbguest

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -24,6 +24,6 @@ jobs:
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.
       # - run: vagrant plugin install vagrant-vbguest
-      - run: NO_SUBMISSIONS=1 SKIP_VBGUEST=1 vagrant up ${{ matrix.image }}
+      - run: NO_SUBMISSIONS=1 vagrant up ${{ matrix.image }}
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:${{ matrix.port }}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,10 +38,6 @@ VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 bash ${GIT_PATH}/.setup/vagrant/setup_vagrant.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_${DISTRO}_${VERSION}.log
 SCRIPT
 
-unless Vagrant.has_plugin?('vagrant-vbguest') || ENV.has_key?('SKIP_VBGUEST')
-  raise 'vagrant-vbguest is not installed! To install, run: vagrant plugin install vagrant-vbguest'
-end
-
 Vagrant.configure(2) do |config|
   # Specify the various machines that we might develop on. After defining a name, we
   # can specify if the vm is our "primary" one (if we don't specify a VM, it'll use


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Currently we use the vbguest plugin in vagrant. This is no longer necessary and creating issues while installing Ubuntu 20.04.

### What is the new behavior?
This PR removes the check for requiring vbguest.

### Other information?
To test make sure you remove vbguest from your system.
This can be done by doing: `vagrant plugin uninstall vagrant-vbguest`
Docs will also be updated to remove the step saying this is a requirement.