### PR TITLE
[Bugfix:Developer] Reorder ldap setup in CI

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -372,6 +372,11 @@ jobs:
               cd $SUBMITTY_REPOSITORY
               sudo -E env "PATH=$PATH" bash .setup/testing/autograder.sh
 
+          - name: Setup ldap
+            run: |
+              cd $SUBMITTY_REPOSITORY
+              sudo -E env "PATH=$PATH" bash .setup/testing/setup_ldap.sh
+
           - name: Configure Test suite
             run: |
               cd $SUBMITTY_REPOSITORY
@@ -384,11 +389,6 @@ jobs:
             run: |
               cd $SUBMITTY_REPOSITORY
               sudo -E env "PATH=$PATH" bash .setup/testing/setup_test_suite.sh
-
-          - name: Setup ldap
-            run: |
-              cd $SUBMITTY_REPOSITORY
-              sudo -E env "PATH=$PATH" bash .setup/testing/setup_ldap.sh
 
           - name: Set up apache
             run: |

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -372,15 +372,15 @@ jobs:
               cd $SUBMITTY_REPOSITORY
               sudo -E env "PATH=$PATH" bash .setup/testing/autograder.sh
 
-          - name: Setup ldap
-            run: |
-              cd $SUBMITTY_REPOSITORY
-              sudo -E env "PATH=$PATH" bash .setup/testing/setup_ldap.sh
-
           - name: Configure Test suite
             run: |
               cd $SUBMITTY_REPOSITORY
               sudo -E env "PATH=$PATH" bash .setup/testing/setup.sh
+
+          - name: Setup ldap
+            run: |
+              cd $SUBMITTY_REPOSITORY
+              sudo -E env "PATH=$PATH" bash .setup/testing/setup_ldap.sh
 
           - name: Set up sample course
             run:  sudo -E env "PATH=$PATH" python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/setup_sample_courses.py --no_grading sample


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #7678 .
`Set up sample course` faults because `ldapadd` (part of the open-ldap) is not present at the time of execution.

### What is the new behavior?
Reordered `Setup Idap` in front of the `Set up sample course`, so `ldapadd` will be available when setup sample course is invoked.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Do we need to refactor `setup_sample_courses.py` so that it fails when external calls fail?
