### PR TITLE
[Bugfix:HelpQueue] Don't show switching if no queue is open

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6404,6 +6404,11 @@ AND gc_id IN (
         return $this->course_db->rows();
     }
 
+    public function getAllOpenQueues() {
+        $this->course_db->query("SELECT * FROM queue_settings where open = true ORDER BY id");
+        return $this->course_db->rows();
+    }
+
     public function getQueueNumberAheadOfYou($queue_code = null) {
         if ($queue_code) {
             $time_in = $this->core->getQueries()->getCurrentQueueState()['time_in'];

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -126,6 +126,10 @@ class OfficeHoursQueueModel extends AbstractModel {
         return $this->core->getQueries()->getAllQueues();
     }
 
+    public function getAllOpenQueues() {
+        return $this->core->getQueries()->getAllOpenQueues();
+    }
+
     public function timeToHM($time) {
         $date_time = new \DateTime($time);
         $date_time->setTimezone($this->core->getConfig()->getTimezone());

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -96,8 +96,15 @@
       <input type="hidden" name="queue_code" value="{{ viewer.getCurrentQueueCode() }}"/>
       <button id="leave_queue" type="submit" class="btn btn-danger">Leave Queue</button>
     </form>
+      {% set my_queue = 'code' %}
       {% set open_queues = viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
-      {% if open_queues|length > 1  %}
+      {% if open_queues|length == 1 %}
+          {% for queue in viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
+            {% set my_queue = queue['code'] %}
+          {% endfor %}
+      {% endif %}
+
+      {% if open_queues|length > 1  or my_queue != viewer.getCurrentQueueCode() %}
       <form method="post" action="{{ base_url }}/{{ viewer.getCurrentQueueCode() | url_encode }}/switch">
           <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
           <input type="hidden" id="name_box" name="name" maxlength="20" value="{{viewer.getName()}}" style="margin:.5rem" required="required">

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -103,7 +103,6 @@
             {% set my_queue = queue['code'] %}
           {% endfor %}
       {% endif %}
-
       {% if open_queues|length > 1  or my_queue != viewer.getCurrentQueueCode() %}
       <form method="post" action="{{ base_url }}/{{ viewer.getCurrentQueueCode() | url_encode }}/switch">
           <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -97,9 +97,9 @@
       <button id="leave_queue" type="submit" class="btn btn-danger">Leave Queue</button>
     </form>
       {% set my_queue = 'code' %}
-      {% set open_queues = viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
+      {% set open_queues = viewer.getAllOpenQueues()%}
       {% if open_queues|length == 1 %}
-          {% for queue in viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
+          {% for queue in viewer.getAllOpenQueues() %}
             {% set my_queue = queue['code'] %}
           {% endfor %}
       {% endif %}

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -99,7 +99,7 @@
       {% set my_queue = 'code' %}
       {% set open_queues = viewer.getAllOpenQueues()%}
       {% if open_queues|length == 1 %}
-          {% for queue in viewer.getAllOpenQueues() %}
+          {% for queue in open_queues %}
             {% set my_queue = queue['code'] %}
           {% endfor %}
       {% endif %}
@@ -117,7 +117,7 @@
               </label>
               <select id="switch_queue_code" class="form-control" name="code" required="required" onchange="toggleSwitchQueueForm()">
                   <option value="">Queue Name</option>
-                  {% for queue in viewer.getAllOpenQueues()%}
+                  {% for queue in open_queues %}
                       {% if queue['code'] != viewer.getCurrentQueueCode() %}
                         <option value="{{queue['code']}}">{{queue['code']}}</option>
                       {% endif %}

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -9,7 +9,7 @@
       </label>
       <select id="queue_code" class="form-control" name="code" required="required">
         <option value="">Queue Name</option>
-        {% for queue in viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
+        {% for queue in viewer.getAllOpenQueues() %}
           <option value="{{queue['code']}}">{{queue['code']}}</option>
         {% endfor %}
       </select>
@@ -117,7 +117,7 @@
               </label>
               <select id="switch_queue_code" class="form-control" name="code" required="required" onchange="toggleSwitchQueueForm()">
                   <option value="">Queue Name</option>
-                  {% for queue in viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
+                  {% for queue in viewer.getAllOpenQueues()%}
                       {% if queue['code'] != viewer.getCurrentQueueCode() %}
                         <option value="{{queue['code']}}">{{queue['code']}}</option>
                       {% endif %}

--- a/site/app/templates/officeHoursQueue/QueueStatus.twig
+++ b/site/app/templates/officeHoursQueue/QueueStatus.twig
@@ -96,6 +96,8 @@
       <input type="hidden" name="queue_code" value="{{ viewer.getCurrentQueueCode() }}"/>
       <button id="leave_queue" type="submit" class="btn btn-danger">Leave Queue</button>
     </form>
+      {% set open_queues = viewer.getAllQueues()|filter(queue => queue['open'] == 'true') %}
+      {% if open_queues|length > 1  %}
       <form method="post" action="{{ base_url }}/{{ viewer.getCurrentQueueCode() | url_encode }}/switch">
           <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
           <input type="hidden" id="name_box" name="name" maxlength="20" value="{{viewer.getName()}}" style="margin:.5rem" required="required">
@@ -128,6 +130,7 @@
           </div>
       </form>
     <br>
+      {% endif %}
       <script>
           $('#switch_queue_code').change(function(){
               const selected_queue =  $('#switch_queue_code').val();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently, if there is only 1 open queue and a student is in that queue, the option to switch queues still displays even though there are no other open queues to switch into.

### What is the new behavior?
The form doesn't display if there is only 1 open queue, unless the queue that is open is not the queue the student is in. For example It could be the case that the student is in queue A, but we close that queue and open queue B.  They should be able to switch to queue B, even if there is only 1 queue option.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
