### PR TITLE
[Bugfix:InstructorUI] Fix Gradeable Submission Date in SAD

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -192,7 +192,7 @@ class DatabaseQueries {
         C AS
         (SELECT distinct on (user_id) user_id,submission_time
         FROM electronic_gradeable_data
-        ORDER BY user_id, submission_time),
+        ORDER BY user_id, submission_time desc),
         D AS
         (SELECT distinct on (user_id) user_id, timestamp
         FROM viewed_responses


### PR DESCRIPTION
### What is the current behavior?
Fixes #6939 
Currently, on the student activity dashboard, the Gradeable Submission Date column shows the oldest submission date instead of the latest.

### What is the new behavior?
The Gradeable Submission Date column now shows the most recent submission date.

