### PR TITLE
[Bugfix:Submission] Cancelled submission bugfixes

### DIFF
--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -177,10 +177,10 @@ class Notebook extends AbstractModel {
                                 $file_path = $this->core->getConfig()->getCoursePath();
                                 $file_path = FileUtils::joinPaths($file_path, "submissions", $gradeable_id, $student_id, $display_version, $question_name);
                                 $version_answer = rtrim(file_get_contents($file_path));
-                            } else {
+                            }
+                            else {
                                 $version_answer = $notebookVal['initial_value'] ?? "";
                             }
-                            
                         }
                         catch (AuthorizationException $e) {
                             // If the user lacked permission then just set to default instructor provided string
@@ -211,10 +211,10 @@ class Notebook extends AbstractModel {
                                 $version_answer = rtrim(file_get_contents($file_path));
                                 // Add field to the array
                                 $new_notebook[$notebookKey]['version_submission'] = $version_answer;
-                            } else {
+                            }
+                            else {
                                 $new_notebook[$notebookKey]['version_submission'] = '';
                             }
-                           
                         }
                         catch (AuthorizationException $e) {
                             // If failed to get the most recent submission then skip

--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -172,10 +172,15 @@ class Notebook extends AbstractModel {
                             // Try to get the most recent submission
                             $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename'], $version, $student_id);
                             //get answer for the selected display version
-                            $question_name = $notebookVal['filename'];
-                            $file_path = $this->core->getConfig()->getCoursePath();
-                            $file_path = FileUtils::joinPaths($file_path, "submissions", $gradeable_id, $student_id, $display_version, $question_name);
-                            $version_answer = rtrim(file_get_contents($file_path));
+                            if ($display_version !== 0) {
+                                $question_name = $notebookVal['filename'];
+                                $file_path = $this->core->getConfig()->getCoursePath();
+                                $file_path = FileUtils::joinPaths($file_path, "submissions", $gradeable_id, $student_id, $display_version, $question_name);
+                                $version_answer = rtrim(file_get_contents($file_path));
+                            } else {
+                                $version_answer = $notebookVal['initial_value'] ?? "";
+                            }
+                            
                         }
                         catch (AuthorizationException $e) {
                             // If the user lacked permission then just set to default instructor provided string
@@ -195,16 +200,21 @@ class Notebook extends AbstractModel {
                     }
                     else {
                         try {
-                            // Try to get the most recent submission
+                            // Try to get the most recent submission and add field to array
                             $recentSubmission = $this->getRecentSubmissionContents($notebookVal['filename'], $version, $student_id);
-                            //get answer for the selected display version
-                            $question_name = $notebookVal['filename'];
-                            $file_path = $this->core->getConfig()->getCoursePath();
-                            $file_path = FileUtils::joinPaths($file_path, "submissions", $gradeable_id, $student_id, $display_version, $question_name);
-                            $version_answer = rtrim(file_get_contents($file_path));
-                            // Add field to the array
                             $new_notebook[$notebookKey]['recent_submission'] = $recentSubmission;
-                            $new_notebook[$notebookKey]['version_submission'] = $version_answer;
+                            //get answer for the selected display version
+                            if ($display_version !== 0) {
+                                $question_name = $notebookVal['filename'];
+                                $file_path = $this->core->getConfig()->getCoursePath();
+                                $file_path = FileUtils::joinPaths($file_path, "submissions", $gradeable_id, $student_id, $display_version, $question_name);
+                                $version_answer = rtrim(file_get_contents($file_path));
+                                // Add field to the array
+                                $new_notebook[$notebookKey]['version_submission'] = $version_answer;
+                            } else {
+                                $new_notebook[$notebookKey]['version_submission'] = '';
+                            }
+                           
                         }
                         catch (AuthorizationException $e) {
                             // If failed to get the most recent submission then skip

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -121,7 +121,7 @@ class HomeworkView extends AbstractView {
             $return .= $this->renderTotalScoreBox($graded_gradeable, $version_instance, $show_hidden_testcases);
         }
 
-        if ($submission_count > 0) {
+        if ($submission_count > 0 && $active_version !== 0) {
             $return .= $this->renderAutogradingBox($graded_gradeable, $version_instance, $show_hidden_testcases);
         }
 
@@ -426,7 +426,7 @@ class HomeworkView extends AbstractView {
 
         $highest_version = $graded_gradeable !== null ? $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : 0;
 
-        $viewing_inactive_version = $highest_version !== $display_version;
+        $viewing_inactive_version = $display_version !== 0 && $highest_version !== $display_version;
 
         // instructors can access this page even if they aren't on a team => don't create errors
         $my_team = $graded_gradeable !== null ? $graded_gradeable->getSubmitter()->getTeam() : "";


### PR DESCRIPTION
### What is the current behavior?
When going to a cancelled submission, the page will reload three times when trying to access "version 0".
Users cannot submit on "version 0" of a cancelled submission.
Cancelling a notebook submission throws errors when viewing "version 0".

### What is the new behavior?
Autograding results are not rendered on "version 0", fixing the page reload issue.
Users can now submit on "version 0".
Viewing "version 0" of a cancelled notebook submission no longer throws errors.
