### PR TITLE
[Bugfix:TAGrading] Fix Bulk Upload Grading With Other Files

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -971,6 +971,7 @@ HTML;
             // This would be more dynamic if $display_version_instance included an expected number, requires more database changes
             if ($pattern_match_flag == true) {
                 $error_message = [
+                    "color" => "var(--standard-vibrant-yellow)", // canary yellow
                     "message" => "Multiple files within submissions"
                 ];
             }


### PR DESCRIPTION
### What is the current behavior?
Currently, in a bulk upload gradeable, if a student has more than just a pdf submitted, a frog robot appears when trying to enter their grading page.

### What is the new behavior?
The grading page can now be accessed like normal, and a yellow color was given to the warning message/background.
![image](https://user-images.githubusercontent.com/28243927/132745092-d6c9c754-010f-47d1-b93e-f9d841e1b276.png)

Fixes #7069