### PR TITLE
[Bugfix:TAGrading] Fix See Who Got This Mark

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4236,6 +4236,9 @@ AND gc_id IN (
     public function getAnonId($user_id) {
         $params = (is_array($user_id)) ? $user_id : [$user_id];
 
+        if (count($params) === 0) {
+            return [];
+        }
         $question_marks = $this->createParamaterList(count($params));
         $this->course_db->query("SELECT user_id, anon_id FROM users WHERE user_id IN {$question_marks}", $params);
         $return = [];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you click "See who got this mark" on a rubric item where no students have received that mark, you will receive a SQL error as shown.
![image](https://user-images.githubusercontent.com/55092742/160049596-b49d350b-f721-42f5-a406-d226665d6260.png)

### What is the new behavior?
Now the button will open the menu with no students listed. This PR fixes it by making sure the SQL statement is never executed with an empty list.
