### PR TITLE
[Bugfix:Submission] Fix switch to most recent button error

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -441,7 +441,7 @@ class HomeworkView extends AbstractView {
         if (!is_null($graded_gradeable)) {
             $graded_gradeable->hasOverriddenGrades();
         }
-        $recent_version_url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion();
+        $recent_version_url = $graded_gradeable ? $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : null;
         $numberUtils = new NumberUtils();
         // TODO: go through this list and remove the variables that are not used
         return $output . $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently if a user clicks on  a team gradeable, but aren't on a team the following frog robot occurs.
![image (1)](https://user-images.githubusercontent.com/66340271/137828018-77e9dd19-d27b-45d8-b139-d4ddd15c8833.png)
The issue is because if someone isn't on a team, $graded_gradeable is null 

### What is the new behavior?
I added a null check for $graded_gradeable, the most recent url is set to null if graded_gradeable is null which isn't a problem because you can't submit to a team gradeable without being on a team anyways so the button would never be used with a null url.


