### PR TITLE
[Testing:System] Specify Timezone in e2e Test

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -249,6 +249,7 @@ jobs:
             env:
               POSTGRES_PASSWORD: submitty_dbuser
               POSTGRES_USER: postgres
+              TZ: America/New_York
             options: >-
               --health-cmd pg_isready
               --health-interval 10s
@@ -280,6 +281,10 @@ jobs:
             with:
               php-version: ${{ env.PHP_VER }}
               extensions: imagick
+
+          - name: Set Timezone
+            run: |
+              sudo timedatectl set-timezone America/New_York
 
           - name: Cache pip
             uses: actions/cache@v2


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now the setup.sh for testing sets the timezone for the site as America/New_York while the rest of the e2e testing suite has no set timezone. This creates a conflict in timezones when storing/viewing data.

### What is the new behavior?
The database (postgres) and testing machine are both set to America/New_York in the e2e test. This is needed for #6824 to pass.

### Other information?
This has been tested in #6824 and has been proven to work during a time where a conflict would happen.

An alternative solution to this would be to remove the specified timezone from the setup.sh and have all of the timezones align to their automatic timezone.
