### PR TITLE
[Bugfix:TAGrading] Change Grade to View Submissions

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -670,6 +670,9 @@ class NavigationView extends AbstractView {
                 if ($list_section != GradeableList::OPEN) {
                     $title = "PREVIEW GRADING";
                 }
+                if (!$gradeable->isTaGrading()) {
+                    $title = "VIEW SUBMISSIONS";
+                }
                 return new Button($this->core, [
                     "title" => $title,
                     "class" => "btn btn-nav btn-nav-grade btn-default",

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -673,12 +673,15 @@ class NavigationView extends AbstractView {
                 if (!$gradeable->isTaGrading()) {
                     $title = "VIEW SUBMISSIONS";
                 }
-                return new Button($this->core, [
+                $array = [
                     "title" => $title,
                     "class" => "btn btn-nav btn-nav-grade btn-default",
-                    "href" => $href,
-                    "progress" => 100 * $progress_bar
-                ]);
+                    "href" => $href
+                ];
+                if ($gradeable->isTaGrading()) {
+                    $array["progress"] = 100 * $progress_bar;
+                }
+                return new Button($this->core, $array);
             }
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If there is an assignment without a due date that has no TA grading it will still say grade.

### What is the new behavior?
Now it is changed to view submissions if it does not have TA grading turned on.
