### PR TITLE
[Bugfix:CourseMaterials] Fix Editing External Links

### DIFF
--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -274,21 +274,23 @@ class CourseMaterialsController extends AbstractController {
             $course_material->setPriority($_POST['sort_priority']);
         }
         if (isset($_POST['link_url']) && isset($_POST['link_title']) && $course_material->isLink()) {
-            $path = $course_material->getPath();
-            $dirs = explode("/", $path);
-            array_pop($dirs);
-            $path = implode("/", $dirs);
-            $path = FileUtils::joinPaths($path, urlencode("link-" . $_POST['link_title']));
-            $tmp_course_material = $this->core->getCourseEntityManager()->getRepository(CourseMaterial::class)
-                ->findOneBy(['path' => $path]);
-            if ($tmp_course_material !== null) {
-                return JsonResponse::getErrorResponse("Link already exists with that title in that directory.");
+            if ($_POST['link_title'] !== $course_material->getUrlTitle()) {
+                $path = $course_material->getPath();
+                $dirs = explode("/", $path);
+                array_pop($dirs);
+                $path = implode("/", $dirs);
+                $path = FileUtils::joinPaths($path, urlencode("link-" . $_POST['link_title']));
+                $tmp_course_material = $this->core->getCourseEntityManager()->getRepository(CourseMaterial::class)
+                    ->findOneBy(['path' => $path]);
+                if ($tmp_course_material !== null) {
+                    return JsonResponse::getErrorResponse("Link already exists with that title in that directory.");
+                }
+                FileUtils::writeFile($path, "");
+                unlink($course_material->getPath());
+                $course_material->setUrlTitle($_POST['link_title']);
+                $course_material->setPath($path);
             }
-            FileUtils::writeFile($path, "");
-            unlink($course_material->getPath());
             $course_material->setUrl($_POST['link_url']);
-            $course_material->setUrlTitle($_POST['link_title']);
-            $course_material->setPath($path);
         }
 
         if (isset($_POST['release_time']) && $_POST['release_time'] != '') {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you edit any field of a course material link it will give you an error that there is already a link with that title in that directory.

### What is the new behavior?
The link title shouldn't be tried to be updated unless it is actually changed now so this error would not happen except in cases where it is supposed to.
