### PR TITLE
[Bugfix:Submission] Fix markdown include on submission page

### DIFF
--- a/site/app/templates/submission/homework/LoadMessagePage.twig
+++ b/site/app/templates/submission/homework/LoadMessagePage.twig
@@ -1,5 +1,5 @@
 <div class="content gradeable_message markdown">
-    {% include "misc/Markdown" with {
+    {% include "misc/Markdown.twig" with {
         "content" : load_gradeable_message
     } only %}
     <div class="content">


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

If a gradeable had a message attached to it, it would cause an exception to be thrown as it attempted to include a template that does not exist. This was because the template was missing its file extension in the include line.

### What is the new behavior?

Adds the missing extension in the include line, getting the page to work as expected and avoid exception being thrown.