### PR TITLE
[Bugfix:Autograding] parse no due date / submission deadline

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -473,12 +473,21 @@ def archive_autograding_results(
                 jobname=item_name,
             )
 
-        gradeable_deadline_string = gradeable_config_obj["date_due"]
         submission_datetime = dateutils.read_submitty_date(submission_string)
-        gradeable_deadline_datetime = dateutils.read_submitty_date(gradeable_deadline_string)
-        gradeable_deadline_longstring = dateutils.write_submitty_date(gradeable_deadline_datetime)
         submission_longstring = dateutils.write_submitty_date(submission_datetime)
-        seconds_late = int((submission_datetime-gradeable_deadline_datetime).total_seconds())
+
+        # compute lateness (if there is a due date / submission deadline)
+        gradeable_deadline_string = gradeable_config_obj["date_due"]
+        if gradeable_deadline_string is None:
+            print ("NO DEADLINE")
+            gradeable_deadline_longstring = "None";
+            seconds_late = 0
+        else:
+            print ("DEADLINE IS '"+str(gradeable_deadline_string)+"'")
+            gradeable_deadline_datetime = dateutils.read_submitty_date(gradeable_deadline_string)
+            gradeable_deadline_longstring = dateutils.write_submitty_date(gradeable_deadline_datetime)
+            seconds_late = int((submission_datetime-gradeable_deadline_datetime).total_seconds())
+
         # compute the access duration in seconds (if it exists)
         access_duration = -1
         if first_access_string != "":

--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -479,11 +479,11 @@ def archive_autograding_results(
         # compute lateness (if there is a due date / submission deadline)
         gradeable_deadline_string = gradeable_config_obj["date_due"]
         if gradeable_deadline_string is None:
-            print ("NO DEADLINE")
-            gradeable_deadline_longstring = "None";
+            print("NO DEADLINE")
+            gradeable_deadline_longstring = "None"
             seconds_late = 0
         else:
-            print ("DEADLINE IS '"+str(gradeable_deadline_string)+"'")
+            print("DEADLINE IS '"+str(gradeable_deadline_string)+"'")
             gradeable_deadline_datetime = dateutils.read_submitty_date(gradeable_deadline_string)
             gradeable_deadline_longstring = dateutils.write_submitty_date(gradeable_deadline_datetime)
             seconds_late = int((submission_datetime-gradeable_deadline_datetime).total_seconds())

--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -263,7 +263,7 @@ def archive(
             False
         )
     except Exception:
-        print("\n\nERROR: Grading incomplete -- could not perform archival")
+        print("\n\nERROR: Grading incomplete -- could not archive autograding results")
         config.logger.log_message(
             "ERROR: could not archive autograding results. See stack trace for more info.",
             job_id=queue_obj['job_id'],


### PR DESCRIPTION
### What is the current behavior?
PR #5969 made the due date / submission deadline optional, but this breaks the computation of lateness within the autograding shipper/worker

### What is the new behavior?
Correctly parse / handle lack of due date.  