### PR TITLE
[UI/UX:TAGrading] Fix Markdown Layout in Overall Comments

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1218,7 +1218,7 @@ div.full-height {
 }
 
 .fill-available {
-    width: available;
+    width: 100%;
 }
 
 /* Makes the cursor change to a hand on the checkpoints so that it is clear they can be clicked on */


### PR DESCRIPTION
### What is the current behavior?
Currently, the layout of the markdown area throughout the site is strange in the Overall Comments section of the TA Grading Rubric page (as well as other places on the site like the forum)

### What is the new behavior?
The layout looks correct.
![image](https://user-images.githubusercontent.com/28243927/143263065-591c1019-9164-4dff-a50e-2140868bc50f.png)

### Other information?
This issue was caused by [this commit](https://github.com/Submitty/Submitty/commit/8b94c95d05acac91bc5ad4b78ff0001549aabb71) by dependabot, specifically this section 
At least in Mac Chrome, `width: available` is ignored by the browser and causes this strange layout. @williamjallen Any ideas on this? Will dependabot keep trying to make this change?
