### PR TITLE
[Testing:Developer] Use constant url for cypress login tests

### DIFF
--- a/site/cypress/integration/login.spec.js
+++ b/site/cypress/integration/login.spec.js
@@ -38,9 +38,9 @@ describe('Test cases revolving around the logging in functionality of the site',
 
         it('should redirect after logging in', () => {
             //try to visit a page not logged in, then log in and see where we are
-            const full_url = buildUrl(['sample', 'gradeable', 'open_homework'], true);
+            const full_url = buildUrl(['sample', 'config'], true);
 
-            cy.visit(['sample', 'gradeable', 'open_homework']);
+            cy.visit(['sample', 'config']);
             cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login?old=${encodeURIComponent(full_url)}`);
 
             cy.login();


### PR DESCRIPTION
### What is the current behavior?
The Cypress login tests currently depend upon the sample course having a fixed configuration.  This can cause issues such as the issues exhibited by https://github.com/Submitty/Submitty/pull/6721.

### What is the new behavior?
This PR makes a slight modification to the path used to verify that the user is logged in by checking to see that the instructor has access to the course config page.