### PR TITLE
[Feature:Developer] Add new flag for quick clean on install

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -58,7 +58,7 @@ if [[ "$#" -ge 1 && "$1" != "test" && "$1" != "clean" && "$1" != "test_rainbow"
        && "$1" != "skip_web_restart" && "$1" != "disable_shipper_worker" ]]; then
     echo -e "Usage:"
     echo -e "   ./INSTALL_SUBMITTY.sh"
-    echo -e "   ./INSTALL_SUBMITTY.sh clean"
+    echo -e "   ./INSTALL_SUBMITTY.sh clean quick"
     echo -e "   ./INSTALL_SUBMITTY.sh clean test"
     echo -e "   ./INSTALL_SUBMITTY.sh clean skip_web_restart"
     echo -e "   ./INSTALL_SUBMITTY.sh clear test  <test_case_1>"
@@ -177,13 +177,26 @@ if [[ "$#" -ge 1 && $1 == "clean" ]] ; then
 
     echo -e "\nDeleting submitty installation directories, ${SUBMITTY_INSTALL_DIR}, for a clean installation\n"
 
-    rm -rf ${SUBMITTY_INSTALL_DIR}/site
-    rm -rf ${SUBMITTY_INSTALL_DIR}/src
-    rm -rf ${SUBMITTY_INSTALL_DIR}/vendor
+    if [[ "$#" -ge 1 && $1 == "quick" ]] ; then
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/app
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/cache
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/cgi-bin
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/config
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/cypress
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/public
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/room_templates
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/socket
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site/tests
+        find ${SUBMITTY_INSTALL_DIR}/site -maxdepth 1 -type f -exec rm {} \;
+    else
+        rm -rf ${SUBMITTY_INSTALL_DIR}/site
+        rm -rf ${SUBMITTY_INSTALL_DIR}/src
+        rm -rf ${SUBMITTY_INSTALL_DIR}/vendor
+        rm -rf ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools
+    fi
     rm -rf ${SUBMITTY_INSTALL_DIR}/bin
     rm -rf ${SUBMITTY_INSTALL_DIR}/sbin
     rm -rf ${SUBMITTY_INSTALL_DIR}/test_suite
-    rm -rf ${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools
 fi
 
 # set the permissions of the top level directory

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -178,6 +178,9 @@ if [[ "$#" -ge 1 && $1 == "clean" ]] ; then
     echo -e "\nDeleting submitty installation directories, ${SUBMITTY_INSTALL_DIR}, for a clean installation\n"
 
     if [[ "$#" -ge 1 && $1 == "quick" ]] ; then
+        # pop this argument from the list of arguments...
+        shift
+
         rm -rf ${SUBMITTY_INSTALL_DIR}/site/app
         rm -rf ${SUBMITTY_INSTALL_DIR}/site/cache
         rm -rf ${SUBMITTY_INSTALL_DIR}/site/cgi-bin


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
There are quite a few developers here that use PHPStorm rather than the code watcher script. PHPStorm will copy the files directly into the site folder while vagrant will copy the changes into the GIT repo on the VM. The rsync command only finds differences between site folder and GIT repo site folder which will always be equivalent with PHPStorm and therefore never update. This causes composer, npm, and permissions to never get updated when using submitty_install.

### What is the new behavior?
There is a new new runtime flag "clean quick" which will do a much shorter version of the submitty_install clean. This would delete most files in site but not all like vendor or node modules to reduce install time. This would be run by PHPStorm users when they switch branches, encounter permission issues, or install a new package.

This also contains an addition to exclude from rsync for CSS linting as there is no reason to compare/send that.

Submitty docs will be updated for PHPStorm to easily use the submitty_install script with the flag.

### Other information
Testing the install scripts:
`submitty_install`: 30 seconds
`submitty_install clean`: 1 min 40 seconds
`submitty_install clean quick`: 50 seconds
This does add a little more time compared to submitty_install but it does make it work well. The alternative would to use code watcher with PHPStorm. The PHPStorm deployment is almost instantaneous while the code watcher takes a few seconds while the site updates. Just a few edits with code watcher would already make the new runtime flag worth running.