### PR TITLE
[Dependency] replace pyyaml with ruamel.yaml

### DIFF
--- a/.setup/bin/partial_reset.py
+++ b/.setup/bin/partial_reset.py
@@ -17,7 +17,9 @@ import shutil
 import json
 import subprocess
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')
 
 CURRENT_PATH = Path(__file__).resolve().parent
 SETUP_DATA_PATH = Path(CURRENT_PATH, "..", "data").resolve()
@@ -36,7 +38,7 @@ def load_data_yaml(file_path):
     if not file_path.is_file():
         raise IOError("Missing the yaml file {}".format(file_path))
     with file_path.open() as open_file:
-        yaml_file = yaml.safe_load(open_file)
+        yaml_file = yaml.load(open_file)
     return yaml_file
 
 

--- a/.setup/bin/reset_system.py
+++ b/.setup/bin/reset_system.py
@@ -15,7 +15,9 @@ import shutil
 import subprocess
 import tempfile
 
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')
 
 CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
 SETUP_DATA_PATH = os.path.join(CURRENT_PATH, "..", "data")
@@ -30,7 +32,7 @@ def load_data_yaml(file_path):
     if not os.path.isfile(file_path):
         raise IOError("Missing the yaml file {}".format(file_path))
     with open(file_path) as open_file:
-        yaml_file = yaml.safe_load(open_file)
+        yaml_file = yaml.load(open_file)
     return yaml_file
 
 

--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -30,17 +30,16 @@ import subprocess
 import uuid
 import os.path
 import string
-import sys
-import configparser
-import csv
 import pdb
 import docker
 from tempfile import TemporaryDirectory
 
 from submitty_utils import dateutils
 
+from ruamel.yaml import YAML
 from sqlalchemy import create_engine, Table, MetaData, bindparam, select, join
-import yaml
+
+yaml = YAML(typ='safe')
 
 CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
 SETUP_DATA_PATH = os.path.join(CURRENT_PATH, "..", "data")
@@ -264,7 +263,7 @@ def generate_random_student_note():
 
 def generate_random_marks(default_value, max_value):
     with open(os.path.join(SETUP_DATA_PATH, 'random', 'marks.yml')) as f:
-        marks_yml = yaml.safe_load(f)
+        marks_yml = yaml.load(f)
     if default_value == max_value and default_value > 0:
         key = 'count_down'
     else:
@@ -374,7 +373,7 @@ def load_data_yaml(file_path):
     if not os.path.isfile(file_path):
         raise IOError("Missing the yaml file {}".format(file_path))
     with open(file_path) as open_file:
-        yaml_file = yaml.safe_load(open_file)
+        yaml_file = yaml.load(open_file)
     return yaml_file
 
 
@@ -1574,7 +1573,7 @@ class Gradeable(object):
                 length=len(graders)
                 for i in range(length):
                     conn.execute(peer_assign.insert(), g_id=self.id, grader_id=graders[i], user_id=students[i])
-            
+
         if self.type == 0:
             conn.execute(electronic_table.insert(), g_id=self.id,
                          eg_submission_open_date=self.submission_open_date,

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -27,7 +27,7 @@ opencv-python==3.4.9.33
 pytz==2021.1 # Submitty-util specific.
 
 python-pam==1.8.4
-PyYAML==3.12
+ruamel.yaml==0.17.10
 psycopg2-binary==2.8.6
 sqlalchemy==1.3.24
 pylint==2.8.1

--- a/.setup/vagrant/setup_vagrant.sh
+++ b/.setup/vagrant/setup_vagrant.sh
@@ -11,7 +11,6 @@ SUBMITTY_REPOSITORY=/usr/local/submitty/GIT_CHECKOUT/Submitty
 # We only need to reset the system only if we've installed pip3,
 # which only happens after we've installed the system
 if [ -x "$(command -v pip3)" ]; then
-    pip3 install -U PyYAML
     python3 ${SUBMITTY_REPOSITORY}/.setup/bin/reset_system.py
 fi
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `PyYAML` dependency we have is stuck on an older version as it's being installed from the package store due to a dependency on `netplan.io`. This is the only python dependency we have that is like that.

### What is the new behavior?

Moves to `ruamel.yaml` which we can install and maintain normally through pip like other dependencies. It is also the slightly better maintained library at the moment as it supports the YAML 1.2 spec, and is a bit faster on parsing than PyYAML.
