### PR TITLE
[Bugfix:System] Drop milliseconds for DB timestamps

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -338,7 +338,7 @@ CREATE TABLE public.forum_posts_history (
     post_id integer NOT NULL,
     edit_author character varying NOT NULL,
     content text NOT NULL,
-    edit_timestamp timestamp with time zone NOT NULL
+    edit_timestamp timestamp(0) with time zone NOT NULL
 );
 
 
@@ -800,8 +800,8 @@ CREATE TABLE public.notifications (
     content text NOT NULL,
     from_user_id character varying(255),
     to_user_id character varying(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    seen_at timestamp with time zone
+    created_at timestamp(0) with time zone NOT NULL,
+    seen_at timestamp(0) with time zone
 );
 
 
@@ -918,7 +918,7 @@ CREATE TABLE public.posts (
     parent_id integer DEFAULT '-1'::integer,
     author_user_id character varying NOT NULL,
     content text NOT NULL,
-    "timestamp" timestamp with time zone NOT NULL,
+    "timestamp" timestamp(0) with time zone NOT NULL,
     anonymous boolean NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     endorsed_by character varying,
@@ -1034,7 +1034,7 @@ ALTER SEQUENCE public.queue_settings_id_seq OWNED BY public.queue_settings.id;
 CREATE TABLE public.regrade_discussion (
     id integer NOT NULL,
     regrade_id integer NOT NULL,
-    "timestamp" timestamp with time zone NOT NULL,
+    "timestamp" timestamp(0) with time zone NOT NULL,
     user_id character varying(255) NOT NULL,
     content text,
     deleted boolean DEFAULT false NOT NULL,
@@ -1069,7 +1069,7 @@ ALTER SEQUENCE public.regrade_discussion_id_seq OWNED BY public.regrade_discussi
 CREATE TABLE public.regrade_requests (
     id integer NOT NULL,
     g_id character varying(255) NOT NULL,
-    "timestamp" timestamp with time zone NOT NULL,
+    "timestamp" timestamp(0) with time zone NOT NULL,
     user_id character varying(255),
     team_id character varying(255),
     status integer DEFAULT 0 NOT NULL,
@@ -1135,7 +1135,7 @@ CREATE TABLE public.solution_ta_notes (
     component_id integer NOT NULL,
     solution_notes text NOT NULL,
     author character varying NOT NULL,
-    edited_at timestamp with time zone NOT NULL,
+    edited_at timestamp(0) with time zone NOT NULL,
     itempool_item character varying(100) DEFAULT ''::character varying NOT NULL
 );
 
@@ -1270,7 +1270,7 @@ CREATE TABLE public.users (
 CREATE TABLE public.viewed_responses (
     thread_id integer NOT NULL,
     user_id character varying NOT NULL,
-    "timestamp" timestamp with time zone NOT NULL
+    "timestamp" timestamp(0) with time zone NOT NULL
 );
 
 

--- a/migration/migrator/migrations/course/20220206171041_drop_milliseconds.py
+++ b/migration/migrator/migrations/course/20220206171041_drop_milliseconds.py
@@ -1,0 +1,40 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE posts ALTER COLUMN timestamp TYPE timestamptz(0);")
+    database.execute("ALTER TABLE forum_posts_history ALTER COLUMN edit_timestamp TYPE timestamptz(0);")
+    database.execute("ALTER TABLE viewed_responses ALTER COLUMN timestamp TYPE timestamptz(0);")
+    database.execute("ALTER TABLE solution_ta_notes ALTER COLUMN edited_at TYPE timestamptz(0);")
+    database.execute("ALTER TABLE notifications ALTER COLUMN created_at TYPE timestamptz(0);")
+    database.execute("ALTER TABLE notifications ALTER COLUMN seen_at TYPE timestamptz(0);")
+    database.execute("ALTER TABLE regrade_discussion ALTER COLUMN timestamp TYPE timestamptz(0);")
+    database.execute("ALTER TABLE regrade_requests ALTER COLUMN timestamp TYPE timestamptz(0);")
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Milliseconds can get inserted into the database when `current_timestamp` is used on a SQL query.

### What is the new behavior?
Now that we are slowly moving to Doctrine, there is an issue where milliseconds and timezone are not supported in conjunction. To avoid this issue, this PR enforces that all of the timestamp types to not use any fractional seconds.

### Other information?
I identified all the places in DatabaseQueries where we use `current_timestamp` in the course database and targeted those columns in this PR.

An alternative fix could be to implement our own Doctrine database type but we also don't really need this level of precision for these fields.
