### PR TITLE
[Bugfix:Developer] Fix localhost port for cypress

### DIFF
--- a/site/cypress.json
+++ b/site/cypress.json
@@ -1,5 +1,5 @@
 {
-	"baseUrl" : "http://localhost:1501",
+	"baseUrl" : "http://localhost:1511",
 	"testFiles" : [
     "*/*.spec.js",
 		"*.spec.js"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
The localhost development port number changed moving to Ubuntu 20 and Cypress tries to connect to 1501 instead of 1511 when the development ide is launched

### What is the new behavior?
Port number is fixed 
