### PR TITLE
[Bugfix:TAGrading] Fix auto open text wrapping

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -29,7 +29,7 @@
                 </script>
                 <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
 
-                <span style="padding-right: 10px"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
+                <span style="padding-right: 10px; white-space: nowrap;"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
             </span>
             <br />
             {# Files #}


### PR DESCRIPTION
### What is the current behavior?
At some screen widths, it is currently possible for one or both of the words "auto open" to wrap to a different line from the associated checkbox.  See screenshot.
![before](https://user-images.githubusercontent.com/16820599/128100448-432366f4-7222-437c-bd93-cb775374c6fc.png)

### What is the new behavior?
The checkbox and text now wrap as a single unit and will always be on the same line.  See screenshot.
![after](https://user-images.githubusercontent.com/16820599/128100511-866b6726-4e9a-4aa6-a686-e4d6d85f7b38.png)
![after](https://user-images.githubusercontent.com/16820599/128100581-b05db7ac-d5c9-4ef3-8bff-8eac6d9c6ea2.png)

