### PR TITLE
[Bugfix:Submission] Always release files on grade release

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionBox.twig
+++ b/site/app/templates/submission/homework/CurrentVersionBox.twig
@@ -1,7 +1,7 @@
 {% import 'functions/Badge.twig' as Badge %}
 
 {# If we have any reason to display this box. #}
-{% if hide_submitted_files == false or team_assignment == true or hide_version_and_test_details == false %}
+{% if hide_submitted_files == false or team_assignment == true or hide_version_and_test_details == false or ta_grades_released == true %}
     <div class="content">
         {% if team_assignment %}
             <h3>Team{% if team_name is not null %} ({{ team_name }}){% endif %}: {{ team_members }}</h3><br />

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -5,7 +5,7 @@
 {% endif %}
 
 {# Submitted files #}
-{% if hide_submitted_files == false %}
+{% if hide_submitted_files == false or ta_grades_released == true %}
     <h4>Submitted Files</h4>
     <div class="row">
         <div class="box col-md-6" id="submitted-files">


### PR DESCRIPTION
### What is the current behavior?
When the options "hide_submitted_files" and "hide_version_and_test_details" are set to true, students do not see their grades even after TA grades are released.

### What is the new behavior?
Works on #7246 
After the TA grade release date, files are always released.

### Other information?
Doesn't add in automated tests