### PR TITLE
[Bugfix:Forum] Fix Markdown Line Number Positioning

### DIFF
--- a/site/app/libraries/CustomCodeBlockRenderer.php
+++ b/site/app/libraries/CustomCodeBlockRenderer.php
@@ -19,7 +19,7 @@ class CustomCodeBlockRenderer implements BlockRendererInterface {
     public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false) {
         $element = $this->baseRenderer->render($block, $htmlRenderer, $inTightList);
         $num_lines = substr_count($element->getContents(), "\n");
-        return new HtmlElement('div', ['style' =>'position: relative'], $this->addLineNumbers($element, $num_lines));
+        return new HtmlElement('div', ["style" => "position: relative;"], $this->addLineNumbers($element, $num_lines));
     }
 
     private function addLineNumbers(HtmlElement $element, int $num_lines) {

--- a/site/app/libraries/CustomCodeBlockRenderer.php
+++ b/site/app/libraries/CustomCodeBlockRenderer.php
@@ -19,7 +19,7 @@ class CustomCodeBlockRenderer implements BlockRendererInterface {
     public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false) {
         $element = $this->baseRenderer->render($block, $htmlRenderer, $inTightList);
         $num_lines = substr_count($element->getContents(), "\n");
-        return new HtmlElement('div', [], $this->addLineNumbers($element, $num_lines));
+        return new HtmlElement('div', ['style' =>'position: relative'], $this->addLineNumbers($element, $num_lines));
     }
 
     private function addLineNumbers(HtmlElement $element, int $num_lines) {


### PR DESCRIPTION
### What is the current behavior?
The line numbers on code blocks do not line up properly with the code block.
![image](https://user-images.githubusercontent.com/28243927/151226330-04fe0e2c-fed2-44c4-a141-af3e991521f3.png)


### What is the new behavior?
The line numbers are properly aligned.
![image](https://user-images.githubusercontent.com/28243927/151226055-dd7d774a-b668-42a2-8e0f-2e59a922f38b.png)


### Other information?
Another issue that was reported seemed to have duplicate/runaway line numbers like in the screenshot below but I have been unable to reproduce this aspect of the bug.
![image](https://user-images.githubusercontent.com/28243927/151226717-5c26ed08-18cb-4554-92f1-70555a42aefb.png)


