### PR TITLE
[Bugfix:TAGrading] Hide custom marks from peer graders

### DIFF
--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -53,7 +53,7 @@ Required inputs:
     {% endfor %}
 {% endblock %}
 
-{% if ta_grading_peer or not peer_component %}
+{% if ta_grading_peer or not component.peer_component %}
 {% block extra_mark_rows %}
     {# Custom mark (only display in non-edit mode and custom marks are enabled #}
     {% set f_mark = component.marks|first %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently peer graders can still see the option to add custom marks however when they try to use them they get a permission error.

### What is the new behavior?
Peer graders don't have the option to use custom marks.


