### PR TITLE
[Feature:Plagiarism] Refresh run log while open

### DIFF
--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -139,20 +139,42 @@
         originalTableWidth = $(".plag-table-cont").width();
     });
 
+    function updateRunLog(gradeable_id, config_id) {
+        const url = buildCourseUrl(['plagiarism', 'gradeable', gradeable_id, 'log']) + `?gradeable_id=${gradeable_id}&config_id=${config_id}`;
+        $.get(url, function (data) {
+            if ($(`#${gradeable_id}_${config_id}_table_row`).next().hasClass("run-log-results")) {
+                data = JSON.parse(data);
+
+                const log = $(`#${gradeable_id}_${config_id}_table_row`).next().find('pre');
+                const stickToBottom = log[0].scrollHeight - log.scrollTop() - log.outerHeight() < 1;
+                log.html(data.data);
+
+                if (stickToBottom) {
+                    log.scrollTop(log[0].scrollHeight);
+                }
+
+                // the log is still open, so refresh it again
+                setTimeout(() => {
+                    updateRunLog(gradeable_id, config_id)
+                }, 50);
+            }
+        });
+    }
+
     function viewRunLog(gradeable_id, config_id) {
         if ($(`#${gradeable_id}_${config_id}_table_row`).next().hasClass("run-log-results")) {
             $(`#${gradeable_id}_${config_id}_table_row`).next().remove();
         }
         else {
-            const url = buildCourseUrl(['plagiarism', 'gradeable', gradeable_id, 'log']) + `?gradeable_id=${gradeable_id}&config_id=${config_id}`;
-            $.get(url, function (data) {
-                data = JSON.parse(data);
-                $(`<tr class="run-log-results">
-                <td colspan="8" class="run-log-data">
-                    <pre style="width:${originalTableWidth}px">${data.data}</pre>
-                </td>
-            </tr>`).insertAfter(`#${gradeable_id}_${config_id}_table_row`);
-            });
+            $(`
+                <tr class="run-log-results">
+                    <td colspan="8" class="run-log-data">
+                        <pre style="width:${originalTableWidth}px"></pre>
+                    </td>
+                </tr>
+            `).insertAfter(`#${gradeable_id}_${config_id}_table_row`);
+
+            updateRunLog(gradeable_id, config_id);
         }
     }
 </script>


### PR DESCRIPTION
### What is the current behavior?
When viewing the run log to see the progress for a given run, the only way to refresh the log is to close and re-open the log.  This can be annoying for instructors who are monitoring the progress of a slow run.

### What is the new behavior?
This PR adds automatic refreshing to the run log so that it's possible to monitor the progress of a run without having to close and re-open the run log.  In addition, the scroll position will remain stuck to the bottom of the log after refreshing unless the user scrolls away.