### PR TITLE
[Feature:System] Increase vagrant ssh timeout value

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,5 +134,6 @@ Vagrant.configure(2) do |config|
     config.ssh.username = 'root'
     config.ssh.password = 'vagrant'
     config.ssh.insert_key = 'true'
+    config.ssh.timeout = 20
   end
 end


### PR DESCRIPTION
### What is the current behavior?
On some windows systems, during vagrant up the machine times out before connecting.

### What is the new behavior?
Timeout value is extended from the default value 10 to 20 to allow additional time for the machine to connect.

