### PR TITLE
[Bugfix:RainbowGrades] Rainbow Grades Post Request Fix

### DIFF
--- a/sbin/generate_grade_summaries.py
+++ b/sbin/generate_grade_summaries.py
@@ -29,7 +29,7 @@ def main():
 
     try:
         grade_generation_response = requests.post(
-            '{}/api/{}/{}/reports/summaries'.format(
+            '{}/api/courses/{}/{}/reports/summaries'.format(
                 base_url, semester, course
             ),
             headers={'Authorization': token}

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -72,7 +72,7 @@ class WebRouter {
             $max_post_bytes = Utils::returnBytes($max_post_length);
             /** if a post request exceeds the max length set in the ini, php will drop everything set under $_POST, however the router might add routing information later so check both cases
             */
-            if (($max_post_bytes > 0 && $_SERVER["CONTENT_LENGTH"] >= $max_post_bytes) || empty($_POST)) {
+            if ($max_post_bytes > 0 && $_SERVER["CONTENT_LENGTH"] >= $max_post_bytes) {
                 $msg = "POST request exceeds maximum size of " . $max_post_length;
                 $this->core->addErrorMessage($msg);
 

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -63,7 +63,7 @@ class WebRouter {
 
 
     /**
-     * If a request is a post request check to see if its less than the post_max_size or if its empty
+     * If a request is a post request check to see if its less than the post_max_size
      * @return MultiResponse|bool
      */
     private function checkPostMaxSize(Request $request) {

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -227,12 +227,5 @@ class WebRouterTester extends BaseUnitTest {
         $this->assertEquals($expected, $response->json_response->json);
         $response = WebRouter::getWebResponse($web_request, $core);
         $this->assertEquals($expected, $response->json_response->json);
-
-        $_SERVER["CONTENT_LENGTH"] = 0;
-        $_POST = [];
-        $response = WebRouter::getApiResponse($request, $core);
-        $this->assertEquals($expected, $response->json_response->json);
-        $response = WebRouter::getWebResponse($web_request, $core);
-        $this->assertEquals($expected, $response->json_response->json);
     }
 }


### PR DESCRIPTION
### What is the current behavior?
If you try to run rainbow grades on the website you will get the following error:
![image](https://user-images.githubusercontent.com/55092742/171525469-d5a586df-e3a0-4a3a-a258-14288d80d016.png)

### What is the new behavior?
The API endpoint URL was incorrect in the code which has been corrected and allows rainbow grades to be generated from the website.

This PR also removes a check from the POST size check that I believe to be unnecessary now. Without this change, the API request fails because it does not send along any POST data.
