### PR TITLE
[Bugfix:Forum] Remove Forum from Core

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -244,7 +244,7 @@ class Core {
             throw new \Exception("Need to load the config before we can create a forum instance.");
         }
 
-        $this->forum = new Forum($this);
+        //$this->forum = new Forum($this);
     }
 
     /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now a Forum model gets created in Core. This Forum model is never used anywhere else in the code.

### What is the new behavior?
The Forum model creation is now commented out in Core. All associated code will be left as another refactor of the forum may come soon.
