### PR TITLE
[Bugfix:Plagiarism] Adjust animation for plagiarism drag bar

### DIFF
--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -246,14 +246,14 @@ main#main.full-screen-mode .plagiarism-result-cont {
 
 .plag-drag-bar {
     height: 100%;
-    width: 20px;
+    width: 14px;
     position: relative;
     cursor: col-resize;
 }
 
 .plag-drag-bar::after {
     content: "";
-    width: 10px;
+    width: 7px;
     height: 25%;
     max-height: 120px;
     border-radius: 10px;
@@ -265,7 +265,7 @@ main#main.full-screen-mode .plagiarism-result-cont {
 }
 
 .plag-drag-bar:hover::after {
-    filter: blur(5px);
+    width: 9px;
 }
 
 .plag-results-header-right {
@@ -324,12 +324,12 @@ main#main.full-screen-mode .plagiarism-result-cont {
     }
 
     .plag-flex-row .user1-select {
-        width: calc(100% - 10px);
+        width: calc(100% - 7px);
     }
 
     .plag-flex-row .user2-select {
-        width: calc(100% - 10px);
-        margin-left: 10px;
+        width: calc(100% - 7px);
+        margin-left: 7px;
     }
 
     .plag-flex-item {

--- a/site/public/js/resizable-panels.js
+++ b/site/public/js/resizable-panels.js
@@ -39,7 +39,7 @@ function initializeResizablePanels (panelSel, dragBarSel, isHorizontalResize= fa
 
         document.documentElement.style.setProperty(
             'cursor',
-            dragBarSel === '.two-panel-drag-bar' ? 'col-resize' : 'ns-resize',
+            dragBarSel === '.two-panel-drag-bar' || dragBarSel === '.plag-drag-bar' ? 'col-resize' : 'ns-resize',
             'important',
         );
 


### PR DESCRIPTION
### What is the current behavior?
The hover animation for the drag bar on the plagiarism interface currently uses a blur effect on hover to indicate that it can be dragged.  This is different from the behavior on the TA Grading Interface which causes the drag bar to increase in size to indicate that it is draggable.

### What is the new behavior?
This PR makes a slight modification to the way the drag bar on the plagiarism results page works to bring it in line with the TA Grading Interface.


https://user-images.githubusercontent.com/16820599/127198309-976758dc-05bc-448c-b075-40485d3504c7.mov



### Other information?
It would be nice if all of the drag bars could share more code.  Unfortunately, differences between the styling on the pages which use the resizable panels means that code sharing is somewhat impractical.
