### PR TITLE
[Bugfix:Developer] Unpin composer version in CI

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -96,7 +96,6 @@ jobs:
             - uses: shivammathur/setup-php@2.7.0
               with:
                 php-version: ${{ env.PHP_VER }}
-                tools: composer:2.1.14
             - name: Cache Composer
               id: composer-cache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -132,7 +131,6 @@ jobs:
           - uses: shivammathur/setup-php@2.7.0
             with:
               php-version: ${{ env.PHP_VER }}
-              tools: composer:2.1.14
               extensions: imagick
               coverage: pcov
           - name: Cache Composer
@@ -283,7 +281,6 @@ jobs:
           - uses: shivammathur/setup-php@2.7.0
             with:
               php-version: ${{ env.PHP_VER }}
-              tools: composer:2.1.14
               extensions: imagick
 
           - name: Set Timezone


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The release of composer 2.2.0 broke running phpunit as it began throwing an error about strict_types (see https://github.com/Submitty/Submitty/runs/4636839459?check_suite_focus=true as an example).

### What is the new behavior?

PHPUnit 8.5.22 fixed the problem, and that was merged into master in #7491, which allows unpinning the composer version in CI.