### PR TITLE
[Feature:System] Websocket Self Healing

### DIFF
--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace app\libraries\socket;
 
+use app\exceptions\DatabaseException;
 use app\libraries\FileUtils;
 use app\libraries\Utils;
 use Ratchet\MessageComponentInterface;
@@ -150,8 +151,24 @@ class Server implements MessageComponentInterface {
      * Check the authentication status of the connection when it gets opened
      */
     public function onOpen(ConnectionInterface $conn): void {
-        if (!$this->checkAuth($conn)) {
-            $conn->close();
+        try {
+            if (!$this->checkAuth($conn)) {
+                $conn->close();
+            }
+        }
+        catch (DatabaseException $de) {
+            try {
+                $this->core->loadMasterDatabase();
+                $this->onOpen($conn);
+            }
+            catch (\Exception $e) {
+                $this->logError($de, $conn);
+                $this->closeWithError($conn);
+            }
+        }
+        catch (\Throwable $t) {
+            $this->logError($t, $conn);
+            $this->closeWithError($conn);
         }
     }
 
@@ -220,6 +237,12 @@ class Server implements MessageComponentInterface {
                 unset($this->users[$user_id]);
             }
         }
+    }
+
+    public function closeWithError(ConnectionInterface $conn): void {
+        $msg = ['error' => 'Server error'];
+        $conn->send(json_encode($msg));
+        $conn->close();
     }
 
     /**


### PR DESCRIPTION
### What is the current behavior?
If the database is restarted while the socket server is running the socket server won't be able to make any database queries and rejects all requests to connect.

### What is the new behavior?
If an exception is thrown in the onOpen function and it is of type DatabaseException then an attempt will be made to reconnect to the database server.

I also made it so the socket error message banner appears if the server has an error rather than making it seem like everything is still normal on the page.
