### PR TITLE
[Refactor:System] Use exclude file for site rsync

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -61,7 +61,7 @@ mv /tmp/index.html ${SUBMITTY_INSTALL_DIR}/site/public
 # copy the website from the repo. We don't need the tests directory in production and then
 # we don't want vendor as if it exists, it was generated locally for testing purposes, so
 # we don't want it
-result=$(rsync -rtz -i --exclude 'tests' --exclude '/site/cache' --exclude '/site/vendor' --exclude 'site/node_modules/' --exclude '/site/phpstan.neon' --exclude '/site/phpstan-baseline.neon' --exclude '/site/.eslintrc.json' --exclude '/site/.eslintignore' --exclude '/site/cypress/' --exclude '/site/cypress.json' --exclude '/site/jest.config.js' --exclude '/site/.babelrc.json' ${SUBMITTY_REPOSITORY}/site ${SUBMITTY_INSTALL_DIR})
+result=$(rsync -rtz -i --exclude-from ${SUBMITTY_REPOSITORY}/site/.rsyncignore ${SUBMITTY_REPOSITORY}/site ${SUBMITTY_INSTALL_DIR})
 
 # check for either of the dependency folders, and if they do not exist, pretend like
 # their respective json file was edited. Composer needs the folder to exist to even

--- a/site/.rsyncignore
+++ b/site/.rsyncignore
@@ -1,0 +1,16 @@
+site/cache
+site/cypress
+site/node_modules
+site/tests
+site/vendor
+site/.babelrc.json
+site/.eslintignore
+site/.eslintrc.json
+site/.rsyncignore
+site/.stylelintrc.json
+site/cypress.json
+site/jest.config.js
+site/phpstan-baseline.neon
+site/phpstan.neon
+
+.DS_Store


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We specify the files to exclude from rysnc into the final location one by one as part of the CLI command. This is very unwieldy.

### What is the new behavior?

We now use an ignore file that we pass to rysnc. This should make it easier to understand changes to what we rsync, as well as avoid constantly touching this bash line.