### PR TITLE
[Bugfix:Developer] Update Xdebug config

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -465,7 +465,7 @@ if [ ${WORKER} == 0 ]; then
 [xdebug]
 xdebug.remote_enable=1
 xdebug.remote_port=9000
-xdebug.remote_host=10.0.2.2
+xdebug.remote_connect_back=1
 EOF
         fi
 

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -450,6 +450,10 @@ if [ ${WORKER} == 0 ]; then
         sed -i '25s/^/\#/' /etc/pam.d/common-password
         sed -i '26s/pam_unix.so obscure use_authtok try_first_pass sha512/pam_unix.so obscure minlen=1 sha512/' /etc/pam.d/common-password
 
+        # Create folder and give permissions to PHP user for xdebug profiling
+        mkdir -p ${SUBMITTY_REPOSITORY}/.vagrant/Ubuntu/profiler
+        usermod -aG vagrant ${PHP_USER}
+
         # Enable xdebug support for debugging
         phpenmod xdebug
 


### PR DESCRIPTION
### What is the current behavior?
Debug for xdebug only accepts connections from 10.0.2.2.
Profiling for xdebug does not work out of the box since the folder where the profiler data would be put is missing.

### What is the new behavior?
Debug for xdebug accepts any connection.
Profiling for xdebug works properly.
