### PR TITLE
[Bugfix:Plagiarism] Fix other gradeables config bug

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -149,7 +149,7 @@ class PlagiarismController extends AbstractController {
         // actually do the collection of gradeables here
         $gradeables = [];
         foreach (scandir(FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), "courses", $term, $course, "submissions")) as $gradeable) {
-            if ($gradeable !== '.' && $gradeable !== '..' && $gradeable !== $this_gradeable) {
+            if ($gradeable !== '.' && $gradeable !== '..' && ($term !== $this->core->getConfig()->getSemester() || $course !== $this->core->getConfig()->getCourse() || $gradeable !== $this_gradeable)) {
                 $gradeables[] = $gradeable;
             }
         }


### PR DESCRIPTION
### What is the current behavior?
An issue currently exists such that it is not possible to add other gradeables from prior terms with the same ID as the currently selected gradeable.  

### What is the new behavior?
Fixes bug by checking whether any of the course/term/gradeable ID are different instead of only checking the ID.