### PR TITLE
[Refactor:Developer] Remove invalid CSS properties

### DIFF
--- a/site/.stylelintrc.json
+++ b/site/.stylelintrc.json
@@ -8,6 +8,7 @@
   },
   "ignoreFiles": [
     "vendor/**",
+    "tests/report/**",
     "public/css/jquery-ui.min.css",
     "public/css/reset.css",
     "public/css/flatpickr.min.css",

--- a/site/public/css/docker_interface.css
+++ b/site/public/css/docker_interface.css
@@ -85,7 +85,6 @@
 .filter-buttons:focus {
     color: var(--text-black);
     opacity: 0.8;
-    filter: alpha(opacity=80);
 }
 
 .filter {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -854,7 +854,6 @@ tbody.collapse.in {
     cursor: not-allowed;
     background-color: transparent;
     background-image: none;
-    filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
 
 .btn-primary {
@@ -1037,7 +1036,6 @@ div.full-height {
 .cat-buttons:hover,
 .cat-buttons:focus {
     opacity: 0.8;
-    filter: alpha(opacity=80);
 }
 
 .peer-feedback-negative-unselected {
@@ -1082,7 +1080,6 @@ div.full-height {
 
 #ui-category-list .handle {
     opacity: 0.8;
-    filter: alpha(opacity=80);
 }
 
 #ui-category-list .handle:hover {


### PR DESCRIPTION
### What is the current behavior?
https://github.com/Submitty/Submitty/pull/7630 is currently failing the `css-stylelint` test because there are a couple places in the codebase that use invalid CSS `filter` properties.  

### What is the new behavior?
This PR removes the offending properties.
