### PR TITLE
[Bugfix:Developer] Add phpcs plugin to allowed-plugins

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -4,7 +4,10 @@
     "platform": {
       "php": "7.2"
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Some upcoming version of Composer 2 requires plugins to be added to an `allow-plugins` list to run. We currently do not have the `dealerdirect/phpcodesniffer-composer-installer` plugin we use on that list.

### What is the new behavior?

Adds the `dealerdirect/phpcodesniffer-composer-installer` to the `allow-plugins` list so that it'll continue working with newer versions of composer.