### PR TITLE
[Bugfix:TAGrading] Fix text color for download button

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -250,14 +250,14 @@ div.btn-container {
 
 #zip_link_limited {
     text-decoration: none;
-    color: var(--text-black);
+    color: var(--btn-text-white);
     padding: 10px;
     padding-left: 0;
 }
 
 #zip_link_full {
     text-decoration: none;
-    color: var(--text-black);
+    color: var(--btn-default-text);
     padding: 10px;
     padding-left: 0;
 }


### PR DESCRIPTION
### What is the current behavior?
The text color for downloading a zip for assigned teams/students on the TA grading stats page is black in light mode, making it difficult to read.

### What is the new behavior?
The text color for downloading a zip for assigned teams/students on the TA grading stats page changes depending on if the user is in light or dark mode.
