### PR TITLE
[UI/UX:System] BugFix runaway markdown table borders

### DIFF
--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -85,7 +85,7 @@
     overflow-x: scroll;
 }
 
-.markdown th, td{
+.markdown th, .markdown td{
     border: 1px solid var(--standard-light-gray);
     padding: 3px;
 }


### PR DESCRIPTION
### What is the current behavior?
#6998 added support for tables in markdown.  Unfortunately, a small portion of the CSS included in that PR applies to all `<td>` elements site-wide which leads to tables having thicker borders as shown below:

<img width="821" alt="Untitled" src="https://user-images.githubusercontent.com/16820599/134787248-0d617a3f-8767-4b05-bde6-d1a259518360.png">


### What is the new behavior?
Fixes the runaway CSS selector.
<img width="823" alt="Untitled" src="https://user-images.githubusercontent.com/16820599/134787232-e201aaa1-9eca-4dba-93be-360085b4a1b8.png">
