### PR TITLE
[Refactor:System] Remove pip installs from setup_distro

### DIFF
--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -130,12 +130,3 @@ apt-get -qqy autoremove
 add-apt-repository ppa:git-core/ppa -y
 apt-get install git -y
 # ------------------------------------------------------------------
-
-# necessary to install these to support the older version of pip
-# that Ubuntu-18.04
-# cryptography>=3.4 includes rust which requires additional stuff
-# to work on ubuntu-18.04, easier to pin to older version
-pip3 install cryptography==3.3.2
-# newer versions of opencv require a very length compile step
-# or newer version of pip, easier to install this older version
-pip3 install opencv-python==3.4.9.33


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We run two `pip install` lines in setup_distro for Ubuntu 18.04. These packages are then "re-installed" when we run `pip install` over `.setup/pip/system_requirements.txt`, rendering these unnecessary.

### What is the new behavior?

Remove these unnecessary installs, and we just rely on the single definition of them in `system_requirements.txt`.