### PR TITLE
[Bugfix:SubminiPolls] Fix invalid markdown template include

### DIFF
--- a/site/app/templates/polls/ViewPollResults.twig
+++ b/site/app/templates/polls/ViewPollResults.twig
@@ -32,7 +32,7 @@
     <h1> Viewing poll results for {{ poll.getName() }} </h1>
 
     <h2> Question: </h2>
-    {% include "misc/Markdown" with {
+    {% include "misc/Markdown.twig" with {
       "content" : poll.getQuestion()
     } only %}
     <br/>


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The include for the `Markdown.twig` template was missing its extension. This would cause an exception to be thrown on trying to view the poll results.

### What is the new behavior?

The template is properly referenced, and an exception is no longer raised.