### PR TITLE
[SECURITY][Bugfix:TAGrading] Don't load or zip symlinks

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -420,7 +420,7 @@ class MiscController extends AbstractController {
                         );
                         foreach ($files as $name => $file) {
                             // Skip directories (they would be added automatically)
-                            if (!$file->isDir()) {
+                            if (!$file->isDir() && !$file->isLink()) {
                                 // Get real and relative path for current file
                                 $filePath = $file->getRealPath();
                                 $relativePath = substr($filePath, strlen($gradeable_path) + 1);

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -45,6 +45,9 @@ class FileUtils {
         if (is_dir($dir)) {
             foreach (new \FilesystemIterator($dir) as $file) {
                 /** @var \SplFileInfo $file */
+                if ($file->isLink()) {
+                    continue;
+                }
                 $entry = $file->getFilename();
                 $path = FileUtils::joinPaths($dir, $entry);
                 // recurse into subdirectories

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -796,6 +796,10 @@ STRING;
         file_put_contents(FileUtils::joinPaths($this->path, 'c', 'e', 'g.cpp'), 'gg');
         file_put_contents(FileUtils::joinPaths($this->path, 'd', 'h.h'), 'hh');
         file_put_contents(FileUtils::joinPaths($this->path, 'd', 'a.txt'), 'gg');
+        // directory symlink
+        symlink(FileUtils::joinPaths($this->path, 'd'), FileUtils::joinPaths($this->path, 'e'));
+        // file symlink
+        symlink(FileUtils::joinPaths($this->path, 'd', 'a.txt'), FileUtils::joinPaths($this->path, 'f'));
     }
 
     public function testGetAllFiles(): void {


### PR DESCRIPTION
### What is the current behavior?
Right now symlinks can cause issues when downloading a zip file of a VCS gradeable. Symlinks can also be used to view their targeting directories in the TA grading file browser.

### What is the new behavior?
Symlinks are now skipped if they appear in the VCS checkout folder. Symlinks are also skipped in the FileUtils getAllFiles function to avoid attempting to follow symlinks from the TA page.
