### PR TITLE
[Bugfix:Autograding] Fix File Path of Access JSON

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -430,7 +430,7 @@ def archive_autograding_results(
         with open(os.path.join(tmp_submission, 'submission', ".submit.timestamp"), 'r') as submission_time_file:
             submission_string = submission_time_file.read().rstrip()
         # grab the first access to the gradeable page (if it exists)
-        user_assignment_access_filename = os.path.join(tmp_submission, ".user_assignment_access.json")
+        user_assignment_access_filename = os.path.join(tmp_submission, "submission", ".user_assignment_access.json")
         if os.path.exists(user_assignment_access_filename):
             with open(user_assignment_access_filename, 'r') as access_file:
                 obj = json.load(access_file)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you make a submission to an assignment with autograding, the first access timestamp will be the current timestamp. #7673 shows screenshots of this behaviour.

Closes #7673

### What is the new behavior?
The first access timestamp will now be correct for all submissions going forward.

### Other information?
All past submissions will still have this bug on the UI but it doesn't necessarily cause any technical or grading issues that I can see. A migration could be written to fix all old cases but I don't think its necessary.
