### PR TITLE
[Bugfix:InstructorUI] Fix markdown editor for NB builder

### DIFF
--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -35,7 +35,7 @@
     {% include "misc/AccessibilityMessage.twig" %}
     <textarea
         id="{{ markdown_area_id }}"
-        class="fill-available {{ class is defined ? class : 'markdown-input'}}"
+        class="fill-available {{ class is defined ? class }}"
         name="{{ markdown_area_name is defined ? markdown_area_name : "markdown_area" }}"
         {% if placeholder is defined %}
             placeholder="{{ placeholder }}"

--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -35,7 +35,7 @@
     {% include "misc/AccessibilityMessage.twig" %}
     <textarea
         id="{{ markdown_area_id }}"
-        class="fill-available {{ class is defined ? class }}"
+        class="fill-available {{ class is defined ? class : 'markdown-input'}}"
         name="{{ markdown_area_name is defined ? markdown_area_name : "markdown_area" }}"
         {% if placeholder is defined %}
             placeholder="{{ placeholder }}"

--- a/site/app/views/MarkdownView.php
+++ b/site/app/views/MarkdownView.php
@@ -16,16 +16,30 @@ class MarkdownView extends AbstractView {
 
     public function renderMarkdownArea($data) {
         $this->core->getOutput()->disableRender();
-        return $this->core->getOutput()->renderTwigTemplate("misc/MarkdownArea.twig", [
-            "markdown_area_id"    => $data['markdown_area_id'],
-            "markdown_area_value" => $data['markdown_area_value'],
-            "placeholder"         => $data['placeholder'],
-            "preview_div_id"      => $data['preview_div_id'],
-            "preview_div_name"    => $data['preview_div_name'],
-            "preview_button_id"   => $data['preview_button_id'],
-            "onclick"             => $data['onclick'],
-            "render_buttons"      => $data['render_buttons'],
-            "min_height"          => $data['min_height']
-        ]);
+        $args = [];
+        $keys = [
+            'markdown_area_id',
+            'markdown_area_name',
+            'markdown_area_value',
+            'class',
+            'onclick',
+            'markdown_buttons_id',
+            'other_textarea_attributes',
+            'render_buttons',
+            'placeholder',
+            'preview_div_id',
+            'textarea_onchange',
+            'textarea_onkeydown',
+            'textarea_onpaste',
+            'textarea_maxlength',
+            'data_previous_comment',
+            'min_height'
+        ];
+        foreach ($keys as $key) {
+            if (isset($data[$key])) {
+                $args[$key] = $data[$key];
+            }
+        }
+        return $this->core->getOutput()->renderTwigTemplate("misc/MarkdownArea.twig", $args);
     }
 }


### PR DESCRIPTION

### What is the current behavior?
closes #6736 

### What is the new behavior?
Adding markdown to a notebook using the notebook builder works as expected.

### To Test
1. As instructor, make a notebook gradeable and use the notebook builder
2. try to add mark down and click save
