### PR TITLE
[Feature:Submission] Add Switch to Most Recent button

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -352,8 +352,7 @@
                     "content" : upload_message
                 } only %}
             </div>
-            <button type="button" id="submit" class="submit-gradeable btn btn-success">
-{#                {{ viewing_inactive_version ? 'Switch To Most Recent Version To Make New Submission' : 'Submit' }}#}
+            <button type="button" id="submit" class="submit-gradeable btn btn-success" {% if viewing_inactive_version %} title="Switch to most recent version to submit"{% endif %}>
                 Submit
             </button>
         {% if viewing_inactive_version %}

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -355,11 +355,11 @@
             <button type="button" id="submit" class="submit-gradeable btn btn-success" {% if viewing_inactive_version %} title="Switch to most recent version to submit"{% endif %}>
                 Submit
             </button>
-        {% if viewing_inactive_version %}
-            <a href="{{ recent_version_url }}" class="btn btn-success" id="switch-to-most-recent">
-                Switch to Most Recent Version
-            </a>
-        {% endif %}
+            {% if viewing_inactive_version %}
+                <a href="{{ recent_version_url }}" class="btn btn-primary">
+                    Switch to Most Recent Version
+                </a>
+            {% endif %}
         {% endif %}
 
         {% if part_names is not empty %}

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -356,9 +356,9 @@
                 Submit
             </button>
         {% if viewing_inactive_version %}
-            <button type="button" id="switch_to_most_recent" class="btn btn-success" onclick="switchToMostRecent('{{ recent_version_url }}')">
+            <a href="{{ recent_version_url }}" class="btn btn-success" id="switch-to-most-recent">
                 Switch to Most Recent Version
-            </button>
+            </a>
         {% endif %}
         {% endif %}
 

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -353,10 +353,16 @@
                 } only %}
             </div>
             <button type="button" id="submit" class="submit-gradeable btn btn-success">
-                {{ viewing_inactive_version ? 'Switch To Most Recent Version To Make New Submission' : 'Submit' }}
+{#                {{ viewing_inactive_version ? 'Switch To Most Recent Version To Make New Submission' : 'Submit' }}#}
+                Submit
+            </button>
+        {% if viewing_inactive_version %}
+            <button type="button" id="switch_to_most_recent" class="btn btn-success" onclick="switchToMostRecent('{{ recent_version_url }}')">
+                Switch to Most Recent Version
             </button>
         {% endif %}
-        
+        {% endif %}
+
         {% if part_names is not empty %}
             <button type="button" id="startnew" class="btn btn-primary">Clear</button>
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -441,6 +441,9 @@ class HomeworkView extends AbstractView {
         if (!is_null($graded_gradeable)) {
             $graded_gradeable->hasOverriddenGrades();
         }
+
+
+        $recent_version_url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
         $numberUtils = new NumberUtils();
         // TODO: go through this list and remove the variables that are not used
         return $output . $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
@@ -501,7 +504,8 @@ class HomeworkView extends AbstractView {
             'viewing_inactive_version' => $viewing_inactive_version,
             'allowed_minutes' => $gradeable->getUserAllowedTime($this->core->getUser()),
             'can_student_submit' => $canStudentSubmit,
-            'is_grader_view' => false
+            'is_grader_view' => false,
+            'recent_version_url' => $recent_version_url
         ]);
     }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -441,7 +441,6 @@ class HomeworkView extends AbstractView {
         if (!is_null($graded_gradeable)) {
             $graded_gradeable->hasOverriddenGrades();
         }
-        
         $recent_version_url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
         $numberUtils = new NumberUtils();
         // TODO: go through this list and remove the variables that are not used

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -441,8 +441,7 @@ class HomeworkView extends AbstractView {
         if (!is_null($graded_gradeable)) {
             $graded_gradeable->hasOverriddenGrades();
         }
-
-
+        
         $recent_version_url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
         $numberUtils = new NumberUtils();
         // TODO: go through this list and remove the variables that are not used

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -615,10 +615,6 @@ function versionChange(url, sel){
     window.location.href = url;
 }
 
-function switchToMostRecent(url){
-    window.location.href = url;
-}
-
 function checkVersionChange(days_late, late_days_allowed){
     if(days_late > late_days_allowed){
         var message = "The max late days allowed for this assignment is " + late_days_allowed + " days. ";

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -612,6 +612,11 @@ function gradeableChange(url, sel){
 }
 function versionChange(url, sel){
     url = url + sel.value;
+    console.log(url);
+    window.location.href = url;
+}
+
+function switchToMostRecent(url){
     window.location.href = url;
 }
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -612,7 +612,6 @@ function gradeableChange(url, sel){
 }
 function versionChange(url, sel){
     url = url + sel.value;
-    console.log(url);
     window.location.href = url;
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
There has been some confusion about the disabled submit button, when not viewing the most recent version of a gradeable. Currently if not viewing the most recent submission the submit button text changes to "Switch to most recent version to make a submission" and is disabled. Clicking it does not actually switch to the most recent version which is what was causing confusion.
<img width="523" alt="pr22_2" src="https://user-images.githubusercontent.com/66340271/135182831-c5c6a21f-6d65-467d-a962-53b8db7c5693.PNG">

### What is the new behavior?
The submit button now always says submit but is disabled when not viewing the most recent submission, there is also a tooltip that says "switch to most recent version to submit". When the button is disabled, there is another button beside it that allows the user to easily switch to their most recent submission.

<img width="413" alt="pr22_1" src="https://user-images.githubusercontent.com/66340271/135182869-d5d56e88-d241-4dee-800e-8fcd910bafb1.PNG">


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
