### PR TITLE
[Bugfix:Forum] Fix exception on viewing post history

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1107,8 +1107,9 @@ class ForumController extends AbstractController {
         $anon = $current_post["anonymous"];
         foreach ($older_posts as $post) {
             $_post['user'] = !$this->modifyAnonymous($oc) && $oc == $post["edit_author"] && $anon ? '' : $post["edit_author"];
-            $_post['content'] = $return = $this->core->getOutput()->renderTwigTemplate("forum/RenderPost.twig", [
-                "post_content" => $post["content"]
+            $_post['content'] = $this->core->getOutput()->renderTwigTemplate("forum/RenderPost.twig", [
+                "post_content" => $post["content"],
+                "render_markdown" => false,
             ]);
             $_post['post_time'] = DateUtils::parseDateTime($post['edit_timestamp'], $this->core->getConfig()->getTimezone())->format("n/j g:i A");
             $output[] = $_post;
@@ -1116,8 +1117,9 @@ class ForumController extends AbstractController {
         if (count($output) == 0) {
             // Current post
             $_post['user'] = !$this->modifyAnonymous($oc) && $anon ? '' : $oc;
-            $_post['content'] = $return = $this->core->getOutput()->renderTwigTemplate("forum/RenderPost.twig", [
-                "post_content" => $current_post["content"]
+            $_post['content'] = $this->core->getOutput()->renderTwigTemplate("forum/RenderPost.twig", [
+                "post_content" => $current_post["content"],
+                "render_markdown" => false,
             ]);
             $_post['post_time'] = DateUtils::parseDateTime($current_post['timestamp'], $this->core->getConfig()->getTimezone())->format("n/j g:i A");
             $output[] = $_post;


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #7677 

When trying to view the history of a post, an exception is thrown about `render_markdown` not being defined within the `ForumPost.twig` template. This is because we're not passing in a value for this variable when rendering the template.

### What is the new behavior?

A value for `render_markdown` is provided when rendering the `ForumPost.twig` template. The modal shows up as expected that shows the post history. It always shows these posts in plain text as we do not capture in the history if a given post was in markdown or not. I'm not sure if anyone wants the markdown in the history, so I think fine just leaving it as plain text for now.