### PR TITLE
[Bugfix:TAGrading] Fix Shaky Overall Comments on Firefox

### DIFF
--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -59,7 +59,7 @@
             {{ other_textarea_attributes }}
         {% endif %}
     >{{ markdown_area_value is defined ? markdown_area_value : '' }}</textarea>
-    <div id="{{ preview_div_id }}" class="fill-available markdown-preview" style="min-height:{{ min_height is defined ? min_height : "0px" }}" hidden></div>
+    <div id="{{ preview_div_id }}" class="fill-available markdown-preview" style="min-height:{{ min_height is defined ? min_height : "0px" }}; max-height:{{ max_height is defined ? max_height : "none" }}" hidden></div>
 </div>
 
 <script>

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -39,7 +39,7 @@ Required Parameters:
             onclick : "previewOverallCommentMarkdown.call(this, '" ~ (overall_comment["logged_in_user"]["user_id"]|escape) ~ "')", 
             render_buttons : true,
             min_height : "100px",
-            textarea_onkeydown : "auto_grow(this)",
+            max_height : "150px",
             textarea_onchange : grading_disabled ? '' : 'onChangeOverallComment()',
             data_previous_comment : (overall_comment["logged_in_user"]["comment"]|escape)
         } only %}

--- a/site/public/templates/misc/MarkdownArea.twig
+++ b/site/public/templates/misc/MarkdownArea.twig
@@ -59,7 +59,7 @@
             {{ other_textarea_attributes }}
         {% endif %}
     >{{ markdown_area_value is defined ? markdown_area_value : '' }}</textarea>
-    <div id="{{ preview_div_id }}" class="fill-available markdown-preview" style="min-height:{{ min_height is defined ? min_height : "0px" }}" hidden></div>
+    <div id="{{ preview_div_id }}" class="fill-available markdown-preview" style="min-height:{{ min_height is defined ? min_height : "0px" }}; max-height:{{ max_height is defined ? max_height : "none" }}" hidden></div>
 </div>
 
 <script>


### PR DESCRIPTION
### What is the current behavior?
Fixes #6856 
Currently, when using the rubric panel on TA Grading to enter an overall comment on Firefox, if you are using a layout that makes this window small (such as 4 panel layout), then every time you type in the box, it shakes.

### What is the new behavior?
The box doesn't shake. However, Firefox does automatically scroll to focus to the line you are typing in. I tried various workarounds to fix this but ultimately they would be very hacky and figured it would be best to let the browser continue its default behavior.