### PR TITLE
[Bugfix:InstructorUI] Hide Release Grades Button

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -851,13 +851,15 @@ class NavigationView extends AbstractView {
                 ]);
             }
             else {
-                $button = new Button($this->core, [
-                    "subtitle" => "RELEASE GRADES NOW",
-                    "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
-                        . http_build_query(['action' => 'release_grades_now']),
-                    "class" => "btn btn-primary btn-nav btn-nav-open",
-                    "name" => "quick-link-btn"
-                ]);
+                if ($gradeable->hasReleaseDate()) {
+                    $button = new Button($this->core, [
+                        "subtitle" => "RELEASE GRADES NOW",
+                        "href" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'quick_link']) . '?'
+                            . http_build_query(['action' => 'release_grades_now']),
+                        "class" => "btn btn-primary btn-nav btn-nav-open",
+                        "name" => "quick-link-btn"
+                    ]);
+                }
             }
         }
         elseif ($list_section === GradeableList::OPEN && $gradeable->hasDueDate()) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The grades release button will appear in some cases when it does not have a release date. When you try to press it you will be told that you cannot set the release date.
Closes #7053 

### What is the new behavior?
The button to set the release date is completely gone for gradeables without a release date.
