### PR TITLE
[Feature:System] Markdown Login Screen Customization

### DIFF
--- a/site/app/templates/Authentication.twig
+++ b/site/app/templates/Authentication.twig
@@ -1,5 +1,9 @@
 <div class="content shadow" id="login-box">
-    <h1 id="login-guest">Login</h1>
+    <div id="login-guest">
+        {% include "misc/Markdown.twig" with {
+            "content": login_content
+        } only %}
+    </div>
     <!--
     <em>Note: Registered students have not yet been uploaded to the Submitty course databases.  Please check back later.</em>
     -->

--- a/site/app/views/AuthenticationView.php
+++ b/site/app/views/AuthenticationView.php
@@ -2,6 +2,8 @@
 
 namespace app\views;
 
+use app\libraries\FileUtils;
+
 class AuthenticationView extends AbstractView {
     public function loginForm($old = null) {
         if (!isset($old)) {
@@ -11,8 +13,16 @@ class AuthenticationView extends AbstractView {
         $this->core->getOutput()->addInternalCss("links.css");
         $this->core->getOutput()->addInternalCss("authentication.css");
         $this->core->getOutput()->enableMobileViewport();
+
+        $login_content = "# Login";
+        $path = FileUtils::joinPaths($this->core->getConfig()->getConfigPath(), "login.md");
+        if (file_exists($path) && is_readable($path)) {
+            $login_content = file_get_contents($path);
+        }
+
         return $this->core->getOutput()->renderTwigTemplate("Authentication.twig", [
-            "login_url" => $this->core->buildUrl(['authentication', 'check_login']) . '?' . http_build_query(['old' => $old])
+            "login_url" => $this->core->buildUrl(['authentication', 'check_login']) . '?' . http_build_query(['old' => $old]),
+            "login_content" => $login_content
         ]);
     }
 }

--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -242,3 +242,8 @@
 #peer-table th {
     border: 1px solid var(--standard-light-gray);
 }
+
+.markdown img {
+    background-color: white;
+    max-width: 100%;
+}


### PR DESCRIPTION
### What is the current behavior?
There is no way to customize the login screen right now.

### What is the new behavior?
A login.md file can be created inside /usr/local/submitty/config which will be rendered on the login screen. By default `# Login` is rendered but the system administrator can choose to customize this however they like.

### Other information?
Documentation PR: https://github.com/Submitty/submitty.github.io/pull/420