### PR TITLE
[Bugfix:System] Delete TS folder on installing site

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -58,6 +58,12 @@ chmod 644 /tmp/index.html
 chown ${CGI_USER}:${CGI_GROUP} /tmp/index.html
 mv /tmp/index.html ${SUBMITTY_INSTALL_DIR}/site/public
 
+# Delete all typescript code to prevent deleted files being left behind and potentially
+# causing compilation errors
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/ts" ]; then
+    rm -r "${SUBMITTY_INSTALL_DIR}/site/ts"
+fi
+
 # copy the website from the repo. We don't need the tests directory in production and then
 # we don't want vendor as if it exists, it was generated locally for testing purposes, so
 # we don't want it


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Right now, all files in `/usr/local/submitty/site/ts` can never be deleted and only added to. If we were to modify the typescript compiler options and delete one of the files, we may get compilation errors during the install.

### What is the new behavior?
This will delete the ts folder every install if it exists so no git deleted files stick around.

### Other information?
How to produce error (this assumes you are currently up to date with master):
1. Run `git checkout 08b9e1d47a0043a7fae7b290207a61c013834b42` or rollback to commit 08b9e1d47a0043a7fae7b290207a61c013834b42. This is the commit right before some typescript modifications were made.
2. Install the code
3. Now run `git checkout master`.
4. Install the code again. (You should get a typescript compilation error here)

Now to test the fix (This assumes you ran the above steps):
1. Checkout my branch
2. Install the code and verify no errors
