### PR TITLE
[Bugfix:CourseMaterials] Fix URL Error

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -243,7 +243,12 @@ class MiscController extends AbstractController {
         }
 
         if ($dir == 'course_materials' && !$this->core->getUser()->accessGrading()) {
-            $access_failure = CourseMaterialsUtils::accessCourseMaterialCheck($this->core, $path);
+            if ($cm === null) {
+                $access_failure = 'Course material not found';
+            }
+            else {
+                $access_failure = CourseMaterialsUtils::finalAccessCourseMaterialCheck($this->core, $cm);
+            }
             if ($access_failure) {
                 $this->core->getOutput()->showError($access_failure);
                 return false;

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -103,6 +103,10 @@ class MiscController extends AbstractController {
         //Is this per-gradeable?
         if ($course_material_id === null && ($dir !== null && $path !== null)) {
             $path = $this->decodeAnonPath($this->core->getAccess()->resolveDirPath($dir, htmlspecialchars_decode(rawurldecode($path))));
+            if ($dir === 'course_materials') {
+                $cm = $this->core->getCourseEntityManager()->getRepository(CourseMaterial::class)
+                    ->findOneBy(['path' => $path]);
+            }
         }
         else {
             $cm = $this->core->getCourseEntityManager()->getRepository(CourseMaterial::class)
@@ -138,7 +142,12 @@ class MiscController extends AbstractController {
             }
 
             if ($dir == 'course_materials' && !$this->core->getUser()->accessGrading()) {
-                $access_failure = CourseMaterialsUtils::finalAccessCourseMaterialCheck($this->core, $cm);
+                if ($cm === null) {
+                    $access_failure = 'Course material not found';
+                }
+                else {
+                    $access_failure = CourseMaterialsUtils::finalAccessCourseMaterialCheck($this->core, $cm);
+                }
                 if ($access_failure) {
                     $this->core->getOutput()->showError($access_failure);
                     return false;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you try and open a course material from the old URL (old URL is with directory and path rather than ID), you will get a Type error.

Revision for PR #6960

### What is the new behavior?
You can now access course materials from their old URLs in case someone has bookmarked them.
