### PR TITLE
[Bugfix:TAGrading] Allow for empty solution notes

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2967,9 +2967,6 @@ class ElectronicGraderController extends AbstractController {
         if (!$gradeable) {
             $error = "Invalid Gradeable ID given!";
         }
-        elseif (empty($solution_text)) {
-            $error = "Please provide some non-empty solution";
-        }
         elseif ($componentItempoolInfo['is_linked'] && empty($itempool_item)) {
             //Itempool must be non-empty when component is linked with the itempool
             $error = 'This component expects only non-empty itempool-item!';


### PR DESCRIPTION
### What is the current behavior?
You can not save if you delete all of the text in the solution notes.

### What is the new behavior?
Fixes #7096 Allows for solution notes to be saved when empty.