### PR TITLE
[Bugfix:Plagiarism] Fix prior gradables select on edit form

### DIFF
--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -261,7 +261,7 @@
             data: {
                 csrf_token: csrfToken,
                 semester_course: semester_course_dropdown.val(),
-                this_gradeable: {{ new_or_edit == "edit" ? "'" + config["gradeable_id"] + "'" : "$('#gradeable_id').val()" }}
+                this_gradeable: {{ new_or_edit == "edit" ? ("'" ~ config["gradeable_id"] ~ "'")|raw : "$('#gradeable_id').val()" }}
             },
             success: function(data) {
                 data = JSON.parse(data);


### PR DESCRIPTION
### What is the current behavior?
When editing a plagiarism configuration, the next php error appears in the console:
![image](https://user-images.githubusercontent.com/71195502/127882318-701cc2d9-23a7-44f1-a03e-b7ab9d060548.png)

### What is the new behavior?
The error is fixed.
