### PR TITLE
[Bugfix:InstructorUI] Preferred Names in Grader Assignment Tab

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2310,8 +2310,8 @@ ORDER BY rotating_section"
     public function getGradersByUserType() {
         $this->course_db->query(
             "SELECT 
-                (CASE WHEN user_preferred_firstname IS NOT NULL THEN user_preferred_firstname ELSE user_firstname END) as user_firstname,
-                (CASE WHEN user_preferred_lastname IS NOT NULL THEN user_preferred_lastname ELSE user_lastname END) as user_lastname,
+                COALESCE(NULLIF(user_preferred_firstname, ''), user_firstname) AS user_firstname,
+                COALESCE(NULLIF(user_preferred_lastname, ''), user_lastname) AS user_lastname,
                 user_id,
                 user_group
             FROM

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2309,7 +2309,17 @@ ORDER BY rotating_section"
 
     public function getGradersByUserType() {
         $this->course_db->query(
-            "SELECT user_firstname, user_lastname, user_id, user_group FROM users WHERE user_group < 4 ORDER BY user_group, user_id ASC"
+            "SELECT 
+                (CASE WHEN user_preferred_firstname IS NOT NULL THEN user_preferred_firstname ELSE user_firstname END) as user_firstname,
+                (CASE WHEN user_preferred_lastname IS NOT NULL THEN user_preferred_lastname ELSE user_lastname END) as user_lastname,
+                user_id,
+                user_group
+            FROM
+                users
+            WHERE
+                user_group < 4
+            ORDER BY
+                user_group, user_id ASC"
         );
         $users = [];
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Closes #7029
Currently "Grader Assignment" tab, when matching TAs to rotating sections, currently displays instructors, graders, TA's legal names
- ![before](https://user-images.githubusercontent.com/43322572/133503614-c629e8da-e6cf-4898-924a-95f1f2796cf4.png)


### What is the new behavior?

Displays instructors, graders, TA's preferred names
- ![after](https://user-images.githubusercontent.com/43322572/133503628-0d23acf4-e9c9-49e1-8ff4-6f94c1004607.png)

### Additional Information
- checked that the only files that use the result of this `getGradersByUserType()` function are `AdminGradeableController.php` → `AdminGradeableGraders.twig`, so I won't be changing display names elsewhere
