### PR TITLE
[Bugfix:System] upgrade worker machine 18.04->20.04

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -32,6 +32,7 @@ if [ -d ${THIS_DIR}/../.vagrant ]; then
     VAGRANT=1
 fi
 
+SUPERVISOR_USER=$(jq -r '.supervisor_user' ${CONF_DIR}/submitty_users.json)
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
 SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)
 WORKER=$([[ $(jq -r '.worker' ${CONF_DIR}/submitty.json) == "true" ]] && echo 1 || echo 0)

--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -73,7 +73,7 @@ poppler-utils
 apt-get install -qqy ninja-build
 
 # NodeJS
-curl -sL https://deb.nodesource.com/setup_16.x | bash -
+umask 0022 && curl -sL https://deb.nodesource.com/setup_16.x | bash -
 apt-get install -y nodejs
 
 #CMAKE

--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -73,7 +73,7 @@ poppler-utils
 apt-get install -qqy ninja-build
 
 # NodeJS
-umask 0022 && curl -sL https://deb.nodesource.com/setup_16.x | bash -
+(umask 0022 && curl -sL https://deb.nodesource.com/setup_16.x | bash -)
 apt-get install -y nodejs
 
 #CMAKE

--- a/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
@@ -71,7 +71,7 @@ g++-multilib jq libseccomp-dev libseccomp2 seccomp junit flex bison poppler-util
 apt-get install -qqy ninja-build
 
 # NodeJS
-curl -sL https://deb.nodesource.com/setup_16.x | bash -
+umask 0022 && curl -sL https://deb.nodesource.com/setup_16.x | bash -
 apt-get install -y nodejs
 
 #CMAKE

--- a/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
@@ -71,7 +71,7 @@ g++-multilib jq libseccomp-dev libseccomp2 seccomp junit flex bison poppler-util
 apt-get install -qqy ninja-build
 
 # NodeJS
-umask 0022 && curl -sL https://deb.nodesource.com/setup_16.x | bash -
+(umask 0022 && curl -sL https://deb.nodesource.com/setup_16.x | bash -)
 apt-get install -y nodejs
 
 #CMAKE


### PR DESCRIPTION
A few errors that were found when upgrading a worker machine from Ubuntu 18.04-> Ubuntu 20.04.  This was not a fresh install of a new server, but rather a patch upgrade.  After the upgrade was complete, ran:  `bash ./.setup/install_system.sh --worker`

The two errors:
* missing definition of SUPERVISOR_USER variable
* permissions error on NodeJS installation