### PR TITLE
[Bugfix:InstructorUI] Fixed Edit Gradeables page

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -27,7 +27,7 @@ main#main.full-screen-mode .content {
 
 #wrapper {
     padding-top: 30px;
-    min-height: 0;
+    min-height: max-content;
 }
 
 aside {

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -26,7 +26,6 @@ main#main.full-screen-mode .content {
 }
 
 #wrapper {
-    padding-top: 30px;
     min-height: max-content;
 }
 

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -111,6 +111,7 @@ nav a > i.f {
 #wrapper {
     display: flex;
     flex-grow: 1;
+    min-height: max-content;
 }
 
 main {


### PR DESCRIPTION
### What is the current behavior?
Fixes #6859, Earlier on create/edit gradeable page the side navigation panel contained scroll and if the content on the page increased in the size then the footer went hidden under the content.

### What is the new behavior?
The scroll from the side navigation is removed and is made consistent with general user interface of the application.

### Other information?
Here is the screenshot for same
![image](https://user-images.githubusercontent.com/92226302/171448817-f7bf5627-0fde-4b29-854f-e614487664d7.png)

