### PR TITLE
[Bugfix:Submission] Fix Git authentication tokens URL

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -506,7 +506,7 @@ class HomeworkView extends AbstractView {
             'can_student_submit' => $canStudentSubmit,
             'is_grader_view' => false,
             'recent_version_url' => $recent_version_url,
-            'git_auth_token_url' => $this->core->buildUrl(['git_auth_tokens']),
+            'git_auth_token_url' => $this->core->buildUrl(['authentication_tokens']),
             'git_auth_token_required' => false
         ]);
     }

--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -45,7 +45,7 @@ class TeamView extends AbstractView {
             "set_message_url" => $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'team', 'seek', 'message']),
             "remove_message_url" => $this->core->buildCourseUrl(['gradeable', $gradeable_id, 'team', 'seek', 'message', 'remove']),
             "csrf_token" => $this->core->getCsrfToken(),
-            'git_auth_token_url' => $this->core->buildUrl(['git_auth_tokens']),
+            'git_auth_token_url' => $this->core->buildUrl(['authentication_tokens']),
             'git_auth_token_required' => false
         ]);
     }


### PR DESCRIPTION
### What is the current behavior?
The "Create and Manage Git Auth Tokens" button is currently broken.

![image](https://user-images.githubusercontent.com/16820599/171028894-de8d3c60-78c3-4e9a-85d1-673e065e9b27.png)


### What is the new behavior?
This PR fixes the URL to point to the correct page.
