### PR TITLE
[Bugfix:System] Secondary Email Profile Changes

### DIFF
--- a/site/app/templates/EditSecondaryEmailForm.twig
+++ b/site/app/templates/EditSecondaryEmailForm.twig
@@ -21,7 +21,8 @@
                    name="user_secondary_email_change"
                    value="{{ user.getSecondaryEmail() }}"
                    id="user-secondary-email-change"
-                   data-current-second-email="{{ user.getSecondaryEmail() }}"/>
+                   data-current-second-email="{{ user.getSecondaryEmail() }}"
+                   oninput="changeSecondaryEmail()"/>
         </div>
 
         <p class="std-margin">
@@ -37,6 +38,9 @@
                    name="user_secondary_email_notify_change"
                    {% if user.getEmailBoth() %}
                        checked
+                   {% endif %}
+                   {% if user.getSecondaryEmail() is null or user.getSecondaryEmail() is empty %}
+                       disabled
                    {% endif %}
                    id="user-secondary-email-notify-change"
                    {% if user.getEmailBoth() %}

--- a/site/app/templates/UserProfile.twig
+++ b/site/app/templates/UserProfile.twig
@@ -23,17 +23,6 @@
             <div class="user-info-cont">
                 <div class="user-info-title" id="basic_info">
                     <span>Basic Information</span>
-                    <span>
-                        <a class="icon" tabindex="0" href="javascript:showUpdatePrefNameForm()" aria-label="Edit user preferred names" title="Edit user preferred names">
-                            <i class="fas fa-pencil-alt"></i> Edit Preferred Names
-                        </a>
-                    </span>
-                    <span>&nbsp;&nbsp;&nbsp;</span>
-                    <span>
-                        <a class="icon" tabindex="0" href="javascript:showUpdateSecondaryEmailForm()" aria-label="Edit user secondary email" title="Edit user secondary email">
-                            <i class="fas fa-pencil-alt"></i> Edit Secondary Email
-                        </a>
-                    </span>
                 </div>
                 <div class="user-info">
                     <div class="flex-row" id="username-row">
@@ -48,17 +37,17 @@
                         <span class="label">
                             First Name:
                         </span>
-                        <span class="value">
-                            {{ user.getDisplayedFirstName() }}
-                        </span>
+                        <button class="icon" tabindex="0" onclick="showUpdatePrefNameForm()" aria-label="Edit user preferred name" title="Edit user preferred name">
+                            <i class="fas fa-pencil-alt"></i> {{ user.getDisplayedFirstName() }}
+                        </button>
                     </div>
                     <div class="flex-row" id="lastname-row">
                         <span class="label">
                             Last Name:
                         </span>
-                        <span class="value">
-                            {{ user.getDisplayedLastName() }}
-                        </span>
+                        <button class="icon" tabindex="0" onclick="showUpdatePrefNameForm()" aria-label="Edit user preferred name" title="Edit user preferred name">
+                            <i class="fas fa-pencil-alt"></i> {{ user.getDisplayedLastName() }}
+                        </button>
                     </div>
                     <div class="flex-row" id="email-row">
                         <span class="label">
@@ -72,21 +61,17 @@
                         <span class="label">
                             Secondary Email:
                         </span>
-                        <span class="value">
-                            {{ user.getSecondaryEmail() }}
-                        </span>
+                        <button class="icon" tabindex="0" onclick="showUpdateSecondaryEmailForm()" aria-label="Edit user secondary email" title="Edit user secondary email">
+                            <i class="fas fa-pencil-alt"></i> {{ user.getSecondaryEmail() }}
+                        </button>
                     </div>
                     <div class="flex-row" id="secondary-email-notify-row">
                         <span class="label">
                             Send Email to Secondary Address:
                         </span>
-                        <span class="value">
-                            {% if user.getEmailBoth() %}
-                                True
-                            {% else %}
-                                False
-                            {% endif %}
-                        </span>
+                        <button class="icon" tabindex="0" onclick="showUpdateSecondaryEmailForm()" aria-label="Edit user secondary email" title="Edit user secondary email">
+                            <i class="fas fa-pencil-alt"></i> {% if user.getEmailBoth() %}True{% else %}False{% endif %}
+                        </button>
                     </div>
                     {% if display_access_level %}
                         <div class="flex-row" id="access-row">

--- a/site/public/css/user-profile.css
+++ b/site/public/css/user-profile.css
@@ -105,6 +105,25 @@
     width: 20em;
 }
 
+.icon {
+    background: none!important;
+    border: none;
+    padding: 0!important;
+    color: var(--external-link-blue);
+    text-decoration: none;
+    font-family: 'Source Sans Pro', 'sans-serif'!important;
+    font-size: 100%;
+    cursor: pointer;
+}
+
+.fas {
+    color: var(--btn-default-text);
+}
+
+.fas:hover {
+    color: var(--external-link-blue);
+}
+
 @media (max-width: 401px) {
     .content {
         margin: 10px 0 0 0;

--- a/site/public/js/user-profile.js
+++ b/site/public/js/user-profile.js
@@ -64,8 +64,9 @@ function updateUserPreferredNames () {
           const {data} = response;
           displaySuccessMessage(data.message);
           //update the preferred names
-          $("#firstname-row .value").text(data.first_name);
-          $("#lastname-row .value").text(data.last_name);
+          const icon = '<i class="fas fa-pencil-alt"></i>';
+          $("#firstname-row .icon").html(icon + ' ' + data.first_name);
+          $("#lastname-row .icon").html(icon + ' ' + data.last_name);
           //update the data attributes
           first_name_field.data('current-name', data.first_name);
           last_name_field.data('current-name', data.last_name);
@@ -155,8 +156,9 @@ function updateUserSecondaryEmail () {
                     if (response.status === "success") {
                         const { data } = response;
                         displaySuccessMessage(data.message);
-                        $('#secondary-email-row .value').text(data.secondary_email);
-                        $('#secondary-email-notify-row .value').text(data.secondary_email_notify);
+                        const icon = '<i class="fas fa-pencil-alt"></i>';
+                        $('#secondary-email-row .icon').html(icon + ' ' + data.secondary_email);
+                        $('#secondary-email-notify-row .icon').html(icon + ' ' + data.secondary_email_notify);
                         second_email.data('current-second-email', data.secondary_email);
                         second_email_notify.data('current-second-email-notify', data.secondary_email_notify === "True" ? 1 : 0);
                     }
@@ -173,6 +175,19 @@ function updateUserSecondaryEmail () {
     }
     $('.popup-form').css('display', 'none');
     return false;
+}
+
+function changeSecondaryEmail() {
+    const email = $('#user-secondary-email-change').val();
+    const checkbox = $('#user-secondary-email-notify-change');
+
+    if (email.length > 0) {
+        checkbox.prop('disabled', false);
+    }
+    else {
+        checkbox.prop('disabled', true);
+        checkbox.prop('checked', false);
+    }
 }
 
 $(document).ready(function() {

--- a/tests/e2e/test_my_profile.py
+++ b/tests/e2e/test_my_profile.py
@@ -26,8 +26,8 @@ class TestMyProfile(BaseTestCase):
     def test_basic_info(self):
         self.setup_test_start()
         student_id = self.driver.find_element(By.XPATH, "//div[@id='username-row']/span[@class='value']").text
-        student_first_name = self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/span[@class='value']").text
-        student_last_name = self.driver.find_element(By.XPATH, "//div[@id='lastname-row']/span[@class='value']").text
+        student_first_name = self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/button").text
+        student_last_name = self.driver.find_element(By.XPATH, "//div[@id='lastname-row']/button").text
         user_time_zone = self.driver.find_element(By.ID, "time_zone_selector_label").get_attribute('data-user_time_zone')
         time_zone_selector = Select(self.driver.find_element(By.ID, "time_zone_drop_down"))
         self.assertEqual(self.student_id, student_id)
@@ -58,7 +58,7 @@ class TestMyProfile(BaseTestCase):
         new_first_name = "Rachel"
         new_last_name = "Green"
         # click on the edit-preferred-name link
-        self.driver.find_element(By.XPATH, "//div[@id='basic_info']/span[2]/a").click()
+        self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/button").click()
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.ID, "edit-username-form")))
         # Hit submit without any changes
         self.driver.find_element(By.XPATH, "//div[@id='edit-username-form']/form/div/div/div[2]/div[2]/div/input").click()
@@ -66,7 +66,7 @@ class TestMyProfile(BaseTestCase):
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.ID, "error-js-0")))
 
         # again click on the edit-preferred-name link
-        self.driver.find_element(By.XPATH, "//div[@id='basic_info']/span[2]/a").click()
+        self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/button").click()
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.ID, "edit-username-form")))
         # Clear the previous name and enter new names
         self.driver.find_element(By.ID, "user-firstname-change").clear()
@@ -74,20 +74,19 @@ class TestMyProfile(BaseTestCase):
         self.driver.find_element(By.ID, "user-firstname-change").send_keys(new_first_name)
         self.driver.find_element(By.ID, "user-lastname-change").send_keys(new_last_name)
         self.driver.find_element(By.XPATH, "//div[@id='edit-username-form']/form/div/div/div[2]/div[2]/div/input").click()
-
         # Look for success message
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.ID, "success-js-1")))
 
         # edit form should be out-of-the screen
         self.assertFalse(self.driver.find_element(By.ID, "edit-username-form").is_displayed())
         # Assert that names are updated
-        displayed_first_name = self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/span[@class='value']").text
-        displayed_last_name = self.driver.find_element(By.XPATH, "//div[@id='lastname-row']/span[@class='value']").text
+        displayed_first_name = self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/button").text
+        displayed_last_name = self.driver.find_element(By.XPATH, "//div[@id='lastname-row']/button").text
         self.assertEqual(new_first_name, displayed_first_name)
         self.assertEqual(new_last_name, displayed_last_name)
 
         # Reset the names back to original
-        self.driver.find_element(By.XPATH, "//div[@id='basic_info']/span[2]/a").click()
+        self.driver.find_element(By.XPATH, "//div[@id='firstname-row']/button").click()
         self.driver.find_element(By.ID, "user-firstname-change").clear()
         self.driver.find_element(By.ID, "user-lastname-change").clear()
         self.driver.find_element(By.ID, "user-firstname-change").send_keys(self.student_first_name)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now there are links for editing preferred names and secondary emails. These will start to wrap as screen size shrinks.
finishes most of the tasks for #6670 
Closes #6553 

### What is the new behavior?
Now there are buttons next to names and the second email address fields to edit these. These have also moved away from a tags to instead use button tags. The two names buttons and two secondary email buttons do the same thing respectively.

![image](https://user-images.githubusercontent.com/55092742/123690869-ebb61b00-d822-11eb-96e5-210bff17c75c.png)
