### PR TITLE
[Bugfix:System] Fix parsing worker-pair arg

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -36,6 +36,21 @@ def get_input(question, default=""):
     return user
 
 
+class StrToBoolAction(argparse.Action):
+    """
+    Custom action that parses strings to boolean values. All values that come
+    from bash are strings, and so need to parse that into the appropriate
+    bool value.
+    """
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values != '0' and values.lower() != 'false')
+
+
 ##############################################################################
 # this script must be run by root or sudo
 if os.getuid() != 0:
@@ -50,8 +65,12 @@ parser.add_argument('--setup-for-sample-courses', action='store_true', default=F
                     help="Sets up Submitty for use with the sample courses. This is a Vagrant convenience "
                          "flag and should not be used in production!")
 parser.add_argument('--worker', action='store_true', default=False, help='Configure Submitty with autograding only')
-parser.add_argument('--worker-pair', default=False, help='Configure Submitty alongside a worker VM. This should only'
-                                                         'be used during development using Vagrant.')
+parser.add_argument(
+    '--worker-pair',
+    default=False,
+    action=StrToBoolAction,
+    help='Configure Submitty alongside a worker VM. This should only be used during development using Vagrant.'
+)
 parser.add_argument('--install-dir', default='/usr/local/submitty', help='Set the install directory for Submitty')
 parser.add_argument('--data-dir', default='/var/local/submitty', help='Set the data directory for Submitty')
 parser.add_argument('--websocket-port', default=8443, type=int, help='Port to use for websocket')


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #7331 

When worker pair is not enabled for vagrant, we pass in `--worker-pair 0` to the configure script, where the `0` gets parsed as a string, and thus evaluates to a truthy string. This causes worker-pair to be enabled, when it should not be.

### What is the new behavior?

This PR implements a custom action parser so that we convert the string argument that's passed for `worker-pair` to a boolean value, such that `0` or `false` strings will give us a false value for `--worker-pair` and `1` or `true` (or any other string) will evaluate to boolean true.