### PR TITLE
[Bugfix:Developer] Fix directory path for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,17 +24,7 @@ updates:
       prefix: "[Dependency] "
       prefix-development: "[DevDependency]"
   - package-ecosystem: pip
-    directory: "/.setup/pip/system_requirements.txt"
-    schedule:
-      interval: daily
-      time: "10:00"
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-    commit-message:
-      prefix: "[Dependency] "
-  - package-ecosystem: pip
-    directory: "/.setup/pip/vagrant_requirements.txt"
+    directory: "/.setup/pip/"
     schedule:
       interval: daily
       time: "10:00"


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `directory` field for the pip dependencies points at the file names, and not the containing directory. This probably prevents dependabot from working properly given it expects to be given a directory [per their docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#directory).

### What is the new behavior?

Fixes the dependabot field to point at the directory. Unfortunately, there's not a way to differentiate between stuff coming out of `vagrant` versus `system`, and so for now that'll have to be handled manually. A GH action could be made to fix it.