### PR TITLE
[Bugfix:Developer] Enable Cypress test retries

### DIFF
--- a/site/cypress.json
+++ b/site/cypress.json
@@ -4,5 +4,9 @@
     "*/*.spec.js",
 		"*.spec.js"
 	],
-	"pageLoadTimeout" : 120000
+	"pageLoadTimeout" : 120000,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }


### PR DESCRIPTION
### What is the current behavior?
Cypress tests appear to fail at random on a limited number pull requests.  Most of the time the issue may be attributed to flakiness in the tests or testing environment and simply rerunning the tests often fixes the issue.  Cypress provides a configuration option to rerun tests a specified number of times on failure, succeeding if any of the attempts succeeds.

### What is the new behavior?
This PR enables Cypress test retries with an initial number of 2 retries per failed test.  If, after retrying twice, the test has not succeeded, Cypress concludes that the test has failed, otherwise the test passes.  This setting is only enabled when using `cypress run`, not using the graphical UI opened by the command `cypress open`.  `cypress run` is the command used in the CI to run all of the tests in sequence while `cypress open` is the standard way to write and verify tests locally.
