### PR TITLE
[Bugfix:InstructorUI] Fixed Typo on Toast Message

### DIFF
--- a/site/public/js/solution-ta-notes.js
+++ b/site/public/js/solution-ta-notes.js
@@ -31,7 +31,7 @@ function updateSolutionTaNotes(gradeable_id, component_id, itempool_item) {
                 $(`#sol-textbox-cont-${component_id}-saved .solution-notes-text`).text(res.data.solution_text);
             }
             else {
-                displayErrorMessage('Something went wrong while upating the solution...');
+                displayErrorMessage('Something went wrong while updating the solution...');
             }
         },
         error: function(err) {


### PR DESCRIPTION
### What is the current behavior?
Fixes #7121 

### What is the new behavior?
Fixed a typo in an error toast message displayed in the Solutions/Notes tab of the Gradeable page, when logged in as an instructor or TA
### Other information?
This is not a breaking change.
No testing was necessary as this is a mere typo fix. 
