### PR TITLE
[Bugfix:TAGrading] Fix other overall comments preview

### DIFF
--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -57,7 +57,7 @@ Required Parameters:
         $(document).ready(function(){
             $('.overall-comment-other').each(function() {
                 const content = $(this).html().trim();
-                const url = buildCourseUrl(['markdown', 'preview']);
+                const url = buildURL(["markdown"]);
                 renderMarkdown($(this), url, content);
             });
         });


### PR DESCRIPTION
### What is the current behavior?
Viewing the overall comment of other users renders the Submitty homepage inside of the box.

### What is the new behavior?
Works on #7369 
Viewing the overall comment of other users properly shows the overall comment.