### PR TITLE
[SECURITY][Bugfix:InstructorUI] Validate Autograding Config Path

### DIFF
--- a/site/app/controllers/admin/NotebookBuilderController.php
+++ b/site/app/controllers/admin/NotebookBuilderController.php
@@ -64,7 +64,7 @@ class NotebookBuilderController extends AbstractController {
                 return new RedirectResponse($failure_url);
             }
 
-            $gradeable->setAutogradingConfigPath($config_dir);
+            $gradeable->setAutogradingConfigPath($config_dir, true);
             $this->core->getQueries()->updateGradeable($gradeable);
             $json_path = FileUtils::joinPaths($config_dir, 'config.json');
             file_put_contents($json_path, '{"notebook": [], "testcases": []}');

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -288,7 +288,7 @@ class Gradeable extends AbstractModel {
         }
 
         if ($this->getType() === GradeableType::ELECTRONIC_FILE) {
-            $this->setAutogradingConfigPath($details['autograding_config_path']);
+            $this->setAutogradingConfigPath($details['autograding_config_path'], true);
             $this->setVcs($details['vcs']);
             $this->setVcsSubdirectory($details['vcs_subdirectory']);
             $this->setVcsHostType($details['vcs_host_type']);
@@ -1395,14 +1395,16 @@ class Gradeable extends AbstractModel {
      * Sets the path to the autograding config
      * @param string $path Must not be blank
      */
-    public function setAutogradingConfigPath($path) {
+    public function setAutogradingConfigPath($path, $skip_path_check = false) {
         if ($path === '') {
             throw new \InvalidArgumentException('Autograding configuration file path cannot be blank');
         }
-        $check = $this->checkPath($path);
-        if (!$this->core->isTesting() && is_string($check)) {
-            // String means an error was found
-            throw new \InvalidArgumentException($check);
+        if (!$skip_path_check) {
+            $check = $this->checkPath($path);
+            if (!$this->core->isTesting() && is_string($check)) {
+                // String means an error was found
+                throw new \InvalidArgumentException($check);
+            }
         }
         $this->autograding_config_path = strval($path);
         $this->modified = true;

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -64,15 +64,19 @@
     {% for error_message in repository_error_messages %}
         <div class="config_search_error">({{error_message}})</div>
     {% endfor %}
-    {% if not currently_valid_repository %}
-        <div class="config_search_error"> The current path is not valid, selecting Rebuild Gradeable without changing it will fail.</div>
-    {% endif %}
+
+        <div class="config_search_error" id="autograding_config_error">
+            {% if not currently_valid_repository %}
+                The current path is not valid, selecting Rebuild Gradeable without changing it will fail.
+            {% endif %}
+        </div>
+
 
     <div class="settings">
         <div>
             <div class="drop-down" id="config-drop-down">
                 <input class="config_search ignore drop-down-box" type="text" id="config_search" placeholder="Search for existing configuration" value="{{ gradeable.getAutogradingConfigPath() }}"
-                    autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="autograding configuration">
+                    autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="autograding configuration" name="autograding_config_path_displayed">
                     <div style="margin-left: -45px; position: absolute; display: inline-block; width: auto; transform: translate(0, 25%);">
                         <a class="fas fa-times key_to_click" id= "clear_search_button" style="margin: 0%;" onclick="clearButtonPress();" tabindex="0"></a>
                         <a class="fas fa-chevron-down" style="padding: 0;" id= "drop-down-arrow"></a>
@@ -273,7 +277,7 @@
         let box = $(options).parent().find(".drop-down-box");
         // set the box's value to the text of the option
         $(box).val($(this).text());
-        $(box).trigger("input");
+        $(box).trigger("focusout");
     }
 
     function hideDropDownOptions(){
@@ -302,7 +306,7 @@
 
         // Update the text box when the path config changes
         onConfigPathChange();
-        $('#config_search').on("input", onConfigPathChange);
+        $('#config_search').on("focusout", onConfigPathChange);
 
         $('input[name=student_view_after_grades]').change(function() {
             let elem = $('#yes_student_view');

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -15,6 +15,12 @@ function updateErrorMessage() {
 }
 
 function setError(name, err) {
+    if (name === 'autograding_config_path') {
+        name = 'autograding_config_path_displayed';
+        const error_elem = $('#autograding_config_error');
+        error_elem.text(err);
+        error_elem.show();
+    }
     $('[name="' + name + '"]').each(function (i, elem) {
         elem.title = err;
         elem.setCustomValidity("Invalid field.");
@@ -23,6 +29,12 @@ function setError(name, err) {
 }
 
 function clearError(name, update) {
+    if (name === 'autograding_config_path') {
+        name = 'autograding_config_path_displayed';
+        const error_elem = $('#autograding_config_error');
+        error_elem.text('');
+        error_elem.hide();
+    }
     $('[name="' + name + '"]').each(function (i, elem) {
         elem.title = '';
         elem.setCustomValidity('');
@@ -357,23 +369,23 @@ function ajaxCheckBuildStatus() {
             if (response['data'] == 'queued') {
                 $('#rebuild-status').html(gradeable_id.concat(' is in the rebuild queue...'));
                 $('#rebuild-log-button').css('display','none');
-                $('.config_search_error').hide();
                 setTimeout(ajaxCheckBuildStatus,1000);
             }
             else if (response['data'] == 'processing') {
                 $('#rebuild-status').html(gradeable_id.concat(' is being rebuilt...'));
                 $('#rebuild-log-button').css('display','none');
-                $('.config_search_error').hide();
                 setTimeout(ajaxCheckBuildStatus,1000);
             }
             else if (response['data'] == 'warnings') {
                 $('#rebuild-status').html('Gradeable built with warnings');
             }
             else if (response['data'] == true) {
+                $('.config_search_error').hide();
                 $('#rebuild-status').html('Gradeable build complete');
             }
             else if (response['data'] == false) {
                 $('#rebuild-status').html('Gradeable build failed');
+                $('#autograding_config_error').text('The current path is not valid, selecting Rebuild Gradeable without changing it will fail.');
                 $('.config_search_error').show();
             }
             else {

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -66,6 +66,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
         $this->core = new Core();
         $this->core->setOutput(new NullOutput($this->core));
+        $this->core->setTesting(true);
 
         $this->core->setUser(new User($this->core, [
             'user_id' => 'testUser',

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -721,6 +721,7 @@ class GradeableListTester extends BaseUnitTest {
         ]);
         $core->setUser($user);
         $core->setConfig(new Config($core));
+        $core->setTesting(true);
         return $core;
     }
 


### PR DESCRIPTION
### What is the current behavior?
Right now there is no validation on the provided autograding config path except to check if it's blank.

### What is the new behavior?
This PR adds a check to validate the config path. It will check for the following conditions:

1. The path is a directory
2. The directory contains a config.json
3. The user requesting this build has valid read permissions of that directory

This also modifies the behavior of error handling on the build page to properly display the reason the path is invalid.
