### PR TITLE
[Bugfix:Submission] Fix Gradeable Timer Display

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -308,7 +308,7 @@ class Gradeable extends AbstractModel {
             $this->setDiscussionBased((bool) $details['discussion_based']);
             $this->setDiscussionThreadId($details['discussion_thread_ids']);
             $this->setAllowCustomMarks($details['allow_custom_marks']);
-            $this->setAllowedMinutes($details['allowed_minutes'] ?? 0);
+            $this->setAllowedMinutes($details['allowed_minutes'] ?? null);
             $this->setDependsOn($details['depends_on']);
             $this->setDependsOnPoints($details['depends_on_points']);
             if (array_key_exists('hidden_files', $details)) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
All gradeables will now show the exam gradeable timer and progress bar due to an automatic 0 being set rather than null for the amount of minutes.

### What is the new behavior?
The amount of minutes will default to null so the exam timer and progress bar will only show when they are supposed to.
