### PR TITLE
[Bugfix:Plagiarism] Disable submit buttons after clicked

### DIFF
--- a/site/app/templates/plagiarism/DeletePlagiarismResultsAndConfig.twig
+++ b/site/app/templates/plagiarism/DeletePlagiarismResultsAndConfig.twig
@@ -1,5 +1,5 @@
 <div class="popup-form"  style="display: none;" id="delete-plagiarism-result-and-config-form">
-    <form name="delete" method="post">
+    <form id="delete-config-form" name="delete" method="post">
         <div class="popup-box">
             <div class="popup-window ui-draggable ui-draggable-handle" style="position: relative;">
                 <div class="form-title">
@@ -12,7 +12,7 @@
                     <div class="form-buttons">
                         <div class="form-button-container">
                             <a onclick="$('#delete-plagiarism-result-and-config-form').css('display', 'none');" class="btn btn-default">Cancel</a>
-                            <input class="btn btn-danger" type="submit" value="Delete" />
+                            <input id="submit-form" class="btn btn-danger" type="submit" value="Delete" />
                         </div>
                     </div>
                 </div>
@@ -22,4 +22,10 @@
 </div>
 <script>
     $(".popup-window").draggable();
+
+    $(document).ready(function() {
+        $('#delete-config-form').submit(function () {
+            $('#submit-form').attr('disabled', true);
+        });
+    });
 </script>

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -181,7 +181,7 @@
             {##################################################################}
             <div>
                 <a href="{{ plagiarism_link }}" class="btn btn-danger">Cancel</a>
-                <input class="btn btn-primary" type="submit" value="Save Configuration" />
+                <input id="submit-form" class="btn btn-primary" type="submit" value="Save Configuration"/>
             </div>
         </form>
     </div>
@@ -190,6 +190,13 @@
 <script>
     const form = $("#save-configuration-form");
     const prior_semester_course_list = JSON.parse(`{{ config["prior_semester_courses"] | json_encode() | raw }}`);
+
+    // SUBMIT FORM /////////////////////////////////////////////////////////////
+    $(document).ready(function() {
+        form.submit(function () {
+            $('#submit-form').attr('disabled', true);
+        });
+    });
 
     // PROVIDED CODE ///////////////////////////////////////////////////////////
     $("#no-code-provided-id").change(function() {
@@ -213,6 +220,12 @@
     });
 
     // PRIOR TERM GRADEABLES ///////////////////////////////////////////////////
+    $(document).ready(function() {
+        if ({{ config["prior_terms"] ? "true" : "false" }} && $("#past-terms-id").is(":checked")) {
+            $("#prev-gradeable-div").show();
+        }
+    });
+
     $('#add-more-prev-gradeable', form).on('click', function(){
         addMorePriorTermGradeable();
     });

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -214,9 +214,6 @@
             $("#current-code-file").show();
             $("#provided-code-file").show();
         }
-        if ({{ config["prior_terms"] ? "true" : "false" }} && $("#past-terms-id").is(":checked")) {
-            $("#prev-gradeable-div").show();
-        }
     });
 
     // PRIOR TERM GRADEABLES ///////////////////////////////////////////////////


### PR DESCRIPTION
### What is the current behavior?
After clicking the "submit form" or "delete" buttons for the first time for plagiarism configurations, the user is still able to click on those buttons in an attempt to create another daemon job to create/edit/delete the config, which results in errors caught by php.
![image](https://user-images.githubusercontent.com/71195502/127393945-4ebe7080-1cec-4561-a628-a09441243e56.png)

### What is the new behavior?
The buttons are disabled after clicked once, to indicate that the request is being processed and to prevent further unnecessary errors.
