### PR TITLE
[Dependency] PyPDF2 v2.0.0

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -38,7 +38,7 @@ xlsx2csv==0.7.8
 pause==0.3
 paramiko==2.11.0
 tzlocal==2.1
-PyPDF2==1.28.2
+PyPDF2==2.0.0
 distro==1.7.0
 jsonschema==3.2.0
 jsonref==0.2

--- a/more_autograding_examples/test_notes_upload/config/test_input/separate_pages.py
+++ b/more_autograding_examples/test_notes_upload/config/test_input/separate_pages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 from PyPDF2 import PdfWriter, PdfReader

--- a/more_autograding_examples/test_notes_upload_3page/config/test_input/separate_pages.py
+++ b/more_autograding_examples/test_notes_upload_3page/config/test_input/separate_pages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 from PyPDF2 import PdfWriter, PdfReader


### PR DESCRIPTION
Related to #7982
2.0.0 release of PyPDF2 drops support for Python 3.5 and older.