### PR TITLE
[Bugfix:InstructorUI] Fix error when adding new component

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1792,7 +1792,7 @@ function onAddComponent(peer) {
             alert('Failed to add component! ' + err.message);
         })
         .then(function () {
-            return closeAllComponents(true);
+            return closeAllComponents(true, true);
         })
         .then(function () {
           return reloadInstructorEditRubric(getGradeableId(), isItempoolAvailable(), getItempoolOptions());


### PR DESCRIPTION
### What is the current behavior?
When adding a new component to an electronic gradeable, an error is thrown. Refreshing the page shows the component.

### What is the new behavior?
An error is no longer thrown when adding a new component to an electronic gradeable.

### Other information?
To reproduce this issue:

1. Login as instructor
2. Go to the sample course
3. Under the gradeable section, click the edit gradeable button (pencil icon) next to `Open Homework`.
4. Click on the Rubric tab
5. Click `Add New Component`
