### PR TITLE
[Bugfix:System] Deny website file access via symlink

### DIFF
--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -746,6 +746,10 @@ class Access {
         //To array of [type, value]
         $subparts = array_combine($subpart_types, $subpart_values);
 
+        if (is_link($path)) {
+            return false;
+        }
+
         //So we can extract parameters from the path
         foreach ($subpart_types as $type) {
             $value = $subparts[$type];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If a symlink somehow got onto the server, our Access.php will let users open the symlink.

### What is the new behavior?
If the file is detected to be a symlink, we will always deny access to it.
