### PR TITLE
[Bugfix:TAGrading] Team Gradeable Revisions

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1188,14 +1188,12 @@ class ElectronicGraderController extends AbstractController {
         }
 
         $team_name = $_POST['team_name'] ?? null;
-        $new_team_name = false;
 
         if ($new_team) {
             $leader = $this->core->getQueries()->getUserById($leader_id);
             try {
                 $gradeable->createTeam($leader, $users, $reg_section, $rot_section, $team_name);
                 $this->core->addSuccessMessage("Created New Team {$team_id}");
-                $new_team_name = true;
             }
             catch (\Exception $e) {
                 $this->core->addErrorMessage("Team may not have been properly initialized: {$e->getMessage()}");
@@ -1208,6 +1206,7 @@ class ElectronicGraderController extends AbstractController {
                 $this->core->addErrorMessage("ERROR: {$team_id} is not a valid Team ID");
                 $this->core->redirect($return_url);
             }
+            $new_team_name = false;
             if ($team_name !== $team->getTeamName()) {
                 $new_team_name = true;
             }

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -135,10 +135,10 @@ class Access {
         $this->permissions["grading.electronic.delete_mark"] = self::CHECK_CSRF | self::ALLOW_MIN_LIMITED_ACCESS_GRADER | self::CHECK_GRADEABLE_MIN_GROUP | self::CHECK_GRADING_SECTION_GRADER;
         $this->permissions["grading.electronic.get_marked_users"] = self::ALLOW_MIN_LIMITED_ACCESS_GRADER | self::CHECK_GRADEABLE_MIN_GROUP;
         $this->permissions["grading.electronic.get_marked_users.full_stats"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
-        $this->permissions["grading.electronic.show_edit_teams"] = self::ALLOW_MIN_INSTRUCTOR;
+        $this->permissions["grading.electronic.show_edit_teams"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
         $this->permissions["grading.electronic.import_teams"] = self::ALLOW_MIN_INSTRUCTOR | self::CHECK_CSRF;
         $this->permissions["grading.electronic.export_teams"] = self::ALLOW_MIN_INSTRUCTOR;
-        $this->permissions["grading.electronic.submit_team_form"] = self::ALLOW_MIN_INSTRUCTOR;
+        $this->permissions["grading.electronic.submit_team_form"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
         $this->permissions["grading.electronic.verify_grader"] = self::ALLOW_MIN_FULL_ACCESS_GRADER;
         $this->permissions["grading.electronic.verify_all"] = self::CHECK_CSRF | self::ALLOW_MIN_FULL_ACCESS_GRADER;
         $this->permissions["grading.electronic.silent_edit"] = self::ALLOW_MIN_INSTRUCTOR;

--- a/site/app/templates/grading/electronic/ta_status/StatusBase.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusBase.twig
@@ -200,7 +200,7 @@
             </a>
             <ul style="margin-left: 25px; margin-top: -5px; float: left">
                 <li>View Submissions</li>
-                {%  if team_assignment %}
+                {%  if team_assignment and can_manage_teams %}
                     <li>Manage Teams</li>
                 {% endif %}
                 {% if component_averages|length != 0 %}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -319,7 +319,8 @@ class ElectronicGraderView extends AbstractView {
             "include_overridden" => array_key_exists('include_overridden', $_COOKIE) ? $_COOKIE['include_overridden'] : 'omit',
             "histograms" => $histogram_data,
             "warnings" => $warnings,
-            "submissions_in_queue" => $submissions_in_queue
+            "submissions_in_queue" => $submissions_in_queue,
+            "can_manage_teams" => $this->core->getAccess()->canI('grading.electronic.show_edit_teams', ["gradeable" => $gradeable])
         ]);
     }
 
@@ -628,7 +629,7 @@ HTML;
                 }
                 $multiple_invites_json = json_encode($multiple_invites);
                 $lock_date = DateUtils::dateTimeToString($gradeable->getTeamLockDate(), false);
-                $team_name = $row->getSubmitter()->getTeam()->getTeamName();
+                $team_name = addslashes($row->getSubmitter()->getTeam()->getTeamName());
                 $info["team_edit_onclick"] = "adminTeamForm(false, '{$row->getSubmitter()->getId()}', '{$reg_section}', '{$rot_section}', {$user_assignment_setting_json}, {$members}, {$pending_members_json}, {$multiple_invites_json}, {$gradeable->getTeamSizeMax()},'{$lock_date}', '{$team_name}');";
                 $team_history = ($row->getSubmitter()->getTeam()->getAssignmentSettings($gradeable))["team_history"] ?? null;
                 $last_edit_date = ($team_history == null || count($team_history) == 0) ? null : $team_history[count($team_history) - 1]["time"];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you are a peer or limited access grader when grading a team gradeable, the bullet list says you can manage teams. Full access graders cannot manage teams.
Closes #6858 

### What is the new behavior?
Full access graders can now manage teams. Only if you are an instructor or full access graders can you see the bullet option to manage teams. Team names with a single quote were able to break the edit button from working which is now fixed as well.
