### PR TITLE
[Bugfix:SubminiPolls] Fix results chart for edited polls

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7401,9 +7401,23 @@ AND gc_id IN (
 
     public function getResults($poll_id) {
         $results = [];
-        foreach ($this->getResponses($poll_id) as $option_id => $answer) {
-            $this->course_db->query("SELECT * FROM poll_responses where poll_id = ? and option_id = ?", [$poll_id, $option_id]);
-            $results[$option_id] = count($this->course_db->rows());
+        $query = <<<SQL
+SELECT
+    po.option_id,
+    pr.count
+FROM
+    poll_options AS po
+    LEFT JOIN (
+        SELECT option_id, COUNT(*) AS count FROM poll_responses WHERE poll_id = ? GROUP BY option_id
+    ) AS pr ON pr.option_id = po.option_id
+WHERE
+    po.poll_id = ?
+ORDER BY
+    po.order_id ASC
+SQL;
+        $this->course_db->query($query, [$poll_id, $poll_id]);
+        foreach ($this->course_db->rows() as $row) {
+            $results[$row["option_id"]] = $row['count'];
         }
         return $results;
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7404,7 +7404,7 @@ AND gc_id IN (
         $query = <<<SQL
 SELECT
     po.option_id,
-    pr.count
+    COALESCE(pr.count, 0) AS count
 FROM
     poll_options AS po
     LEFT JOIN (

--- a/site/app/templates/polls/ViewPollResults.twig
+++ b/site/app/templates/polls/ViewPollResults.twig
@@ -1,28 +1,18 @@
 <script>
     window.onload = function() {
-        const xPoints = [];
-        const xPointsIndexes = [];
-        const yPoints = [];
-        let string;
-        {% for answer, number in results %}
-            string = "{{ poll.getResponseString(answer) }}";
-            xPoints.push(string);
-            xPointsIndexes.push({{ answer }});
-            yPoints.push({{ number }});
-        {% endfor %}
         const data = [
           {
-            y: yPoints,
-            type: 'bar'
+            type: "bar",
+            x: [],
+            y: [],
           }
         ];
+        {% for answer, number in results %}
+            data[0].x.push("{{ poll.getResponseString(answer) }}");
+            data[0].y.push({{ number }});
+        {% endfor %}
         const layout = {
           title: "{{ poll.getName() }}",
-          xaxis: {
-            tickmode: "array",
-            ticktext: xPoints,
-            tickvals: xPointsIndexes
-          }
         }
         Plotly.newPlot("chartContainer", data, layout);
     }


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #6868 

If you edit a poll and re-arrange the responses, then the poll results would display incorrectly. This was because we were using the `option_id` for the response in graphing for plotly. An example would be a poll with three options (`Yes`, `No`, `Maybe`) where after poll creation and people have put in responses, we switch the ordering of `Yes` and `No`. This means that `Yes` would have `{option_id: 0, order_id: 1}` and `No` would have `{option_id: 1, order_id: 0}`.

After filling out the responses for a number of students, we might have the following data we were plugging into the graph:

```
tick_text = {
	  0: "No"
	  1: "Yes"
	  2: "Maybe"
};

tick_val = {
	  0: 1
	  1: 0
	  2: 2
};

y_data = {
	  0: 1
	  1: 3
	  2: 1
}
```

where plotly would sort itself on the `tick_val` under the hood, but then break the implicit ordering we had in `y_data` that depended on plotly putting things in the order as we gave it (i.e. the ticks being in order of `1, 0, 2`).

### What is the new behavior?

This PR fixes the poll results so that it displays correctly. Instead of trying to do some complicated logic with `tickvals` or `ticktext`, we can just use the [basic bar chart API](https://plotly.com/javascript/bar-charts/#basic-bar-chart) to give plotly an object that has both x,y data and plotly graphs it as is, giving us both the expected graphing result as well as simpler code overall.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
