### PR TITLE
[Bugfix:System] Fix configure crash on disabling email

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -312,6 +312,7 @@ else:
             EMAIL_REPLY_TO = defaults['email_reply_to']
             EMAIL_SERVER_HOSTNAME = defaults['email_server_hostname']
             EMAIL_SERVER_PORT = defaults['email_server_port']
+            EMAIL_INTERNAL_DOMAIN = defaults['email_internal_domain']
             break
     print()
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #7038 

Right now, when running `CONFIGURE_SUBMITTY.py` and disabling email, a `NameError` will get thrown. This is because the `EMAIL_INTERNAL_DOMAIN` is only set within the `if` branch, and not the `else` branch.

### What is the new behavior?

The `EMAIL_INTERNAL_DOMAIN` is now defined similar to the other email variables in the `else` branch, so the crash is avoided.
