### PR TITLE
[Bugfix:TAGrading] Restore Version Conflict Message

### DIFF
--- a/site/public/templates/grading/GradingComponentHeader.twig
+++ b/site/public/templates/grading/GradingComponentHeader.twig
@@ -38,7 +38,7 @@
         'cancel_on_click': 'onCancelComponent(this)'
     } only %}
 </span>
-{% if component_version_conflict is same as(1) and not grading_disabled %}
+{% if component_version_conflict is same as(true) and not grading_disabled %}
     <span class="version-warning col-5">
         Please edit or ensure that comments from version {{ graded_component.graded_version }} still apply.
     </span>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The message warning you to edit or ensure the grade per component is missing which makes it tough to correct version conflicts.
Closes #6912

### What is the new behavior?
The message now shows when a version conflict exists.

### Other information?
To test you need to reload your caches as this is Twig.js. In chrome you have to open inspect element, right click the reload button, and click empty cache and hard reload.
