### PR TITLE
[Bugfix:TAGrading] Prevent hidden file url hack

### DIFF
--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -766,6 +766,7 @@ class Access {
                     }
                     $hidden_files = $args["gradeable"]->getHiddenFiles();
                     foreach (explode(",", $hidden_files) as $file_regex) {
+                        $file_regex = trim($file_regex);
                         if (fnmatch($file_regex, $subpart_values[count($subpart_values) - 1]) && $this->core->getUser()->getGroup() > 3) {
                             return false;
                         }


### PR DESCRIPTION

### What is the current behavior?
A peer grader can do a url hack to download files that are hidden from them.

### What is the new behavior?
Hidden files are now totally protected from people without access to them.

### Other information?
Shail, follow the same steps you were using before
