### PR TITLE
[Bugfix:Forum] Fixing CSS issues on pin borders 

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -5,16 +5,16 @@
             {% if userGroup <= 2 and activeThreadAnnouncement %}
 
                 {% set expiringVisual = (expiring) ? 'active-thread-remove-expiring-announcement' : 'active-thread-remove-announcement' %}
-                <a class="{{expiringVisual}} key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to unpin this thread?', 0, '{{ csrf_token }}')" title="Pinned announcement -- will expire soon" aria-label="Pinned announcement -- will expire soon"><i class="fas fa-thumbtack"></i></a>
+                <a class="{{expiringVisual}} key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to unpin this thread?', 0, '{{ csrf_token }}')" title="Pinned thread -- will expire soon" aria-label="Pinned thread -- will expire soon"><i class="fas fa-thumbtack"></i></a>
 
             {% elseif activeThreadAnnouncement %}
 
                 {% set expiringVisual = (expiring) ? 'active-thread-announcement-expiring' : 'active-thread-announcement' %}
-                <i class="fas fa-thumbtack {{expiringVisual}}" title = "Pinned Announcement" aria-label="Pinned Announcement"></i>
+                <i class="fas fa-thumbtack {{expiringVisual}}" title = "Pinned Thread" aria-label="Pinned Thread"></i>
 
             {% elseif userGroup <= 2 and not activeThreadAnnouncement %}
 
-                <a class="not-active-thread-announcement key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to pin this thread to the top for seven days?', 1, '{{ csrf_token }}')" title="Make thread an announcement" aria-label="Pin Thread"><i class="fas fa-thumbtack golden_hover" title = "Make Announcement"></i></a>
+                <a class="not-active-thread-announcement key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to pin this thread to the top for seven days?', 1, '{{ csrf_token }}')" title="Pin thread to the top" aria-label="Pin Thread"><i class="fas fa-thumbtack golden_hover" title = "Pin Thread"></i></a>
 
             {% endif %}
 

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -5,12 +5,12 @@
             {% if userGroup <= 2 and activeThreadAnnouncement %}
 
                 {% set expiringVisual = (expiring) ? 'active-thread-remove-expiring-announcement' : 'active-thread-remove-announcement' %}
-                <a class="{{expiringVisual}} key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to unpin this thread?', 0, '{{ csrf_token }}')" title="Unpin Thread" aria-label="Unpin Thread"><i class="fas fa-thumbtack reverse_golden_hover"></i></a>
+                <a class="{{expiringVisual}} key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to unpin this thread?', 0, '{{ csrf_token }}')" title="Pinned announcement -- will expire soon" aria-label="Pinned announcement -- will expire soon"><i class="fas fa-thumbtack"></i></a>
 
             {% elseif activeThreadAnnouncement %}
 
                 {% set expiringVisual = (expiring) ? 'active-thread-announcement-expiring' : 'active-thread-announcement' %}
-                <i class="fas fa-thumbtack {{expiringVisual}}" title = "Pinned Thread" aria-label="Pinned Thread"></i>
+                <i class="fas fa-thumbtack {{expiringVisual}}" title = "Pinned Announcement" aria-label="Pinned Announcement"></i>
 
             {% elseif userGroup <= 2 and not activeThreadAnnouncement %}
 
@@ -20,7 +20,7 @@
 
             {% if isCurrentFavorite %}
 
-                <a class="current-favorite key_to_click" tabindex="0" onClick="bookmarkThread({{ activeThread.id }}, '0');" title="Bookmark Thread" aria-label="Bookmark Thread"><i class="fas fa-bookmark reverse_golden_hover"></i></a>
+                <a class="current-favorite key_to_click" tabindex="0" onClick="bookmarkThread({{ activeThread.id }}, '0');" title="Bookmark Thread" aria-label="Bookmark Thread"><i class="fas fa-bookmark"></i></a>
 
             {% else %}
 

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -5,7 +5,7 @@
             {% if userGroup <= 2 and activeThreadAnnouncement %}
 
                 {% set expiringVisual = (expiring) ? 'active-thread-remove-expiring-announcement' : 'active-thread-remove-announcement' %}
-                <a class="{{expiringVisual}} key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to unpin this thread?', 0, '{{ csrf_token }}')" title="Pinned thread -- will expire soon" aria-label="Pinned thread -- will expire soon"><i class="fas fa-thumbtack"></i></a>
+                <a class="{{expiringVisual}} key_to_click" tabindex="0" onClick="alterAnnouncement({{ activeThread.id }}, 'Are you sure you want to unpin this thread?', 0, '{{ csrf_token }}')" title="Thread is expiring soon click to unpin" aria-label="Thread is expiring soon click to unpin"><i class="fas fa-thumbtack"></i></a>
 
             {% elseif activeThreadAnnouncement %}
 

--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -19,7 +19,7 @@
                     <span>
                         {% if thread.pinned %}
                             {% set expiringVisual = (thread.expiring) ? 'thread-announcement-expiring' : 'thread-announcement' %}
-                            {% set hoverText = (thread.expiring) ? 'Pinned announcement -- will expire soon' : 'Pinned Announcement' %}
+                            {% set hoverText = (thread.expiring) ? 'Pinned thread -- will expire soon' : 'Pinned thread' %}
                             <i class="fas fa-thumbtack {{expiringVisual}}" title ="{{hoverText}}" aria-label="{{hoverText}}"></i>
                         {% endif %}
                         {% if thread.favorite %}

--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -19,7 +19,8 @@
                     <span>
                         {% if thread.pinned %}
                             {% set expiringVisual = (thread.expiring) ? 'thread-announcement-expiring' : 'thread-announcement' %}
-                            <i class="fas fa-thumbtack {{expiringVisual}}" title = "Pinned to the top" aria-label="Pinned to the top"></i>
+                            {% set hoverText = (thread.expiring) ? 'Pinned announcement -- will expire soon' : 'Pinned Announcement' %}
+                            <i class="fas fa-thumbtack {{expiringVisual}}" title ="{{hoverText}}" aria-label="{{hoverText}}"></i>
                         {% endif %}
                         {% if thread.favorite %}
                             <i class="fas fa-bookmark thread-favorite" title="Bookmarked as my favorite" aria-label="Bookmarked as my favorite"></i>

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -202,16 +202,8 @@
     color: #e0e0e0 !important;
 }
 
-.golden_hover:hover {
-    color: gold !important;
-}
-
 .reverse_golden_hover {
     color: gold;
-}
-
-.reverse_golden_hover:hover {
-    color: #e0e0e0 !important;
 }
 
 .text-decoration-none {
@@ -252,7 +244,7 @@
 }
 
 .current-favorite i.fas,
-.active-thread-remove-announcement i.fas
+.active-thread-remove-announcement i.fas,
 .active-thread-remove-expiring-announcement i.fas {
     position: relative;
     display: inline-block;
@@ -260,13 +252,16 @@
     -webkit-text-stroke-color: black;
 }
 
-.current-favorite i.fas,
+.current-favorite i.fas{
+    color: var(--standard-medium-red) !important;
+}
+
 .active-thread-remove-expiring-announcement i.fas {
-  color: gold;
+  color: gold !important;
 }
 
 .active-thread-remove-announcement i.fas {
-    color: var(--submitty-logo-blue);
+    color: var(--submitty-logo-blue) !important;
 }
 
 #thread_form {
@@ -299,9 +294,11 @@
     -webkit-text-stroke-color: black;
 }
 
-.thread-announcement-expiring,
-.thread-favorite {
+.thread-announcement-expiring{
     color: gold;
+}
+.thread-favorite {
+    color: var(--standard-medium-red);
 }
 .thread-announcement {
     color: var(--submitty-logo-blue);

--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -194,7 +194,7 @@ class TestForum(BaseTestCase):
     def announce_thread(self, title):
         assert not self.icon_exists(title, "thread-announcement")
         self.view_thread(title)
-        self.driver.find_element(By.XPATH, "//a[@title='Make thread an announcement']").click()
+        self.driver.find_element(By.XPATH, "//a[@title='Pin thread to the top']").click()
         self.driver.switch_to.alert.accept()
         self.wait_after_ajax()
         assert self.icon_exists(title, "thread-announcement")


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<img width="314" alt="Screen Shot 2021-10-13 at 10 44 40 AM" src="https://user-images.githubusercontent.com/25368899/139896857-ad07f5d2-fbe9-480b-b48d-fe260d8db46c.png">

Currently the borders on the pins are missing for the instructors and the tooltips have not been updated to say gold pins are expiring soon.
### What is the new behavior?
<img width="701" alt="Screen Shot 2021-11-02 at 12 05 58 PM" src="https://user-images.githubusercontent.com/25368899/139895580-6edf6989-1fec-4efe-9ec2-54ce4e936cee.png">
The boarder has been fixed, the tooltip text has been updated, and the bookmark color has been changed to red.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
