### PR TITLE
[Bugfix:CourseMaterials] Restrict course material for no section

### DIFF
--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -461,7 +461,7 @@ class CourseMaterialsController extends AbstractController {
         if (isset($_POST['sections']) && $sections_lock) {
             $sections = $_POST['sections'];
             $sections_exploded = @explode(",", $sections);
-            if (empty($sections_exploded)) {
+            if ($sections_exploded[0] == "") {
                 return JsonResponse::getErrorResponse("Select at least one section");
             }
             $details['sections'] = $sections_exploded;

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -461,6 +461,9 @@ class CourseMaterialsController extends AbstractController {
         if (isset($_POST['sections']) && $sections_lock) {
             $sections = $_POST['sections'];
             $sections_exploded = @explode(",", $sections);
+            if (empty($sections_exploded)) {
+                return JsonResponse::getErrorResponse("Select at least one section");
+            }
             $details['sections'] = $sections_exploded;
         }
         else {

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -461,7 +461,7 @@ class CourseMaterialsController extends AbstractController {
         if (isset($_POST['sections']) && $sections_lock) {
             $sections = $_POST['sections'];
             $sections_exploded = @explode(",", $sections);
-            if ($sections_exploded[0] == "") {
+            if ($sections_exploded[0] === "") {
                 return JsonResponse::getErrorResponse("Select at least one section");
             }
             $details['sections'] = $sections_exploded;

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -145,10 +145,10 @@
                 if(document.getElementById('show_Some_Section_Selection').style.display == "none"){
                     sections = null;
                 }
-                if(sections == null || sections.length > 0){
-                    var cmPath = document.getElementById('cm_path').innerHTML;
-                    var requestedPath = document.getElementById("input-provide-full-path").value;
-                    var sections_lock = document.getElementById('all_Sections_Showing_yes').checked === true;
+                if(sections === null || sections.length > 0){
+                    const cmPath = document.getElementById('cm_path').innerHTML;
+                    const requestedPath = document.getElementById("input-provide-full-path").value;
+                    const sections_lock = document.getElementById('all_Sections_Showing_yes').checked === true;
                     makeSubmission(expandZip, hideFromStudents, cmPath, requestedPath, cmTime, sort, sections, sections_lock);
                 }
                 else {

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -145,10 +145,15 @@
                 if(document.getElementById('show_Some_Section_Selection').style.display == "none"){
                     sections = null;
                 }
-                var cmPath = document.getElementById('cm_path').innerHTML;
-                var requestedPath = document.getElementById("input-provide-full-path").value;
-                var sections_lock = document.getElementById('all_Sections_Showing_yes').checked === true;
-                makeSubmission(expandZip, hideFromStudents, cmPath, requestedPath, cmTime, sort, sections, sections_lock);
+                if(sections == null || sections.length > 0){
+                    var cmPath = document.getElementById('cm_path').innerHTML;
+                    var requestedPath = document.getElementById("input-provide-full-path").value;
+                    var sections_lock = document.getElementById('all_Sections_Showing_yes').checked === true;
+                    makeSubmission(expandZip, hideFromStudents, cmPath, requestedPath, cmTime, sort, sections, sections_lock);
+                }
+                else {
+                    alert("Select at least one section");
+                }
                 e.stopPropagation();
             });
         });

--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -289,7 +289,7 @@ describe('Test cases revolving around course material uploading and access contr
             cy.get('#cm_path').click();
             cy.get('#submit-materials').click();
             cy.on('window:alert', (alert) => {
-                expect(alert).eq("Select at least one section");
+                expect(alert).eq('Select at least one section');
             });
         });
 

--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -281,6 +281,18 @@ describe('Test cases revolving around course material uploading and access contr
 
         });
 
+        it('Should display warning alert when no section selected for restrict course materials', () => {
+            cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
+            cy.get('#all_Sections_Showing_yes').click();
+            cy.get('#upload1').attachFile(['file1.txt', 'file2.txt'] , { subjectType: 'drag-n-drop' });
+            cy.get('#upload_picker').clear().type('2021-06-29 21:37:53');
+            cy.get('#cm_path').click();
+            cy.get('#submit-materials').click();
+            cy.on('window:alert', (alert) => {
+                expect(alert).eq("Select at least one section");
+            });
+        });
+
         it('Should restrict course materials within folders', () => {
             cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
             cy.get('#all_Sections_Showing_yes').click();

--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -281,7 +281,7 @@ describe('Test cases revolving around course material uploading and access contr
 
         });
 
-        it('Should display warning alert when no section selected for restrict course materials', () => {
+        it('Should not upload file when no section selected for restrict course materials', () => {
             cy.get('[onclick="newUploadCourseMaterialsForm()"]').click();
             cy.get('#all_Sections_Showing_yes').click();
             cy.get('#upload1').attachFile(['file1.txt', 'file2.txt'] , { subjectType: 'drag-n-drop' });
@@ -291,6 +291,9 @@ describe('Test cases revolving around course material uploading and access contr
             cy.on('window:alert', (alert) => {
                 expect(alert).eq('Select at least one section');
             });
+
+            cy.reload();
+            cy.get('.file-viewer').should('not.exist');
         });
 
         it('Should restrict course materials within folders', () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #7765
### What is the new behavior?
In the front-end this generates an alert with message "Select at least one section" when restrict section is selected but no section is selected under it and the submit form button is clicked.
In the backend this sends error response with message "Select at least one section"
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
