### PR TITLE
[Bugfix:Submission] Fix TAs Submission Type Select

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -45,7 +45,7 @@ class HomeworkView extends AbstractView {
         $is_team_assignment = $gradeable->isTeamAssignment();
 
         if ($this->core->getUser()->accessFullGrading()) {
-            $this->core->getOutput()->addInternalModuleJs('ta-submission.js');
+            $this->core->getOutput()->addInternalModuleJs('grader-submission.js');
         }
 
         // Only show the late banner if the submission has a due date

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -44,8 +44,8 @@ class HomeworkView extends AbstractView {
         $on_team = $this->core->getUser()->onTeam($gradeable->getId());
         $is_team_assignment = $gradeable->isTeamAssignment();
 
-        if ($is_admin) {
-            $this->core->getOutput()->addInternalModuleJs('instructor-submission.js');
+        if ($this->core->getUser()->accessFullGrading()) {
+            $this->core->getOutput()->addInternalModuleJs('ta-submission.js');
         }
 
         // Only show the late banner if the submission has a due date

--- a/site/ts/grader-submission.ts
+++ b/site/ts/grader-submission.ts
@@ -1,5 +1,5 @@
 /**
- * ta-submission.ts contains logic for special submission modes available to TAs and instructors
+ * grader-submission.ts contains logic for special submission modes available to full access graders and instructors
  */
 
 

--- a/site/ts/ta-submission.ts
+++ b/site/ts/ta-submission.ts
@@ -1,5 +1,5 @@
 /**
- * instructor-submission.ts contains logic for special submission modes available to instructors
+ * ta-submission.ts contains logic for special submission modes available to TAs and instructors
  */
 
 


### PR DESCRIPTION
### What is the current behavior?
Full access graders / TAs are shown the option to make a submission for another student or bulk upload but choosing those options does not do anything. The code to make those functional is only sent to instructors.

### What is the new behavior?
The code is now also sent to full access graders. In SubmitBox.twig on line 67, it can be seen that being a full access grader controls whether or not you would receive the submission type buttons.

This PR also renames instructor-submission.ts to ta-submission.ts as the functionality is not limited to instructors only anymore.