### PR TITLE
[Bugfix:Submission] Fix VCS git-user-id not set

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -497,7 +497,7 @@
             }
             // no user id entered, upload for whoever is logged in
             else if (user_id == ""){
-                makeSubmission(user_id, {{ highest_version }}, false, "", git_repo_id);
+                makeSubmission(user_id, {{ highest_version }}, false, "", git_user_id, git_repo_id);
             }
             // user id entered, need to validate first
             else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
When submitting a VCS assignment with a GitHub user name and repo id, the git user id is never passed into the proper functions and instead your user id is set to equal your repo id and your repo id is set to undefined.

### What is the new behavior?
The user id is passed in and both variables are set properly

### Other information?
To test:
1. First on master, configure a VCS assignment
2. attempt to submit, fill out id and repo fields, click submit, see that when it reloads the inputs aren't correct
3. repeat on new branch
