### PR TITLE
[Bugfix:InstructorUI] Fix NaN bug when changing date field

### DIFF
--- a/site/public/js/extensions.js
+++ b/site/public/js/extensions.js
@@ -58,7 +58,9 @@ function setLateDays() {
     const new_date = new Date($('#late-calendar').val());
     const old_date = new Date($('#due-date').data('date'));
     const diff = (new_date.getTime() - old_date.getTime()) / (1000 * 3600 * 24);
-    document.getElementById('late-days').value = diff;
+    if (!isNaN(diff)) {
+        document.getElementById('late-days').value = diff;
+    }
 }
 
 function confirmExtension(option){


### PR DESCRIPTION
### What is the current behavior?
Fixes #7054

### What is the new behavior?
Fixes bug such that the number of late days specified manually will only be overwritten when a valid date is selected.  Perhaps @bmcutler has thoughts here?  An alternative would be to overwrite the manually specified late days when the date field is not empty, even if it has an invalid date in it.  
