### PR TITLE
[Refactor:System] Remove env vars from INSTALL_SUBMITTY.sh

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -139,7 +139,7 @@ NUM_GRADING_SCHEDULER_WORKERS = 5
 SETUP_INSTALL_DIR = os.path.join(SUBMITTY_INSTALL_DIR, '.setup')
 SETUP_REPOSITORY_DIR = os.path.join(SUBMITTY_REPOSITORY, '.setup')
 
-CONFIGURATION_FILE = os.path.join(SETUP_INSTALL_DIR, 'INSTALL_SUBMITTY.sh')
+INSTALL_FILE = os.path.join(SETUP_INSTALL_DIR, 'INSTALL_SUBMITTY.sh')
 CONFIGURATION_JSON = os.path.join(SETUP_INSTALL_DIR, 'submitty_conf.json')
 SITE_CONFIG_DIR = os.path.join(SUBMITTY_INSTALL_DIR, "site", "config")
 CONFIG_INSTALL_DIR = os.path.join(SUBMITTY_INSTALL_DIR, 'config')
@@ -215,7 +215,7 @@ print()
 
 if args.worker:
     SUPERVISOR_USER = get_input('What is the id for your submitty user?', defaults['supervisor_user'])
-    print('SUPERVISOR USER : {}'.format(SUPERVISOR_USER)) 
+    print('SUPERVISOR USER : {}'.format(SUPERVISOR_USER))
 else:
     DATABASE_HOST = get_input('What is the database host?', defaults['database_host'])
     print()
@@ -389,30 +389,14 @@ else:
     config['worker'] = 0
 
 
-with open(CONFIGURATION_FILE, 'w') as open_file:
+with open(INSTALL_FILE, 'w') as open_file:
     def write(x=''):
         print(x, file=open_file)
     write('#!/bin/bash')
     write()
+    write(f'bash {SETUP_REPOSITORY_DIR}/INSTALL_SUBMITTY_HELPER.sh  "$@"')
 
-    write('# Variables prepared by CONFIGURE_SUBMITTY.py')
-    write('# Manual editing is allowed (but will be clobbered if CONFIGURE_SUBMITTY.py is re-run)')
-    write()
-
-    for key, value in config.items():
-        key = str(key).upper()
-        if isinstance(value, str):
-            # To escape a single quote in bash, use '\'' because bash is awful
-            write("{}='{}'".format(key, value.replace("'", "'\''")))
-        elif isinstance(value, bool):
-            write('{}={}'.format(key, 'true' if value is True else 'false'))
-        else:
-            write('{}={}'.format(key, value))
-    write()
-    write('# Now actually run the installation script')
-    write('source '+SETUP_REPOSITORY_DIR+'/INSTALL_SUBMITTY_HELPER.sh  "$@"')
-
-os.chmod(CONFIGURATION_FILE, 0o700)
+os.chmod(INSTALL_FILE, 0o700)
 
 with open(CONFIGURATION_JSON, 'w') as json_file:
     json.dump(config, json_file, indent=2)
@@ -643,7 +627,7 @@ if not args.worker:
 ##############################################################################
 
 print('Configuration completed. Now you may run the installation script')
-print('    sudo ' + CONFIGURATION_FILE)
+print(f'    sudo {INSTALL_FILE}')
 print('          or')
-print('    sudo {} clean'.format(CONFIGURATION_FILE))
+print(f'    sudo {INSTALL_FILE} clean')
 print("\n")

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -34,6 +34,7 @@ fi
 
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
 SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)
+WORKER=$([[ $(jq -r '.worker' ${CONF_DIR}/submitty.json) == "true" ]] && echo 1 || echo 0)
 
 source ${THIS_DIR}/bin/versions.sh
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Part of #4011

In early versions of Submitty, we relied on the environment variables being set in `/usr/local/submitty/.setup/INSTALL_SUBMITTY.sh` script to be then read during execution of `.setup/INSTALL_SUBMITTY_HELPER.sh`. Eventually, we migrated over to having configuration JSON files in `/usr/local/submitty/config`, and that `.setup/INSTALL_SUBMITTY_HELPER.sh` started to reading in those variables directly as we found we needed to wait till after the migrator was run for a number of them (as migrator could affect them). At this point, the environment variables we wrote into that original install script are all largely unused except for `${WORKER}`.

### What is the new behavior?

The `${WORKER}` env var is ported over into `.setup/INSTALL_SUBMITTY_HELPER.sh` and read in from the configuration json files. The environment variables that were being written into the header of `/usr/local/submitty/.setup/INSTALL_SUBMITTY.sh` will no longer be as they're now completely unused. Functionally, there is no change in behavior yet for end users.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
