### PR TITLE
[Bugfix:InstructorUI] New Gradeable Twig Error

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -154,9 +154,9 @@
                 <fieldset class="grade_inquiry_per_component_allowed" id="gi_component_enable_container">
                     <legend>Should grade inquiries be associated with a specific component of the rubric?</legend>
                     <input type="radio" id="yes_grade_inquiry_per_component_allowed" name="grade_inquiry_per_component_allowed" value="true" class="bool_val auto_save"
-                            {{ gradeable.isGradeInquiryPerComponentAllowed() ? 'checked' : '' }} /> <label for="yes_grade_inquiry_per_component_allowed">Yes</label>
+                            {{ action != 'new' and gradeable.isGradeInquiryPerComponentAllowed() ? 'checked' : '' }} /> <label for="yes_grade_inquiry_per_component_allowed">Yes</label>
                     <input type="radio" id="no_grade_inquiry_per_component_allowed" name="grade_inquiry_per_component_allowed" value="false" class="bool_val auto_save"
-                            {{ not gradeable.isGradeInquiryPerComponentAllowed() ? 'checked' : '' }} /> <label for= "no_grade_inquiry_per_component_allowed">No</label>
+                            {{ not (action != 'new' and gradeable.isGradeInquiryPerComponentAllowed()) ? 'checked' : '' }} /> <label for= "no_grade_inquiry_per_component_allowed">No</label>
                 </fieldset>
             {% endif %}
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If grade inquiries are enabled and you go to create a gradeable you will get a Twig error.

### What is the new behavior?
The page loads fine when grade inquiries are enabled.

