### PR TITLE
[Testing:Developer] Mark css-lint required for e2e tests

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -236,11 +236,12 @@ jobs:
     e2e:
         needs:
           - js-lint
+          - js-unit          
           - php-lint
           - php-unit
           - python-lint
           - python-unit
-          - js-unit
+          - css-lint
         runs-on: ubuntu-18.04
         services:
           postgres:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `css-lint` CI job was not required for the e2e job, though all other jobs were.

### What is the new behavior?

Adds `css-lint` as a required job of the e2e job.