### PR TITLE
[Bugfix:System] Fix Grade Inquiry Date Validation

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1088,6 +1088,8 @@ class AdminGradeableController extends AbstractController {
             }
         }
 
+        $regrade_modified = false;
+
         // Apply other new values for all properties submitted
         foreach ($details as $prop => $post_val) {
             // Convert boolean values into booleans
@@ -1143,6 +1145,12 @@ class AdminGradeableController extends AbstractController {
                 }
             }
 
+            if ($prop === 'regrade_allowed') {
+                if ($post_val !== $gradeable->isRegradeAllowed()) {
+                    $regrade_modified = true;
+                }
+            }
+
             // Try to set the property
             try {
                 //convert the property name to a setter name
@@ -1169,7 +1177,7 @@ class AdminGradeableController extends AbstractController {
         //  affect date validation
         if ($date_set) {
             try {
-                $gradeable->setDates($dates);
+                $gradeable->setDates($dates, $regrade_modified);
                 $updated_properties = $gradeable->getDateStrings(false);
             }
             catch (ValidationException $e) {

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1088,6 +1088,7 @@ class AdminGradeableController extends AbstractController {
             }
         }
 
+        // Set default value which may be set in loop below
         $regrade_modified = false;
 
         // Apply other new values for all properties submitted

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -692,7 +692,7 @@ class Gradeable extends AbstractModel {
      * Gets the dates that require validation for the gradeable's current configuration.
      * @return string[] array of date property names that need validation
      */
-    private function getDateValidationSet($regrade_modified = false) {
+    private function getDateValidationSet(bool $regrade_modified = false) {
         if ($this->type === GradeableType::ELECTRONIC_FILE) {
             if (!$this->isStudentSubmit()) {
                 if ($this->isTaGrading()) {
@@ -760,7 +760,7 @@ class Gradeable extends AbstractModel {
      * @param \DateTime[] $dates Array of dates, indexed by property name
      * @return \DateTime[] Array of dates, indexed by property name
      */
-    private function coerceDates(array $dates, $regrade_modified = false) {
+    private function coerceDates(array $dates, bool $regrade_modified = false) {
         // Takes an array of date properties (in order) and date values (indexed by property)
         //  and returns the modified date values to comply with the provided order, using
         //  a compare function, which returns true when first parameter should be coerced


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Courses that have grade inquiries enabled on gradeables will produce a date validation error when trying to load the gradeables page.

### What is the new behavior?
The error is now gone and date validation is handled properly for grade inquiries.
