### PR TITLE
[Feature:System] Add Option to Spin Up VM-Worker Pair

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -210,7 +210,8 @@ print('Hit enter to use default in []')
 print()
 
 if args.worker:
-    SUPERVISOR_USER = get_input('What is the id for your submitty user?', defaults['supervisor_user'])
+    SUPERVISOR_USER = get_input('What is the id for your submitty user?', 'submitty')
+    print('SUPERVISOR USER : {}'.format(SUPERVISOR_USER)) 
 else:
     DATABASE_HOST = get_input('What is the database host?', defaults['database_host'])
     print()

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -51,6 +51,7 @@ parser.add_argument('--setup-for-sample-courses', action='store_true', default=F
                     help="Sets up Submitty for use with the sample courses. This is a Vagrant convenience "
                          "flag and should not be used in production!")
 parser.add_argument('--worker', action='store_true', default=False, help='Configure Submitty with autograding only')
+parser.add_argument('--worker-helper', default=False, help='Configure Submitty alongside a worker VM')
 parser.add_argument('--install-dir', default='/usr/local/submitty', help='Set the install directory for Submitty')
 parser.add_argument('--data-dir', default='/var/local/submitty', help='Set the data directory for Submitty')
 
@@ -461,10 +462,19 @@ if not args.worker:
                 "capabilities": ["default"],
                 "address": "localhost",
                 "username": "",
-                "num_autograding_workers": NUM_GRADING_SCHEDULER_WORKERS,
+                "num_autograding_workers": 0,
                 "enabled" : True
             }
         }
+
+        if args.worker_helper:
+            worker_dict["submitty-worker"] = {
+                "capabilities": ['default'],
+                "address": "192.168.1.8",
+                "username": "submitty",
+                "num_autograding_workers": 5,
+                "enabled": True
+            }
 
         if args.setup_for_sample_courses:
             worker_dict['primary']['capabilities'].extend([

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -51,7 +51,7 @@ parser.add_argument('--setup-for-sample-courses', action='store_true', default=F
                     help="Sets up Submitty for use with the sample courses. This is a Vagrant convenience "
                          "flag and should not be used in production!")
 parser.add_argument('--worker', action='store_true', default=False, help='Configure Submitty with autograding only')
-parser.add_argument('--worker-helper', default=False, help='Configure Submitty alongside a worker VM')
+parser.add_argument('--worker-pair', action='store_true', default=False, help='Configure Submitty alongside a worker VM')
 parser.add_argument('--install-dir', default='/usr/local/submitty', help='Set the install directory for Submitty')
 parser.add_argument('--data-dir', default='/var/local/submitty', help='Set the data directory for Submitty')
 
@@ -467,7 +467,7 @@ if not args.worker:
             }
         }
 
-        if args.worker_helper:
+        if args.worker_pair:
             worker_dict["submitty-worker"] = {
                 "capabilities": ['default'],
                 "address": "192.168.1.8",

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -462,7 +462,7 @@ if not args.worker:
                 "capabilities": ["default"],
                 "address": "localhost",
                 "username": "",
-                "num_autograding_workers": 0,
+                "num_autograding_workers": NUM_GRADING_SCHEDULER_WORKERS,
                 "enabled" : True
             }
         }
@@ -472,12 +472,18 @@ if not args.worker:
                 "capabilities": ['default'],
                 "address": "192.168.1.8",
                 "username": "submitty",
-                "num_autograding_workers": 5,
+                "num_autograding_workers": NUM_GRADING_SCHEDULER_WORKERS,
                 "enabled": True
             }
 
         if args.setup_for_sample_courses:
             worker_dict['primary']['capabilities'].extend([
+                'cpp',
+                'python',
+                'et-cetera',
+                'notebook',
+            ])
+            worker_dict['submitty-worker']['capabilities'].extend([
                 'cpp',
                 'python',
                 'et-cetera',

--- a/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
@@ -52,6 +52,8 @@ mkdir -p ${SUBMITTY_INSTALL_DIR}/sbin
 chown root:root ${SUBMITTY_INSTALL_DIR}/sbin
 chmod 755 ${SUBMITTY_INSTALL_DIR}/sbin
 
+echo "1..."
+
 mkdir -p ${SUBMITTY_INSTALL_DIR}/autograder
 mkdir -p ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils
 
@@ -67,6 +69,8 @@ find ${SUBMITTY_INSTALL_DIR}/sbin -type f -exec chmod 500 {} \;
 chown root:www-data ${SUBMITTY_INSTALL_DIR}/sbin/authentication.py
 chmod 550 ${SUBMITTY_INSTALL_DIR}/sbin/authentication.py
 
+echo "2..."
+
 # everyone needs to be able to run this script
 chmod 555 ${SUBMITTY_INSTALL_DIR}/sbin/killall.py
 
@@ -77,17 +81,24 @@ for i in "${array[@]}"; do
     chmod -R 750 ${SUBMITTY_INSTALL_DIR}/sbin/${i}
 done
 
+echo "3..."
+
 # DAEMON_USER only things in autograder
 chown -R root:"${DAEMON_GROUP}" ${SUBMITTY_INSTALL_DIR}/autograder
 chmod -R 750 ${SUBMITTY_INSTALL_DIR}/autograder
 
+echo "4..."
+echo "${SUPERVISOR_USER}"
+
 if [ "${WORKER}" == 1 ]; then
-    chown -R root:${SUPERVISOR_USER} ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils
+    chown -R ${SUPERVISOR_USER} ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils
 else
     chown -R root:${DAEMON_GROUP} ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils
 fi
 chmod 750 ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils
 chmod 550 ${SUBMITTY_INSTALL_DIR}/sbin/shipper_utils/*
+
+echo "5..."
 
 # set the permissions here in the case we JUST run this script or else things will break
 if [ -f ${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute ]; then
@@ -95,7 +106,12 @@ if [ -f ${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute ]; then
     chmod 4550             ${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute
 fi
 
+echo "6..."
+
 if [ -f ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out ]; then
     chown root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out
     chmod 550                           ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out
 fi
+
+echo "7..."
+

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -61,7 +61,7 @@ source ${CURRENT_DIR}/bin/versions.sh
 export VAGRANT=0
 export NO_SUBMISSIONS=0
 export WORKER=0
-export WORKER_HELPER=0
+export WORKER_PAIR=0
 
 # Read through the flags passed to the script reading them in and setting
 # appropriate bash variables, breaking out of this once we hit something we
@@ -78,9 +78,9 @@ while :; do
             export NO_SUBMISSIONS=1
             echo 'no_submissions'
             ;;
-        --worker-helper)
-            export WORKER_HELPER=1
-            echo "worker_helper"
+        --worker-pair)
+            export WORKER_PAIR=1
+            echo "worker_pair"
             ;;
         *) # No more options, so break out of the loop.
             break
@@ -291,7 +291,7 @@ fi
 
 if ! cut -d ':' -f 1 /etc/passwd | grep -q ${DAEMON_USER} ; then
     useradd -m -c "First Last,RoomNumber,WorkPhone,HomePhone" "${DAEMON_USER}"
-    if [ ${WORKER_HELPER} == 1 ]; then
+    if [ ${WORKER_PAIR} == 1 ]; then
         echo -e "attempting to create ssh key for submitty_daemon..."
         su submitty_daemon -c "cd ~/"
         su submitty_daemon -c "ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ''"
@@ -648,7 +648,7 @@ submitty@vagrant
 do-not-reply@vagrant
 localhost
 25
-" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses --worker-helper 1
+" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses --worker-pair 1
     else
         python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py
     fi

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -628,6 +628,7 @@ else
         if [ -z "${SUBMISSION_URL}" ]; then
             SUBMISSION_URL='http://192.168.56.101'
         fi
+        #TODO: make this string into variable so i can only pass worker helper arg when needed
         echo -e "/var/run/postgresql
 ${DB_USER}
 ${DATABASE_PASSWORD}
@@ -647,13 +648,9 @@ submitty@vagrant
 do-not-reply@vagrant
 localhost
 25
-" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses
+" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses --worker-helper 1
     else
-        if [ ${WORKER_HELPER} == 1 ]; then
-            python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --worker-helper 1
-        else
-            python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py
-        fi
+        python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py
     fi
 fi
 

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -602,8 +602,8 @@ echo Beginning Submitty Setup
 
 #If in worker mode, run configure with --worker option.
 if [ ${WORKER} == 1 ]; then
-    echo  Running configure submitty in worker mode
-    python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --worker
+    echo "Running configure submitty in worker mode"
+    echo "submitty" | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --worker
 else
     if [ ${VAGRANT} == 1 ]; then
         # This should be set by setup_distro.sh for whatever distro we have, but
@@ -639,6 +639,12 @@ fi
 if [ ${WORKER} == 1 ]; then
    #Add the submitty user to /etc/sudoers if in worker mode.
     SUPERVISOR_USER=$(jq -r '.supervisor_user' ${SUBMITTY_INSTALL_DIR}/config/submitty_users.json)
+    if id "${SUPERVISOR_USER}" &>/dev/null; then
+        echo "Supervisor user found"
+    else
+        echo "Supervisor user not found... creating user: ${SUPERVISOR_USER}"
+        adduser ${SUPERVISOR_USER}
+    fi
     if ! grep -q "${SUPERVISOR_USER}" /etc/sudoers; then
         echo "" >> /etc/sudoers
         echo "#grant the submitty user on this worker machine access to install submitty" >> /etc/sudoers

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -61,6 +61,7 @@ source ${CURRENT_DIR}/bin/versions.sh
 export VAGRANT=0
 export NO_SUBMISSIONS=0
 export WORKER=0
+export WORKER_HELPER=0
 
 # Read through the flags passed to the script reading them in and setting
 # appropriate bash variables, breaking out of this once we hit something we
@@ -76,6 +77,10 @@ while :; do
         --no_submissions)
             export NO_SUBMISSIONS=1
             echo 'no_submissions'
+            ;;
+        --worker-helper)
+            export WORKER_HELPER=1
+            echo "worker_helper"
             ;;
         *) # No more options, so break out of the loop.
             break
@@ -281,6 +286,13 @@ fi
 
 if ! cut -d ':' -f 1 /etc/passwd | grep -q ${DAEMON_USER} ; then
     useradd -m -c "First Last,RoomNumber,WorkPhone,HomePhone" "${DAEMON_USER}"
+    if [ ${WORKER_HELPER} == 1 ]; then
+        echo -e "attempting to create ssh key for submitty_daemon..."
+        su submitty_daemon -c "cd ~/"
+        su submitty_daemon -c "ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ''"
+        su submitty_daemon -c "echo 'successfully created ssh key'"
+        su submitty_daemon -c "ssh-copy-id -i ~/.ssh/id_rsa.pub submitty@192.168.1.8"
+    fi
 fi
 
 # The VCS directores (/var/local/submitty/vcs) are owfned by root:$DAEMONCGI_GROUP

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -650,7 +650,7 @@ localhost
 " | python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --debug --setup-for-sample-courses
     else
         if [ ${WORKER_HELPER} == 1 ]; then
-            python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --worker-helper
+            python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py --worker-helper 1
         else
             python3 ${SUBMITTY_REPOSITORY}/.setup/CONFIGURE_SUBMITTY.py
         fi

--- a/.setup/install_worker.sh
+++ b/.setup/install_worker.sh
@@ -7,7 +7,12 @@
 GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
 SUPERVISOR_USER=submitty
 
-adduser ${SUPERVISOR_USER}
+echo "checking ${SUPERVISOR_USER} user"
+if ! cut -d ':' -f 1 /etc/passwd | grep -q ${SUPERVISOR_USER} ; then
+    echo "attempting to add ${SUPERVISOR_USER} user"
+    useradd -m -p $(openssl passwd -crypt submitty) -c "First Last,RoomNumber,WorkPhone,HomePhone" "${SUPERVISOR_USER}"
+    [ -d "/home/${SUPERVISOR_USER}" ] && echo "Directory /home/${SUPERVISOR_USER} exists." || echo "Error: Directory /home/${SUPERVISOR_USER} does not exists."
+fi
 
 bash ${GIT_PATH}/.setup/install_system.sh --worker 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker_system.log
 echo "--- FINISHED INSTALLING SYSTEM ---"
@@ -18,3 +23,6 @@ sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/distro_setup/ubuntu/r
 sudo usermod -a -G submitty_daemon ${SUPERVISOR_USER}
 sudo usermod -a -G submitty_daemonphp ${SUPERVISOR_USER}
 sudo usermod -a -G docker ${SUPERVISOR_USER}
+
+echo "add worker machine to primary_workers --WIP--"
+echo "run submitty install again"

--- a/.setup/install_worker.sh
+++ b/.setup/install_worker.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Usage:
+#   install_worker.sh
+
+
+GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
+SUPERVISOR_USER=submitty
+
+adduser ${SUPERVISOR_USER}
+
+bash ${GIT_PATH}/.setup/install_system.sh --worker 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker_system.log
+echo "--- FINISHED INSTALLING SYSTEM ---"
+echo "installing worker..."
+
+sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/distro_setup/ubuntu/rpi.sh
+
+sudo usermod -a -G submitty_daemon ${SUPERVISOR_USER}
+sudo usermod -a -G submitty_daemonphp ${SUPERVISOR_USER}
+sudo usermod -a -G docker ${SUPERVISOR_USER}

--- a/.setup/install_worker.sh
+++ b/.setup/install_worker.sh
@@ -3,13 +3,17 @@
 # Usage:
 #   install_worker.sh
 
+# This script is used to set up the worker machine in a vagrant worker pair
+# made by running WORKER_PAIR=1 vagrant up
 
-GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
 SUPERVISOR_USER=submitty
 
 echo "checking ${SUPERVISOR_USER} user"
+# Create the submitty user here on the worker machine
+# This is the user that submitty_daemon on the main vagrant machine will ssh into.
 if ! cut -d ':' -f 1 /etc/passwd | grep -q ${SUPERVISOR_USER} ; then
     echo "attempting to add ${SUPERVISOR_USER} user"
+    #set up submitty user with password 'submitty'
     useradd -m -p $(openssl passwd -crypt submitty) -c "First Last,RoomNumber,WorkPhone,HomePhone" "${SUPERVISOR_USER}"
     [ -d "/home/${SUPERVISOR_USER}" ] && echo "Directory /home/${SUPERVISOR_USER} exists." || echo "Error: Directory /home/${SUPERVISOR_USER} does not exists."
 fi
@@ -23,6 +27,3 @@ sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/distro_setup/ubuntu/r
 sudo usermod -a -G submitty_daemon ${SUPERVISOR_USER}
 sudo usermod -a -G submitty_daemonphp ${SUPERVISOR_USER}
 sudo usermod -a -G docker ${SUPERVISOR_USER}
-
-echo "add worker machine to primary_workers --WIP--"
-echo "run submitty install again"

--- a/.setup/vagrant/setup_vagrant.sh
+++ b/.setup/vagrant/setup_vagrant.sh
@@ -15,6 +15,7 @@ if [ -x "$(command -v pip3)" ]; then
     python3 ${SUBMITTY_REPOSITORY}/.setup/bin/reset_system.py
 fi
 
+echo "args: $@"
 sudo bash ${SUBMITTY_REPOSITORY}/.setup/install_system.sh --vagrant ${@}
 if [ $? -ne 0 ]; then
     DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,7 @@ Vagrant.configure(2) do |config|
   config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-20.04'
     ubuntu.vm.network "private_network", ip: "192.168.1.8"
+    #ubuntu.ssh.username = 'root'
     ubuntu.vm.provision 'shell', inline: $worker_script
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,18 +24,29 @@ $stdout.sync = true
 $stderr.sync = true
 
 extra_command = ''
+autostart_worker = false
 if ENV.has_key?('NO_SUBMISSIONS')
     extra_command << '--no_submissions '
 end
 if ENV.has_key?('EXTRA')
     extra_command << ENV['EXTRA']
 end
+if ENV.has_key?('WORKER')
+    autostart_worker = true
+end
+  
 
 $script = <<SCRIPT
 GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
 DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
 VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 bash ${GIT_PATH}/.setup/vagrant/setup_vagrant.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_${DISTRO}_${VERSION}.log
+if $autostart_worker; then
+  su submitty_daemon
+  cd ~/
+  ssh-keygen
+  ssh-copy-id -i ~/.ssh/id_rsa.pub submitty@192.168.1.8
+fi
 SCRIPT
 
 Vagrant.configure(2) do |config|
@@ -58,6 +69,19 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.network 'forwarded_port', guest: 1511, host: 1511   # site
     ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16442  # database
+    ubuntu.vm.provision 'shell', inline: $script
+  end
+  
+  config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
+    ubuntu.vm.box = 'bento/ubuntu-20.04'
+    ubuntu.vm.network "private_network", ip: "192.168.1.8"
+    $script = <<SCRIPT
+GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
+DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
+VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
+bash ${GIT_PATH}/.setup/install_worker.sh --worker 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker.log
+SCRIPT
+    ubuntu.vm.provision 'shell', inline: $script
   end
 
   config.vm.provider 'virtualbox' do |vb|
@@ -102,8 +126,6 @@ Vagrant.configure(2) do |config|
       config.vm.synced_folder repo_path, "/usr/local/submitty/GIT_CHECKOUT/" + repo, owner: owner, group: group, mount_options: mount_options
     end
   }
-
-  config.vm.provision 'shell', inline: $script
 
   if ARGV.include?('ssh')
     config.ssh.username = 'root'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@
 #   NO_SUBMISSIONS=1 vagrant up
 #       or
 #   EXTRA=rpi vagrant up
+#       or
+#   WORKER_PAIR=1 vagrant up
 #
 #
 # If you want to install extra packages (such as rpi or matlab), you need to have the environment
@@ -31,9 +33,9 @@ end
 if ENV.has_key?('EXTRA')
     extra_command << ENV['EXTRA']
 end
-if ENV.has_key?('WORKER')
+if ENV.has_key?('WORKER_PAIR')
     autostart_worker = true
-    extra_command << '--worker-helper '
+    extra_command << '--worker-pair '
 end
   
 
@@ -48,7 +50,7 @@ $worker_script = <<SCRIPT
 GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
 DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
 VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
-bash ${GIT_PATH}/.setup/install_worker.sh --worker 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker.log
+bash ${GIT_PATH}/.setup/install_worker.sh 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker.log
 SCRIPT
 
 Vagrant.configure(2) do |config|
@@ -68,8 +70,9 @@ Vagrant.configure(2) do |config|
 
   config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-20.04'
+    # If this IP address changes, it must be changed in install_system.sh and 
+    # CONFIGURE_SUBMITTY.pyto allow the ssh connection
     ubuntu.vm.network "private_network", ip: "192.168.1.8"
-    #ubuntu.ssh.username = 'root'
     ubuntu.vm.provision 'shell', inline: $worker_script
   end
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Closes #4744 
Currently, developers are required to manually install worker machines using [the worker installation instructions](https://submitty.org/sysadmin/worker_installation).

### What is the new behavior?
A vagrant VM-worker pair can be set up by running `WORKER_PAIR=1 vagrant up`.
To set up a worker machine on a specific machine that already exists, run `install_worker.sh` on that machine. This will perform steps 1-7 of  [the worker installation instructions](https://submitty.org/sysadmin/worker_installation), with `submitty` as the `SUPERVISOR_USER`. By default, RPI installations are included, but you can run `install_worker.sh --no-rpi` to not include these.
