### PR TITLE
[Testing:CourseMaterials] Disable failing  Cypress tests in CI

### DIFF
--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -89,102 +89,102 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('.file-viewer').should('not.exist');
     });
 
-    it('Should release course materials by date', () => {
-        const date = '2021-06-29 21:37:53';
-        cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
-        cy.get('#upload_picker').clear().type(date);
-        cy.get('#cm_path').click();
-        cy.get('#upload1').attachFile(['file1.txt', 'file2.txt'] , { subjectType: 'drag-n-drop' });
-        cy.get('#submit-materials').click();
-
-        cy.get('#date_to_release_sf1').should('have.value', date);
-        cy.get('#date_to_release_sf1').should('have.value', date);
-
-        cy.reload(); //dom elements become detatched after uploading?
-
-        cy.get('.fa-pencil-alt').first().click();
-        cy.get('#edit-picker').clear().type('9998-01-01 00:00:00');
-        cy.get('#submit-edit').click({force: true}); //div covering button
-        cy.get('#date_to_release_sf1').should('have.value', '9998-01-01 00:00:00');
-
-        cy.reload();
-
-        cy.logout();
-        cy.login('aphacker');
-        cy.visit(['sample', 'course_materials']);
-        cy.get('.file-viewer').should('have.length', 1);
-
-        const fileTgt = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file2.txt`;
-
-        cy.visit(fileTgt);
-        cy.get('pre').should('have.text', 'b\n');
-        cy.visit(['sample', 'course_materials']);
-
-        const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file1.txt`;
-        cy.visit(fileTgt2);
-
-        cy.reload(true);
-        cy.get('.content').contains('Reason: You may not access this file until it is released');
-
-        cy.logout();
-        cy.login();
-
-        cy.visit(['sample', 'course_materials']);
-        cy.reload();
-
-        cy.get('.fa-trash').first().click();
-        cy.get('.btn-danger').click();
-
-        cy.get('.fa-trash').click();
-        cy.get('.btn-danger').click();
-    });
-
-    it('Should hide course materials visually', () => {
-        cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
-        cy.get('#upload1').attachFile('file1.txt' , { subjectType: 'drag-n-drop' });
-        cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
-        cy.get('#hide-materials-checkbox').check();
-        cy.get('#submit-materials').click();
-
-        cy.reload();
-
-        cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
-        cy.get('#input-provide-full-path').type('option1');
-        cy.get('#upload1').attachFile('file2.txt' , { subjectType: 'drag-n-drop' });
-        cy.get('#hide-materials-checkbox').check();
-        cy.get('#submit-materials').click();
-
-        cy.reload();
-
-        cy.logout();
-        cy.login('aphacker');
-        cy.visit(['sample', 'course_materials']);
-
-        cy.get('.file-viewer').should('not.exist');
-        const fileTgt = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file1.txt`;
-        cy.visit(fileTgt);
-        cy.get('pre').should('have.text', 'a\n');
-        cy.visit(['sample', 'course_materials']);
-
-        const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/option1/file2.txt`;
-        cy.visit(fileTgt2);
-        cy.get('.content').contains('Reason: You may not access this file until it is released');
-
-        cy.logout();
-        cy.login();
-        cy.visit(['sample', 'course_materials']);
-
-        cy.get('.fa-trash').first().click();
-        cy.get('.btn-danger').click();
-
-        cy.get('.fa-trash').first().click();
-        cy.get('.btn-danger').click();
-        cy.get('.file-viewer').should('not.exist');
-    });
-
     // These are not run in the CI because they are extremely flaky.  There is no other technical reason why they can't
     // be run on the CI and ultimately they should be uncommented.
     skipOn(Cypress.env('run_area') === 'CI', () => {
+        it('Should release course materials by date', () => {
+            const date = '2021-06-29 21:37:53';
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#upload_picker').clear().type(date);
+            cy.get('#cm_path').click();
+            cy.get('#upload1').attachFile(['file1.txt', 'file2.txt'] , { subjectType: 'drag-n-drop' });
+            cy.get('#submit-materials').click();
+
+            cy.get('#date_to_release_sf1').should('have.value', date);
+            cy.get('#date_to_release_sf1').should('have.value', date);
+
+            cy.reload(); //dom elements become detatched after uploading?
+
+            cy.get('.fa-pencil-alt').first().click();
+            cy.get('#edit-picker').clear().type('9998-01-01 00:00:00');
+            cy.get('#submit-edit').click({force: true}); //div covering button
+            cy.get('#date_to_release_sf1').should('have.value', '9998-01-01 00:00:00');
+
+            cy.reload();
+
+            cy.logout();
+            cy.login('aphacker');
+            cy.visit(['sample', 'course_materials']);
+            cy.get('.file-viewer').should('have.length', 1);
+
+            const fileTgt = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file2.txt`;
+
+            cy.visit(fileTgt);
+            cy.get('pre').should('have.text', 'b\n');
+            cy.visit(['sample', 'course_materials']);
+
+            const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file1.txt`;
+            cy.visit(fileTgt2);
+
+            cy.reload(true);
+            cy.get('.content').contains('Reason: You may not access this file until it is released');
+
+            cy.logout();
+            cy.login();
+
+            cy.visit(['sample', 'course_materials']);
+            cy.reload();
+
+            cy.get('.fa-trash').first().click();
+            cy.get('.btn-danger').click();
+
+            cy.get('.fa-trash').click();
+            cy.get('.btn-danger').click();
+        });
+
+        it('Should hide course materials visually', () => {
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#upload1').attachFile('file1.txt' , { subjectType: 'drag-n-drop' });
+            cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
+            cy.get('#hide-materials-checkbox').check();
+            cy.get('#submit-materials').click();
+
+            cy.reload();
+
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#input-provide-full-path').type('option1');
+            cy.get('#upload1').attachFile('file2.txt' , { subjectType: 'drag-n-drop' });
+            cy.get('#hide-materials-checkbox').check();
+            cy.get('#submit-materials').click();
+
+            cy.reload();
+
+            cy.logout();
+            cy.login('aphacker');
+            cy.visit(['sample', 'course_materials']);
+
+            cy.get('.file-viewer').should('not.exist');
+            const fileTgt = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file1.txt`;
+            cy.visit(fileTgt);
+            cy.get('pre').should('have.text', 'a\n');
+            cy.visit(['sample', 'course_materials']);
+
+            const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/option1/file2.txt`;
+            cy.visit(fileTgt2);
+            cy.get('.content').contains('Reason: You may not access this file until it is released');
+
+            cy.logout();
+            cy.login();
+            cy.visit(['sample', 'course_materials']);
+
+            cy.get('.fa-trash').first().click();
+            cy.get('.btn-danger').click();
+
+            cy.get('.fa-trash').first().click();
+            cy.get('.btn-danger').click();
+            cy.get('.file-viewer').should('not.exist');
+        });
+
         it('Should upload and unzip zip files', () => {
             cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
             cy.get('#expand-zip-checkbox').check();

--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -182,145 +182,147 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('.file-viewer').should('not.exist');
     });
 
-    it('Should upload and unzip zip files', () => {
-        cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
-        cy.get('#expand-zip-checkbox').check();
-        cy.get('#upload1').attachFile('zip.zip' , { subjectType: 'drag-n-drop' });
-        cy.get('#submit-materials').click();
-
-        cy.reload();
-        cy.get('[onclick=\'setCookie("foldersOpen",openAllDivForCourseMaterials());\']').click();
-        cy.get('.file-viewer').should('have.length', 23);
-
-        cy.get('#file-container .btn').eq(6).click();
-        cy.get('#date_to_release').clear().type('2021-06-29 21:37:53');
-        cy.get('#submit_time').click();
-
-        cy.reload();
-
-        for (let i = 0; i < 3; i++) {
-            cy.get('[name="release_date"]').eq(i).should('have.value', '9998-01-01 00:00:00');
-        }
-
-        for (let i = 3; i < 6; i++) {
-            cy.get('[name="release_date"]').eq(i).should('have.value', '2021-06-29 21:37:53');
-        }
-
-        for (let i = 6; i < 22; i++) {
-            cy.get('[name="release_date"]').eq(i).should('have.value', '9998-01-01 00:00:00');
-        }
-
-        cy.logout();
-        cy.login('aphacker');
-        cy.visit(['sample','course_materials']);
-
-        cy.get('.file-viewer').should('have.length', 3);
-
-        const fileTgt = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/zip/2/3/7/9/10/10_1.txt`;
-        cy.visit(fileTgt);
-        cy.get('body').should('have.text','');
-
-        const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/zip/1_1.txt`;
-        cy.visit(fileTgt2);
-        cy.get('.content').contains('Reason: You may not access this file until it is released');
-
-        cy.logout();
-        cy.login();
-
-        cy.visit(['sample', 'course_materials']);
-        cy.get('.fa-trash').first().click();
-        cy.get('.btn-danger').click();
-        cy.get('.file-viewer').should('not.exist');
-    });
-
-    it('Should restrict course materials by section', () => {
-        cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
-        cy.get('#all_Sections_Showing_yes').click();
-        cy.get('#upload1').attachFile(['file1.txt', 'file2.txt'] , { subjectType: 'drag-n-drop' });
-        cy.get('#section-1').check();
-        cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
-        cy.get('#cm_path').click();
-        cy.get('#submit-materials').click();
-
-        cy.reload();
-        cy.get('.fa-pencil-alt').last().click();
-        cy.get('#section-edit-2').check();
-        cy.get('#submit-edit').click();
-
-        cy.reload();
-        cy.logout();
-        cy.login('aphacker');
-        cy.visit(['sample', 'course_materials']);
-
-        cy.get('.file-viewer').should('have.length', 2);
-
-        cy.logout();
-        cy.login('browna');
-        cy.visit(['sample', 'course_materials']);
-
-        cy.get('.file-viewer').should('have.length', 1);
-
-        const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file1.txt`;
-
-        cy.visit(fileTgt2);
-        cy.wait(1000);
-        cy.get('.content').contains('Reason: Your section may not access this file');
-
-        cy.visit('/');
-        cy.wait(1000);
-        cy.logout();
-        cy.reload(true);
-        cy.login();
-
-        cy.visit(['sample', 'course_materials']);
-        cy.get('.fa-trash').first().click();
-        cy.get('.btn-danger').click();
-
-        cy.get('.fa-trash').click();
-        cy.get('.btn-danger').click();
-        cy.get('.file-viewer').should('not.exist');
-
-    });
-
-    it('Should restrict course materials within folders', () => {
-        cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
-        cy.get('#all_Sections_Showing_yes').click();
-        cy.get('#upload1').attachFile('zip.zip' , { subjectType: 'drag-n-drop' });
-        cy.get('#section-1').check();
-        cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
-        cy.get('#expand-zip-checkbox').check();
-        cy.get('#submit-materials').click();
-
-        cy.reload();
-        cy.get('[onclick=\'setCookie("foldersOpen",openAllDivForCourseMaterials());\']').click();
-        cy.get('.fa-pencil-alt').eq(24).click();
-        cy.get('#all-sections-showing-yes').click();
-        cy.get('#section-edit-2').check();
-        cy.get('#submit-edit').click();
-
-        cy.reload(true);
-        cy.logout();
-        cy.login('browna');
-        cy.visit(['sample', 'course_materials']);
-
-        cy.get('.file-viewer').should('have.length', 1);
-        const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/zip/1_1.txt`;
-        cy.visit(fileTgt2);
-
-        cy.wait(1000);
-        cy.get('.content').contains('Reason: Your section may not access this file');
-        cy.visit('/');
-        cy.wait(1000);
-        cy.logout();
-        cy.reload(true);
-
-        cy.login();
-        cy.visit(['sample', 'course_materials']);
-        cy.get('.fa-trash').first().click();
-        cy.get('.btn-danger').click();
-    });
-
+    // These are not run in the CI because they are extremely flaky.  There is no other technical reason why they can't
+    // be run on the CI and ultimately they should be uncommented.
     skipOn(Cypress.env('run_area') === 'CI', () => {
+        it('Should upload and unzip zip files', () => {
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#expand-zip-checkbox').check();
+            cy.get('#upload1').attachFile('zip.zip' , { subjectType: 'drag-n-drop' });
+            cy.get('#submit-materials').click();
+
+            cy.reload();
+            cy.get('[onclick=\'setCookie("foldersOpen",openAllDivForCourseMaterials());\']').click();
+            cy.get('.file-viewer').should('have.length', 23);
+
+            cy.get('#file-container .btn').eq(6).click();
+            cy.get('#date_to_release').clear().type('2021-06-29 21:37:53');
+            cy.get('#submit_time').click();
+
+            cy.reload();
+
+            for (let i = 0; i < 3; i++) {
+                cy.get('[name="release_date"]').eq(i).should('have.value', '9998-01-01 00:00:00');
+            }
+
+            for (let i = 3; i < 6; i++) {
+                cy.get('[name="release_date"]').eq(i).should('have.value', '2021-06-29 21:37:53');
+            }
+
+            for (let i = 6; i < 22; i++) {
+                cy.get('[name="release_date"]').eq(i).should('have.value', '9998-01-01 00:00:00');
+            }
+
+            cy.logout();
+            cy.login('aphacker');
+            cy.visit(['sample','course_materials']);
+
+            cy.get('.file-viewer').should('have.length', 3);
+
+            const fileTgt = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/zip/2/3/7/9/10/10_1.txt`;
+            cy.visit(fileTgt);
+            cy.get('body').should('have.text','');
+
+            const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/zip/1_1.txt`;
+            cy.visit(fileTgt2);
+            cy.get('.content').contains('Reason: You may not access this file until it is released');
+
+            cy.logout();
+            cy.login();
+
+            cy.visit(['sample', 'course_materials']);
+            cy.get('.fa-trash').first().click();
+            cy.get('.btn-danger').click();
+            cy.get('.file-viewer').should('not.exist');
+        });
+
+        it('Should restrict course materials by section', () => {
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#all_Sections_Showing_yes').click();
+            cy.get('#upload1').attachFile(['file1.txt', 'file2.txt'] , { subjectType: 'drag-n-drop' });
+            cy.get('#section-1').check();
+            cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
+            cy.get('#cm_path').click();
+            cy.get('#submit-materials').click();
+
+            cy.reload();
+            cy.get('.fa-pencil-alt').last().click();
+            cy.get('#section-edit-2').check();
+            cy.get('#submit-edit').click();
+
+            cy.reload();
+            cy.logout();
+            cy.login('aphacker');
+            cy.visit(['sample', 'course_materials']);
+
+            cy.get('.file-viewer').should('have.length', 2);
+
+            cy.logout();
+            cy.login('browna');
+            cy.visit(['sample', 'course_materials']);
+
+            cy.get('.file-viewer').should('have.length', 1);
+
+            const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/file1.txt`;
+
+            cy.visit(fileTgt2);
+            cy.wait(1000);
+            cy.get('.content').contains('Reason: Your section may not access this file');
+
+            cy.visit('/');
+            cy.wait(1000);
+            cy.logout();
+            cy.reload(true);
+            cy.login();
+
+            cy.visit(['sample', 'course_materials']);
+            cy.get('.fa-trash').first().click();
+            cy.get('.btn-danger').click();
+
+            cy.get('.fa-trash').click();
+            cy.get('.btn-danger').click();
+            cy.get('.file-viewer').should('not.exist');
+
+        });
+
+        it('Should restrict course materials within folders', () => {
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#all_Sections_Showing_yes').click();
+            cy.get('#upload1').attachFile('zip.zip' , { subjectType: 'drag-n-drop' });
+            cy.get('#section-1').check();
+            cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
+            cy.get('#expand-zip-checkbox').check();
+            cy.get('#submit-materials').click();
+
+            cy.reload();
+            cy.get('[onclick=\'setCookie("foldersOpen",openAllDivForCourseMaterials());\']').click();
+            cy.get('.fa-pencil-alt').eq(24).click();
+            cy.get('#all-sections-showing-yes').click();
+            cy.get('#section-edit-2').check();
+            cy.get('#submit-edit').click();
+
+            cy.reload(true);
+            cy.logout();
+            cy.login('browna');
+            cy.visit(['sample', 'course_materials']);
+
+            cy.get('.file-viewer').should('have.length', 1);
+            const fileTgt2 = `${buildUrl(['sample', 'display_file'])}?dir=course_materials&path=${encodeURIComponent(defaultFilePath)}/zip/1_1.txt`;
+            cy.visit(fileTgt2);
+
+            cy.wait(1000);
+            cy.get('.content').contains('Reason: Your section may not access this file');
+            cy.visit('/');
+            cy.wait(1000);
+            cy.logout();
+            cy.reload(true);
+
+            cy.login();
+            cy.visit(['sample', 'course_materials']);
+            cy.get('.fa-trash').first().click();
+            cy.get('.btn-danger').click();
+        });
+
         it('Should sort course materials', () => {
             cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
             cy.get('#input-provide-full-path').type('a');


### PR DESCRIPTION
### What is the current behavior?
The course materials Cypress tests have been failing on GitHub Actions with regularity since being added but work locally.  Several attempts have been made to fix them and have failed.  The flakiness of these tests has led to a potentially dangerous lack of caution when merging pull requests with failing tests because the frequency is so high.

### What is the new behavior?
This PR is a (hopefully) temporary fix to disable the failing course materials tests on GitHub Actions until they can be fixed permanently.  