### PR TITLE
[Testing:System] Move Python versions to env variable

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -11,9 +11,9 @@ env:
   SUBMITTY_INSTALL_DIR: /usr/local/submitty
   SUBMITTY_REPOSITORY: /usr/local/submitty/GIT_CHECKOUT/Submitty
   POSTGRES_HOST: localhost
-  PHP_VER: 7.4
-  NODE_VERSION: 12
-  PYTHON_VERSION: 3.8
+  PHP_VER: 7.2
+  NODE_VERSION: 10
+  PYTHON_VERSION: 3.6
 
 jobs:
     css-lint:

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -11,8 +11,9 @@ env:
   SUBMITTY_INSTALL_DIR: /usr/local/submitty
   SUBMITTY_REPOSITORY: /usr/local/submitty/GIT_CHECKOUT/Submitty
   POSTGRES_HOST: localhost
-  PHP_VER: 7.2
-  NODE_VERSION: 10
+  PHP_VER: 7.4
+  NODE_VERSION: 12
+  PYTHON_VERSION: 3.8
 
 jobs:
     css-lint:
@@ -159,7 +160,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
           with:
-            python-version: '3.6'
+            python-version: ${{ env.PYTHON_VERSION }}
         - name: Cache Pip
           uses: actions/cache@v2
           with:
@@ -181,7 +182,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
           with:
-            python-version: '3.6'
+            python-version: ${{ env.PYTHON_VERSION }}
         - name: Cache Pip
           uses: actions/cache@v2
           with:
@@ -276,7 +277,7 @@ jobs:
 
           - uses: actions/setup-python@v2
             with:
-              python-version: '3.6'
+              python-version: ${{ env.PYTHON_VERSION }}
           - uses: shivammathur/setup-php@2.7.0
             with:
               php-version: ${{ env.PHP_VER }}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
Whenever we setup python for a github actions job, each job has its python version set locally instead of reading from an env variable 

### What is the new behavior?
Created python version variable to make changing it in all places easier
