### PR TITLE
[Bugfix:Plagiarism] Fix dates

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -447,7 +447,7 @@ class PlagiarismController extends AbstractController {
             $configuration = [
                 "g_id" => $config->getGradeableID(),
                 "g_title" => $all_gradeables[$config->getGradeableID()],
-                "g_grade_due_date" => $this->core->getQueries()->getDateForGradeableById($config->getGradeableID()),
+                "due_date" => $this->core->getQueries()->getDueDateForGradeableById($config->getGradeableID()),
                 "g_config_version" => $config->getConfigID(),
                 "last_run_timestamp" => $config->getLastRunTimestamp(),
                 "has_been_viewed" => $config->userHasAccessed($user_id)
@@ -456,9 +456,13 @@ class PlagiarismController extends AbstractController {
         }
 
         usort($all_configurations, function ($a, $b) {
-            return $a['g_grade_due_date'] > $b['g_grade_due_date']
-                   || ($a["g_grade_due_date"] == $b["g_grade_due_date"] && $a["g_title"] > $b["g_title"])
-                   || ($a["g_grade_due_date"] == $b["g_grade_due_date"] && $a["g_title"] === $b["g_title"] && $a["g_config_version"] > $b["g_config_version"]);
+            if ($a['due_date'] == null) {
+                return false;
+            }
+
+            return $a['due_date'] > $b['due_date']
+                   || ($a["due_date"] == $b["due_date"] && $a["g_title"] > $b["g_title"])
+                   || ($a["due_date"] == $b["due_date"] && $a["g_title"] === $b["g_title"] && $a["g_config_version"] > $b["g_config_version"]);
         });
 
         // TODO: return to this and enable later
@@ -558,7 +562,7 @@ class PlagiarismController extends AbstractController {
                 'title' => $gradeable['g_title'],
                 'id' => $gradeable['g_id'],
                 'config_id' => $gradeable['g_config_version'],
-                'duedate' => $gradeable['g_grade_due_date']->format($gradeable_date_format),
+                'duedate' => $gradeable['due_date'] == null ? null : $gradeable['due_date']->format($gradeable_date_format),
                 'timestamp' => $timestamp,
                 'submissions' => $submissions,
                 'in_queue' => $in_queue,
@@ -1016,12 +1020,19 @@ class PlagiarismController extends AbstractController {
                 unset($gradeable_ids_titles[$i]);
                 continue;
             }
-            $duedate = $this->core->getQueries()->getDateForGradeableById($gradeable_id_title['g_id']);
-            $gradeable_ids_titles[$i]['g_grade_due_date'] = $duedate->format($this->core->getConfig()->getDateTimeFormat()->getFormat('late_days_allowed'));
+            $duedate = $this->core->getQueries()->getDueDateForGradeableById($gradeable_id_title['g_id']);
+            $gradeable_ids_titles[$i]['due_date'] = $duedate == null ? 'no due date' : $duedate->format($this->core->getConfig()->getDateTimeFormat()->getFormat('late_days_allowed'));
         }
 
         usort($gradeable_ids_titles, function ($a, $b) {
-            return new DateTime($a['g_grade_due_date']) > new DateTime($b['g_grade_due_date']);
+            if ($a['due_date'] === 'no due date') {
+                return true;
+            }
+            if ($b['due_date'] === 'no due date') {
+                return false;
+            }
+
+            return new DateTime($a['due_date']) > new DateTime($b['due_date']);
         });
 
         $em = $this->core->getCourseEntityManager();

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2829,9 +2829,14 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
      * @param string $id
      * @return \DateTime
      */
-    public function getDateForGradeableById($id) {
-        $this->course_db->query("SELECT g_grade_due_date FROM gradeable WHERE g_id=?", [$id]);
-        return new \DateTime($this->course_db->rows()[0]['g_grade_due_date']);
+    public function getDueDateForGradeableById(string $id): ?\DateTime {
+        $this->course_db->query("SELECT eg_submission_due_date FROM electronic_gradeable WHERE g_id=? AND eg_has_due_date", [$id]);
+        if (count($this->course_db->rows()) > 0) { // the gradeable has a due date
+            return new \DateTime($this->course_db->rows()[0]['eg_submission_due_date']);
+        }
+        else {
+            return null;
+        }
     }
 
     public function getAllGradeablesIds() {

--- a/site/app/templates/plagiarism/Plagiarism.twig
+++ b/site/app/templates/plagiarism/Plagiarism.twig
@@ -92,7 +92,7 @@
                 {{ row['title'] }}
             {% endif %}
             <br/>
-            Due: {{ row['duedate'] }}
+            {% if row['duedate'] != null %} Due: {{ row['duedate'] }} {% endif %}
         </td>
         <td>
             {{ row['config_id'] }}

--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -12,7 +12,7 @@
                     {% if new_or_edit == "new" %}
                         <select name="gradeable_id" id="gradeable_id">
                             {% for gradeable_id_title in config["gradeable_ids_titles"] %}
-                                <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }} [{{ gradeable_id_title['g_id'] }}] ({{ gradeable_id_title['g_grade_due_date'] }})</option>
+                                <option value="{{ gradeable_id_title['g_id'] }}">{{ gradeable_id_title['g_title'] }} [{{ gradeable_id_title['g_id'] }}] ({{ gradeable_id_title['due_date'] }})</option>
                             {% endfor %}
                         </select>
                     {% else %}


### PR DESCRIPTION
### What is the current behavior?
Various places in the plagiarism interface use the `g_grade_due_date` database column as the data source for gradeable due dates.  This is the wrong column and does not display the submission due date as seen by the students

### What is the new behavior?
Fixes the bug.  In addition, the behavior when dealing with gradeables with no due dates has been improved such that no due date is displayed on the interface.

New interface:
<img width="1133" alt="Untitled" src="https://user-images.githubusercontent.com/16820599/151672040-c09c6341-22be-4494-845d-faa9d028ef55.png">

