### PR TITLE
[Bugfix:TAGrading] Improve late day banner visuals

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -894,7 +894,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, string $late_status, $rollbackSubmission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, $rollbackSubmission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading) {
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $isPeerPanel = false;
         $isStudentInfoPanel = true;
@@ -949,7 +949,7 @@ HTML;
                 "message" => "Overridden grades"
             ];
         }
-        elseif ($graded_gradeable->getAutoGradedGradeable()->getActiveVersion() === 0) {
+        elseif ($graded_gradeable->getAutoGradedGradeable()->getActiveVersion() === LateDayInfo::STATUS_NO_ACTIVE_VERSION) {
             if ($graded_gradeable->getAutoGradedGradeable()->hasSubmission()) {
                 $error_message = [
                     "color" => "var(--standard-creamsicle-orange)", // mango orange
@@ -963,13 +963,13 @@ HTML;
                 ];
             }
         }
-        elseif ($late_status == LateDayInfo::STATUS_LATE) {
+        elseif ($late_status === LateDayInfo::STATUS_LATE) {
             $error_message = [
                 "color" => "var(--standard-creamsicle-orange)", // fire engine red
                 "message" => "Late Submission"
             ];
         }
-        elseif ($late_status == LateDayInfo::STATUS_BAD) {
+        elseif ($late_status === LateDayInfo::STATUS_BAD) {
             if ($rollbackSubmission === -1) {
                 $error_message = [
                     "color" => "var(--standard-red-orange)", // fire engine red

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -975,13 +975,13 @@ HTML;
                     "color" => "var(--standard-red-orange)", // fire engine red
                     "message" => "Bad Submission (no valid submission available)"
                 ];
-            } else {
+            }
+            else {
                 $error_message = [
                     "color" => "var(--standard-red-orange)", // fire engine red
                     "message" => "Bad Submission (submitter has valid submission - Version #" . $rollbackSubmission . ")"
                 ];
             }
-            
         }
         elseif ($graded_gradeable->getAutoGradedGradeable()->hasSubmission() && count($display_version_instance->getFiles()["submissions"]) > 1 && $graded_gradeable->getGradeable()->isScannedExam()) {
             $pattern1 = "upload.pdf";

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -963,17 +963,25 @@ HTML;
                 ];
             }
         }
-        elseif ($rollbackSubmission != -1) {
+        elseif ($late_status == LateDayInfo::STATUS_LATE) {
             $error_message = [
                 "color" => "var(--standard-creamsicle-orange)", // fire engine red
-                "message" => "Late Submission (Rollback to on-time submission - " . $rollbackSubmission . ")"
+                "message" => "Late Submission"
             ];
         }
-        elseif ($late_status != LateDayInfo::STATUS_GOOD && $late_status != LateDayInfo::STATUS_LATE) {
-            $error_message = [
-                "color" => "var(--standard-red-orange)", // fire engine red
-                "message" => "Late Submission (No on time submission available)"
-            ];
+        elseif ($late_status == LateDayInfo::STATUS_BAD) {
+            if ($rollbackSubmission === -1) {
+                $error_message = [
+                    "color" => "var(--standard-red-orange)", // fire engine red
+                    "message" => "Bad Submission (no valid submission available)"
+                ];
+            } else {
+                $error_message = [
+                    "color" => "var(--standard-red-orange)", // fire engine red
+                    "message" => "Bad Submission (submitter has valid submission - Version #" . $rollbackSubmission . ")"
+                ];
+            }
+            
         }
         elseif ($graded_gradeable->getAutoGradedGradeable()->hasSubmission() && count($display_version_instance->getFiles()["submissions"]) > 1 && $graded_gradeable->getGradeable()->isScannedExam()) {
             $pattern1 = "upload.pdf";


### PR DESCRIPTION
### What is the current behavior?
* #7581 

### What is the new behavior?
Closes #7581 
Shows `Late Submission` in orange when selected submission is late but has enough late days/extensions to cover it.

Shows `Bad Submission (submitter has valid submission - Version #X)` in red when selected submission is late and does not have enough late days/extensions to cover it, but has a previous submission that is valid.

Shows `Bad Submission (no valid submission available)` in red when selected submission is late and does not have enough late days/extensions to cover it, and does not have a previous submission that is valid.
