### PR TITLE
[Bugfix:Forum] Fix Markdown Toggle not Persisting

### DIFF
--- a/site/app/templates/forum/createThread.twig
+++ b/site/app/templates/forum/createThread.twig
@@ -38,7 +38,8 @@
             "submit_label" : "Publish thread",
             "manage_categories_url" : manage_categories_url,
             "email_enabled": email_enabled,
-            "expiration_placeholder" : expiration_placeholder
+            "expiration_placeholder" : expiration_placeholder,
+            "render_markdown" : render_markdown
         } %}
 
     </form>

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -299,7 +299,8 @@ class ForumThreadView extends AbstractView {
                 "post_box_id" => $generatePostContent["post_box_id"],
                 "merge_url" => $this->core->buildCourseUrl(['forum', 'threads', 'merge']),
                 "split_url" => $this->core->buildCourseUrl(['forum', 'posts', 'split']),
-                "post_content_limit" => $post_content_limit
+                "post_content_limit" => $post_content_limit,
+                "render_markdown" => $markdown_enabled
             ]);
 
             $return = $this->core->getOutput()->renderJsonSuccess(["html" => json_encode($return)]);
@@ -1200,7 +1201,8 @@ class ForumThreadView extends AbstractView {
             "csrf_token" => $this->core->getCsrfToken(),
             "email_enabled" => $this->core->getConfig()->isEmailEnabled(),
             "search_url" => $this->core->buildCourseUrl(['forum', 'search']),
-            "expiration_placeholder" => $expiration->add(new \DateInterval('P7D'))->format('Y-m-d')
+            "expiration_placeholder" => $expiration->add(new \DateInterval('P7D'))->format('Y-m-d'),
+            "render_markdown" => isset($_COOKIE['markdown_enabled']) ? $_COOKIE['markdown_enabled'] : 0
         ]);
     }
 


### PR DESCRIPTION
### What is the current behavior?
Fixes #6750
When creating a new thread, the markdown option is always initially set to disabled. 
Also, when switching between threads, the markdown toggle doesn't have the correct value until the page is refreshed.

### What is the new behavior?
The markdown toggle persists on the create thread page as well as switching between threads.
