### PR TITLE
[UI/UX:System] Add Close Features to Pop Up

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -9,10 +9,11 @@
                     <div class="form-title">
                         {% block title_tag %}
                             <h1>{% block title %}Untitled Form{% endblock %}</h1>
-                            <a
+                            <button
                                 onclick="closePopup('{{ block('popup_id') }}')"
                                 class="btn btn-default close-button key_to_click"
-                            >Close</a>
+                                tabindex="-1"
+                            >Close</button>
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -1,14 +1,15 @@
 {# This is the control shown/hidden #}
-<div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;">
+<div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;" onclick="closePopup('{{ block('popup_id') }}')">
     {% block form %}
         {# This lets us center the window #}
         <div class="popup-box">
             {# Actual displayed window #}
-            <div class="popup-window">
+            <div class="popup-window" onclick="event.stopPropagation()">
                 {% block title_panel %}
                     <div class="form-title">
                         {% block title_tag %}
                             <h1>{% block title %}Untitled Form{% endblock %}</h1>
+                            <i class="fas fa-times fa-2x popup-close-icon" onclick="closePopup('{{ block('popup_id') }}')"></i>
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -9,7 +9,10 @@
                     <div class="form-title">
                         {% block title_tag %}
                             <h1>{% block title %}Untitled Form{% endblock %}</h1>
-                            <i class="fas fa-times fa-2x popup-close-icon" onclick="closePopup('{{ block('popup_id') }}')"></i>
+                            <a
+                                onclick="closePopup('{{ block('popup_id') }}')"
+                                class="btn btn-default close-button key_to_click"
+                            >Close</a>
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1165,6 +1165,15 @@ div.full-height {
     margin-bottom: 10px;
 }
 
+.form-title {
+    display: flex;
+    justify-content: space-between;
+}
+
+.popup-close-icon:hover {
+    color: var(--external-link-blue);
+}
+
 .popup-form .form-body {
     flex-grow: 1;
     overflow-y: auto;

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -337,7 +337,7 @@ function captureTabInModal(formName, resetFocus=true){
     form.off('keydown');//Remove any old redirects
 
     /*get all the elements to tab through*/
-    var inputs = form.find(':focusable').filter(':visible');
+    var inputs = form.find(':tabbable').filter(':visible');
     var firstInput = inputs.first();
     var lastInput = inputs.last();
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Currently the only way to close a pop up is to click the close button at the bottom. If the pop up is long you may have to scroll down to see the close button.
Closes #7637

### What is the new behavior?
This PR adds an X at the top right corner of all pop ups. It also adds the ability to click anywhere not in the pop up and it will get closed.

### Pictures
Light Mode:
![image](https://user-images.githubusercontent.com/55092742/156968022-fa9116ca-a84b-42db-b6ef-29d9ff04e544.png)

Dark Mode:
![image](https://user-images.githubusercontent.com/55092742/156967973-0425db76-bf74-47a4-be99-52fe9052e9e5.png)

