### PR TITLE
[Bugfix:System] autoupdate Python dependencies

### DIFF
--- a/.setup/install_submitty/install_bin.sh
+++ b/.setup/install_submitty/install_bin.sh
@@ -99,3 +99,6 @@ if [ -f ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out ]; then
     chmod 550                           ${SUBMITTY_INSTALL_DIR}/bin/system_call_check.out
 fi
 
+
+echo -e "Updating system dependencies"
+bash "${SUBMITTY_REPOSITORY}/.setup/update_system.sh"

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -201,19 +201,6 @@ DATABASE_PASSWORD=submitty_dbuser
 
 source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 
-#################################################################
-# PYTHON PACKAGE SETUP
-#########################
-
-#libraries for QR code processing:
-#install DLL for zbar
-apt-get install libzbar0 --yes
-
-pip3 install -r ${CURRENT_DIR}/pip/system_requirements.txt
-
-if [ ${VAGRANT} == 1 ] && [ ${WORKER} == 0 ] ; then
-    pip3 install -r ${CURRENT_DIR}/pip/vagrant_requirements.txt
-fi
 
 #################################################################
 # Node Package Setup

--- a/.setup/update_system.sh
+++ b/.setup/update_system.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Usage:
+#   update_system.sh
+
+# print commands as we execute and fail early
+set -ev
+
+# this script must be run by root or sudo
+if [[ "$UID" -ne "0" ]] ; then
+    echo "ERROR: This script must be run by root or sudo"
+    exit 1
+fi
+
+
+# PATHS
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONF_DIR="${CURRENT_DIR}/../../../config"
+
+SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
+SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)
+WORKER=$([[ $(jq -r '.worker' ${CONF_DIR}/submitty.json) == "true" ]] && echo 1 || echo 0)
+VAGRANT=0
+
+if [ -d "${CURRENT_DIR}/../.vagrant" ]; then
+    VAGRANT=1
+fi
+
+#libraries for QR code processing:
+#install DLL for zbar
+apt-get install libzbar0 --yes
+
+##source ${CURRENT_DIR}/distro_setup/setup_distro.sh
+
+#################################################################
+# PYTHON PACKAGE SETUP
+#########################
+
+pip3 install -r ${CURRENT_DIR}/pip/system_requirements.txt
+
+if [ ${VAGRANT} == 1 ] && [ ${WORKER} == 0 ] ; then
+    pip3 install -r ${CURRENT_DIR}/pip/vagrant_requirements.txt
+fi
+
+echo "Done."
+exit 0


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant (Will do after review)

### What is the current behavior?
Currently, pip installation that is done in the initial Submitty installation or vagrant up are only ever done once via `install_system.sh`.

### What is the new behavior?
The pip install has been moved out and into their own file called `update_system.sh` which is now invoked with the `INSTALL_SUBMITTY` script 

### Other information?
Currently, I only moved over the pip installation, will look into OS dependencies next and then specific installs like DrMemory, Haskell Stack - etc.

