### PR TITLE
[Feature:System] Remove hardcoding of websocket port

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -11,7 +11,6 @@ import shutil
 import string
 import tzlocal
 import tempfile
-import readline
 
 
 def get_uid(user):
@@ -53,6 +52,7 @@ parser.add_argument('--setup-for-sample-courses', action='store_true', default=F
 parser.add_argument('--worker', action='store_true', default=False, help='Configure Submitty with autograding only')
 parser.add_argument('--install-dir', default='/usr/local/submitty', help='Set the install directory for Submitty')
 parser.add_argument('--data-dir', default='/var/local/submitty', help='Set the data directory for Submitty')
+parser.add_argument('--websocket-port', default=8443, type=int, help='Port to use for websocket')
 
 args = parser.parse_args()
 
@@ -74,6 +74,8 @@ if not os.path.isdir(SUBMITTY_DATA_DIR) or not os.access(SUBMITTY_DATA_DIR, os.R
 
 TAGRADING_LOG_PATH = os.path.join(SUBMITTY_DATA_DIR, 'logs')
 AUTOGRADING_LOG_PATH = os.path.join(SUBMITTY_DATA_DIR, 'logs', 'autograding')
+
+WEBSOCKET_PORT = args.websocket_port
 
 ##############################################################################
 
@@ -366,6 +368,7 @@ else:
     config['vcs_url'] = VCS_URL
     config['submission_url'] = SUBMISSION_URL
     config['cgi_url'] = CGI_URL
+    config['websocket_port'] = WEBSOCKET_PORT
 
     config['institution_name'] = INSTITUTION_NAME
     config['username_change_text'] = USERNAME_TEXT
@@ -532,6 +535,7 @@ if not args.worker:
     config['submission_url'] = SUBMISSION_URL
     config['vcs_url'] = VCS_URL
     config['cgi_url'] = CGI_URL
+    config['websocket_port'] = WEBSOCKET_PORT
     config['institution_name'] = INSTITUTION_NAME
     config['username_change_text'] = USERNAME_TEXT
     config['institution_homepage'] = INSTITUTION_HOMEPAGE

--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -10,6 +10,7 @@ if [ ${VAGRANT} == 1 ]; then
     export SUBMISSION_URL='http://localhost:1501'
     export SUBMISSION_PORT=1501
     export DATABASE_PORT=16432
+    export WEBSOCKET_PORT=8433
 fi
 
 #################################################################

--- a/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
@@ -10,6 +10,7 @@ if [ ${VAGRANT} == 1 ]; then
     export SUBMISSION_URL='http://localhost:1511'
     export SUBMISSION_PORT=1511
     export DATABASE_PORT=16442
+    export WEBSOCKET_PORT=8443
 fi
 
 #################################################################

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -465,6 +465,9 @@ EOF
     rm -f /etc/nginx/sites-enabled/submitty.conf
     ln -s /etc/nginx/sites-available/submitty.conf /etc/nginx/sites-enabled/submitty.conf
 
+    if [ ${VAGRANT} == 1 ]; then
+        sed -i -e "s/8443/${WEBSOCKET_PORT}/g" /etc/nginx/sites-available/submitty.conf
+    fi
 
     #################################################################
     # PHP SETUP
@@ -630,7 +633,7 @@ submitty@vagrant
 do-not-reply@vagrant
 localhost
 25
-" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses
+" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses --websocket-port ${WEBSOCKET_PORT}
     else
         python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py
     fi

--- a/.setup/nginx/submitty.conf
+++ b/.setup/nginx/submitty.conf
@@ -1,18 +1,18 @@
 server {
-        listen 8443 default_server;
-        listen [::]:8443 default_server;
-        server_name _;
+    listen 8443 default_server;
+    listen [::]:8443 default_server;
+    server_name _;
 
-        location / {
+    location / {
         return 404;
-        }
+    }
 
-        location /ws {
-               proxy_pass http://127.0.0.1:41983/; #Yes, http is proper here for nginx web socket
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "Upgrade";
-            proxy_set_header Host $host;
-        }
+    location /ws {
+        proxy_pass http://127.0.0.1:41983/; #Yes, http is proper here for nginx web socket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
 
 }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure(2) do |config|
   config.vm.define 'ubuntu-18.04', autostart: false do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-18.04'
     ubuntu.vm.network 'forwarded_port', guest: 1501, host: 1501   # site
-    ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
+    ubuntu.vm.network 'forwarded_port', guest: 8433, host: 8433   # Websockets
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432  # database
   end
 

--- a/site/app/models/Config.php
+++ b/site/app/models/Config.php
@@ -20,6 +20,7 @@ use app\libraries\FileUtils;
  * @method string getBaseUrl()
  * @method string getVcsUrl()
  * @method string getCgiUrl()
+ * @method integer getWebsocketPort()
  * @method string getSubmittyPath()
  * @method string getCgiTmpPath()
  * @method string getCoursePath()
@@ -117,6 +118,8 @@ class Config extends AbstractModel {
     protected $vcs_url;
     /** @prop @var string */
     protected $cgi_url;
+    /** @prop @var int */
+    protected $websocket_port = 8443;
     /** @prop @var string */
     protected $authentication;
     /** @prop @var DateTimeZone */
@@ -352,6 +355,10 @@ class Config extends AbstractModel {
 
         if (isset($submitty_json['system_message'])) {
             $this->system_message = strval($submitty_json['system_message']);
+        }
+
+        if (isset($submitty_json['websocket_port'])) {
+            $this->websocket_port = $submitty_json['websocket_port'];
         }
 
         $this->base_url = rtrim($this->base_url, "/") . "/";

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -5,6 +5,13 @@
     <title>{{ page_title }}</title>
     <link rel="shortcut icon" href="{{ base_url }}img/favicon.ico" type="image/x-icon" />
 
+    <script>
+        window.baseUrl = "{{ base_url }}";
+        window.courseUrl = "{{ course_url }}";
+        window.csrfToken = "{{ csrf_token }}";
+        window.websocketPort = {{ websocket_port }};
+    </script>
+
     {% for css_ref in css %}
     <link rel='stylesheet' type='text/css' href='{{ css_ref }}' />
     {% endfor %}

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -47,6 +47,7 @@ class GlobalView extends AbstractView {
             "user_first_name" => $this->core->getUser() ? $this->core->getUser()->getDisplayedFirstName() : "",
             "base_url" => $this->core->getConfig()->getBaseUrl(),
             "course_url" => $this->core->buildCourseUrl(),
+            "websocket_port" => $this->core->getConfig()->getWebsocketPort(),
             "notifications_info" => $notifications_info,
             "wrapper_enabled" => $this->core->getConfig()->wrapperEnabled(),
             "wrapper_urls" => $wrapper_urls,

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1,13 +1,4 @@
-var csrfToken = undefined;
-
-window.addEventListener("load", function() {
-  for (const elem in document.body.dataset) {
-    window[elem] = document.body.dataset[elem];
-  }
-});
-
 window.addEventListener("resize", checkSidebarCollapse);
-
 
 ////////////Begin: Removed redundant link in breadcrumbs////////////////////////
 //See this pr for why we might want to remove this code at some point

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -32,7 +32,7 @@ class WebSocketClient {
         this.onmessage = null;
         // We do string replacement here so that http -> ws, https -> wss.
         const my_url = new URL(document.body.dataset.baseUrl.replace('http', 'ws'));
-        my_url.port = 8443;
+        my_url.port = window.websocketPort;
         my_url.pathname = 'ws';
         this.url = my_url.href;
     }

--- a/site/tests/app/models/ConfigTester.php
+++ b/site/tests/app/models/ConfigTester.php
@@ -231,6 +231,7 @@ class ConfigTester extends \PHPUnit\Framework\TestCase {
             'course' => 'csci0000',
             'base_url' => 'http://example.com/',
             'cgi_url' => 'http://example.com/cgi-bin/',
+            'websocket_port' => 8443,
             'submitty_path' => $this->temp_dir,
             'course_path' => $this->temp_dir . '/courses/s17/csci0000',
             'submitty_log_path' => $this->temp_dir . '/logs',


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The websocket port within Submitty is hardcoded in the code to use `8443`. This caused collisions if trying to use Ubuntu 18.04 and 20.04 VMs at the same time (let alone additional worker machines).

### What is the new behavior?

This reworks the code to allow the websocket to be set to arbitrary values, being set within the `/usr/local/submitty/config/submitty.json` file, and then that's read in when loading the page. If the value is not set, it'll falback to the default value of `8443` like before. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Documentation for this will be done as part of #6813.