### PR TITLE
[Bugfix:HelpQueue] Fix stats page table header

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueStats.twig
+++ b/site/app/templates/officeHoursQueue/QueueStats.twig
@@ -64,7 +64,7 @@
   <table class="table">
     <thead>
       <tr>
-      {% if 0 in week_day_this_week_data %}
+      {% if not week_day_this_week_data is empty %}
         {% for key, item in week_day_this_week_data[0] %}
           <th style="padding:.4rem">{{viewer.statNiceName(key)}}</th>
         {% endfor %}


### PR DESCRIPTION
### What is the current behavior?
The header row for the "This Week's Data" table doesn't show up on the office hours queue stats page:
![image](https://user-images.githubusercontent.com/71195502/135010307-28310c15-5548-44dd-bab8-180f4f7b0607.png)

### What is the new behavior?
The header shows up correctly
![image](https://user-images.githubusercontent.com/71195502/135010264-28a6430d-27fd-419a-81af-f0c9e861953d.png)
