### PR TITLE
[Bugfix:Plagiarism] Fix other gradeables dropdown bug

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -874,7 +874,7 @@ class PlagiarismController extends AbstractController {
                     }
                 }
 
-                if (isset($_POST["other-gradeable-paths"])) {
+                if (isset($_POST["other-gradeable-paths"]) && $_POST["other-gradeable-paths"] !== "") {
                     $paths = explode(",", $_POST["other-gradeable-paths"]);
                     $other_gradeable_paths = [];
                     foreach ($paths as $path) {


### PR DESCRIPTION
### What is the current behavior?
The "other gradeables" feature of the plagiarism detection interface currently displays an error when you attempt to add an "other gradeable" via the dropdown menus.  This is due to a faulty assumption about how PHP's `explode()` function works.  

### What is the new behavior?
Fixes the bug.  Other gradeables can now be added via either the dropdowns or the manual gradeable path entry field.
