### PR TITLE
[Feature:Developer] Make Vagrantfile parallels compatible

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,6 @@ if ENV.has_key?('WORKER_PAIR')
     autostart_worker = true
     extra_command << '--worker-pair '
 end
-  
 
 $script = <<SCRIPT
 GIT_PATH=/usr/local/submitty/GIT_CHECKOUT/Submitty
@@ -53,22 +52,60 @@ VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 bash ${GIT_PATH}/.setup/install_worker.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker.log
 SCRIPT
 
+# Bento does not yet make available ARM64 compatible boxes, so we need to use an alternative box that's built from bento's sources
+ubuntu_2004_box = if Vagrant::Util::Platform.darwin? && (`uname -m`.chomp == "arm64" || (`sysctl -n machdep.cpu.brand_string`.chomp.include? 'M1'))
+  'jeffnoxon/ubuntu-20.04-arm64'
+else
+  'bento/ubuntu-20.04'
+end
+
+def mount_folders(config, mount_options)
+  # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
+  # till post-provision (and this is mounted before provisioning), we want the group to be 'vagrant'
+  # which is guaranteed to exist and that during install_system.sh we add submitty_daemon/submitty_php/etc to the
+  # vagrant group so that they can write to this shared folder, primarily just for the log files
+  owner = 'root'
+  group = 'vagrant'
+  config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT/Submitty', create: true, owner: owner, group: group, mount_options: mount_options
+
+  optional_repos = %w(AnalysisTools Lichen RainbowGrades Tutorial CrashCourseCPPSyntax LichenTestData)
+  optional_repos.each {|repo|
+    repo_path = File.expand_path("../" + repo)
+    if File.directory?(repo_path)
+      config.vm.synced_folder repo_path, "/usr/local/submitty/GIT_CHECKOUT/" + repo, owner: owner, group: group, mount_options: mount_options
+    end
+  }
+end
+
 Vagrant.configure(2) do |config|
+  mount_options = []
+
   # Specify the various machines that we might develop on. After defining a name, we
   # can specify if the vm is our "primary" one (if we don't specify a VM, it'll use
   # that one) as well as making sure all non-primary ones have "autostart: false" set
   # so that when we do "vagrant up", it doesn't spin up those machines.
 
   config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
-    ubuntu.vm.box = 'bento/ubuntu-20.04'
-    # If this IP address changes, it must be changed in install_system.sh and 
+    ubuntu.vm.box = ubuntu_2004_box
+    # If this IP address changes, it must be changed in install_system.sh and
     # CONFIGURE_SUBMITTY.py to allow the ssh connection
     ubuntu.vm.network "private_network", ip: "172.18.2.8"
     ubuntu.vm.network 'forwarded_port', guest: 22, host: 2220, id: 'ssh'
     ubuntu.vm.provision 'shell', inline: $worker_script
   end
 
-  # This is what RPI uses as of Fall 2018, though currently migrating to 20.04
+  # Our primary development target, RPI uses it as of Fall 2021
+  config.vm.define 'ubuntu-20.04', primary: true do |ubuntu|
+    ubuntu.vm.box = ubuntu_2004_box
+    ubuntu.vm.network 'forwarded_port', guest: 1511, host: 1511   # site
+    ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
+    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16442  # database
+    ubuntu.vm.network 'forwarded_port', guest: 22, host: 2222, id: 'ssh'
+    ubuntu.vm.provision 'shell', inline: $script
+  end
+
+  # Deprecated: This will be removed in the future and should not be relied upon.
+  # Note: This box is not compatible with macos M1
   config.vm.define 'ubuntu-18.04', autostart: false do |ubuntu|
     ubuntu.vm.box = 'bento/ubuntu-18.04'
     ubuntu.vm.network 'forwarded_port', guest: 1501, host: 1501   # site
@@ -77,17 +114,7 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.provision 'shell', inline: $script
   end
 
-  # Our primary development target, RPI uses it as of Fall 2021
-  config.vm.define 'ubuntu-20.04', primary: true do |ubuntu|
-    ubuntu.vm.box = 'bento/ubuntu-20.04'
-    ubuntu.vm.network 'forwarded_port', guest: 1511, host: 1511   # site
-    ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
-    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16442  # database
-    ubuntu.vm.network 'forwarded_port', guest: 22, host: 2222, id: 'ssh'
-    ubuntu.vm.provision 'shell', inline: $script
-  end
-
-  config.vm.provider 'virtualbox' do |vb|
+  config.vm.provider 'virtualbox' do |vb, override|
     vb.memory = 2048
     vb.cpus = 2
     # When you put your computer (while running the VM) to sleep, then resume work some time later the VM will be out
@@ -104,31 +131,25 @@ Vagrant.configure(2) do |config|
     # See https://serverfault.com/a/453260 for more info.
     # vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+
+    mount_folders(override, ["dmode=775", "fmode=664"])
   end
 
-  config.vm.provider "vmware_desktop" do |vm|
-    vm.vmx["memsize"] = "2048"
-    vm.vmx["numvcpus"] = "2"
+  config.vm.provider "parallels" do |prl, override|
+    prl.memory = 2048
+    prl.cpus = 2
+
+    mount_folders(override, ["share", "nosuid"])
+  end
+
+  config.vm.provider "vmware_desktop" do |vmware, override|
+    vmware.vmx["memsize"] = "2048"
+    vmware.vmx["numvcpus"] = "2"
+
+    mount_folders(override, [])
   end
 
   config.vm.provision :shell, :inline => " sudo timedatectl set-timezone America/New_York", run: "once"
-
-  # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
-  # till post-provision (and this is mounted before provisioning), we want the group to be 'vagrant'
-  # which is guaranteed to exist and that during install_system.sh we add submitty_daemon/submitty_php/etc to the
-  # vagrant group so that they can write to this shared folder, primarily just for the log files
-  owner = 'root'
-  group = 'vagrant'
-  mount_options = %w(dmode=775 fmode=664)
-  config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT/Submitty', create: true, owner: owner, group: group, mount_options: mount_options
-
-  optional_repos = %w(AnalysisTools Lichen RainbowGrades Tutorial CrashCourseCPPSyntax LichenTestData)
-  optional_repos.each {|repo|
-    repo_path = File.expand_path("../" + repo)
-    if File.directory?(repo_path)
-      config.vm.synced_folder repo_path, "/usr/local/submitty/GIT_CHECKOUT/" + repo, owner: owner, group: group, mount_options: mount_options
-    end
-  }
 
   if ARGV.include?('ssh')
     config.ssh.username = 'root'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -133,6 +133,10 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
 
     mount_folders(override, ["dmode=775", "fmode=664"])
+
+    if ARGV.include?('ssh')
+      override.ssh.timeout = 20
+    end
   end
 
   config.vm.provider "parallels" do |prl, override|
@@ -155,6 +159,5 @@ Vagrant.configure(2) do |config|
     config.ssh.username = 'root'
     config.ssh.password = 'vagrant'
     config.ssh.insert_key = 'true'
-    config.ssh.timeout = 20
   end
 end


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Right now, the Vagrantfile only officially supports VirtualBox, however the latter does not support (and will never support) macos M1, meaning we need an alternative supported vendor.

### What is the new behavior?

This adds support for [Parallels](https://www.parallels.com/) to the Vagrantfile to add support for M1. An unfortunate side effect of this is that we need to use the Pro version of the software which is $99 / yr compared to VirtualBox which is free. I did try to see if I could get VMWare to work, but I could not get their website to even let me download the software, so I gave up on it. Additionally, unfortunately bento project does not yet offer arm64 images (though support to the repo was added in https://github.com/chef/bento/pull/1374), we use a comparable image that does support arm64 for now. I hope to be able to drop that if statement in a future PR and go back to just specifying `bento/*` images. There is no support for the older ubuntu 18.04 image.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

The changes here should have no effect on anyone's existing x86_64 machine.