### PR TITLE
[Bugfix:Submission] Sort Gradeables Without Due Date

### DIFF
--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -118,7 +118,25 @@ class GradeableList extends AbstractModel {
         ];
         foreach ($sort_array as $list => $function) {
             uasort($this->$list, function (Gradeable $a, Gradeable $b) use ($function) {
-                if ($a->$function() == $b->$function()) {
+                $skip = false;
+                if ($a->hasDueDate() && !$b->hasDueDate()) {
+                    return 1;
+                }
+                elseif (!$a->hasDueDate() && $b->hasDueDate()) {
+                    return -1;
+                }
+                elseif (!$a->hasDueDate() && !$b->hasDueDate()) {
+                    if ($a->getSubmissionOpenDate() > $b->getSubmissionOpenDate()) {
+                        return 1;
+                    }
+                    elseif ($a->getSubmissionOpenDate() < $b->getSubmissionOpenDate()) {
+                        return -1;
+                    }
+                    else {
+                        $skip = true;
+                    }
+                }
+                if ($skip || $a->$function() == $b->$function()) {
                     if (strtolower($a->getTitle()) == strtolower($b->getTitle())) {
                         if (strtolower($a->getId()) < strtolower($b->getId())) {
                             return -1;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Gradeables that have no due date still have a hidden due date which is being used to calculate how the gradeables are sorted.
Closes #6938

### What is the new behavior?
All gradeables without a due date will float to the top and get sorted by their submission open date while preserving the sorting of gradeables with due dates.
