### PR TITLE
[Bugfix:Submission] Fix dark mode CM highlight contrast

### DIFF
--- a/site/app/libraries/CodeMirrorUtils.php
+++ b/site/app/libraries/CodeMirrorUtils.php
@@ -94,9 +94,6 @@ class CodeMirrorUtils {
      * @param Core $core
      */
     public static function loadDefaultDependencies(Core $core): void {
-        $core->getOutput()->addInternalJs('code-mirror-utils.js');
-        $core->getOutput()->addInternalCss('code-mirror-utils.css');
-
         foreach (self::DEFAULT_JS_FILES as $file) {
             $core->getOutput()->addVendorJs($file);
         }
@@ -104,5 +101,8 @@ class CodeMirrorUtils {
         foreach (self::DEFAULT_CSS_FILES as $file) {
             $core->getOutput()->addVendorCss($file);
         }
+
+        $core->getOutput()->addInternalJs('code-mirror-utils.js');
+        $core->getOutput()->addInternalCss('code-mirror-utils.css');
     }
 }

--- a/site/app/views/MiscView.php
+++ b/site/app/views/MiscView.php
@@ -18,6 +18,7 @@ class MiscView extends AbstractView {
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'codemirror.css'));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'theme', 'eclipse.css'));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('codemirror', 'theme', 'monokai.css'));
+        $this->core->getOutput()->addInternalCss('code-mirror-utils.css');
 
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('jquery', 'jquery.min.js'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('codemirror', 'codemirror.js'));

--- a/site/public/css/code-mirror-utils.css
+++ b/site/public/css/code-mirror-utils.css
@@ -5,6 +5,7 @@
 }
 
 /* override monokai's highlighting to make it a bluish color with more contrast against text and background */
+
 /* disabling stylelint as we're overriding CodeMirror, and have no control over how it's named its classes */
 /* stylelint-disable */
 .cm-s-monokai .CodeMirror-line::selection,

--- a/site/public/css/code-mirror-utils.css
+++ b/site/public/css/code-mirror-utils.css
@@ -3,3 +3,19 @@
     text-decoration: red dotted underline;
     text-underline-position: under;
 }
+
+/* override monokai's highlighting to make it a bluish color with more contrast against text / background */
+.cm-s-monokai .CodeMirror-line::selection,
+.cm-s-monokai .CodeMirror-line > span::selection,
+.cm-s-monokai .CodeMirror-line > span > span::selection {
+    background: #3357a0;
+}
+.cm-s-monokai .CodeMirror-line::-moz-selection,
+.cm-s-monokai .CodeMirror-line > span::-moz-selection,
+.cm-s-monokai .CodeMirror-line > span > span::-moz-selection {
+    background: #3357a0;
+}
+
+.cm-s-monokai div.CodeMirror-selected {
+    background: #3357a0;
+}

--- a/site/public/css/code-mirror-utils.css
+++ b/site/public/css/code-mirror-utils.css
@@ -4,7 +4,9 @@
     text-underline-position: under;
 }
 
-/* override monokai's highlighting to make it a bluish color with more contrast against text / background */
+/* override monokai's highlighting to make it a bluish color with more contrast against text and background */
+/* disabling stylelint as we're overriding CodeMirror, and have no control over how it's named its classes */
+/* stylelint-disable */
 .cm-s-monokai .CodeMirror-line::selection,
 .cm-s-monokai .CodeMirror-line > span::selection,
 .cm-s-monokai .CodeMirror-line > span > span::selection {
@@ -19,3 +21,4 @@
 .cm-s-monokai div.CodeMirror-selected {
     background: #3357a0;
 }
+/* stylelint-enable */


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Closes #7694 

The color used for highlighting text in codemirror on the submission page under dark mode provides little to no contrast against the text, making it hard to see what's currently highlighted. It's a darkish yellow color, but it does not show up well.

<img width="731" alt="Screen Shot 2022-03-02 at 7 58 55 PM" src="https://user-images.githubusercontent.com/1845314/156475650-e124676a-4aa2-4df7-887d-22f5aa35d1a8.png">

### What is the new behavior?

I've modified it to be a bluish color that's a bit more prominent. It shows up better against the backgrounds, but I still think the contrast could be improved, but it might involve tweaking the input background which I'm not prepared to tackle at this time. I didn't want to go too bright with the blue (like the default chrome color) as then it ruins being able to read the highlighted code that's been highlighted.
 
<img width="731" alt="Screen Shot 2022-03-02 at 7 50 15 PM" src="https://user-images.githubusercontent.com/1845314/156475483-3f6b982d-335d-471c-ab7c-9c315a551d0f.png">
