### PR TITLE
[Bugfix:Submission] Upload bulk/student with previous files

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -26,82 +26,82 @@
         <tbody>
             {% for file in files %}
                 {% if file.cover_image is not empty %}
-                {# Display files uploaded only on bulk upload mode #}
+                    {# Display files uploaded only on bulk upload mode #}
 
-                {% if file["valid"] == false %}
-                    <tr class="tr tr-vertically-centered" style="background-color:pink;" id="row-{{ loop.index}}">
-                {% else %}
-                    <tr class="tr tr-vertically-centered" id="row-{{ loop.index }}" >
-                {% endif %}
-                    <td>{{ loop.index }}</td>
-                    <td>{{ file.clean_timestamp }}</td>
-                    <td>
-                        {{ file.filename_full }}
-                        <br>
-                        <div class="scrollable-image" >
-                            <img src="{{ file.cover_image.url }}" width="100%" alt = "{{ file.filename_full }} preview"/>
-                        </div>
-                    </td>
-                    <td>
-                        <a href="javascript:openFile('{{ file.url_full }}');" aria-label="View full PDF in a new window">
-                            <i class="fas fa-window-restore"></i>
-			            </a>
-                    </td>
-                    <td id="input_area">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
-                        <div id="users_{{ loop.index }}">
-                            <input type="text" id="bulk_user_id_{{ loop.index }}" aria-label = "Enter User ID to assign"
-                                value ="{{ file["id"] }}"
-                                {# we should only submit on enter for normal bulk uploads or on the last team upload box #}
-                                {% if not team_assignment %}
-                                    onkeydown="uploadOnEnter( {{ loop.index }}, event );"
-                                {% else %}
-                                    onkeydown="focusNextOnEnter({{ loop.index }}, 0)"
-                                {% endif %}
-                            />
-
-
-                            {# Display any similar matches if using OCR #}
-                            {% if use_ocr %}
-                                {% if file["matches"] | length  > 1 %}
-                                <br>
-                                <p> Similar Matches </p>
-                                </br>
-                                {% endif %}
-                                {% for match in file["matches"] %}
-                                    {% if match != file["id"] %}
-                                    <p> {{ match }} </p> 
+                    {% if file["valid"] == false %}
+                        <tr class="tr tr-vertically-centered" style="background-color:pink;" id="row-{{ loop.index}}">
+                    {% else %}
+                        <tr class="tr tr-vertically-centered" id="row-{{ loop.index }}" >
+                    {% endif %}
+                        <td>{{ loop.index }}</td>
+                        <td>{{ file.clean_timestamp }}</td>
+                        <td>
+                            {{ file.filename_full }}
+                            <br>
+                            <div class="scrollable-image" >
+                                <img src="{{ file.cover_image.url }}" width="100%" alt = "{{ file.filename_full }} preview"/>
+                            </div>
+                        </td>
+                        <td>
+                            <a href="javascript:openFile('{{ file.url_full }}');" aria-label="View full PDF in a new window">
+                                <i class="fas fa-window-restore"></i>
+                            </a>
+                        </td>
+                        <td id="input_area">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
+                            <div id="users_{{ loop.index }}">
+                                <input type="text" id="bulk_user_id_{{ loop.index }}" aria-label = "Enter User ID to assign"
+                                    value ="{{ file["id"] }}"
+                                    {# we should only submit on enter for normal bulk uploads or on the last team upload box #}
+                                    {% if not team_assignment %}
+                                        onkeydown="uploadOnEnter( {{ loop.index }}, event );"
+                                    {% else %}
+                                        onkeydown="focusNextOnEnter({{ loop.index }}, 0)"
                                     {% endif %}
-                                {% endfor %}
-                            {% endif %}
+                                />
 
-                            {% if team_assignment %}
-                                {# (size - 1) because twig loops are range inclusive #}
-                                {% set outer_loop = loop %}
-                                {% for i in 1..(max_team_size - 1) %}
-                                    <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value =""
-                                        {# if this is the last input box submit on enter, otherwise move to next box#}
-                                        {% if i == (max_team_size - 1) %}
-                                            onkeydown="uploadOnEnter({{ outer_loop.index }}, event);"
-                                        {% else %}
-                                            onkeydown="focusNextOnEnter({{ outer_loop.index}}, {{ i }} )"
+
+                                {# Display any similar matches if using OCR #}
+                                {% if use_ocr %}
+                                    {% if file["matches"] | length  > 1 %}
+                                    <br>
+                                    <p> Similar Matches </p>
+                                    </br>
+                                    {% endif %}
+                                    {% for match in file["matches"] %}
+                                        {% if match != file["id"] %}
+                                        <p> {{ match }} </p> 
                                         {% endif %}
-                                    />
-                                {% endfor %}
-                            {% endif %}
-                        </div>
-                    </td>
-                    <td class="pdf_page_count" id="page_count_{{ loop.index }}">
-                        {{ file["page_count"] }}
-                    </td>
-                    <td>
-                        <button type="button" id="bulk_submit_{{ loop.index }}" class="btn btn-primary key_to_click" tabindex="0"
-                        onclick="uploadSplit( {{ loop.index }} )">Submit</button>
-                    </td>
-                    <td>
-                        <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default key_to_click" tabindex="0" onclick="deleteSplit({{ loop.index }})">Delete</button>
-                    </td>
-                </tr>
+                                    {% endfor %}
+                                {% endif %}
+
+                                {% if team_assignment %}
+                                    {# (size - 1) because twig loops are range inclusive #}
+                                    {% set outer_loop = loop %}
+                                    {% for i in 1..(max_team_size - 1) %}
+                                        <input type="text" id="bulk_user_id_{{ outer_loop.index }}[{{ i }}]" value =""
+                                            {# if this is the last input box submit on enter, otherwise move to next box#}
+                                            {% if i == (max_team_size - 1) %}
+                                                onkeydown="uploadOnEnter({{ outer_loop.index }}, event);"
+                                            {% else %}
+                                                onkeydown="focusNextOnEnter({{ outer_loop.index}}, {{ i }} )"
+                                            {% endif %}
+                                        />
+                                    {% endfor %}
+                                {% endif %}
+                            </div>
+                        </td>
+                        <td class="pdf_page_count" id="page_count_{{ loop.index }}">
+                            {{ file["page_count"] }}
+                        </td>
+                        <td>
+                            <button type="button" id="bulk_submit_{{ loop.index }}" class="btn btn-primary key_to_click" tabindex="0"
+                            onclick="uploadSplit( {{ loop.index }} )">Submit</button>
+                        </td>
+                        <td>
+                            <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default key_to_click" tabindex="0" onclick="deleteSplit({{ loop.index }})">Delete</button>
+                        </td>
+                    </tr>
                 {% endif %}
             {% endfor %}
         </tbody>

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -25,6 +25,9 @@
         </thead>
         <tbody>
             {% for file in files %}
+                {% if file.cover_image is not empty %}
+                {# Display files uploaded only on bulk upload mode #}
+
                 {% if file["valid"] == false %}
                     <tr class="tr tr-vertically-centered" style="background-color:pink;" id="row-{{ loop.index}}">
                 {% else %}
@@ -99,6 +102,7 @@
                         <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default key_to_click" tabindex="0" onclick="deleteSplit({{ loop.index }})">Delete</button>
                     </td>
                 </tr>
+                {% endif %}
             {% endfor %}
         </tbody>
     </table>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -69,16 +69,16 @@
             <fieldset id="submission-mode">
                 <legend> Select submission mode: </legend>
                 <label for="radio-normal">
-                    <input type='radio' id="radio-normal" name="submission_type" checked="checked">
+                    <input type='radio' id="radio-normal" name="submission-type" checked="checked">
                     Normal Submission
                 </label>
                 <label for="radio-student">
-                    <input type='radio' id="radio-student" name="submission_type">
+                    <input type='radio' id="radio-student" name="submission-type">
                     Make Submission for a Student
                 </label>
                 {% if part_names|length == 1 and not is_vcs %}
                     <label for="radio-bulk">
-                        <input type='radio' id="radio-bulk" name="submission_type">
+                        <input type='radio' id="radio-bulk" name="submission-type">
                         Bulk PDF Upload
                         <a aria-label="Bulk PDF Upload Help" href = "https://submitty.org/instructor/bulk_pdf_upload" target="_blank">
                             <i title="Bulk PDF Upload Help" class="far fa-question-circle"></i>
@@ -125,6 +125,10 @@
                 </div>
             </div>
         </form>
+
+        <div class="text-center">
+            <h2 id="submission-mode-warning" class="warning"></h2>
+        </div>
 
         <script>
             $(function() {
@@ -247,6 +251,7 @@
                 $("#user_id").autocomplete({
                     source: students_full
                 });
+
             });
         </script>
     {% endif %}
@@ -374,6 +379,14 @@
                             addLabel('{{ file.name }}', '{{ file.size }}', {{ file.part }}, true);
                             readPrevious('{{ file.name }}', {{ file.part }});
                         {% endfor %}
+
+                        //TODO: move logic for loading submission mode from session storage into module file
+                        if(document.querySelector('input[name="submission-type"]:checked').id !== 'radio-normal'){
+                            for(let idx = 1; idx <= window.num_submission_boxes; idx++){
+                                window.deleteFiles(idx);
+                            }
+                        }
+
                     });
                 </script>
             {% endif %}
@@ -409,16 +422,24 @@
             // GET FILES OF THE HIGHEST VERSION
             if (assignment_version == highest_version && highest_version > 0) {
                 $("#getprev").click(function(e){
-                    $("#startnew").click();
+                    loadPreviousFilesOnDropBoxes();
+                    e.stopPropagation();
+                });
+            }
+
+            function loadPreviousFilesOnDropBoxes(){
+                $("#startnew").click();
                     {% for file in old_files %}
                         addLabel('{{ file.name }}', '{{ file.size }}', {{ file.part }}, true);
                         readPrevious('{{ file.name }}', {{ file.part }});
                     {% endfor %}
                     setUsePrevious();
                     setButtonStatus();
-                    e.stopPropagation();
-                });
             }
+
+            window.loadPreviousFilesOnDropBoxes = loadPreviousFilesOnDropBoxes;
+            //TODO: move the logic on loading submission mode into a module
+
         </script>
     {% endif %}
 </div>
@@ -429,6 +450,8 @@
 {% endif %}
 
 <script>
+    window.num_submission_boxes = {{ part_names | length }};
+
     function makeSubmission(user_id, highest_version, is_pdf, path, git_user_id, git_repo_id, merge_previous=false, clobber=false) {
         // submit the selected pdf
         path = decodeURIComponent(path);

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -126,8 +126,7 @@
             </div>
         </form>
 
-        <div class="text-center">
-            <h2 id="submission-mode-warning" class="warning"></h2>
+        <div id="submission-mode-warning" class="text-center">
         </div>
 
         <script>
@@ -381,10 +380,22 @@
                         {% endfor %}
 
                         //TODO: move logic for loading submission mode from session storage into module file
-                        if(document.querySelector('input[name="submission-type"]:checked').id !== 'radio-normal'){
+                        const selected_radio_id = document.querySelector('input[name="submission-type"]:checked').id;
+                        if(selected_radio_id !== 'radio-normal'){
                             for(let idx = 1; idx <= window.num_submission_boxes; idx++){
                                 window.deleteFiles(idx);
                             }
+
+                            const warning_banner = document.getElementById('submission-mode-warning');
+                            if (!warning_banner.hasChildNodes()){
+                                warning_banner.appendChild( document.createElement('h2') );
+                                warning_banner.firstChild.classList.add('warning');
+                            }
+
+                            message = selected_radio_id === 'radio-bulk' ? 'Warning: Submitting files for bulk upload!' :
+                                'Warning: Submitting files for a student!';
+                            warning_banner.firstChild.textContent = message;
+
                         }
 
                     });

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -32,6 +32,7 @@ class HomeworkView extends AbstractView {
 
         $this->core->getOutput()->addInternalJs('drag-and-drop.js');
         $this->core->getOutput()->addInternalCss('table.css');
+        $this->core->getOutput()->addInternalModuleJs('submission.js');
 
         // The number of days late this gradeable would be if submitted now (including exceptions)
         $late_days_use = 0;

--- a/site/ts/submission.ts
+++ b/site/ts/submission.ts
@@ -1,4 +1,4 @@
-
+// TODO: this should be removed as the file upload logic is moved into a module
 declare global {
     interface Window{
         file_array: File[][];

--- a/site/ts/submission.ts
+++ b/site/ts/submission.ts
@@ -1,9 +1,12 @@
-interface Window{
-    file_array: File[][];
-    num_submission_boxes: number;
-    deleteFiles(Number): void;
-    addFile(File, Number, Boolean):void;
-    loadPreviousFilesOnDropBoxes():void;
+
+declare global {
+    interface Window{
+        file_array: File[][];
+        num_submission_boxes: number;
+        deleteFiles(Number): void;
+        addFile(File, Number, Boolean):void;
+        loadPreviousFilesOnDropBoxes():void;
+    }
 }
 
 const warning_banner = document.getElementById('submission-mode-warning');
@@ -49,3 +52,9 @@ function changeSubmissionMode(event: Event){
 
 
 document.addEventListener('DOMContentLoaded', () => init());
+
+// export or import statement required to modify Window interface to global scope
+// otherwise TypeScript will assume everything in the file is in the global scope
+export {
+
+};

--- a/site/ts/submission.ts
+++ b/site/ts/submission.ts
@@ -1,0 +1,51 @@
+interface Window{
+    file_array: File[][];
+    num_submission_boxes: number;
+    deleteFiles(Number): void;
+    addFile(File, Number, Boolean):void;
+    loadPreviousFilesOnDropBoxes():void;
+}
+
+const warning_banner = document.getElementById('submission-mode-warning');
+
+function init(){
+    document.getElementsByName('submission-type')
+        .forEach(radio_btn => radio_btn.addEventListener('change', changeSubmissionMode));
+
+    warning_banner.textContent = '';
+}
+
+
+/**
+ * handle switching between normal, submit for student, and bulk upload modes
+ */
+function changeSubmissionMode(event: Event){
+    const element = event.target as HTMLInputElement;
+
+    if (window.file_array[0].length > 0){
+        if (!confirm('Switching submission modes will remove all unsubmitted files, are you sure?')){
+            return;
+        }
+    }
+
+    //remove all files in each submission box
+    for (let idx = 1; idx <= window.num_submission_boxes; idx++){
+        window.deleteFiles(idx);
+    }
+
+    switch (element.id){
+        case 'radio-normal':
+            window.loadPreviousFilesOnDropBoxes();
+            warning_banner.textContent = '';
+            break;
+        case 'radio-student':
+            warning_banner.textContent = 'Warning: Submitting files for a student!';
+            break;
+        case 'radio-bulk':
+            warning_banner.textContent = 'Warning: Submitting files for bulk upload!';
+
+    }
+}
+
+
+document.addEventListener('DOMContentLoaded', () => init());

--- a/site/ts/submission.ts
+++ b/site/ts/submission.ts
@@ -36,18 +36,26 @@ function changeSubmissionMode(event: Event){
         window.deleteFiles(idx);
     }
 
+    let message = '';
     switch (element.id){
         case 'radio-normal':
             window.loadPreviousFilesOnDropBoxes();
-            warning_banner.textContent = '';
+            message = '';
             break;
         case 'radio-student':
-            warning_banner.textContent = 'Warning: Submitting files for a student!';
+            message = 'Warning: Submitting files for a student!';
             break;
         case 'radio-bulk':
-            warning_banner.textContent = 'Warning: Submitting files for bulk upload!';
+            message = 'Warning: Submitting files for bulk upload!';
 
     }
+
+    if (!warning_banner.hasChildNodes()){
+        const child = warning_banner.appendChild( document.createElement('h2') );
+        child.classList.add('warning');
+    }
+
+    warning_banner.firstChild.textContent = message;
 }
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
If an instructor uploads a normal submission file and then switches to either bulk or submit for student mode, the 
the previous submission needs to be deleted every time.

### What is the new behavior?
Files submitted on normal submission are auto removed when switching modes and restored when switching back to normal submission mode.

### Other information?
Note: Since there is no distinction between files submitted for a student, bulk upload and normal submission - previous files are no only shown for normal submission. Unsure if this is ideal behavior or if displaying previous files is needed for each mode @bmcutler ?


The display also shows a warning banner when changing modes:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/12129065/141064084-9dcdab66-709b-4383-835b-baee4d5bd5bf.png">

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/12129065/141064112-b26e888b-f98e-4319-966a-bcfdbea2f45e.png">

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/12129065/141064155-2c6f411e-55e3-4d16-9514-698f69744339.png">

closes #7190

