### PR TITLE
[Bugfix:SubminiPolls] Add default release date to new poll

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -400,10 +400,10 @@
     $(document).ready(function() {
         {% if not poll is defined %}
             const today = new Date();
-            const year = today.getFullYear().toString().padStart(4, '0')
-            const month = (today.getMonth() + 1).toString().padStart(2, '0')
-            const day =  today.getDate().toString().padStart(2, '0')
-            const date_string = year + "-" + month + "-" + day
+            const year = today.getFullYear().toString().padStart(4, '0');
+            const month = (today.getMonth() + 1).toString().padStart(2, '0');
+            const day =  today.getDate().toString().padStart(2, '0');
+            const date_string = year + "-" + month + "-" + day;
             $("#poll-date").flatpickr({
                 defaultDate:date_string
             })

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -403,7 +403,7 @@
             const year = today.getFullYear().toString().padStart(4, '0');
             const month = (today.getMonth() + 1).toString().padStart(2, '0');
             const day =  today.getDate().toString().padStart(2, '0');
-            const date_string = year + "-" + month + "-" + day;
+            const date_string = year + '-' + month + '-' + day;
             $("#poll-date").flatpickr({
                 defaultDate:date_string
             })

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -398,6 +398,13 @@
     }
 
     $(document).ready(function() {
+        {% if not poll is defined %}
+            const today = new Date();
+            const date_string = today.getFullYear() + "-" + (today.getMonth() + 1) + "-" + today.getDate();
+            $("#poll-date").flatpickr({
+                defaultDate:date_string
+            })
+        {% endif %}
         setEventHandlers();
         $("#new-poll-form").on("change click", submitErrorChecks);
         $("#edit-poll-form").on("change click", submitErrorChecks);

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -400,7 +400,10 @@
     $(document).ready(function() {
         {% if not poll is defined %}
             const today = new Date();
-            const date_string = today.getFullYear() + "-" + (today.getMonth() + 1) + "-" + today.getDate();
+            const year = today.getFullYear().toString().padStart(4, '0')
+            const month = (today.getMonth() + 1).toString().padStart(2, '0')
+            const day =  today.getDate().toString().padStart(2, '0')
+            const date_string = year + "-" + month + "-" + day
             $("#poll-date").flatpickr({
                 defaultDate:date_string
             })

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -398,14 +398,14 @@
     }
 
     $(document).ready(function() {
-        {% if not poll is defined %}
+        {% if poll is not defined %}
             const today = new Date();
             const year = today.getFullYear().toString().padStart(4, '0');
             const month = (today.getMonth() + 1).toString().padStart(2, '0');
-            const day =  today.getDate().toString().padStart(2, '0');
+            const day = today.getDate().toString().padStart(2, '0');
             const date_string = `${year}-${month}-${day}`;
             $("#poll-date").flatpickr({
-                defaultDate:date_string
+                defaultDate: date_string
             })
         {% endif %}
         setEventHandlers();

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -406,7 +406,7 @@
             const date_string = `${year}-${month}-${day}`;
             $("#poll-date").flatpickr({
                 defaultDate: date_string
-            })
+            });
         {% endif %}
         setEventHandlers();
         $("#new-poll-form").on("change click", submitErrorChecks);

--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -403,7 +403,7 @@
             const year = today.getFullYear().toString().padStart(4, '0');
             const month = (today.getMonth() + 1).toString().padStart(2, '0');
             const day =  today.getDate().toString().padStart(2, '0');
-            const date_string = year + '-' + month + '-' + day;
+            const date_string = `${year}-${month}-${day}`;
             $("#poll-date").flatpickr({
                 defaultDate:date_string
             })

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -181,7 +181,6 @@ describe('Test cases revolving around polls functionality', () => {
         cy.logout();
         cy.login();
         cy.visit(['sample', 'polls']);
-        cy.get('#old-table-dropdown').click();
         cy.contains('Poll Cypress Test').siblings(':nth-child(5)').children().click();
         cy.wait(1000);
 

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -30,9 +30,6 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#poll_2_view_results').should('not.be.checked');
         cy.get('#poll_2_responses').invoke('text').then(parseInt).should('be.gt', 0);
 
-        // poll 3 release date is initially set to today but we
-        // can't rely on the test being run on the same day as
-        // when the vagrant environment was created
         cy.get('#poll_3_visible').should('be.checked');
         cy.get('#poll_3_view_results').should('be.checked');
         cy.get('#poll_3_responses').invoke('text').then(parseInt).should('be.eq', 0);

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -261,7 +261,7 @@ describe('Test cases revolving around polls functionality', () => {
         const year = today.getFullYear().toString().padStart(4, '0');
         const month = (today.getMonth() + 1).toString().padStart(2, '0');
         const day =  today.getDate().toString().padStart(2, '0');
-        const date_string = year + "-" + month + "-" + day;
+        const date_string = year + '-' + month + '-' + day;
         cy.get('#poll-date').invoke('val').should('eq', date_string);
         cy.get('.poll_response').should('contain', 'Answer 1');
         cy.get('.correct-box').eq(0).should('be.checked');

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -154,8 +154,8 @@ describe('Test cases revolving around polls functionality', () => {
         cy.contains('New Poll').click();
         cy.get('#poll-name').type('Poll Cypress Test');
         cy.get('#poll-question').type('# Question goes here...?');
-        cy.get('#poll-date').clear();
-        cy.get('#poll-date').type('1970-01-01');
+        cy.get('#poll-date').clear({force: true});
+        cy.get('#poll-date').type('1970-01-01', {force: true});
         cy.get('#image-file').attachFile('sea_animals.png');
         cy.contains('+ Add Response').click();
         cy.contains('+ Add Response').click();

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -30,6 +30,9 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#poll_2_view_results').should('not.be.checked');
         cy.get('#poll_2_responses').invoke('text').then(parseInt).should('be.gt', 0);
 
+        // poll 3 release date is initially set to today but we
+        // can't rely on the test being run on the same day as
+        // when the vagrant environment was created
         cy.get('#poll_3_visible').should('be.checked');
         cy.get('#poll_3_view_results').should('be.checked');
         cy.get('#poll_3_responses').invoke('text').then(parseInt).should('be.eq', 0);
@@ -151,6 +154,8 @@ describe('Test cases revolving around polls functionality', () => {
         cy.contains('New Poll').click();
         cy.get('#poll-name').type('Poll Cypress Test');
         cy.get('#poll-question').type('# Question goes here...?');
+        cy.get('#poll-date').clear();
+        cy.get('#poll-date').type('1970-01-01');
         cy.get('#image-file').attachFile('sea_animals.png');
         cy.contains('+ Add Response').click();
         cy.contains('+ Add Response').click();
@@ -178,6 +183,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.logout();
         cy.login();
         cy.visit(['sample', 'polls']);
+        cy.get('#old-table-dropdown').click();
         cy.contains('Poll Cypress Test').siblings(':nth-child(5)').children().click();
         cy.wait(1000);
 
@@ -253,12 +259,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#poll-type-multiple-response-exact').should('not.be.checked');
         cy.get('#poll-type-multiple-response-flexible').should('not.be.checked');
         cy.get('#poll-type-multiple-response-survey').should('not.be.checked');
-        const today = new Date();
-        const year = today.getFullYear().toString().padStart(4, '0');
-        const month = (today.getMonth() + 1).toString().padStart(2, '0');
-        const day =  today.getDate().toString().padStart(2, '0');
-        const date_string = `${year}-${month}-${day}`;
-        cy.get('#poll-date').invoke('val').should('eq', date_string);
+        cy.get('#poll-date').invoke('val').should('eq', '1970-01-01');
         cy.get('.poll_response').should('contain', 'Answer 1');
         cy.get('.correct-box').eq(0).should('be.checked');
         cy.get('.poll_response').should('contain', 'Answer 2');

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -154,7 +154,6 @@ describe('Test cases revolving around polls functionality', () => {
         cy.contains('New Poll').click();
         cy.get('#poll-name').type('Poll Cypress Test');
         cy.get('#poll-question').type('# Question goes here...?');
-        cy.get('#poll-date').type('1970-01-01', {force: true});
         cy.get('#image-file').attachFile('sea_animals.png');
         cy.contains('+ Add Response').click();
         cy.contains('+ Add Response').click();
@@ -258,7 +257,12 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#poll-type-multiple-response-exact').should('not.be.checked');
         cy.get('#poll-type-multiple-response-flexible').should('not.be.checked');
         cy.get('#poll-type-multiple-response-survey').should('not.be.checked');
-        cy.get('#poll-date').invoke('val').should('eq', '1970-01-01');
+        const today = new Date();
+        const year = today.getFullYear().toString().padStart(4, '0')
+        const month = (today.getMonth() + 1).toString().padStart(2, '0')
+        const day =  today.getDate().toString().padStart(2, '0')
+        const date_string = year + "-" + month + "-" + day
+        cy.get('#poll-date').invoke('val').should('eq', date_string);
         cy.get('.poll_response').should('contain', 'Answer 1');
         cy.get('.correct-box').eq(0).should('be.checked');
         cy.get('.poll_response').should('contain', 'Answer 2');

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -258,10 +258,10 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#poll-type-multiple-response-flexible').should('not.be.checked');
         cy.get('#poll-type-multiple-response-survey').should('not.be.checked');
         const today = new Date();
-        const year = today.getFullYear().toString().padStart(4, '0')
-        const month = (today.getMonth() + 1).toString().padStart(2, '0')
-        const day =  today.getDate().toString().padStart(2, '0')
-        const date_string = year + "-" + month + "-" + day
+        const year = today.getFullYear().toString().padStart(4, '0');
+        const month = (today.getMonth() + 1).toString().padStart(2, '0');
+        const day =  today.getDate().toString().padStart(2, '0');
+        const date_string = year + "-" + month + "-" + day;
         cy.get('#poll-date').invoke('val').should('eq', date_string);
         cy.get('.poll_response').should('contain', 'Answer 1');
         cy.get('.correct-box').eq(0).should('be.checked');

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -154,7 +154,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.contains('New Poll').click();
         cy.get('#poll-name').type('Poll Cypress Test');
         cy.get('#poll-question').type('# Question goes here...?');
-        cy.get('#poll-date').type('1970-01-01');
+        cy.get('#poll-date').type('1970-01-01', {force: true});
         cy.get('#image-file').attachFile('sea_animals.png');
         cy.contains('+ Add Response').click();
         cy.contains('+ Add Response').click();

--- a/site/cypress/integration/polls.spec.js
+++ b/site/cypress/integration/polls.spec.js
@@ -261,7 +261,7 @@ describe('Test cases revolving around polls functionality', () => {
         const year = today.getFullYear().toString().padStart(4, '0');
         const month = (today.getMonth() + 1).toString().padStart(2, '0');
         const day =  today.getDate().toString().padStart(2, '0');
-        const date_string = year + '-' + month + '-' + day;
+        const date_string = `${year}-${month}-${day}`;
         cy.get('#poll-date').invoke('val').should('eq', date_string);
         cy.get('.poll_response').should('contain', 'Answer 1');
         cy.get('.correct-box').eq(0).should('be.checked');


### PR DESCRIPTION
### What is the current behavior?
Currently, the release date field is blank for new polls

### What is the new behavior?
Now, the default release date will be the current date
