### PR TITLE
[Bugfix:TAGrading] Fix panel container height w/banner

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -494,8 +494,16 @@ function adjustGradingPanelHeader () {
   } else {
     navBarBox.removeClass('mobile-view');
   }
-  // From the complete content remove the height occupied by navigation-bar and panel-header element
-  document.querySelector('.panels-container').style.height = "calc(100% - " + (header.outerHeight() + navBar.outerHeight()) + "px)";
+
+  // From the complete content remove the height occupied by other elements
+  let height = 0;
+  $(".panels-container").first().siblings().each(function() {
+    if ($(this).css("display") !== 'none') {
+      height += $(this).outerHeight(true);
+    }
+  });
+  
+  document.querySelector('.panels-container').style.height = "calc(100% - " + (height) + "px)";
 }
 
 function onAjaxInit() {}


### PR DESCRIPTION
### What is the current behavior?
When there is an additional banner (such as the `No Submission` banner) in TA grading, the height of the panel container is not correct.

### What is the new behavior?
The height of the panel container now factors in the height of all siblings of the panel container.