### PR TITLE
[Bugfix:Submission] Ignore empty preferred names

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7722,7 +7722,11 @@ SELECT    leaderboard.*,
           anon_id,
           user_group,
           anonymous_leaderboard,
-          Concat(COALESCE (user_preferred_firstname, user_firstname ), ' ', COALESCE (user_preferred_lastname, user_lastname )) as name
+          Concat(
+                COALESCE (NULLIF(user_preferred_firstname, ''), user_firstname ),
+                ' ',
+                COALESCE (NULLIF(user_preferred_lastname, ''), user_lastname )
+            ) as name
 FROM      (
                    SELECT     Round(Cast(Sum(elapsed_time) AS NUMERIC), 1) AS time,
                               Sum(max_rss_size)                            AS memory,

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7723,11 +7723,11 @@ SELECT    leaderboard.*,
           user_group,
           anonymous_leaderboard,
           Concat(
-                COALESCE (NULLIF(user_preferred_firstname, ''), user_firstname ),
-                ' ',
-                COALESCE (NULLIF(user_preferred_lastname, ''), user_lastname )
-            ) as name
-FROM      (
+              COALESCE (NULLIF(user_preferred_firstname, ''), user_firstname),
+              ' ',
+              COALESCE (NULLIF(user_preferred_lastname, ''), user_lastname)
+          ) as name
+FROM (
                    SELECT     Round(Cast(Sum(elapsed_time) AS NUMERIC), 1) AS time,
                               Sum(max_rss_size)                            AS memory,
                               metrics.g_id                                 AS gradeable_id,
@@ -7750,7 +7750,7 @@ FROM      (
                    GROUP BY   metrics.user_id,
                               metrics.team_id,
                               metrics.g_id
-                   ) AS leaderboard
+) AS leaderboard
 LEFT JOIN users
 ON        leaderboard.user_id = users.user_id
 LEFT JOIN electronic_gradeable_version


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently the database query for identifying a student's name on the leaderboard will return an empty string if the student has never set a preferred name.

### What is the new behavior?
This change updates the database query to ignore empty strings in the user's preferred name, therefore falling back to the user's base name if they did not set a preferred one.