### PR TITLE
[Bugfix:TAGrading] Lab navigation for checkpoint fix

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -717,6 +717,11 @@ function setupSimpleGrading(action) {
                     }
 
                     if (direction == "down") {
+                        // Check if cell needs to move beyond null section
+                        if (new_selector_array[1] === "") {
+                            break;
+                        }
+
                         // Check if cell needs to move to next section
                         new_selector_array[1] += 1;
                         new_selector_array[2] = 0;

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -648,7 +648,10 @@ function setupSimpleGrading(action) {
         if(prev_cell.length) {
             // ids have the format cell-#SECTION-ROW#-COL#
             var new_selector_array = prev_cell.attr("id").split("-");
-            new_selector_array[1] = parseInt(new_selector_array[1]);
+
+            if (new_selector_array[1].length) {
+                new_selector_array[1] = parseInt(new_selector_array[1]);
+            }
             new_selector_array[2] = parseInt(new_selector_array[2]);
             new_selector_array[3] = parseInt(new_selector_array[3]);
 
@@ -658,10 +661,19 @@ function setupSimpleGrading(action) {
             else if (direction == "left") new_selector_array[3] -= 1;
             else if (direction == "right") new_selector_array[3] += 1;
 
-            // TODO: cannot move to NULL section (all cells with id 'cell--#-#')
             if (new_selector_array[2] < 0 && direction == "up") {
-                // // Selection needs to move to above section, if one exists
                 new_selector_array[2] += 1;
+                // // Selection needs to move to above the null section
+                if (new_selector_array[1] == "") {
+                    new_selector_array[1] = 1;
+                    while (true) {
+                        let temp_cell = $("#" + new_selector_array.join("-"));
+                        if (!temp_cell.length) break;
+                    new_selector_array[1] += 1;
+                    }
+                }
+
+                // // Selection needs to move to above section, if one exists
                 // // Find the previous section visible to the grader
                 while (new_selector_array[1] >= 0) {
                     new_selector_array[1] -= 1;
@@ -690,7 +702,7 @@ function setupSimpleGrading(action) {
             else {
                 // Try once with the new cell generated above, otherwise try moving down to the next section
                 let tries;
-                for (tries = 0; tries < 2; tries++) {
+                for (tries = 0; tries < 3; tries++) {
                     // get new cell
                     var new_cell = $("#" + new_selector_array.join("-"));
                     if (new_cell.length) {
@@ -708,7 +720,9 @@ function setupSimpleGrading(action) {
                         // Check if cell needs to move to next section
                         new_selector_array[1] += 1;
                         new_selector_array[2] = 0;
-                        new_selector_array[3] = 0;
+
+                        // Check if cell needs to move to null section
+                        if (tries == 1 && new_selector_array[1] != "") {new_selector_array[1] = "";}
                     } else break;
                 }
             }
@@ -746,32 +760,10 @@ function setupSimpleGrading(action) {
 
     // register empty function locked event handlers for "enter" so they show up in the hotkeys menu
     registerKeyHandler({name: "Search", code: "Enter", locked: true}, function() {});
-    // make arrow keys in lab section changeable now
-    if(action == 'lab') {
-        registerKeyHandler({name: "Move Right", code: "ArrowRight", locked: false}, function(event) {
-            event.preventDefault();
-            movement("right");
-        });
-        registerKeyHandler({name: "Move Left", code: "ArrowLeft", locked: false}, function(event) {
-            event.preventDefault();
-            movement("left");
-        });
-        registerKeyHandler({name: "Move Up", code: "ArrowUp", locked: false}, function(event) {
-            event.preventDefault();
-            movement("up");
-        });
-        registerKeyHandler({name: "Move Down", code: "ArrowDown", locked: false}, function(event) {
-            event.preventDefault();
-            movement("down");
-        });
-    }
-    //the arrow keys in test section remain unchangeable as setting up other keys will disturb the input
-    else{
-        registerKeyHandler({name: "Move Right", code: "ArrowRight", locked: true}, function() {});
-        registerKeyHandler({name: "Move Left", code: "ArrowLeft", locked: true}, function() {});
-        registerKeyHandler({name: "Move Up", code: "ArrowUp", locked: true}, function() {});
-        registerKeyHandler({name: "Move Down", code: "ArrowDown", locked: true}, function(event) {});
-    }
+    registerKeyHandler({name: "Move Right", code: "ArrowRight", locked: true}, function() {});
+    registerKeyHandler({name: "Move Left", code: "ArrowLeft", locked: true}, function() {});
+    registerKeyHandler({name: "Move Up", code: "ArrowUp", locked: true}, function() {});
+    registerKeyHandler({name: "Move Down", code: "ArrowDown", locked: true}, function() {});
 
     // check if a cell is focused, then update value
     function keySetCurrentCell(event, options) {

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -664,10 +664,10 @@ function setupSimpleGrading(action) {
             if (new_selector_array[2] < 0 && direction == "up") {
                 new_selector_array[2] += 1;
                 // // Selection needs to move to above the null section
-                if (new_selector_array[1] == "") {
+                if (new_selector_array[1] === "") {
                     new_selector_array[1] = 1;
                     while (true) {
-                        let temp_cell = $("#" + new_selector_array.join("-"));
+                        const temp_cell = $("#" + new_selector_array.join("-"));
                         if (!temp_cell.length) break;
                     new_selector_array[1] += 1;
                     }
@@ -722,7 +722,9 @@ function setupSimpleGrading(action) {
                         new_selector_array[2] = 0;
 
                         // Check if cell needs to move to null section
-                        if (tries == 1 && new_selector_array[1] != "") {new_selector_array[1] = "";}
+                        if (tries === 1 && new_selector_array[1] !== "") {
+                            new_selector_array[1] = "";
+                        }
                     } else break;
                 }
             }


### PR DESCRIPTION
### What is the current behavior?
Fixes #7761
If the user tries to navigate vertically with the arrow keys through the lab checkpoints, the selection will move 2 cells at once. The arrow keys also do not work in the null section.

### What is the new behavior?
The arrow keys now correctly move 1 cell at a time when the user wants to navigate vertically. They also function correctly in null sections.

https://user-images.githubusercontent.com/79226246/168719906-8704f0c1-415f-4a53-a6d1-2bb32955a3cc.mp4