### PR TITLE
[Bugfix:TAGrading] Fix undefined twig variable

### DIFF
--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -40,7 +40,7 @@ $( document ).ready(function() {
             {% endfor %}
         {% endif %}
 
-        {% if overall_comments|length > 0 %}
+        {% if grader_info is not empty %}
         <div class="no-border-box" style="padding: 10px; word-break: break-word;">
             {% for user in grader_info | keys | sort %}
                 <div class="overall-comment-box">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

#7397 conflicted with changes from #7296, where `overall_comments` was removed in favor of `grader_info` array.

### What is the new behavior?

Replaces the undefined `overall_comments` with `grader_info` which took its place within the twig template.