### PR TITLE
[Bugfix:System] Get arm64 sources for docker

### DIFF
--- a/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
@@ -89,7 +89,7 @@ apt-get install -qqy emacs
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 apt-key fingerprint 0EBFCD88
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+add-apt-repository "deb [arch=amd64,arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
 apt-get install -qqy docker-ce docker-ce-cli
 systemctl status docker | head -n 100


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Right now, we only fetch sources for `amd64` for the docker apt repository. This prevents installing it on arm64 (M1).

### What is the new behavior?

Adds fetching `arm64` to the docker repository we're fetching from, so that the same line works on both amd64 or arm64. By specifying both, there's a few kb more download on fetching the repository, but we avoid doing any sort of complicated logic to make sure we're fetching the right arch name using flags.
