### PR TITLE
[Bugfix:Submission] git submission file/branch ambiguity

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -906,7 +906,8 @@ def checkout_vcs_repo(config, my_file):
             # determine which version we need to checkout
             # if the repo is empty or the specified branch does not exist, this command will fail
             try:
-                what_version = subprocess.check_output(['git', 'rev-list', '-n', '1', which_branch, '--'])
+                what_version = subprocess.check_output(['git', 'rev-list', '-n', '1',
+                                                        which_branch, '--'])
                 # old method:  when we had the full history, roll-back to a version by date
                 # what_version = subprocess.check_output(['git', 'rev-list', '-n', '1',
                 #                                         '--before="'+submission_string+'"',

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -906,7 +906,7 @@ def checkout_vcs_repo(config, my_file):
             # determine which version we need to checkout
             # if the repo is empty or the specified branch does not exist, this command will fail
             try:
-                what_version = subprocess.check_output(['git', 'rev-list', '-n', '1', which_branch])
+                what_version = subprocess.check_output(['git', 'rev-list', '-n', '1', which_branch, '--'])
                 # old method:  when we had the full history, roll-back to a version by date
                 # what_version = subprocess.check_output(['git', 'rev-list', '-n', '1',
                 #                                         '--before="'+submission_string+'"',


### PR DESCRIPTION
### What is the current behavior?
For assignment submission by git, if a student has a file in their repo, 
named simply 'main' there is an ambiguity when checking out the student's work.

The error causes a file named "failed_to_determine_version_on_specifed_branch.txt" 
to be included in the checkout folder.  

The initial autograding apparently proceeds normally, but if the assignment is batch
regraded, there are significant problems and the score is zero.

### What is the new behavior?
The change resolves the ambiguity, now repos with a main file autograde fine.