### PR TITLE
[Feature:Autograding] Use static libraries for autograding

### DIFF
--- a/grading/CMakeLists.txt
+++ b/grading/CMakeLists.txt
@@ -14,7 +14,7 @@ set (JSONCODE ${SUBMITTY_INSTALL_DIR}/vendor/include)
 ###################################################################################
 # source files
 
-add_library(submitty_grading
+add_library(submitty_grading STATIC
   ${GRADINGCODE}/grading/load_config_json.cpp
   ${GRADINGCODE}/grading/TestCase.cpp
   ${GRADINGCODE}/grading/dispatch.cpp
@@ -31,8 +31,10 @@ add_library(submitty_grading
 
 ###################################################################################
 
-SET(CMAKE_CXX_FLAGS "-lpthread")
+#delete this line
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread")
 
+#target_link_libraries(submitty_grading seccomp pthread)
 target_link_libraries(submitty_grading seccomp)
 
 set_property(TARGET submitty_grading APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")

--- a/grading/CMakeLists.txt
+++ b/grading/CMakeLists.txt
@@ -32,9 +32,8 @@ add_library(submitty_grading STATIC
 ###################################################################################
 
 #delete this line
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
-#target_link_libraries(submitty_grading seccomp pthread)
 target_link_libraries(submitty_grading seccomp)
 
 set_property(TARGET submitty_grading APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")

--- a/grading/CMakeLists.txt
+++ b/grading/CMakeLists.txt
@@ -31,7 +31,6 @@ add_library(submitty_grading STATIC
 
 ###################################################################################
 
-#delete this line
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 target_link_libraries(submitty_grading seccomp)

--- a/grading/Sample_CMakeLists.txt
+++ b/grading/Sample_CMakeLists.txt
@@ -122,18 +122,22 @@ add_executable(validate.out
 ###################################################################################
 
 #delete this line
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 target_link_libraries(custom_functions seccomp)
-#target_link_libraries(compile.out                ${GRADINGLIB}  seccomp  custom_functions  pthread)
+
 target_link_libraries(compile.out                ${GRADINGLIB}  seccomp  custom_functions)
 target_link_libraries(run.out                    ${GRADINGLIB}  seccomp  custom_functions)
 target_link_libraries(validate.out               ${GRADINGLIB}  seccomp  custom_functions)
 
-set_property(TARGET custom_functions         APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
-set_property(TARGET compile.out              APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
-set_property(TARGET run.out                  APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
-set_property(TARGET validate.out             APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
+set_property(TARGET custom_functions         APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
+set_property(TARGET compile.out              APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
+set_property(TARGET run.out                  APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
+set_property(TARGET validate.out             APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
+
+set_property(TARGET compile.out              APPEND_STRING PROPERTY LINK_FLAGS "-static")
+set_property(TARGET run.out                  APPEND_STRING PROPERTY LINK_FLAGS "-static")
+set_property(TARGET validate.out             APPEND_STRING PROPERTY LINK_FLAGS "-static")
 
 include_directories(${MY_DIR})
 include_directories(${GRADINGCODE})

--- a/grading/Sample_CMakeLists.txt
+++ b/grading/Sample_CMakeLists.txt
@@ -99,7 +99,7 @@ file(WRITE json_generated.cpp "${cpp_header}${complete_config_obj}${cpp_footer}"
 # source files
 
 # build this as a library, so we only have to compile it once
-add_library(custom_functions
+add_library(custom_functions STATIC
   ${GRADINGCODE}/grading/seccomp_functions.cpp
   json_generated.cpp
   ${custom_files}
@@ -121,17 +121,19 @@ add_executable(validate.out
 
 ###################################################################################
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+#delete this line
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread")
 
 target_link_libraries(custom_functions seccomp)
+#target_link_libraries(compile.out                ${GRADINGLIB}  seccomp  custom_functions  pthread)
 target_link_libraries(compile.out                ${GRADINGLIB}  seccomp  custom_functions)
 target_link_libraries(run.out                    ${GRADINGLIB}  seccomp  custom_functions)
 target_link_libraries(validate.out               ${GRADINGLIB}  seccomp  custom_functions)
 
-set_property(TARGET custom_functions         APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
-set_property(TARGET compile.out              APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
-set_property(TARGET run.out                  APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
-set_property(TARGET validate.out             APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11")
+set_property(TARGET custom_functions         APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
+set_property(TARGET compile.out              APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
+set_property(TARGET run.out                  APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
+set_property(TARGET validate.out             APPEND_STRING PROPERTY COMPILE_FLAGS "-g -std=c++11 -static")
 
 include_directories(${MY_DIR})
 include_directories(${GRADINGCODE})

--- a/grading/Sample_CMakeLists.txt
+++ b/grading/Sample_CMakeLists.txt
@@ -121,7 +121,6 @@ add_executable(validate.out
 
 ###################################################################################
 
-#delete this line
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 target_link_libraries(custom_functions seccomp)


### PR DESCRIPTION
### What is the current behavior?
Currently, we build C++ executables for autograding on the server, and execute these programs on worker machines and inside of docker containers.  If the gcc library versions on the worker machine and/or within the docker container are not compatible, this is problematic.

### What is the new behavior?
By staticly linking the libraries, this should facilitate execution on a wider range of machines.