### PR TITLE
[Bugfix:TAGrading] Always display comment/uploaded PDFs

### DIFF
--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -38,6 +38,9 @@ $( document ).ready(function() {
             {% for component in ta_components %}
                 {{ TAResultsFunctions.renderComponent(component, false, num_decimals) }}
             {% endfor %}
+        {% endif %}
+
+        {% if overall_comments|length > 0 %}
         <div class="no-border-box" style="padding: 10px; word-break: break-word;">
             {% for user in overall_comments | keys | sort %}
                 <div class="overall-comment-box">
@@ -54,6 +57,7 @@ $( document ).ready(function() {
                 </div>
             {% endfor %}
         </div>
+        {% endif %}
 
         {% if uploaded_pdfs|length >= 1 %}
             <div class = "no-border-box">
@@ -99,7 +103,6 @@ $( document ).ready(function() {
         </div>
         {# Overview #}
         {# /Component boxes #}
-    {% endif %}
     {% if is_grade_inquiry_yet_to_start %}
         <i>Grade Inquiries will start from</i> <b>{{ grade_inquiry_start_date|date(date_time_format)  }}</b>
     {% elseif regrade_available %}


### PR DESCRIPTION
### What is the current behavior?
Overall comments/PDFs from graders will not display if there is no TA graded component present.

This causes issues on assignments where users with grading access peer grade a gradeable with no TA components, leading to comments not showing up.

### What is the new behavior?
Closes #7369

Overall comments/PDFs from graders will always show up if they exist, regardless of the presence of TA graded components.