### PR TITLE
[UI/UX:Developer] Fix Contact link on README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Submitty project is hosted on [GitHub](https://github.com/Submitty).
 
 # Contact Us
 
-If you have a question, please [contact us](https://submitty.org/#contact-us) through email or our Slack.
+If you have a question, please [contact us](https://submitty.org/index/contact) through email or our Slack.
 
 
 ### LICENSING


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
The current contact page link only brings you to the overview page on the submitty docs, while this page does have a separate link to the contact page there, someone may miss it 

### What is the new behavior?
Contact link directly links to contact page

