### PR TITLE
[Bugfix:Plagiarism] Properly set last run timestamp

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -1194,6 +1194,13 @@ class PlagiarismController extends AbstractController {
             return new RedirectResponse($return_url);
         }
 
+        // Update the last run timestamp
+        $em = $this->core->getCourseEntityManager();
+        /** @var PlagiarismConfig $plagiarism_config */
+        $plagiarism_config = $em->getRepository(PlagiarismConfig::class)->findOneBy(["gradeable_id" => $gradeable_id, "config_id" => $config_id]);
+        $plagiarism_config->setLastRunToCurrentTime();
+        $em->flush();
+
         try {
             $this->enqueueLichenJob("RunLichen", $gradeable_id, $config_id);
         }

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -22,7 +22,6 @@ class TestSidebar(BaseTestCase):
 
         title_map = {
             'Manage Sections': 'Manage Registration Sections',
-            'Plagiarism Detection': 'Plagiarism Detection -- WORK IN PROGRESS',
             'My Late Days/Extensions': 'My Late Day Usage'
         }
 

--- a/tests/e2e/test_sidebar.py
+++ b/tests/e2e/test_sidebar.py
@@ -22,6 +22,7 @@ class TestSidebar(BaseTestCase):
 
         title_map = {
             'Manage Sections': 'Manage Registration Sections',
+            'Plagiarism Detection': 'Plagiarism Detection -- WORK IN PROGRESS',
             'My Late Days/Extensions': 'My Late Day Usage'
         }
 


### PR DESCRIPTION
### What is the current behavior?
The timestamp of the last plagiarism run is currently only set for the initial plagiarism run.  It should update it every time the re-run button is clicked.

### What is the new behavior?
This PR changes the behavior to properly reflect the last time the configuration was run.