### PR TITLE
[Testing:TAGrading] Add primitive TA grading cypress tests

### DIFF
--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -5,7 +5,7 @@ describe('Test cases involving the files panel', () => {
 
     function assertSubmissionsBrowserOpen() {
         // have to increase timeout so that the file can be loaded properly in the CI
-        cy.get('#div_viewer_sd1').should('be.visible', { timeout: 20000 });
+        cy.get('#div_viewer_sd1', { timeout: 20000 }).should('be.visible');
     }
 
     function assertResultsBrowserClosed() {
@@ -14,7 +14,7 @@ describe('Test cases involving the files panel', () => {
 
     function assertResultsBrowserOpen() {
         // have to increase timeout so that the file can be loaded properly in the CI
-        cy.get('#div_viewer_rd1').should('be.visible', { timeout: 20000 });
+        cy.get('#div_viewer_rd1', { timeout: 20000 }).should('be.visible');
     }
 
     beforeEach(() => {

--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -13,8 +13,9 @@ describe('Test cases involving the files panel', () => {
     }
 
     function assertResultsBrowserOpen() {
-        // have to increase timeout so that the file can be loaded properly in the CI
-        cy.get('#div_viewer_rd1', { timeout: 20000 }).should('be.visible');
+        // we can't check that it is visible because in the CI it's possible
+        // that autograding hasn't finished yet
+        cy.get('#div_viewer_rd1', { timeout: 20000 }).should('exist');
     }
 
     beforeEach(() => {

--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -13,7 +13,7 @@ describe('Test cases involving the files panel', () => {
     }
 
     function assertResultsBrowserOpen() {
-        // have to increase timeout so that the file can be loaded properly in the CI 
+        // have to increase timeout so that the file can be loaded properly in the CI
         cy.get('#div_viewer_rd1').should('be.visible', { timeout: 20000 });
     }
 

--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -1,76 +1,76 @@
 describe('Test cases involving the files panel', () => {
     function assertSubmissionsBrowserClosed() {
-        cy.get('#div_viewer_sd1').should('not.be.visible')
+        cy.get('#div_viewer_sd1').should('not.be.visible');
     }
 
     function assertSubmissionsBrowserOpen() {
-        cy.get('#div_viewer_sd1').should('be.visible')
+        cy.get('#div_viewer_sd1').should('be.visible');
     }
 
     function assertResultsBrowserClosed() {
-        cy.get('#div_viewer_rd1').should('not.be.visible')
+        cy.get('#div_viewer_rd1').should('not.be.visible');
     }
 
     function assertResultsBrowserOpen() {
-        cy.get('#div_viewer_rd1').should('be.visible')
+        cy.get('#div_viewer_rd1').should('be.visible');
     }
 
     beforeEach(() => {
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
         cy.login('instructor');
-        cy.get('.btn').contains('View All').click()
-        cy.get('#details-table').contains('aphacker').siblings().eq(6).click()
-        cy.get('#submission_browser_btn').click()
+        cy.get('.btn').contains('View All').click();
+        cy.get('#details-table').contains('aphacker').siblings().eq(6).click();
+        cy.get('#submission_browser_btn').click();
     });
 
     it('test the open/close submissions and results buttons', () => {
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserClosed()
-        cy.get('#toggleSubmissionButton').click() // open submissions browser
-        assertSubmissionsBrowserOpen()
-        assertResultsBrowserClosed()
-        cy.get('#toggleSubmissionButton').click() // close submissions browser
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserClosed()
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserClosed();
+        cy.get('#toggleSubmissionButton').click(); // open submissions browser
+        assertSubmissionsBrowserOpen();
+        assertResultsBrowserClosed();
+        cy.get('#toggleSubmissionButton').click(); // close submissions browser
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserClosed();
 
-        cy.get('#toggleResultButton').click() // open results browser
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserOpen()
-        cy.get('#toggleResultButton').click() // close results browser
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserClosed()
+        cy.get('#toggleResultButton').click(); // open results browser
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserOpen();
+        cy.get('#toggleResultButton').click(); // close results browser
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserClosed();
     });
 
     it('test the auto open checkbox', () => {
-        cy.get('#autoscroll_id').click()
-        cy.get('#autoscroll_id').should('be.checked')
+        cy.get('#autoscroll_id').click();
+        cy.get('#autoscroll_id').should('be.checked');
 
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserClosed()
-        cy.get('#submissions').click() // open submissions browser
-        cy.get('#results').click() // open results browser
-        assertSubmissionsBrowserOpen()
-        assertResultsBrowserOpen()
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserClosed();
+        cy.get('#submissions').click(); // open submissions browser
+        cy.get('#results').click(); // open results browser
+        assertSubmissionsBrowserOpen();
+        assertResultsBrowserOpen();
 
-        cy.get('#next-student').click()
-        assertSubmissionsBrowserOpen()
-        assertResultsBrowserOpen()
+        cy.get('#next-student').click();
+        assertSubmissionsBrowserOpen();
+        assertResultsBrowserOpen();
 
-        cy.get('#submissions').click() // close submissions browser
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserOpen()
+        cy.get('#submissions').click(); // close submissions browser
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserOpen();
 
-        cy.get('#prev-student').click()
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserOpen()
+        cy.get('#prev-student').click();
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserOpen();
 
-        cy.get('#results').click() // close results browser
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserClosed()
+        cy.get('#results').click(); // close results browser
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserClosed();
 
-        cy.get('#next-student').click()
-        assertSubmissionsBrowserClosed()
-        assertResultsBrowserClosed()
+        cy.get('#next-student').click();
+        assertSubmissionsBrowserClosed();
+        assertResultsBrowserClosed();
     });
 
     it('test the full panel view', () => {
@@ -78,13 +78,13 @@ describe('Test cases involving the files panel', () => {
         // displays an iframe which is inaccessible to Cypress for the most part
         // We just test that the full panel view opens, and that an iframe appears.
 
-        cy.get('#submissions').click()
-        cy.get('#file_viewer_full_panel_iframe').should('not.exist')
-        cy.get('i[title="Show file in full panel"]').first().click()
-        cy.get('#grading_file_name').should('contain', '.submit.timestamp')
-        cy.get('#file_viewer_full_panel_iframe').should('be.visible')
+        cy.get('#submissions').click();
+        cy.get('#file_viewer_full_panel_iframe').should('not.exist');
+        cy.get('i[title="Show file in full panel"]').first().click();
+        cy.get('#grading_file_name').should('contain', '.submit.timestamp');
+        cy.get('#file_viewer_full_panel_iframe').should('be.visible');
 
-        cy.get('[aria-label="Collapse File"]').click()
-        cy.get('#file_viewer_full_panel_iframe').should('not.exist')
+        cy.get('[aria-label="Collapse File"]').click();
+        cy.get('#file_viewer_full_panel_iframe').should('not.exist');
     });
 });

--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -4,7 +4,8 @@ describe('Test cases involving the files panel', () => {
     }
 
     function assertSubmissionsBrowserOpen() {
-        cy.get('#div_viewer_sd1').should('be.visible');
+        // have to increase timeout so that the file can be loaded properly in the CI
+        cy.get('#div_viewer_sd1').should('be.visible', { timeout: 20000 });
     }
 
     function assertResultsBrowserClosed() {
@@ -12,7 +13,8 @@ describe('Test cases involving the files panel', () => {
     }
 
     function assertResultsBrowserOpen() {
-        cy.get('#div_viewer_rd1').should('be.visible');
+        // have to increase timeout so that the file can be loaded properly in the CI 
+        cy.get('#div_viewer_rd1').should('be.visible', { timeout: 20000 });
     }
 
     beforeEach(() => {

--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -1,0 +1,90 @@
+describe('Test cases involving the files panel', () => {
+    function assertSubmissionsBrowserClosed() {
+        cy.get('#div_viewer_sd1').should('not.be.visible')
+    }
+
+    function assertSubmissionsBrowserOpen() {
+        cy.get('#div_viewer_sd1').should('be.visible')
+    }
+
+    function assertResultsBrowserClosed() {
+        cy.get('#div_viewer_rd1').should('not.be.visible')
+    }
+
+    function assertResultsBrowserOpen() {
+        cy.get('#div_viewer_rd1').should('be.visible')
+    }
+
+    beforeEach(() => {
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
+        cy.login('instructor');
+        cy.get('.btn').contains('View All').click()
+        cy.get('#details-table').contains('aphacker').parent().children().eq(7).click()
+        cy.get('#submission_browser_btn').click()
+    });
+
+    it('test the open/close submissions and results buttons', () => {
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserClosed()
+        cy.get('#toggleSubmissionButton').click() // open submissions browser
+        assertSubmissionsBrowserOpen()
+        assertResultsBrowserClosed()
+        cy.get('#toggleSubmissionButton').click() // close submissions browser
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserClosed()
+
+        cy.get('#toggleResultButton').click() // open results browser
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserOpen()
+        cy.get('#toggleResultButton').click() // close results browser
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserClosed()
+    });
+
+    it('test the auto open checkbox', () => {
+        cy.get('#autoscroll_id').click()
+        cy.get('#autoscroll_id').should('be.checked')
+
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserClosed()
+        cy.get('#submissions').click() // open submissions browser
+        cy.get('#results').click() // open results browser
+        assertSubmissionsBrowserOpen()
+        assertResultsBrowserOpen()
+
+        cy.get('#next-student').click()
+        assertSubmissionsBrowserOpen()
+        assertResultsBrowserOpen()
+
+        cy.get('#submissions').click() // close submissions browser
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserOpen()
+
+        cy.get('#prev-student').click()
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserOpen()
+
+        cy.get('#results').click() // close results browser
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserClosed()
+
+        cy.get('#next-student').click()
+        assertSubmissionsBrowserClosed()
+        assertResultsBrowserClosed()
+    });
+
+    it('test the full panel view', () => {
+        // this test is somewhat limited in what it can do because the page
+        // displays an iframe which is inaccessible to Cypress for the most part
+        // We just test that the full panel view opens, and that an iframe appears.
+
+        cy.get('#submissions').click()
+        cy.get('#file_viewer_full_panel_iframe').should('not.exist')
+        cy.get('i[title="Show file in full panel"]').first().click()
+        cy.get('#grading_file_name').should('contain', '.submit.timestamp')
+        cy.get('#file_viewer_full_panel_iframe').should('be.visible')
+
+        cy.get('[aria-label="Collapse File"]').click()
+        cy.get('#file_viewer_full_panel_iframe').should('not.exist')
+    });
+});

--- a/site/cypress/integration/grading_interface/files_panel.spec.js
+++ b/site/cypress/integration/grading_interface/files_panel.spec.js
@@ -19,7 +19,7 @@ describe('Test cases involving the files panel', () => {
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
         cy.login('instructor');
         cy.get('.btn').contains('View All').click()
-        cy.get('#details-table').contains('aphacker').parent().children().eq(7).click()
+        cy.get('#details-table').contains('aphacker').siblings().eq(6).click()
         cy.get('#submission_browser_btn').click()
     });
 

--- a/site/cypress/integration/grading_interface/student_info_panel.spec.js
+++ b/site/cypress/integration/grading_interface/student_info_panel.spec.js
@@ -2,9 +2,9 @@ describe('Test cases involving the files panel', () => {
     beforeEach(() => {
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
         cy.login('instructor');
-        cy.get('.btn').contains('View All').click()
-        cy.get('#details-table').contains('reynoa').siblings().eq(6).click()
-        cy.get('#student_info_btn').click()
+        cy.get('.btn').contains('View All').click();
+        cy.get('#details-table').contains('reynoa').siblings().eq(6).click();
+        cy.get('#student_info_btn').click();
     });
 
     it('test cancelling and reinstating assignment', () => {

--- a/site/cypress/integration/grading_interface/student_info_panel.spec.js
+++ b/site/cypress/integration/grading_interface/student_info_panel.spec.js
@@ -1,0 +1,65 @@
+describe('Test cases involving the files panel', () => {
+    beforeEach(() => {
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
+        cy.login('instructor');
+        cy.get('.btn').contains('View All').click()
+        cy.get('#details-table').contains('reynoa').siblings().eq(6).click()
+        cy.get('#student_info_btn').click()
+    });
+
+    it('test cancelling and reinstating assignment', () => {
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 2 / 3');
+
+        cy.get('#submission-version-select').children().should('have.length', 3);
+        cy.get('#submission-version-select').find(':selected').should('contain', 'Version #2');
+        cy.get('#submission-version-select').find(':selected').should('contain', 'GRADE THIS VERSION');
+        cy.get('[value="Grade This Version"]').should('not.exist');
+
+        cy.get('[value="Cancel Student Submission"]').click();
+        cy.get('#bar_banner').should('contain', 'Cancelled Submission');
+        cy.get('[value="Cancel Student Submission"]').should('not.exist');
+        cy.get('[value="Grade This Version"]').should('not.exist');
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 0 / 3');
+
+        cy.get('#submission-version-select').select('Version #2');
+        cy.get('[value="Cancel Student Submission"]').should('not.exist');
+        cy.get('[value="Grade This Version"]').click();
+        cy.get('#submission-version-select').find(':selected').should('contain', 'Version #2');
+        cy.get('#submission-version-select').find(':selected').should('contain', 'GRADE THIS VERSION');
+        cy.get('[value="Grade This Version"]').should('not.exist');
+
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 2 / 3');
+    });
+
+    it('test switching versions', () => {
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 2 / 3');
+
+        cy.get('#submission-version-select').find(':selected').should('contain', 'Version #2');
+        cy.get('#submission-version-select').find(':selected').should('contain', 'GRADE THIS VERSION');
+        cy.get('[value="Grade This Version"]').should('not.exist');
+
+        cy.get('#submission-version-select').select('Version #1');
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 2 / 3');
+        cy.get('[value="Cancel Student Submission"]').should('not.exist');
+        cy.get('[value="Grade This Version"]').click();
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 1 / 3');
+        cy.get('#submission-version-select').find(':selected').should('contain', 'Version #1');
+        cy.get('#submission-version-select').find(':selected').should('contain', 'GRADE THIS VERSION');
+
+        cy.get('#submission-version-select').select('Version #2');
+        cy.get('[value="Cancel Student Submission"]').should('not.exist');
+        cy.get('[value="Grade This Version"]').click();
+        cy.get('#submission-version-select').find(':selected').should('contain', 'Version #2');
+        cy.get('#submission-version-select').find(':selected').should('contain', 'GRADE THIS VERSION');
+        cy.get('[value="Grade This Version"]').should('not.exist');
+
+        cy.get('.rubric-title').should('contain', 'Alysha Reynolds (reynoa)');
+        cy.get('.rubric-title').should('contain', 'Submission Number: 2 / 3');
+    });
+});


### PR DESCRIPTION
### What is the current behavior?
There are currently no tests which are run in the CI for much of the TA grading interface.

### What is the new behavior?
This PR adds a few basic tests for the student info and files panels on the TA grading interface.  These tests are not meant to be comprehensive and should be expanded as bugs are identified and fixed, but the basic structure is here to make it easy to add more tests in the future.  A future follow-up PR will introduce basic tests for the other TA grading interface panes.
