### PR TITLE
[Bugfix:Autograding] Remove unused boost/progress import

### DIFF
--- a/bin/calculate_extensions.cpp
+++ b/bin/calculate_extensions.cpp
@@ -17,7 +17,6 @@
 
 #include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
-#include "boost/progress.hpp"
 
 #include "boost/date_time/gregorian/gregorian.hpp"
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Fixes #7548

The `bin/calculate_extensions.cpp` script imports `boost/progress`, but never uses anything from it. This causes a deprecation warning as shown in #7548.

### What is the new behavior?

Removes the unused import.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This is not a breaking change, and `calculate_extensions` still compiles correctly.
