### PR TITLE
[UI/UX:TAGrading] Show Team/Student Scrollbar When Needed

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -516,7 +516,7 @@ progress::-webkit-progress-value {
 
 #grading-panel-student-name {
     position: absolute;
-    overflow-y: scroll;
+    overflow-y: auto;
     border-right: 1px solid var(--standard-light-medium-gray);
     left: 5px;
     top: 5px;


### PR DESCRIPTION
### What is the current behavior?
Fixes #6952 
A vertical scrollbar appears by the student name / team members in the grading interface, even if there is no content to scroll to.

### What is the new behavior?
The scrollbar only shows up when necessary.

### Other information?
I only was able to test this on Mac which has some differences when displaying scrollbars, it would be good if someone with Windows can test this.