### PR TITLE
[Refactor:Developer] Alphabetize composer dep list

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -3,7 +3,8 @@
   "config": {
     "platform": {
       "php": "7.2"
-    }
+    },
+    "sort-packages": true
   },
   "autoload": {
     "psr-4": {
@@ -16,30 +17,30 @@
     }
   },
   "require": {
-    "twig/twig": "2.13.1",
-    "ramsey/uuid": "4.1.1",
     "aptoma/twig-markdown": "3.4.0",
+    "cboden/ratchet": "0.4.3",
+    "doctrine/annotations": "1.13.1",
+    "doctrine/cache": "1.11.3",
+    "doctrine/orm": "2.9.3",
+    "egulias/email-validator": "3.1.1",
     "lcobucci/jwt": "3.4.5",
-    "symfony/routing": "4.4.25",
+    "league/commonmark": "1.6.5",
+    "maennchen/zipstream-php": "2.1.0",
+    "php-ds/php-ds": "1.3.0",
+    "ramsey/uuid": "4.1.1",
+    "spatie/commonmark-highlighter": "2.1.1",
     "symfony/config": "4.4.26",
     "symfony/http-foundation": "4.4.26",
-    "doctrine/annotations": "1.13.1",
-    "php-ds/php-ds": "1.3.0",
-    "cboden/ratchet": "0.4.3",
+    "symfony/routing": "4.4.25",
     "textalk/websocket": "1.5.4",
-    "egulias/email-validator": "3.1.1",
-    "maennchen/zipstream-php": "^2.1",
-    "doctrine/orm": "2.9.3",
-    "doctrine/cache": "1.11.3",
-    "league/commonmark": "1.6.5",
-    "spatie/commonmark-highlighter": "2.1.1"
+    "twig/twig": "2.13.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "8.5.17",
-    "submitty/php-codesniffer": "2.5.0",
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
     "php-mock/php-mock-phpunit": "2.6.0",
-    "phpstan/phpstan": "0.12.92"
+    "phpstan/phpstan": "0.12.92",
+    "phpunit/phpunit": "8.5.17",
+    "submitty/php-codesniffer": "2.5.0"
   },
   "scripts": {
     "test": "phpunit -c tests/phpunit.xml",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b594cb9d55b6de424c8721045979169",
+    "content-hash": "b20bab354e4d9c70ac35d9efd2f10526",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -1656,6 +1656,10 @@
                 "stream",
                 "zip"
             ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://opencollective.com/zipstream",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The composer dependency lists are not in alphabetical order. This makes it annoying to scan through for a specific named dependency.

### What is the new behavior?

The dependency list is alphabetized, with a config flag added to keep it such.