### PR TITLE
[Bugfix:Submission] Fix bad breadcrumb link for peer grading

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1577,7 +1577,7 @@ class ElectronicGraderController extends AbstractController {
             $peer = false;
         }
 
-        $gradeableUrl = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'status']);
+        $gradeableUrl = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'details']);
         $this->core->getOutput()->addBreadcrumb("{$gradeable->getTitle()} Grading", $gradeableUrl);
         $indexUrl = $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'grading', 'details']);
         $this->core->getOutput()->addBreadcrumb('Grading Interface ' . GradingOrder::getGradingOrderMessage($sort, $direction));


### PR DESCRIPTION


### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #7780
The broken header link goes to http://localhost:1511/courses/s22/sample/gradeable/grading_only_peer_team_homework/grading/status 

### What is the new behavior?
The header link now goes to 
http://localhost:1511/courses/s22/sample/gradeable/grading_only_peer_team_homework/grading/details

