### PR TITLE
[Bugfix:HelpQueue] Encode queue codes within URLs

### DIFF
--- a/site/app/templates/officeHoursQueue/CurrentQueue.twig
+++ b/site/app/templates/officeHoursQueue/CurrentQueue.twig
@@ -20,7 +20,7 @@
 
           {% if entry['current_state'] == 'waiting' %}
             <td>
-              <form method="post" action="{{base_url}}/{{entry['queue_code']}}/startHelp" {% if entry['paused'] %}onsubmit="return confirm('Are you sure you want to start helping this student? This student is currently paused.');"{% endif %}>
+              <form method="post" action="{{base_url}}/{{entry['queue_code'] | url_encode }}/startHelp" {% if entry['paused'] %}onsubmit="return confirm('Are you sure you want to start helping this student? This student is currently paused.');"{% endif %}>
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                 <input type="hidden" name="user_id" value="{{entry['user_id']}}"/>
                 {% if entry['paused'] %}
@@ -43,9 +43,9 @@
           {% elseif entry['current_state'] == 'being_helped' %}
             <td>
               {% if entry['help_started_by'] == viewer.getUserId() %}
-                <form method="post" action="{{base_url}}/{{entry['queue_code']}}/finishHelp">
+                <form method="post" action="{{base_url}}/{{entry['queue_code'] | url_encode }}/finishHelp">
               {% else %}
-                <form method="post" action="{{base_url}}/{{entry['queue_code']}}/finishHelp" onsubmit="return confirm('{{entry['help_started_by']}} was the one who originally clicked to say they were helping this student, are you sure you want to finish helping {{entry['name']}}?');">
+                <form method="post" action="{{base_url}}/{{entry['queue_code'] | url_encode }}/finishHelp" onsubmit="return confirm('{{entry['help_started_by']}} was the one who originally clicked to say they were helping this student, are you sure you want to finish helping {{entry['name']}}?');">
               {% endif %}
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                 <input type="hidden" name="user_id" value="{{entry['user_id']}}"/>
@@ -72,7 +72,7 @@
 
           <td>{{ entry['queue_code'] }}</td>
           <td>
-            <form method="post" action="{{base_url}}/{{entry['queue_code']}}/remove" onsubmit="return confirm('Are you sure you want to remove {{ entry['name'] }} from the queue?');">
+            <form method="post" action="{{base_url}}/{{entry['queue_code'] | url_encode }}/remove" onsubmit="return confirm('Are you sure you want to remove {{ entry['name'] }} from the queue?');">
               <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
               <input type="hidden" name="user_id" value="{{entry['user_id']}}"/>
               <button type="submit" class="btn btn-default remove_from_queue_btn">Remove</button>

--- a/site/app/templates/officeHoursQueue/QueueFilter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFilter.twig
@@ -49,14 +49,14 @@
               <input type="checkbox" class="toggle-queue-checkbox" aria-label="Toggle open/close for: {{queue['code']|upper}}" id="toggle-queue-{{loop.index}}" onchange="toggleQueue({{loop.index}}, '{{queue['code']}}')" {% if queue['open'] %} checked {% endif %} />
           </td>
           <td>
-            <form method="post" action="{{base_url}}/{{queue['code']}}/empty" onsubmit="return confirm('Are you sure you want to empty the queue? This will kick everyone out of the queue.');">
+            <form method="post" action="{{base_url}}/{{queue['code'] | url_encode}}/empty" onsubmit="return confirm('Are you sure you want to empty the queue? This will kick everyone out of the queue.');">
               <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
               <input type="hidden" name="queue_code" value="{{queue['code']}}"/>
               <button type="submit" class="btn btn-danger filter_settings_btn empty_queue_btn">Empty</button>
             </form>
           </td>
           <td>
-            <form method="post" action="{{base_url}}/{{queue['code']}}/deleteQueue" onsubmit="return confirm('Are you sure you want to delete the queue? This will remove all students currently in that queue and remove the queue from your list of queues');">
+            <form method="post" action="{{base_url}}/{{queue['code'] | url_encode}}/deleteQueue" onsubmit="return confirm('Are you sure you want to delete the queue? This will remove all students currently in that queue and remove the queue from your list of queues');">
               <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
               <input type="hidden" name="queue_code" value="{{queue['code']}}"/>
               <button type="submit" class="btn btn-danger filter_settings_btn delete_queue_btn">Delete</button>

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -146,7 +146,7 @@
   {% if viewer.isGrader() %}
 
       $('#old_queue_code').change(function(){
-          document.getElementById('change_queue_token').action = '{{base_url}}/'+this.value+'/change_token';
+          document.getElementById('change_queue_token').action = '{{base_url}}/'+encodeURIComponent(this.value)+'/change_token';
       });
 
       var notifications_enabled = localStorage.getItem('office_hour_queue_notifications') === "true";
@@ -303,7 +303,7 @@
   }
 
   function toggleQueue(index, code){
-      $.post( `{{base_url}}/${code}/toggle`, {
+      $.post( `{{base_url}}/${encodeURIComponent(code)}/toggle`, {
           csrf_token: '{{ csrf_token }}',
           queue_code: code,
           queue_state: $(`#toggle-queue-${index}`)[0].checked ? 0:1

--- a/site/app/templates/officeHoursQueue/QueueHistory.twig
+++ b/site/app/templates/officeHoursQueue/QueueHistory.twig
@@ -70,7 +70,7 @@
             {% endif %}
             {% if viewer.isGrader() %}
               <td>
-                <form method="post" action="{{base_url}}/{{entry['queue_code']}}/restore" onsubmit="return confirm('Are you sure you want to restore {{ entry['name'] }} to the queue?');">
+                <form method="post" action="{{base_url}}/{{entry['queue_code'] | url_encode }}/restore" onsubmit="return confirm('Are you sure you want to restore {{ entry['name'] }} to the queue?');">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                   <input type="hidden" name="entry_id" value="{{entry['entry_id']}}"/>
                   <button type="submit" class="btn btn-danger queue_restore_btn">Restore</button>

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -26,7 +26,7 @@
   </form>
     <script>
         $('#queue_code').change(function(){
-        document.getElementById('add_to_queue').action = '{{base_url}}/'+this.value+'/add';
+        document.getElementById('add_to_queue').action = '{{base_url}}/'+encodeURIComponent(this.value)+'/add';
         });
     </script>
 
@@ -73,7 +73,7 @@
       {{plurality_picker(num_ahead_today, 'person', 'people')}} {{ end_text }}.
     </p>
 
-    <form method="post" action="{{base_url}}/{{ viewer.getCurrentQueueCode() }}/remove" onsubmit="return confirm('Are you sure you want to leave the queue? Leaving will reset your position in the queue');">
+    <form method="post" action="{{base_url}}/{{ viewer.getCurrentQueueCode() | url_encode }}/remove" onsubmit="return confirm('Are you sure you want to leave the queue? Leaving will reset your position in the queue');">
       <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
       <input type="hidden" name="user_id" value="{{viewer.getUserId()}}"/>
       <input type="hidden" name="queue_code" value="{{ viewer.getCurrentQueueCode() }}"/>
@@ -106,7 +106,7 @@
     <form
       method="post"
       id="finish_help"
-      action="{{base_url}}/{{ viewer.getCurrentQueueCode() }}/finishHelp"
+      action="{{base_url}}/{{ viewer.getCurrentQueueCode() | url_encode }}/finishHelp"
       onsubmit="return confirm('WARNING: Do not click this unless the mentor/TA forgot to do it. This button is only a backup so that you dont get stuck if a mentor forgets.');">
       <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
       <input type="hidden" name="user_id" value="{{viewer.getUserId()}}"/>


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The URLs for dealing with queues that utilize the queue code does not properly encode the queue code within the URL. Because the queue codes could have any character, this can lead to invalid / broken HTML. An example would be the queue code `Foo Bar` would end up with the URL `/office_hours_queue/Foo Bar/empty` where the space character is unencoded, and illegal (though browsers seem to handle it alright). This was also being marked as an error for accessibility.

### What is the new behavior?

The queue code is now properly encoded when used within the URL. The above example would be `/office_hours_queue/Foo%20/empty`. No changes are necessary to the controller as the `$_GET` parameter are automatically url decoded.
