### PR TITLE
[Feature:Plagiarism] Add loading indicators

### DIFF
--- a/site/app/templates/plagiarism/PlagiarismResult.twig
+++ b/site/app/templates/plagiarism/PlagiarismResult.twig
@@ -5,7 +5,7 @@
 </script>
 <div class="content plagiarism-result-cont">
     <div id="result-title-bar">
-        <h2 style="display:inline;">{{ gradeable_title }} <span class="config-id-title">#{{ config_id }}</span> </h2>
+        <h2 style="display:inline;">{{ gradeable_title }} <span class="config-id-title">#{{ config_id }}</span></h2>
         <span class="plag-results-header-right">
             <a class="btn btn-primary" onclick="showPlagiarismHighKey()">View Key</a>
             <a class="btn btn-primary" onclick="toggleFullScreenMode();">Toggle Full-Screen</a>
@@ -40,11 +40,17 @@
     <div class="code-cont">
         <div class="sub">
             <div class="sub-item left-sub-item">
-                <textarea id="code_box_1" name="code_box_1"></textarea>
+                <div class="loading-animation left-loader"></div>
+                <div class="left-sub-item-middle blurry">
+                    <textarea id="code_box_1" name="code_box_1"></textarea>
+                </div>
             </div>
             <div class="plag-drag-bar"></div>
             <div class="sub-item right-sub-item">
-                <textarea id="code_box_2" name="code_box_2"></textarea>
+                <div class="loading-animation right-loader"></div>
+                <div class="right-sub-item-middle blurry">
+                    <textarea id="code_box_2" name="code_box_2"></textarea>
+                </div>
             </div>
         </div>
     </div>

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -236,12 +236,36 @@ main#main.full-screen-mode .plagiarism-result-cont {
     min-width: 100px;
 }
 
+.loading-animation {
+    border: 5px solid var(--standard-dark-gray);
+    border-top: 5px solid rgba(0,0,0,0);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    width: 3em;
+    height: 3em;
+    position: absolute;
+    top: calc(50% - 1.5em);
+    z-index: 1000;
+}
+
+.loading-animation.left-loader {
+    left: calc(25% - 7px - 1.5em);
+}
+
+.loading-animation.right-loader {
+    left: calc(75% - 7px - 1.5em);
+}
+
 .left-sub-item {
-    width: 49%;
+    width: calc(50% - 7px);
 }
 
 .right-sub-item {
-    flex: 1 1 0%;
+    flex: 1 1 0;
+}
+
+.blurry {
+    filter: blur(1px);
 }
 
 .plag-drag-bar {

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -256,6 +256,11 @@ main#main.full-screen-mode .plagiarism-result-cont {
     left: calc(75% - 7px - 1.5em);
 }
 
+.left-sub-item-middle,
+.right-sub-item-middle {
+    height: 100%;
+}
+
 .left-sub-item {
     width: calc(50% - 7px);
 }

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -102,6 +102,8 @@ function user1DropdownChanged(state) {
     state.editor2.refresh();
 
     // the call to trigger the chain of updates
+    showLoadingIndicatorRight();
+    showLoadingIndicatorLeft();
     loadUser1VersionDropdownList(state);
 }
 
@@ -121,6 +123,8 @@ function user1VersionDropdownChanged(state) {
     state.editor2.refresh();
 
     // the call to trigger the chain of updates
+    showLoadingIndicatorRight();
+    showLoadingIndicatorLeft();
     loadUser2DropdownList(state);
     loadConcatenatedFileForEditor(state, 1);
 }
@@ -142,6 +146,7 @@ function user2DropdownChanged(state) {
     }
 
     // load new content for the editor
+    showLoadingIndicatorRight();
     loadConcatenatedFileForEditor(state, 2);
     loadColorInfo(state);
 }
@@ -318,7 +323,7 @@ function refreshUser2Dropdown(state) {
 function refreshColorInfo(state) {
     state.editor1.operation(() => {
         state.editor2.operation(() => {
-            // codemirror doesn't preovide an easy way to remove text marks so we just wipe the contents of the document and reset
+            // codemirror doesn't provide an easy way to remove text marks so we just wipe the contents of the document and reset
             const val = state.editor1.getDoc().getValue();
             const scrollPos = state.editor1.getScrollInfo();
             state.editor1.getDoc().setValue('');
@@ -392,6 +397,8 @@ function refreshColorInfo(state) {
     });
     state.editor1.refresh();
     state.editor2.refresh();
+    hideLoadingIndicatorLeft();
+    hideLoadingIndicatorRight();
 }
 
 
@@ -472,6 +479,7 @@ function handleClickedMarks(state) {
                 $(`#others_menu_${i}`).on('click', () => {
                     // hiding the popup and resetting the text color immediately makes the page feel faster
                     $('#popup_to_show_matches_id').css('display', 'none');
+                    showLoadingIndicatorRight();
                     clickedMark.className = clickedMark.attributes.original_color;
                     state.editor2.getDoc().setValue('');
                     state.editor2.refresh();
@@ -497,6 +505,30 @@ function handleClickedMarks(state) {
         state.editor1.refresh();
         state.editor2.refresh();
     };
+}
+
+
+function showLoadingIndicatorLeft() {
+    $('.left-sub-item-middle').addClass('blurry');
+    $('.left-loader').css('display', 'block');
+}
+
+
+function hideLoadingIndicatorLeft() {
+    $('.left-sub-item-middle').removeClass('blurry');
+    $('.left-loader').css('display', 'none');
+}
+
+
+function showLoadingIndicatorRight() {
+    $('.right-sub-item-middle').addClass('blurry');
+    $('.right-loader').css('display', 'block');
+}
+
+
+function hideLoadingIndicatorRight() {
+    $('.right-sub-item-middle').removeClass('blurry');
+    $('.right-loader').css('display', 'none');
 }
 
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -419,6 +419,8 @@ function refreshColorInfo(state) {
     if (previousSelectedMark !== null) {
         handleClickedMark_editor1(state, previousSelectedMark);
     }
+    hideLoadingIndicatorLeft();
+    hideLoadingIndicatorRight();
 }
 
 


### PR DESCRIPTION
### What is the current behavior?
Currently, it is sometimes hard to tell whether the plagiarism results page has loaded fully.  An attempt was made to visually indicate that the data is loading by clearing the code boxes immediately and repopulating them when the data has loaded but it's not ideal. 

### What is the new behavior?
This PR introduces loading indicators which cover editors when they are loading data to make it explicitly clear when the data has finished loading.

https://user-images.githubusercontent.com/16820599/128772925-784b300a-8b1c-4e73-911c-50d1aa6cfe30.mov

