### PR TITLE
[UI/UX:Plagiarism] Reduce plagiarism interface distractions

### DIFF
--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -153,12 +153,12 @@ input[type="text"]:invalid {
 /* ==== Results Page ======================================================== */
 .match-style {
     background-color: yellow;
-    border: 1px solid black;
+    border-right: 1px solid var(--text-white);
 }
 
 .specific-match-style {
     background-color: orange;
-    border: 1px solid black;
+    border-right: 1px solid var(--text-white);
 }
 
 .common-code-style {

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -305,10 +305,10 @@ function recreateUser1Dropdown(state) {
         if (state.anon_mode_enabled) {
             const hashedDisplayName = element.display_name !== '' ? hashString(element.display_name) : '';
             const hashedUserID = hashString(element.user_id);
-            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}, ${element.match_count} hashes) ${hashedDisplayName} &lt;${hashedUserID}&gt;</option>`);
+            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(${element.percent}, ${element.match_count} hashes) ${hashedDisplayName} &lt;${hashedUserID}&gt;</option>`);
         }
         else {
-            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(Max Match: ${element.percent}, ${element.match_count} hashes) ${element.display_name} &lt;${element.user_id}&gt;</option>`);
+            $('#user-1-dropdown-list').append(`<option value="${element.user_id}">(${element.percent}, ${element.match_count} hashes) ${element.display_name} &lt;${element.user_id}&gt;</option>`);
         }
     });
 }
@@ -348,10 +348,10 @@ function refreshUser2Dropdown(state) {
         if (state.anon_mode_enabled) {
             const hashedDisplayName = users.display_name !== '' ? hashString(users.display_name) : '';
             const hashedUserID = hashString(users.user_id);
-            append_options += `>(${users.percent} Match) ${hashedDisplayName} &lt;${hashedUserID}&gt; (version: ${users.version}) `;
+            append_options += `>(${users.percent} hashes) ${hashedDisplayName} &lt;${hashedUserID}&gt; (version ${users.version}) `;
         }
         else {
-            append_options += `>(${users.percent} Match) ${users.display_name} &lt;${users.user_id}&gt; (version: ${users.version}) `;
+            append_options += `>(${users.percent} hashes) ${users.display_name} &lt;${users.user_id}&gt; (version ${users.version}) `;
         }
 
         if (users.source_gradeable !== state.this_term_course_gradeable) {


### PR DESCRIPTION
### What is the current behavior?
The dark borders between matching blocks on the plagiarism interface can be distracting when there are many overlapping blocks.  At the same time, it must be clear where blocks begin and end so they can be effectively clicked on.  This PR changes the border style to be less distracting.  Red- and blue-highlighted text still retains the previous black borders since the emphasis is desired in such cases.

Before:
<img width="559" alt="before" src="https://user-images.githubusercontent.com/16820599/159141349-3894f3e9-2f19-450e-8d97-198065341405.png">

### What is the new behavior?
After:
<img width="560" alt="after" src="https://user-images.githubusercontent.com/16820599/159141352-e76a71a8-f37d-4ff9-92d4-fe0b22a8d860.png">


### Other information?
https://github.com/Submitty/Lichen/pull/79 made modifications to the ranking output files which necessitated a few minor text changes which have been included in this PR.
