### PR TITLE
[Bugfix:System] Add Warning Message to Build

### DIFF
--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -10,9 +10,6 @@ import datetime
 import os
 import sys
 import json
-import errno
-
-HAS_ERROR = False
 
 try:
     CONFIG_PATH = os.path.join(
@@ -21,22 +18,10 @@ try:
     with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
         SUBMITTY_CONFIG = json.load(open_file)
 
-    try:
-        with open(os.path.join(CONFIG_PATH, 'database.json')) as open_file:
-            DATABASE_CONFIG = json.load(open_file)
-    except IOError as e:
-        if e.errno == errno.EACCES:
-            HAS_ERROR = True
-
 except Exception as config_fail_error:
     print("[{}] ERROR: CORE SUBMITTY CONFIGURATION ERROR {}".format(
         str(datetime.datetime.now()), str(config_fail_error)))
     sys.exit(1)
-
-if not HAS_ERROR:
-    DB_HOST = DATABASE_CONFIG['database_host']
-    DB_USER = DATABASE_CONFIG['database_user']
-    DB_PASSWORD = DATABASE_CONFIG['database_password']
 
 CONFIG_FILE_PATH = sys.argv[1]
 SEMESTER = sys.argv[2]
@@ -46,14 +31,23 @@ GRADEABLE = sys.argv[4]
 
 def setup_db():
     """Set up a connection with the course database."""
+    with open(os.path.join(CONFIG_PATH, 'database.json')) as open_file:
+        db_config = json.load(open_file)
     db_name = "submitty_{}_{}".format(SEMESTER, COURSE)
     # If using a UNIX socket, have to specify a slightly different connection string
-    if os.path.isdir(DB_HOST):
+    if os.path.isdir(db_config['database_host']):
         conn_string = "postgresql://{}:{}@/{}?host={}".format(
-            DB_USER, DB_PASSWORD, db_name, DB_HOST)
+            db_config['database_user'],
+            db_config['database_password'],
+            db_name, db_config['database_host']
+            )
     else:
         conn_string = "postgresql://{}:{}@{}/{}".format(
-            DB_USER, DB_PASSWORD, DB_HOST, db_name)
+            db_config['database_user'],
+            db_config['database_password'],
+            db_config['database_host'],
+            db_name
+            )
 
     engine = create_engine(conn_string)
     db = engine.connect()
@@ -93,14 +87,14 @@ def main():
         if 'override' in timelimit_case['validation'][0]:
             override = timelimit_case['validation'][0]['override']
         try:
-            if HAS_ERROR:
-                print("WARNING: You do not have access to set allowed minutes from CLI." +
-                      " Please use website to set that.")
-                exit()
             db, metadata = setup_db()
             send_data(db, allowed_minutes, override)
         except exc.IntegrityError:
             sys.exit(1)
+        except IOError:
+            print("WARNING: You do not have access to set allowed minutes from CLI." +
+                  " Please use website to set that.")
+            exit()
 
 
 if __name__ == "__main__":

--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -40,14 +40,14 @@ def setup_db():
             db_config['database_user'],
             db_config['database_password'],
             db_name, db_config['database_host']
-            )
+        )
     else:
         conn_string = "postgresql://{}:{}@{}/{}".format(
             db_config['database_user'],
             db_config['database_password'],
             db_config['database_host'],
             db_name
-            )
+        )
 
     engine = create_engine(conn_string)
     db = engine.connect()

--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -39,7 +39,8 @@ def setup_db():
         conn_string = "postgresql://{}:{}@/{}?host={}".format(
             db_config['database_user'],
             db_config['database_password'],
-            db_name, db_config['database_host']
+            db_name,
+            db_config['database_host']
         )
     else:
         conn_string = "postgresql://{}:{}@{}/{}".format(

--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -94,7 +94,8 @@ def main():
             override = timelimit_case['validation'][0]['override']
         try:
             if HAS_ERROR:
-                print("WARNING: You do not have access to set allowed minutes from CLI. Please use website to set that.")
+                print("WARNING: You do not have access to set allowed minutes from CLI." +
+                " Please use website to set that.")
                 exit()
             db, metadata = setup_db()
             send_data(db, allowed_minutes, override)

--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -95,7 +95,7 @@ def main():
         try:
             if HAS_ERROR:
                 print("WARNING: You do not have access to set allowed minutes from CLI." +
-                " Please use website to set that.")
+                      " Please use website to set that.")
                 exit()
             db, metadata = setup_db()
             send_data(db, allowed_minutes, override)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If a non-sudo unix user wanted to rebuild the gradeables in the course, the script would fail since they can't access the database password.
Closes #6982

### What is the new behavior?
There is an extra check to see if the user can access the file. If not and they are trying to build a gradeable with allowed minutes, a warning will appear. Warning message put below:

WARNING: You do not have access to set allowed minutes from CLI. Please use website to set that.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
