### PR TITLE
[Bugfix:TAGrading] Clarify sections in grading index

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -69,6 +69,11 @@
             </div>
         </div>
     {% endif %}
+    {% if message is not empty %}
+    <div class="details-warning-box{% if message_warning %} details-warning-highlight{% else %} details-warning-neutral{% endif %}">
+        {{ message }}
+    </div>
+    {% endif %}
     <div class="details-action-box">
         {# Import+Export teams buttons #}
         {% if show_import_teams_button %}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -778,15 +778,17 @@ HTML;
         $message_warning = false;
         if ($this->core->getUser()->getGroup() === User::GROUP_INSTRUCTOR || $this->core->getUser()->getGroup() === User::GROUP_FULL_ACCESS_GRADER) {
             if ($view_all) {
-                if (sizeof($grader_registration_sections) !== 0) {
+                if (count($grader_registration_sections) !== 0) {
                     $message = 'Notice: You are assigned to grade a subset of students for this gradeable, but you are currently viewing all students. Select "View Your Sections" to see only your sections.';
                     $message_warning = true;
                 }
-            } else if(sizeof($grader_registration_sections) === 0) {
+            }
+            elseif (count($grader_registration_sections) === 0) {
                 $message = 'Notice: You are not assigned to grade any students for this gradeable. Select "View All" to see the whole class.';
                 $message_warning = true;
             }
-        } else if(sizeof($grader_registration_sections) === 0) {
+        }
+        elseif (count($grader_registration_sections) === 0) {
             $message = 'Notice: You are not assigned to grade any students for this gradeable.';
         }
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -772,6 +772,24 @@ HTML;
             ];
         }
 
+        $grader_registration_sections = $gradeable->getGraderAssignmentMethod() === Gradeable::ROTATING_SECTION ? $gradeable->getRotatingGraderSections()[$this->core->getUser()->getId()] ?? [] : $this->core->getUser()->getGradingRegistrationSections();
+
+        $message = "";
+        $message_warning = false;
+        if ($this->core->getUser()->getGroup() === User::GROUP_INSTRUCTOR || $this->core->getUser()->getGroup() === User::GROUP_FULL_ACCESS_GRADER) {
+            if ($view_all) {
+                if (sizeof($grader_registration_sections) !== 0) {
+                    $message = 'Notice: You are assigned to grade a subset of students for this gradeable, but you are currently viewing all students. Select "View Your Sections" to see only your sections.';
+                    $message_warning = true;
+                }
+            } else if(sizeof($grader_registration_sections) === 0) {
+                $message = 'Notice: You are not assigned to grade any students for this gradeable. Select "View All" to see the whole class.';
+                $message_warning = true;
+            }
+        } else if(sizeof($grader_registration_sections) === 0) {
+            $message = 'Notice: You are not assigned to grade any students for this gradeable.';
+        }
+
         $team_gradeable_view_history = $gradeable->isTeamAssignment() ? $this->core->getQueries()->getAllTeamViewedTimesForGradeable($gradeable) : [];
         foreach ($team_gradeable_view_history as $team_id => $team) {
             $not_viewed_yet = true;
@@ -837,7 +855,9 @@ HTML;
             "semester" => $this->core->getConfig()->getSemester(),
             "course" => $this->core->getConfig()->getCourse(),
             "blind_status" => $gradeable->getPeerBlind(),
-            "is_instructor" => $this->core->getUser()->getGroup() === 1
+            "is_instructor" => $this->core->getUser()->getGroup() === 1,
+            "message" => $message,
+            "message_warning" => $message_warning
         ]);
     }
 

--- a/site/public/css/details.css
+++ b/site/public/css/details.css
@@ -46,6 +46,20 @@
     flex-direction: column-reverse;
 }
 
+.details-warning-box {
+    text-align: center;
+    padding: 20px;
+    margin-top: 20px;
+}
+
+.details-warning-highlight {
+    background-color: var(--standard-vibrant-orange);
+}
+
+.details-warning-neutral {
+    background-color: var(--standard-hover-light-gray);
+}
+
 .details-action-box > * {
     margin-top: 0;
     white-space: initial;


### PR DESCRIPTION
### What is the current behavior?
There is no banner on the TA grading index.

### What is the new behavior?
Closes #7065 
A banner will appear on the TA grading index to clarify certain cases to help make it more clear of what graders need to grade.

When instructors/full access graders are viewing all students but they have at least one assigned section, they will get the message: `Notice: You are assigned to grade a subset of students for this gradeable, but you are currently viewing all students. Select "View Your Sections" to see only your sections.`

![image](https://user-images.githubusercontent.com/15370948/133513356-c2921772-cb68-4cc4-b4b7-5997a0b3a4df.png)

When instructors/full access graders are viewing their own sections but they have no assigned sections, they will get the message: `Notice: You are not assigned to grade any students for this gradeable. Select "View All" to see the whole class.`

![image](https://user-images.githubusercontent.com/15370948/133513660-e8e21463-8773-424b-9f6f-2c7e9ebee393.png)

When graders who are not instructors/full access graders are viewing their own sections but they have no assigned sections, they will get the message: `Notice: You are not assigned to grade any students for this gradeable.`

![image](https://user-images.githubusercontent.com/15370948/133513688-a238bb97-7389-420f-95db-39b02e69718d.png)
