### PR TITLE
[Bugfix:Developer] Fix generation of sample team IDs

### DIFF
--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -37,7 +37,7 @@ from tempfile import TemporaryDirectory
 from submitty_utils import dateutils
 
 from ruamel.yaml import YAML
-from sqlalchemy import create_engine, Table, MetaData, bindparam, select, join
+from sqlalchemy import create_engine, Table, MetaData, bindparam, select, join, func
 
 yaml = YAML(typ='safe')
 
@@ -1079,23 +1079,12 @@ class Course(object):
         json_team_history = {}
         gradeable_teams_table = Table("gradeable_teams", self.metadata, autoload=True)
         teams_table = Table("teams", self.metadata, autoload=True)
-        ucounter = 0
+        ucounter = self.conn.execute(select([func.count()]).select_from(gradeable_teams_table)).scalar()
         for user in self.users:
             #the unique team id is made up of 5 digits, an underline, and the team creater's userid.
             #example: 00001_aphacker
+
             unique_team_id=str(ucounter).zfill(5)+"_"+user.get_detail(self.code, "id")
-            team_in_other_gradeable = select([gradeable_teams_table]).where(
-            gradeable_teams_table.c['team_id'] == unique_team_id)
-            res = self.conn.execute(team_in_other_gradeable)
-            num = res.rowcount
-            while num is not 0:
-                ucounter+=1
-                unique_team_id=str(ucounter).zfill(5)+"_"+user.get_detail(self.code, "id")
-                team_in_other_gradeable = select([gradeable_teams_table]).where(
-                gradeable_teams_table.c['team_id'] == unique_team_id)
-                res = self.conn.execute(team_in_other_gradeable)
-                num = res.rowcount
-            res.close()
             reg_section = user.get_detail(self.code, "registration_section")
             if reg_section is None:
                 continue


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now, in the sample course, teams are generated with an incremental number ID per gradeable. There is a check in the setup_sample_courses script to make sure no duplicated IDs. This still produces a different set of IDs compared to what production would generate where the number ID is incremental across the entire course.

![image](https://user-images.githubusercontent.com/55092742/126179244-4d0417bc-38dc-435b-8225-52b650f81740.png)

### What is the new behavior?
The setup script uses a similar method to the site code to generate the numeric IDs to model a production environment better. The numeric IDs are now always unique per course.

### Other information?
Below is a Vagrant Up workflow run on this branch to show that it works on a full vagrant up.
https://github.com/Submitty/Submitty/actions/runs/1045366739
