### PR TITLE
[Bugfix:Developer] Fix Doctrine debug mode type issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ coverage.xml
 /site/cypress/screenshots/
 /site/cypress/videos/
 /site/public/mjs/
-site/report/
+/site/report/
 
 db_update.php
 .setup/data/random_users.txt

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ coverage.xml
 /site/cypress/screenshots/
 /site/cypress/videos/
 /site/public/mjs/
+site/report/
 
 db_update.php
 .setup/data/random_users.txt

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -7,9 +7,9 @@ namespace app\libraries\database;
 use app\libraries\DateUtils;
 
 class DatabaseUtils {
-    public static function formatQuery($sql, $params): string {
-        if (is_null($params)) {
-            return '';
+    public static function formatQuery(string $sql, ?array $params): string {
+        if ($params === null) {
+            return $sql;
         }
 
         foreach ($params as $param) {

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -11,7 +11,7 @@ class DatabaseUtils {
         if (is_null($params)) {
             return '';
         }
-        
+
         foreach ($params as $param) {
             if (gettype($param) == 'object' && get_class($param) == get_class(new \DateTime())) {
                 $param = DateUtils::dateTimeToString($param);

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -4,9 +4,18 @@ declare(strict_types=1);
 
 namespace app\libraries\database;
 
+use app\libraries\DateUtils;
+
 class DatabaseUtils {
     public static function formatQuery($sql, $params): string {
+        if (is_null($params)) {
+            return '';
+        }
+        
         foreach ($params as $param) {
+            if (gettype($param) == 'object' && get_class($param) == get_class(new \DateTime())) {
+                $param = DateUtils::dateTimeToString($param);
+            }
             $sql = preg_replace('/\?/', is_numeric($param) ? $param : "'{$param}'", $sql, 1);
         }
         return $sql;

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -13,7 +13,7 @@ class DatabaseUtils {
         }
 
         foreach ($params as $param) {
-            if (gettype($param) == 'object' && get_class($param) == get_class(new \DateTime())) {
+            if ($param instanceof \DateTime) {
                 $param = DateUtils::dateTimeToString($param);
             }
             $sql = preg_replace('/\?/', is_numeric($param) ? $param : "'{$param}'", $sql, 1);

--- a/site/tests/app/libraries/database/DatabaseUtilsTester.php
+++ b/site/tests/app/libraries/database/DatabaseUtilsTester.php
@@ -13,6 +13,8 @@ class DatabaseUtilsTester extends \PHPUnit\Framework\TestCase {
             ['SELECT * FROM foo WHERE id = ?', [1], 'SELECT * FROM foo WHERE id = 1'],
             ['SELECT * FROM foo WHERE id IN (?,?,?)', [1,2,3], 'SELECT * FROM foo WHERE id IN (1,2,3)'],
             ['SELECT * FROM foo WHERE id = ?', ['test'], "SELECT * FROM foo WHERE id = 'test'"],
+            ['SELECT * FROM foo WHERE timestamp = ?', [new \DateTime('2999-10-16 12:15:10')], "SELECT * FROM foo WHERE timestamp = '2999-10-16 12:15:10+0000'"],
+            ['SELECT * FROM foo', [], "SELECT * FROM foo"],
         ];
     }
 

--- a/site/tests/app/libraries/database/DatabaseUtilsTester.php
+++ b/site/tests/app/libraries/database/DatabaseUtilsTester.php
@@ -15,6 +15,7 @@ class DatabaseUtilsTester extends \PHPUnit\Framework\TestCase {
             ['SELECT * FROM foo WHERE id = ?', ['test'], "SELECT * FROM foo WHERE id = 'test'"],
             ['SELECT * FROM foo WHERE timestamp = ?', [new \DateTime('2999-10-16 12:15:10')], "SELECT * FROM foo WHERE timestamp = '2999-10-16 12:15:10+0000'"],
             ['SELECT * FROM foo', [], "SELECT * FROM foo"],
+            ['SELECT * FROM foo', null, "SELECT * FROM foo"],
         ];
     }
 


### PR DESCRIPTION
### What is the current behavior?
A PHP error currently occurs in some cases when Doctrine queries with DateTime objects are run in debug mode.  This behavior was likely introduced in https://github.com/Submitty/Submitty/pull/7295.

### What is the new behavior?
Resolves issue by formatting DateTime objects appropriately before displaying.  In addition, this PR fixes a secondary issue where the `$params` parameter in `formatQuery()` is null and thus unable to be iterated over.