### PR TITLE
[UI/UX:Submission] Change "Grade My Repository" button color

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -170,7 +170,14 @@
             {% endif %}
 
         {% endif %}
-        <input type="submit" id="submit" class="submit-gradeable btn btn-primary" value="Grade My Repository" />
+
+        <h3>Grade your repository:</h3>
+        <div class="upload-message">
+            {% include "misc/Markdown.twig" with {
+                "content" : upload_message
+            } only %}
+        </div>
+        <input type="submit" id="submit" class="submit-gradeable btn btn-success" value="Grade My Repository" />
     {% else %}
 
     {% if is_notebook %}

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -146,12 +146,12 @@
             <span><em>Note: There may be a delay before your repository is prepared, please refer to assignment instructions.</em></span><br />
             <samp>git  clone  {{ repository_path }}  SPECIFY_TARGET_DIRECTORY</samp>
             {# Below will get uncommented once SAML is active #}
-            {# <p>You will need to use a Git auth token.</p> #}
+            {# <p>You will need to use a Git Authentication Token.</p> #}
             <br><br>
             {% if git_auth_token_required %}
-                <span>Note: Your school requires that you use Git Auth Tokens.</span><br>
+                <span>Note: Your school requires that you use Git Authentication Tokens.</span><br>
             {% endif %}
-            <a href="{{ git_auth_token_url }}" class="btn btn-primary">Create and Manage Git Auth Tokens</a>
+            <a href="{{ git_auth_token_url }}" class="btn btn-primary">Manage Authentication Tokens</a>
             <br><br>
         {% endif %}
 


### PR DESCRIPTION
### What is the current behavior?
The Git submission interface is currently somewhat confusing.  The "Grade My Repository" and "Create and Manage Git Auth Tokens" buttons are both primary buttons, and are close to each other.

![image](https://user-images.githubusercontent.com/16820599/171032230-4b49e403-e5a3-4bed-b041-d28fd4528319.png)


### What is the new behavior?
The "Grade My Repository" button has been changed to a green color to match the style of the "Submit" button for regular gradeables.  Additionally, the "upload message" seen on regular upload gradeables has been added along with a small heading to further clarify the interface.  The words on the authentication tokens button have also been adjusted.

![image](https://user-images.githubusercontent.com/16820599/171032613-d545507c-2ba0-4705-9e3a-c298be91dc27.png)

