### PR TITLE
[Bugfix:InstructorUI] Hidden file errors

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -37,7 +37,7 @@
             <div class="card col-md-12" style="margin:0px">
                 <div class="content"style="margin:0px">
                     Enter any file wildcards that should not be viewable by students. Seperate wildcards with commas <br>
-                    <input type="text" id="hidden_files" name = "hidden_files" class="auto_save" placeholder="" value = {{hidden_files}}>
+                    <input type="text" id="hidden_files" name = "hidden_files" class="auto_save" placeholder="" value = "{{hidden_files}}">
             </div>
         </div>
 </div>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -507,12 +507,14 @@
         {% set btn_class = "btn-primary" %}
     {% endif %}
     <td>
-        <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId() }}&sort={{ context.sort }}&direction={{ context.direction }}">
-            {{ contents }}
-            {% if badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
-                <span class="notification-badge">{{ badge_count }}</span>
-            {% endif %}
-        </a>
+        {% if badge_count is defined %}
+            <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId() }}&sort={{ context.sort }}&direction={{ context.direction }}">
+                {{ contents }}
+                {% if badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
+                    <span class="notification-badge">{{ badge_count }}</span>
+                {% endif %}
+            </a>
+        {% endif %}
     </td>
 {% endmacro %}
 
@@ -604,18 +606,18 @@
 
 {# Total Point Summary (peer) #}
 {% macro render_column_total_peer(context, section, graded_gradeable, index, info, column) %}
-    {# todo: test this (no way to create peer assignments currently) #}
-    {# todo: this is a lot of math for the view, we should move this into the Gradeable model #}
+     todo: test this (no way to create peer assignments currently)
+     todo: this is a lot of math for the view, we should move this into the Gradeable model
     {% set graded = gradeable.getGradedNonHiddenPoints() %}
     {% set components = gradeable.getComponentsGradedBy(core.getUser().getId()) %}
     {% for component in components %}
-        {# getScore is only the custom "mark" need to write a getTotalComponentScore and also make it clear or change name of Score #}
+         getScore is only the custom "mark" need to write a getTotalComponentScore and also make it clear or change name of Score
         {% set graded = graded + component.getScore() %}
     {% endfor %}
-    {#
+
         instead of autograding_score it should be total autograding possible
         I don't think total_peer_grading_points ever gets set...it should be set in the gradeable constructor
-    #}
+
     {% set total_possible = gradeable.getGradedNonHiddenPoints() + gradeable.getTotalPeerGradingPoints() %}
     <td>
         {% if gradeable.validateVersions() %}

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -606,17 +606,17 @@
 
 {# Total Point Summary (peer) #}
 {% macro render_column_total_peer(context, section, graded_gradeable, index, info, column) %}
-     todo: test this (no way to create peer assignments currently)
-     todo: this is a lot of math for the view, we should move this into the Gradeable model
+{#     todo: test this (no way to create peer assignments currently)#}
+{#     todo: this is a lot of math for the view, we should move this into the Gradeable model#}
     {% set graded = gradeable.getGradedNonHiddenPoints() %}
     {% set components = gradeable.getComponentsGradedBy(core.getUser().getId()) %}
     {% for component in components %}
-         getScore is only the custom "mark" need to write a getTotalComponentScore and also make it clear or change name of Score
+{#         getScore is only the custom "mark" need to write a getTotalComponentScore and also make it clear or change name of Score#}
         {% set graded = graded + component.getScore() %}
     {% endfor %}
 
-        instead of autograding_score it should be total autograding possible
-        I don't think total_peer_grading_points ever gets set...it should be set in the gradeable constructor
+{#        instead of autograding_score it should be total autograding possible#}
+{#        I don't think total_peer_grading_points ever gets set...it should be set in the gradeable constructor#}
 
     {% set total_possible = gradeable.getGradedNonHiddenPoints() + gradeable.getTotalPeerGradingPoints() %}
     <td>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -606,18 +606,18 @@
 
 {# Total Point Summary (peer) #}
 {% macro render_column_total_peer(context, section, graded_gradeable, index, info, column) %}
-{#     todo: test this (no way to create peer assignments currently)#}
-{#     todo: this is a lot of math for the view, we should move this into the Gradeable model#}
+    {# todo: test this (no way to create peer assignments currently) #}
+    {# todo: this is a lot of math for the view, we should move this into the Gradeable model #}
     {% set graded = gradeable.getGradedNonHiddenPoints() %}
     {% set components = gradeable.getComponentsGradedBy(core.getUser().getId()) %}
     {% for component in components %}
-{#         getScore is only the custom "mark" need to write a getTotalComponentScore and also make it clear or change name of Score#}
+        {# getScore is only the custom "mark" need to write a getTotalComponentScore and also make it clear or change name of Score #}
         {% set graded = graded + component.getScore() %}
     {% endfor %}
-
-{#        instead of autograding_score it should be total autograding possible#}
-{#        I don't think total_peer_grading_points ever gets set...it should be set in the gradeable constructor#}
-
+    {#
+        instead of autograding_score it should be total autograding possible
+        I don't think total_peer_grading_points ever gets set...it should be set in the gradeable constructor
+    #}
     {% set total_possible = gradeable.getGradedNonHiddenPoints() + gradeable.getTotalPeerGradingPoints() %}
     <td>
         {% if gradeable.validateVersions() %}

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -344,7 +344,7 @@
 {# Autograding (peer) #}
 {% macro render_column_autograding_peer(context, section, graded_gradeable, index, info, column) %}
     <td>
-        {% if graded_gradeable.getAutoGradedGradeable().getHighestVersion() != 0 %}
+        {% if graded_gradeable.getAutoGradedGradeable().getHighestVersion() != 0 and graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance() is not null %}
             {{ graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance().getNonHiddenPoints() }} / {{ graded_gradeable.getGradeable.getAutogradingConfig().getTotalNonHiddenNonExtraCredit() }}
         {% endif %}
     </td>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1273,6 +1273,7 @@ HTML;
                 foreach ($new_files as $file) {
                     $skipping = false;
                     foreach (explode(",", $hidden_files) as $file_regex) {
+                        $file_regex = trim($file_regex);
                         if (fnmatch($file_regex, $file["name"]) && $this->core->getUser()->getGroup() > 3) {
                             $skipping = true;
                         }


### PR DESCRIPTION
### What is the current behavior?
closes #6020
closes #5924 

### What is the new behavior?
All wildcard / file names entered in the input box are saved and displayed correctly.

### Other information?
<!-- How did you test -->
- As an instructor, edit a peer gradeable
- Go to the peer matrix panel
- Attempt to enter file names with spaces or wildcards with spaces in the "Enter any Wildcards..." box
- save and reload
- see error

### NOTE 
if you get a twig error "gradeable does not exist" when trying to get to the student index while logged in as a peer grader,
comment out lines 609-626 in app/templates/grading/electronic/details.twig. The total column for peer grading has been broken for a while but the recent changes to twig settings makes it so errors are thrown. There is another open PR that will fix this so just ignore it for now.

Since the error had to do with spaces, I made sure that the matching function properly matches file names with spaces and it works as expected. 


