### PR TITLE
[Bugfix:InstructorUI] Prevent Enter Key Removing Team Members

### DIFF
--- a/site/public/js/admin-team-form.js
+++ b/site/public/js/admin-team-form.js
@@ -212,6 +212,7 @@ function getTeamFormButtonString(id_prefix, button_class, text, user_num, onclic
                 id="${id_prefix + user_num}"
                 class="btn ${button_class} admin-team-form-button" 
                 onclick="${onclick.name}(${onclickArgs.join(', ')})" 
+                type="button"
             >
                 ${text}
             </button>`;
@@ -223,6 +224,7 @@ function getTeamFormAddMoreUsersButtonString(user_num){
                 onclick="addTeamMemberInput(this, ${user_num});" 
                 aria-label="Add More Users"
                 class="btn btn-primary"
+                type="button"
             >
                 <i class="fas fa-plus-square"></i>
                 Add More Users


### PR DESCRIPTION
### What is the current behavior?
Pressing the enter key while editing team members will start deleting the top team members. These buttons are assumed of type submit which is why the enter key can trigger them.

### What is the new behavior?
The enter button would submit the form rather than deleting members. The buttons are all of type button except for the true submit button.
