### PR TITLE
[Bugfix:CourseMaterials] Fix hiding empty folders and showing new tags

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -190,9 +190,6 @@
     }
 
     window.onload = function () {
-        // hide the folders which have no content for the current user ..ie empty folders
-        hideEmptyCourseMaterialFolders();
-
         //determine if folders have been left open or closed
         var folderCookie = getCookie('foldersOpen');
         //if the cookie says it is open

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -148,8 +148,9 @@ class CourseMaterialsView extends AbstractView {
                 if ($this->removeEmptyFolders($course_material)) {
                     unset($course_materials[$path]);
                 }
-            } else {
-                return false;   
+            }
+            else {
+                return false;
             }
         }
         return true;

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -121,6 +121,8 @@ class CourseMaterialsView extends AbstractView {
                 [$file_name => $course_material] + array_slice($path_to_place, $index, null, true);
         }
 
+        $this->removeEmptyFolders($final_structure);
+
         $this->setSeen($final_structure, $seen, $base_course_material_path);
 
         return $this->core->getOutput()->renderTwigTemplate("course/CourseMaterials.twig", [
@@ -140,6 +142,19 @@ class CourseMaterialsView extends AbstractView {
         ]);
     }
 
+    private function removeEmptyFolders(array &$course_materials): bool {
+        foreach ($course_materials as $path => $course_material) {
+            if (is_array($course_material)) {
+                if ($this->removeEmptyFolders($course_material)) {
+                    unset($course_materials[$path]);
+                }
+            } else {
+                return false;   
+            }
+        }
+        return true;
+    }
+
     private function setSeen(array $course_materials, array &$seen, string $cur_path): bool {
         $has_unseen = false;
         foreach ($course_materials as $path => $course_material) {
@@ -147,6 +162,7 @@ class CourseMaterialsView extends AbstractView {
             if (is_array($course_material)) {
                 if ($this->setSeen($course_material, $seen, FileUtils::joinPaths($cur_path, $path))) {
                     $seen[FileUtils::joinPaths($cur_path, $path)] = false;
+                    $has_unseen = true;
                 }
                 else {
                     $seen[FileUtils::joinPaths($cur_path, $path)] = true;

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -770,13 +770,6 @@ function markViewed(ids, redirect) {
     });
 }
 
-function hideEmptyCourseMaterialFolders() {
-  // fetch all the folders and remove those one which have no `file` within.
-  $('.folder-container').each(function() {
-    $(this).find('.file-container').length === 0 ? $(this).remove() : null;
-  });
-}
-
 function closeDivForCourseMaterials(num) {
     var elem = $('#div_viewer_' + num);
     elem.hide();


### PR DESCRIPTION
### What is the current behavior?
Empty folders will briefly appear when loading the course materials page before disappearing.
New tags on a file/folder only show up on the file/folder and direct parent folder.

### What is the new behavior?
Closes #7533 
Empty folders will not show up when loading the course materials page.
Closes #7372 
New tags on a file/folder extend all the way up to the root folder on the course materials page.