### PR TITLE
[Feature:Plagiarism] Add C as supported language

### DIFF
--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -134,7 +134,7 @@
                         <select name="language">
                             <option value="plaintext" {{ config["language"]["plaintext"] }}>Plain Text</option>
                             <option value="python" {{ config["language"]["python"] }}>Python</option>
-                            <option value="cpp" {{ config["language"]["cpp"] }}>C++</option>
+                            <option value="cpp" {{ config["language"]["cpp"] }}>C/C++</option>
                             <option value="java" {{ config["language"]["java"] }}>Java</option>
                             <option value="mips" {{ config["language"]["mips"] }}>MIPS Assembly</option>
                         </select>


### PR DESCRIPTION
### What is the current behavior?
On the plagiarism configuration page, the dropdown for tokenization per language has an item only for C++.

### What is the new behavior?
As requested, the dropdown item has been update to display the text `C/C++`, as the tokenization used for C++ supports C as well.