### PR TITLE
[Feature:Developer] Set indent size for twig in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 indent_style = space
 charset = utf-8
 
-[*.{py,php,java,sh,css,html,js}]
+[*.{py,php,java,sh,css,html,js,twig}]
 indent_size = 4
 
 [{MakefileHelper,SAMPLE_Makefile}]


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Twig files were not covered in our editorconfig to set a default indent size.

### What is the new behavior?

Twig files are now set as having four spaces, similar to other files.