### PR TITLE
[Feature:Plagiarism] Plagiarism anonymous mode

### DIFF
--- a/site/app/templates/plagiarism/PlagiarismResult.twig
+++ b/site/app/templates/plagiarism/PlagiarismResult.twig
@@ -17,9 +17,7 @@
         <div class="plag-flex-row">
             <span class="plag-flex-item">
                 <select id="user-1-dropdown-list" name="user_id_1" class="user1-select">
-                    {% for ranking in rankings %}
-                        <option value="{{ ranking["user_id"] }}">(Max Match: {{ ranking["percent"] }}) {{ ranking["display_name"] }} &lt;{{ ranking["user_id"] }}&gt;</option>
-                    {% endfor %}
+                    <option>Loading...</option>
                 </select>
             </span>
             <a id="swap-students-button" class="btn btn-secondary pl-1 pr-1" title="Switch Focused Student"><i class="fa fa-long-arrow-alt-left fa-lg"></i></a>

--- a/site/app/templates/plagiarism/PlagiarismResult.twig
+++ b/site/app/templates/plagiarism/PlagiarismResult.twig
@@ -7,8 +7,9 @@
     <div id="result-title-bar">
         <h2 style="display:inline;">{{ gradeable_title }} <span class="config-id-title">#{{ config_id }}</span></h2>
         <span class="plag-results-header-right">
-            <a class="btn btn-primary" onclick="showPlagiarismHighKey()">View Key</a>
-            <a class="btn btn-primary" onclick="toggleFullScreenMode();">Toggle Full-Screen</a>
+            <button id="toggle-anon-mode-btn" class="btn btn-secondary">Enter Anonymous Mode</button>
+            <button id="show-plag-high-key-btn" class="btn btn-primary">View Key</button>
+            <button id="toggle-fullscreen-btn" class="btn btn-primary">Toggle Full-Screen</button>
         </span>
     </div>
     <hr />

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -298,10 +298,10 @@ function recreateUser1Dropdown(state) {
         if (state.anon_mode_enabled) {
             const hashedDisplayName = hashString(element.display_name);
             const hashedUserID = hashString(element.user_id);
-            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}) ${hashedDisplayName} &lt;${hashedUserID}&gt;</option>`)
+            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}) ${hashedDisplayName} &lt;${hashedUserID}&gt;</option>`);
         }
         else {
-            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}) ${element.display_name} &lt;${element.user_id}&gt;</option>`)
+            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}) ${element.display_name} &lt;${element.user_id}&gt;</option>`);
         }
     });
 }

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -62,6 +62,7 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
             'start_char': -1,
             'end_char': -1,
         },
+        'anon_mode_enabled': false,
     };
 
     // force the page to load default data for user 1 with highest % match
@@ -83,6 +84,18 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
 
     $('#swap-students-button').click(() => {
         swapStudents(state);
+    });
+
+    $('#show-plag-high-key-btn').click(() => {
+        showPlagiarismHighKey();
+    });
+
+    $('#toggle-fullscreen-btn').click(() => {
+        toggleFullScreenMode();
+    });
+
+    $('#toggle-anon-mode-btn').click(() => {
+        toggleAnonymousMode(state);
     });
 
     handleClickedMarks(state);
@@ -652,15 +665,24 @@ function hideLoadingIndicatorRight() {
 }
 
 
-// eslint-disable-next-line no-unused-vars
 function showPlagiarismHighKey() {
     $('#Plagiarism-Highlighting-Key').css('display', 'block');
 }
 
 
-// eslint-disable-next-line no-unused-vars
 function toggleFullScreenMode() {
     $('main#main').toggleClass('full-screen-mode');
+}
+
+function toggleAnonymousMode(state) {
+    if (state.anon_mode_enabled) {
+        $('#toggle-anon-mode-btn').text('Enter Anonymous Mode');
+        state.anon_mode_enabled = false;
+    }
+    else {
+        $('#toggle-anon-mode-btn').text('Exit Anonymous Mode');
+        state.anon_mode_enabled = true;
+    }
 }
 
 

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -296,7 +296,7 @@ function recreateUser1Dropdown(state) {
     $('#user-1-dropdown-list').empty();
     $.each(state.user_1_dropdown_list, (i, element) => {
         if (state.anon_mode_enabled) {
-            const hashedDisplayName = hashString(element.display_name);
+            const hashedDisplayName = element.display_name !== '' ? hashString(element.display_name) : '';
             const hashedUserID = hashString(element.user_id);
             $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}) ${hashedDisplayName} &lt;${hashedUserID}&gt;</option>`);
         }
@@ -339,7 +339,7 @@ function refreshUser2Dropdown(state) {
         }
 
         if (state.anon_mode_enabled) {
-            const hashedDisplayName = hashString(users.display_name);
+            const hashedDisplayName = users.display_name !== '' ? hashString(users.display_name) : '';
             const hashedUserID = hashString(users.user_id);
             append_options += `>(${users.percent} Match) ${hashedDisplayName} &lt;${hashedUserID}&gt; (version: ${users.version}) `;
         }

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -62,8 +62,15 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
             'start_char': -1,
             'end_char': -1,
         },
-        'anon_mode_enabled': false,
+        'anon_mode_enabled': localStorage.getItem('plagiarism-anon-mode-enabled') === 'true',
     };
+
+    if (state.anon_mode_enabled) {
+        $('#toggle-anon-mode-btn').text('Exit Anonymous Mode');
+    }
+    else {
+        $('#toggle-anon-mode-btn').text('Enter Anonymous Mode');
+    }
 
     // put data in the user 1 dropdown
     recreateUser1Dropdown(state);
@@ -706,10 +713,12 @@ function toggleAnonymousMode(state) {
     if (state.anon_mode_enabled) {
         $('#toggle-anon-mode-btn').text('Enter Anonymous Mode');
         state.anon_mode_enabled = false;
+        localStorage.removeItem('plagiarism-anon-mode-enabled');
     }
     else {
         $('#toggle-anon-mode-btn').text('Exit Anonymous Mode');
         state.anon_mode_enabled = true;
+        localStorage.setItem('plagiarism-anon-mode-enabled', 'true');
     }
 
     // update the user 1 dropdown, which triggers the other dropdowns to update as well


### PR DESCRIPTION
### What is the current behavior?
Currently, it is difficult for instructors to report bugs in the plagiarism results page due to confidentiality matters, primarily involving the association of code/plagiarism results with specific names.

### What is the new behavior?
This pull request introduces a new "anonymous mode" feature to the plagiarism results interface which allows the instructor to toggle between showing names and random hashes.

<img width="894" alt="Untitled" src="https://user-images.githubusercontent.com/16820599/133189084-fba7eb85-9f9a-4d4e-898e-25fe0285f5e9.png">


### Other information?
This is not meant to be a completely anonymous mode such as is the case for blinded grading.  Since instructors can always turn this off, we only care about the visual display of data being anonymized so that instructors can more freely share screenshots and/or show students accused of cheating the evidence against them with fewer confidentiality concerns.  