### PR TITLE
[Refactor:HelpQueue] Rearrange OH queue columns

### DIFF
--- a/site/app/templates/officeHoursQueue/CurrentQueue.twig
+++ b/site/app/templates/officeHoursQueue/CurrentQueue.twig
@@ -9,14 +9,18 @@
         <th scope="col">Total Time Paused</th>
         <th scope="col">Queue</th>
         <th scope="col">Remove</th>
-        <th scope="col" class="mobile-hide">ID</th>
       </tr>
     </thead>
     <tbody>
       {% for entry in viewer.getCurrentQueue() %}
         <tr class="row_color_{{viewer.getIndexFromCode(entry['queue_code'])}} queue_current_{{viewer.cleanForId(entry['queue_code'])}} current_queue_row" style="display:none;">
           <th scope="row" class="row_number">{{entry['row_number'] }}</th>
-          <td>{{ entry['name'] }}</td>
+          <td>
+            {{ entry['name'] }}
+            <a class="post-user-info" onclick="unhideId(this,'{{ entry['user_id'] }}')" onkeypress="unhideId(this,'{{ entry['user_id'] }}')" title="Show user id" aria-label="Show user id" tabindex="0">
+              <i class="fas fa-eye"></i>
+            </a>
+          </td>
 
           {% if entry['current_state'] == 'waiting' %}
             <td>
@@ -26,17 +30,22 @@
                 {% if entry['paused'] %}
                   <button type="submit" class="btn btn-primary help_btn" title="Student paused" data-ready="false">
                     <i class="fas fa-pause"></i>
-                    Help</button>
+                    Help
+                  </button>
                 {% elseif viewer.firstTimeInQueueThisWeek(entry['last_time_in_queue']) %}
                   <button type="submit" class="btn btn-primary help_btn" title="First time in this queue this week" data-ready="true">
                     <i class="fas fa-star"></i>
-                    Help</button>
+                    Help
+                  </button>
                 {% elseif viewer.firstTimeInQueueToday(entry['last_time_in_queue']) %}
                   <button type="submit" class="btn btn-primary help_btn" title="First time in this queue today" data-ready="true">
                     <i class="fas fa-star-half"></i>
-                    Help</button>
+                    Help
+                  </button>
                 {% else %}
-                  <button type="submit" class="btn btn-primary help_btn" data-ready="true">Help</button>
+                  <button type="submit" class="btn btn-primary help_btn" data-ready="true">
+                    Help
+                  </button>
                 {% endif %}
               </form>
             </td>
@@ -77,11 +86,6 @@
               <input type="hidden" name="user_id" value="{{entry['user_id']}}"/>
               <button type="submit" class="btn btn-default remove_from_queue_btn">Remove</button>
             </form>
-          </td>
-          <td class="mobile-hide">
-            <a class="post-user-info" onclick="unhideId(this,'{{ entry['user_id'] }}')" onkeypress="unhideId(this,'{{ entry['user_id'] }}')" title="Show user id" aria-label="Show user id" tabindex="0">
-              <i class="fas fa-eye"></i>
-            </a>
           </td>
         </tr>
         {% if viewer.isContactInfoEnabled() %}

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -105,7 +105,8 @@
   }
 
   function unhideId(element, id) {
-    element.parentElement.innerHTML = id;
+    element.parentElement.append("<" + id + ">");
+    element.remove();
   }
 
   function updateTimerInterval() {

--- a/site/app/templates/officeHoursQueue/QueueHistory.twig
+++ b/site/app/templates/officeHoursQueue/QueueHistory.twig
@@ -15,7 +15,6 @@
     <thead>
       <tr>
         <th scope="col">#</th>
-        <th scope="col" class="mobile-hide">ID</th>
         <th scope="col">Name</th>
         <th scope="col">Queue</th>
         <th scope="col">Time Entered</th>
@@ -35,12 +34,12 @@
           {% set history_count = history_count + 1 %}
           <tr class="queue_history_{{entry['queue_code']}} queue_history_row">
             <th scope="row">{{history_count}}</th>
-            <td class="mobile-hide">
+            <td>
+              {{ entry['name'] }}
               <a onclick="unhideId(this, '{{ entry['user_id'] }}')" onkeypress="unhideId(this, '{{ entry['user_id'] }}')" title="Show user id" aria-label="Show user id" tabindex="0">
                 <i class="fas fa-eye"></i>
               </a>
             </td>
-            <td>{{ entry['name'] }}</td>
             <td>{{ entry['queue_code'] }}</td>
             <td>{{ viewer.timeToHM(entry['time_in']) }}</td>
 


### PR DESCRIPTION
### What is the current behavior?
The office hours queue page currently includes an ID column which contains clickable icons which reveal the users's ID.  

### What is the new behavior?
This PR updates the arrangement of the ID column such that the clickable icon appears in the name column.  See attached screen recordings:

Before:

https://user-images.githubusercontent.com/16820599/130450930-fe5d6ea6-aa05-4572-afbf-8fb84e98cde8.mov

After:

https://user-images.githubusercontent.com/16820599/130450966-20445bb6-70e9-411b-9c57-f492052b59c1.mov



### Other information?
Closes https://github.com/Submitty/Submitty/issues/6831
