### PR TITLE
[Bugfix:InstructorUI] Fixed Textbox not displaying

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -65,12 +65,7 @@
                 <h2>Messages</h2>
                 <div id="cust_messages_collapse" class="collapsible_area">
                     <label for="cust_messages_textarea" class="rg_info_message">You may enter a message that will appear above the student's rainbow grades.</label>
-
-                    {% if 0 in messages|keys %}
-                    <textarea id="cust_messages_textarea">{{ messages[0] }}</textarea>
-                    {% else %}
-                    <textarea id="cust_messages_textarea"></textarea>
-                    {% endif %}
+                    <textarea id="cust_messages_textarea">{% if 0 in messages|keys %}{{ messages[0] }}{% endif %}</textarea>
                 </div>
             </div>
             <div id="section_labels" class="customization_item">

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -65,8 +65,11 @@
                 <h2>Messages</h2>
                 <div id="cust_messages_collapse" class="collapsible_area">
                     <label for="cust_messages_textarea" class="rg_info_message">You may enter a message that will appear above the student's rainbow grades.</label>
+
                     {% if 0 in messages|keys %}
                     <textarea id="cust_messages_textarea">{{ messages[0] }}</textarea>
+                    {% else %}
+                    <textarea ></textarea>
                     {% endif %}
                 </div>
             </div>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -69,7 +69,7 @@
                     {% if 0 in messages|keys %}
                     <textarea id="cust_messages_textarea">{{ messages[0] }}</textarea>
                     {% else %}
-                    <textarea ></textarea>
+                    <textarea id="cust_messages_textarea"></textarea>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION

### What is the current behavior?
Closes #7985 
In instructor UI for a course,
Go to`  "Grade Reports"> "Web-Based Rainbow Grades Generation" > "Messages"'`

In the  section, there should be a form text box allowing you to enter messages, but it is not displayed in the message is currently empty. 

### What is the new behavior?
Empty TextBox is displayed allowing you to add and save the message.
### Other information?
Here is the screenshot for same.

![image](https://user-images.githubusercontent.com/92226302/171697079-5ab020d7-541c-4b7d-b78d-0877ad25f1e6.png)

