### PR TITLE
[Bugfix:Developer] Fix KeyError in setup script

### DIFF
--- a/.setup/bin/setup_sample_courses.py
+++ b/.setup/bin/setup_sample_courses.py
@@ -1688,8 +1688,8 @@ class Gradeable(object):
                 self.max_team_size = gradeable['eg_max_team_size']
             if 'eg_team_lock_date' in gradeable:
                 self.team_lock_date = submitty_utils.parse_datetime(gradeable['eg_team_lock_date'])
-            self.has_due_date = gradeable['eg_has_due_date']
-            self.has_release_date = gradeable['eg_has_release_date']
+            self.has_due_date = gradeable['eg_has_due_date'] if 'eg_has_due_date' in gradeable else True
+            self.has_release_date = gradeable['eg_has_release_date'] if 'eg_has_release_date' in gradeable else True
             if self.config_path is None:
                 examples_path = os.path.join(MORE_EXAMPLES_DIR, self.id, "config")
                 tutorial_path = os.path.join(TUTORIAL_DIR, self.id, "config")


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

`setup_sample_courses.py` was erroring out for me due to the new plagarisism course not having the `eg_has_due_date` or `eg_has_release_date` keys for any of the electronic gradeables.

### What is the new behavior?

This modifies the setup script to allow these fields to be optional and defaulting to true if they're omitted. This is inline with the vast majority of how we use this particular field in the various course yml files.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
