### PR TITLE
[Bugfix:TAGrading] Submission download

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -646,16 +646,15 @@ function check_server(url) {
 }
 
 function downloadFile(path, dir) {
-    window.open(buildCourseUrl(['download']) + `?dir=${encodeURIComponent(dir)}&path=${encodeURIComponent(path)}`, "_blank");
+    window.location = buildCourseUrl(['download']) + `?dir=${encodeURIComponent(dir)}&path=${encodeURIComponent(path)}`;
 }
 
 function downloadStudentAnnotations(url, path, dir) {
     window.open(url, "_blank", "toolbar=no, scrollbars=yes, resizable=yes, width=700, height=600");
-    //window.location = buildCourseUrl(['download']) + `?dir=${dir}&path=${path}`;
 }
 
 function downloadSubmissionZip(grade_id, user_id, version, origin = null, is_anon = false) {
-    window.location = buildCourseUrl(['gradeable', grade_id, 'download_zip']) + `?dir=submissions&user_id=${user_id}&version=${version}&origin=${origin}&is_anon=${is_anon}`;
+    window.open(buildCourseUrl(['gradeable', grade_id, 'download_zip']) + `?dir=submissions&user_id=${user_id}&version=${version}&origin=${origin}&is_anon=${is_anon}`, "_blank");
     return false;
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -646,7 +646,7 @@ function check_server(url) {
 }
 
 function downloadFile(path, dir) {
-    window.location = buildCourseUrl(['download']) + `?dir=${encodeURIComponent(dir)}&path=${encodeURIComponent(path)}`;
+    window.open(buildCourseUrl(['download']) + `?dir=${encodeURIComponent(dir)}&path=${encodeURIComponent(path)}`);
 }
 
 function downloadStudentAnnotations(url, path, dir) {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -646,7 +646,7 @@ function check_server(url) {
 }
 
 function downloadFile(path, dir) {
-    window.open(buildCourseUrl(['download']) + `?dir=${encodeURIComponent(dir)}&path=${encodeURIComponent(path)}`);
+    window.open(buildCourseUrl(['download']) + `?dir=${encodeURIComponent(dir)}&path=${encodeURIComponent(path)}`, "_blank");
 }
 
 function downloadStudentAnnotations(url, path, dir) {


### PR DESCRIPTION

### What is the current behavior?
closes #6291

### What is the new behavior?
Downloading the zip file happens in a new tab and is asynchronous so the submitty page is not effected. The new tab auto closes when the download is complete.

### Other information?
To test:
Use the "download zip file button" on the TA grading interface.
