### PR TITLE
[UI/UX:InstructorUI] Omit values of 0

### DIFF
--- a/site/app/templates/AutogradingStatus.twig
+++ b/site/app/templates/AutogradingStatus.twig
@@ -42,8 +42,17 @@
                     <td>{{ course_name[0] }}</td>
                     <td>{{ course_name[1] }}</td>
                     <td>{{ gradeable }}</td>
-                    <td>{{ types["interactive"] }}</td>
-                    <td>{{ types["regrade"] }}</td>
+					
+                    <td>
+					{% if types["interactive"] != 0 %}
+						{{ types["interactive"] }}
+					{% endif %}
+					</td>
+                    <td>
+					{% if types["regrade"] != 0 %}
+						{{ types["regrade"] }}
+					{% endif %}
+					</td>
                 </tr>
             {% endfor %}
         {% endfor %}
@@ -160,31 +169,45 @@
                     {{ progress["time"] }}
                 </td>
                 <td>
-                    {{ progress["queue_counts"]["interactive_ongoing"] }}
+					{% if progress["queue_counts"]["interactive_ongoing"] != 0 %}
+                    	{{ progress["queue_counts"]["interactive_ongoing"] }}
+					{% endif %}
                 </td>
                 <td class="right-boarder">
-                    {{ progress["queue_counts"]["interactive"] }}
+					{% if progress["queue_counts"]["interactive"] != 0 %}
+                    	{{ progress["queue_counts"]["interactive"] }}
+					{% endif %}
                 </td>
                 <td>
-                    {{ progress["queue_counts"]["regrade_ongoing"] }}
+					{% if progress["queue_counts"]["regrade_ongoing"] != 0 %}
+                    	{{ progress["queue_counts"]["regrade_ongoing"] }}
+					{% endif %}
                 </td>
                 <td class="right-boarder">
-                    {{ progress["queue_counts"]["regrade"] }}
+					{% if progress["queue_counts"]["regrade"] != 0 %}
+                    	{{ progress["queue_counts"]["regrade"] }}
+					{% endif %}
                 </td>
                 {% for machine, count in progress["machine_grading_counts"] %}
                     {% if machine == progress["machine_grading_counts"]|keys|last %}
                     <td class="right-boarder">
-                        {{ count }}
+						{% if count != 0 %}
+                        	{{ count }}
+						{% endif %}
                     </td>
                     {% else %}
                     <td>
-                        {{ count }}
+						{% if count != 0 %}
+                        	{{ count }}
+						{% endif %}
                     </td>
                     {% endif %}
                 {% endfor %}
                 {% for count in progress["capability_queue_counts"]%}
                 <td>
-                    {{ count }}
+					{% if count != 0 %}
+                    	{{ count }}
+					{% endif %}
                 </td>
                 {% endfor %}
             </tr>

--- a/site/app/templates/AutogradingStatus.twig
+++ b/site/app/templates/AutogradingStatus.twig
@@ -13,7 +13,7 @@
     <h2>
         Course Statistics
     </h2>
-    {# css was added to enable the column names to show up when the windows become to small causing the table to become "mobile-fied"#}
+    {# css was added to enable the column names to show up when the windows become to small causing the table to become "mobile-fied"#}    
     <table class="table table-striped mobile-table" id="course-table">
         <thead>
             <tr>
@@ -42,17 +42,17 @@
                     <td>{{ course_name[0] }}</td>
                     <td>{{ course_name[1] }}</td>
                     <td>{{ gradeable }}</td>
-					
+
                     <td>
-					{% if types["interactive"] != 0 %}
-						{{ types["interactive"] }}
-					{% endif %}
-					</td>
+                        {% if types["interactive"] != 0 %}
+                            {{ types["interactive"] }}
+                        {% endif %}
+                    </td>
                     <td>
-					{% if types["regrade"] != 0 %}
-						{{ types["regrade"] }}
-					{% endif %}
-					</td>
+                        {% if types["regrade"] != 0 %}
+                            {{ types["regrade"] }}
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         {% endfor %}
@@ -75,7 +75,7 @@
         </thead>
         <tbody>
             {% for machine, worker_info in progress["ongoing_job_info"] %}
-                    {% for info in worker_info %}
+                {% for info in worker_info %}
                     <tr>
                         <td> {{machine}} </td>
                         <td> {{info["semester"]}} </td>
@@ -85,7 +85,7 @@
                         <td> {{info["elapsed_time"]}} </td>
                         <td> {{info["error"]}} </td>
                     </tr>
-                    {% endfor %}
+                {% endfor %}
             {% endfor %}
         </tbody>
     </table>
@@ -131,32 +131,32 @@
                 </th>
                 {% for machines in progress["machine_grading_counts"]|keys %}
                     {% if machines == progress["machine_grading_counts"]|keys|last %}
-                    <th class="col-md-2 right-boarder">
-                        {{ machines|upper }}
-                    </th>
+                        <th class="col-md-2 right-boarder">
+                            {{ machines|upper }}
+                        </th>
                     {% else %}
-                    <th class="col-md-2">
-                        {{ machines|upper }}
-                    </th>
+                        <th class="col-md-2">
+                            {{ machines|upper }}
+                        </th>
                     {% endif %}
                 {% endfor %}
                 {% for capability in progress["capability_queue_counts"]|keys %}
-                <th class="col-md-2" rowspan="2">
-                    {{ capability|upper }}
-                </th>
+                    <th class="col-md-2" rowspan="2">
+                        {{ capability|upper }}
+                    </th>
                 {% endfor %}
             </tr>
             <tr>
                 {# Should display number of shippers instead for each machine #}
                 {% for machine in progress["machine_grading_counts"]|keys %}
                     {% if machine == progress["machine_grading_counts"]|keys|last %}
-                    <th class="right-boarder">
-                        {{ progress["num_autograding_workers"][machine] }}
-                    </th>
+                        <th class="right-boarder">
+                            {{ progress["num_autograding_workers"][machine] }}
+                        </th>
                     {% else %}
-                    <th>
-                        {{ progress["num_autograding_workers"][machine] }}
-                    </th>
+                        <th>
+                            {{ progress["num_autograding_workers"][machine] }}
+                        </th>
                     {% endif %}
                 {% endfor %}
                 <th colspan="{{ progress["capability_queue_counts"]|keys|length }}">
@@ -169,46 +169,46 @@
                     {{ progress["time"] }}
                 </td>
                 <td>
-					{% if progress["queue_counts"]["interactive_ongoing"] != 0 %}
-                    	{{ progress["queue_counts"]["interactive_ongoing"] }}
-					{% endif %}
+                    {% if progress["queue_counts"]["interactive_ongoing"] != 0 %}
+                        {{ progress["queue_counts"]["interactive_ongoing"] }}
+                    {% endif %}
                 </td>
                 <td class="right-boarder">
-					{% if progress["queue_counts"]["interactive"] != 0 %}
-                    	{{ progress["queue_counts"]["interactive"] }}
-					{% endif %}
+                    {% if progress["queue_counts"]["interactive"] != 0 %}
+                        {{ progress["queue_counts"]["interactive"] }}
+                    {% endif %}
                 </td>
                 <td>
-					{% if progress["queue_counts"]["regrade_ongoing"] != 0 %}
-                    	{{ progress["queue_counts"]["regrade_ongoing"] }}
-					{% endif %}
+                    {% if progress["queue_counts"]["regrade_ongoing"] != 0 %}
+                        {{ progress["queue_counts"]["regrade_ongoing"] }}
+                    {% endif %}
                 </td>
                 <td class="right-boarder">
-					{% if progress["queue_counts"]["regrade"] != 0 %}
-                    	{{ progress["queue_counts"]["regrade"] }}
-					{% endif %}
+                    {% if progress["queue_counts"]["regrade"] != 0 %}
+                        {{ progress["queue_counts"]["regrade"] }}
+                    {% endif %}
                 </td>
                 {% for machine, count in progress["machine_grading_counts"] %}
                     {% if machine == progress["machine_grading_counts"]|keys|last %}
-                    <td class="right-boarder">
-						{% if count != 0 %}
-                        	{{ count }}
-						{% endif %}
-                    </td>
+                        <td class="right-boarder">
+                            {% if count != 0 %}
+                                {{ count }}
+                            {% endif %}
+                        </td>
                     {% else %}
                     <td>
-						{% if count != 0 %}
-                        	{{ count }}
-						{% endif %}
+                        {% if count != 0 %}
+                            {{ count }}
+                        {% endif %}
                     </td>
                     {% endif %}
                 {% endfor %}
                 {% for count in progress["capability_queue_counts"]%}
-                <td>
-					{% if count != 0 %}
-                    	{{ count }}
-					{% endif %}
-                </td>
+                    <td>
+                        {% if count != 0 %}
+                            {{ count }}
+                        {% endif %}
+                    </td>
                 {% endfor %}
             </tr>
         </tbody>

--- a/site/cypress/integration/autograding_status_1.spec.js
+++ b/site/cypress/integration/autograding_status_1.spec.js
@@ -51,19 +51,19 @@ skipOn(Cypress.env('run_area') === 'CI', () => {
             cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
             cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
             cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
-            cy.get('#course-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', '0'));
+            cy.get('#course-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
             cy.get('#course-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
 
             cy.wait(500);
-            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', '0'));
+            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
             cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
-            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', '0'));
+            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
             cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '101'));
 
             // add a non regrade job and see that the site is updated
@@ -83,15 +83,15 @@ skipOn(Cypress.env('run_area') === 'CI', () => {
             cy.get('#course-table tbody tr td').should('contain', 'future_no_tas_homework');
             cy.get('#course-table tbody tr td').should('contain', '1');
 
-            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', '0'));
+            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
             cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', '1'));
-            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', '0'));
+            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
             cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
-            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', '0'));
-            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', '0'));
+            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
             cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '102'));
 
         });

--- a/site/public/js/autograding-status.js
+++ b/site/public/js/autograding-status.js
@@ -41,8 +41,14 @@ function updateTable() {
                         new_row.insertCell().innerHTML = course_name[0];
                         new_row.insertCell().innerHTML = course_name[1];
                         new_row.insertCell().innerHTML = key2;
-                        new_row.insertCell().innerHTML = info.interactive;
-                        new_row.insertCell().innerHTML = info.regrade;
+						const int_box = new_row.insertCell();
+						if (info.interactive != 0) {
+                        	int_box.innerHTML = info.interactive;
+						}
+						const regrade_box = new_row.insertCell();
+						if (info.regrade != 0) {
+                        	regrade_box.innerHTML = info.regrade;
+						}
                     });
                 });
 
@@ -69,26 +75,48 @@ function updateTable() {
                 let new_cell = new_row.insertCell();
                 new_cell.innerHTML = json.time;
                 new_cell.className = 'right-boarder';
-                new_row.insertCell().innerHTML = json.queue_counts.interactive_ongoing;
+
+				new_cell = new_row.insertCell();
+				if (json.queue_counts.interactive_ongoing != 0) {
+                	new_cell.innerHTML = json.queue_counts.interactive_ongoing;
+				}
+
                 new_cell = new_row.insertCell();
-                new_cell.innerHTML = json.queue_counts.interactive;
+				if (json.queue_counts.interactive != 0) {
+                	new_cell.innerHTML = json.queue_counts.interactive;
+				}
                 new_cell.className = 'right-boarder';
-                new_row.insertCell().innerHTML = json.queue_counts.regrade_ongoing;
+
+				new_cell = new_row.insertCell();
+				if (json.queue_counts.regrade_ongoing != 0) {
+                	new_cell.innerHTML = json.queue_counts.regrade_ongoing;
+				}
                 new_cell = new_row.insertCell();
-                new_cell.innerHTML = json.queue_counts.regrade;
+
+				if (json.queue_counts.regrade != 0) {
+                	new_cell.innerHTML = json.queue_counts.regrade;
+				}
                 new_cell.className = 'right-boarder';
                 Object.keys(json.machine_grading_counts).forEach((key, i) => {
                     if (i === Object.keys(json.machine_grading_counts).length - 1) {
                         new_cell = new_row.insertCell();
-                        new_cell.innerHTML = json.machine_grading_counts[key];
+						if (json.machine_grading_counts[key] != 0) {
+	                        new_cell.innerHTML = json.machine_grading_counts[key];
+						}
                         new_cell.className = 'right-boarder';
                     }
                     else {
-                        new_row.insertCell().innerHTML = json.machine_grading_counts[key];
-                    }
+						new_cell = new_row.insertCell();
+						if (json.machine_grading_counts[key] != 0) {
+                        	new_cell.innerHTML = json.machine_grading_counts[key];
+						}
+					}
                 });
                 Object.keys(json.capability_queue_counts).forEach(key => {
-                    new_row.insertCell().innerHTML = json.capability_queue_counts[key];
+					const new_cell = new_row.insertCell()
+					if (json.capability_queue_counts[key] != 0) {
+                    	new_cell.innerHTML = json.capability_queue_counts[key];
+					}
                 });
                 // Check if old logs should be removed to make room for new logs
                 if ($('#autograding-status-table tbody tr').length > max_log) {

--- a/site/public/js/autograding-status.js
+++ b/site/public/js/autograding-status.js
@@ -78,7 +78,7 @@ function updateTable() {
 
                 new_cell = new_row.insertCell();
                 if (json.queue_counts.interactive_ongoing != 0) {
-                 new_cell.innerHTML = json.queue_counts.interactive_ongoing;
+                    new_cell.innerHTML = json.queue_counts.interactive_ongoing;
                 }
 
                 new_cell = new_row.insertCell();
@@ -108,13 +108,13 @@ function updateTable() {
                     else {
                         new_cell = new_row.insertCell();
                         if (json.machine_grading_counts[key] != 0) {
-                                            new_cell.innerHTML = json.machine_grading_counts[key];
+                            new_cell.innerHTML = json.machine_grading_counts[key];
                         }
                     }
                 });
 
                 Object.keys(json.capability_queue_counts).forEach(key => {
-                    const new_cell = new_row.insertCell()
+                    const new_cell = new_row.insertCell();
                     if (json.capability_queue_counts[key] != 0) {
                         new_cell.innerHTML = json.capability_queue_counts[key];
                     }

--- a/site/public/js/autograding-status.js
+++ b/site/public/js/autograding-status.js
@@ -44,7 +44,7 @@ function updateTable() {
                         const int_box = new_row.insertCell();
                         if (info.interactive != 0) {
                             int_box.innerHTML = info.interactive;
-      }
+                        }
                         const regrade_box = new_row.insertCell();
                         if (info.regrade != 0) {
                             regrade_box.innerHTML = info.regrade;
@@ -76,48 +76,48 @@ function updateTable() {
                 new_cell.innerHTML = json.time;
                 new_cell.className = 'right-boarder';
 
-    new_cell = new_row.insertCell();
+                new_cell = new_row.insertCell();
                 if (json.queue_counts.interactive_ongoing != 0) {
                  new_cell.innerHTML = json.queue_counts.interactive_ongoing;
-    }
+                }
 
                 new_cell = new_row.insertCell();
                 if (json.queue_counts.interactive != 0) {
                     new_cell.innerHTML = json.queue_counts.interactive;
-    }
+                }
                 new_cell.className = 'right-boarder';
 
                 new_cell = new_row.insertCell();
-    if (json.queue_counts.regrade_ongoing != 0) {
-                 new_cell.innerHTML = json.queue_counts.regrade_ongoing;
-    }
+                if (json.queue_counts.regrade_ongoing != 0) {
+                    new_cell.innerHTML = json.queue_counts.regrade_ongoing;
+                }
                 new_cell = new_row.insertCell();
 
-    if (json.queue_counts.regrade != 0) {
-                 new_cell.innerHTML = json.queue_counts.regrade;
-    }
+                if (json.queue_counts.regrade != 0) {
+                    new_cell.innerHTML = json.queue_counts.regrade;
+                }
                 new_cell.className = 'right-boarder';
                 Object.keys(json.machine_grading_counts).forEach((key, i) => {
                     if (i === Object.keys(json.machine_grading_counts).length - 1) {
                         new_cell = new_row.insertCell();
-      if (json.machine_grading_counts[key] != 0) {
-                         new_cell.innerHTML = json.machine_grading_counts[key];
-      }
+                        if (json.machine_grading_counts[key] != 0) {
+                            new_cell.innerHTML = json.machine_grading_counts[key];
+                        }
                         new_cell.className = 'right-boarder';
                     }
                     else {
-      new_cell = new_row.insertCell();
-      if (json.machine_grading_counts[key] != 0) {
-                         new_cell.innerHTML = json.machine_grading_counts[key];
-      }
-     }
+                        new_cell = new_row.insertCell();
+                        if (json.machine_grading_counts[key] != 0) {
+                                            new_cell.innerHTML = json.machine_grading_counts[key];
+                        }
+                    }
                 });
 
                 Object.keys(json.capability_queue_counts).forEach(key => {
-     const new_cell = new_row.insertCell()
-     if (json.capability_queue_counts[key] != 0) {
-                     new_cell.innerHTML = json.capability_queue_counts[key];
-     }
+                    const new_cell = new_row.insertCell()
+                    if (json.capability_queue_counts[key] != 0) {
+                        new_cell.innerHTML = json.capability_queue_counts[key];
+                    }
                 });
                 // Check if old logs should be removed to make room for new logs
                 if ($('#autograding-status-table tbody tr').length > max_log) {

--- a/site/public/js/autograding-status.js
+++ b/site/public/js/autograding-status.js
@@ -41,14 +41,14 @@ function updateTable() {
                         new_row.insertCell().innerHTML = course_name[0];
                         new_row.insertCell().innerHTML = course_name[1];
                         new_row.insertCell().innerHTML = key2;
-						const int_box = new_row.insertCell();
-						if (info.interactive != 0) {
-                        	int_box.innerHTML = info.interactive;
-						}
-						const regrade_box = new_row.insertCell();
-						if (info.regrade != 0) {
-                        	regrade_box.innerHTML = info.regrade;
-						}
+                        const int_box = new_row.insertCell();
+                        if (info.interactive != 0) {
+                            int_box.innerHTML = info.interactive;
+      }
+                        const regrade_box = new_row.insertCell();
+                        if (info.regrade != 0) {
+                            regrade_box.innerHTML = info.regrade;
+                        }
                     });
                 });
 
@@ -76,47 +76,48 @@ function updateTable() {
                 new_cell.innerHTML = json.time;
                 new_cell.className = 'right-boarder';
 
-				new_cell = new_row.insertCell();
-				if (json.queue_counts.interactive_ongoing != 0) {
-                	new_cell.innerHTML = json.queue_counts.interactive_ongoing;
-				}
+    new_cell = new_row.insertCell();
+                if (json.queue_counts.interactive_ongoing != 0) {
+                 new_cell.innerHTML = json.queue_counts.interactive_ongoing;
+    }
 
                 new_cell = new_row.insertCell();
-				if (json.queue_counts.interactive != 0) {
-                	new_cell.innerHTML = json.queue_counts.interactive;
-				}
+                if (json.queue_counts.interactive != 0) {
+                    new_cell.innerHTML = json.queue_counts.interactive;
+    }
                 new_cell.className = 'right-boarder';
 
-				new_cell = new_row.insertCell();
-				if (json.queue_counts.regrade_ongoing != 0) {
-                	new_cell.innerHTML = json.queue_counts.regrade_ongoing;
-				}
+                new_cell = new_row.insertCell();
+    if (json.queue_counts.regrade_ongoing != 0) {
+                 new_cell.innerHTML = json.queue_counts.regrade_ongoing;
+    }
                 new_cell = new_row.insertCell();
 
-				if (json.queue_counts.regrade != 0) {
-                	new_cell.innerHTML = json.queue_counts.regrade;
-				}
+    if (json.queue_counts.regrade != 0) {
+                 new_cell.innerHTML = json.queue_counts.regrade;
+    }
                 new_cell.className = 'right-boarder';
                 Object.keys(json.machine_grading_counts).forEach((key, i) => {
                     if (i === Object.keys(json.machine_grading_counts).length - 1) {
                         new_cell = new_row.insertCell();
-						if (json.machine_grading_counts[key] != 0) {
-	                        new_cell.innerHTML = json.machine_grading_counts[key];
-						}
+      if (json.machine_grading_counts[key] != 0) {
+                         new_cell.innerHTML = json.machine_grading_counts[key];
+      }
                         new_cell.className = 'right-boarder';
                     }
                     else {
-						new_cell = new_row.insertCell();
-						if (json.machine_grading_counts[key] != 0) {
-                        	new_cell.innerHTML = json.machine_grading_counts[key];
-						}
-					}
+      new_cell = new_row.insertCell();
+      if (json.machine_grading_counts[key] != 0) {
+                         new_cell.innerHTML = json.machine_grading_counts[key];
+      }
+     }
                 });
+
                 Object.keys(json.capability_queue_counts).forEach(key => {
-					const new_cell = new_row.insertCell()
-					if (json.capability_queue_counts[key] != 0) {
-                    	new_cell.innerHTML = json.capability_queue_counts[key];
-					}
+     const new_cell = new_row.insertCell()
+     if (json.capability_queue_counts[key] != 0) {
+                     new_cell.innerHTML = json.capability_queue_counts[key];
+     }
                 });
                 // Check if old logs should be removed to make room for new logs
                 if ($('#autograding-status-table tbody tr').length > max_log) {


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently, the tables in autograding status page have a lot of 0s which may overwhelm users.

Fixes #7145

### What is the new behavior?
The values of the tables are checked and are omitted where it makes sense within the page.

Example of the new changes below:
![image](https://user-images.githubusercontent.com/49821332/142299393-336d16c9-8ff4-40b6-8f79-ef6a9326d501.png)
