### PR TITLE
[Bugfix:Forum] Missing expiration datepicker fix

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -788,7 +788,8 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
                 var thread_title = json.title;
                 var thread_lock_date =  json.lock_thread_date;
                 var thread_status = json.thread_status;
-                var expiration = json.expiration;
+                var expiration = json.expiration.replace("-", "/");
+                expiration = expiration.replace("-", "/");
                 $("#title").prop('disabled', false);
                 $(".edit_thread").show();
                 $('#label_lock_thread').show();
@@ -798,7 +799,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
                 if (Date.parse(expiration) > new Date()) {
                   $(".expiration").show();
                 }
-                $("#expirationDate").val(expiration);
+                $("#expirationDate").val(json.expiration);
 
                 // Categories
                 $(".cat-buttons").removeClass('btn-selected');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently on firefox the expiration date picker does not show up due to an issue with date.parse not working with "-"  in the date

### What is the new behavior?
The new behavior replaces the "-" with "/". This is only a temporary fix when issue #6415 is implemented this will also be fixed.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
