### PR TITLE
[Bugfix:TAGrading] Add Panel Message for All Empty Panels

### DIFF
--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -105,7 +105,7 @@
 
         const overlap_margin = 15;
         const overlapping = (panel_buttons_bbox.left - name_div_bbox.right) < overlap_margin;
-        if (overlapping) {
+        if (overlapping || taLayoutDet.isFullLeftColumnMode) {
             $('#grading-panel-student-name').hide()
         }
     });

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -104,7 +104,7 @@
         const name_div_bbox = name_div[0].getClientRects()[0];
 
         const overlap_margin = 15;
-        const overlapping = (toolbar_bbox.left - name_div_bbox.right) < overlap_margin;
+        const overlapping = (panel_buttons_bbox.left - name_div_bbox.right) < overlap_margin;
         if (overlapping) {
             $('#grading-panel-student-name').hide()
         }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -989,7 +989,6 @@ HTML;
 
             $return .= <<<HTML
                 <div class="panels-container">
-                    <h3 id="panel-instructions">Click above to select a panel for display</h3>
                     <div class="two-panel-cont">
                          <div class="two-panel-item two-panel-left active">
                             <div class="panel-item-section left-top"></div>

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -391,6 +391,7 @@ progress::-webkit-progress-value {
 .panels-container {
     margin: 0;
     background: var(--standard-medium-gray);
+    position:relative;
 }
 
 .two-panel-cont {
@@ -406,6 +407,11 @@ progress::-webkit-progress-value {
 .two-panel-item {
     min-width: 200px;
     width: 50%;
+    position: relative;
+}
+
+.panel-item-section {
+    position: relative;
 }
 
 .panel-item-section.left-top,
@@ -500,11 +506,12 @@ progress::-webkit-progress-value {
     width: 9px;
 }
 
-#panel-instructions {
+.panel-instructions {
     color: dimgray;
-    display: flex;
-    justify-content: center;
-    padding-top: 20%;
+    position: absolute;
+    top: 50%;
+    width:100%;
+    text-align: center;
 }
 
 #grading-panel-student-name {

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -986,14 +986,14 @@ function updatePanelLayoutModes () {
   const rightTopPanel = document.getElementById(taLayoutDet.currentTwoPanels.rightTop);
   const rightBottomPanel = document.getElementById(taLayoutDet.currentTwoPanels.rightBottom);
 
+  //remove all panel instructions
+  $('.panel-instructions').remove();
   setMultiPanelModeVisiblities();
   for (const panelIdx in panelsBucket) {
     const panelCont = document.querySelector(panelsBucket[panelIdx]).childNodes;
     // Move all the panels from the left and right buckets to the main panels-container
     for (let idx = 0; idx < panelCont.length; idx++) {
       document.querySelector(".panels-container").append(panelCont[idx]);
-      //remove all panel instructions
-      $('.panel-instructions').remove();
     }
   }
 

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -690,6 +690,8 @@ function resetSinglePanelLayout() {
   $('.two-panel-cont').removeClass("active");
   $("#two-panel-exchange-btn").removeClass("active");
 
+  $('.panels-container').append('<h3 class="panel-instructions">Click above to select a panel for display</h3>');
+  $('.panels-container > .panel-instructions').hide();
   // Remove the full-left-column view (if it's currently present or is in-view) as it's meant for two-panel-mode only
   $(".two-panel-item.two-panel-left, .two-panel-drag-bar").removeClass("active");
 
@@ -753,7 +755,6 @@ function checkForTwoPanelLayoutChange (isPanelAdded, panelId = null, panelPositi
 
 // Keep only those panels which are part of the two panel layout
 function setMultiPanelModeVisiblities () {
-    $("#panel-instructions").hide();
     panelElements.forEach((panel) => {
       let id_str = document.getElementById("#" + panel.str + "_btn") ? "#" + panel.str + "_btn" : "#" + panel.str + "-btn";
 
@@ -788,12 +789,7 @@ function setPanelsVisibilities (ele, forceVisible=null, position=null) {
       } else {
         // update the global variable
         taLayoutDet.currentOpenPanel = eleVisibility ? panel.str : null;
-      }
-      if (taLayoutDet.currentOpenPanel === null) {
-        $("#panel-instructions").show();
-      }
-      else {
-        $("#panel-instructions").hide();
+        $('.panels-container > .panel-instructions').toggle(!taLayoutDet.currentOpenPanel);
       }
     } else if ((taLayoutDet.numOfPanelsEnabled && !isMobileView
       && taLayoutDet.currentTwoPanels.rightTop !== panel.str
@@ -869,12 +865,6 @@ function togglePanelLayoutModes(forceVal = false) {
   const twoPanelCont = $('.two-panel-cont');
   if (!forceVal) {
     taLayoutDet.numOfPanelsEnabled = +taLayoutDet.numOfPanelsEnabled === 3 ? 1 : +taLayoutDet.numOfPanelsEnabled + 1;
-  }
-  if (taLayoutDet.currentOpenPanel === null) {
-    $("#panel-instructions").show();
-  }
-  else {
-    $("#panel-instructions").hide();
   }
 
   if (taLayoutDet.numOfPanelsEnabled === 2 && !isMobileView) {
@@ -1001,20 +991,23 @@ function updatePanelLayoutModes () {
     // Move all the panels from the left and right buckets to the main panels-container
     for (let idx = 0; idx < panelCont.length; idx++) {
       document.querySelector(".panels-container").append(panelCont[idx]);
+      //remove all panel instructions
+      $('.panel-instructions').remove();
     }
   }
-  // finally append the latest panels to their respective buckets
-  if (leftTopPanel) {
-    document.querySelector(panelsBucket.leftTopSelector).append(leftTopPanel);
-  }
-  if (leftBottomPanel) {
-    document.querySelector(panelsBucket.leftBottomSelector).append(leftBottomPanel);
-  }
-  if (rightTopPanel) {
-    document.querySelector(panelsBucket.rightTopSelector).append(rightTopPanel);
-  }
-  if (rightBottomPanel) {
-    document.querySelector(panelsBucket.rightBottomSelector).append(rightBottomPanel);
+
+  //loop through panel positions (topLeft, topRight, etc)
+  for (let panel in taLayoutDet.currentTwoPanels) {
+    //get panel corresponding with the layout position
+    const layout_panel = $(`${panelsBucket[`${panel}Selector`]}`);
+    //get panel corresponsing with what the user selected to use for this spot (autograding, rubric, etc)
+    const dom_panel = document.getElementById(`${taLayoutDet.currentTwoPanels[panel]}`);
+    if (dom_panel) {
+      $(layout_panel).append(dom_panel);
+    }
+    else {
+      $(layout_panel).append('<h3 class="panel-instructions">Click above to select a panel for display</h3>');
+    }
   }
   saveTaLayoutDetails();
 }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -691,7 +691,7 @@ function resetSinglePanelLayout() {
   $("#two-panel-exchange-btn").removeClass("active");
 
   $('.panels-container').append('<h3 class="panel-instructions">Click above to select a panel for display</h3>');
-  $('.panels-container > .panel-instructions').hide();
+  $('.panels-container :not(.panel-instructions').css('z-index', '2');
   // Remove the full-left-column view (if it's currently present or is in-view) as it's meant for two-panel-mode only
   $(".two-panel-item.two-panel-left, .two-panel-drag-bar").removeClass("active");
 
@@ -979,6 +979,7 @@ function togglePanelLayoutModes(forceVal = false) {
 
 // Handles the DOM manipulation to update the two panel layout
 function updatePanelLayoutModes () {
+  $('.panels-container *').css('z-index', '');
   // fetch the panels by their ids
   const leftTopPanel = document.getElementById(taLayoutDet.currentTwoPanels.leftTop);
   const leftBottomPanel = document.getElementById(taLayoutDet.currentTwoPanels.leftBottom);


### PR DESCRIPTION
### What is the current behavior?
Fixes #6368 
Currently, when there are empty panels when grading, a message telling the user to choose one from above only displays if the user is in single panel mode. All other modes don't show this message.

![image](https://user-images.githubusercontent.com/28243927/125123778-1e82cd80-e0c5-11eb-9819-dc356e6d0180.png)
---
![image](https://user-images.githubusercontent.com/28243927/125124156-a963c800-e0c5-11eb-8055-6fad7b874b6c.png)
---
![image](https://user-images.githubusercontent.com/28243927/125124127-9ea93300-e0c5-11eb-9359-20f9766964ad.png)

### What is the new behavior?
Now all panel layouts have this functionality

![image](https://user-images.githubusercontent.com/28243927/125123778-1e82cd80-e0c5-11eb-9819-dc356e6d0180.png)
---
![image](https://user-images.githubusercontent.com/28243927/125123833-30647080-e0c5-11eb-9631-572fcb5f40be.png)
---
![image](https://user-images.githubusercontent.com/28243927/125123864-3eb28c80-e0c5-11eb-8081-57a383608e5c.png)

### Other Information
Also, a small fix was made to the header to stop the buttons from overlapping the student/team name on small screens.