### PR TITLE
[Feature:System] Add web socket failure banner message

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -223,6 +223,9 @@
                 {{ system_message }}
             </div>
             {% endif %}
+            <div class="system-message warning" id="socket-server-system-message" hidden>
+                You are not connected to socket server. You will not receive live updates. Please notify system administrator if issue persists.
+            </div>
             <div id='messages'>
                 <!-- If the below <div> definition changes, update the design in server.js in displayMessage function -->
                 {% for message in messages %}

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -225,7 +225,7 @@
             {% endif %}
             <div class="system-message warning" id="socket-server-system-message" hidden>
                 Warning: Failed to connect to websocket server. This page will not dynamically update.
-                Manually reload this page to see updates.{% if sysadmin_email is defined %} Notify the
+                Manually reload this page to see updates.{% if sysadmin_email is not empty %} Notify the
                 sysadmin at <a href='mailto:{{ sysadmin_email }}'>{{ sysadmin_email }}</a>.{% endif %}
             </div>
             <div id='messages'>

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -225,7 +225,8 @@
             {% endif %}
             <div class="system-message warning" id="socket-server-system-message" hidden>
                 Warning: Failed to connect to websocket server. This page will not dynamically update.
-                Manually reload this page to see updates. Notify the sysadmin {{ sysadmin_email }}.
+                Manually reload this page to see updates.{% if sysadmin_email is defined %} Notify the
+                sysadmin at <a href='mailto:{{ sysadmin_email }}'>{{ sysadmin_email }}</a>.{% endif %}
             </div>
             <div id='messages'>
                 <!-- If the below <div> definition changes, update the design in server.js in displayMessage function -->

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -224,7 +224,8 @@
             </div>
             {% endif %}
             <div class="system-message warning" id="socket-server-system-message" hidden>
-                You are not connected to socket server. You will not receive live updates. Please notify system administrator if issue persists.
+                Warning: Failed to connect to websocket server. This page will not dynamically update.
+                Manually reload this page to see updates. Notify the sysadmin {{ sysadmin_email }}.
             </div>
             <div id='messages'>
                 <!-- If the below <div> definition changes, update the design in server.js in displayMessage function -->

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -56,6 +56,7 @@ class GlobalView extends AbstractView {
             "enable_banner" => $this->core->getConfig()->isDuckBannerEnabled(),
             "duck_img" => $duck_img,
             "use_mobile_viewport" => $this->output->useMobileViewport(),
+            "sysadmin_email" => $this->core->getConfig()->getSysAdminEmail(),
             "collapse_sidebar" => array_key_exists('collapse_sidebar', $_COOKIE) ? $_COOKIE['collapse_sidebar'] === 'true' : false
         ]);
     }

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -42,6 +42,7 @@ class WebSocketClient {
         this.client = new WebSocket(this.url);
         this.client.onopen = () => {
             console.log('WebSocket: connected');
+            $('#socket-server-system-message').hide();
             if (this.onopen) {
                 this.onopen();
             }
@@ -69,7 +70,7 @@ class WebSocketClient {
                     console.log('WebSocket: Closed');
                     break;
                 default:
-                    this.reconnect();
+                    this.reconnect(page);
                     break;
             }
             //this.onclose(event);
@@ -78,7 +79,7 @@ class WebSocketClient {
         this.client.onerror = (error) => {
             switch (error.code) {
                 case 'ECONNREFUSED':
-                    this.reconnect();
+                    this.reconnect(page);
                     break;
                 default:
                     //console.log(`WebSocket: Error - ${error.code}`);
@@ -100,12 +101,12 @@ class WebSocketClient {
         this.client.onerror = null;
     }
 
-    reconnect() {
+    reconnect(page) {
         console.log(`WebSocketClient: Retry in ${this.autoReconnectInterval}ms`);
         this.removeClientListeners();
         setTimeout(() => {
             console.log('WebSocketClient: Reconnecting...');
-            this.open(this.url);
+            this.open(page);
         }, this.autoReconnectInterval);
     }
 }

--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -85,6 +85,7 @@ class WebSocketClient {
                     //this.onerror(error);
                     break;
             }
+            $('#socket-server-system-message').show();
         };
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently the only way to tell that your browser did not connect to the web socket server is by looking in the Javascript console. There is also an error in the websocket.js file that I fixed in this PR. When the socket tries to reconnect it does to with a page name of the full URL rather than the actual page name it initially tried to connect with.
Closes #7018 

### What is the new behavior?
If there was a connection failure, a message will appear saying that the websocket server is not working right now and to contact sysadmin. If while on the same page instance the connection opens back up then the message will go away and continue as expected. Now the socket will reconnect with the appropriate page name rather than the URL.