### PR TITLE
[Bugfix:TAGrading] Fix Markdown on Overall Comments

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2423,7 +2423,6 @@ function toggleComponent(component_id, saveChanges) {
 
 function open_overall_comment_tab(user) {
     const textarea = $(`#overall-comment-${user}`);
-    const content = textarea.html();
 
     $('#overall-comments').children().hide();
     $('#overall-comment-tabs').children().removeClass('active-btn');
@@ -2437,12 +2436,6 @@ function open_overall_comment_tab(user) {
         }
     } else {
         textarea.show();
-    }
-
-    //if it is someone not the current user's comment and it hasn't been rendered yet
-    if(textarea.hasClass('markdown-preview') && !textarea.find('.markdown').length){
-        const url = buildCourseUrl(['markdown', 'preview']);
-        renderMarkdown($(`#overall-comment-${user}`), url, content);
     }
 }
 

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -47,13 +47,20 @@ Required Parameters:
             <div
               id="overall-comment-{{user | escape }}"
               style="display:none;"
-              class="general-comment-entry markdown-preview noscroll key_to_click" tabindex="0"
+              class="general-comment-entry markdown-preview overall-comment-other noscroll key_to_click" tabindex="0"
             >
               {{comment|escape }}
             </div>
         {% endfor %}
     </div>
     <script>
+        $(document).ready(function(){
+            $('.overall-comment-other').each(function() {
+                const content = $(this).html().trim();
+                const url = buildCourseUrl(['markdown', 'preview']);
+                renderMarkdown($(this), url, content);
+            });
+        });
         var grader = "{{overall_comment["logged_in_user"]["user_id"] | escape('js') }}";
         $(document).on('input','#overall-comment-' + grader,function () {
             var currentOverallComment  = $('textarea#overall-comment-' + grader).val();


### PR DESCRIPTION
### What is the current behavior?
Currently, when viewing other grader's comments on the rubric panel, the first paragraph gets interpreted as code and is put all on one line.
![image](https://user-images.githubusercontent.com/28243927/126042464-e922d620-fd03-4cb7-a89e-bd6387c37224.png)


### What is the new behavior?
The markdown looks as expected. Also, other user's comments are loaded when the page loads to hopefully eliminate having to wait for the markdown to render the first time you open the comment.
![image](https://user-images.githubusercontent.com/28243927/126042423-fce6ebb7-cdeb-4772-9575-28697a8c01db.png)
