### PR TITLE
[Refactor:TAGrading] fix vague Grading sorting order button

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -43,7 +43,7 @@
                 {% endif %}
                 <a class="btn btn-default"
                    href="{{ order_toggle_url }}">
-                    {{ sort == 'random' ? "Default Order" : "Random Order" }}
+                    {{ sort == 'random' ? "Switch to Default Order" : "Switch to Random Order" }}
                 </a>
                 {% if toggle_anon_button %}
                 <a class="btn btn-default" id="toggle-anon-button"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
closes #7133 
<img width="476" alt="pr21_2" src="https://user-images.githubusercontent.com/66340271/135011462-73de63d4-7bfe-42be-b71c-c47629bf5183.PNG">

### What is the new behavior?
The Default/Random order buttons now say "Switch to Default Order" and "Switch to Random Order"
<img width="183" alt="pr21_1" src="https://user-images.githubusercontent.com/66340271/135011598-298553e9-3f39-46a5-962b-f8065be6bc8a.PNG">

