### PR TITLE
[Feature:Plagiarism] Plagiarism ignore submissions

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -64,7 +64,7 @@ class PlagiarismController extends AbstractController {
         return $return;
     }
 
-    private function getIgnoreSubmissionType(array $usernames) : array {
+    private function getIgnoreSubmissionType(array $usernames): array {
         $ignore = [];
         $ignore[0] = [];
         $ignore[1] = [];
@@ -410,7 +410,8 @@ class PlagiarismController extends AbstractController {
             }
             $graders = $this->core->getQueries()->getAllGraders();
             foreach ($graders as $grader) {
-                if ($grader->getGroup() == 1 && in_array("ignore_instructors", $_POST['ignore_submission_option'])
+                if (
+                    $grader->getGroup() == 1 && in_array("ignore_instructors", $_POST['ignore_submission_option'])
                     || $grader->getGroup() == 2 && in_array("ignore_full_access_graders", $_POST['ignore_submission_option'])
                     || $grader->getGroup() == 3 && in_array("ignore_limited_access_graders", $_POST['ignore_submission_option'])
                     ) {

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -414,7 +414,7 @@ class PlagiarismController extends AbstractController {
                     $grader->getGroup() == 1 && in_array("ignore_instructors", $_POST['ignore_submission_option'])
                     || $grader->getGroup() == 2 && in_array("ignore_full_access_graders", $_POST['ignore_submission_option'])
                     || $grader->getGroup() == 3 && in_array("ignore_limited_access_graders", $_POST['ignore_submission_option'])
-                    ) {
+                ) {
                     array_push($ignore_submission_option, $grader->getId());
                 }
             }

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -64,6 +64,39 @@ class PlagiarismController extends AbstractController {
         return $return;
     }
 
+    private function getIgnoreSubmissionType(array $usernames) : array {
+        $ignore = [];
+        $ignore[0] = [];
+        $ignore[1] = [];
+        foreach ($usernames as $user_id) {
+            $user_obj = $this->core->getQueries()->getUserById($user_id);
+            if ($user_obj != null) {
+                switch ($user_obj->getGroup()) {
+                    case 1:
+                        if (!in_array("instructors", $ignore[0])) {
+                            array_push($ignore[0], "instructors");
+                        }
+                        break;
+                    case 2:
+                        if (!in_array("full_access_graders", $ignore[0])) {
+                            array_push($ignore[0], "full_access_graders");
+                        }
+                        break;
+                    case 3:
+                        if (!in_array("limited_access_graders", $ignore[0])) {
+                            array_push($ignore[0], "limited_access_graders");
+                        }
+                        break;
+                    default:
+                        if (!in_array("others", $ignore[0])) {
+                            array_push($ignore[0], "others");
+                        }
+                        array_push($ignore[1], $user_id);
+                }
+            }
+        }
+        return $ignore;
+    }
 
     /**
      * @param string $gradeable_id
@@ -366,7 +399,32 @@ class PlagiarismController extends AbstractController {
         }
 
         // Submissions to ignore
-        $ignore_submission_option = isset($_POST['ignore_submission_option']) ? $_POST['ignore_submission_option'] : "";
+        $ignore_submission_option = [];
+        if (isset($_POST['ignore_submission_option'])) {
+            $valid_inputs = ["ignore_instructors", "ignore_full_access_graders", "ignore_limited_access_graders", "ignore_others"];
+            foreach ($_POST['ignore_submission_option'] as $ignore_type) {
+                if (!in_array($ignore_type, $valid_inputs)) {
+                    $this->core->addErrorMessage("Invalid type provided for users to ignore");
+                    $this->core->redirect($return_url);
+                }
+            }
+            $graders = $this->core->getQueries()->getAllGraders();
+            foreach ($graders as $grader) {
+                if ($grader->getGroup() == 1 && in_array("ignore_instructors", $_POST['ignore_submission_option'])
+                    || $grader->getGroup() == 2 && in_array("ignore_full_access_graders", $_POST['ignore_submission_option'])
+                    || $grader->getGroup() == 3 && in_array("ignore_limited_access_graders", $_POST['ignore_submission_option'])
+                    ) {
+                    array_push($ignore_submission_option, $grader->getId());
+                }
+            }
+            if (in_array("ignore_others", $_POST['ignore_submission_option']) && isset($_POST["ignore_others_list"])) {
+                // parse and push to the array of users
+                $other_users = explode(", ", $_POST["ignore_others_list"]);
+                foreach ($other_users as $other_user) {
+                    array_push($ignore_submission_option, $other_user);
+                }
+            }
+        }
 
         // Save the config.json
         $json_file = FileUtils::joinPaths($course_path, "lichen", "config", "lichen_{$semester}_{$course}_{$gradeable_id}.json");
@@ -493,7 +551,7 @@ class PlagiarismController extends AbstractController {
         });
 
         $prior_term_gradeables = $this->getGradeablesFromPriorTerm();
-        $this->core->getOutput()->renderOutput(['admin', 'Plagiarism'], 'configureGradeableForPlagiarismForm', 'new', $gradeable_ids_titles, $prior_term_gradeables, null, null);
+        $this->core->getOutput()->renderOutput(['admin', 'Plagiarism'], 'configureGradeableForPlagiarismForm', 'new', $gradeable_ids_titles, $prior_term_gradeables, null, null, null, null);
     }
 
 
@@ -518,7 +576,9 @@ class PlagiarismController extends AbstractController {
             $title = $this->core->getQueries()->getGradeableConfig($saved_config['gradeable'])->getTitle();
         }
 
-        $this->core->getOutput()->renderOutput(['admin', 'Plagiarism'], 'configureGradeableForPlagiarismForm', 'edit', null, $prior_term_gradeables, $saved_config, $title);
+        $ignore_submissions = $this->getIgnoreSubmissionType($saved_config['ignore_submissions']);
+
+        $this->core->getOutput()->renderOutput(['admin', 'Plagiarism'], 'configureGradeableForPlagiarismForm', 'edit', null, $prior_term_gradeables, $ignore_submissions[0], $ignore_submissions[1], $saved_config, $title);
     }
 
 

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -424,7 +424,6 @@ class PlagiarismController extends AbstractController {
                 ) {
                     array_push($ignore_submission_option, $grader->getId());
                 }
-
             }
             // parse and append user id's specified in "Others"
             if (in_array("ignore_others", $_POST['ignore_submission_option']) && isset($_POST["ignore_others_list"])) {

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -366,21 +366,7 @@ class PlagiarismController extends AbstractController {
         }
 
         // Submissions to ignore
-        $ignore_submission_option = $_POST['ignore_submission_option'];
-        if ($ignore_submission_option !== "ignore" && $ignore_submission_option !== "no_ignore") {
-            $this->core->addErrorMessage("Invalid ignore submission options, expected \"ignore\" or \"no_ignore\", got \"" . $ignore_submission_option . "\".");
-            $this->core->redirect($return_url);
-        }
-        $ignore_submission_number = $_POST['ignore_submission_number'];
-        $ignore_submissions = [];
-        if ($ignore_submission_option === "ignore") {
-            for ($i = 0; $i < $ignore_submission_number; $i++) {
-                if (isset($_POST['ignore_submission_' . $i]) && $_POST['ignore_submission_' . $i] !== '') {
-                    array_push($ignore_submissions, $_POST['ignore_submission_' . $i]);
-                }
-            }
-        }
-
+        $ignore_submission_option = isset($_POST['ignore_submission_option']) ? $_POST['ignore_submission_option'] : "";
 
         // Save the config.json
         $json_file = FileUtils::joinPaths($course_path, "lichen", "config", "lichen_{$semester}_{$course}_{$gradeable_id}.json");
@@ -396,7 +382,7 @@ class PlagiarismController extends AbstractController {
             // "hash" => bin2hex(random_bytes(8)),
             "sequence_length" => $sequence_length,
             "prev_term_gradeables" => $prev_term_gradeables,
-            "ignore_submissions" => $ignore_submissions
+            "ignore_submissions" => $ignore_submission_option
         ];
 
         if (!@file_put_contents($json_file, json_encode($json_data, JSON_PRETTY_PRINT))) {

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -5,7 +5,6 @@
         <form method="post" action="{{ form_action_link }}" enctype="multipart/form-data">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <input type="hidden" name="prior_term_gradeables_number" value="{{ prior_term_gradeables_number }}" />
-            <input type="hidden" name="ignore_submission_number" value="{{ ignore_submission_number }}" /><br />
             {##################################################################}
             <div class="plag-data-group">
                 <div class="plag-data-label">Select Gradeable:</div>
@@ -204,34 +203,8 @@
             <div class="plag-data-group">
                 <div class="plag-data-label">Users to be Ignored:</div>
                 <div id="ignore_submission_div" class="plag-data">
-                    <span class="radio-label-pair">
-                        <input type="radio" id="ignore_none_id" value="no_ignore" name="ignore_submission_option" {{ ignore_submissions ? "" : "checked" }}>
-                        <label for="ignore_none_id">No</label>
-                    </span>
-                    <span class="radio-label-pair">
-                        <input type="radio" id="ignore_id" value="ignore" name="ignore_submission_option" {{ ignore_submissions ? "checked" : "" }}>
-                        <label for="ignore_id">Yes</label>
-                    </span>
-
-                    <div id="add_more_ignore" class="add-more" aria-label="Add more">
-                        <i class="fas fa-plus-square"></i>Add more
-                    </div>
-
-                    <div id="text_ignore_submission">
-                        {% if new_or_edit == "edit" %}
-                            {# {% for saved_ignore_submission in saved_config['ignore_submissions'] %}
-                                <div name="wrapper_ignore_submission_{{ loop.index0 }}">
-                                    <input type="text" name="ignore_submission_{{ loop.index0 }}" class="low-margin-top deletable-text" value="{{ saved_ignore_submission }}"/>
-                                    <i class="fa fa-trash delete-btn"></i>
-                                </div>
-                            {% endfor %} #}
-                        {% else %}
-                            <div name="wrapper_ignore_submission_0">
-                                <input type="text" name="ignore_submission_0" class="low-margin-top deletable-text"/>
-                                <i class="fa fa-trash delete-btn"></i>
-                            </div>
-                        {% endif %}
-                    </div>
+                    <input type="checkbox" id="ignore_staff" value="ignore_staff" name="ignore_submission_option" {{ ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore_none_id">Course staff</label>
                 </div>
             </div>
             {##################################################################}
@@ -281,42 +254,6 @@
 
     $("#past_terms_id").change(function() {
         $(".past-terms-wrapper").show();
-    });
-
-    // IGNORED SUBMISSIONS /////////////////////////////////////////////////////
-    $("#ignore_none_id").change(function() {
-        if ($("#ignore_none_id").is(":checked")) {
-            $("#text_ignore_submission").hide();
-            $("#add_more_ignore").hide();
-        }
-    });
-
-    $("#ignore_id").change(function() {
-        if ($("#ignore_id").is(":checked")) {
-            $("#text_ignore_submission").show();
-            $("#add_more_ignore").show();
-        }
-    });
-
-    $('#add_more_ignore', form).on('click', function(){
-        const ignore_submission_number = $('[name="ignore_submission_number"]', form).val();
-        $('#text_ignore_submission', form).append(`
-            <div name="wrapper_ignore_submission_` + ignore_submission_number + `">
-                <input type="text" name="ignore_submission_` + ignore_submission_number + `" class="low-margin-top deletable-text"/>
-                <i class="fa fa-trash delete-btn"></i>
-            </div>
-        `);
-        $('[name="ignore_submission_number"]', form).val(parseInt(ignore_submission_number)+1);
-    });
-
-    $(".delete-btn").on("click", function() {
-        // delete the div with the text field whose delete icon was clicked
-        $(this).parent().remove();
-        // renumber all other fields
-        $(".deletable-text").each(function(index) {
-            $(this).attr("name", "ignore_submission_"+index);
-            $(this).parent().attr("name", "wrapper_ignore_submission_"+index);
-        });
     });
 
     // OTHER RANDOM JS //////////////////////////////////////////////////////////////

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -29,17 +29,17 @@
                 </div>
                 <div class="plag-data">
                     <span class="radio-label-pair">
-                        <input type="radio" id="no_code_provided_id" value="no_code_provided" name="provided_code_option" {{ provided_code ? "" : "checked" }} >
-                        <label for="no_code_provided_id">No</label>
+                        <input type="radio" id="no-code-provided-id" value="no_code_provided" name="provided_code_option" {{ provided_code ? "" : "checked" }} >
+                        <label for="no-code-provided-id">No</label>
                     </span>
                     <span class="radio-label-pair">
-                        <input type="radio" id="code_provided_id" value="code_provided" name="provided_code_option" {{ provided_code ? "checked" : "" }}>
-                        <label for="code_provided_id">Yes</label>
+                        <input type="radio" id="code-provided-id" value="code_provided" name="provided_code_option" {{ provided_code ? "checked" : "" }}>
+                        <label for="code-provided-id">Yes</label>
                     </span>
                 </div>
-                <div class="low-margin-top"><input id="provided_code_file" type="file" name="provided_code_file"></div>
+                <div class="low-margin-top"><input id="provided-code-file" type="file" name="provided_code_file"></div>
                 {% if new_or_edit == "edit" and provided_code %}
-                    <div id="current_code_file">
+                    <div id="current-code-file">
                         <br />
                         <div>Current Provided Code:</div>
                         {% for file_name in provided_code_filenames %}
@@ -53,12 +53,12 @@
                 <div class="plag-data-label">Version:</div>
                 <div class="plag-data">
                     <span class="radio-label-pair">
-                        <input type="radio" id="all_version_id" value="all_versions" name="version_option" {{ version == "all_versions" ? "checked" : "" }} >
-                        <label for="all_version_id">All Versions</label>
+                        <input type="radio" id="all-version-id" value="all_versions" name="version_option" {{ version == "all_versions" ? "checked" : "" }} >
+                        <label for="all-version-id">All Versions</label>
                     </span>
                     <span class="radio-label-pair">
-                        <input type="radio" id="active_version_id" value="active_version" name="version_option" {{ version == "all_versions" ? "" : "checked" }}>
-                        <label for="active_version_id">Only Active Version</label>
+                        <input type="radio" id="active-version-id" value="active_version" name="version_option" {{ version == "all_versions" ? "" : "checked" }}>
+                        <label for="active-version-id">Only Active Version</label>
                     </span>
                 </div>
             </div>
@@ -66,7 +66,7 @@
             <div class="plag-data-group">
                 <div class="plag-data-label">Files to be Compared:</div>
                 <div class="plag-data">
-                    <div id="files_to_be_compared">
+                    <div id="files-to-be-compared">
                         <span class="option-alt">
                             <a target=_blank href="https://submitty.org/instructor/course_management/plagiarism">How do I specify a regex expression?
                                 <i style="font-style: normal;" class="fa-question-circle"></i>
@@ -74,19 +74,19 @@
                         </span>
                         <span class="right">
                             <span class="radio-label-pair">
-                                <input type="checkbox" id="regex_submissions_dir" name="regex_dir[]" value="submissions" {{ "submissions" in regex_dirs ? "checked" : ""}} />
-                                <label for="regex_submissions_dir">Submissions</label>
+                                <input type="checkbox" id="regex-submissions-dir" name="regex_dir[]" value="submissions" {{ "submissions" in regex_dirs ? "checked" : ""}} />
+                                <label for="regex-submissions-dir">Submissions</label>
                             </span>
                             <span class="radio-label-pair">
-                                <input type="checkbox" id="regex_results_dir" name="regex_dir[]" value="results" {{ "results" in regex_dirs ? "checked" : "" }} />
-                                <label for="regex_results_dir">Results</label>
+                                <input type="checkbox" id="regex-results-dir" name="regex_dir[]" value="results" {{ "results" in regex_dirs ? "checked" : "" }} />
+                                <label for="regex-results-dir">Results</label>
                             </span>
                             <span class="radio-label-pair">
-                                <input type="checkbox" id="regex_checkout_dir" name="regex_dir[]" value="checkout" {{ "checkout" in regex_dirs ? "checked" : "" }} />
-                                <label for="regex_checkout_dir">Checkout</label>
+                                <input type="checkbox" id="regex-checkout-dir" name="regex_dir[]" value="checkout" {{ "checkout" in regex_dirs ? "checked" : "" }} />
+                                <label for="regex-checkout-dir">Checkout</label>
                             </span>
                         </span>
-                        <input type="text" id="regex_to_select_files" name="regex_to_select_files" class="low-margin-top" value="{{ regex }}" placeholder="Leave blank to select all files"/>
+                        <input type="text" id="regex-to-select-files" name="regex_to_select_files" class="low-margin-top" value="{{ regex }}" placeholder="Leave blank to select all files"/>
                     </div>
                 </div>
             </div>
@@ -114,9 +114,9 @@
             {##################################################################}
             <div class="plag-data-group">
                 <div class="plag-data-label">Sequence Length:</div>
-                <label for="sequence_length">This is the minimum size of matching regions</label>
+                <label for="sequence-length">This is the minimum size of matching regions</label>
                 <div class="plag-data">
-                    <input type="number" id="sequence_length" name="sequence_length" value="{{ sequence_length }}" placeholder="(Required)" min="1"/>
+                    <input type="number" id="sequence-length" name="sequence_length" value="{{ sequence_length }}" placeholder="(Required)" min="1"/>
                 </div>
             </div>
             {##################################################################}
@@ -124,15 +124,15 @@
                 <div class="plag-data-label">Prior Terms Gradeables:</div>
                 <div class="plag-data">
                     <span class="radio-label-pair">
-                        <input type="radio" id="no_past_terms_id" value="no_past_terms" name="past_terms_option" {{ prior_terms ? "" : "checked" }}>
-                        <label for="no_past_terms_id">No</label>
+                        <input type="radio" id="no-past-terms-id" value="no_past_terms" name="past_terms_option" {{ prior_terms ? "" : "checked" }}>
+                        <label for="no-past-terms-id">No</label>
                     </span>
                     <span class="radio-label-pair">
-                        <input type="radio" id="past_terms_id" value="past_terms" name="past_terms_option" {{ prior_terms ? "checked" : "" }}>
-                        <label for="past_terms_id">Yes</label>
+                        <input type="radio" id="past-terms-id" value="past_terms" name="past_terms_option" {{ prior_terms ? "checked" : "" }}>
+                        <label for="past-terms-id">Yes</label>
                     </span>
-                    <div class="past-terms-wrapper" id="prev_gradeable_div">
-                        <div id="add_more_prev_gradeable" class="add-more" aria-label="Add more">
+                    <div class="past-terms-wrapper" id="prev-gradeable-div">
+                        <div id="add-more-prev-gradeable" class="add-more" aria-label="Add more">
                             <i class="fas fa-plus-square"></i>Add more
                         </div>
                         {# {% if new_or_edit == "edit" %}
@@ -203,21 +203,21 @@
             <div class="plag-data-group">
                 <div class="plag-data-label">Users to be Ignored:</div>
                 <div class="plag-data radio-label-pair">
-                    <input type="checkbox" id="ignore_instructors" value="ignore_instructors" name="ignore_submission_option[]" {{ "instructors" in ignore_submissions ? "checked" : "" }}>
-                    <label for="ignore_instructors">Instructors</label>
+                    <input type="checkbox" id="ignore-instructors" value="ignore_instructors" name="ignore_submission_option[]" {{ "instructors" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore-instructors">Instructors</label>
                 </div>
                 <div class="plag-data radio-label-pair">
-                    <input type="checkbox" id="ignore_full_access_graders" value="ignore_full_access_graders" name="ignore_submission_option[]" {{ "full_access_graders" in ignore_submissions ? "checked" : "" }}>
-                    <label for="ignore_full_access_graders">Full Access Graders</label>
+                    <input type="checkbox" id="ignore-full-access-graders" value="ignore_full_access_graders" name="ignore_submission_option[]" {{ "full_access_graders" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore-full-access-graders">Full Access Graders</label>
                 </div>
                 <div class="plag-data radio-label-pair">
-                    <input type="checkbox" id="ignore_limited_access_graders" value="ignore_limited_access_graders" name="ignore_submission_option[]" {{ "limited_access_graders" in ignore_submissions ? "checked" : "" }}>
-                    <label for="ignore_limited_access_graders">Limited Access Graders</label>
+                    <input type="checkbox" id="ignore-limited-access-graders" value="ignore_limited_access_graders" name="ignore_submission_option[]" {{ "limited_access_graders" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore-limited-access-graders">Limited Access Graders</label>
                 </div>
                 <div class="plag-data radio-label-pair" id="ignore-others-container">
-                    <input type="checkbox" id="ignore_others" value="ignore_others" name="ignore_submission_option[]" {{ "others" in ignore_submissions ? "checked" : "" }}>
-                    <label for="ignore_others">Others:</label>
-                    <input type="text" id="ignore_others_list" value="{{ ignore_submissions_list }}" placeholder="List user ID's separated by commas and spaces" name="ignore_others_list">
+                    <input type="checkbox" id="ignore-others" value="ignore_others" name="ignore_submission_option[]" {{ "others" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore-others">Others:</label>
+                    <input type="text" id="ignore-others-list" value="{{ ignore_submissions_list }}" placeholder="List user ID's separated by commas and spaces" name="ignore_others_list">
                 </div>
             </div>
             {##################################################################}
@@ -246,26 +246,26 @@
     });
 
     // PROVIDED CODE ///////////////////////////////////////////////////////////
-    $("#no_code_provided_id").change(function() {
-        $("#current_code_file").hide();
-        $("#provided_code_file").hide();
+    $("#no-code-provided-id").change(function() {
+        $("#current-code-file").hide();
+        $("#provided-code-file").hide();
     });
 
-    $("#code_provided_id").change(function() {
-        $("#current_code_file").show();
-        $("#provided_code_file").show();
+    $("#code-provided-id").change(function() {
+        $("#current-code-file").show();
+        $("#provided-code-file").show();
     });
 
     // PRIOR TERM GRADEABLES ///////////////////////////////////////////////////
-    $('#add_more_prev_gradeable', form).on('click', function(){
+    $('#add-more-prev-gradeable', form).on('click', function(){
         addMorePriorTermGradeable(prior_term_gradeables);
     });
 
-    $("#no_past_terms_id").change(function() {
+    $("#no-past-terms-id").change(function() {
         $(".past-terms-wrapper").hide();
     });
 
-    $("#past_terms_id").change(function() {
+    $("#past-terms-id").change(function() {
         $(".past-terms-wrapper").show();
     });
 
@@ -290,7 +290,7 @@
             to_append += '<option value="'+ sem +'">'+ sem +'</option>';
         });
         to_append += '</select><select name="prev_course_'+ prior_term_gradeables_number +'"><option value="">None</option></select><select name="prev_gradeable_'+ prior_term_gradeables_number +'"><option value="">None</option></select>';
-        $('#prev_gradeable_div', form).append(to_append);
+        $('#prev-gradeable-div', form).append(to_append);
         $('[name="prior_term_gradeables_number"]', form).val(parseInt(prior_term_gradeables_number)+1);
         $("select", form).change(function(){
             const select_element_name = $(this).attr("name");

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -202,9 +202,22 @@
             {##################################################################}
             <div class="plag-data-group">
                 <div class="plag-data-label">Users to be Ignored:</div>
-                <div id="ignore_submission_div" class="plag-data">
-                    <input type="checkbox" id="ignore_staff" value="ignore_staff" name="ignore_submission_option" {{ ignore_submissions ? "checked" : "" }}>
-                    <label for="ignore_none_id">Course staff</label>
+                <div class="plag-data">
+                    <input type="checkbox" id="ignore_instructors" value="ignore_instructors" name="ignore_submission_option[]" {{ "instructors" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore_instructors">Instructors</label>
+                </div>
+                <div class="plag-data">
+                    <input type="checkbox" id="ignore_full_access_graders" value="ignore_full_access_graders" name="ignore_submission_option[]" {{ "full_access_graders" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore_full_access_graders">Full Access Graders</label>
+                </div>
+                <div class="plag-data">
+                    <input type="checkbox" id="ignore_limited_access_graders" value="ignore_limited_access_graders" name="ignore_submission_option[]" {{ "limited_access_graders" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore_limited_access_graders">Limited Access Graders</label>
+                </div>
+                <div class="plag-data">
+                    <input type="checkbox" id="ignore_others" value="ignore_others" name="ignore_submission_option[]" {{ "others" in ignore_submissions ? "checked" : "" }}>
+                    <label for="ignore_others">Others:</label>
+                    <input type="text" id="ignore_others_list" value="{{ ignore_submissions_list }}" placeholder="Type user ID's separated by commas and spaces" name="ignore_others_list" style="width:80%;">
                 </div>
             </div>
             {##################################################################}

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -202,22 +202,22 @@
             {##################################################################}
             <div class="plag-data-group">
                 <div class="plag-data-label">Users to be Ignored:</div>
-                <div class="plag-data">
+                <div class="plag-data radio-label-pair">
                     <input type="checkbox" id="ignore_instructors" value="ignore_instructors" name="ignore_submission_option[]" {{ "instructors" in ignore_submissions ? "checked" : "" }}>
                     <label for="ignore_instructors">Instructors</label>
                 </div>
-                <div class="plag-data">
+                <div class="plag-data radio-label-pair">
                     <input type="checkbox" id="ignore_full_access_graders" value="ignore_full_access_graders" name="ignore_submission_option[]" {{ "full_access_graders" in ignore_submissions ? "checked" : "" }}>
                     <label for="ignore_full_access_graders">Full Access Graders</label>
                 </div>
-                <div class="plag-data">
+                <div class="plag-data radio-label-pair">
                     <input type="checkbox" id="ignore_limited_access_graders" value="ignore_limited_access_graders" name="ignore_submission_option[]" {{ "limited_access_graders" in ignore_submissions ? "checked" : "" }}>
                     <label for="ignore_limited_access_graders">Limited Access Graders</label>
                 </div>
-                <div class="plag-data">
+                <div class="plag-data radio-label-pair" id="ignore-others-container">
                     <input type="checkbox" id="ignore_others" value="ignore_others" name="ignore_submission_option[]" {{ "others" in ignore_submissions ? "checked" : "" }}>
                     <label for="ignore_others">Others:</label>
-                    <input type="text" id="ignore_others_list" value="{{ ignore_submissions_list }}" placeholder="Type user ID's separated by commas and spaces" name="ignore_others_list" style="width:80%;">
+                    <input type="text" id="ignore_others_list" value="{{ ignore_submissions_list }}" placeholder="List user ID's separated by commas and spaces" name="ignore_others_list">
                 </div>
             </div>
             {##################################################################}

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -147,14 +147,13 @@ class PlagiarismView extends AbstractView {
             $threshold = (int) $saved_config['threshold'];
             $sequence_length = (int) $saved_config['sequence_length'];
             $prior_terms = false; // $prior_term_gradeables_number > 1;
-            $ignore_submissions = count($saved_config['ignore_submissions']) > 0;
+            $ignore_submissions = $saved_config['ignore_submissions'] == "ignore_staff" ? true : false;
         }
 
         return $this->core->getOutput()->renderTwigTemplate('plagiarism/PlagiarismConfigurationForm.twig', [
             "new_or_edit" => $new_or_edit,
             "form_action_link" => $this->core->buildCourseUrl(['plagiarism', 'configuration', 'new']) . "?new_or_edit={$new_or_edit}&gradeable_id={$gradeable_id}",
             "csrf_token" => $this->core->getCsrfToken(),
-            //"ignore_submission_number" => $ignore_submission_number,
             //"prior_term_gradeables_number" => $prior_term_gradeables_number,
             "provided_code" => $provided_code,
             "gradeable_ids_titles" => $gradeable_ids_titles,

--- a/site/app/views/admin/PlagiarismView.php
+++ b/site/app/views/admin/PlagiarismView.php
@@ -102,7 +102,7 @@ class PlagiarismView extends AbstractView {
         ]);
     }
 
-    public function configureGradeableForPlagiarismForm($new_or_edit, $gradeable_ids_titles, $prior_term_gradeables, $saved_config, $title) {
+    public function configureGradeableForPlagiarismForm($new_or_edit, $gradeable_ids_titles, $prior_term_gradeables, $ignore_submissions, $ignore_submissions_others, $saved_config, $title) {
         $this->core->getOutput()->addBreadcrumb('Plagiarism Detection', $this->core->buildCourseUrl(['plagiarism']));
         $this->core->getOutput()->addBreadcrumb('Configure New Gradeable');
         $this->core->getOutput()->addInternalCss("plagiarism.css");
@@ -123,9 +123,7 @@ class PlagiarismView extends AbstractView {
         $sequence_length = 4;
         //$prior_term_gradeables_number = $saved_config['prev_term_gradeables'] ? count($saved_config['prev_term_gradeables']) + 1 : 1;
         $prior_terms = false;
-        $ignore_submissions = false;
-        //$ignore_submission_number = $saved_config['ignore_submissions'] ? count($saved_config['ignore_submissions']) + 1 : 1;
-
+        $ignore_submissions_list = null;
 
         // Values which are in saved configuration
         if ($new_or_edit == "edit") {
@@ -147,7 +145,7 @@ class PlagiarismView extends AbstractView {
             $threshold = (int) $saved_config['threshold'];
             $sequence_length = (int) $saved_config['sequence_length'];
             $prior_terms = false; // $prior_term_gradeables_number > 1;
-            $ignore_submissions = $saved_config['ignore_submissions'] == "ignore_staff" ? true : false;
+            $ignore_submissions_list = implode(", ", $ignore_submissions_others);
         }
 
         return $this->core->getOutput()->renderTwigTemplate('plagiarism/PlagiarismConfigurationForm.twig', [
@@ -167,6 +165,7 @@ class PlagiarismView extends AbstractView {
             "sequence_length" => $sequence_length,
             "prior_terms" => $prior_terms,
             "ignore_submissions" => $ignore_submissions,
+            "ignore_submissions_list" => $ignore_submissions_list,
             "plagiarism_link" => $this->core->buildCourseUrl(['plagiarism']),
             "prior_term_gradeables" => $prior_term_gradeables,
             "prior_term_gradeables_json" => $prior_term_gradeables_json

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -76,7 +76,7 @@ input[type=text]:invalid {
     color: var(--alert-invalid-entry-pink);
 }
 
-#prev_gradeable_div {
+#prev-gradeable-div {
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -84,24 +84,24 @@ input[type=text]:invalid {
     padding-bottom: 30px;
 }
 
-#prev_gradeable_div select {
+#prev-gradeable-div select {
     width: calc(100% / 3 - 10px);
     margin: 5px;
 }
 
-#prev_gradeable_div select:nth-child(3n+2) {
+#prev-gradeable-div select:nth-child(3n+2) {
     margin-left: 0;
 }
 
-#prev_gradeable_div select:nth-child(3n+1) {
+#prev-gradeable-div select:nth-child(3n+1) {
     margin-right: 0;
 }
 
-#current_code_file, #provided_code_file, #prev_gradeable_div {
+#current-code-file, #provided-code-file, #prev-gradeable-div {
     display: none;
 }
 
-#ignore_others_list {
+#ignore-others-list {
     flex-grow: 100;
     margin-left: 0.5em;
 }

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -97,9 +97,17 @@ input[type=text]:invalid {
     margin-right: 0;
 }
 
-#text_ignore_submission, #current_code_file, #provided_code_file,
-#add_more_ignore, #prev_gradeable_div {
+#current_code_file, #provided_code_file, #prev_gradeable_div {
     display: none;
+}
+
+#ignore_others_list {
+    flex-grow: 100;
+    margin-left: 0.5em;
+}
+
+#ignore-others-container {
+    display: inline-flex;
 }
 
 .radio-label-pair {

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -97,11 +97,6 @@ input[type=text]:invalid {
     margin-right: 0;
 }
 
-#ignore_submission_div {
-    position: relative;
-    padding-bottom: 30px;
-}
-
 #text_ignore_submission, #current_code_file, #provided_code_file,
 #add_more_ignore, #prev_gradeable_div {
     display: none;


### PR DESCRIPTION
### What is the current behavior?
There is no functional backend to the "ignored submissions" option in the configuration form for the plagiarism detection tool.

### What is the new behavior?
Instructors can specify which users to ignore when running the plagiarism matching algorithm.
![image](https://user-images.githubusercontent.com/71195502/123285874-6efe0680-d4db-11eb-87d2-1c4b6bc2ffc9.png)
The users in each category are queried from the database to compile a list of user id's, which is then written into the `config.json` of the gradeable.

### Other information?
This PR is related to, but independent from the Lichen PR https://github.com/Submitty/Lichen/pull/37, since the "ignore_submissions" field exists in the config.json in the current Submitty master branch. This PR writes user id's to ignore into that field in the config, and everything works normally if nothing is written into it.