### PR TITLE
[Bugfix:System] Fix sidebar cookie bug

### DIFF
--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -55,7 +55,7 @@ class GlobalView extends AbstractView {
             "duck_img" => $duck_img,
             "use_mobile_viewport" => $this->output->useMobileViewport(),
             "sysadmin_email" => $this->core->getConfig()->getSysAdminEmail(),
-            "collapse_sidebar" => array_key_exists('collapse_sidebar', $_COOKIE) ? $_COOKIE['collapse_sidebar'] === 'true' : false,
+            "collapse_sidebar" => array_key_exists('collapse_sidebar', $_COOKIE) && $_COOKIE['collapse_sidebar'] === 'true',
             "content_only" => $content_only,
         ]);
     }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1282,13 +1282,12 @@ $.fn.isInViewport = function() {                                        // jQuer
 };
 
 function checkSidebarCollapse() {
-    var size = $(document.body).width();
-    if (size < 1150) {
-        document.cookie = "collapse_sidebar=true;";
+    if ($(document.body).width() < 1150) {
+        document.cookie = "collapse_sidebar=true;path=/";
         $("aside").toggleClass("collapsed", true);
     }
     else{
-        document.cookie = "collapse_sidebar=false;";
+        document.cookie = "collapse_sidebar=false;path=/";
         $("aside").toggleClass("collapsed", false);
     }
 }
@@ -1334,10 +1333,10 @@ $(document).ready(function() {
 
 //Called from the DOM collapse button, toggle collapsed and save to localStorage
 function toggleSidebar() {
-    var sidebar = $("aside");
-    var shown = sidebar.hasClass("collapsed");
+    const sidebar = $("aside");
+    const shown = sidebar.hasClass("collapsed");
 
-    document.cookie = "collapse_sidebar=" + (!shown).toString() + ";";
+    document.cookie = "collapse_sidebar=" + (!shown).toString() + ";path=/";
     sidebar.toggleClass("collapsed", !shown);
 }
 
@@ -1356,11 +1355,6 @@ $(document).ready(function() {
                 return ""
             }
         }
-    });
-
-    //If they make their screen too small, collapse the sidebar to allow more horizontal space
-    $(document.body).resize(function() {
-        checkSidebarCollapse();
     });
 });
 

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1,5 +1,3 @@
-window.addEventListener("resize", checkSidebarCollapse);
-
 ////////////Begin: Removed redundant link in breadcrumbs////////////////////////
 //See this pr for why we might want to remove this code at some point
 //https://github.com/Submitty/Submitty/pull/5071
@@ -1356,6 +1354,8 @@ $(document).ready(function() {
             }
         }
     });
+
+    window.addEventListener("resize", checkSidebarCollapse);
 });
 
 function checkBulkProgress(gradeable_id){


### PR DESCRIPTION
### What is the current behavior?
Currently, if you: visit a course homepage, visit a subpage of that course, close the sidebar, navigate back to the homepage of the course, open the sidebar, and reload the page, the sidebar will remain closed.

@KCony reported this issue with the sidebar via slack.  The following screen recording is from that bug report.
![firefox_tntajgsqxe](https://user-images.githubusercontent.com/16820599/159817060-ce551c24-a92e-4fc6-9410-ca9d95951be6.gif)

### What is the new behavior?
The sidebar is now able to be opened/closed from any page.  This means that it is no longer possible to have page-specific sidebar settings, but it makes the general UI more user-friendly.

Note: I was unable to reproduce the issue after making these changes but due to the finicky nature of cookies, it is possible that these changes are not enough and there may be edge cases where the sidebar still does not behave properly.
