### PR TITLE
[Refactor:Plagiarism] Reduce plag. results page load time

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -199,8 +199,8 @@ class PlagiarismController extends AbstractController {
         }
 
         $content = file_get_contents($file_path);
-        $content = trim(str_replace(["\r", "\n"], ' ', $content));
-        $rankings = preg_split('/ +/', $content);
+        $content = trim($content);
+        $rankings = preg_split('/\s+/', $content);
         $rankings = array_chunk($rankings, 3);
         return $rankings;
     }
@@ -221,8 +221,8 @@ class PlagiarismController extends AbstractController {
         }
 
         $content = file_get_contents($file_path);
-        $content = trim(str_replace(["\r", "\n"], ' ', $content));
-        $rankings = preg_split('/ +/', $content);
+        $content = trim($content);
+        $rankings = preg_split('/\s+/', $content);
         $rankings = array_chunk($rankings, 4);
         return $rankings;
     }
@@ -390,11 +390,25 @@ class PlagiarismController extends AbstractController {
         }
 
         $is_team_assignment = $this->core->getQueries()->getGradeableConfig($gradeable_id)->isTeamAssignment();
+
+        $user_ids_and_names = [];
+        if (!$is_team_assignment) {
+            $user_ids = [];
+            foreach ($rankings_data as $item) {
+                $user_ids[] = $item[1];
+            }
+
+            $user_ids_and_names = $this->core->getQueries()->getUsersByIds($user_ids);
+            if ($user_ids_and_names === null) {
+                return JsonResponse::getErrorResponse("Error: Unable to load left dropdown list");
+            }
+        }
+
         $rankings = [];
         foreach ($rankings_data as $item) {
             $display_name = "";
             if (!$is_team_assignment) {
-                $display_name = "{$this->core->getQueries()->getUserById($item[1])->getDisplayedFirstName()} {$this->core->getQueries()->getUserById($item[1])->getDisplayedLastName()}";
+                $display_name = "{$user_ids_and_names[$item[1]]->getDisplayedFirstName()} {$user_ids_and_names[$item[1]]->getDisplayedLastName()}";
             }
             $temp = [
                 "percent" => $item[0],
@@ -1213,12 +1227,26 @@ class PlagiarismController extends AbstractController {
             return JsonResponse::getErrorResponse($e->getMessage());
         }
 
-        $return = [];
         $is_team_assignment = $this->core->getQueries()->getGradeableConfig($gradeable_id)->isTeamAssignment();
+
+        $user_ids_and_names = [];
+        if (!$is_team_assignment) {
+            $user_ids = [];
+            foreach ($ranking as $item) {
+                $user_ids[] = $item[1];
+            }
+
+            $user_ids_and_names = $this->core->getQueries()->getUsersByIds($user_ids);
+            if ($user_ids_and_names === null) {
+                return JsonResponse::getErrorResponse("Error: Unable to load right dropdown list");
+            }
+        }
+
+        $return = [];
         foreach ($ranking as $item) {
             $display_name = "";
             if (!$is_team_assignment) {
-                $display_name = "{$this->core->getQueries()->getUserById($item[1])->getDisplayedFirstName()} {$this->core->getQueries()->getUserById($item[1])->getDisplayedLastName()}";
+                $display_name = "{$user_ids_and_names[$item[1]]->getDisplayedFirstName()} {$user_ids_and_names[$item[1]]->getDisplayedLastName()}";
             }
             $temp = [
                 "percent" => $item[0],

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -481,7 +481,8 @@ class PlagiarismController extends AbstractController {
 
             $user_ids_and_names = $this->core->getQueries()->getUsersByIds($user_ids);
             if ($user_ids_and_names === null) {
-                return JsonResponse::getErrorResponse("Error: Unable to load left dropdown list");
+                $this->core->addErrorMessage("Error: Unable to load left dropdown list");
+                return new RedirectResponse($error_return_url);
             }
         }
 

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -476,8 +476,9 @@ class PlagiarismController extends AbstractController {
         if (!$is_team_assignment) {
             $user_ids = [];
             foreach ($rankings_data as $item) {
-                $user_ids[] = $item[1];
+                $user_ids[$item[1]] = null;
             }
+            $user_ids = array_keys($user_ids);
 
             $user_ids_and_names = $this->core->getQueries()->getUsersByIds($user_ids);
             if ($user_ids_and_names === null) {
@@ -1316,8 +1317,9 @@ class PlagiarismController extends AbstractController {
         if (!$is_team_assignment) {
             $user_ids = [];
             foreach ($ranking as $item) {
-                $user_ids[] = $item[1];
+                $user_ids[$item[1]] = null;
             }
+            $user_ids = array_keys($user_ids);
 
             $user_ids_and_names = $this->core->getQueries()->getUsersByIds($user_ids);
             if ($user_ids_and_names === null) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7181,7 +7181,7 @@ AND gc_id IN (
         }
 
         $users = [];
-        foreach ($details_list as &$details) {
+        foreach ($details_list as $details) {
             $users[$details['user_id']] = new User($this->core, $details);
         }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -153,6 +153,16 @@ class DatabaseQueries {
     }
 
     /**
+     * Gets a user from the database given a numeric user_id.
+     *
+     * @param int $numeric_id
+     * @return User|null
+     */
+    public function getUserByNumericId(int $numeric_id): ?User {
+        return $this->getUser($numeric_id, true);
+    }
+
+    /**
      * Gets a list of first and last names from the database given an array of IDs.
      *
      * @param array $user_id_list
@@ -162,26 +172,6 @@ class DatabaseQueries {
         return $this->getUsers($user_id_list);
     }
 
-    /**
-     * @param int $numeric_id
-     * @return User|null
-     */
-    public function getUserByNumericId(int $numeric_id): ?User {
-        return $this->getUser($numeric_id, true);
-    }
-
-    /**
-     * @param int|string $id
-     * @return User|null
-     */
-    public function getUserByIdOrNumericId($id): ?User {
-        $ret = $this->getUser($id);
-        if ($ret === null) {
-            return $this->getUser($id, true);
-        }
-
-        return $ret;
-    }
     /**
      * Retrieves all students from a course and their virtual attendance
      * information such as logs for the course materials page, and logs

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7177,18 +7177,18 @@ AND gc_id IN (
             );
 
             $updated_details_list = [];
-             if ($this->course_db->getRowCount() > 0) {
-                 $i = 0;
-                 foreach ($details_list as $details) {
-                     $user = $this->course_db->rows()[$i];
-                     if (isset($user['grading_registration_sections'])) {
-                         $user['grading_registration_sections'] = $this->course_db->fromDatabaseToPHPArray($user['grading_registration_sections']);
-                     }
-                     $updated_details_list[] = array_merge($details, $user);
-                     $i++;
-                 }
-                 $details_list = $updated_details_list;
-             }
+            if ($this->course_db->getRowCount() > 0) {
+                $i = 0;
+                foreach ($details_list as $details) {
+                    $user = $this->course_db->rows()[$i];
+                    if (isset($user['grading_registration_sections'])) {
+                        $user['grading_registration_sections'] = $this->course_db->fromDatabaseToPHPArray($user['grading_registration_sections']);
+                    }
+                    $updated_details_list[] = array_merge($details, $user);
+                    $i++;
+                }
+                $details_list = $updated_details_list;
+            }
         }
 
         $users = [];

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7193,9 +7193,6 @@ AND gc_id IN (
 
         $users = [];
         foreach ($details_list as $details) {
-            if (isset($users[$details['user_id']])) {
-                $test = $details['user_id'];
-            }
             $users[$details['user_id']] = new User($this->core, $details);
         }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -163,15 +163,15 @@ class DatabaseQueries {
     }
 
     /**
-     * @param $numeric_id
+     * @param int $numeric_id
      * @return User|null
      */
-    public function getUserByNumericId($numeric_id): ?User {
+    public function getUserByNumericId(int $numeric_id): ?User {
         return $this->getUser($numeric_id, true);
     }
 
     /**
-     * @param $id
+     * @param int|string $id
      * @return User|null
      */
     public function getUserByIdOrNumericId($id): ?User {
@@ -7122,11 +7122,11 @@ AND gc_id IN (
     /**
      * Given an array of user IDs, return an array of corresponding user objects or null if any one of them wasn't found
      *
-     * @param $user_id_list
+     * @param array $user_id_list
      * @param bool $is_numeric
-     * @return User|null
+     * @return array|null
      */
-    private function getUsers($user_id_list, bool $is_numeric = false): ?array {
+    private function getUsers(array $user_id_list, bool $is_numeric = false): ?array {
         $placeholders = $this->createParamaterList(count($user_id_list));
 
         if (!$is_numeric) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7176,21 +7176,26 @@ AND gc_id IN (
                 $user_id_list
             );
 
-            $i = 0;
-            foreach ($details_list as &$details) {
-                if ($this->course_db->getRowCount() > 0) {
-                    $user = $this->course_db->rows()[$i];
-                    if (isset($user['grading_registration_sections'])) {
-                        $user['grading_registration_sections'] = $this->course_db->fromDatabaseToPHPArray($user['grading_registration_sections']);
-                    }
-                    $details = array_merge($details, $user);
-                }
-                $i++;
-            }
+            $updated_details_list = [];
+             if ($this->course_db->getRowCount() > 0) {
+                 $i = 0;
+                 foreach ($details_list as $details) {
+                     $user = $this->course_db->rows()[$i];
+                     if (isset($user['grading_registration_sections'])) {
+                         $user['grading_registration_sections'] = $this->course_db->fromDatabaseToPHPArray($user['grading_registration_sections']);
+                     }
+                     $updated_details_list[] = array_merge($details, $user);
+                     $i++;
+                 }
+                 $details_list = $updated_details_list;
+             }
         }
 
         $users = [];
         foreach ($details_list as $details) {
+            if (isset($users[$details['user_id']])) {
+                $test = $details['user_id'];
+            }
             $users[$details['user_id']] = new User($this->core, $details);
         }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -634,7 +634,12 @@ class HomeworkView extends AbstractView {
 
                 if (array_key_exists('id', $data)) {
                     $id = $data['id'];
-                    $is_valid = null !== $this->core->getQueries()->getUserByIdOrNumericId($id);
+                    if (is_numeric($id)) {
+                        $is_valid = $this->core->getQueries()->getUserByNumericId($id) !== null;
+                    }
+                    else {
+                        $is_valid = $this->core->getQueries()->getUserById($id) !== null;
+                    }
                 }
                 else {
                     //set the blank id as invalid for now, after a page refresh it will recorrect


### PR DESCRIPTION
### What is the current behavior?
Currently, loading the plagiarism results page takes a substantial amount of time.  Most of this time is not spent loading what should be the most expensive parts of the page, but rather making repeated database queries to determine the first and last name associated with each submission.

### What is the new behavior?
This PR combines the repeated database queries into a single query.  In testing, this more than halved the overall page load time for a gradeable with 75 submissions with results.  In the case of a large class of 300 students, each making 5-10 submissions, the load time improvements could be even greater than the ones observed in testing.