### PR TITLE
[UI/UX:Autograding] Fixed empty cell problem

### DIFF
--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -35,8 +35,8 @@
         <tr data-enabled = {{worker['enabled'] == true and (worker['name'] not in machine_to_update | keys or machine_to_update[worker['name']] == true)? 'true' : 'false'}}>
             <th>{{worker['name']}}</th>
             <td>{{worker['num_autograding_workers']}}</td>
-            {% for capability in worker['capabilities'] %}
-                {% if capability %}
+            {% for capability in capabilities %}
+                {% if capability in worker['capabilities'] %}
                     <td><i class="fas fa-check"></i></td>
                 {% else %}
                     <td></td>


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #6904
If the machine does not have a capability that another machine has, there is no empty cell displayed for that capability and all of the capabilities check marks are rendered together making it impossible to interpret the information.

### What is the new behavior?
The empty cells are displayed properly.
![image](https://user-images.githubusercontent.com/49821332/128549406-27fc1016-8f2d-4356-93d5-d60374d787e7.png)

To test, you can edit `autograding_workers.json` in `/usr/local/submitty/config` folder on your vm to have a second machine.
