### PR TITLE
[Dependency] Pin onnx to 1.9.0 for Ubuntu 18.04 support

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -57,4 +57,5 @@ numpy==1.19.5
 
 # python libraries for OCR for digit recognition
 # newer versions are not supported on 18.04
+onnx==1.9.0
 onnxruntime==1.3.0


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

`vagrant up` is failing for Ubuntu 18.04 due to a new version of `onnx` being released, which `onnxruntime` (which we do pin) depends on.

### What is the new behavior?

Pins the version of `onnx` to install to one that'll work on Ubuntu 18.04.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Testing this via the `Vagrant Up` GH action: https://github.com/Submitty/Submitty/actions/runs/1097417549
