### PR TITLE
[Bugfix:Autograding] ignore dangling symlinks & add logging

### DIFF
--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -75,10 +75,15 @@ def copytree_if_exists(config, job_id, source, target):
         os.mkdir(target)
     else:
         try:
+            # NOTE: Now that we have ignore_dangling_symlinks there
+            # will be no system failure, but it may be unclear to
+            # students why their files are 'missing'.  It would be
+            # nice to pass a warning message of the dangling symlink
+            # back to the student.
             shutil.copytree(source, target, symlinks=False, ignore_dangling_symlinks=True)
         except Exception as error:
             config.logger.log_message(
-                message="ERROR: '"+str(error)+"' attempting to copytree_if_exists: '"+source+"' -> '"+target+"'",
+                f"ERROR: '{str(error)} attempting to copytree_if_exists: {source}->{target}",
                 job_id=job_id,
             )
 
@@ -230,23 +235,19 @@ def prepare_autograding_and_submission_zip(
     tmp_submission = os.path.join(tmp, "TMP_SUBMISSION")
     os.mkdir(tmp_submission)
 
-    copytree_if_exists(config,job_id,provided_code_path, os.path.join(tmp_autograding, "provided_code"))
-    copytree_if_exists(config,job_id,test_input_path, os.path.join(tmp_autograding, "test_input"))
-    copytree_if_exists(config,job_id,test_output_path, os.path.join(tmp_autograding, "test_output"))
-    copytree_if_exists(config,job_id,generated_output_path, os.path.join(tmp_autograding, "generated_output"))
-    copytree_if_exists(config,job_id,bin_path, os.path.join(tmp_autograding, "bin"))
-    copytree_if_exists(
-        config,
-        job_id,
-        instructor_solution_path,
-        os.path.join(tmp_autograding, "instructor_solution")
-    )
-    copytree_if_exists(
-        config,
-        job_id,
-        custom_validation_code_path,
-        os.path.join(tmp_autograding, "custom_validation_code")
-    )
+    copytree_if_exists(config, job_id, provided_code_path,
+                       os.path.join(tmp_autograding, "provided_code"))
+    copytree_if_exists(config, job_id, test_input_path,
+                       os.path.join(tmp_autograding, "test_input"))
+    copytree_if_exists(config, job_id, test_output_path,
+                       os.path.join(tmp_autograding, "test_output"))
+    copytree_if_exists(config, job_id, generated_output_path,
+                       os.path.join(tmp_autograding, "generated_output"))
+    copytree_if_exists(config, job_id, bin_path, os.path.join(tmp_autograding, "bin"))
+    copytree_if_exists(config, job_id, instructor_solution_path,
+                       os.path.join(tmp_autograding, "instructor_solution"))
+    copytree_if_exists(config, job_id, custom_validation_code_path,
+                       os.path.join(tmp_autograding, "custom_validation_code"))
 
     # Copy the default submitty_router into bin.
     router_path = os.path.join(
@@ -296,8 +297,10 @@ def prepare_autograding_and_submission_zip(
                 )
 
     if "generate_output" not in obj:
-        copytree_if_exists(config,job_id,submission_path, os.path.join(tmp_submission, "submission"))
-        copytree_if_exists(config,job_id,checkout_path, os.path.join(tmp_submission, "checkout"))
+        copytree_if_exists(config, job_id, submission_path,
+                           os.path.join(tmp_submission, "submission"))
+        copytree_if_exists(config, job_id, checkout_path,
+                           os.path.join(tmp_submission, "checkout"))
     obj["queue_time"] = dateutils.write_submitty_date(queue_time)
     obj["regrade"] = is_batch_job
     obj["waittime"] = waittime

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -66,7 +66,7 @@ def get_vcs_info(config, top_dir, semester, course, gradeable, userid,  teamid):
     return is_vcs, vcs_type, vcs_base_url, vcs_subdirectory
 
 
-def copytree_if_exists(source, target):
+def copytree_if_exists(config, job_id, source, target):
     # target must not exist!
     if os.path.exists(target):
         raise RuntimeError("ERROR: the target directory already exists", target)
@@ -74,7 +74,13 @@ def copytree_if_exists(source, target):
     if not os.path.isdir(source):
         os.mkdir(target)
     else:
-        shutil.copytree(source, target)
+        try:
+            shutil.copytree(source, target, symlinks=False, ignore_dangling_symlinks=True)
+        except Exception as error:
+            config.logger.log_message(
+                message="ERROR: '"+str(error)+"' attempting to copytree_if_exists: '"+source+"' -> '"+target+"'",
+                job_id=job_id,
+            )
 
 
 def unzip_queue_file(zipfilename):
@@ -224,16 +230,20 @@ def prepare_autograding_and_submission_zip(
     tmp_submission = os.path.join(tmp, "TMP_SUBMISSION")
     os.mkdir(tmp_submission)
 
-    copytree_if_exists(provided_code_path, os.path.join(tmp_autograding, "provided_code"))
-    copytree_if_exists(test_input_path, os.path.join(tmp_autograding, "test_input"))
-    copytree_if_exists(test_output_path, os.path.join(tmp_autograding, "test_output"))
-    copytree_if_exists(generated_output_path, os.path.join(tmp_autograding, "generated_output"))
-    copytree_if_exists(bin_path, os.path.join(tmp_autograding, "bin"))
+    copytree_if_exists(config,job_id,provided_code_path, os.path.join(tmp_autograding, "provided_code"))
+    copytree_if_exists(config,job_id,test_input_path, os.path.join(tmp_autograding, "test_input"))
+    copytree_if_exists(config,job_id,test_output_path, os.path.join(tmp_autograding, "test_output"))
+    copytree_if_exists(config,job_id,generated_output_path, os.path.join(tmp_autograding, "generated_output"))
+    copytree_if_exists(config,job_id,bin_path, os.path.join(tmp_autograding, "bin"))
     copytree_if_exists(
+        config,
+        job_id,
         instructor_solution_path,
         os.path.join(tmp_autograding, "instructor_solution")
     )
     copytree_if_exists(
+        config,
+        job_id,
         custom_validation_code_path,
         os.path.join(tmp_autograding, "custom_validation_code")
     )
@@ -286,8 +296,8 @@ def prepare_autograding_and_submission_zip(
                 )
 
     if "generate_output" not in obj:
-        copytree_if_exists(submission_path, os.path.join(tmp_submission, "submission"))
-        copytree_if_exists(checkout_path, os.path.join(tmp_submission, "checkout"))
+        copytree_if_exists(config,job_id,submission_path, os.path.join(tmp_submission, "submission"))
+        copytree_if_exists(config,job_id,checkout_path, os.path.join(tmp_submission, "checkout"))
     obj["queue_time"] = dateutils.write_submitty_date(queue_time)
     obj["regrade"] = is_batch_job
     obj["waittime"] = waittime


### PR DESCRIPTION
### What is the current behavior?
Currently if a student submits a git repo with a dangling symlink, 
the autograding copy directory tree code will infinite loop and fill up /tmp.

### What is the new behavior?
ignore danling symlinks in this copy tree
