### PR TITLE
[Bugfix:Developer] Fix port in Selenium e2e tests

### DIFF
--- a/tests/e2e/base_testcase.py
+++ b/tests/e2e/base_testcase.py
@@ -33,7 +33,7 @@ class BaseTestCase(unittest.TestCase):
     override user_id, user_name, and user_password as necessary for a
     particular testcase and this class will handle the rest to setup the test.
     """
-    TEST_URL = "http://localhost:1501"
+    TEST_URL = "http://localhost:1511"
     USER_ID = "student"
     USER_NAME = "Joe"
     USER_PASSWORD = "student"


### PR DESCRIPTION
### What is the current behavior?
If you try to run selenium tests on Ubuntu 20.04, they will all error out due to the wrong port number in the URL.

### What is the new behavior?
The correct port, 1511, is set in the base testcase for all selenium tests.