### PR TITLE
[Feature:System] Update OS Versions after Installation

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -933,4 +933,10 @@ else
         python3 -u ${SUBMITTY_INSTALL_DIR}/sbin/restart_shipper_and_all_workers.py
         echo -e -n "Done restarting shipper & workers\n\n"
     fi
+
+    # Update OS / Docker versions for all machines
+    echo "Update OS and Docker versions for all machines"
+    DATE_YMD=`date +%Y%m%d`
+    echo -e '{\n  "job": "UpdateDockerImages"\n}' > ${SUBMITTY_DATA_DIR}/daemon_job_queue/docker${DATE_YMD}.json
+    echo "Dispatched version updating job"
 fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -936,7 +936,7 @@ else
 
     # Update OS / Docker versions for all machines
     echo "Update OS and Docker versions for all machines"
-    DATE_YMD=`date +%Y%m%d`
+    DATE_YMD=$(date +%Y%m%d)
     echo -e '{\n  "job": "UpdateDockerImages"\n}' > "${SUBMITTY_DATA_DIR}/daemon_job_queue/docker${DATE_YMD}.json"
     echo "Dispatched version updating job"
 fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -937,6 +937,6 @@ else
     # Update OS / Docker versions for all machines
     echo "Update OS and Docker versions for all machines"
     DATE_YMD=`date +%Y%m%d`
-    echo -e '{\n  "job": "UpdateDockerImages"\n}' > ${SUBMITTY_DATA_DIR}/daemon_job_queue/docker${DATE_YMD}.json
+    echo -e '{\n  "job": "UpdateDockerImages"\n}' > "${SUBMITTY_DATA_DIR}/daemon_job_queue/docker${DATE_YMD}.json"
     echo "Dispatched version updating job"
 fi


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Closes #7744 

Currently, instructors need to manually click “[Update dockers and machines](https://submitty.cs.rpi.edu/admin/update_docker)” button to retrieve the Docker/OS versions.  

### What is the new behavior?

[DockerUI page](https://submitty.cs.rpi.edu/admin/docker) could display the versions after installations and updates.  

### Other information?

This PR changes the [installation script](files).  At the end of the installation/update, it will dispatch a daemon job to update all versions (identical to pushing the update button on the [DockerUI page](https://submitty.cs.rpi.edu/admin/docker)).  

Not sure if this is a good implementation: according to the [original issue](../issues/7744), it should be updated every time the [`update_and_install_workers.py`](../blob/master/sbin/shipper_utils/update_and_install_workers.py) is called.  So far, it is only called by the [installation script](../blob/master/.setup/INSTALL_SUBMITTY_HELPER.sh#L925) and the [DockerUI controller](../blob/master/site/app/controllers/DockerInterfaceController.php#L170).  

