### PR TITLE
[Feature:Plagiarism] Add ability to click on right panel mark

### DIFF
--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -385,6 +385,10 @@ function refreshColorInfo(state) {
                             'type': interval.type,
                             'matching_positions': mp_text_marks,
                             'others': interval.others,
+                            'start_line': interval.start_line - 1,
+                            'end_line': interval.start_line - 1,
+                            'start_char': interval.start_char - 1,
+                            'end_char': interval.end_char - 1,
                         },
                         className: color,
                     },
@@ -539,6 +543,7 @@ function handleClickedMarks(state) {
 
         clickedMark.className = 'selected-style-red';
         state.editor1.operation(() => {
+            let first_mark = true;
             marks_editor1.forEach(mark => {
                 $.each(mark.attributes.matching_positions, (i, mp) => {
                     if (mp.attributes.start_line === clickedMark.attributes.start_line &&
@@ -548,6 +553,11 @@ function handleClickedMarks(state) {
                     ) {
                         mark.attributes.selected = true;
                         mark.className = 'selected-style-red';
+                        if (first_mark) {
+                            console.log(mark.attributes.end_line)
+                            state.editor1.scrollIntoView({line: mark.attributes.end_line, ch: 0}, 400);
+                            first_mark = false;
+                        }
                     }
                 });
             });

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -595,7 +595,7 @@ function handleClickedMarks(state) {
         }
 
         handleClickedMark_editor2(state, clickedMark);
-    }
+    };
 }
 
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -361,6 +361,8 @@ function refreshColorInfo(state) {
                                 'original_color': color,
                                 'start_line': mp.start_line - 1,
                                 'end_line': mp.start_line - 1,
+                                'start_char': mp.start_char - 1,
+                                'end_char': mp.end_char - 1,
                             },
                             className: color,
                         },
@@ -497,6 +499,64 @@ function handleClickedMarks(state) {
         state.editor1.refresh();
         state.editor2.refresh();
     };
+
+    state.editor2.getWrapperElement().onmouseup = function(e) {
+        const lineCh = state.editor2.coordsChar({ left: e.clientX, top: e.clientY });
+        const markers = state.editor2.findMarksAt(lineCh);
+
+
+        // hide the "others" popup in case it was visible
+        $('#popup_to_show_matches_id').css('display', 'none');
+
+
+        // Only grab the first one if there is overlap...
+        const clickedMark = markers[0];
+
+        // reset all previous marks
+        const marks_editor1 = state.editor1.getAllMarks();
+        state.editor1.operation(() => {
+            marks_editor1.forEach(mark => {
+                if (markers.length === 0 || mark !== clickedMark) {
+                    mark.className = mark.attributes.original_color;
+                    mark.attributes.selected = false;
+                }
+            });
+        });
+        const marks_editor2 = state.editor2.getAllMarks();
+        state.editor2.operation(() => {
+            marks_editor2.forEach(mark => {
+                mark.className = mark.attributes.original_color;
+            });
+        });
+
+
+        // Did not select a marker
+        if (markers.length === 0) {
+            state.editor1.refresh();
+            state.editor2.refresh();
+            return;
+        }
+
+        clickedMark.className = 'selected-style-red';
+        state.editor1.operation(() => {
+            marks_editor1.forEach(mark => {
+                $.each(mark.attributes.matching_positions, (i, mp) => {
+                    if (mp.attributes.start_line === clickedMark.attributes.start_line &&
+                        mp.attributes.end_line === clickedMark.attributes.end_line &&
+                        mp.attributes.start_char === clickedMark.attributes.start_char &&
+                        mp.attributes.end_char === clickedMark.attributes.end_char
+                    ) {
+                        mark.attributes.selected = true;
+                        mark.className = 'selected-style-red';
+                    }
+                });
+            });
+        });
+
+        // Refresh editors
+        state.editor1.refresh();
+        state.editor2.refresh();
+    }
 }
 
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -56,6 +56,12 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
         'editor1': editor1,
         'editor2': editor2,
         'color_info': [],
+        'previous_selection': {
+            'start_line': -1,
+            'end_line': -1,
+            'start_char': -1,
+            'end_char': -1,
+        },
     };
 
     // force the page to load default data for user 1 with highest % match
@@ -316,6 +322,7 @@ function refreshUser2Dropdown(state) {
 
 
 function refreshColorInfo(state) {
+    let previousSelectedMark = null;
     state.editor1.operation(() => {
         state.editor2.operation(() => {
             // codemirror doesn't preovide an easy way to remove text marks so we just wipe the contents of the document and reset
@@ -345,6 +352,8 @@ function refreshColorInfo(state) {
 
                 const mp_text_marks = [];
 
+                const wasPreviousSelection = interval.start_line - 1 === state.previous_selection.start_line && interval.end_line - 1 === state.previous_selection.end_line && interval.start_char - 1 === state.previous_selection.start_char && interval.end_char - 1 === state.previous_selection.end_char;
+
                 $.each(interval.matching_positions, (i, mp) => {
                     const color = 'specific-match-style';
                     mp_text_marks[i] = state.editor2.markText(
@@ -369,7 +378,7 @@ function refreshColorInfo(state) {
                     );
                 });
 
-                state.editor1.markText(
+                const mark = state.editor1.markText(
                     { // start position
                         line: interval.start_line - 1,
                         ch: interval.start_char - 1,
@@ -390,12 +399,117 @@ function refreshColorInfo(state) {
                             'start_char': interval.start_char - 1,
                             'end_char': interval.end_char - 1,
                         },
-                        className: color,
+                        className: wasPreviousSelection ? 'selected-style-red' : color,
                     },
                 );
+                if (wasPreviousSelection) {
+                    previousSelectedMark = mark;
+                }
             });
         });
     });
+    state.editor1.refresh();
+    state.editor2.refresh();
+
+    if (previousSelectedMark !== null) {
+        handleClickedMark_editor1(state, previousSelectedMark);
+    }
+}
+
+
+function handleClickedMark_editor1(state, clickedMark, e = null) {
+    // mark the clicked mark on both sides
+    if (clickedMark.attributes.type === 'specific-match' && !clickedMark.attributes.selected) {
+        clickedMark.attributes.selected = true;
+        clickedMark.className = 'selected-style-red';
+
+        // highlight the matching regions on the right side
+        state.editor2.operation(() => {
+            $.each(clickedMark.attributes.matching_positions, (i, mp) => {
+                mp.className = 'selected-style-red';
+            });
+            state.editor2.scrollIntoView({line: clickedMark.attributes.matching_positions[0].attributes.end_line, ch: 0}, 400);
+        });
+    }
+    else if (clickedMark.attributes.type === 'match' || (clickedMark.attributes.type === 'specific-match' && clickedMark.attributes.selected)) {
+        clickedMark.attributes.selected = true;
+        clickedMark.className = 'selected-style-blue';
+
+        $('#popup_to_show_matches_id').css('left', `${e.clientX}px`);
+        $('#popup_to_show_matches_id').css('top', `${e.clientY}px`);
+        $('#popup_to_show_matches_id').empty();
+
+        $.each(clickedMark.attributes.others, (i, other) => {
+            let humanified_source_gradeable = other.source_gradeable;
+            humanified_source_gradeable = humanified_source_gradeable.replaceAll('__', '/');
+
+            const sg = other.source_gradeable === state.this_term_course_gradeable ? '' : ` (${humanified_source_gradeable})`;
+
+            $('#popup_to_show_matches_id').append(`
+                    <li id="others_menu_${i}" class="ui-menu-item">
+                        <div tabindex="-1" class="ui-menu-item-wrapper">
+                            ${other.user_id}: ${other.version}${sg}
+                        </div>
+                    </li>
+                `);
+            $(`#others_menu_${i}`).on('click', () => {
+                // hiding the popup and resetting the text color immediately makes the page feel faster
+                $('#popup_to_show_matches_id').css('display', 'none');
+                clickedMark.className = clickedMark.attributes.original_color;
+                state.editor2.getDoc().setValue('');
+                state.editor2.refresh();
+                state.editor1.refresh();
+
+                // set the selected user in the user 2 dropdown
+                $.each(state.user_2_dropdown_list, (i, item) => {
+                    if (item.user_id === other.user_id && item.version === other.version && item.source_gradeable === other.source_gradeable) {
+                        state.user_2_selected = item;
+
+                        state.previous_selection.start_line = clickedMark.attributes.start_line;
+                        state.previous_selection.end_line = clickedMark.attributes.end_line;
+                        state.previous_selection.start_char = clickedMark.attributes.start_char;
+                        state.previous_selection.end_char = clickedMark.attributes.end_char;
+                    }
+                });
+
+                // all async so order doesn't particularly matter
+                loadConcatenatedFileForEditor(state, 2);
+                loadColorInfo(state);
+                refreshUser2Dropdown(state);
+            });
+        });
+        $('#popup_to_show_matches_id').css('display', 'block');
+    }
+
+    // Refresh editors
+    state.editor1.refresh();
+    state.editor2.refresh();
+}
+
+
+function handleClickedMark_editor2(state, clickedMark) {
+    clickedMark.className = 'selected-style-red';
+    state.editor1.operation(() => {
+        let first_mark = true;
+        state.editor1.getAllMarks().forEach(mark => {
+            $.each(mark.attributes.matching_positions, (i, mp) => {
+                if (mp.attributes.start_line === clickedMark.attributes.start_line &&
+                    mp.attributes.end_line === clickedMark.attributes.end_line &&
+                    mp.attributes.start_char === clickedMark.attributes.start_char &&
+                    mp.attributes.end_char === clickedMark.attributes.end_char
+                ) {
+                    mark.attributes.selected = true;
+                    mark.className = 'selected-style-red';
+                    if (first_mark) {
+                        state.editor1.scrollIntoView({line: mark.attributes.end_line, ch: 0}, 400);
+                        first_mark = false;
+                    }
+                }
+            });
+        });
+    });
+
+    // Refresh editors
     state.editor1.refresh();
     state.editor2.refresh();
 }
@@ -440,68 +554,7 @@ function handleClickedMarks(state) {
             return;
         }
 
-
-        // mark the clicked mark on both sides
-        if (clickedMark.attributes.type === 'specific-match' && !clickedMark.attributes.selected) {
-            clickedMark.attributes.selected = true;
-            clickedMark.className = 'selected-style-red';
-
-            // highlight the matching regions on the right side
-            state.editor2.operation(() => {
-                $.each(clickedMark.attributes.matching_positions, (i, mp) => {
-                    mp.className = 'selected-style-red';
-                });
-                state.editor2.scrollIntoView({line: clickedMark.attributes.matching_positions[0].attributes.end_line, ch: 0}, 400);
-            });
-        }
-        else if (clickedMark.attributes.type === 'match' || (clickedMark.attributes.type === 'specific-match' && clickedMark.attributes.selected)) {
-            clickedMark.attributes.selected = true;
-            clickedMark.className = 'selected-style-blue';
-
-            $('#popup_to_show_matches_id').css('left', `${e.clientX}px`);
-            $('#popup_to_show_matches_id').css('top', `${e.clientY}px`);
-            $('#popup_to_show_matches_id').empty();
-
-            $.each(clickedMark.attributes.others, (i, other) => {
-                let humanified_source_gradeable = other.source_gradeable;
-                humanified_source_gradeable = humanified_source_gradeable.replaceAll('__', '/');
-
-                const sg = other.source_gradeable === state.this_term_course_gradeable ? '' : ` (${humanified_source_gradeable})`;
-
-                $('#popup_to_show_matches_id').append(`
-                    <li id="others_menu_${i}" class="ui-menu-item">
-                        <div tabindex="-1" class="ui-menu-item-wrapper">
-                            ${other.user_id}: ${other.version}${sg}
-                        </div>
-                    </li>
-                `);
-                $(`#others_menu_${i}`).on('click', () => {
-                    // hiding the popup and resetting the text color immediately makes the page feel faster
-                    $('#popup_to_show_matches_id').css('display', 'none');
-                    clickedMark.className = clickedMark.attributes.original_color;
-                    state.editor2.getDoc().setValue('');
-                    state.editor2.refresh();
-                    state.editor1.refresh();
-
-                    // set the selected user in the user 2 dropdown
-                    $.each(state.user_2_dropdown_list, (i, item) => {
-                        if (item.user_id === other.user_id && item.version === other.version && item.source_gradeable === other.source_gradeable) {
-                            state.user_2_selected = item;
-                        }
-                    });
-
-                    // all async so order doesn't particularly matter
-                    loadConcatenatedFileForEditor(state, 2);
-                    loadColorInfo(state);
-                    refreshUser2Dropdown(state);
-                });
-            });
-            $('#popup_to_show_matches_id').css('display', 'block');
-        }
-
-        // Refresh editors
-        state.editor1.refresh();
-        state.editor2.refresh();
+        handleClickedMark_editor1(state, clickedMark, e);
     };
 
     state.editor2.getWrapperElement().onmouseup = function(e) {
@@ -541,30 +594,7 @@ function handleClickedMarks(state) {
             return;
         }
 
-        clickedMark.className = 'selected-style-red';
-        state.editor1.operation(() => {
-            let first_mark = true;
-            marks_editor1.forEach(mark => {
-                $.each(mark.attributes.matching_positions, (i, mp) => {
-                    if (mp.attributes.start_line === clickedMark.attributes.start_line &&
-                        mp.attributes.end_line === clickedMark.attributes.end_line &&
-                        mp.attributes.start_char === clickedMark.attributes.start_char &&
-                        mp.attributes.end_char === clickedMark.attributes.end_char
-                    ) {
-                        mark.attributes.selected = true;
-                        mark.className = 'selected-style-red';
-                        if (first_mark) {
-                            state.editor1.scrollIntoView({line: mark.attributes.end_line, ch: 0}, 400);
-                            first_mark = false;
-                        }
-                    }
-                });
-            });
-        });
-
-        // Refresh editors
-        state.editor1.refresh();
-        state.editor2.refresh();
+        handleClickedMark_editor2(state, clickedMark);
     }
 }
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -355,7 +355,7 @@ function refreshColorInfo(state) {
                 const wasPreviousSelection = interval.start_line - 1 === state.previous_selection.start_line && interval.end_line - 1 === state.previous_selection.end_line && interval.start_char - 1 === state.previous_selection.start_char && interval.end_char - 1 === state.previous_selection.end_char;
 
                 $.each(interval.matching_positions, (i, mp) => {
-                    const color = 'specific-match-style';
+                    const color2 = 'specific-match-style';
                     mp_text_marks[i] = state.editor2.markText(
                         { // start position
                             line: mp.start_line - 1,
@@ -367,13 +367,13 @@ function refreshColorInfo(state) {
                         },
                         {
                             attributes: {
-                                'original_color': color,
+                                'original_color': color2,
                                 'start_line': mp.start_line - 1,
-                                'end_line': mp.start_line - 1,
+                                'end_line': mp.end_line - 1,
                                 'start_char': mp.start_char - 1,
                                 'end_char': mp.end_char - 1,
                             },
-                            className: color,
+                            className: color2,
                         },
                     );
                 });
@@ -395,7 +395,7 @@ function refreshColorInfo(state) {
                             'matching_positions': mp_text_marks,
                             'others': interval.others,
                             'start_line': interval.start_line - 1,
-                            'end_line': interval.start_line - 1,
+                            'end_line': interval.end_line - 1,
                             'start_char': interval.start_char - 1,
                             'end_char': interval.end_char - 1,
                         },
@@ -429,6 +429,20 @@ function handleClickedMark_editor1(state, clickedMark, e = null) {
                 mp.className = 'selected-style-red';
             });
             state.editor2.scrollIntoView({line: clickedMark.attributes.matching_positions[0].attributes.end_line, ch: 0}, 400);
+        });
+
+        // highlight the other matching regions on the left side
+        state.editor1.getAllMarks().forEach(mark => {
+            $.each(mark.attributes.matching_positions, (i, mp) => {
+                if (mp.attributes.start_line === clickedMark.attributes.matching_positions[0].attributes.start_line &&
+                    mp.attributes.end_line === clickedMark.attributes.matching_positions[0].attributes.end_line &&
+                    mp.attributes.start_char === clickedMark.attributes.matching_positions[0].attributes.start_char &&
+                    mp.attributes.end_char === clickedMark.attributes.matching_positions[0].attributes.end_char
+                ) {
+                    mark.attributes.selected = true;
+                    mark.className = 'selected-style-red';
+                }
+            });
         });
     }
     else if (clickedMark.attributes.type === 'match' || (clickedMark.attributes.type === 'specific-match' && clickedMark.attributes.selected)) {
@@ -492,20 +506,27 @@ function handleClickedMark_editor2(state, clickedMark) {
     state.editor1.operation(() => {
         let first_mark = true;
         state.editor1.getAllMarks().forEach(mark => {
+            let mark_does_contain_mp = false;
             $.each(mark.attributes.matching_positions, (i, mp) => {
                 if (mp.attributes.start_line === clickedMark.attributes.start_line &&
                     mp.attributes.end_line === clickedMark.attributes.end_line &&
                     mp.attributes.start_char === clickedMark.attributes.start_char &&
                     mp.attributes.end_char === clickedMark.attributes.end_char
                 ) {
-                    mark.attributes.selected = true;
-                    mark.className = 'selected-style-red';
+                    mark_does_contain_mp = true;
+                }
+            });
+            if (mark_does_contain_mp) {
+                mark.attributes.selected = true;
+                mark.className = 'selected-style-red';
+                $.each(mark.attributes.matching_positions, (i, mp) => {
+                    mp.className = 'selected-style-red';
                     if (first_mark) {
                         state.editor1.scrollIntoView({line: mark.attributes.end_line, ch: 0}, 400);
                         first_mark = false;
                     }
-                }
-            });
+                });
+            }
         });
     });
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -554,7 +554,6 @@ function handleClickedMarks(state) {
                         mark.attributes.selected = true;
                         mark.className = 'selected-style-red';
                         if (first_mark) {
-                            console.log(mark.attributes.end_line)
                             state.editor1.scrollIntoView({line: mark.attributes.end_line, ch: 0}, 400);
                             first_mark = false;
                         }


### PR DESCRIPTION
### What is the current behavior?
It is currently possible to click a mark on the left panel which highlights a matching region (or several) in red but impossible to do the reverse and click a mark on the right panel.  In addition, when clicking on a user in the matching users popup, the mark which was clicked is not highlighted after the colors refresh and it may be difficult for the instructor to find it.

### What is the new behavior?
This PR addresses both of the above issues.  It is now possible to click regions on either the right or left pane with proper highlighting, and the UI will now automatically highlight the clicked region after the colors reload when clicking a user in the matching users popup.
