### PR TITLE
[Bugfix:TAGrading] Fix peer component creation

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -395,7 +395,7 @@ class AdminGradeableController extends AbstractController {
             'max_value' => 0,
             'upper_clamp' => 0,
             'text' => false,
-            'peer' => false,
+            'peer_component' => false,
             'order' => -1,
             'page' => Component::PDF_PAGE_NONE,
             'is_itempool_linked' => false,

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1179,7 +1179,7 @@ class Gradeable extends AbstractModel {
             'max_value' => $max_value,
             'upper_clamp' => $upper_clamp,
             'text' => $text,
-            'peer' => $peer,
+            'peer_component' => $peer,
             'page' => $pdf_page,
             'id' => 0,
             'order' => count($this->components)


### PR DESCRIPTION
### What is the current behavior?
Peer component creation does not work on rubric configuration page in "Edit Gradeable" page.

### What is the new behavior?
Peer component creation works on rubric configuration page in "Edit Gradeable" page.
