### PR TITLE
[UI/UX:Plagiarism] Change text on config form button

### DIFF
--- a/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
+++ b/site/app/templates/plagiarism/PlagiarismConfigurationForm.twig
@@ -226,7 +226,7 @@
             <hr/>
             <div>
                 <a href="{{ plagiarism_link }}" class="btn btn-danger">Cancel</a>
-                <input id="submit-form" class="btn btn-primary" type="submit" value="{% if new_or_edit == "new" %} Create {% else %} Save {% endif %} Configuration"/>
+                <input id="submit-form" class="btn btn-primary" type="submit" value="{% if new_or_edit == "new" %} Create {% else %} Save {% endif %} and Run Configuration"/>
             </div>
         </form>
     </div>


### PR DESCRIPTION
This PR changes the text on the "submit" button of the configuration form for plagiarism, to clarify that submitting will trigger a new run for the new or edited configuration.