### PR TITLE
[Bugfix:Developer] Fix setting debug mode for doctrine

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -172,8 +172,8 @@ class Core {
 
     private function createEntityManager(AbstractDatabase $database): EntityManager {
         $config = Setup::createAnnotationMetadataConfiguration(
-            [FileUtils::joinPaths(__DIR__, '..', 'app', 'entities')],
-            false,
+            [FileUtils::joinPaths(__DIR__, '..', 'entities')],
+            $this->config->isDebug(),
             null,
             null,
             false


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We are not setting Doctrine debug mode.

### What is the new behavior?

This fixes setting the Doctrine debug mode to be based on the debug flag. This mode sets what cache is used by default, where under debug the cache is `ArrayCache` vs `AcpuCache`. The latter is good in production where the entity code cache is stable and not changing often vs the former. This is especially true as we may look to configure more of the recommended settings to tune doctrine performance.

This PR also fixes a path problem when doing a mapping lookup, but does not currently affect anything.