### PR TITLE
[Bugfix:Submission] Fix seating chart in dark mode

### DIFF
--- a/site/app/templates/navigation/RoomSeating.twig
+++ b/site/app/templates/navigation/RoomSeating.twig
@@ -5,12 +5,12 @@
     {% endif %}
     <tr><td>
         <table border=0 cellpadding=5 cellspacing=0>
-            <tr><td colspan=2>{{ core.getDisplayedCourseName() }}{{ gradeable_title != null ? ': '~gradeable_title : ''}}</td></tr>
-            <tr><td>{{ user_seating_details.date }} </td><td align=center>{{ user_seating_details.time }}</td></tr>
-            <tr><td>Your room assignment: </td><td align=center>{{ user_seating_details.building }} {{ user_seating_details.room }}</td></tr>
-            <tr><td>Your zone assignment: </td><td align=center>{{ user_seating_details.zone }}</td></tr>
-            <tr><td>Your row assignment: </td><td align=center>{{ user_seating_details.row }}</td></tr>
-            <tr><td>Your seat assignment: </td><td align=center>{{ user_seating_details.seat }}</td></tr>
+            <tr class="seating-chart-table"><td colspan=2>{{ core.getDisplayedCourseName() }}{{ gradeable_title != null ? ': '~gradeable_title : ''}}</td></tr>
+            <tr class="seating-chart-table"><td>{{ user_seating_details.date }} </td><td align=center>{{ user_seating_details.time }}</td></tr>
+            <tr class="seating-chart-table"><td>Your room assignment: </td><td align=center>{{ user_seating_details.building }} {{ user_seating_details.room }}</td></tr>
+            <tr class="seating-chart-table"><td>Your zone assignment: </td><td align=center>{{ user_seating_details.zone }}</td></tr>
+            <tr class="seating-chart-table"><td>Your row assignment: </td><td align=center>{{ user_seating_details.row }}</td></tr>
+            <tr class="seating-chart-table"><td>Your seat assignment: </td><td align=center>{{ user_seating_details.seat }}</td></tr>
         </table>
     </td></tr>
     <tr><td style="background-color:var( --standard-focus-cornflowe-blue);">

--- a/site/app/templates/navigation/RoomSeating.twig
+++ b/site/app/templates/navigation/RoomSeating.twig
@@ -1,5 +1,5 @@
 {# This is a layout table #}
-<table style="border:1px solid yellowgreen; background-color:#ddffdd; width:auto;">
+<table style="background-color:var( --standard-focus-cornflowe-blue); width:auto;">
     {% if seating_only_for_instructor %}
         <div class="option-alt">Visible only to Instructors</div>
     {% endif %}

--- a/site/app/templates/navigation/RoomSeating.twig
+++ b/site/app/templates/navigation/RoomSeating.twig
@@ -13,7 +13,7 @@
             <tr><td>Your seat assignment: </td><td align=center>{{ user_seating_details.seat }}</td></tr>
         </table>
     </td></tr>
-    <tr><td style="background-color:#ffffff;">
+    <tr><td style="background-color:var( --standard-focus-cornflowe-blue);">
         {% if seating_config != null %}
             {% include '@room_templates/'~user_seating_details.building~'/'~user_seating_details.room~'.twig' %}
         {% else %}

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -79,6 +79,10 @@
     display: inline;
 }
 
+.seating-chart-table {
+    border:2px solid black;
+}
+
 @media (max-width: 401px) {
     .course-section-heading,
     .course-main .course-title {


### PR DESCRIPTION

### What is the current behavior?
closes #7125 
<img width="573" alt="pr20_1" src="https://user-images.githubusercontent.com/66340271/134830819-0453c93f-1683-430d-9af6-745202f239b5.PNG">


### What is the new behavior?
The table is clearly visible in light and dark mode
<img width="470" alt="pr20_2" src="https://user-images.githubusercontent.com/66340271/134831072-77507ae1-eba3-4059-b522-065c7064cdd4.PNG">
<img width="397" alt="pr20_3" src="https://user-images.githubusercontent.com/66340271/134831077-af539528-57d9-41c7-9355-3ed4010004cc.PNG">


### Other information?
To test:
I couldn't figure out how to actually upload a seating chart so I just edited a few lines in Navigation.twig and Roomseating.twig to get the table to show up