### PR TITLE
[Refactor:Developer] Mark Ubuntu 18.04 as unsupported

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -1,6 +1,6 @@
 name: Vagrant Up
 
-on: 
+on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -11,12 +11,10 @@ permissions:
 jobs:
   vagrant-up:
     runs-on: macos-10.15
-    
+
     strategy:
       matrix:
         include:
-          - image: ubuntu-18.04
-            port: 1501
           - image: ubuntu-20.04
             port: 1511
       fail-fast: false

--- a/.setup/distro_setup/debian/8/setup_distro.sh
+++ b/.setup/distro_setup/debian/8/setup_distro.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 #####################################################################
-#            DEPRECATED
+#            UNSUPPORTED
 #
-# Support for Debian 8 (jessie) is deprecated as of 05/01/2019.
+# Support for Debian 8 (jessie) is unsupported as of 05/01/2019.
 # This script has not been maintained since then and we will not
 # accept PRs fixing any drift that exists. Use at your own risk.
 #

--- a/.setup/distro_setup/ubuntu/16.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/16.04/setup_distro.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 #####################################################################
-#            DEPRECATED
+#            UNSUPPORTED
 #
-# Support for Ubuntu 16.04 (xenial) is deprecated as of 05/01/2019.
+# Support for Ubuntu 16.04 (xenial) is unsupported as of 05/01/2019.
 # This script has not been maintained since then and we will not
 # accept PRs fixing any drift that exists. Use at your own risk.
 #

--- a/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/18.04/setup_distro.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+#####################################################################
+#            UNSUPPORTED
+#
+# Support for Ubuntu 18.04 (bionic) is unsupported as of 06/01/2022.
+# This script has not been maintained since then and we will not
+# accept PRs fixing any drift that exists. Use at your own risk.
+#
+# To see the officially supported distros, please go to:
+#     https://submitty.org/sysadmin/server_os
+#
+#####################################################################
+
 # this script must be run by root or sudo
 if [[ "$UID" -ne "0" ]] ; then
     echo "ERROR: This script must be run by root or sudo"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,16 +104,6 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.provision 'shell', inline: $script
   end
 
-  # Deprecated: This will be removed in the future and should not be relied upon.
-  # Note: This box is not compatible with macos M1
-  config.vm.define 'ubuntu-18.04', autostart: false do |ubuntu|
-    ubuntu.vm.box = 'bento/ubuntu-18.04'
-    ubuntu.vm.network 'forwarded_port', guest: 1501, host: 1501   # site
-    ubuntu.vm.network 'forwarded_port', guest: 8433, host: 8433   # Websockets
-    ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16432  # database
-    ubuntu.vm.provision 'shell', inline: $script
-  end
-
   config.vm.provider 'virtualbox' do |vb, override|
     vb.memory = 2048
     vb.cpus = 2


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We currently mark Ubuntu 18.04 as being supported for running Submitty. This version of Ubuntu has a number of old packages (e.g. pip) that prevent us from keeping some stuff about the project up-to-date, as well as use newer language features. 

### What is the new behavior?

Running Submitty on Ubuntu 18.04 is now considered unsupported and a "at your own risk". Once we do stuff like update some pip dependencies, it will be definitely broken out of the box. I believe all RPI machines at this point have moved to 20.04, so this shouldn't break anything for us, and at this point, there's been plenty of time to update to 20.04 for any interested parties. This would ideally go hand in hand with supporting 22.04 in the near future.