### PR TITLE
[Bugfix:TAGrading] Allow pen/text resize with pen tool

### DIFF
--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -269,6 +269,19 @@ function render(gradeable_id, user_id, grader_id, file_name, file_path, page_num
                                 $('#save_status').css('color', 'red');
                             }
                         });
+                        document.getElementById(`pageContainer${page_id}`).addEventListener('mouseenter', () => {
+                            const selected = $($('.tool-selected')[0]).attr('value');
+                            if(selected === "pen"){
+                                PDFAnnotate.UI.enablePen();
+                            }
+                        });
+                        document.getElementById(`pageContainer${page_id}`).addEventListener('mouseleave', () => {
+                            //disable pen when mouse leaves the pdf page to allow for selecting inputs (like pen size)
+                            const selected = $($('.tool-selected')[0]).attr('value');
+                            if(selected === "pen"){
+                                PDFAnnotate.UI.disablePen();
+                            }
+                        });
                     });
                 }
             });

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -271,14 +271,14 @@ function render(gradeable_id, user_id, grader_id, file_name, file_path, page_num
                         });
                         document.getElementById(`pageContainer${page_id}`).addEventListener('mouseenter', () => {
                             const selected = $($('.tool-selected')[0]).attr('value');
-                            if(selected === "pen"){
+                            if (selected === 'pen') {
                                 PDFAnnotate.UI.enablePen();
                             }
                         });
                         document.getElementById(`pageContainer${page_id}`).addEventListener('mouseleave', () => {
                             //disable pen when mouse leaves the pdf page to allow for selecting inputs (like pen size)
                             const selected = $($('.tool-selected')[0]).attr('value');
-                            if(selected === "pen"){
+                            if (selected === 'pen') {
                                 PDFAnnotate.UI.disablePen();
                             }
                         });


### PR DESCRIPTION
### What is the current behavior?
Fixes #4599 
Currently, on the pdf annotating interface, the pen/text size cannot be changed with the pen tool selected.
Also, any other inputs even in other tabs of the ta grading interface are disabled when the pen is selected.

### What is the new behavior?
The pen/text size can be adjusted with the pen tool selected, and all other inputs can be used with the pen tool selected.