### PR TITLE
[Bugfix:Autograding] Remove duplicate one_of field from json

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -1250,12 +1250,13 @@ void General_Helper(nlohmann::json &single_testcase) {
 }
 
 void FileCheck_Helper(nlohmann::json &single_testcase) {
-  nlohmann::json::iterator f_itr,v_itr,m_itr,itr;
+  nlohmann::json::iterator f_itr,v_itr,m_itr,o_itr,itr;
 
   // Check the required fields for all test types
   f_itr = single_testcase.find("actual_file");
   v_itr = single_testcase.find("validation");
   m_itr = single_testcase.find("max_submissions");
+  o_itr = single_testcase.find("one_of");
 
   if (f_itr != single_testcase.end()) {
     // need to rewrite to use a validation
@@ -1279,6 +1280,7 @@ void FileCheck_Helper(nlohmann::json &single_testcase) {
     }
     single_testcase["validation"].push_back(v);
     single_testcase.erase(f_itr);
+    single_testcase.erase(o_itr);
   } else if (v_itr != single_testcase.end()) {
     // already has a validation
   } else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Building a test case with the one_of field will cause a schema validation error as there will be two one_of fields in the inflated json.
Closes #6257 

### What is the new behavior?
The top level one_of field is removed when built.

### Other information?
I tested the same example provided in the issue before and after and this fixes it.
