### PR TITLE
[Bugfix:HelpQueue] Fix Twig Error

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueStats.twig
+++ b/site/app/templates/officeHoursQueue/QueueStats.twig
@@ -60,9 +60,11 @@
   <table class="table">
     <thead>
       <tr>
+      {% if 0 in week_day_this_week_data %}
         {% for key, item in week_day_this_week_data[0] %}
           <th style="padding:.4rem">{{viewer.statNiceName(key)}}</th>
         {% endfor %}
+      {% endif %}
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The office hour queue stats page has a twig error preventing loading of the page.
Closes #6909 

### What is the new behavior?
An array index gets checked for before there is an attempt to access it.

