### PR TITLE
[Bugfix:Forum] Fix edit post markdown preview

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -189,12 +189,7 @@
             </div>
         {% endif %}
         {% if show_cancel_edit_form is defined and show_cancel_edit_form %}
-        <a onclick="
-                 $(`#markdown_buttons_0`).find('.preview-button').trigger('click');
-                 $('#edit-user-post').css('display', 'none');
-                 $(this).closest('.thread-post-form').find('[name=thread_post_content]').val('');
-                 $('#title').val('');
-                 $(this).closest('form').trigger('reinitialize.areYouSure');"
+        <a onclick="cancelEditPostForum.call()"
                      class="btn btn-default close-button key_to_click" tabindex="0">Cancel</a>
         {% endif %}
         <input type="submit" name="post" value="{{ submit_label }}" class="btn btn-primary inline-block" />

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -189,7 +189,9 @@
             </div>
         {% endif %}
         {% if show_cancel_edit_form is defined and show_cancel_edit_form %}
-        <a onclick="$('#edit-user-post').css('display', 'none');
+        <a onclick="
+                 $(`#markdown_buttons_0`).find('.preview-button').trigger('click');
+                 $('#edit-user-post').css('display', 'none');
                  $(this).closest('.thread-post-form').find('[name=thread_post_content]').val('');
                  $('#title').val('');
                  $(this).closest('form').trigger('reinitialize.areYouSure');"

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -189,7 +189,7 @@
             </div>
         {% endif %}
         {% if show_cancel_edit_form is defined and show_cancel_edit_form %}
-        <a onclick="cancelEditPostForum.call()"
+        <a onclick="cancelEditPostForum()"
                      class="btn btn-default close-button key_to_click" tabindex="0">Cancel</a>
         {% endif %}
         <input type="submit" name="post" value="{{ submit_label }}" class="btn btn-primary inline-block" />

--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -25,7 +25,7 @@
         <button title="Insert a code segment" type="button" onclick="addMarkdownCode(0, $('#{{ markdown_area_id }}'))" class="btn btn-default btn-markdown key_to_click"  tabindex="0">Code <i class="fas fa-code fa-1x"></i></button>
         <button title="Insert bold text" type="button" onclick="addMarkdownCode(2, $('#{{ markdown_area_id }}'))" class="btn btn-default btn-markdown key_to_click"  tabindex="0">Bold <i class="fas fa-bold fa-1x"></i></button>
         <button title="Insert italic text" type="button" onclick="addMarkdownCode(3, $('#{{ markdown_area_id }}'))" class="btn btn-default btn-markdown key_to_click"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
-        <button title="Preview Markdown" type="button" onclick="{{ onclick }}" class="btn btn-default btn-markdown key_to_click" tabindex="0">Preview <i class="fas fa-eye fa-1x"></i></button>
+        <button title="Preview Markdown" type="button" onclick="{{ onclick }}" class="btn btn-default btn-markdown key_to_click preview-button" tabindex="0" data-mode="edit">Preview <i class="fas fa-eye fa-1x"></i></button>
         <a target="_blank" href="https://submitty.org/student/communication/markdown">
             Supports Markdown
             <i style="font-style:normal;" class="fa-question-circle"></i>

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1594,7 +1594,7 @@ function toggleMarkdown(post_box_id, triggered) {
   $(`#markdown_buttons_${post_box_id}`).toggle();
   $(this).toggleClass('markdown-active markdown-inactive');
   if( $(this).hasClass('markdown-inactive') && post_box_id === 0) {
-    $(`#markdown_buttons_0`).find(".preview-button").trigger('click');
+    $(`#markdown_buttons_0`).find('.preview-button').trigger('click');
   }
   if (!triggered) {
     $('.markdown-toggle').not(this).each(function() {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1582,6 +1582,9 @@ function toggleMarkdown(post_box_id, triggered) {
   if(post_box_id === undefined) post_box_id = '';
   $(`#markdown_buttons_${post_box_id}`).toggle();
   $(this).toggleClass('markdown-active markdown-inactive');
+  if( $(this).hasClass('markdown-inactive') && post_box_id === 0) {
+    $(`#markdown_buttons_0`).find(".preview-button").trigger('click');
+  }
   if (!triggered) {
     $('.markdown-toggle').not(this).each(function() {
       toggleMarkdown.call(this, this.id.split('_')[2], true);

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1594,7 +1594,11 @@ function toggleMarkdown(post_box_id, triggered) {
   $(`#markdown_buttons_${post_box_id}`).toggle();
   $(this).toggleClass('markdown-active markdown-inactive');
   if( $(this).hasClass('markdown-inactive') && post_box_id === 0) {
-    $(`#markdown_buttons_0`).find('.preview-button').trigger('click');
+    let preview_button = $(`#markdown_buttons_0`).find('.preview-button')
+    let data_mode = preview_button.attr("data-mode");
+    if (data_mode === 'preview') {
+      preview_button.trigger('click');
+    }
   }
   if (!triggered) {
     $('.markdown-toggle').not(this).each(function() {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -728,6 +728,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             csrf_token: csrf_token
         },
         success: function(data){
+            //console.log("some data", data)
             try {
                 var json = JSON.parse(data);
             } catch (err){
@@ -738,6 +739,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
                 displayErrorMessage(json['message']);
                 return;
             }
+            console.log("json", json)
             json = json['data'];
             var post_content = json.post;
             var lines = post_content.split(/\r|\r\n|\n/).length;
@@ -758,6 +760,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             var editUserPrompt = document.getElementById('edit_user_prompt');
             editUserPrompt.innerHTML = 'Editing a post by: ' + user_id + ' on ' + date + ' at ' + time;
             contentBox.value = post_content;
+            console.log(contentBox);
             document.getElementById('edit_post_id').value = post_id;
             document.getElementById('edit_thread_id').value = thread_id;
             if(change_anon) {
@@ -1597,6 +1600,7 @@ function toggleMarkdown(post_box_id, triggered) {
 
 function previewForumMarkdown(){
   let post_box_num = $(this).closest('.thread-post-form').data('post_box_id');
+  console.log("post_box_num", post_box_num);
   if (post_box_num === undefined) {
     post_box_num = '';
   }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -728,7 +728,6 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             csrf_token: csrf_token
         },
         success: function(data){
-            //console.log("some data", data)
             try {
                 var json = JSON.parse(data);
             } catch (err){
@@ -739,7 +738,6 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
                 displayErrorMessage(json['message']);
                 return;
             }
-            console.log("json", json)
             json = json['data'];
             var post_content = json.post;
             var lines = post_content.split(/\r|\r\n|\n/).length;
@@ -760,7 +758,6 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             var editUserPrompt = document.getElementById('edit_user_prompt');
             editUserPrompt.innerHTML = 'Editing a post by: ' + user_id + ' on ' + date + ' at ' + time;
             contentBox.value = post_content;
-            console.log(contentBox);
             document.getElementById('edit_post_id').value = post_id;
             document.getElementById('edit_thread_id').value = thread_id;
             if(change_anon) {
@@ -1600,7 +1597,6 @@ function toggleMarkdown(post_box_id, triggered) {
 
 function previewForumMarkdown(){
   let post_box_num = $(this).closest('.thread-post-form').data('post_box_id');
-  console.log("post_box_num", post_box_num);
   if (post_box_num === undefined) {
     post_box_num = '';
   }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -828,6 +828,17 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
     });
 }
 
+function cancelEditPostForum() {
+  let preview_button = $(`#markdown_buttons_0`).find('.preview-button');
+  let data_mode = preview_button.attr('data-mode');
+  if (data_mode === 'preview') {
+    preview_button.trigger('click');
+  }
+  $('#edit-user-post').css('display', 'none');
+  $(this).closest('.thread-post-form').find('[name=thread_post_content]').val('');
+  $('#title').val('');
+  $(this).closest('form').trigger('reinitialize.areYouSure');
+}
 
 function changeDisplayOptions(option){
     thread_id = $('#current-thread').val();

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1570,6 +1570,8 @@ function getFocusableElements() {
 function previewMarkdown(markdown_textarea, preview_element, preview_button, data) {
     const enablePreview = preview_element.is(':hidden');
 
+    console.log(preview_button)
+
     $.ajax({
         url: buildCourseUrl(['markdown', 'preview']),
         type: 'POST',
@@ -1588,6 +1590,9 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
                 preview_button.empty();
                 preview_button.append('Edit <i class="fa fa-edit fa-1x"></i>');
 
+                console.log("hello");
+                preview_button.data("mode", "preview");
+
             }
             else {
                 preview_element.hide();
@@ -1595,6 +1600,9 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
 
                 preview_button.empty();
                 preview_button.append('Preview <i class="fas fa-eye fa-1x"></i>');
+
+                console.log("hi")
+                preview_button.data("mode", "edit");
             }
         },
         error: function() {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1570,8 +1570,6 @@ function getFocusableElements() {
 function previewMarkdown(markdown_textarea, preview_element, preview_button, data) {
     const enablePreview = preview_element.is(':hidden');
 
-    console.log(preview_button)
-
     $.ajax({
         url: buildCourseUrl(['markdown', 'preview']),
         type: 'POST',
@@ -1589,8 +1587,6 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
 
                 preview_button.empty();
                 preview_button.append('Edit <i class="fa fa-edit fa-1x"></i>');
-                
-                console.log(preview_button.data("mode"))
                 preview_button.attr("data-mode", "preview");
 
             }
@@ -1600,8 +1596,6 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
 
                 preview_button.empty();
                 preview_button.append('Preview <i class="fas fa-eye fa-1x"></i>');
-
-                console.log("hi")
                 preview_button.attr("data-mode", "edit");
             }
         },

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1587,7 +1587,7 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
 
                 preview_button.empty();
                 preview_button.append('Edit <i class="fa fa-edit fa-1x"></i>');
-                preview_button.attr("data-mode", "preview");
+                preview_button.attr('data-mode', 'preview');
 
             }
             else {
@@ -1596,7 +1596,7 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
 
                 preview_button.empty();
                 preview_button.append('Preview <i class="fas fa-eye fa-1x"></i>');
-                preview_button.attr("data-mode", "edit");
+                preview_button.attr('data-mode', 'edit');
             }
         },
         error: function() {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1589,9 +1589,9 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
 
                 preview_button.empty();
                 preview_button.append('Edit <i class="fa fa-edit fa-1x"></i>');
-
-                console.log("hello");
-                preview_button.data("mode", "preview");
+                
+                console.log(preview_button.data("mode"))
+                preview_button.attr("data-mode", "preview");
 
             }
             else {
@@ -1602,7 +1602,7 @@ function previewMarkdown(markdown_textarea, preview_element, preview_button, dat
                 preview_button.append('Preview <i class="fas fa-eye fa-1x"></i>');
 
                 console.log("hi")
-                preview_button.data("mode", "edit");
+                preview_button.attr("data-mode", "edit");
             }
         },
         error: function() {


### PR DESCRIPTION
### What is the current behavior?
Fixes #7003 and Fixes #7035
Currently, toggling out of markdown while markdown preview is on will leave the text unable to be edited, because it is still in preview mode. Additionally, if you cancel the edit popup while in preview mode and open the edit menu for a different message, the markdown preview for the previous message will be shown.

### What is the new behavior?
Now, when you toggle out of markdown the preview button will be toggled if it is currently in preview mode. Additionally, if you cancel the edit window while in preview mode, you will also be taken out of preview mode before canceling, ensuring that when you reopen an edit popup you will be in edit mode. This also follows the behavior of the update post button.
