### PR TITLE
[Bugfix:System] Remove unnecessary system socket closes

### DIFF
--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -230,15 +230,6 @@ class Server implements MessageComponentInterface {
         }
         elseif (isset($msg['user_id'])) {
             // user_id is only sent with socket clients open from a php user_agent
-            $user_open_clients = $this->getSocketClients($msg['user_id']);
-            if (is_array($user_open_clients)) {
-                foreach ($user_open_clients as $original_client) {
-                    if ($this->getSocketClientPage($original_client) === $msg['page']) {
-                        $original_client->close();
-                        break;
-                    }
-                }
-            }
             unset($msg['user_id']);
             $new_msg_string = json_encode($msg);
             $this->broadcast($from, $new_msg_string, $msg['page']);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The Server.php socket manager closes an extra socket for an unknown reason. This causes CI to fail in #6817 when deleting other queues.

### What is the new behavior?
The code closing the socket has been removed.
