### PR TITLE
[Bugfix:TAGrading] Fix Grade Button in Anonymous Mode

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -511,14 +511,12 @@
         {% set btn_class = "btn-primary" %}
     {% endif %}
     <td>
-        {% if badge_count is defined %}
-            <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId() }}&sort={{ context.sort }}&direction={{ context.direction }}">
-                {{ contents }}
-                {% if badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
-                    <span class="notification-badge">{{ badge_count }}</span>
-                {% endif %}
-            </a>
-        {% endif %}
+        <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId() }}&sort={{ context.sort }}&direction={{ context.direction }}">
+            {{ contents }}
+            {% if badge_count is defined and badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
+                <span class="notification-badge">{{ badge_count }}</span>
+            {% endif %}
+        </a>
     </td>
 {% endmacro %}
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you are grading an individual assignment and are in anonymous mode, the grade buttons do not show.

### What is the new behavior?
The grade buttons are now shown.
