### PR TITLE
[Bugfix:Forum] Fix using markdown in forums

### DIFF
--- a/site/app/templates/forum/RenderPost.twig
+++ b/site/app/templates/forum/RenderPost.twig
@@ -1,1 +1,1 @@
-{% if render_markdown %}{% include "misc/Markdown.twig" with { content: post_content } only %}</span>{% else %}{{ post_content }}{% endif %}
+{% if render_markdown %}{% include "misc/Markdown.twig" with { content: post_content } only %}{% else %}{{ post_content }}{% endif %}

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -89,7 +89,7 @@
             "preview_div_id" : "preview_box_" ~ post_box_id,
             "preview_div_name" : "preview_box_" ~ post_box_id,
             "onclick" : "previewForumMarkdown.call(this)",
-            "render_buttons" : render_markdown is defined ? render_markdown : false,
+            "render_buttons" : render_markdown is defined and render_markdown ? render_markdown : false,
             "markdown_buttons_id" : "markdown_buttons_" ~ post_box_id,
             "min_height" : min_height,
             "textarea_maxlength" : post_content_limit is defined ? post_content_limit : null,

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -39,7 +39,7 @@
 
 .post_content {
     margin-right: 5px;
-    white-space: pre;
+    white-space: pre-wrap;
 }
 
 .post_viewed_btn {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1584,13 +1584,6 @@ function toggleMarkdown(post_box_id) {
   $(this).toggleClass('markdown-active markdown-inactive'); 
   $(`#markdown_input_${post_box_id}`).val($(`#markdown_input_${post_box_id}`).val() == 0 ? '1':'0');
   $(`#markdown-info-${post_box_id}`).toggleClass('disabled');
-  // const show_markdown_buttons = localStorage.getItem('render_markdown_buttons');
-  // if (show_markdown_buttons === null) {
-  //   localStorage.setItem('render_markdown_buttons', true);
-  // } 
-  // else {
-  //   localStorage.setItem('render_markdown_buttons', !JSON.parse(show_markdown_buttons));
-  // }
 }
 
 function previewForumMarkdown(){

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1581,9 +1581,16 @@ function bookmarkThread(thread_id, type){
 function toggleMarkdown(post_box_id) {
   if(post_box_id === undefined) post_box_id = '';
   $(`#markdown_buttons_${post_box_id}`).toggle();
-  $(this).toggleClass('markdown-active'); 
+  $(this).toggleClass('markdown-active markdown-inactive'); 
   $(`#markdown_input_${post_box_id}`).val($(`#markdown_input_${post_box_id}`).val() == 0 ? '1':'0');
   $(`#markdown-info-${post_box_id}`).toggleClass('disabled');
+  // const show_markdown_buttons = localStorage.getItem('render_markdown_buttons');
+  // if (show_markdown_buttons === null) {
+  //   localStorage.setItem('render_markdown_buttons', true);
+  // } 
+  // else {
+  //   localStorage.setItem('render_markdown_buttons', !JSON.parse(show_markdown_buttons));
+  // }
 }
 
 function previewForumMarkdown(){
@@ -1888,7 +1895,7 @@ function updateThread(e) {
     lock_thread_date: $('input#lock_thread_date').text(),
     expirationDate: $('input#expirationDate').val(),
     cat,
-    markdown_status: $("input#markdown_input_").val() ? $("input#markdown_input_").val() : 0,
+    markdown_status: parseInt($("input#markdown_input_").val()),
   };
 
   $.ajax({

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1578,10 +1578,15 @@ function bookmarkThread(thread_id, type){
     });
 }
 
-function toggleMarkdown(post_box_id) {
+function toggleMarkdown(post_box_id, triggered) {
   if(post_box_id === undefined) post_box_id = '';
   $(`#markdown_buttons_${post_box_id}`).toggle();
-  $(this).toggleClass('markdown-active markdown-inactive'); 
+  $(this).toggleClass('markdown-active markdown-inactive');
+  if (!triggered) {
+    $('.markdown-toggle').not(this).each(function() {
+      toggleMarkdown.call(this, this.id.split('_')[2], true);
+    });
+  }
   $(`#markdown_input_${post_box_id}`).val($(`#markdown_input_${post_box_id}`).val() == 0 ? '1':'0');
   $(`#markdown-info-${post_box_id}`).toggleClass('disabled');
   document.cookie = `markdown_enabled=${$(`#markdown_input_${post_box_id}`).val()}; path=/;`;

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1584,6 +1584,7 @@ function toggleMarkdown(post_box_id) {
   $(this).toggleClass('markdown-active markdown-inactive'); 
   $(`#markdown_input_${post_box_id}`).val($(`#markdown_input_${post_box_id}`).val() == 0 ? '1':'0');
   $(`#markdown-info-${post_box_id}`).toggleClass('disabled');
+  document.cookie = `markdown_enabled=${$(`#markdown_input_${post_box_id}`).val()}; path=/;`;
 }
 
 function previewForumMarkdown(){


### PR DESCRIPTION
### What is the current behavior?
Fixes #6750 
* Forum posts without markdown ignore newlines
* Some forum posts are missing line wrapping 
* The markdown toggle setting was not being saved properly

![image](https://user-images.githubusercontent.com/28243927/126202162-66f4ada7-1a27-4a44-b97d-e9d8fee07a03.png)

### What is the new behavior?
* Newlines on all posts are rendered properly
* Line wrapping occurs on all posts
* Markdown toggle setting is saved
  * This setting is saved every time you toggle the button, whether you post or not
  * All markdown toggles will toggle collectively

![image](https://user-images.githubusercontent.com/28243927/126201947-24c88222-0f94-4946-977d-163509a061a8.png)


