### PR TITLE
[Bugfix:Submission] VCS submission bug fix

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -385,6 +385,7 @@ class HomeworkView extends AbstractView {
                 $who_id = $this->core->getUser()->getId();
                 $user_path = FileUtils::joinPaths($gradeable_path, $who_id);
                 $highest_version = $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
+                $display_version = $version_instance != null ? $version_instance->getVersion() : 0;
                 $version_path = FileUtils::joinPaths($user_path, $highest_version);
                 $path = FileUtils::joinPaths($version_path, ".submit.VCS_CHECKOUT");
 


### PR DESCRIPTION

### What is the current behavior?
closes #6759
$display_version was not being set for VCS gradeables so $viewing_inactive_version was being set to true no matter what.

### What is the new behavior?
Submissions for VCS gradeables work as expected

### Other information?
To test:
Configure a VCS gradeable and make submissions
