### PR TITLE
[Bugfix:TAGrading] Always show grade inquiry in index

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -429,11 +429,6 @@
     {% elseif graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0 %}
         {% set contents = "Cancelled Submission" %}
         {% set btn_class = "btn-default" %}
-        {% if graded_gradeable.hasActiveRegradeRequest() %}
-            {% set contents = contents ~ " + Grade Inquiry" %}
-            {% set btn_class = "btn-danger" %}
-            {% set badge_count = graded_gradebable.getActiveGradeInquiryCount()  %}
-        {%  endif %}
     {% elseif graded_gradeable.getGradeable().isTaGrading() %}
         {% set contents = "Grade" %}
         {% set btn_class = "btn-primary" %}
@@ -452,19 +447,17 @@
             {% elseif graded_gradeable.isTaGradingComplete() and core.getUser().getGroup() < 4 and graded_gradeable.isPeerGradingComplete() %}
                 {% set contents = graded_gradeable.getTaGradedGradeable.getTotalScore() ~ " / " ~ graded_gradeable.getGradeable().getManualGradingPoints() %}
                 {% set btn_class = "btn-default" %}
-
-
             {% endif %}
         {% endif %}
-        {% if graded_gradeable.hasActiveRegradeRequest() %}
-            {% set contents = contents ~ " + Grade Inquiry" %}
-            {% set btn_class = "btn-danger" %}
-            {% set badge_count = graded_gradeable.getActiveGradeInquiryCount() %}
-        {%  endif %}
     {% else %}
         {% set contents = "View" %}
         {% set btn_class = "btn-primary" %}
     {% endif %}
+    {% if graded_gradeable.hasActiveRegradeRequest() %}
+        {% set contents = contents ~ " + Grade Inquiry" %}
+        {% set btn_class = "btn-danger" %}
+        {% set badge_count = graded_gradeable.getActiveGradeInquiryCount()  %}
+    {%  endif %}
     <td style="text-align: center;">
         <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId() }}&sort={{ context.sort }}&direction={{ context.direction }}">
             {{ contents }}
@@ -486,11 +479,6 @@
     {% elseif graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0 %}
         {% set contents = "Cancelled Submission" %}
         {% set btn_class = "btn-default" %}
-        {% if graded_gradeable.hasActiveRegradeRequest() %}
-            {% set contents = contents ~ " + Grade Inquiry" %}
-            {% set btn_class = "btn-danger" %}
-            {% set badge_count = graded_gradebable.getActiveGradeInquiryCount()  %}
-        {%  endif %}
     {% elseif graded_gradeable.getGradeable().isTaGrading() %}
         {% set contents = "Grade" %}
         {% set btn_class = "btn-primary" %}
@@ -508,15 +496,15 @@
             {% set btn_class = "btn-default" %}
             {% endif %}
         {% endif %}
-        {% if graded_gradeable.hasActiveRegradeRequest() %}
-            {% set contents = contents ~ " + Grade Inquiry" %}
-            {% set btn_class = "btn-danger" %}
-            {% set badge_count = graded_gradeable.getActiveGradeInquiryCount() %}
-        {%  endif %}
     {% else %}
         {% set contents = "View" %}
         {% set btn_class = "btn-primary" %}
     {% endif %}
+    {% if graded_gradeable.hasActiveRegradeRequest() %}
+        {% set contents = contents ~ " + Grade Inquiry" %}
+        {% set btn_class = "btn-danger" %}
+        {% set badge_count = graded_gradeable.getActiveGradeInquiryCount()  %}
+    {%  endif %}
     <td>
         <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId() }}&sort={{ context.sort }}&direction={{ context.direction }}">
             {{ contents }}


### PR DESCRIPTION
### What is the current behavior?
On the TA grading index, it will not show that a user has a grade inquiry if their grade is overridden or if they have no submission for the assignment.

### What is the new behavior?
Closes #7461 
It will always show if a user has a grade inquiry on the button in the grading index.

