### PR TITLE
[Bugfix:InstructorUI] Fix rainbow grades link

### DIFF
--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -240,8 +240,8 @@
                 <span class="option-alt">
                     Show Rainbow Grades summaries to students.
                     <strong>Note:</strong>
-                    <a target=_blank href="http://submitty.org/instructor/rainbow_grades/">
-                    You must manually run rainbow grades. <i style="font-style:normal;" class="fa-question-circle"></i></a>
+                    <a target=_blank href="https://submitty.org/instructor/course_settings/rainbow_grades/index">
+                    You must configure rainbow grades first. <i style="font-style:normal;" class="fa-question-circle"></i></a>
                 </span>
             </label>
         </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
Broken link on course settings page for rainbow grades

### What is the new behavior?
Fixes link to point to overview section of rainbow grades, changes wording since automatic configuration is an option 

### Other information?
N/A
