### PR TITLE
[Refactor:Plagiarism] Rebranding Lichen

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -646,11 +646,11 @@ CREATE TABLE public.lichen (
     regex_dir_checkout boolean NOT NULL,
     language character varying(255) NOT NULL,
     threshold smallint NOT NULL,
-    sequence_length smallint NOT NULL,
+    hash_size smallint NOT NULL,
     other_gradeables text,
     ignore_submissions text,
     CONSTRAINT lichen_config_id_check CHECK ((config_id > 0)),
-    CONSTRAINT lichen_sequence_length_check CHECK ((sequence_length > 1)),
+    CONSTRAINT lichen_hash_size_check CHECK ((hash_size > 1)),
     CONSTRAINT lichen_threshold_check CHECK ((threshold > 1))
 );
 

--- a/migration/migrator/migrations/course/20211011122951_plagiarism_rebrand.py
+++ b/migration/migrator/migrations/course/20211011122951_plagiarism_rebrand.py
@@ -1,0 +1,35 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE lichen RENAME COLUMN sequence_length TO hash_size;")
+    database.execute("ALTER TABLE lichen RENAME CONSTRAINT lichen_sequence_length_check TO lichen_hash_size_check;")
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE lichen RENAME COLUMN hash_size TO sequence_length;")
+    database.execute("ALTER TABLE lichen RENAME CONSTRAINT lichen_hash_size_check TO lichen_sequence_length_check;")

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -131,7 +131,7 @@ class PlagiarismController extends AbstractController {
      * @return array
      * @throws Exception
      */
-    private function getOtherotherGradeables(string $term, string $course, string $this_gradeable): array {
+    private function getOtherGradeables(string $term, string $course, string $this_gradeable): array {
         // check for backwards crawling
         if (str_contains($term, '..') || str_contains($course, '..')) {
             throw new Exception('Error: path contains invalid component ".."');
@@ -1065,7 +1065,7 @@ class PlagiarismController extends AbstractController {
         $other_gradeables_array = $plagiarism_config->getOtherGradeables();
         foreach ($other_gradeables_array as &$gradeable) {
             try {
-                $gradeable["other_gradeables"] = $this->getOtherotherGradeables($gradeable["other_semester"], $gradeable["other_course"], $gradeable_id);
+                $gradeable["other_gradeables"] = $this->getOtherGradeables($gradeable["other_semester"], $gradeable["other_course"], $gradeable_id);
             }
             catch (Exception $e) {
                 $this->core->addErrorMessage($e->getMessage());
@@ -1250,7 +1250,7 @@ class PlagiarismController extends AbstractController {
         $course = $tokens[1];
 
         try {
-            $return = $this->getOtherotherGradeables($semester, $course, $_POST['this_gradeable']);
+            $return = $this->getOtherGradeables($semester, $course, $_POST['this_gradeable']);
         }
         catch (Exception $e) {
             return JsonResponse::getErrorResponse($e->getMessage());

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -107,11 +107,11 @@ class PlagiarismController extends AbstractController {
     }
 
     /**
-     * Gets a list of courses which have the same group as the current course and are thus eligible prior terms
+     * Gets a list of courses which have the same group as the current course and are thus eligible other terms
      * @return array
      * @throws Exception
      */
-    private function getPriorSemesterCourses(): array {
+    private function getOtherSemesterCourses(): array {
         $this_semester = $this->core->getConfig()->getSemester();
         $this_course = $this->core->getConfig()->getCourse();
         $valid_courses = $this->core->getQueries()->getOtherCoursesWithSameGroup($this_semester, $this_course);
@@ -131,7 +131,7 @@ class PlagiarismController extends AbstractController {
      * @return array
      * @throws Exception
      */
-    private function getOtherPriorGradeables(string $term, string $course, string $this_gradeable): array {
+    private function getOtherotherGradeables(string $term, string $course, string $this_gradeable): array {
         // check for backwards crawling
         if (str_contains($term, '..') || str_contains($course, '..')) {
             throw new Exception('Error: path contains invalid component ".."');
@@ -333,8 +333,8 @@ class PlagiarismController extends AbstractController {
                 "regex_dirs" => $regex_dirs,
                 "language" => $config->getLanguage(),
                 "threshold" => $config->getThreshold(),
-                "sequence_length" => $config->getSequenceLength(),
-                "prior_term_gradeables" => $config->getOtherGradeables(),
+                "hash_size" => $config->getHashSize(),
+                "other_gradeables" => $config->getOtherGradeables(),
                 "ignore_submissions" => $config->getIgnoredSubmissions()
             ];
 
@@ -406,8 +406,8 @@ class PlagiarismController extends AbstractController {
             "regex_dirs" => $regex_dirs,
             "language" => $config->getLanguage(),
             "threshold" => $config->getThreshold(),
-            "sequence_length" => $config->getSequenceLength(),
-            "prior_term_gradeables" => $config->getOtherGradeables(),
+            "hash_size" => $config->getHashSize(),
+            "other_gradeables" => $config->getOtherGradeables(),
             "ignore_submissions" => $config->getIgnoredSubmissions()
         ];
     }
@@ -710,7 +710,7 @@ class PlagiarismController extends AbstractController {
 
                 // This is a little ugly/repetitive but it can be frustrating for users to get nondescriptive errors
                 // so we try to make potential error cases a little more helpful
-                $keys = ["version", "regex", "regex_dirs", "language", "threshold", "sequence_length", "prior_term_gradeables", "ignore_submissions"];
+                $keys = ["version", "regex", "regex_dirs", "language", "threshold", "hash_size", "other_gradeables", "ignore_submissions"];
                 $error_message = "";
                 foreach ($keys as $key) {
                     if (!isset($data[$key])) {
@@ -733,8 +733,8 @@ class PlagiarismController extends AbstractController {
                     in_array("checkout", $data["regex_dirs"]),
                     $data["language"],
                     $data["threshold"],
-                    $data["sequence_length"],
-                    $data["prior_term_gradeables"],
+                    $data["hash_size"],
+                    $data["other_gradeables"],
                     $data["ignore_submissions"]
                 );
                 $em->persist($new_config);
@@ -758,7 +758,7 @@ class PlagiarismController extends AbstractController {
                     $source_config->isRegexDirCheckoutSelected(),
                     $source_config->getLanguage(),
                     $source_config->getThreshold(),
-                    $source_config->getSequenceLength(),
+                    $source_config->getHashSize(),
                     $source_config->getOtherGradeables(),
                     $source_config->getIgnoredSubmissions()
                 );
@@ -792,55 +792,55 @@ class PlagiarismController extends AbstractController {
             $threshold = (int) $_POST['threshold'] ?? 0;
 
 
-            // Sequence length /////////////////////////////////////////////////////
-            $sequence_length = (int) $_POST['sequence_length'] ?? 0;
+            // Hash Size ///////////////////////////////////////////////////////////
+            $hash_size = (int) $_POST['hash_size'] ?? 0;
 
 
-            // Prior terms /////////////////////////////////////////////////////////
-            $prev_term_gradeables = [];
-            if ($_POST["past_terms_option"] === "past_terms") {
-                if (isset($_POST["prior_semester_course"]) !== isset($_POST["prior_gradeable"])) {
-                    $this->core->addErrorMessage("Invalid input provided for prior term gradeables");
+            // other gradeables ////////////////////////////////////////////////////
+            $other_gradeables = [];
+            if ($_POST["other_gradeables_option"] === "has_other_gradeables") {
+                if (isset($_POST["other_semester_course"]) !== isset($_POST["other_gradeable"])) {
+                    $this->core->addErrorMessage("Invalid input provided for other gradeables");
                     $this->core->redirect($return_url);
                 }
-                foreach ($_POST["prior_semester_course"] as $index => $sem_course) {
-                    if (!isset($_POST["prior_gradeable"][$index])) {
-                        $this->core->addErrorMessage("Invalid input provided for prior term gradeables");
+                foreach ($_POST["other_semester_course"] as $index => $sem_course) {
+                    if (!isset($_POST["other_gradeable"][$index])) {
+                        $this->core->addErrorMessage("Invalid input provided for other term gradeables");
                         $this->core->redirect($return_url);
                     }
                     else {
                         $tokens = explode(" ", $sem_course);
                         if (count($tokens) !== 2) {
-                            $this->core->addErrorMessage("Invalid input provided for prior semester and course");
+                            $this->core->addErrorMessage("Invalid input provided for other semester and course");
                             $this->core->redirect($return_url);
                         }
-                        $prior_semester = $tokens[0];
-                        $prior_course = $tokens[1];
-                        $prior_gradeable = $_POST["prior_gradeable"][$index];
+                        $other_semester = $tokens[0];
+                        $other_course = $tokens[1];
+                        $other_gradeable = $_POST["other_gradeable"][$index];
                         // Error checking
-                        if (str_contains($prior_semester, '..') || str_contains($prior_course, '..') || str_contains($prior_gradeable, '..')) {
-                            $this->core->addErrorMessage("Error: prior term gradeables string contains invalid component '..'");
+                        if (str_contains($other_semester, '..') || str_contains($other_course, '..') || str_contains($other_gradeable, '..')) {
+                            $this->core->addErrorMessage("Error: other gradeables string contains invalid component '..'");
                             return new RedirectResponse($return_url);
                         }
-                        $prior_g_submissions_path = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "courses", $prior_semester, $prior_course, "submissions", $prior_gradeable);
-                        if (!is_dir($prior_g_submissions_path) || count(scandir($prior_g_submissions_path)) === 2) {
-                            $this->core->addErrorMessage("Error: submssions to prior term gradeable provided not found");
+                        $other_g_submissions_path = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "courses", $other_semester, $other_course, "submissions", $other_gradeable);
+                        if (!is_dir($other_g_submissions_path) || count(scandir($other_g_submissions_path)) === 2) {
+                            $this->core->addErrorMessage("Error: submssions to other gradeable provided not found");
                             return new RedirectResponse($return_url);
                         }
                         $to_append = [
-                            "prior_semester" => $prior_semester,
-                            "prior_course" => $prior_course,
-                            "prior_gradeable" => $prior_gradeable
+                            "other_semester" => $other_semester,
+                            "other_course" => $other_course,
+                            "other_gradeable" => $other_gradeable
                         ];
-                        if ($prior_semester === $semester && $prior_course === $course && $prior_gradeable === $gradeable_id) {
+                        if ($other_semester === $semester && $other_course === $course && $other_gradeable === $gradeable_id) {
                             $this->core->addErrorMessage("Error: attempt to compare this gradeable '{$gradeable_id}' to itself as other gradeable");
                             return new RedirectResponse($return_url);
                         }
-                        if (in_array($to_append, $prev_term_gradeables)) {
-                            $this->core->addErrorMessage("Error: duplicate other gradeable found: {$prior_semester} {$prior_course} {$prior_gradeable}");
+                        if (in_array($to_append, $other_gradeables)) {
+                            $this->core->addErrorMessage("Error: duplicate other gradeable found: {$other_semester} {$other_course} {$other_gradeable}");
                             return new RedirectResponse($return_url);
                         }
-                        $prev_term_gradeables[] = $to_append;
+                        $other_gradeables[] = $to_append;
                     }
                 }
             }
@@ -891,8 +891,8 @@ class PlagiarismController extends AbstractController {
                         in_array("checkout", $regex_directories),
                         $language,
                         $threshold,
-                        $sequence_length,
-                        $prev_term_gradeables,
+                        $hash_size,
+                        $other_gradeables,
                         $ignore_submission_option
                     );
                 }
@@ -906,8 +906,8 @@ class PlagiarismController extends AbstractController {
                     $plagiarism_config->setRegexDirCheckout(in_array("checkout", $regex_directories));
                     $plagiarism_config->setLanguage($language);
                     $plagiarism_config->setThreshold($threshold);
-                    $plagiarism_config->setSequenceLength($sequence_length);
-                    $plagiarism_config->setOtherGradeables($prev_term_gradeables);
+                    $plagiarism_config->setHashSize($hash_size);
+                    $plagiarism_config->setOtherGradeables($other_gradeables);
                     $plagiarism_config->setIgnoredSubmissions($ignore_submission_option);
                 }
                 $em->persist($plagiarism_config);
@@ -1011,10 +1011,10 @@ class PlagiarismController extends AbstractController {
         $config["language"] = array_fill_keys(array_keys(PlagiarismUtils::SUPPORTED_LANGUAGES), "");
         $config["language"]["plaintext"] = "selected";
         $config["threshold"] = PlagiarismUtils::DEFAULT_THRESHOLD;
-        $config["sequence_length"] = PlagiarismUtils::SUPPORTED_LANGUAGES["plaintext"]["sequence_length"];
-        $config["prior_terms"] = false;
-        $config["prior_semester_courses"] = $this->getPriorSemesterCourses();
-        $config["prior_term_gradeables"] = [];
+        $config["hash_size"] = PlagiarismUtils::SUPPORTED_LANGUAGES["plaintext"]["hash_size"];
+        $config["has_other_gradeables"] = false;
+        $config["other_semester_courses"] = $this->getOtherSemesterCourses();
+        $config["other_gradeables"] = [];
         $config["ignore_submissions"] = [];
         $config["ignore_submissions_list"] = "";
 
@@ -1062,10 +1062,10 @@ class PlagiarismController extends AbstractController {
             }
         }
         $ignore = $this->getIgnoreSubmissionType($plagiarism_config->getIgnoredSubmissions());
-        $prior_term_gradeables_array = $plagiarism_config->getOtherGradeables();
-        foreach ($prior_term_gradeables_array as &$gradeable) {
+        $other_gradeables_array = $plagiarism_config->getOtherGradeables();
+        foreach ($other_gradeables_array as &$gradeable) {
             try {
-                $gradeable["other_gradeables"] = $this->getOtherPriorGradeables($gradeable["prior_semester"], $gradeable["prior_course"], $gradeable_id);
+                $gradeable["other_gradeables"] = $this->getOtherotherGradeables($gradeable["other_semester"], $gradeable["other_course"], $gradeable_id);
             }
             catch (Exception $e) {
                 $this->core->addErrorMessage($e->getMessage());
@@ -1098,10 +1098,10 @@ class PlagiarismController extends AbstractController {
         $config["language"] = array_fill_keys(array_keys(PlagiarismUtils::SUPPORTED_LANGUAGES), "");
         $config["language"][$plagiarism_config->getLanguage()] = "selected";
         $config["threshold"] = $plagiarism_config->getThreshold();
-        $config["sequence_length"] = $plagiarism_config->getSequenceLength();
-        $config["prior_terms"] = count($plagiarism_config->getOtherGradeables()) > 0;
-        $config["prior_semester_courses"] = $this->getPriorSemesterCourses();
-        $config["prior_term_gradeables"] = $prior_term_gradeables_array;
+        $config["hash_size"] = $plagiarism_config->getHashSize();
+        $config["has_other_gradeables"] = count($plagiarism_config->getOtherGradeables()) > 0;
+        $config["other_semester_courses"] = $this->getOtherSemesterCourses();
+        $config["other_gradeables"] = $other_gradeables_array;
         $config["ignore_submissions"] = $ignore[0];
         $config["ignore_submissions_list"] = implode(", ", $ignore[1]);
 
@@ -1238,11 +1238,11 @@ class PlagiarismController extends AbstractController {
 
 
     /**
-     * @Route("/courses/{_semester}/{_course}/plagiarism/configuration/getPriorGradeables", methods={"POST"})
+     * @Route("/courses/{_semester}/{_course}/plagiarism/configuration/getOtherGradeables", methods={"POST"})
      */
-    public function getPriorGradeables(): JsonResponse {
+    public function getOtherGradeables(): JsonResponse {
         if (!isset($_POST['semester_course']) || !isset($_POST['this_gradeable'])) {
-            return JsonResponse::getErrorResponse("Error: Unable to get prior gradeables");
+            return JsonResponse::getErrorResponse("Error: Unable to get other gradeables");
         }
 
         $tokens = explode(' ', $_POST['semester_course']);
@@ -1250,7 +1250,7 @@ class PlagiarismController extends AbstractController {
         $course = $tokens[1];
 
         try {
-            $return = $this->getOtherPriorGradeables($semester, $course, $_POST['this_gradeable']);
+            $return = $this->getOtherotherGradeables($semester, $course, $_POST['this_gradeable']);
         }
         catch (Exception $e) {
             return JsonResponse::getErrorResponse($e->getMessage());

--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -131,7 +131,7 @@ class PlagiarismController extends AbstractController {
      * @return array
      * @throws Exception
      */
-    private function getOtherGradeables(string $term, string $course, string $this_gradeable): array {
+    private function getOtherOtherGradeables(string $term, string $course, string $this_gradeable): array {
         // check for backwards crawling
         if (str_contains($term, '..') || str_contains($course, '..')) {
             throw new Exception('Error: path contains invalid component ".."');
@@ -1065,7 +1065,7 @@ class PlagiarismController extends AbstractController {
         $other_gradeables_array = $plagiarism_config->getOtherGradeables();
         foreach ($other_gradeables_array as &$gradeable) {
             try {
-                $gradeable["other_gradeables"] = $this->getOtherGradeables($gradeable["other_semester"], $gradeable["other_course"], $gradeable_id);
+                $gradeable["other_gradeables"] = $this->getOtherOtherGradeables($gradeable["other_semester"], $gradeable["other_course"], $gradeable_id);
             }
             catch (Exception $e) {
                 $this->core->addErrorMessage($e->getMessage());
@@ -1250,7 +1250,7 @@ class PlagiarismController extends AbstractController {
         $course = $tokens[1];
 
         try {
-            $return = $this->getOtherGradeables($semester, $course, $_POST['this_gradeable']);
+            $return = $this->getOtherOtherGradeables($semester, $course, $_POST['this_gradeable']);
         }
         catch (Exception $e) {
             return JsonResponse::getErrorResponse($e->getMessage());

--- a/site/app/entities/plagiarism/PlagiarismConfig.php
+++ b/site/app/entities/plagiarism/PlagiarismConfig.php
@@ -84,7 +84,7 @@ class PlagiarismConfig {
      * @ORM\Column(type="smallint")
      * @var int
      */
-    protected $sequence_length;
+    protected $hash_size;
 
     /**
      * @ORM\Column(type="json")
@@ -114,7 +114,7 @@ class PlagiarismConfig {
         bool $regex_dir_checkout,
         string $language,
         int $threshold,
-        int $sequence_length,
+        int $hash_size,
         array $other_gradeables,
         array $ignored_submissions
     ) {
@@ -127,7 +127,7 @@ class PlagiarismConfig {
         $this->setRegexDirCheckout($regex_dir_checkout);
         $this->setLanguage($language);
         $this->setThreshold($threshold);
-        $this->setSequenceLength($sequence_length);
+        $this->setHashSize($hash_size);
         $this->setOtherGradeables($other_gradeables);
         $this->setIgnoredSubmissions($ignored_submissions);
     }
@@ -232,19 +232,19 @@ class PlagiarismConfig {
         }
     }
 
-    public function getSequenceLength(): int {
-        return $this->sequence_length;
+    public function getHashSize(): int {
+        return $this->hash_size;
     }
 
     /**
      * @throws ValidationException
      */
-    public function setSequenceLength(int $sequence_length): void {
-        if ($sequence_length > 1) {
-            $this->sequence_length = $sequence_length;
+    public function setHashSize(int $hash_size): void {
+        if ($hash_size > 1) {
+            $this->hash_size = $hash_size;
         }
         else {
-            throw new ValidationException("Error: Invalid sequence length", []);
+            throw new ValidationException("Error: Invalid hash size", []);
         }
     }
 

--- a/site/app/libraries/plagiarism/PlagiarismUtils.php
+++ b/site/app/libraries/plagiarism/PlagiarismUtils.php
@@ -6,25 +6,25 @@ use Ds\Stack;
 
 class PlagiarismUtils {
     /**
-     * This constant represents the default configuration for each language supported.  Currently, only the sequence
-     * length and language name are listed but more parameters can be added in the future.
+     * This constant represents the default configuration for each language supported.  Currently, only the
+     * hash size and language name are listed but more parameters can be added in the future.
      * @var int
      */
     const SUPPORTED_LANGUAGES = [
         "plaintext" => [
-            "sequence_length" => 14
+            "hash_size" => 14
         ],
         "python" => [
-            "sequence_length" => 14
+            "hash_size" => 14
         ],
         "java" => [
-            "sequence_length" => 14
+            "hash_size" => 14
         ],
         "cpp" => [
-            "sequence_length" => 14
+            "hash_size" => 14
         ],
         "mips" => [
-            "sequence_length" => 5
+            "hash_size" => 5
         ]
     ];
 

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -151,11 +151,11 @@
                 </div>
                 {##################################################################}
                 <div class="plag-data-group">
-                    <div class="plag-data-label">Sequence Length:</div>
-                    <label for="sequence-length">Matching regions smaller than this limit won't be marked as plagiarism.<br>
+                    <div class="plag-data-label">Hash Size:</div>
+                    <label for="hash-size">Matching regions smaller than this limit won't be marked as plagiarism.<br>
                                                  The default value is sufficient in most cases.</label>
                     <div class="plag-data">
-                        <input type="number" id="sequence-length" name="sequence_length" value="{{ config["sequence_length"] }}" placeholder="(Required)" min="1"/>
+                        <input type="number" id="hash-size" name="hash_size" value="{{ config["hash_size"] }}" placeholder="(Required)" min="1"/>
                     </div>
                 </div>
                 {##################################################################}
@@ -164,38 +164,38 @@
                     <label>Add gradeables from current or prior courses to compare against</label>
                     <div class="plag-data">
                         <span class="radio-label-pair">
-                            <input type="radio" id="no-past-terms-id" value="no_past_terms" name="past_terms_option" {{ config["prior_terms"] ? "" : "checked" }}>
-                            <label for="no-past-terms-id">No</label>
+                            <input type="radio" id="no-other-gradeables-id" value="no_other_gradeables" name="other_gradeables_option" {{ config["has_other_gradeables"] ? "" : "checked" }}>
+                            <label for="no-other-gradeables-id">No</label>
                         </span>
                         <span class="radio-label-pair">
-                            <input type="radio" id="past-terms-id" value="past_terms" name="past_terms_option" {{ config["prior_terms"] ? "checked" : "" }}>
-                            <label for="past-terms-id">Yes</label>
+                            <input type="radio" id="other-gradeables-id" value="has_other_gradeables" name="other_gradeables_option" {{ config["has_other_gradeables"] ? "checked" : "" }}>
+                            <label for="other-gradeables-id">Yes</label>
                         </span>
-                        <div class="past-terms-wrapper" id="prev-gradeable-div">
-                            <div id="past-terms-content">
+                        <div class="other-gradeables-wrapper" id="other-gradeable-div">
+                            <div id="other-gradeables-content">
                                 {% if new_or_edit == "edit" %}
-                                    {% for row in config["prior_term_gradeables"] %}
-                                        <div id="prior-g-option-{{ loop.index0 }}" class="prior-gradeable-wrapper">
-                                            <select name='prior_semester_course[]' onchange='getGradeables(this)'>
-                                                {% for semester_course in config["prior_semester_courses"] %}
+                                    {% for row in config["other_gradeables"] %}
+                                        <div id="other-g-option-{{ loop.index0 }}" class="other-gradeable-wrapper">
+                                            <select name='other_semester_course[]' onchange='getGradeables(this)'>
+                                                {% for semester_course in config["other_semester_courses"] %}
                                                     {% set tokens = semester_course|split(' ') %}
-                                                    <option value="{{ tokens[0] }} {{ tokens[1] }}" {{ tokens[0] == row["prior_semester"] and tokens[1] == row["prior_course"] ? "selected" : "" }}>{{ tokens[0] }}/{{ tokens[1] }}</option>
+                                                    <option value="{{ tokens[0] }} {{ tokens[1] }}" {{ tokens[0] == row["other_semester"] and tokens[1] == row["other_course"] ? "selected" : "" }}>{{ tokens[0] }}/{{ tokens[1] }}</option>
                                                 {% endfor %}
                                             </select>
-                                            <select name='prior_gradeable[]'>
+                                            <select name='other_gradeable[]'>
                                                 {% for other_gradeable in row["other_gradeables"] %}
-                                                    <option value="{{ other_gradeable }}" {{ other_gradeable == row["prior_gradeable"] ? "selected" : "" }}>{{ other_gradeable }}</option>
+                                                    <option value="{{ other_gradeable }}" {{ other_gradeable == row["other_gradeable"] ? "selected" : "" }}>{{ other_gradeable }}</option>
                                                 {% endfor %}
                                             </select>
-                                            <span class="remove-prev-gradeable" onclick="deletePrevGradeable(this)">
+                                            <span class="remove-other-gradeable" onclick="deleteOtherGradeable(this)">
                                                 <i class="fas fa-trash"></i>
                                             </span>
                                         </div>
                                     {% endfor %}
                                 {% endif %}
                             </div>
-                            <div id="add-more-prev-gradeable" class="add-more" aria-label="Add more">
-                                <i class="fas fa-plus-square"></i>Add more
+                            <div id="add-more-other-gradeable" class="add-more" aria-label="Add more">
+                                <i class="fas fa-plus-square"></i>&nbsp;Add more
                             </div>
                         </div>
                     </div>
@@ -234,7 +234,7 @@
 
 <script>
     const form = $("#save-configuration-form");
-    const prior_semester_course_list = JSON.parse(`{{ config["prior_semester_courses"] | json_encode() | raw }}`);
+    const other_semester_course_list = JSON.parse(`{{ config["other_semester_courses"] | json_encode() | raw }}`);
     const gradeables_with_plag_configs = JSON.parse(`{{ gradeables_with_plag_configs | json_encode() | raw }}`);
 
     // SUBMIT FORM /////////////////////////////////////////////////////////////
@@ -298,33 +298,33 @@
         reloadConfigs($("#import-config-gradeable").val());
     });
 
-    // PRIOR TERM GRADEABLES ///////////////////////////////////////////////////
+    // OTHER GRADEABLES ////////////////////////////////////////////////////////
     $(document).ready(() => {
-        if ({{ config["prior_terms"] ? "true" : "false" }} && $("#past-terms-id").is(":checked")) {
-            $("#prev-gradeable-div").show();
+        if ({{ config["has_other_gradeables"] ? "true" : "false" }} && $("#other-gradeables-id").is(":checked")) {
+            $("#other-gradeable-div").show();
         }
     });
 
-    $('#add-more-prev-gradeable', form).on('click', () => {
-        addMorePriorTermGradeable();
+    $('#add-more-other-gradeable', form).on('click', () => {
+        addMoreOtherGradeable();
     });
 
-    $("#no-past-terms-id").change(() => {
-        $(".past-terms-wrapper").hide();
-        $('#past-terms-content', form).html('');
+    $("#no-other-gradeables-id").change(() => {
+        $(".other-gradeables-wrapper").hide();
+        $('#other-gradeables-content', form).html('');
     });
 
-    $("#past-terms-id").change(() => {
-        $(".past-terms-wrapper").show();
-        addMorePriorTermGradeable();
+    $("#other-gradeables-id").change(() => {
+        $(".other-gradeables-wrapper").show();
+        addMoreOtherGradeable();
     });
 
-    function deletePrevGradeable(clickedElement) {
+    function deleteOtherGradeable(clickedElement) {
         // remove element
         $($(clickedElement).parent()).remove();
         // renumber the rest of the rows
-        for (let i = 0; i < $(".prior-gradeable-wrapper").length; i++) {
-            $($(".prior-gradeable-wrapper")[i]).attr("id", "prior-g-option-" + i);
+        for (let i = 0; i < $(".other-gradeable-wrapper").length; i++) {
+            $($(".other-gradeable-wrapper")[i]).attr("id", "other-g-option-" + i);
         }
     }
 
@@ -335,7 +335,7 @@
         gradeable_dropdown.empty();
         gradeable_dropdown.append("<option value=''>Loading...</option>");
         $.ajax({
-            url: `{{ base_url }}/getPriorGradeables`,
+            url: `{{ base_url }}/getOtherGradeables`,
             type: "POST",
             data: {
                 csrf_token: csrfToken,
@@ -361,24 +361,24 @@
         });
     }
 
-    function addMorePriorTermGradeable() {
+    function addMoreOtherGradeable() {
         const form = $("#save-configuration-form");
         // add a new row with the next index, with empty dropdowns
-        let first_free_index = $(".prior-gradeable-wrapper").length;
-        $('#past-terms-content', form).append(`
-            <div id='prior-g-option-${first_free_index}' class='prior-gradeable-wrapper'>
-                <select name='prior_semester_course[]' onchange='getGradeables(this)'>
+        let first_free_index = $(".other-gradeable-wrapper").length;
+        $('#other-gradeables-content', form).append(`
+            <div id='other-g-option-${first_free_index}' class='other-gradeable-wrapper'>
+                <select name='other_semester_course[]' onchange='getGradeables(this)'>
                 </select>
-                <select name='prior_gradeable[]'>
+                <select name='other_gradeable[]'>
                 </select>
-                <span class="remove-prev-gradeable" onclick="deletePrevGradeable(this)">
+                <span class="remove-other-gradeable" onclick="deleteOtherGradeable(this)">
                     <i class="fas fa-trash"></i>
                 </span>
             </div>
         `);
         // fill in the left dropdown
-        let semester_course_dropdown = $(`#prior-g-option-${first_free_index}`).children().first();
-        $.each(prior_semester_course_list, (index, semester_course) => {
+        let semester_course_dropdown = $(`#other-g-option-${first_free_index}`).children().first();
+        $.each(other_semester_course_list, (index, semester_course) => {
             let tokens_array = semester_course.split(" ");
             semester_course_dropdown.append(`<option value='${semester_course}'>${tokens_array[0]}/${tokens_array[1]}</option>`);
         });
@@ -386,9 +386,9 @@
         getGradeables(semester_course_dropdown[0]);
     }
 
-    // SEQUENCE LENGTH + LANGUAGE //////////////////////////////////////////////
+    // HASH SIZE + LANGUAGE ////////////////////////////////////////////////////
 
-    function updateSequenceLengthForLanguage() {
+    function updateHashSizeForLanguage() {
         const form = $("#save-configuration-form")
         // Following code is used to set default window size for different languages
         // that will appear in 'configureNewGradeableForPlagiarismForm'
@@ -396,12 +396,12 @@
 
         {% for key, value in supported_languages %}
             if ($('[name="language"]', form).val() === '{{ key }}') {
-                $('[name="sequence_length"]', form).val({{ supported_languages[key]["sequence_length"] }});
+                $('[name="hash_size"]', form).val({{ supported_languages[key]["hash_size"] }});
             }
         {% endfor %}
     }
 
     $("select[name='language']").change(() => {
-        updateSequenceLengthForLanguage();
+        updateHashSizeForLanguage();
     });
 </script>

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -89,7 +89,7 @@ input[type=text]:invalid {
     color: var(--alert-invalid-entry-pink);
 }
 
-#prev-gradeable-div {
+#other-gradeable-div {
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -97,22 +97,22 @@ input[type=text]:invalid {
     padding-bottom: 30px;
 }
 
-#prev-gradeable-div select {
+#other-gradeable-div select {
     width: calc(100% / 3 - 10px);
     margin: 5px;
 }
 
-#prev-gradeable-div select:nth-child(3n+2) {
+#other-gradeable-div select:nth-child(3n+2) {
     margin-left: 0;
 }
 
-#prev-gradeable-div select:nth-child(3n+1) {
+#other-gradeable-div select:nth-child(3n+1) {
     margin-right: 0;
 }
 
 #current-code-file,
 #provided-code-file,
-#prev-gradeable-div {
+#other-gradeable-div {
     display: none;
 }
 
@@ -141,16 +141,6 @@ input[type=text]:invalid {
 
 .low-margin-top {
     margin-top: 5px;
-}
-
-.add-more {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-}
-
-.plag-data-group .fa-plus-square {
-    margin-right: 10px;
 }
 
 /* ==== Results Page ======================================================== */


### PR DESCRIPTION
### What is the current behavior?
All places in the code base refer to the number of tokens that make up a hash as `sequence length` and many places refer to `other gradeables` as `prior term gradeables`.

### What is the new behavior?
The term `sequence length` is now referred to as `hash size`, and `prior term gradeables` are referred to as `other gradeables`. All previous references to the old names have been changed for consistency. Related PR's were all other repositories to update these terms: https://github.com/Submitty/Lichen/pull/64, https://github.com/Submitty/submitty.github.io/pull/380, https://github.com/Submitty/LichenTestData/pull/5.

### Other information?
No changes in the behavior of any program/script, except for two parameters in the `config.json` that were renamed:

- "sequence_length" is now "hash_size"
- "prior_term_gradeables" is now "other_gradeables", and its sub-keys are also changed:
    - "prior_semester" -> "other_semester"
    - "prior_course" -> "other_course"
    - "prior_gradeable" -> "other_gradeable"

Due to this change, this PR has to be merged and released together with the PR on the Lichen repo.
