### PR TITLE
[UI/UX:InstructorUI] Update late day text on settings page

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -164,7 +164,7 @@
             <span class="option-title">Initial Allowed Late Days (Per Student, Per Semester)</span>
             <br>
             <span class="option-alt">
-                Base number of late days given to all students at the start of the course.
+                Initial number of late days given to all students at the start of the course.
                 Additional late days can be granted (e.g., as incentives) using the "Late Days Allowed" form.
             </span>
         </label>

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -164,9 +164,8 @@
             <span class="option-title">Initial Allowed Late Days (Per Student, Per Semester)</span>
             <br>
             <span class="option-alt">
-                Number of allowed late days given to each student when they are added to
-                the course.  Additional late days can be granted (e.g., as incentives)
-                using the "Late Days Allowed" form.
+                Base number of late days given to all students at the start of the course.
+                Additional late days can be granted (e.g., as incentives) using the "Late Days Allowed" form.
             </span>
         </label>
         <input class="config-row" type="number" name="default_student_late_days" id="default-student-late-days" value="{{ fields['default_student_late_days'] }}" />


### PR DESCRIPTION
### What is the current behavior?
The current text on the "Initial Allowed Late Days" section of the course settings page currently reads: Number of allowed late days given to each student when they are added to the course.  Additional late days can be granted (e.g., as incentives) using the "Late Days Allowed" form.

This text is confusing because the number for all students can be changed at any time, not just when students are added to the course.

### What is the new behavior?
Changed the text to read: Base number of late days given to all students at the start of the course. Additional late days can be granted (e.g., as incentives) using the "Late Days Allowed" form.
