### PR TITLE
[Bugfix:TAGrading] Fix download button duplication

### DIFF
--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -50,6 +50,10 @@
     //render download annotations button on toolbar
     $(function() {
         const download_annotations_button = document.getElementById('download-annotations-btn-template').content.cloneNode(true);
-        $('#pdf-buttons').append(download_annotations_button);
+        if ($('#pdf-buttons').has('#download-annotations-btn').length) {
+            $('#pdf-buttons', '#download-annotations-btn').replaceWith(download_annotations_button);
+        } else {
+            $('#pdf-buttons').append(download_annotations_button);
+        }
     });
 </script>


### PR DESCRIPTION
### What is the current behavior?
Going in and out of a PDF annotation duplicates the download button in the PDF toolbar.

### What is the new behavior?
Going in and out of a PDF annotation no longer duplicates the download button in the PDF toolbar.
