### PR TITLE
[Refactor:SubminiPolls] Expand poll title input field

### DIFF
--- a/site/app/templates/polls/NewPollPage.twig
+++ b/site/app/templates/polls/NewPollPage.twig
@@ -7,10 +7,12 @@
             <input type="hidden" name="response_count" id="response-count" value="0"/>
             <input type="hidden" name="removed_responses" id="removed-responses" value=""/>
 
-            <label for="poll-name" class="option-title">
-                Poll Name:
-            </label>
-            <input type="text" name="name" id="poll-name" placeholder="Enter name here..."/>
+            <div id="poll-name-container">
+                <label for="poll-name" class="option-title">
+                    Poll Name:
+                </label>
+                <input type="text" name="name" id="poll-name" placeholder="Enter name here..."/>
+            </div>
             <br/> <br/>
 
             <p class="option-title">Question:</p>
@@ -83,10 +85,12 @@
             <input type="hidden" name="response_count" id="response-count" value="{{ poll.getResponses()|length }}"/>
             <input type="hidden" name="removed_responses" id="removed-responses" value=""/>
 
-            <label for="poll-name" class="option-title">
-                Poll Name:
-            </label>
-            <input type="text" name="name" id="poll-name" value="{{ poll.getName() }}"/>
+            <div id="poll-name-container">
+                <label for="poll-name" class="option-title">
+                    Poll Name:
+                </label>
+                <input type="text" name="name" id="poll-name" value="{{ poll.getName() }}"/>
+            </div>
             <br/> <br/>
 
             <p class="option-title">Question:</p>

--- a/site/public/css/polls.css
+++ b/site/public/css/polls.css
@@ -62,3 +62,14 @@ input[type="radio"][disabled=""]:checked::before {
 form {
     display: inline;
 }
+
+#poll-name-container {
+    display: inline-flex;
+    width: 100%;
+    align-items: center;
+}
+
+#poll-name {
+    flex-grow: 100;
+    margin-left: 0.5em;
+}


### PR DESCRIPTION
### What is the current behavior?
See https://github.com/Submitty/Submitty/issues/7186

Before:
<img width="697" alt="before" src="https://user-images.githubusercontent.com/16820599/147421994-8720c814-8665-4cf6-a552-358c25c498ef.png">


### What is the new behavior?
This PR increases the length of the poll title input field such that it extends all the way to the right side of the window.  Closes https://github.com/Submitty/Submitty/issues/7186

After:
<img width="693" alt="after" src="https://user-images.githubusercontent.com/16820599/147421980-99ec9bff-0a70-4620-bb23-ac45eb928984.png">

