### PR TITLE
[Bugfix:SubminiPolls] Fix doubly-escaped HTML in hist title

### DIFF
--- a/site/app/templates/polls/ViewPollResults.twig
+++ b/site/app/templates/polls/ViewPollResults.twig
@@ -11,8 +11,9 @@
             data[0].x.push("{{ poll.getResponseString(answer) }}");
             data[0].y.push({{ number }});
         {% endfor %}
+        const title_text = new DOMParser().parseFromString("{{ poll.getName() }}", "text/html");
         const layout = {
-          title: "{{ poll.getName() }}",
+          title: title_text.documentElement.textContent,
         }
         Plotly.newPlot("chartContainer", data, layout);
     }


### PR DESCRIPTION
### What is the current behavior?
HTML special characters are currently doubly-escaped in the title of the poll results histogram which leads to the issue described in #7098.

### What is the new behavior?
This PR fixes #7098 by safely un-encoding the title of the poll before passing it to the plotting library which encodes it again.  Care was taken to mitigate possible opportunities for XSS vulnerabilities by using `DOMParser().parseFromString` to decode the string after Twig renders it without sacrificing usability.