### PR TITLE
[Bugfix:TAGrading] PDF page assignment bugfixes

### DIFF
--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -276,7 +276,7 @@ function render(gradeable_id, user_id, grader_id, file_name, file_path, page_num
                             // scroll to page on load
                             const initialPage = $(`#pageContainer${page_id}`);
                             if (initialPage.length) {
-                                $('#file-content').animate({scrollTop: initialPage[0].offsetTop}, 500);
+                                $('#submission_browser').scrollTop(initialPage[0].offsetTop);
                             }
                         }
                         document.getElementById(`pageContainer${page_id}`).addEventListener('pointerdown', () => {

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2254,7 +2254,7 @@ function setPdfPageAssignment(page) {
         page = 1;
     }
 
-    return closeAllComponents(true)
+    return closeAllComponents(true, true)
         .then(function () {
             return ajaxSaveComponentPages(getGradeableId(), {'page': page});
         })
@@ -2668,11 +2668,11 @@ function scrollToPage(page_num){
             let page = $("#pageContainer" + page_num);
             if($("#file-view").is(":visible")){
                 if(page.length) {
-                    $('#file-content').animate({scrollTop: page[0].offsetTop}, 500);
+                    $('#submission_browser').scrollTop(page[0].offsetTop);
                 }
             }
             else {
-                expandFile("upload.pdf", files[i].getAttribute("file-url"), page_num-1);
+                viewFileFullPanel("upload.pdf", files[i].getAttribute("file-url"), page_num-1);
             }
         }
     }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2665,6 +2665,7 @@ function scrollToPage(page_num){
     let files = $(".openable-element-submissions");
     for(let i = 0; i < files.length; i++){
         if(files[i].innerText.trim() == "upload.pdf"){
+            page_num = Math.min($("#viewer > .page").length, page_num);
             let page = $("#pageContainer" + page_num);
             if($("#file-view").is(":visible")){
                 if(page.length) {


### PR DESCRIPTION
### What is the current behavior?
* #7735 

### What is the new behavior?
Closes #7735

Fixes error popup on edit gradeable page when the PDF page number is edited.

Fixes PDF page assignment scrolling (with submission browser + rubric in TA grading).

### Other information?
This can be tested by: 
0. Get a multi-page PDF.
1. Create a gradeable with the type `Students will submit one or more files by direct upload to the Submitty website`
2. Edit the gradeable and go to the rubric tab.
3. Under `And do you expect each specific problem/item/component to appear on a specific page number of the PDF document?`, select `Yes`.
4. Click on the component, and on the right side of the title line enter a valid page number for your multi-page PDF.
5. Add more components and set their page numbers as needed.
6. Submit the PDF to the gradeable and go to grade the PDF (gradeables -> grade -> <find user ID> -> Grade (under TA grading column)
7. If not in multi-panel mode, click on the panel selector: 
![image](https://user-images.githubusercontent.com/15370948/161546815-501a3d73-980b-4f2e-a0d4-4107880eedd5.png) 
and select `side-by-side` under `Two panel options`.
8. Select and open the `Files` panel in one column and the `Rubric` panel in the other column.
9. Open one of the components in the `Rubric` panel by clicking on the component title. The PDF and page should automatically open in the `Files` panel.

If you submit with multiple accounts, switching between them with the rubric and files panels active should automatically open the PDF to the correct page after the rubric component is opened.

