### PR TITLE
[Bugfix:SubminiPolls] Fix newlines in poll histograms

### DIFF
--- a/site/app/templates/polls/ViewPollResults.twig
+++ b/site/app/templates/polls/ViewPollResults.twig
@@ -8,7 +8,7 @@
           }
         ];
         {% for answer, number in results %}
-            data[0].x.push("{{ poll.getResponseString(answer) }}");
+            data[0].x.push("{{ poll.getResponseString(answer)|replace({"\n": " ", "\r": " ", "\t": " "}) }}");
             data[0].y.push({{ number }});
         {% endfor %}
         const layout = {


### PR DESCRIPTION
### What is the current behavior?
Newlines in poll answers break the histogram as described in #7106.

### What is the new behavior?
Removes newlines from poll histogram labels to prevent JS syntax errors when rendering the histogram.

Fixes #7106