### PR TITLE
[Testing:Developer] Syntax check php files in CI

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -37,7 +37,7 @@ jobs:
               run: npm run css-stylelint
 
 
-    eslint:
+    js-lint:
         runs-on: ubuntu-18.04
         defaults:
             run:
@@ -85,7 +85,7 @@ jobs:
                   flags: js
 
 
-    php-lint-static:
+    php-lint:
         runs-on: ubuntu-18.04
         defaults:
             run:
@@ -108,10 +108,14 @@ jobs:
 
             - name: Install dependencies
               run: composer install --prefer-dist --dev
-            - name: Run php linting and static analysis
-              run : |
+            - name: Check syntax
+              run: find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+            - name: Lint PHP code
+              run: |
                   php vendor/bin/phpcs --version
                   php vendor/bin/phpcs --standard=tests/ruleset.xml
+            - name: Static analysis
+              run: |
                   php vendor/bin/phpstan  --version
                   php vendor/bin/phpstan analyze app
 

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -235,8 +235,8 @@ jobs:
 
     e2e:
         needs:
-          - eslint
-          - php-lint-static
+          - js-lint
+          - php-lint
           - php-unit
           - python-lint
           - python-unit


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

In the move from Travis-CI to GitHub CI, we lost the check on PHP syntax. While phpstan or phpcs will usually error out on syntax, this error can be mangled with other errors, making it not obvious why this happens, or where exactly within the file it happens.

### What is the new behavior?

This re-adds the syntax check as a stage of the php-lint workflow. This should help with understanding when the test suite fails on syntax.