### PR TITLE
[Bugfix:Forum] Add Table Support for Markdown

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -8,6 +8,7 @@ use app\libraries\FileUtils;
 use app\models\Breadcrumb;
 use app\views\ErrorView;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Block\Element\IndentedCode;
 use League\CommonMark\Inline\Element\Code;
@@ -141,6 +142,7 @@ HTML;
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addExtension(new AutolinkExtension());
+        $environment->addExtension(new TableExtension());
         $environment->addBlockRenderer(FencedCode::class, new CustomFencedCodeRenderer());
         $environment->addBlockRenderer(IndentedCode::class, new CustomIndentedCodeRenderer());
         $environment->addInlineRenderer(Code::class, new CustomCodeInlineRenderer());

--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -85,12 +85,9 @@
     overflow-x: scroll;
 }
 
-.markdown th {
+.markdown th, td{
     border: 1px solid var(--text-black);
-}
-
-.markdown td {
-    border: 1px solid var(--text-black);
+    padding: 3px;
 }
 
 .markdown-preview {

--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -86,7 +86,7 @@
 }
 
 .markdown th, td{
-    border: 1px solid var(--text-black);
+    border: 1px solid var(--standard-light-gray);
     padding: 3px;
 }
 


### PR DESCRIPTION
### What is the current behavior?
Currently, tables aren't rendered in markdown
![Screen Shot 2021-08-31 at 6 45 02 PM](https://user-images.githubusercontent.com/28243927/131586952-117c5f4f-d1d0-4190-8736-1238bffe4d25.jpg)

### What is the new behavior?
Tables now work as expected in markdown
![image](https://user-images.githubusercontent.com/28243927/131587073-45cdb5a2-5541-4b78-a41c-d1a6286147a1.png)
