### PR TITLE
[Bugfix:Developer] Pin composer version for CI

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -96,6 +96,7 @@ jobs:
             - uses: shivammathur/setup-php@2.7.0
               with:
                 php-version: ${{ env.PHP_VER }}
+                tools: composer:2.1.14
             - name: Cache Composer
               id: composer-cache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -131,6 +132,7 @@ jobs:
           - uses: shivammathur/setup-php@2.7.0
             with:
               php-version: ${{ env.PHP_VER }}
+              tools: composer:2.1.14
               extensions: imagick
               coverage: pcov
           - name: Cache Composer
@@ -281,6 +283,7 @@ jobs:
           - uses: shivammathur/setup-php@2.7.0
             with:
               php-version: ${{ env.PHP_VER }}
+              tools: composer:2.1.14
               extensions: imagick
 
           - name: Set Timezone


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

CI is currently failing when running the unit tests. This seems to be due to a bug in the recently released 2.2.0 composer.

### What is the new behavior?

Pins us to 2.1.14 of composer which worked previously. Will monitor composer releases and unpin us when a new bugfix release comes from them.