### PR TITLE
[Bugfix:Submission] Remove Future Closed Submission Banner

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -55,7 +55,7 @@ class HomeworkView extends AbstractView {
             $late_days = LateDays::fromUser($this->core, $this->core->getUser());
             $return .= $this->renderLateDayMessage($late_days, $gradeable, $graded_gradeable);
         }
-        if (!$gradeable->canStudentSubmit()) {
+        if (!$gradeable->canStudentSubmit() && $gradeable->getSubmissionOpenDate() < $this->core->getDateTimeNow()) {
             $return .= $this->renderSubmissionsClosedBox();
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently, a banner saying that submissions are no longer being accepted is showing to instructors when the gradeable is in the future category.
Closes #6984

### What is the new behavior?
This banner will not show in this category anymore due to the extra date check.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
