### PR TITLE
[Bugfix:Autograding] short circuit gradeable with no due date

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1364,11 +1364,11 @@ def try_short_circuit(config: dict, queue_file: str) -> bool:
         )
         return False
 
-    job_id = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(6))
-    config.logger.log_message(f"Short-circuiting {gradeable_id}", job_id=job_id)
-
     if not can_short_circuit(config_obj):
         return False
+
+    job_id = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(6))
+    config.logger.log_message(f"Short-circuiting {gradeable_id}", job_id=job_id)
 
     # Augment the queue object
     base, path = os.path.split(queue_file)

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1275,9 +1275,13 @@ def history_short_circuit_helper(
     with open(submit_timestamp_path) as fd:
         submit_timestamp = dateutils.read_submitty_date(fd.read().rstrip())
     submit_time = dateutils.write_submitty_date(submit_timestamp)
-    gradeable_deadline_dt = dateutils.read_submitty_date(gradeable_deadline)
 
-    seconds_late = int((submit_timestamp - gradeable_deadline_dt).total_seconds())
+    # compute lateness (if there is a due date / submission deadline)
+    if gradeable_deadline is None:
+        seconds_late = 0
+    else:
+        gradeable_deadline_dt = dateutils.read_submitty_date(gradeable_deadline)
+        seconds_late = int((submit_timestamp - gradeable_deadline_dt).total_seconds())
 
     first_access = ''
     access_duration = -1


### PR DESCRIPTION
### What is the current behavior?
Assignments with no due date that have no autograding (can be short circuited) were hitting an bug trying to calculate the number of seconds late parsing a due date = None.

### What is the new behavior?
When due date is none, late seconds is set to zero correctly, allowing short circuiting again.

Also a log message was moved to a more appropriate location.