### PR TITLE
[BugFix:TAGrading]removed arrow key overrides

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -667,35 +667,6 @@ function setupSimpleGrading(action) {
         }
     }
 
-    // default key movement
-    $(document).on("keydown", function(event) {
-        // if input cell selected, use this to check if cursor is in the right place
-        var input_cell = $("input.cell-grade:focus");
-
-        // if there is no selection OR there is a selection to the far left with 0 length
-        if(event.code === "ArrowLeft" && (!input_cell.length || (
-                input_cell[0].selectionStart == 0 &&
-                input_cell[0].selectionEnd - input_cell[0].selectionStart == 0))) {
-            event.preventDefault();
-            movement("left");
-        }
-        else if(event.code === "ArrowUp") {
-            event.preventDefault();
-            movement("up");
-        }
-        // if there is no selection OR there is a selection to the far right with 0 length
-        else if(event.code === "ArrowRight" && (!input_cell.length || (
-                input_cell[0].selectionEnd == input_cell[0].value.length &&
-                input_cell[0].selectionEnd - input_cell[0].selectionStart == 0))) {
-            event.preventDefault();
-            movement("right");
-        }
-        else if(event.code === "ArrowDown") {
-            event.preventDefault();
-            movement("down");
-        }
-    });
-
     // register empty function locked event handlers for "enter" so they show up in the hotkeys menu
     registerKeyHandler({name: "Search", code: "Enter", locked: true}, function() {});
     // make arrow keys in lab section changeable now

--- a/site/public/js/ta-grading-keymap.js
+++ b/site/public/js/ta-grading-keymap.js
@@ -73,7 +73,7 @@ window.onkeyup = function(e) {
 
 window.onkeydown = function(e) {
     if (remapping.active) {
-        e.preventDefault();
+        //e.preventDefault();
         return;
     }
 
@@ -82,7 +82,7 @@ window.onkeydown = function(e) {
         return;
     }
 
-    if (e.target.tagName === "TEXTAREA" || (e.target.tagName === "INPUT" && e.target.type !== "checkbox") || e.target.tagName === "SELECT") return; // disable keyboard event when typing to textarea/input
+    if ((e.target.tagName === "INPUT" && e.target.type !== "checkbox") || e.target.tagName === "SELECT") return; // disable keyboard event when typing to textarea/input
 
     var codeName = eventToKeyCode(e);
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #6953 

Arrow keys are overridden to select different HTML elements instead of moving the cursors of the selected element.

### What is the new behavior?
The arrow keys are no longer overridden. However, I am not familiar with why this page so I am not sure why this was a thing to begin with so my fix might be problematic for other pages.
