### PR TITLE
[Bugfix:Autograding] Remove CGI for Docker UI

### DIFF
--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -35,26 +35,7 @@ class DockerInterfaceController extends AbstractController {
             );
         }
 
-        try {
-            $response = $this->core->curlRequest(
-                FileUtils::joinPaths($this->core->getConfig()->getCgiUrl(), "docker_ui.cgi")
-            );
-        }
-        catch (CurlException $exc) {
-            $msg = "Failed to get response from CGI process, please try again";
-            return new MultiResponse(
-                JsonResponse::getFailResponse($msg),
-                new WebResponse("Error", "errorPage", $msg)
-            );
-        }
-        $json = json_decode($response, true);
-
-        if ($json['success'] === false) {
-            return new MultiResponse(
-                JsonResponse::getFailResponse($json['error']),
-                new WebResponse("Error", "errorPage", $json['error'])
-            );
-        }
+        $json = [];
 
         $json['autograding_containers'] = FileUtils::readJsonFile(
             FileUtils::joinPaths(

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -2,20 +2,21 @@
     <h1>Submitty Docker Interface</h1>
 
     <h2>System Wide information:</h2>
-    {% if docker_info is not null %}
-        {# TODO: include worker information here in the future #}
-        <p>Docker Version : {{ docker_info['ServerVersion'] }} </p>
-        <p>Updated on: {{last_updated}}</p>
-        {% if error_logs | length > 0 %}
-            <h2 style="margin-top: 1vh;">Error Logs associated with the last update attempt:</h2>
-            <pre class="error-log">
-                {% for error_log in error_logs %}
-                    {{error_log ~ "\n"}}
-                {% endfor %}
-            </pre>
-        {% endif %}
-        <button class="btn btn-primary" id="update-machines" onclick=updateImage("{{admin_url}}/update_docker") style="margin-top: 1em"> Update dockers and machines</button>
+    {# TODO: include worker information here in the future #}
+    {#
+    Should be added back eventually, ideally showing workers' version as well
+    <p>Docker Version : {{ docker_info['ServerVersion'] }} </p>
+    #}
+    <p>Updated on: {{last_updated}}</p>
+    {% if error_logs | length > 0 %}
+        <h2 style="margin-top: 1vh;">Error Logs associated with the last update attempt:</h2>
+        <pre class="error-log">
+            {% for error_log in error_logs %}
+                {{error_log ~ "\n"}}
+            {% endfor %}
+        </pre>
     {% endif %}
+    <button class="btn btn-primary" id="update-machines" onclick=updateImage("{{admin_url}}/update_docker") style="margin-top: 1em"> Update dockers and machines</button>
 </div>
 
 <div class="content">
@@ -68,42 +69,21 @@
             <tr style="background: #000000">
                 <th>Image Name</th>
                 <th>Tag</th>
-                <th>ID</th>
-                <th>Alias</th>
-                <th>Created Date</th>
                 <th>Capabilities Containing This Image</th>
             </tr>
         </thead>
         <tbody>
-        {% for key, value in autograding_containers['all_images'] %}
-            <tr class="image-row" data-error={{value["name"] in fail_images ? "true" : "false"}}>
-                <td>{{ value["name"] }}</th>
-                <td>{{ value["tag"] }} </td>
-                <td>{{ value["short_id"] | trim("sha256:") }} </td>
+        {% for key, value in image_to_capability %}
+            <tr class="image-row" data-error={{key in fail_images ? "true" : "false"}}>
+                {% set full = key|split(":")  %}
+                {% set name = full[0] %}
+                {% set tag = full[1] %}
+                <td>{{ name }}</th>
+                <td>{{ tag }} </td>
                 <td>
-                {% if value["additional_names"] | length > 0 %}
-                <ul class="tag-list">
-                    {% for name in value["additional_names"] %}
-                    <li>{{ name }}</li>
+                    {% for capability in value %}
+                        <span class="badge" style="background-color:{{capability_to_color[capability]}}">{{capability}}</span>
                     {% endfor %}
-                </ul>
-                {% endif %}
-                </td>
-                <td> {{ value["created"] }} </td>
-                <td>
-                    {% if value["name"] ~ ':' ~ value["tag"] in image_to_capability|keys %}
-                        {% for capability in image_to_capability[value["name"] ~':'~ value["tag"]] %}
-                            <span class="badge" style="background-color:{{capability_to_color[capability]}}">{{capability}}</span>
-                        {% endfor %}
-                    {% else %}
-                        {% for name in value["additional_names"] %}
-                            {% if name in image_to_capability|keys %}
-                                {% for capability in image_to_capability[name] %}
-                                    <span class="badge" style="background-color:{{capability_to_color[capability]}}">{{capability}}</span>
-                                {% endfor %}
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
                 </td>
             </tr>
         {% endfor %}

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -56,7 +56,7 @@
             <div style="display:inline-block;">
                 <button class="btn btn-primary" id="show-all">Show All</button>
                 {% for capability in capabilities %}
-                    <button data-capability="{{capability}}" class="btn filter-buttons" style="background-color:var(--category-color-{{capability_to_color[capability]}}); border-color: {{capability_to_color[capability]}}">
+                    <button data-capability="{{capability}}" class="btn filter-buttons" style="background-color:var(--category-color-{{capability_to_color[capability]}});">
                         {{capability}}
                     </button>
                 {% endfor %}

--- a/site/app/views/admin/DockerView.php
+++ b/site/app/views/admin/DockerView.php
@@ -17,56 +17,6 @@ class DockerView extends AbstractView {
         $this->core->getOutput()->addInternalCss('table.css');
         $this->core->getOutput()->enableMobileViewport();
 
-        $found_images = [];
-        $not_found = [];
-        $autograding_containers = $docker_data['autograding_containers']['default'];
-
-        //make data more human readable
-        $copy = [];
-        foreach ($docker_data['docker_images'] as $image) {
-            $full_name = $image['tags'][0];
-            $parts = explode(":", $full_name);
-            $date = \DateTime::createFromFormat('Y-m-d\TH:i:s+', $image['created'])->format("Y-m-d H:i:s");
-            $image["name"] = $parts[0];
-            $image["tag"] = $parts[1];
-            $image["created"] = $date;
-            $image["size"] = Utils::formatBytes('mb', $image["size"], true);
-            $image["virtual_size"] = Utils::formatBytes('mb', $image["virtual_size"], true);
-            $image["additional_names"] = array_slice($image['tags'], 1);
-
-            $copy[$full_name] = $image;
-        }
-
-        $docker_data['docker_images'] = $copy;
-
-        //figure out which images are installed and listed in the config
-        foreach ($docker_data['docker_images'] as $image) {
-            foreach ($autograding_containers as $container) {
-                if (in_array($container, $image['tags'])) {
-                    $found_images[] = $image;
-                    break;
-                }
-            }
-        }
-
-        //figure out which images are listed in the config but not found
-        foreach ($autograding_containers as $autograding_image) {
-            $found = false;
-            foreach ($docker_data['docker_images'] as $image) {
-                $name = $image['tags'][0];
-
-                if (in_array($autograding_image, $image['tags'])) {
-                    $found = true;
-                    break;
-                }
-            }
-
-            if (!$found) {
-                $not_found[] = $autograding_image;
-            }
-        }
-
-
         //sort containers alphabetically
         $sort_containers = function (array $containers, string $key, int $order = SORT_ASC): array {
             $names = array_column($containers, $key);
@@ -75,11 +25,14 @@ class DockerView extends AbstractView {
         };
 
 
-        $autograding_containers = [
-            "found" => $sort_containers($found_images, 'name'),
-            "all_images" => $sort_containers($docker_data['docker_images'], 'name'),
-            "not_found" => sort($not_found)
-        ];
+        $images = [];
+        foreach ($docker_data['autograding_containers'] as $capability => $image_list) {
+            foreach ($image_list as $image) {
+                $images[] = $image;
+            }
+        }
+
+        $images = array_unique($images);
 
         $capabilities = [];
         $worker_machines = [];
@@ -108,17 +61,6 @@ class DockerView extends AbstractView {
                     $no_image_capabilities[] = $capability;
                 }
             }
-            // Get ride of duplicate images
-            $image_names = array_unique($image_names);
-            foreach ($image_names as $image) {
-                // Extra precaution since data is quite messy
-                if (array_key_exists($image, $autograding_containers['all_images'])) {
-                    $worker_temp['images'][] = $autograding_containers['all_images'][$image];
-                }
-                else {
-                    $worker_temp['images_not_found'][] = $image;
-                }
-            }
             $worker_machines[] = $worker_temp;
         }
 
@@ -126,7 +68,7 @@ class DockerView extends AbstractView {
         foreach ($image_to_capability as $image => $map) {
             $image_to_capability[$image] = array_unique($map);
         }
-        asort($capabilities);
+        sort($capabilities);
         $capability_to_color = [];
         $colors = ['#c3a2d2','#99b270','#cd98aa','#6bb88f','#c8938d','#6b9fb8','#c39e83','#98a3cd','#8ac78e','#b39b61','#6eb9aa','#b4be79','#94a2cc','#80be79','#b48b64','#b9b26e','#83a0c3','#ada5d4','#e57fcf','#c0c246'];
         for ($i = 0; $i < count($capabilities); $i++) {
@@ -196,8 +138,7 @@ class DockerView extends AbstractView {
         return $this->output->renderTwigTemplate(
             "admin/Docker.twig",
             [
-                "autograding_containers" => $autograding_containers,
-                "docker_info" => $docker_data['docker_info'],
+                "autograding_containers" => $docker_data['autograding_containers'],
                 "capabilities" => $capabilities,
                 "worker_machines" => $worker_machines,
                 "no_image_capabilities" => $no_image_capabilities,

--- a/site/tests/app/controllers/DockerInterfaceControllerTester.php
+++ b/site/tests/app/controllers/DockerInterfaceControllerTester.php
@@ -22,14 +22,7 @@ class DockerInterfaceControllerTester extends BaseUnitTest {
 
 
     public function testShowDockerInterface() {
-        $mock_data = [
-            'success' => true,
-            'docker_images' => [],
-            'docker_info' => []
-        ];
-
-
-        $this->core->expects($this->once())->method("curlRequest")->willReturn(json_encode($mock_data));
+        $mock_data = [];
 
         $docker = new DockerInterfaceController($this->core);
         $response = ($docker->showDockerInterface());
@@ -38,6 +31,6 @@ class DockerInterfaceControllerTester extends BaseUnitTest {
         $mock_data['autograding_workers'] = false;
 
         $this->assertTrue($api['status'] === "success");
-        $this->assertEquals($api['data'], $mock_data);
+        $this->assertEquals($mock_data, $api['data']);
     }
 }


### PR DESCRIPTION
Closes #6955

### What is the current behavior?
Currently, the page tries to cross reference the cgi results and the json files to make sure the results matches up before displaying the images. However, since only the primary machines run the cgi script, the images that do not exist on the primary machine is not displayed on the page.

### What is the new behavior?
Removed all usage and dependency on the cgi script. This means the table for images to capabilities will lose some columns, however, this can be fixed in the future by logging the docker information onto the log from the worker machine. This will be the first step toward a more scalable solution as the number of worker machines increases.

### Additional Information
#6961 Should be merged before this PR