### PR TITLE
[Bugfix:Submission] Gradeable access bugfix when view is no

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -72,6 +72,7 @@ class SubmissionController extends AbstractController {
             // FIXME if $graded_gradeable is null, the user isn't on a team, so we want to redirect
             // FIXME    to nav with an error
         }
+
         // ORIGINAL
         //if (!$gradeable->isSubmissionOpen() && !$this->core->getUser()->accessAdmin()) {
         // TEMPORARY - ALLOW LIMITED & FULL ACCESS GRADERS TO PRACTICE ALL FUTURE HOMEWORKS
@@ -80,9 +81,11 @@ class SubmissionController extends AbstractController {
             && (
                 !$gradeable->isSubmissionOpen()
                 || !$gradeable->isStudentView()
-                || $gradeable->isStudentView()
-                && $gradeable->isStudentViewAfterGrades()
-                && !$gradeable->isTaGradeReleased()
+                || (
+                    $gradeable->isStudentView()
+                    && $gradeable->isStudentViewAfterGrades()
+                    && !$gradeable->isTaGradeReleased()
+                )
             )
         ) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -81,11 +81,8 @@ class SubmissionController extends AbstractController {
             && (
                 !$gradeable->isSubmissionOpen()
                 || !$gradeable->isStudentView()
-                || (
-                    $gradeable->isStudentView()
-                    && $gradeable->isStudentViewAfterGrades()
-                    && !$gradeable->isTaGradeReleased()
-                )
+                || $gradeable->isStudentViewAfterGrades()
+                && !$gradeable->isTaGradeReleased()
             )
         ) {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -72,7 +72,6 @@ class SubmissionController extends AbstractController {
             // FIXME if $graded_gradeable is null, the user isn't on a team, so we want to redirect
             // FIXME    to nav with an error
         }
-
         // ORIGINAL
         //if (!$gradeable->isSubmissionOpen() && !$this->core->getUser()->accessAdmin()) {
         // TEMPORARY - ALLOW LIMITED & FULL ACCESS GRADERS TO PRACTICE ALL FUTURE HOMEWORKS
@@ -80,6 +79,7 @@ class SubmissionController extends AbstractController {
             !$this->core->getUser()->accessGrading()
             && (
                 !$gradeable->isSubmissionOpen()
+                || !$gradeable->isStudentView()
                 || $gradeable->isStudentView()
                 && $gradeable->isStudentViewAfterGrades()
                 && !$gradeable->isTaGradeReleased()


### PR DESCRIPTION
### What is the current behavior?
Students can view a gradeable by the URL when viewing by students is set to `No`.

### What is the new behavior?
Students can no longer view a gradeable by the URL when viewing by students is set to `No`.

### Other information?
This can be tested by editing a gradeable and setting `View the gradeable on the course home page and download submitted files?` to `No` (`Edit Gradeable` -> `Submissions/Autograding` -> `What are students allowed to do?`) and going to the URL directly (it will not appear under `Gradeables`); this does not impact `When grades are released`.
