### PR TITLE
[Feature:Autograding] WIP: Add syscalls for Rust compilation and improve Docker image regex

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -509,7 +509,8 @@ if not args.worker:
                           "submitty/autograding-default:latest",
                           "submitty/java:11",
                           "submitty/python:3.6",
-                          "submittyrpi/csci1200:default"
+                          "submittyrpi/csci1200:default",
+                          "rust:1.58-slim"
                        ]
         }
 

--- a/.setup/data/courses/development.yml
+++ b/.setup/data/courses/development.yml
@@ -97,7 +97,7 @@ gradeables:
   eg_has_due_date: true
   eg_has_release_date: true
   eg_max_random_submissions: 0
-  
+
 - gradeable_config: cpp_custom
   components:
   - gc_lower_clamp: 0
@@ -265,7 +265,7 @@ gradeables:
   eg_has_due_date: true
   eg_has_release_date: true
   eg_max_random_submissions: 0
-  
+
 - gradeable_config: image_diff_mirror
   components:
   - gc_lower_clamp: 0
@@ -745,3 +745,26 @@ gradeables:
   eg_has_due_date: true
   eg_has_release_date: true
   eg_max_random_submissions: 0
+
+- gradeable_config: rust
+  components:
+  - gc_lower_clamp: 0
+    gc_default: 11
+    gc_max_value: 11
+    gc_upper_clamp: 11
+    gc_title: Question 1
+    marks:
+      - gcm_note: Full Credit
+        gcm_points : 0
+  eg_submission_due_date: 1972-01-01 23:59:59
+  eg_submission_open_date: 1971-01-01 23:59:59
+  g_grade_due_date: 9998-12-31 23:59:59
+  g_grade_released_date: 9998-12-31 23:59:59
+  eg_grade_inquiry_start_date: 9999-01-01 23:59:59
+  eg_grade_inquiry_due_date: 9999-01-06 23:59:59
+  eg_has_due_date: true
+  eg_has_release_date: true
+  g_grade_start_date: 9997-12-31 23:59:59
+  g_ta_view_start_date: 1970-01-01 23:59:59
+  g_title: Rust Example
+  g_bucket: homework

--- a/.setup/data/courses/sample.yml
+++ b/.setup/data/courses/sample.yml
@@ -1714,3 +1714,26 @@ gradeables:
   eg_grade_inquiry_due_date: 9999-01-06 23:59:59
   eg_has_due_date: true
   eg_has_release_date: true
+
+- gradeable_config: rust
+  components:
+  - gc_lower_clamp: 0
+    gc_default: 11
+    gc_max_value: 11
+    gc_upper_clamp: 11
+    gc_title: Question 1
+    marks:
+      - gcm_note: Full Credit
+        gcm_points : 0
+  eg_submission_due_date: 1972-01-01 23:59:59
+  eg_submission_open_date: 1971-01-01 23:59:59
+  g_grade_due_date: 9998-12-31 23:59:59
+  g_grade_released_date: 9998-12-31 23:59:59
+  eg_grade_inquiry_start_date: 9999-01-01 23:59:59
+  eg_grade_inquiry_due_date: 9999-01-06 23:59:59
+  eg_has_due_date: true
+  eg_has_release_date: true
+  g_grade_start_date: 9997-12-31 23:59:59
+  g_ta_view_start_date: 1970-01-01 23:59:59
+  g_title: Rust example
+  g_bucket: homework

--- a/.setup/data/courses/sample.yml
+++ b/.setup/data/courses/sample.yml
@@ -60,7 +60,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -128,7 +128,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -194,7 +194,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -266,7 +266,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -334,7 +334,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -402,7 +402,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -496,7 +496,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -571,7 +571,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -645,7 +645,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -720,7 +720,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -742,7 +742,7 @@ gradeables:
   g_bucket: homework
   g_grader_assignment_method: 2
 
-  
+
 - g_id: closed_team_homework
   eg_peer_grading: true
   components:
@@ -791,7 +791,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -861,7 +861,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -929,7 +929,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1261,7 +1261,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1330,7 +1330,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1398,7 +1398,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1466,7 +1466,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1534,7 +1534,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1605,7 +1605,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1673,7 +1673,7 @@ gradeables:
     gc_max_value: 0
     gc_upper_clamp: 5
     gc_title: Extra Credit
-    marks: 
+    marks:
       - gcm_note: No Credit
         gcm_points: 0
       - gcm_note: Extra credit done poorly
@@ -1714,26 +1714,3 @@ gradeables:
   eg_grade_inquiry_due_date: 9999-01-06 23:59:59
   eg_has_due_date: true
   eg_has_release_date: true
-
-- gradeable_config: rust
-  components:
-  - gc_lower_clamp: 0
-    gc_default: 11
-    gc_max_value: 11
-    gc_upper_clamp: 11
-    gc_title: Question 1
-    marks:
-      - gcm_note: Full Credit
-        gcm_points : 0
-  eg_submission_due_date: 1972-01-01 23:59:59
-  eg_submission_open_date: 1971-01-01 23:59:59
-  g_grade_due_date: 9998-12-31 23:59:59
-  g_grade_released_date: 9998-12-31 23:59:59
-  eg_grade_inquiry_start_date: 9999-01-01 23:59:59
-  eg_grade_inquiry_due_date: 9999-01-06 23:59:59
-  eg_has_due_date: true
-  eg_has_release_date: true
-  g_grade_start_date: 9997-12-31 23:59:59
-  g_ta_view_start_date: 1970-01-01 23:59:59
-  g_title: Rust example
-  g_bucket: homework

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -127,6 +127,9 @@ bool system_program(const std::string &program, std::string &full_path_executabl
     { "cmake",                   "/usr/bin/cmake" },
     { "make",                    "/usr/bin/make" },
 
+    // for Rust
+    { "cargo",                   "/usr/local/cargo/bin/cargo" },
+
     // for Network Programming
     { "timeout",                 "/usr/bin/timeout" },
     { "mpicc.openmpi",           "/usr/bin/mpicc.openmpi" },

--- a/grading/system_call_categories.cpp
+++ b/grading/system_call_categories.cpp
@@ -221,6 +221,7 @@ void allow_system_calls(scmp_filter_ctx sc, const std::set<std::string> &categor
   ALLOW_SYSCALL(stat64);
   ALLOW_SYSCALL(statfs);
   ALLOW_SYSCALL(statfs64);
+  ALLOW_SYSCALL(statx);
   ALLOW_SYSCALL(sync);
   ALLOW_SYSCALL(sync_file_range);
   ALLOW_SYSCALL(syncfs);

--- a/more_autograding_examples/rust/config/config.json
+++ b/more_autograding_examples/rust/config/config.json
@@ -1,0 +1,36 @@
+{
+  "autograding_method": "docker",
+  "grading_parameters": {
+    "TOTAL_POINTS": 15,
+    "AUTO_POINTS": 15,
+    "TA_POINTS": 0,
+    "EXTRA_CREDIT_POINTS": 0
+  },
+
+  "autograding": {
+    "submission_to_compilation": ["Cargo.toml", "src/*"]
+  }
+
+  "testcases": [{
+      "type": "Compilation",
+      "title": "Compilation",
+      "containers": [{
+        "container_image": "rust:slim",
+        "commands": ["cargo build", "mv target/debug/example a.out"]
+      }],
+      "executable_name": "a.out",
+      "points": 5
+    },
+    {
+      // Notice how this doesn't need to be in a container since Rust statically links binaries
+      "title": "Output validation",
+      "command": "./a.out",
+      "points": 10,
+      "validation": [{
+        "method": "diff",
+        "actual_file": "STDOUT.txt",
+        "expected_file": "hello_world.txt"
+      }]
+    }
+  ]
+}

--- a/more_autograding_examples/rust/config/config.json
+++ b/more_autograding_examples/rust/config/config.json
@@ -15,7 +15,7 @@
       "type": "Compilation",
       "title": "Compilation",
       "containers": [{
-        "container_image": "rust:slim",
+        "container_image": "rust:1.58-slim",
         "commands": ["cargo build", "mv target/debug/example a.out"]
       }],
       "executable_name": "a.out",

--- a/more_autograding_examples/rust/config/test_output/hello_world.txt
+++ b/more_autograding_examples/rust/config/test_output/hello_world.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/more_autograding_examples/rust/submissions/example/Cargo.toml
+++ b/more_autograding_examples/rust/submissions/example/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/more_autograding_examples/rust/submissions/example/src/main.rs
+++ b/more_autograding_examples/rust/submissions/example/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/more_autograding_examples/rust/submissions/submissions.yml
+++ b/more_autograding_examples/rust/submissions/submissions.yml
@@ -1,0 +1,1 @@
+- example

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -80,7 +80,7 @@ class DockerInterfaceController extends AbstractController {
         }
 
         // check for proper format
-        $match = preg_match('/^[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+\/[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/', $_POST['image']);
+        $match = preg_match('/^([a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+\/)?[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/', $_POST['image']);
 
         if ($match === false) {
             return JsonResponse::getErrorResponse("An error has occurred when verifying image name");

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -51,7 +51,7 @@ function showAll() {
 
 function addFieldOnChange() {
     const command = $(this).val();
-    const regex = new RegExp('^[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+/[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$');
+    const regex = new RegExp('/^([a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+\/)?[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/');
     if (!regex.test(command)) {
         $('#send-button').attr('disabled',true);
         if (command !== '') {


### PR DESCRIPTION
### What is the current behavior?
Autograding tests trying to run `cargo` fail on the `statx` syscall.

### What is the new behavior?
Autograding tests can now use `cargo`.  Due to issues when copying files from the compilation stage to the run stage, `cargo run` will recompile programs even if they were built in a previous testcase.  The example Rust gradeable avoids this issue by just copying the built binary from the compilation stage.

### Other Information
The existing Docker regex doesn't allow official Docker images to be imported (they don't belong to an organization).  The new regex makes the organization component of the image URI optional.