### PR TITLE
[Bugfix:TAGrading] Remove grading stats for peer graders

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -480,6 +480,7 @@ class ElectronicGraderController extends AbstractController {
     /**
      * Shows statistics for the grading status of a given electronic submission. This is shown to all full access
      * graders. Limited access graders will only see statistics for the sections they are assigned to.
+     * @AccessControl(role="LIMITED_ACCESS_GRADER")
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grading/status")
      */
     public function showStatus($gradeable_id) {

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -54,7 +54,9 @@
             </div>
         </div>
     </div>
-    <a href="{{ stats_url }}" class="btn btn-primary">Grading Stats</a>
+    {% if not is_student %}
+        <a href="{{ stats_url }}" class="btn btn-primary">Grading Stats</a>
+    {% endif %}
     {% if not is_instructor %}
         <button class="btn btn-default" onclick="showGradeableMessage()">Responsibilities as a Grader</button>
     {% endif %}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -855,7 +855,8 @@ HTML;
             "semester" => $this->core->getConfig()->getSemester(),
             "course" => $this->core->getConfig()->getCourse(),
             "blind_status" => $gradeable->getPeerBlind(),
-            "is_instructor" => $this->core->getUser()->getGroup() === 1,
+            "is_instructor" => $this->core->getUser()->getGroup() === User::GROUP_INSTRUCTOR,
+            "is_student" => $this->core->getUser()->getGroup() === User::GROUP_STUDENT,
             "message" => $message,
             "message_warning" => $message_warning
         ]);


### PR DESCRIPTION
### What is the current behavior?
See https://github.com/Submitty/Submitty/issues/7112

### What is the new behavior?
This PR addresses the issue mentioned in https://github.com/Submitty/Submitty/issues/7112 by blocking the grading stats page for peer grading and removing the grading stats button from the UI.  If it is determined that this behavior is not ideal, it would also be possible to enable statistics for peer graders but that does not seem to be the intended behavior here so I have removed the button altogether.

<img width="890" alt="Untitled" src="https://user-images.githubusercontent.com/16820599/147422319-68e739d8-ea7b-4626-8e10-a5e273596de1.png">


### Other information?
Closes https://github.com/Submitty/Submitty/issues/7112
