### PR TITLE
[Bugfix:System] Fix SQL course dump discrepancies

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -264,9 +264,9 @@ CREATE TABLE public.electronic_gradeable (
     eg_peer_blind integer DEFAULT 3,
     eg_grade_inquiry_start_date timestamp(6) with time zone NOT NULL,
     eg_hidden_files character varying(1024),
-    eg_has_release_date boolean DEFAULT true NOT NULL,
     eg_depends_on character varying(255) DEFAULT NULL::character varying,
     eg_depends_on_points integer,
+    eg_has_release_date boolean DEFAULT true NOT NULL,
     CONSTRAINT eg_grade_inquiry_due_date_max CHECK ((eg_grade_inquiry_due_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
     CONSTRAINT eg_grade_inquiry_start_date_max CHECK ((eg_grade_inquiry_start_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
     CONSTRAINT eg_regrade_allowed_true CHECK (((eg_regrade_allowed IS TRUE) OR (eg_grade_inquiry_per_component_allowed IS FALSE))),
@@ -808,7 +808,7 @@ CREATE TABLE public.polls (
     release_date date NOT NULL,
     image_path text,
     question_type character varying(35) DEFAULT 'single-response-multiple-correct'::character varying,
-    release_histogram character varying(10) NOT NULL
+    release_histogram character varying(10) DEFAULT 'never'::character varying
 );
 
 
@@ -1878,18 +1878,18 @@ ALTER TABLE ONLY public.course_materials_sections
 
 
 --
--- Name: gradeable_allowed_minutes_override fk_user_id; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.gradeable_allowed_minutes_override
-    ADD CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES public.users(user_id);
-
-
---
 -- Name: course_materials_access fk_user_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.course_materials_access
+    ADD CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES public.users(user_id);
+
+
+--
+-- Name: gradeable_allowed_minutes_override fk_user_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gradeable_allowed_minutes_override
     ADD CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES public.users(user_id);
 
 

--- a/migration/migrator/migrations/course/20211008201616_course_materials_access_fk.py
+++ b/migration/migrator/migrations/course/20211008201616_course_materials_access_fk.py
@@ -1,0 +1,18 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE course_materials_access DROP CONSTRAINT IF EXISTS fk_course_material_id")
+    database.execute("ALTER TABLE course_materials_access ADD CONSTRAINT fk_course_material_id FOREIGN KEY (course_material_id) REFERENCES course_materials(id)")

--- a/migration/migrator/migrations/course/20211009030429_release_histogram_default.py
+++ b/migration/migrator/migrations/course/20211009030429_release_histogram_default.py
@@ -1,0 +1,18 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE polls ALTER COLUMN release_histogram DROP NOT NULL")
+    database.execute("ALTER TABLE polls ALTER COLUMN release_histogram SET DEFAULT 'never'")


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The PRs #6848 had a migration that created two foreign key constraints for the new `course_materials_access` in a migration, but failed to add it to the SQL dump. #6966 added it to the dump, but there remains a period of time where that field was missing and fresh Vagrant instances could be missing it if made between when those two PRs were made.

#7041 added a new `release_histogram` field, but the default for it did not match what was in the dump.

### What is the new behavior?

This PR adds two new migrations to:
* Handle setting `release_histogram` to a `not null` with default of `never`
* Set FK constraint on `course_materials_access` to the `course_materials` table.

Both of these are runnable from existing DBs and should get things to an equal state between running a fresh installation or migration an existing one.