### PR TITLE
[Testing:System] Update Cypress Access Check

### DIFF
--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -1,4 +1,4 @@
-import {buildUrl} from '../support/utils.js';
+import {buildUrl, getCurrentSemesterYearString} from '../support/utils.js';
 
 describe('Test cases revolving around the logging in functionality of the site', () => {
     describe('Test cases where the user should succesfully login', () => {
@@ -52,7 +52,8 @@ describe('Test cases revolving around the logging in functionality of the site',
         it('should check if you can access a course', () => {
             cy.login('pearsr');
             cy.visit(['sample']);
-            cy.get('.content').should('have.text', '\n    You don\'t have access to this course. \n    This is sample for Spring 2021. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n');
+            const semesterYear = getCurrentSemesterYearString();
+            cy.get('.content').should('have.text', `\n    You don\'t have access to this course. \n    This is sample for ${semesterYear}. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n`);
         });
     });
 

--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -52,8 +52,7 @@ describe('Test cases revolving around the logging in functionality of the site',
         it('should check if you can access a course', () => {
             cy.login('pearsr');
             cy.visit(['sample']);
-            const semesterYear = getCurrentSemesterYearString();
-            cy.get('.content').should('have.text', `\n    You don't have access to this course. \n    This is sample for ${semesterYear}. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n`);
+            cy.get('.content').contains('You don\'t have access to this course.');
         });
     });
 

--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -1,4 +1,4 @@
-import {buildUrl, getCurrentSemesterYearString} from '../support/utils.js';
+import {buildUrl} from '../support/utils.js';
 
 describe('Test cases revolving around the logging in functionality of the site', () => {
     describe('Test cases where the user should succesfully login', () => {

--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -53,7 +53,7 @@ describe('Test cases revolving around the logging in functionality of the site',
             cy.login('pearsr');
             cy.visit(['sample']);
             const semesterYear = getCurrentSemesterYearString();
-            cy.get('.content').should('have.text', `\n    You don\'t have access to this course. \n    This is sample for ${semesterYear}. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n`);
+            cy.get('.content').should('have.text', `\n    You don't have access to this course. \n    This is sample for ${semesterYear}. \n    If you think this is a mistake, please contact your instructor to gain access. \n    click  here  to back to homepage and see your courses list.\n`);
         });
     });
 

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -16,19 +16,6 @@ export function getCurrentSemester(){
 }
 
 /**
- * Generates semester + year string like Spring 2021 based on today's date
- *
- * @returns {String}
- */
-export function getCurrentSemesterYearString(){
-    const today = new Date();
-    const year = today.getFullYear().toString();
-    const semester = ((today.getMonth() + 1) < 7) ? 'Spring' : 'Fall';
-
-    return `${semester} ${year}`;
-}
-
-/**
 * Build a courseURL based on an array of 'parts', e.g [foo, bar] -> courses/s21/foo/bar
 *
 * @param {String[]} [parts=[]] array of parts to string together

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -16,6 +16,19 @@ export function getCurrentSemester(){
 }
 
 /**
+ * Generates semester + year string like Spring 2021 based on today's date
+ *
+ * @returns {String}
+ */
+export function getCurrentSemesterYearString(){
+    const today = new Date();
+    const year = today.getFullYear().toString();
+    const semester = ((today.getMonth() + 1) < 7) ? 'Spring' : 'Fall';
+
+    return `${semester} ${year}`;
+}
+
+/**
 * Build a courseURL based on an array of 'parts', e.g [foo, bar] -> courses/s21/foo/bar
 *
 * @param {String[]} [parts=[]] array of parts to string together


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now Cypress tests have a hard-coded semester/year string.

### What is the new behavior?
Cypress generates the string every time it's run so when the next semester code starts the tests pass without needed a change on this.
