### PR TITLE
[Bugfix:HelpQueue] Breadcrumb showing incorrect text color

### DIFF
--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -20,6 +20,14 @@ th {
     display: none;
 }
 
+.current_queue_row {
+    color: var(--btn-text-black);
+}
+
+.current_queue_row, a > i.fas {
+    color: var(--btn-text-black);
+}
+
 .announcement-setting {
     min-height: 7em;
     flex: 1 0 auto;

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -24,7 +24,7 @@ th {
     color: var(--btn-text-black);
 }
 
-.current_queue_row, a > i.fas {
+.current_queue_row a > i.fas {
     color: var(--btn-text-black);
 }
 

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -20,11 +20,6 @@ th {
     display: none;
 }
 
-.current_queue_row,
-a > i.fas {
-    color: var(--text-black);
-}
-
 .announcement-setting {
     min-height: 7em;
     flex: 1 0 auto;

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -22,7 +22,7 @@ th {
 
 .current_queue_row,
 a > i.fas {
-    color: var(--btn-text-black);
+    color: var(--text-black);
 }
 
 .announcement-setting {

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -20,10 +20,7 @@ th {
     display: none;
 }
 
-.current_queue_row {
-    color: var(--btn-text-black);
-}
-
+.current_queue_row,
 .current_queue_row a > i.fas {
     color: var(--btn-text-black);
 }


### PR DESCRIPTION
Fixes #7008

### What is the current behavior?
Breadcrumbs on the office hours queue page are the wrong color for dark modes
<img width="921" alt="Screen Shot 2021-09-06 at 9 43 39 PM" src="https://user-images.githubusercontent.com/65693478/132271643-c97d360e-5570-45f6-a689-85eb477e8d21.png">

### What is the new behavior?
Breadcrumbs correctly inherit text color from external-breadcrumb class
<img width="926" alt="Screen Shot 2021-09-06 at 9 58 26 PM" src="https://user-images.githubusercontent.com/65693478/132272673-d4e09961-a6ac-4750-a933-399d407a3c4a.png">
