### PR TITLE
[Bugfix:System] Install libjpeg-dev on Ubuntu 18.04

### DIFF
--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -20,7 +20,7 @@ fi
 apt-get -qqy update
 
 apt-get install -qqy apt-transport-https ca-certificates curl software-properties-common
-apt-get install -qqy python python-dev python3 python3-dev libpython3.6 python3-pip
+apt-get install -qqy python python-dev python3 python3-dev libpython3.6 python3-pip libjpeg-dev
 
 ############################
 # NTP: Network Time Protocol

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -199,8 +199,6 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 #libraries for QR code processing:
 #install DLL for zbar
 apt-get install libzbar0 --yes
-#headers required for installing pillow on ubuntu 18
-apt-get install libjpeg-dev --yes
 
 pip3 install -r ${CURRENT_DIR}/pip/system_requirements.txt
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
Vagrant up nightly was failing on ubuntu 18 trying to install python pillow dependency 

### What is the new behavior?
Manually install dependency that was missing by pillow for Ubuntu 18
