### PR TITLE
[Bugfix:TAGrading] Fix Grade Button Without Release Date

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -696,12 +696,13 @@ class NavigationView extends AbstractView {
                 $date_text = 'grades due ';
                 $date_time = $gradeable->getGradeDueDate();
             }
+            elseif ($list_section === GradeableList::GRADING && !$gradeable->hasReleaseDate()) {
+                $title = 'GRADE';
+            }
             elseif ($list_section === GradeableList::GRADING && $date < $grades_released) {
                 $title = 'GRADE';
-                if ($gradeable->hasReleaseDate()) {
-                    $date_text = 'grades will be released ';
-                    $date_time = $grades_released;
-                }
+                $date_text = 'grades will be released ';
+                $date_time = $grades_released;
             }
             else {
                 $title = 'REGRADE';

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -698,8 +698,10 @@ class NavigationView extends AbstractView {
             }
             elseif ($list_section === GradeableList::GRADING && $date < $grades_released) {
                 $title = 'GRADE';
-                $date_text = 'grades will be released ';
-                $date_time = $grades_released;
+                if ($gradeable->hasReleaseDate()) {
+                    $date_text = 'grades will be released ';
+                    $date_time = $grades_released;
+                }
             }
             else {
                 $title = 'REGRADE';


### PR DESCRIPTION
### What is the current behavior?
When on the gradeables page as a grader, the grade button for an assignment without a release date will still show the database's release date value.
![image](https://user-images.githubusercontent.com/55092742/165870387-a07e20d2-2237-437e-9115-a510447ad9a0.png)

### What is the new behavior?
The button will only say grade if the gradeable has no release date.