### PR TITLE
[Bugfix:Developer] Fix undefined variable reference

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -699,6 +699,9 @@ class UsersController extends AbstractController {
      * @return array $contents  Data rows and columns read from xlsx or csv file
      */
     private function getUserDataFromUpload($filename, $tmp_name, $return_url) {
+        $csv_file = '';
+        $xlsx_file = '';
+
         // Data is confidential, and therefore must be deleted immediately after
         // this process ends, regardless if process completes successfully or not.
         register_shutdown_function(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `register_shutdown_function` uses a late binding closure to capture the values of `$csv_value` and `$xlsx_value`. However, they're not always defined in all cases, which phpstan doesn't fully like (#7606).

### What is the new behavior?

We make sure the two variables are always defined to something, and then overwrite them in the course of the `getUserDataFromUpload` execution.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
