### PR TITLE
[Dependency] Add symfony/polyfill-php80 to use new PHP 8 functions

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -72,7 +72,7 @@ class AuthenticationController extends AbstractController {
      * @return MultiResponse
      */
     public function loginForm($old = null) {
-        if (!is_null($old) && !Utils::startsWith(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
+        if (!is_null($old) && !str_starts_with(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
             $old = null;
         }
         return MultiResponse::webOnlyResponse(
@@ -92,7 +92,7 @@ class AuthenticationController extends AbstractController {
      * @return MultiResponse
      */
     public function checkLogin($old = null) {
-        if (!is_null($old) && !Utils::startsWith(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
+        if (!is_null($old) && !str_starts_with(urldecode($old), $this->core->getConfig()->getBaseUrl())) {
             $old = null;
         }
         if (isset($old)) {

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -215,7 +215,7 @@ class GlobalController extends AbstractController {
                         if (empty($link['icon'])) {
                             $link['icon'] = "fa-question";
                         }
-                        if (!Utils::startsWith($link['icon'], "fa-")) {
+                        if (!str_starts_with($link['icon'], "fa-")) {
                             $link['icon'] = "fa-" . $link['icon'];
                         }
                         $sidebar_buttons[] = new NavButton($this->core, [
@@ -558,7 +558,7 @@ class GlobalController extends AbstractController {
                             continue 2;
                         default:
                             //Validation OK.  Include $row.
-                            if (isset($row['icon']) && !Utils::startsWith($row['icon'], "fa-")) {
+                            if (isset($row['icon']) && !str_starts_with($row['icon'], "fa-")) {
                                 $row['icon'] = "fa-" . $row['icon'];
                             }
                             $footer_links[] = $row;

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -77,7 +77,7 @@ class MiscController extends AbstractController {
             $section = $submitter->getRotatingSection();
         }
 
-        if (!Utils::startsWith($file_path, $check_path)) {
+        if (!str_starts_with($file_path, $check_path)) {
             return MultiResponse::JsonOnlyResponse(
                 JsonResponse::getFailResponse("Invalid file path")
             );
@@ -165,7 +165,7 @@ class MiscController extends AbstractController {
         $file_type = FileUtils::getContentType($file_name);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
-        if ($mime_type === "application/pdf" || (Utils::startsWith($mime_type, "image/") && $mime_type !== "image/svg+xml")) {
+        if ($mime_type === "application/pdf" || (str_starts_with($mime_type, "image/") && $mime_type !== "image/svg+xml")) {
             header("Content-type: " . $mime_type);
             header('Content-Disposition: inline; filename="' . $file_name . '"');
             readfile($corrected_name);

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -73,7 +73,7 @@ class CourseMaterialsController extends AbstractController {
         $all_files = $this->core->getCourseEntityManager()->getRepository(CourseMaterial::class)->findAll();
 
         foreach ($all_files as $file) {
-            if (Utils::startsWith($file->getPath(), $path)) {
+            if (str_starts_with($file->getPath(), $path)) {
                 $this->core->getCourseEntityManager()->remove($file);
             }
         }
@@ -192,7 +192,7 @@ class CourseMaterialsController extends AbstractController {
     private function setFileTimeStamp(CourseMaterial $courseMaterial, array $courseMaterials, \DateTime $dateTime) {
         if ($courseMaterial->isDir()) {
             foreach ($courseMaterials as $cm) {
-                if (Utils::startsWith($cm->getPath(), $courseMaterial->getPath()) && $cm->getPath() !== $courseMaterial->getPath()) {
+                if (str_starts_with($cm->getPath(), $courseMaterial->getPath()) && $cm->getPath() !== $courseMaterial->getPath()) {
                     $this->setFileTimeStamp($cm, $courseMaterials, $dateTime);
                 }
             }
@@ -244,7 +244,7 @@ class CourseMaterialsController extends AbstractController {
     private function recursiveEditFolder(array $course_materials, CourseMaterial $main_course_material) {
         foreach ($course_materials as $course_material) {
             if (
-                Utils::startsWith($course_material->getPath(), $main_course_material->getPath())
+                str_starts_with($course_material->getPath(), $main_course_material->getPath())
                 && $course_material->getPath() != $main_course_material->getPath()
             ) {
                 if ($course_material->isDir()) {
@@ -550,7 +550,7 @@ class CourseMaterialsController extends AbstractController {
                             $entries = array_filter($entries, function ($entry) use ($disallowed_folders, $disallowed_files) {
                                 $name = strtolower($entry);
                                 foreach ($disallowed_folders as $folder) {
-                                    if (Utils::startsWith($folder, $name)) {
+                                    if (str_starts_with($folder, $name)) {
                                         return false;
                                     }
                                 }

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -853,7 +853,7 @@ class Access {
         $path = implode(DIRECTORY_SEPARATOR, $parts);
 
         //Make sure it starts with the dir base
-        if (!Utils::startsWith($path, $info["base"])) {
+        if (!str_starts_with($path, $info["base"])) {
             //This both prevents people from accessing files outside the base dir
             // and lets us have relative paths. Convenient!
             if ($path[0] === "/") {

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -391,7 +391,7 @@ HTML;
      * @return string
      */
     private function getView($class) {
-        if (!Utils::startsWith($class, "app\\views")) {
+        if (!str_starts_with($class, "app\\views")) {
             $class = "app\\views\\{$class}View";
         }
         if (!isset($this->loaded_views[$class])) {

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -99,28 +99,6 @@ class Utils {
     }
 
     /**
-     * Checks if string $haystack begins with the string $needle, returning TRUE if it does or FALSE otherwise.
-     *
-     * @param string $haystack
-     * @param string $needle
-     * @return bool
-     */
-    public static function startsWith(string $haystack, string $needle): bool {
-        return substr($haystack, 0, strlen($needle)) === $needle;
-    }
-
-    /**
-     * Checks if string $haystack ends with the string $needle, returning TRUE if it does or FALSE otherwise.
-     *
-     * @param string $haystack
-     * @param string $needle
-     * @return bool
-     */
-    public static function endsWith(string $haystack, string $needle): bool {
-        return substr($haystack, (-1 * strlen($needle)), strlen($needle)) === $needle;
-    }
-
-    /**
      * Wrapper around the PHP function setcookie that deals with figuring out if we should be setting this cookie
      * such that it should only be accessed via HTTPS (secure) as well as allow easily passing an array to set as
      * the cookie data. This will also set the value in the $_COOKIE superglobal so that it's available without a

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -209,7 +209,7 @@ abstract class AbstractDatabase {
      */
     public function queryIterator(string $query, array $parameters = [], $callback = null) {
         $lower = trim(strtolower($query));
-        if (!Utils::startsWith($lower, "select")) {
+        if (!str_starts_with($lower, "select")) {
             return $this->query($query, $parameters);
         }
         try {

--- a/site/app/libraries/database/QueryIdentifier.php
+++ b/site/app/libraries/database/QueryIdentifier.php
@@ -15,7 +15,7 @@ class QueryIdentifier {
 
     public static function identify(string $query): string {
         $query = strtolower(trim($query));
-        if (Utils::startsWith($query, 'with')) {
+        if (str_starts_with($query, 'with')) {
             $tokens = str_split($query);
             $pos = 4;
             $tokenCount = count($tokens);
@@ -66,16 +66,16 @@ class QueryIdentifier {
             $query = implode("", array_slice($tokens, $pos));
         }
 
-        if (Utils::startsWith($query, QueryIdentifier::SELECT)) {
+        if (str_starts_with($query, QueryIdentifier::SELECT)) {
             return QueryIdentifier::SELECT;
         }
-        elseif (Utils::startsWith($query, QueryIdentifier::UPDATE)) {
+        elseif (str_starts_with($query, QueryIdentifier::UPDATE)) {
             return QueryIdentifier::UPDATE;
         }
-        elseif (Utils::startsWith($query, QueryIdentifier::INSERT)) {
+        elseif (str_starts_with($query, QueryIdentifier::INSERT)) {
             return QueryIdentifier::INSERT;
         }
-        elseif (Utils::startsWith($query, QueryIdentifier::DELETE)) {
+        elseif (str_starts_with($query, QueryIdentifier::DELETE)) {
             return QueryIdentifier::DELETE;
         }
         return QueryIdentifier::UNKNOWN;

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -102,7 +102,7 @@ class WebRouter {
             // prevent user that is not logged in from going anywhere except AuthenticationController
             if (
                 !$logged_in
-                && !Utils::endsWith($router->parameters['_controller'], 'AuthenticationController')
+                && !str_ends_with($router->parameters['_controller'], 'AuthenticationController')
             ) {
                 return new MultiResponse(JsonResponse::getFailResponse("Unauthenticated access. Please log in."));
             }
@@ -263,7 +263,7 @@ class WebRouter {
      * @return MultiResponse|bool
      */
     private function loginRedirectCheck(bool $logged_in) {
-        if (!$logged_in && !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')) {
+        if (!$logged_in && !str_ends_with($this->parameters['_controller'], 'AuthenticationController')) {
             $old_request_url = $this->request->getUriForPath($this->request->getPathInfo());
 
             $query_obj = $this->request->query->all();
@@ -282,7 +282,7 @@ class WebRouter {
         elseif (
             $this->core->getConfig()->isCourseLoaded()
             && !$this->core->getAccess()->canI("course.view", ["semester" => $this->core->getConfig()->getSemester(), "course" => $this->core->getConfig()->getCourse()])
-            && !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')
+            && !str_ends_with($this->parameters['_controller'], 'AuthenticationController')
             && $this->parameters['_method'] !== 'noAccess'
         ) {
             return MultiResponse::RedirectOnlyResponse(
@@ -291,7 +291,7 @@ class WebRouter {
         }
         elseif (
             $logged_in
-            && Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')
+            && str_ends_with($this->parameters['_controller'], 'AuthenticationController')
             && $this->parameters['_method'] !== 'logout'
         ) {
             return MultiResponse::RedirectOnlyResponse(
@@ -299,7 +299,7 @@ class WebRouter {
             );
         }
 
-        if (!$this->core->getConfig()->isCourseLoaded() && !Utils::endsWith($this->parameters['_controller'], 'MiscController')) {
+        if (!$this->core->getConfig()->isCourseLoaded() && !str_ends_with($this->parameters['_controller'], 'MiscController')) {
             if ($logged_in) {
                 if (isset($this->parameters['_semester']) && isset($this->parameters['_course'])) {
                     return MultiResponse::RedirectOnlyResponse(
@@ -307,7 +307,7 @@ class WebRouter {
                     );
                 }
             }
-            elseif (!Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')) {
+            elseif (!str_ends_with($this->parameters['_controller'], 'AuthenticationController')) {
                 return MultiResponse::RedirectOnlyResponse(
                     new RedirectResponse($this->core->buildUrl(['authentication', 'login']))
                 );
@@ -324,7 +324,7 @@ class WebRouter {
     private function csrfCheck() {
         if (
             $this->request->isMethod('POST')
-            && !Utils::endsWith($this->parameters['_controller'], 'AuthenticationController')
+            && !str_ends_with($this->parameters['_controller'], 'AuthenticationController')
             && !$this->core->checkCsrfToken()
         ) {
             $msg = "Invalid CSRF token.";

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -132,19 +132,19 @@ abstract class AbstractModel {
     public function __call($name, $arguments) {
         $class_name = get_class($this);
         if (!isset(static::$cache[$class_name][$name])) {
-            if (Utils::startsWith($name, "set")) {
+            if (str_starts_with($name, "set")) {
                 static::$cache[$class_name][$name] = [
                     "function_type" => AbstractModel::CALL_SET,
                     "property_name" => $this->convertName($name)
                 ];
             }
-            elseif (Utils::startsWith($name, "get")) {
+            elseif (str_starts_with($name, "get")) {
                 static::$cache[$class_name][$name] = [
                     "function_type" => AbstractModel::CALL_GET,
                     "property_name" => $this->convertName($name)
                 ];
             }
-            elseif (Utils::startsWith($name, "is")) {
+            elseif (str_starts_with($name, "is")) {
                 static::$cache[$class_name][$name] = [
                     "function_type" => AbstractModel::CALL_IS,
                     "property_name" => $this->convertName($name, 2)

--- a/site/composer.json
+++ b/site/composer.json
@@ -31,6 +31,7 @@
     "symfony/cache": "4.4.31",
     "symfony/config": "4.4.30",
     "symfony/http-foundation": "4.4.30",
+    "symfony/polyfill-php80": "1.23.1",
     "symfony/routing": "4.4.30",
     "textalk/websocket": "1.5.5",
     "twig/twig": "2.13.1"

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb8e357542f9809512ab3fc6bf55ddea",
+    "content-hash": "cbb633f95b337f228f2d154f66a8ec1e",
     "packages": [
         {
             "name": "aptoma/twig-markdown",

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -120,7 +120,7 @@ if (empty($_COOKIE['submitty_token'])) {
 
 $is_api = explode('/', $request->getPathInfo())[1] === 'api';
 if ($is_api) {
-    if (!empty($_SERVER['CONTENT_TYPE']) && Utils::startsWith($_SERVER['CONTENT_TYPE'], 'application/json')) {
+    if (!empty($_SERVER['CONTENT_TYPE']) && str_starts_with($_SERVER['CONTENT_TYPE'], 'application/json')) {
         $_POST = json_decode(file_get_contents('php://input'), true);
     }
     $response = WebRouter::getApiResponse($request, $core);

--- a/site/tests/BaseUnitTest.php
+++ b/site/tests/BaseUnitTest.php
@@ -200,7 +200,7 @@ class BaseUnitTest extends \PHPUnit\Framework\TestCase {
                 }
             }
             foreach ($reflection->getMethods() as $method) {
-                if (!Utils::startsWith($method->getName(), "__")) {
+                if (!str_starts_with($method->getName(), "__")) {
                     $methods[] = $method->getName();
                 }
             }

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -329,7 +329,7 @@ class SubmissionControllerTester extends BaseUnitTest {
                     $content = $value;
                 }
                 $file_path = FileUtils::joinPaths($dir, $filename);
-                if (Utils::endsWith($filename, '.zip') === true) {
+                if (str_ends_with($filename, '.zip') === true) {
                     $file = new ZipArchive();
                     $file->open($file_path, ZipArchive::CREATE || ZipArchive::OVERWRITE);
                     $file->addFromString('test1.txt', 'a');

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -39,50 +39,6 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals(16, strlen(Utils::generateRandomString(8)));
     }
 
-    public function stringStarts() {
-        return [
-            ["test", "test", true],
-            ["test", "tes", true],
-            ["test", "te", true],
-            ["test", "t", true],
-            ["test", "", true],
-            ["test", "st", false]
-        ];
-    }
-
-    /**
-     * @dataProvider stringStarts
-     *
-     * @param $haystack
-     * @param $needle
-     * @param $result
-     */
-    public function testStartsWith($haystack, $needle, $result) {
-        $this->assertEquals(Utils::startsWith($haystack, $needle), $result);
-    }
-
-    public function stringEnds() {
-        return [
-            ["test", "test", true],
-            ["test", "est", true],
-            ["test", "st", true],
-            ["test", "t", true],
-            ["test", "", true],
-            ["test", "te", false]
-        ];
-    }
-
-    /**
-     * @dataProvider stringEnds
-     *
-     * @param $haystack
-     * @param $needle
-     * @param $result
-     */
-    public function testEndsWith($haystack, $needle, $result) {
-        $this->assertEquals(Utils::endsWith($haystack, $needle), $result);
-    }
-
     public function testPrepareHtmlString() {
         $string = "<test\n\ntest>";
         $this->assertEquals("&lt;test<br />\n<br />\ntest&gt;", Utils::prepareHtmlString($string));

--- a/site/tests/phpstan/ModelClassExtension.php
+++ b/site/tests/phpstan/ModelClassExtension.php
@@ -10,7 +10,7 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
 
 class ModelClassExtension implements MethodsClassReflectionExtension {
     public function hasMethod(ClassReflection $reflection, string $method_name): bool {
-        if (!Utils::startsWith($reflection->getName(), 'app\\models')) {
+        if (!str_starts_with($reflection->getName(), 'app\\models')) {
             return false;
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We currently have our own hand-rolled versions of `str_starts_with` (`Utils::startsWith`) and `str_ends_with` (`Utils::endsWith`), which while they work, is just additional overhead for us to have. Additionally, we've had a number of PRs from students submitted that wanted to use the PHP 8 functions, and required extra diligence on our end to catch it.

### What is the new behavior?

Adds the `symfony/polyfill-php80` package which allows us to use the new PHP 8.0 functions "as is", polyfilling them in for any PHP version < 8.0. This allows us to remove our versions of the functions, as well as not worry about people using them without realizing they were added in PHP 8.0.