### PR TITLE
[Bugfix:Developer] Do not install haskell on non-x86_64

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -218,7 +218,8 @@ fi
 # STACK SETUP
 #################
 
-if [ ${VAGRANT} == 1 ] && [ ${WORKER} == 0 ]; then
+# stack is not available for non-x86_64 systems
+if [ ${VAGRANT} == 1 ] && [ ${WORKER} == 0 ] && [ "$(uname -m)" = "x86_64" ]; then
     # We only might build analysis tools from source while using vagrant
     echo "Installing stack (haskell)"
     curl -sSL https://get.haskellstack.org/ | sh


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We install haskell to help developing analysis tools within Vagrant. Unfortunately, this is only available on x86_64 architecture, and not yet available on running on other architectures like arm64 (necessary for M1).

### What is the new behavior?

This disables downloading and installing haskell / stack on non-x86_64 machines, fixing running `install_system.sh` on M1 vagrant (or any other architecture). While an alternative might be to migrate to GHCup to get this to work, as we look to migrate off AnalysisTools anyway, I don't think it's worth spending the time trying to get the toolchain to work as we look to remove it altogether soon anyway.