### PR TITLE
[Refactor:Plagiarism] Improve other gradeables UI

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7478,7 +7478,20 @@ SQL;
         return $this->submitty_db->rows();
     }
 
+    public function getGroupForCourse(string $semester, string $course): string {
+        $this->submitty_db->query(
+            'SELECT group_name FROM courses WHERE semester = ? AND course = ?',
+            [$semester, $course]
+        );
+        return count($this->submitty_db->rows()) === 1 ? $this->submitty_db->rows()[0]['group_name'] : '';
+    }
+
     public function getOtherCoursesWithSameGroup(string $semester, string $course): array {
+        // some courses are archived and assigned the group "root" on production.  We want to exclude these.
+        if ($this->getGroupForCourse($semester, $course) === 'root') {
+            return [];
+        }
+
         $this->submitty_db->query(
             'SELECT c2.course, c2.semester FROM courses c1 INNER JOIN courses c2 ON c1.group_name = c2.group_name
                    WHERE c1.semester = ? AND c1.course = ?',

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7478,23 +7478,10 @@ SQL;
         return $this->submitty_db->rows();
     }
 
-    public function getGroupForCourse(string $semester, string $course): string {
-        $this->submitty_db->query(
-            'SELECT group_name FROM courses WHERE semester = ? AND course = ?',
-            [$semester, $course]
-        );
-        return count($this->submitty_db->rows()) === 1 ? $this->submitty_db->rows()[0]['group_name'] : '';
-    }
-
     public function getOtherCoursesWithSameGroup(string $semester, string $course): array {
-        // some courses are archived and assigned the group "root" on production.  We want to exclude these.
-        if ($this->getGroupForCourse($semester, $course) === 'root') {
-            return [];
-        }
-
         $this->submitty_db->query(
-            'SELECT c2.course, c2.semester FROM courses c1 INNER JOIN courses c2 ON c1.group_name = c2.group_name
-                   WHERE c1.semester = ? AND c1.course = ?',
+            "SELECT c2.course, c2.semester FROM courses c1 INNER JOIN courses c2 ON c1.group_name = c2.group_name
+                   WHERE c1.semester = ? AND c1.course = ? AND c1.group_name != 'root'",
             [$semester, $course]
         );
         return $this->submitty_db->rows();

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -6,7 +6,7 @@
             <span style="margin-left:0.5em;"></span>
             Configure New Gradeable for Plagiarism Detection
         </a>
-        <a target=_blank class="right" style="margin-top: 1em;" href="https://submitty.org/instructor/course_management/plagiarism#plagiarism-main-page">
+        <a target=_blank class="right option-alt" style="margin-top: 1em;" href="https://submitty.org/instructor/course_management/plagiarism#plagiarism-main-page">
             How to use Lichen Plagiarism Detection
             <i style="font-style: normal;" class="fa-question-circle"></i>
         </a>

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -1,9 +1,15 @@
 <div class="content">
-    <h1>Plagiarism Detection -- WORK IN PROGRESS</h1><br>
+    <h1>Plagiarism Detection -- WORK IN PROGRESS</h1>
     <div class="nav-buttons">
-        <a class="btn btn-primary"
-           href="{{ new_plagiarism_config_link }}"
-        ><i class="fas fa-plus"></i><span style="margin-left:0.5em;"></span>Configure New Gradeable for Plagiarism Detection</a>
+        <a class="btn btn-primary" href="{{ new_plagiarism_config_link }}">
+            <i class="fas fa-plus"></i>
+            <span style="margin-left:0.5em;"></span>
+            Configure New Gradeable for Plagiarism Detection
+        </a>
+        <a target=_blank class="right" style="margin-top: 1em;" href="https://submitty.org/instructor/course_management/plagiarism#plagiarism-main-page">
+            How to use Lichen Plagiarism Detection
+            <i style="font-style: normal;" class="fa-question-circle"></i>
+        </a>
     </div>
     {% if plagiarism_results_info|length > 0 %}
         <div class="plag-table-cont">

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -10,7 +10,7 @@
                 <div class="plag-data">
 
                     {% if new_or_edit == "new" %}
-                        <select name="gradeable_id">
+                        <select name="gradeable_id" id="gradeable_id">
                             {% for gradeable_id_title in config["gradeable_ids_titles"] %}
                                 <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }} (Due {{ gradeable_id_title['g_grade_due_date'] }})</option>
                             {% endfor %}
@@ -132,29 +132,31 @@
                         <label for="past-terms-id">Yes</label>
                     </span>
                     <div class="past-terms-wrapper" id="prev-gradeable-div">
+                        <div id="past-terms-content">
+                            {% if new_or_edit == "edit" %}
+                                {% for row in config["prior_term_gradeables"] %}
+                                    <div id="prior-g-option-{{ loop.index0 }}" class="prior-gradeable-wrapper">
+                                        <select name='prior_semester_course[]' onchange='getGradeables(this)'>
+                                            {% for semester_course in config["prior_semester_courses"] %}
+                                                {% set tokens = semester_course|split(' ') %}
+                                                <option value="{{ tokens[0] }} {{ tokens[1] }}" {{ tokens[0] == row["prior_semester"] and tokens[1] == row["prior_course"] ? "selected" : "" }}>{{ tokens[0] }}/{{ tokens[1] }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <select name='prior_gradeable[]'>
+                                            {% for other_gradeable in row["other_gradeables"] %}
+                                                <option value="{{ other_gradeable }}" {{ other_gradeable == row["prior_gradeable"] ? "selected" : "" }}>{{ other_gradeable }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <span class="remove-prev-gradeable" onclick="deletePrevGradeable(this)">
+                                            <i class="fas fa-trash"></i>
+                                        </span>
+                                    </div>
+                                {% endfor %}
+                            {% endif %}
+                        </div>
                         <div id="add-more-prev-gradeable" class="add-more" aria-label="Add more">
                             <i class="fas fa-plus-square"></i>Add more
                         </div>
-                        {% if new_or_edit == "edit" %}
-                            {% for row in config["prior_term_gradeables"] %}
-                                <div id="prior-g-option-{{ loop.index0 }}" class="prior-gradeable-wrapper">
-                                    <select name='prior_semester_course[]' onchange='getGradeables(this)'>
-                                        {% for semester_course in config["prior_semester_courses"] %}
-                                            {% set tokens = semester_course|split(' ') %}
-                                            <option value="{{ tokens[0] }} {{ tokens[1] }}" {{ tokens[0] == row["prior_semester"] and tokens[1] == row["prior_course"] ? "selected" : "" }}>{{ tokens[0] }}/{{ tokens[1] }}</option>
-                                        {% endfor %}
-                                    </select>
-                                    <select name='prior_gradeable[]'>
-                                        {% for other_gradeable in row["other_gradeables"] %}
-                                            <option value="{{ other_gradeable }}" {{ other_gradeable == row["prior_gradeable"] ? "selected" : "" }}>{{ other_gradeable }}</option>
-                                        {% endfor %}
-                                    </select>
-                                    <span class="remove-prev-gradeable" onclick="deletePrevGradeable(this)">
-                                        <i class="fas fa-trash"></i>
-                                    </span>
-                                </div>
-                            {% endfor %}
-                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -220,10 +222,12 @@
 
     $("#no-past-terms-id").change(function() {
         $(".past-terms-wrapper").hide();
+        $('#past-terms-content', form).html('');
     });
 
     $("#past-terms-id").change(function() {
         $(".past-terms-wrapper").show();
+        addMorePriorTermGradeable();
     });
 
     function deletePrevGradeable(clickedElement) {
@@ -242,11 +246,12 @@
         gradeable_dropdown.empty();
         gradeable_dropdown.append("<option value=''>Loading...</option>");
         $.ajax({
-            url: "{{ base_url }}" + "/getPriorGradeables",
+            url: `{{ base_url }}/getPriorGradeables`,
             type: "POST",
             data: {
                 csrf_token: csrfToken,
-                semester_course: semester_course_dropdown.val()
+                semester_course: semester_course_dropdown.val(),
+                this_gradeable: {{ new_or_edit == "edit" ? "'" + config["gradeable_id"] + "'" : "$('#gradeable_id').val()" }}
             },
             success: function(data) {
                 data = JSON.parse(data);
@@ -257,7 +262,7 @@
 
                 gradeable_dropdown.empty();
                 $.each(data.data, function(index, gradeable) {
-                    gradeable_dropdown.append("<option value='" + gradeable + "'>" + gradeable + "</option>");
+                    gradeable_dropdown.append(`<option value='${gradeable}'>${gradeable}</option>`);
                 });
             },
             error: function(e) {
@@ -271,8 +276,8 @@
         const form = $("#save-configuration-form");
         // add a new row with the next index, with empty dropdowns
         let first_free_index = $(".prior-gradeable-wrapper").length;
-        $('#prev-gradeable-div', form).append(`
-            <div id='prior-g-option-`+first_free_index+`' class='prior-gradeable-wrapper'>
+        $('#past-terms-content', form).append(`
+            <div id='prior-g-option-${first_free_index}' class='prior-gradeable-wrapper'>
                 <select name='prior_semester_course[]' onchange='getGradeables(this)'>
                 </select>
                 <select name='prior_gradeable[]'>
@@ -283,10 +288,10 @@
             </div>
         `);
         // fill in the left dropdown
-        let semester_course_dropdown = $("#prior-g-option-"+first_free_index).children().first();
+        let semester_course_dropdown = $(`#prior-g-option-${first_free_index}`).children().first();
         $.each(prior_semester_course_list, function(index, semester_course) {
             let tokens_array = semester_course.split(" ");
-            semester_course_dropdown.append("<option value='" + tokens_array[0] + " " + tokens_array[1] + "'>" + tokens_array[0] + "/" + tokens_array[1] + "</option>");
+            semester_course_dropdown.append(`<option value='${semester_course}'>${tokens_array[0]}/${tokens_array[1]}</option>`);
         });
         // fill in the right dropdown
         getGradeables(semester_course_dropdown[0]);

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -67,7 +67,7 @@
                 <div class="plag-data">
                     <div id="files-to-be-compared">
                         <span class="option-alt">
-                            <a target=_blank href="https://submitty.org/instructor/course_management/plagiarism">How do I specify a regex expression?
+                            <a target=_blank href="https://submitty.org/instructor/course_management/plagiarism#files-to-be-compared">How do I specify a regex expression?
                                 <i style="font-style: normal;" class="fa-question-circle"></i>
                             </a>
                         </span>
@@ -120,7 +120,8 @@
             </div>
             {##################################################################}
             <div class="plag-data-group">
-                <div class="plag-data-label">Prior Terms Gradeables:</div>
+                <div class="plag-data-label">Other Gradeables:</div>
+                <label>Add gradeables from current or prior courses to compare against</label>
                 <div class="plag-data">
                     <span class="radio-label-pair">
                         <input type="radio" id="no-past-terms-id" value="no_past_terms" name="past_terms_option" {{ config["prior_terms"] ? "" : "checked" }}>


### PR DESCRIPTION
### What is the new behavior?
PR https://github.com/Submitty/Submitty/pull/6777 introduced new functionality to Lichen/plagiarism.  After discussion, a few improvements were suggested.  This PR is a follow-up PR which makes a few tweaks to the UI and makes a change to the permissions checking requested in https://github.com/Submitty/Submitty/pull/6777.

In full, this PR:
- Adds error-checking to prevent the current gradeable from being compared with itself and for duplicate values entered for that field in the form
- Changes the wording/descriptive text of the other gradeables subheading
- Excludes courses with the group "root" from being used as the source for other gradeables, regardless of the group attached to the current course
- Adds links to submitty.org documentation where appropriate 

### Screenshots:
Before:
![before](https://user-images.githubusercontent.com/16820599/127327867-23e9306c-3ab1-4bee-b07a-1a3eeb84f749.png)
After:
![after](https://user-images.githubusercontent.com/16820599/127327986-47cf00aa-959a-4fdd-ab5b-21d6d274b783.png)
