### PR TITLE
[Bugfix:Developer] Fix phpunit not finding any tests

### DIFF
--- a/site/phpunit.xml
+++ b/site/phpunit.xml
@@ -26,7 +26,7 @@
     </filter>
 
     <logging>
-        <log type="coverage-clover" target="report/clover.xml"/>
-        <log type="coverage-html"   target="report" />
+        <log type="coverage-clover" target="tests/report/clover.xml"/>
+        <log type="coverage-html"   target="tests/report" />
     </logging>
 </phpunit>

--- a/site/phpunit.xml
+++ b/site/phpunit.xml
@@ -1,17 +1,17 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
     convertDeprecationsToExceptions="true"
-    bootstrap="tests/bootstrap.php"
+    bootstrap="./tests/bootstrap.php"
     colors="true"
     verbose="true"
 >
     <testsuites>
         <testsuite name="Unit Tests">
-            <directory suffix="Tester.php">app</directory>
+            <directory suffix="Tester.php">./tests/app</directory>
         </testsuite>
         <testsuite name="phpstan extension">
-            <directory suffix="Tester.php">phpstan</directory>
+            <directory suffix="Tester.php">./tests/phpstan</directory>
         </testsuite>
     </testsuites>
 

--- a/site/tests/app/libraries/database/DatabaseUtilsTester.php
+++ b/site/tests/app/libraries/database/DatabaseUtilsTester.php
@@ -22,7 +22,7 @@ class DatabaseUtilsTester extends \PHPUnit\Framework\TestCase {
     /**
      * @dataProvider formatQueryProvider
      */
-    public function testFormatQuery(string $sql, array $params, string $expected): void {
+    public function testFormatQuery(string $sql, ?array $params, string $expected): void {
         $this->assertEquals($expected, DatabaseUtils::formatQuery($sql, $params));
     }
 }

--- a/site/tests/phpstan/ModelClassExtensionTester.php
+++ b/site/tests/phpstan/ModelClassExtensionTester.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace tests\phpstan;
 
 use app\models\Button;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\PHPStanTestCase;
 
-class ModelClassExtensionTester extends TestCase {
+class ModelClassExtensionTester extends PHPStanTestCase {
     public function methodDataProvider() {
         return [
             [Button::class, 'getOnclick', true],


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #7375 

On moving the `phpunit.xml` file in #7303, it seems like I missed some paths, which meant that phpunit was no longer finding any tests to execute. This was reported as a warning within phpunit, but did not cause the CI to fail, and so I thought everything was working as expected.

### What is the new behavior?

This PR fixes the paths in the `phpunit.xml` file so that the tests are discovered properly again, as well as fixing some new failing tests that started due to us not running the test suite properly for a month or so. This also fixes codecov so that it reports stats properly again.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
