### PR TITLE
[Bugfix:InstructorUI] sql toolbox - invalid CTE queries

### DIFF
--- a/site/app/libraries/database/QueryIdentifier.php
+++ b/site/app/libraries/database/QueryIdentifier.php
@@ -45,7 +45,7 @@ class QueryIdentifier {
                 }
 
                 $token = '';
-                while (preg_match("/[a-zA-Z0-9\._]/", $tokens[$pos])) {
+                while ($pos < $tokenCount && preg_match("/[a-zA-Z0-9\._]/", $tokens[$pos])) {
                     $token .= $tokens[$pos];
                     $pos++;
                 }

--- a/site/tests/app/libraries/database/QueryIdentifierTester.php
+++ b/site/tests/app/libraries/database/QueryIdentifierTester.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace tests\app\libraries\database;
 
 use app\libraries\database\QueryIdentifier;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
-use PHPUnit\Framework\ExpectationFailedException;
 
 class QueryIdentifierTester extends \PHPUnit\Framework\TestCase {
     public function dataProvider(): array {
@@ -76,5 +74,20 @@ class QueryIdentifierTester extends \PHPUnit\Framework\TestCase {
             ORDER BY A.registration_section, A.user_lastname, A.user_firstname, A.user_id;
 SQL;
           $this->assertEquals(QueryIdentifier::SELECT, QueryIdentifier::identify($query));
+    }
+
+    public function invalidQueriesDataProvider(): array {
+        return [
+            ['invalid query'],
+            // trailing comma on CTE
+            ["WITH assigned AS (SELECT * FROM foo), SELECT * FROM bar"]
+        ];
+    }
+
+    /**
+     * @dataProvider invalidQueriesDataProvider
+     */
+    public function testInvalidQueriesReturnUnknown(string $query): void {
+          $this->assertEquals(QueryIdentifier::UNKNOWN, QueryIdentifier::identify($query));
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

A fatal error is raised within the `QueryIdentifier` if it is given a CTE with an invalid trailing comma.

### What is the new behavior?

This fixes the library so that it does not raise a fatal error, and instead more gracefully returns the query type as "unknown", similar to what it'll do for other types of invalid queries.