### PR TITLE
[Bugfix:Plagiarism] Remove creation of lichen subdirs

### DIFF
--- a/sbin/create_course.sh
+++ b/sbin/create_course.sh
@@ -234,8 +234,6 @@ create_and_set  u=rwx,g=rwxs,o=   $instructor  $ta_www_group   $course_dir/custo
 #               drwxrws---       $PHP_USER        ta_www_group    uploads/seating
 #               drwxrws---       $PHP_USER        ta_www_group    rainbow_grades
 #               drwxrws---       $DAEMON_USER     ta_www_group    lichen/
-#               drwxrws---       $PHP_USER        ta_www_group    lichen/config
-#               drwxrws---       $PHP_USER        ta_www_group    lichen/provided_code
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/submissions
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/forum_attachments
 create_and_set  u=rwx,g=rxs,o=   $PHP_USER        $ta_www_group   $course_dir/annotations
@@ -255,8 +253,6 @@ create_and_set  u=rwx,g=rwxs,o=  $DAEMON_USER     $ta_www_group   $course_dir/up
 create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/uploads/seating
 create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/rainbow_grades
 create_and_set  u=rwx,g=rwxs,o=  $DAEMON_USER     $ta_www_group   $course_dir/lichen
-create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/lichen/config
-create_and_set  u=rwx,g=rwxs,o=  $PHP_USER        $ta_www_group   $course_dir/lichen/provided_code
 
 
 # NOTE:    instructor uploads TA HW grade reports & overall grade scores here


### PR DESCRIPTION
### What is the current behavior?
The `sbin/create_course.sh` script currently creates `<course_path>/lichen/provided_code` and `<course_path>/lichen/config` when setting up the directories for a course. Those directories are remnants of the old directory structure Lichen used to have, and they are not used anymore. All the directories used for every Lichen run are created when necessary in `Lichen/bin/process_all.sh`.

### What is the new behavior?
The unused directories are not created anymore.
