### PR TITLE
[Testing:CourseMaterials] Fix flaky test

### DIFF
--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -7,6 +7,7 @@ describe('Test cases revolving around course material uploading and access contr
     before(() => {
         cy.visit('/');
         cy.login();
+        cy.wait(500);
         cy.visit(['sample', 'course_materials']);
     });
 
@@ -356,6 +357,5 @@ describe('Test cases revolving around course material uploading and access contr
 
         cy.get('.fa-trash').first().click();
         cy.get('.btn-danger').click();
-        cy.wait(1000);
     });
 });

--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -346,7 +346,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('#upload1').attachFile('file5.txt' , { subjectType: 'drag-n-drop' });
         cy.get('#upload_sort').clear().type('0');
         cy.get('#submit-materials').click();
-        cy.reload();
+        cy.reload(true);
         cy.get('[onclick=\'setCookie("foldersOpen",openAllDivForCourseMaterials());\']').click();
 
 

--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -356,5 +356,6 @@ describe('Test cases revolving around course material uploading and access contr
 
         cy.get('.fa-trash').first().click();
         cy.get('.btn-danger').click();
+        cy.wait(1000);
     });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The last test in the course materials cypress tests is flaky and often fails waiting for a page load.
This may be from a long test running and cypress slowing down the CI Job by recording everything

### What is the new behavior?
Force reload and add a wait to try and avoid getting stuck on a page

