### PR TITLE
[Bugfix:TAGrading] Fix TA grading notebook bugs

### DIFF
--- a/site/app/libraries/CodeMirrorUtils.php
+++ b/site/app/libraries/CodeMirrorUtils.php
@@ -12,6 +12,7 @@ class CodeMirrorUtils {
 
     const DEFAULT_JS_FILES = [
         'codemirror/codemirror.js',
+        'codemirror/addon/display/autorefresh.js',
         'codemirror/addon/display/placeholder.js',
         'codemirror/addon/mode/overlay.js',
         'codemirror/mode/clike/clike.js',

--- a/site/app/templates/grading/electronic/NotebookPanel.twig
+++ b/site/app/templates/grading/electronic/NotebookPanel.twig
@@ -17,7 +17,7 @@
         'viewing_inactive_version' : false,
         "is_grader_view" : is_grader_view,
         "is_timed" : false,
-        "allowed_minutes" : false
+        "allowed_minutes" : 0
     } %}
     {% include "grading/electronic/FileView.twig" with {
         "panel": "notebook",

--- a/site/app/templates/misc/SourceSettings.twig
+++ b/site/app/templates/misc/SourceSettings.twig
@@ -3,7 +3,8 @@
         lineNumbers: true,
         readOnly: true,
         cursorHeight: 0.0,
-        lineWrapping: true
+        lineWrapping: true,
+        autoRefresh: true,
     });
 
     var lineCount = editor{{ number }}.lineCount();

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1121,7 +1121,8 @@ function generateCodeMirrorBlocks(container_element) {
             lineNumbers: true,
             readOnly: true,
             cursorHeight: 0.0,
-            lineWrapping: true
+            lineWrapping: true,
+            autoRefresh: true,
         });
 
         var lineCount = editor0.lineCount();

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -18,6 +18,7 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
         readOnly: true,
         cursorHeight: 0.0,
         lineWrapping: true,
+        autoRefresh: true,
     });
     // eslint-disable-next-line no-undef
     const editor2 = CodeMirror.fromTextArea(document.getElementById('code_box_2'), {
@@ -25,6 +26,7 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
         readOnly: true,
         cursorHeight: 0.0,
         lineWrapping: true,
+        autoRefresh: true,
     });
 
     editor1.setSize('100%', '100%');

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -160,9 +160,6 @@ $(function () {
       checkNotebookScroll();
     }
   });
-  notebookScrollLoad();
-
-  checkNotebookScroll();
 
   if(localStorage.getItem('notebook-setting-file-submission-expand') == 'true') {
     let notebookPanel = $('#notebook-view');
@@ -188,6 +185,9 @@ $(function () {
   // calling it for the first time i.e initializing
   adjustGradingPanelHeader();
   resizeObserver.observe(document.getElementById('grading-panel-header'));
+
+  notebookScrollLoad();
+  checkNotebookScroll();
 });
 
 function changeStudentArrowTooltips(data) {
@@ -302,7 +302,7 @@ function notebookScrollLoad() {
     }
     if (element !== null) {
       if (element.length !== 0) {
-        notebookView.animate({scrollTop: (element.offset().top - notebookView.offset().top + notebookView.scrollTop())}, 100);
+        notebookView.scrollTop(element.offset().top - notebookView.offset().top + notebookView.scrollTop());
       } else {
         localStorage.removeItem('ta-grading-notebook-view-scroll-id');
         localStorage.removeItem('ta-grading-notebook-view-scroll-item');

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -809,7 +809,7 @@ function setPanelsVisibilities (ele, forceVisible=null, position=null) {
       $("#" + panel.str).toggle(eleVisibility);
       $(panel.icon).toggleClass('icon-selected', eleVisibility);
       $(id_str).toggleClass('active', eleVisibility);
-      // $("#" + panel.str).find(".CodeMirror").each(function() {this.CodeMirror.refresh()});
+      $("#" + panel.str).find(".CodeMirror").each(function() {this.CodeMirror.refresh()});
 
       if (taLayoutDet.numOfPanelsEnabled > 1 && !isMobileView) {
         checkForTwoPanelLayoutChange(eleVisibility, panel.str, position);

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -302,7 +302,7 @@ function notebookScrollLoad() {
     }
     if (element !== null) {
       if (element.length !== 0) {
-        notebookView.scrollTop(element.offset().top - notebookView.offset().top + notebookView.scrollTop());
+        notebookView.animate({scrollTop: (element.offset().top - notebookView.offset().top + notebookView.scrollTop())}, 100);
       } else {
         localStorage.removeItem('ta-grading-notebook-view-scroll-id');
         localStorage.removeItem('ta-grading-notebook-view-scroll-item');
@@ -809,7 +809,7 @@ function setPanelsVisibilities (ele, forceVisible=null, position=null) {
       $("#" + panel.str).toggle(eleVisibility);
       $(panel.icon).toggleClass('icon-selected', eleVisibility);
       $(id_str).toggleClass('active', eleVisibility);
-      $("#" + panel.str).find(".CodeMirror").each(function() {this.CodeMirror.refresh()});
+      // $("#" + panel.str).find(".CodeMirror").each(function() {this.CodeMirror.refresh()});
 
       if (taLayoutDet.numOfPanelsEnabled > 1 && !isMobileView) {
         checkForTwoPanelLayoutChange(eleVisibility, panel.str, position);


### PR DESCRIPTION
### What is the current behavior?
* #7734 

### What is the new behavior?
Closes #7734 
Fixes TA grading notebook autoscroll by adding a brief transition period to the scroll.

Attempted to fix issue with empty notebook boxes by adding and enabling the CodeMirror autoreload addon (https://codemirror.net/doc/manual.html#addon_autorefresh) where CodeMirror boxes are enabled.

### Other information?
Was unable to reproduce empty notebook boxes on Chrome/Edge/Firefox on Windows 10; needs testing on Chrome on macOS.
