### PR TITLE
[Bugfix:System] Patch authentication.json

### DIFF
--- a/migration/migrator/migrations/system/20220417174632_patch_authentication_method.py
+++ b/migration/migrator/migrations/system/20220417174632_patch_authentication_method.py
@@ -12,7 +12,7 @@ def up(config):
     authentication_file = config.config_path / 'authentication.json'
     with authentication_file.open('r+') as auth_file:
         auth_info = json.load(auth_file, object_pairs_hook=OrderedDict)
-        if auth_info['ldap_options'] == []:
+        if not isinstance(auth_info['ldap_options'], dict):
             auth_info['ldap_options'] = {}
             auth_file.seek(0)
             auth_file.truncate()

--- a/migration/migrator/migrations/system/20220417174632_patch_authentication_method.py
+++ b/migration/migrator/migrations/system/20220417174632_patch_authentication_method.py
@@ -1,0 +1,29 @@
+"""Migration for the Submitty system."""
+from collections import OrderedDict
+import json
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    authentication_file = config.config_path / 'authentication.json'
+    with authentication_file.open('r+') as auth_file:
+        auth_info = json.load(auth_file, object_pairs_hook=OrderedDict)
+        if auth_info['ldap_options'] == []:
+            auth_info['ldap_options'] = {}
+            auth_file.seek(0)
+            auth_file.truncate()
+            auth_file.write(json.dumps(auth_info, indent=4))
+
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    pass


### PR DESCRIPTION
### What is the current behavior?
Running CONFIGURE_SUBMITTY.py on older systems may crash. (Specifically any system created before PR mentioned below that is running up to date code)

PR #7444 contained a migration which moved the authentication method into authentication.json and added an ldap_options field. This migration set the default value of ldap_options to [] when it should have been {} because CONFIGURE_SUBMITTY.py expects ldap_options to be a dictionary rather than a list.

### What is the new behavior?
CONFIGURE_SUBMITTY.py does not crash.

This PR adds a system migration to check if [] is the value of ldap_options in authentication.json and if so, changes it to {}. When CONFIGURE_SUBMITTY.py gets run, the url, uid, and bind values would get filled in.

### Other information?
Another option besides this migration could be to modify the CONFIGURE_SUBMITTY.py script to check for [] and change it to a {} but we would always have to keep that code there for backwards compatability. So I think this PR is the better option.
