### PR TITLE
[Feature:Developer] Add workflow to fix dependabot PR titles

### DIFF
--- a/.github/workflows/dependabot_title_fix.yml
+++ b/.github/workflows/dependabot_title_fix.yml
@@ -11,6 +11,6 @@ jobs:
   title-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: submitty/action-dependabot-title-fixer@master
+      - uses: submitty/action-dependabot-title-fixer@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_title_fix.yml
+++ b/.github/workflows/dependabot_title_fix.yml
@@ -1,0 +1,16 @@
+name: 'Dependabot PR Title Fixer'
+on:
+  pull_request:
+    # check when PR
+    # * is created,
+    # * title is edited, and
+    # * new commits are added (to ensure failing title blocks merging)
+    types: [ opened, reopened, edited, synchronize ]
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: submitty/action-dependabot-title-fixer@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Any new PR for a dev dependency comes with the prefix `[DevDependency]:` that needs to be fixed by a human so that it'll pass CI title check workflow.

### What is the new behavior?

Adds a CI action to automatically update the PR title in the above case so that a human won't have to go in and rename the PR title manually.