### PR TITLE
[Bugfix:Forum] Fix using forum search

### DIFF
--- a/site/app/templates/forum/searchResults.twig
+++ b/site/app/templates/forum/searchResults.twig
@@ -3,9 +3,9 @@
     {%  include "forum/ForumBar.twig" with {
         "forum_bar_buttons_right" : buttons,
         "forum_bar_buttons_left" : [],
-        "show_threads" : False,
-        "thread_exists" : True,
-        "show_more" : False,
+        "show_threads" : false,
+        "thread_exists" : false,
+        "show_more" : false,
         "show_filter": false
     } %}
 
@@ -27,7 +27,7 @@
                         <tr title="Go to post" class="cursor-pointer key_to_click" tabindex="0" onclick="window.location = '{{ post.post_link }}';" id="search-row-{{ post.count }}" class="hoverable">
                             <td align="left"><pre style="max-width: 67vw">
                                     <p class="post_content pre-wrap" style="word-wrap: break-word;">
-                                        {% include "forum/RenderPost.twig" with { "post_content": post.post_content } only %}
+                                        {% include "forum/RenderPost.twig" with { "post_content": post.post_content, "render_markdown": true } only %}
                                     </p></pre></td>
                             <td>{{ post.visible_username }}</td>
                             <td>{{ post.posted_on }}</td>

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -114,7 +114,7 @@ class ForumThreadView extends AbstractView {
                     "visible_username" => $visible_username,
                     "posted_on" => $posted_on
                 ];
-                
+
                 $count++;
             }
             $thread_list[] = [

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -81,11 +81,9 @@ class ForumThreadView extends AbstractView {
 
         foreach ($threadArray as $thread_id => $data) {
             $thread_title = $fromIdtoTitle[$thread_id];
-
             $thread_link = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
 
-            $thread_list[$count - 1] = ["thread_title" => $thread_title, "thread_link" => $thread_link, "posts" => []];
-
+            $thread_posts = [];
             foreach ($data as $post) {
                 $author = $post['author'];
                 $user_info = $this->core->getQueries()->getDisplayUserInfoFromUserId($post["p_author"]);
@@ -109,18 +107,22 @@ class ForumThreadView extends AbstractView {
 
                 $posted_on = DateUtils::convertTimeStamp($this->core->getUser(), $post['timestamp_post'], $this->core->getConfig()->getDateTimeFormat()->getFormat('forum'));
 
-                $thread_list[$count - 1]["posts"][] = [
+                $thread_posts[] = [
                     "post_link" => $post_link,
                     "count" => $count,
                     "post_content" => $post_content,
                     "visible_username" => $visible_username,
                     "posted_on" => $posted_on
                 ];
-
+                
                 $count++;
             }
+            $thread_list[] = [
+                "thread_title" => $thread_title,
+                "thread_link" => $thread_link,
+                "posts" => $thread_posts
+            ];
         }
-
 
         return $this->core->getOutput()->renderTwigTemplate("forum/searchResults.twig", [
             "buttons" => $buttons,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently, if you try to use the forum "search" feature, you get a twig error. While investigating this and trying to debug, I discovered multiple issues stacked on top of each other:
- Some invalid twig syntax causing the initial error I saw
- A call for a twig template has not been updated since we added the global markdown template everywhere on Submitty
- The forum search view had a logic bug where the threads and their responses that came up in the search were not being stored in the right hierarchical order in the array passed to the twig

Note: I think that right now on production (where errors are suppressed) the only output the search yields is only the first response for each post, however this should be fixed with this PR.

### What is the new behavior?
Feature works as expected.
