### PR TITLE
[Bugfix:Submission] Fix Line Wrapping on Notebook Inputs

### DIFF
--- a/site/public/js/code-mirror-utils.js
+++ b/site/public/js/code-mirror-utils.js
@@ -22,6 +22,7 @@ function getLargeCodeMirror(attachment_elem, codemirror_config) {
         CodeMirrorSpellChecker({
             codeMirrorInstance:  CodeMirror,
         });
+        codemirror_config.lineWrapping = true;
         codemirror_config.mode = 'spell-checker';
     }
 


### PR DESCRIPTION
### What is the current behavior?
Currently, lines aren't wrapping properly on notebook gradeable inputs. In inputs with regular text (not code), the text should be wrapping, but it is not.
![image](https://user-images.githubusercontent.com/28243927/139604502-f502a343-6a4e-446f-b79a-4f1795cf47eb.png)

### What is the new behavior?
The short answer inputs on notebooks will have wrapping enabled when no language is specified (plaintext). Otherwise, if a language is specified, there will be no line wrapping.
![image](https://user-images.githubusercontent.com/28243927/139604340-5f8bbd8b-651e-4ec4-867e-ae6c0719da3b.png)
