### PR TITLE
[Feature:System] Add Websocket Error Logging

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -263,6 +263,7 @@ if [ "${WORKER}" == 0 ]; then
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/bulk_uploads
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/emails
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/site_errors
+    mkdir -p ${SUBMITTY_DATA_DIR}/logs/socket_errors
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/ta_grading
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/course_creation
     mkdir -p ${SUBMITTY_DATA_DIR}/logs/vcs_generation
@@ -305,6 +306,7 @@ if [ "${WORKER}" == 0 ]; then
     chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/course_creation
     chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/rainbow_grades
     chown  -R ${PHP_USER}:${COURSE_BUILDERS_GROUP}    ${SUBMITTY_DATA_DIR}/logs/site_errors
+    chown  -R ${PHP_USER}:${COURSE_BUILDERS_GROUP}    ${SUBMITTY_DATA_DIR}/logs/socket_errors
     chown  -R ${PHP_USER}:${COURSE_BUILDERS_GROUP}    ${SUBMITTY_DATA_DIR}/logs/ta_grading
     chown  -R ${DAEMON_USER}:${COURSE_BUILDERS_GROUP} ${SUBMITTY_DATA_DIR}/logs/vcs_generation
     chown  -R postgres:${DAEMON_GROUP}                ${SUBMITTY_DATA_DIR}/logs/psql

--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace app\libraries\socket;
 
+use app\libraries\FileUtils;
+use app\libraries\Utils;
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
 use app\libraries\Core;
@@ -37,6 +39,30 @@ class Server implements MessageComponentInterface {
         if ($this->core->getConfig()->isDebug()) {
             echo $message . "\n";
         }
+    }
+
+    private function logError(\Throwable $error, ConnectionInterface $conn) {
+        $page = $this->pages[$conn->resourceId] ?? "null";
+
+        $date = getdate(time());
+        $timestamp = Utils::pad($date['hours']) . ":" . Utils::pad($date['minutes']) . ":" . Utils::pad($date['seconds']);
+        $timestamp .= " ";
+        $timestamp .= Utils::pad($date['mon']) . "/" . Utils::pad($date['mday']) . "/" . $date['year'];
+
+        $message  = $timestamp . "\n";
+        $message .= "Message:\n";
+        $message .= $error->getMessage() . "\n\n";
+        $message .= "Stack Trace:\n";
+        $message .= $error->getTraceAsString() . "\n\n";
+        $message .= "Page: " . $page . "\n";
+        $message .= str_repeat("=-", 30) . "=" . "\n";
+
+        $filename = $date['year'] . Utils::pad($date['mon']) . Utils::pad($date['mday']);
+        file_put_contents(
+            FileUtils::joinPaths($this->core->getConfig()->getLogPath(), "socket_errors", "{$filename}.log"),
+            $message,
+            FILE_APPEND | LOCK_EX
+        );
     }
 
     /**
@@ -170,7 +196,7 @@ class Server implements MessageComponentInterface {
             }
         }
         catch (\Throwable $t) {
-            // TODO: Add logging for the message in $t
+            $this->logError($t, $from);
         }
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
When an error or exceptions occurs during a websocket message, there is a try catch where the catch currently does not do anything.
Closes #7862

### What is the new behavior?
The catch now calls a logError function which logs errors in the same manner as regular site errors except it is stored in the socket_errors folder inside /var/local/submitty/logs.

Example exception/error:
<img width="1297" alt="image" src="https://user-images.githubusercontent.com/55092742/168490393-210a3782-04f8-4049-8958-35961bdc006b.png">


### Other information?
Documentation PR: https://github.com/Submitty/submitty.github.io/pull/426
