### PR TITLE
[Bugfix:System] Fix Popup Submit on Close

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -10,9 +10,9 @@
                         {% block title_tag %}
                             <h1>{% block title %}Untitled Form{% endblock %}</h1>
                             <button
-                                onclick="closePopup('{{ block('popup_id') }}')"
+                                onclick="{{ block('close_click_action') }}"
                                 class="btn btn-default close-button key_to_click"
-                                tabindex="-1"
+                                tabindex="-1" type="button"
                             >Close</button>
                         {% endblock %}
                     </div>

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -1,5 +1,5 @@
 {# This is the control shown/hidden #}
-<div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;" onclick="closePopup('{{ block('popup_id') }}')">
+<div class="popup-form" id="{% block popup_id %}#popup-form{% endblock %}" style="display: none;" onclick="{{ block('close_click_action') }}">
     {% block form %}
         {# This lets us center the window #}
         <div class="popup-box">


### PR DESCRIPTION
### What is the current behavior?
When pushing the top close button, the form may accidentally submit since the default type of button is usually submit.

This can be seen on the Mange Students / Manage Graders page.

### What is the new behavior?
The type of the button is now button and I also used the block for the close action rather than assuming it will always only just close the popup.
