### PR TITLE
[Refactor:System] Remove duplicate SUPERVISOR_USER define

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -32,7 +32,6 @@ if [ -d ${THIS_DIR}/../.vagrant ]; then
     VAGRANT=1
 fi
 
-SUPERVISOR_USER=$(jq -r '.supervisor_user' ${CONF_DIR}/submitty_users.json)
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
 SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)
 WORKER=$([[ $(jq -r '.worker' ${CONF_DIR}/submitty.json) == "true" ]] && echo 1 || echo 0)


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `INSTALL_SUBMITTY_HELPER.sh` script defines `SUPERVISOR_USER` twice, once on line 35 (added in #7729) and a second time on line 145 (added in #7668). Nothing between those lines uses the `SUPERVISOR_USER` variable. While the double assignment doesn't affect anything really, would be good to just have the one assignment just in case we ever need to update the line and don't need to update two lines (or worse, one line is missed).

### What is the new behavior?

Removes the assignment on line 35, and just leaves the one on line 145. We want the latter one in case the migrator modifies the value of that variable in some way, similar to the other variables that are defined there. The variable defines on line 35 are just the minimal set required to run the stuff between 35 and 145, which isn't much.
