### PR TITLE
[Bugfix:Notifications] Secondary email notification fix

### DIFF
--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -176,7 +176,7 @@ class UserProfileController extends AbstractController {
         if (isset($_POST['secondary_email']) && isset($_POST['secondary_email_notify'])) {
             $secondaryEmail = trim($_POST['secondary_email']);
             $secondaryEmailNotify = trim($_POST['secondary_email_notify']) === "true";
-            if ((!$secondaryEmailNotify && $secondaryEmail == "") || (!(($secondaryEmail == "") && $secondaryEmailNotify)) && ($user->validateUserData('user_email_secondary', $secondaryEmail) === true)) {
+            if (((!$secondaryEmailNotify && $secondaryEmail == "")) || (($user->validateUserData('user_email_secondary', $secondaryEmail) === true) && !($secondaryEmail == ""))) {
                 $user->setSecondaryEmail($secondaryEmail);
                 $user->setEmailBoth($secondaryEmailNotify);
                 $this->core->getQueries()->updateUser($user);
@@ -187,7 +187,7 @@ class UserProfileController extends AbstractController {
                 ]);
             }
             else {
-                if (($secondaryEmail == "") && $secondaryEmailNotify) {
+                if ($secondaryEmail == "") {
                     return JsonResponse::getErrorResponse("Secondary email can't be empty if secondary email notify is true");
                 }
                 return JsonResponse::getErrorResponse("Secondary email address must be a valid email");

--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -176,7 +176,7 @@ class UserProfileController extends AbstractController {
         if (isset($_POST['secondary_email']) && isset($_POST['secondary_email_notify'])) {
             $secondaryEmail = trim($_POST['secondary_email']);
             $secondaryEmailNotify = trim($_POST['secondary_email_notify']) === "true";
-            if ((!$secondaryEmailNotify && $secondaryEmail == "") || (($user->validateUserData('user_email_secondary', $secondaryEmail) === true) && !(($secondaryEmail == "") && $secondaryEmailNotify))) {
+            if ((!$secondaryEmailNotify && $secondaryEmail == "") || (!(($secondaryEmail == "") && $secondaryEmailNotify)) && ($user->validateUserData('user_email_secondary', $secondaryEmail) === true)) {
                 $user->setSecondaryEmail($secondaryEmail);
                 $user->setEmailBoth($secondaryEmailNotify);
                 $this->core->getQueries()->updateUser($user);

--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -176,8 +176,7 @@ class UserProfileController extends AbstractController {
         if (isset($_POST['secondary_email']) && isset($_POST['secondary_email_notify'])) {
             $secondaryEmail = trim($_POST['secondary_email']);
             $secondaryEmailNotify = trim($_POST['secondary_email_notify']) === "true";
-
-            if ((!$secondaryEmailNotify && $secondaryEmail == "") || $user->validateUserData('user_email_secondary', $secondaryEmail) === true) {
+            if ((!$secondaryEmailNotify && $secondaryEmail == "") || (($user->validateUserData('user_email_secondary', $secondaryEmail) === true) && !(($secondaryEmail == "") && $secondaryEmailNotify))) {
                 $user->setSecondaryEmail($secondaryEmail);
                 $user->setEmailBoth($secondaryEmailNotify);
                 $this->core->getQueries()->updateUser($user);
@@ -188,6 +187,9 @@ class UserProfileController extends AbstractController {
                 ]);
             }
             else {
+                if (($secondaryEmail == "") && $secondaryEmailNotify) {
+                    return JsonResponse::getErrorResponse("Secondary email can't be empty if secondary email notify is true");
+                }
                 return JsonResponse::getErrorResponse("Secondary email address must be a valid email");
             }
         }

--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -176,7 +176,7 @@ class UserProfileController extends AbstractController {
         if (isset($_POST['secondary_email']) && isset($_POST['secondary_email_notify'])) {
             $secondaryEmail = trim($_POST['secondary_email']);
             $secondaryEmailNotify = trim($_POST['secondary_email_notify']) === "true";
-            if (((!$secondaryEmailNotify && $secondaryEmail == "")) || (($user->validateUserData('user_email_secondary', $secondaryEmail) === true) && !($secondaryEmail == ""))) {
+            if ((!$secondaryEmailNotify && $secondaryEmail === "") || (($secondaryEmail !== "") && $user->validateUserData('user_email_secondary', $secondaryEmail) === true)) {
                 $user->setSecondaryEmail($secondaryEmail);
                 $user->setEmailBoth($secondaryEmailNotify);
                 $this->core->getQueries()->updateUser($user);
@@ -187,7 +187,7 @@ class UserProfileController extends AbstractController {
                 ]);
             }
             else {
-                if ($secondaryEmail == "") {
+                if ($secondaryEmail === "") {
                     return JsonResponse::getErrorResponse("Secondary email can't be empty if secondary email notify is true");
                 }
                 return JsonResponse::getErrorResponse("Secondary email address must be a valid email");


### PR DESCRIPTION
### What is the current behavior?
Fixes #7959 
"Send Email to Secondary Address" can be set to true in the user profile even if secondary email address is empty, this is something that UI prevents from happening but a crafted request can lead to this unexpected behavior.

### What is the new behavior?
Doing so now results in error "Secondary email can't be empty if secondary email notify is true".
