### PR TITLE
[Bugfix:Forum] Fix Button Alignment in Empty Forum

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -1,6 +1,6 @@
 {% set user_group = core.getUser().getGroup() %}
 
-{% if show_more %}
+{% if show_more is defined and show_more %}
 	<script>
 
 		$(document).ready(function() {
@@ -77,7 +77,7 @@
 
 	<div class="col-4">
 
-	{% if show_more %}
+	{% if show_more is defined and show_more %}
 	    <div class="dropdown more-dropdown">
 			<div class="btn-group">
 				<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/site/app/templates/forum/showFullThreadsPage.twig
+++ b/site/app/templates/forum/showFullThreadsPage.twig
@@ -13,10 +13,10 @@
             "cookie_selected_categories" : filterFormData.cookie_selected_categories,
             "cookie_selected_thread_status" : filterFormData.cookie_selected_thread_status,
             "cookie_selected_unread_value" : filterFormData.cookie_selected_unread_value,
-            "display_option" : filterFormData.display_option,
+            "display_option" : filterFormData.display_option is defined ? filterFormData.display_option : '',
             "thread_exists" : filterFormData.thread_exists,
-            "attachment_all_button" : generate_post_content.attachment_all_button,
-            "total_attachments" : generate_post_content.total_attachments,
+            "attachment_all_button" : generate_post_content is defined ? generate_post_content.attachment_all_button : '',
+            "total_attachments" : generate_post_content is defined ? generate_post_content.total_attachments : '',
             "show_filter": true,
             "is_full_threads_page": true,
         } %}

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -21,6 +21,7 @@
     margin-right: 10px;
     padding-left: 15px;
     margin-top: 10px;
+    min-height: 30px;
 }
 
 #thread_list {


### PR DESCRIPTION
### What is the current behavior?
Fixes #6629 
The Create Thread button is overlapping other items when the forum is empty.
![Untitled](https://user-images.githubusercontent.com/16820599/122571181-75433d00-d01a-11eb-9194-05cec447ce7e.png)

### What is the new behavior?
The Create Thread button doesn't overlap anything.
![image](https://user-images.githubusercontent.com/28243927/127224672-c35d8d7a-f136-49af-9d27-a25b0f66b6e0.png)
