### PR TITLE
[Bugfix:TAGrading] Custom mark arrows

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -37,12 +37,6 @@ aside {
     overflow-y: auto;
 }
 
-.custom-mark-number-input::-webkit-outer-spin-button,
-.custom-mark-number-input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-}
-
 #electronic-gradeable-container {
     height: 100%;
     padding: 0;
@@ -714,6 +708,12 @@ progress::-webkit-progress-value {
     height: 22px;
     width: 22px;
     margin: 5px;
+}
+
+.custom-mark-number-input::-webkit-outer-spin-button,
+.custom-mark-number-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
 }
 
 .ta-nav-wrapper {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -37,6 +37,12 @@ aside {
     overflow-y: auto;
 }
 
+.custom-mark-number-input::-webkit-outer-spin-button,
+.custom-mark-number-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
 #electronic-gradeable-container {
     height: 100%;
     padding: 0;

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -716,6 +716,10 @@ progress::-webkit-progress-value {
     margin: 0;
 }
 
+.custom-mark-arrow-icon:hover {
+    color: var(--standard-light-medium-gray);
+}
+
 .ta-nav-wrapper {
     width: 100%;
 }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2495,15 +2495,22 @@ function toggleCommonMark(component_id, mark_id) {
 /**
  * Call to update the custom mark state when any of the custom mark fields change
  * @param {int} component_id
+ * @return {Promise}
  */
 function updateCustomMark(component_id) {
     if (hasCustomMark(component_id)) {
         // Check the mark if it isn't already
         checkDOMCustomMark(component_id);
+
+        // Uncheck the first mark just in case it's checked
+        return unCheckFirstMark(component_id);
     }
     else {
         // Automatically uncheck the custom mark if it's no longer relevant
         unCheckDOMCustomMark(component_id);
+
+        // Note: this is in the else block since `unCheckFirstMark` calls this function
+        return refreshGradedComponent(component_id, true);
     }
 }
 

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2495,22 +2495,15 @@ function toggleCommonMark(component_id, mark_id) {
 /**
  * Call to update the custom mark state when any of the custom mark fields change
  * @param {int} component_id
- * @return {Promise}
  */
 function updateCustomMark(component_id) {
     if (hasCustomMark(component_id)) {
         // Check the mark if it isn't already
         checkDOMCustomMark(component_id);
-
-        // Uncheck the first mark just in case it's checked
-        return unCheckFirstMark(component_id);
     }
     else {
         // Automatically uncheck the custom mark if it's no longer relevant
         unCheckDOMCustomMark(component_id);
-
-        // Note: this is in the else block since `unCheckFirstMark` calls this function
-        return refreshGradedComponent(component_id, true);
     }
 }
 

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -81,17 +81,27 @@ Required inputs:
             </script>
             <span class="col-no-gutters mark-points">
                 <label for="extra-mark-{{ component.id }}" tabIndex="0" class="screen-reader">Extra Mark</label>
-                <button onclick="gang()">+</button>
                 <input id = "extra-mark-{{ component.id }}"
+                       class="custom-mark-number-input"
                        type="number"
                        step="{{ precision }}"
                        style="background-color:var(--default-white)"
-                       onchange="onCustomMarkChange(this),changeExtraColor('{{ f_mark.title }}',this)"
                        value="{{ graded_component.score | default('0')}}">
+                <div class="plus-minus">
+                    <i onclick="increment(this)"class="fa fa-caret-up"></i>
+                    <i onclick="decrement(this)"class="fa fa-caret-down"></i>
+                </div>
                         <script>
-                             function gang(){
-                                 $("#extra-mark-{{ component.id }}").val(+$("#extra-mark-{{ component.id }}").val()+ {{ precision }});
+                             function increment(me){
+                                 $("#extra-mark-{{ component.id }}").val(+$("#extra-mark-{{ component.id }}").val() + {{ precision }});
+                                 return onCustomMarkChange(me);
                              }
+
+                             function decrement(me){
+                                 $("#extra-mark-{{ component.id }}").val(+$("#extra-mark-{{ component.id }}").val() - {{ precision }});
+                                 return onCustomMarkChange(me);
+                             }
+
                             {% if f_mark.title == "Full Credit" %}
                                 if(document.getElementById("extra-mark-{{ component.id }}").value>0){
                                     document.getElementById("extra-mark-{{ component.id }}").style.backgroundColor="var(--standard-vibrant-yellow)";
@@ -104,7 +114,7 @@ Required inputs:
                         </script>
 
             </span>
-            <span class="col-sm mark-title">
+            <span class="col-sm mark-title" >
                 Custom:
                 <textarea onchange="onCustomMarkChange(this)"
                           onkeyup="auto_grow(this)"

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -81,6 +81,7 @@ Required inputs:
             </script>
             <span class="col-no-gutters mark-points">
                 <label for="extra-mark-{{ component.id }}" tabIndex="0" class="screen-reader">Extra Mark</label>
+                <button onclick="gang()">+</button>
                 <input id = "extra-mark-{{ component.id }}"
                        type="number"
                        step="{{ precision }}"
@@ -88,6 +89,9 @@ Required inputs:
                        onchange="onCustomMarkChange(this),changeExtraColor('{{ f_mark.title }}',this)"
                        value="{{ graded_component.score | default('0')}}">
                         <script>
+                             function gang(){
+                                 $("#extra-mark-{{ component.id }}").val(10);
+                             }
                             {% if f_mark.title == "Full Credit" %}
                                 if(document.getElementById("extra-mark-{{ component.id }}").value>0){
                                     document.getElementById("extra-mark-{{ component.id }}").style.backgroundColor="var(--standard-vibrant-yellow)";
@@ -160,3 +164,4 @@ Required inputs:
         </div>
     {% endif %}
 {% endblock %}
+

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -90,7 +90,7 @@ Required inputs:
                        value="{{ graded_component.score | default('0')}}">
                         <script>
                              function gang(){
-                                 $("#extra-mark-{{ component.id }}").val(10);
+                                 $("#extra-mark-{{ component.id }}").val(+$("#extra-mark-{{ component.id }}").val()+ {{ precision }});
                              }
                             {% if f_mark.title == "Full Credit" %}
                                 if(document.getElementById("extra-mark-{{ component.id }}").value>0){

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -89,8 +89,8 @@ Required inputs:
                        onchange="onCustomMarkChange(this),changeExtraColor('{{ f_mark.title }}',this)"
                        value="{{ graded_component.score | default('0')}}">
                 <div class="plus-minus">
-                    <i onclick="increment(this)"class="fa fa-caret-up"></i>
-                    <i onclick="decrement(this)"class="fa fa-caret-down"></i>
+                    <i onclick="increment(this)"class="fa fa-caret-up custom-mark-arrow-icon"></i>
+                    <i onclick="decrement(this)"class="fa fa-caret-down custom-mark-arrow-icon"></i>
                 </div>
                         <script>
                              function increment(me) {

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -86,18 +86,19 @@ Required inputs:
                        type="number"
                        step="{{ precision }}"
                        style="background-color:var(--default-white)"
+                       onchange="onCustomMarkChange(this),changeExtraColor('{{ f_mark.title }}',this)"
                        value="{{ graded_component.score | default('0')}}">
                 <div class="plus-minus">
                     <i onclick="increment(this)"class="fa fa-caret-up"></i>
                     <i onclick="decrement(this)"class="fa fa-caret-down"></i>
                 </div>
                         <script>
-                             function increment(me){
+                             function increment(me) {
                                  $("#extra-mark-{{ component.id }}").val(+$("#extra-mark-{{ component.id }}").val() + {{ precision }});
                                  return onCustomMarkChange(me);
                              }
 
-                             function decrement(me){
+                             function decrement(me) {
                                  $("#extra-mark-{{ component.id }}").val(+$("#extra-mark-{{ component.id }}").val() - {{ precision }});
                                  return onCustomMarkChange(me);
                              }
@@ -114,7 +115,7 @@ Required inputs:
                         </script>
 
             </span>
-            <span class="col-sm mark-title" >
+            <span class="col-sm mark-title">
                 Custom:
                 <textarea onchange="onCustomMarkChange(this)"
                           onkeyup="auto_grow(this)"
@@ -174,4 +175,3 @@ Required inputs:
         </div>
     {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
closes #6694


### What is the new behavior?
I had to disable the default arrows and add custom ones that don't glitch when the rubric refreshes and updates scores. 

NOTE:

### Other information?
to test:
first on master, mash the up arrow when trying to give someone a custom mark and see error
Now try on new branch
