### PR TITLE
[Bugfix:InstructorUI] Fixed Hard Coded colors

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -947,7 +947,7 @@ function numericSocketHandler(elem_id, anon_id, value, total) {
     elem.data('origval', value);
     elem.attr('data-origval', value);
     elem.val(value);
-    elem.css("background-color", "white");
+    elem.css("background-color", "--always-default-white");
     if(value == 0) {
       elem.css("color", "--standard-light-medium-gray");
     }

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -417,7 +417,7 @@ function setupNumericTextCells() {
             return;
         }
         if(this.value == 0) {
-            elem.css("color", "#bbbbbb");
+            elem.css("color", "--standard-light-medium-gray");
         }
         else{
             elem.css("color", "");
@@ -554,14 +554,14 @@ function setupNumericTextCells() {
                                                 let elem = $('#cell-'+$(this).parent().parent().data("section")+'-'+$(this).parent().data("row")+'-'+(z-starting_index2));
                                                 elem.val(returned_data['data'][x][value_temp_str]);
                                                 if (returned_data['data'][x][status_temp_str] === "OK") {
-                                                    elem.css("background-color", "#ffffff");
+                                                    elem.css("background-color", "--main-body-white");
                                                 }
                                                 else {
                                                     elem.css("background-color", "#ff7777");
                                                 }
 
                                                 if(elem.val() == 0) {
-                                                    elem.css("color", "#bbbbbb");
+                                                    elem.css("color", "--standard-light-medium-gray");
                                                 }
                                                 else {
                                                     elem.css("color", "");
@@ -949,7 +949,7 @@ function numericSocketHandler(elem_id, anon_id, value, total) {
     elem.val(value);
     elem.css("background-color", "white");
     if(value == 0) {
-      elem.css("color", "#bbbbbb");
+      elem.css("color", "--standard-light-medium-gray");
     }
     else{
       elem.css("color", "");

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -463,7 +463,7 @@ function setupNumericTextCells() {
               window.socketClient.send({'type': "update_numeric", 'elem': split_id[3], 'user': row_el.data("anon"), 'value': value, 'total': total});
             },
             function() {
-                elem.css("background-color", "#ff7777");
+                elem.css("background-color", "--standard-light-pink");
             }
         );
     });
@@ -557,7 +557,7 @@ function setupNumericTextCells() {
                                                     elem.css("background-color", "--main-body-white");
                                                 }
                                                 else {
-                                                    elem.css("background-color", "#ff7777");
+                                                    elem.css("background-color", "--standard-light-pink");
                                                 }
 
                                                 if(elem.val() == 0) {


### PR DESCRIPTION
### What is the current behavior?
Fixes #7568  : Colors are hard coded  for numeric gradeables instead of using 'colors.css'. This mainly causes problems with the dark mode version of the site. 

### What is the new behavior?
Standard names for the colors are used as described in colors.css instead of hashcodes , also the color '#ff7777'(not available in colors.css) is replaced with '#ff9999'(available in colors.css).

