### PR TITLE
[Bugfix:System] Fix db dumps to work on postgresql 10

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -120,7 +120,6 @@ $_$;
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
 
 --
 -- Name: categories_list; Type: TABLE; Schema: public; Owner: -

--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -271,7 +271,6 @@ CREATE FUNCTION public.sync_user() RETURNS trigger
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
 
 --
 -- Name: courses; Type: TABLE; Schema: public; Owner: -

--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -537,49 +537,49 @@ ALTER TABLE ONLY public.users
 -- Name: courses_users after_delete_sync_delete_user_cleanup; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER after_delete_sync_delete_user_cleanup AFTER DELETE ON public.courses_users FOR EACH ROW EXECUTE FUNCTION public.sync_delete_user_cleanup();
+CREATE TRIGGER after_delete_sync_delete_user_cleanup AFTER DELETE ON public.courses_users FOR EACH ROW EXECUTE PROCEDURE public.sync_delete_user_cleanup();
 
 
 --
 -- Name: courses_users before_delete_sync_delete_user; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER before_delete_sync_delete_user BEFORE DELETE ON public.courses_users FOR EACH ROW EXECUTE FUNCTION public.sync_delete_user();
+CREATE TRIGGER before_delete_sync_delete_user BEFORE DELETE ON public.courses_users FOR EACH ROW EXECUTE PROCEDURE public.sync_delete_user();
 
 
 --
 -- Name: courses_registration_sections delete_sync_registration_id; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER delete_sync_registration_id BEFORE DELETE ON public.courses_registration_sections FOR EACH ROW EXECUTE FUNCTION public.sync_delete_registration_section();
+CREATE TRIGGER delete_sync_registration_id BEFORE DELETE ON public.courses_registration_sections FOR EACH ROW EXECUTE PROCEDURE public.sync_delete_registration_section();
 
 
 --
 -- Name: users generate_api_key; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER generate_api_key BEFORE INSERT OR UPDATE OF user_password ON public.users FOR EACH ROW EXECUTE FUNCTION public.generate_api_key();
+CREATE TRIGGER generate_api_key BEFORE INSERT OR UPDATE OF user_password ON public.users FOR EACH ROW EXECUTE PROCEDURE public.generate_api_key();
 
 
 --
 -- Name: courses_registration_sections insert_sync_registration_id; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER insert_sync_registration_id AFTER INSERT OR UPDATE ON public.courses_registration_sections FOR EACH ROW EXECUTE FUNCTION public.sync_insert_registration_section();
+CREATE TRIGGER insert_sync_registration_id AFTER INSERT OR UPDATE ON public.courses_registration_sections FOR EACH ROW EXECUTE PROCEDURE public.sync_insert_registration_section();
 
 
 --
 -- Name: courses_users user_sync_courses_users; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER user_sync_courses_users AFTER INSERT OR UPDATE ON public.courses_users FOR EACH ROW EXECUTE FUNCTION public.sync_courses_user();
+CREATE TRIGGER user_sync_courses_users AFTER INSERT OR UPDATE ON public.courses_users FOR EACH ROW EXECUTE PROCEDURE public.sync_courses_user();
 
 
 --
 -- Name: users user_sync_users; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER user_sync_users AFTER UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION public.sync_user();
+CREATE TRIGGER user_sync_users AFTER UPDATE ON public.users FOR EACH ROW EXECUTE PROCEDURE public.sync_user();
 
 
 --

--- a/migration/migrator/dumper.py
+++ b/migration/migrator/dumper.py
@@ -12,6 +12,7 @@ def dump_database(db_name: str, out_file: str) -> bool:
     ], universal_newlines=True)
     out = out.replace("SELECT pg_catalog.set_config(\'search_path\', \'\', false);\n", "")
     out = re.sub(r"\-\- Dumped (from|by)[^\n]*\n", '', out, flags=re.IGNORECASE)
+    out = re.sub(r"SET default_table_access_method = ([a-z]+);\n", '', out, flags=re.IGNORECASE)
     out = re.sub(r"FOR EACH ROW EXECUTE FUNCTION", "FOR EACH ROW EXECUTE PROCEDURE", out)
     out_file.write_text(out)
     return True

--- a/migration/migrator/dumper.py
+++ b/migration/migrator/dumper.py
@@ -1,0 +1,17 @@
+from subprocess import check_output
+import re
+
+
+def dump_database(db_name: str, out_file: str) -> bool:
+    out = check_output([
+        'su',
+        '-',
+        'postgres',
+        '-c',
+        f'pg_dump -d {db_name} --schema-only --no-privileges --no-owner'
+    ], universal_newlines=True)
+    out = out.replace("SELECT pg_catalog.set_config(\'search_path\', \'\', false);\n", "")
+    out = re.sub(r"\-\- Dumped (from|by)[^\n]*\n", '', out, flags=re.IGNORECASE)
+    out = re.sub(r"FOR EACH ROW EXECUTE FUNCTION", "FOR EACH ROW EXECUTE PROCEDURE", out)
+    out_file.write_text(out)
+    return True

--- a/migration/migrator/main.py
+++ b/migration/migrator/main.py
@@ -7,11 +7,11 @@ import os
 from pathlib import Path
 import re
 from typing import Set
-import subprocess
 
 from sqlalchemy.exc import OperationalError
 
 from . import db, get_dir_path, get_migrations_path, get_environments
+from .dumper import dump_database
 from .loader import load_module, load_migrations
 
 
@@ -449,17 +449,7 @@ def dump(args):
     if 'master' in args.environments:
         out_file = data_dir / 'submitty_db.sql'
         print(f'Dumping master environment to {str(out_file)}... ', end='')
-        out = subprocess.check_output([
-            'su',
-            '-',
-            'postgres',
-            '-c',
-            'pg_dump -d submitty --schema-only --no-privileges --no-owner'
-        ], universal_newlines=True)
-
-        out = out.replace("SELECT pg_catalog.set_config(\'search_path\', \'\', false);\n", "")
-        out = re.sub(r"\-\- Dumped (from|by)[^\n]*\n", '', out, flags=re.IGNORECASE)
-        out_file.write_text(out)
+        dump_database('submitty', out_file)
         print('DONE')
 
     if 'course' in args.environments:
@@ -467,15 +457,5 @@ def dump(args):
         print(f'Dumping course environment to {str(out_file)}... ', end='')
         today = datetime.today()
         semester = f"{'s' if today.month < 7 else 'f'}{str(today.year)[-2:]}"
-
-        out = subprocess.check_output([
-            'su',
-            '-',
-            'postgres',
-            '-c',
-            f'pg_dump -d submitty_{semester}_sample --schema-only --no-privileges --no-owner'
-        ], universal_newlines=True)
-        out = out.replace("SELECT pg_catalog.set_config(\'search_path\', \'\', false);\n", "")
-        out = re.sub(r"\-\- Dumped (from|by)[^\n]*\n", '', out, flags=re.IGNORECASE)
-        out_file.write_text(out)
+        dump_database(f'submitty_{semester}_sample', data_dir / 'course_tables.sql')
         print('DONE')

--- a/migration/tests/test_dump.py
+++ b/migration/tests/test_dump.py
@@ -133,7 +133,7 @@ class TestDump(TestCase):
     def tearDown(self):
         sys.stdout = sys.__stdout__
 
-    @patch('migrator.main.subprocess.check_output', side_effect=[
+    @patch('migrator.dumper.check_output', side_effect=[
         MASTER_DB_FRAGMENT,
         COURSE_DB_FRAGMENT
     ])
@@ -162,7 +162,7 @@ class TestDump(TestCase):
                 r"Dumping course environment to .*/data/course_tables.sql... DONE\n"
             )
 
-    @patch('migrator.main.subprocess.check_output', side_effect=[
+    @patch('migrator.dumper.check_output', side_effect=[
         MASTER_DB_FRAGMENT
     ])
     def test_dump_master(self, subprocess):
@@ -186,7 +186,7 @@ class TestDump(TestCase):
                 r"Dumping master environment to .*/data/submitty_db.sql... DONE"
             )
 
-    @patch('migrator.main.subprocess.check_output', side_effect=[
+    @patch('migrator.dumper.check_output', side_effect=[
         COURSE_DB_EXPECTED
     ])
     def test_dump_course(self, subprocess):

--- a/migration/tests/test_dumper.py
+++ b/migration/tests/test_dumper.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from migrator.dumper import dump_database
+
+DB_FRAGMENT = """
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)
+-- Dumped by pg_dump version 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: courses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.courses (
+    semester character varying(255) NOT NULL,
+    course character varying(255) NOT NULL,
+    status smallint DEFAULT 1 NOT NULL
+);
+
+CREATE TRIGGER user_sync_courses_users AFTER INSERT OR UPDATE ON public.courses_users FOR EACH ROW EXECUTE FUNCTION public.sync_courses_user();
+"""
+
+DB_EXPECTED = """
+--
+-- PostgreSQL database dump
+--
+
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: courses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.courses (
+    semester character varying(255) NOT NULL,
+    course character varying(255) NOT NULL,
+    status smallint DEFAULT 1 NOT NULL
+);
+
+CREATE TRIGGER user_sync_courses_users AFTER INSERT OR UPDATE ON public.courses_users FOR EACH ROW EXECUTE PROCEDURE public.sync_courses_user();
+"""
+
+
+class TestDumper(TestCase):
+    @patch('migrator.dumper.check_output', side_effect=[
+        DB_FRAGMENT,
+    ])
+    def test_dump_database(self, subprocess):
+        with TemporaryDirectory() as tmp_dirname:
+            data_dir = Path(tmp_dirname, 'data')
+            data_dir.mkdir()
+            submitty_db = data_dir / 'submitty_db.sql'
+            self.assertTrue(dump_database('submitty', submitty_db))
+            self.assertTrue(submitty_db.exists())
+            self.assertEqual(DB_EXPECTED, submitty_db.read_text())

--- a/migration/tests/test_dumper.py
+++ b/migration/tests/test_dumper.py
@@ -24,6 +24,8 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+SET default_table_access_method = heap;
+
 --
 -- Name: courses; Type: TABLE; Schema: public; Owner: -
 --
@@ -52,6 +54,7 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
 
 --
 -- Name: courses; Type: TABLE; Schema: public; Owner: -


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The DB dump in #6966 introduced syntax in the DB dumps that did not work on postgresql 10, which is used by Ubuntu 18.04. This new syntax is a new default setting (`default_table_access_method`) and then an alternative term (`FUNCTION` instead of `PROCEDURE`).

### What is the new behavior?

The `SET` for default arg of `default_table_access_method` has been removed and we now now use `PROCEDURE` for dumps. This is done automatically as part of migrator, and tests added for it. There's no change in behavior of how the dumps work between postgresql 10 or postgresql 12 (Ubuntu 20.04).