### PR TITLE
[Bugfix:TAGrading] Fix usort for late day events

### DIFF
--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -230,7 +230,7 @@ class LateDays extends AbstractModel {
         // Sort by 'timestamp'
         usort($late_day_events, function ($e1, $e2) {
             $diff = 0;
-            if ($e1['timestamp'] !== null && $e1['timestamp'] !== null) {
+            if ($e1['timestamp'] !== null && $e2['timestamp'] !== null) {
                 $diff = $e1['timestamp']->getTimestamp() - $e2['timestamp']->getTimestamp();
             }
             elseif ($e2['timestamp'] !== null) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The late day events are ran through based on timestamp. They are used in order to create late day information. The null check isn't being applied to the elements properly. All events should have timestamps, so it did not introduce any bugs as of yet.

### What is the new behavior?
The null check is applies correctly within usort ($e1 and $e2)

### Other information?
Not a breaking change, the bug wasn't necessarily an issue to begin with.
