### PR TITLE
[DevDependency] Add deprecation checker to phpstan

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -120,7 +120,7 @@ jobs:
             - name: Static analysis
               run: |
                   php vendor/bin/phpstan  --version
-                  php vendor/bin/phpstan analyze app
+                  php vendor/bin/phpstan analyze app public
 
 
     php-unit:

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -120,7 +120,7 @@ jobs:
             - name: Static analysis
               run: |
                   php vendor/bin/phpstan  --version
-                  php vendor/bin/phpstan analyze app public
+                  php vendor/bin/phpstan analyze app public/index.php socket/index.php
 
 
     php-unit:

--- a/site/composer.json
+++ b/site/composer.json
@@ -43,12 +43,13 @@
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
     "php-mock/php-mock-phpunit": "2.6.0",
     "phpstan/phpstan": "1.6.8",
+    "phpstan/phpstan-deprecation-rules": "1.0",
     "phpunit/phpunit": "8.5.26",
     "submitty/php-codesniffer": "2.5.0"
   },
   "scripts": {
     "test": "phpunit",
     "lint": "phpcs",
-    "static-analysis": "phpstan analyze app"
+    "static-analysis": "phpstan analyze app public"
   }
 }

--- a/site/composer.json
+++ b/site/composer.json
@@ -50,6 +50,6 @@
   "scripts": {
     "test": "phpunit",
     "lint": "phpcs",
-    "static-analysis": "phpstan analyze app public"
+    "static-analysis": "phpstan analyze app public/index.php socket/index.php"
   }
 }

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da0d4ec5c364889538f5b1813dea676b",
+    "content-hash": "be3b3a8bb445b1565a0d4489432b6bc7",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -5241,6 +5241,56 @@
                 }
             ],
             "time": "2022-05-10T06:54:21+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "e5ccafb0dd8d835dd65d8d7a1a0d2b1b75414682"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/e5ccafb0dd8d835dd65d8d7a1a0d2b1b75414682",
+                "reference": "e5ccafb0dd8d835dd65d8d7a1a0d2b1b75414682",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.0.0"
+            },
+            "time": "2021-09-23T11:02:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -11,6 +11,30 @@ parameters:
 			path: app/controllers/AbstractController.php
 
 		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 13
+			path: app/controllers/AuthenticationController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/AuthenticationController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/AuthenticationController.php
+
+		-
 			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
 			count: 2
 			path: app/controllers/AuthenticationController.php
@@ -26,6 +50,22 @@ parameters:
 			path: app/controllers/GlobalController.php
 
 		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/HomePageController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/HomePageController.php
+
+		-
 			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
 			count: 4
 			path: app/controllers/HomePageController.php
@@ -36,14 +76,142 @@ parameters:
 			path: app/controllers/HomePageController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
-			count: 1
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 3
 			path: app/controllers/MiscController.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
 			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/NotificationController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 3
+			path: app/controllers/NotificationController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/NotificationController.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 41
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 5
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 28
+			path: app/controllers/PollController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 7
+			path: app/controllers/PollController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/UserProfileController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
+			count: 1
 			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/admin/AutogradingConfigController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/admin/AutogradingConfigController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/admin/AutogradingConfigController.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 9
+			path: app/controllers/admin/ConfigurationController.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 18
+			path: app/controllers/admin/LateController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/admin/LateController.php
 
 		-
 			message: "#^Negated boolean expression is always true\\.$#"
@@ -59,6 +227,46 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between mixed and '' will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 2
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 7
+			path: app/controllers/admin/WrapperController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 3
+			path: app/controllers/admin/WrapperController.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between array\\<int, app\\\\entities\\\\course\\\\CourseMaterial\\> and null will always evaluate to false\\.$#"
@@ -86,9 +294,49 @@ parameters:
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 10
+			path: app/controllers/grading/SimpleGraderController.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 4
+			path: app/controllers/grading/SimpleGraderController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 4
+			path: app/controllers/grading/SimpleGraderController.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/grading/SimpleGraderController.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 11
+			path: app/controllers/student/GradeInquiryController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/student/GradeInquiryController.php
 
 		-
 			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
@@ -109,6 +357,14 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: """
+				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return WebResponse directly$#
+			"""
+			count: 1
+			path: app/controllers/superuser/SuperuserEmailController.php
 
 		-
 			message: "#^Property app\\\\entities\\\\email\\\\EmailEntity\\:\\:\\$body is never written, only read\\.$#"
@@ -174,6 +430,14 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 2
 			path: app/libraries/Access.php
+
+		-
+			message: """
+				#^Casting class Lcobucci\\\\JWT\\\\Token to string is deprecated\\.\\:
+				This method has been removed from the interface in v4\\.0$#
+			"""
+			count: 3
+			path: app/libraries/Core.php
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
@@ -269,6 +533,22 @@ parameters:
 			message: "#^PHPDoc tag @var for constant app\\\\libraries\\\\plagiarism\\\\PlagiarismUtils\\:\\:SUPPORTED_LANGUAGES with type int is incompatible with value array\\{plaintext\\: array\\{hash_size\\: 14\\}, python\\: array\\{hash_size\\: 14\\}, java\\: array\\{hash_size\\: 14\\}, cpp\\: array\\{hash_size\\: 14\\}, mips\\: array\\{hash_size\\: 5\\}\\}\\.$#"
 			count: 1
 			path: app/libraries/plagiarism/PlagiarismUtils.php
+
+		-
+			message: """
+				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return JsonResponse directly$#
+			"""
+			count: 3
+			path: app/libraries/routers/WebRouter.php
+
+		-
+			message: """
+				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
+				should not be used, just return RedirectResponse directly$#
+			"""
+			count: 7
+			path: app/libraries/routers/WebRouter.php
 
 		-
 			message: "#^Instanceof between bool and app\\\\libraries\\\\response\\\\WebResponse will always evaluate to false\\.$#"
@@ -549,4 +829,13 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/views/submission/HomeworkView.php
+
+		-
+			message: """
+				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
+				This method is deprecated and will be removed in
+				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
+			"""
+			count: 1
+			path: public/index.php
 

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - %rootDir%/../../../phpstan-baseline.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
     ignoreErrors:


### PR DESCRIPTION
### What is the current behavior?
Right now if a PHP library were to get updated and deprecate something that we use, we would have no idea in without looking at the library updates carefully.

An example of this is: https://github.com/Submitty/Submitty/pull/7870
I plan to test this on that PR to make sure it reports a failure in the phpstan test.

### What is the new behavior?
A deprecated checker library was added that extends upon phpstan to look for any deprecations within our codebase. If there is a new deprecation the test will fail.

This PR does NOT update any current deprecations but it does update the baseline so that phpstan will continue to pass. Most of the current deprecations are from our MultiResponse but a few are from some dependencies. These can be fixed in future PRs and the baseline can be updated.

Also the phpstan command was updated to contain the index.php inside of both public and socket directories.

### Other information?
This PR only contains changes to developer related files so it should not affect any production related features.

The only documentation I might need to change is how to run the tests as this adds 2 more arguments to the phpstan command if we keep them. If this is merged as is or without changing that then I'll make a documentation PR on that.