### PR TITLE
[Bugfix:Forum] Validate Forum Thread IDs

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -916,6 +916,18 @@ class ForumController extends AbstractController {
      * @Route("/courses/{_semester}/{_course}/forum/threads/single", methods={"POST"})
      */
     public function getSingleThread() {
+        // Checks if thread id is null. If so, render "fail" json response case informing that thread id is null.
+        if ($_POST['thread_id'] == null) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NULL ID)", $_POST['thread_id']);
+        }
+        // Checks if thread id is not an integer value. If so, render "fail" json response case informing that thread id is not an integer value.
+        if (!ctype_digit($_POST['thread_id'])) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-INTEGER ID)", $_POST['thread_id']);
+        }
+        // Checks if thread id does not exist. If so, render "fail" json response case informing that the thread does not exist.
+        if (!$this->core->getQueries()->existsThread($_POST['thread_id'])) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-EXISTANT ID)", $_POST['thread_id']);
+        }
         $thread_id = $_POST['thread_id'];
         $thread = $this->core->getQueries()->getThread($thread_id);
         $categories_ids = $this->core->getQueries()->getCategoriesIdForThread($thread_id);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -916,24 +916,20 @@ class ForumController extends AbstractController {
      * @Route("/courses/{_semester}/{_course}/forum/threads/single", methods={"POST"})
      */
     public function getSingleThread() {
-        // Checks if thread id is undefined. If so, render "fail" json response case informing that thread id is not set.
-        if (!isset($_POST['thread_id'])) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (UNSET ID)");
-        }
-        // Checks if thread id is null. If so, render "fail" json response case informing that thread id is null.
-        if ($_POST['thread_id'] == null) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NULL ID)");
+        $thread_id = $_POST['thread_id'];
+        // Checks if thread id is empty. If so, render "fail" json response case informing that thread id is empty.
+        if (empty($thread_id)) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (EMPTY ID)");
         }
         // Checks if thread id is not an integer value. If so, render "fail" json response case informing that thread id is not an integer value.
-        if (!(is_int($_POST['thread_id']) || ctype_digit($_POST['thread_id']))) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-INTEGER)");
+        if (!(is_int($thread_id) || ctype_digit($_POST['thread_id']))) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-INTEGER ID)");
         }
-        // Checks if thread id does not exist. If so, render "fail" json response case informing that the thread does not exist.
-        if (!$this->core->getQueries()->existsThread($_POST['thread_id'])) {
+        $thread = $this->core->getQueries()->getThread($thread_id);
+        // Checks if no threads were found. If so, render "fail" json response case informing that the no threads were found with the given ID.
+        if (!(count($thread) > 0)) {
             return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-EXISTENT ID)");
         }
-        $thread_id = $_POST['thread_id'];
-        $thread = $this->core->getQueries()->getThread($thread_id);
         $categories_ids = $this->core->getQueries()->getCategoriesIdForThread($thread_id);
         $show_deleted = $this->showDeleted();
         $currentCourse = $this->core->getConfig()->getCourse();

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -918,15 +918,15 @@ class ForumController extends AbstractController {
     public function getSingleThread() {
         // Checks if thread id is null. If so, render "fail" json response case informing that thread id is null.
         if ($_POST['thread_id'] == null) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NULL ID)", $_POST['thread_id']);
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NULL ID)");
         }
         // Checks if thread id is not an integer value. If so, render "fail" json response case informing that thread id is not an integer value.
-        if (!ctype_digit($_POST['thread_id'])) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-INTEGER ID)", $_POST['thread_id']);
+        if (!(is_int($_POST['thread_id']) || ctype_digit($_POST['thread_id']))) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-INTEGER)");
         }
         // Checks if thread id does not exist. If so, render "fail" json response case informing that the thread does not exist.
         if (!$this->core->getQueries()->existsThread($_POST['thread_id'])) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-EXISTANT ID)", $_POST['thread_id']);
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-EXISTENT ID)");
         }
         $thread_id = $_POST['thread_id'];
         $thread = $this->core->getQueries()->getThread($thread_id);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -916,6 +916,10 @@ class ForumController extends AbstractController {
      * @Route("/courses/{_semester}/{_course}/forum/threads/single", methods={"POST"})
      */
     public function getSingleThread() {
+        // Checks if thread id is undefined. If so, render "fail" json response case informing that thread id is not set.
+        if (!isset($_POST['thread_id'])) {
+            return $this->core->getOutput()->renderJsonFail("Invalid thread id (UNSET ID)");
+        }
         // Checks if thread id is null. If so, render "fail" json response case informing that thread id is null.
         if ($_POST['thread_id'] == null) {
             return $this->core->getOutput()->renderJsonFail("Invalid thread id (NULL ID)");

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -710,6 +710,10 @@ class ForumThreadView extends AbstractView {
         $thread_content = [];
 
         foreach ($threads as $thread) {
+            // Checks if thread ID is null. If so, skip this threads.
+            if ($thread["id"] == null) {
+                continue;
+            }
             $first_post = $this->core->getQueries()->getFirstPostForThread($thread["id"]);
             if (is_null($first_post)) {
                 // Thread without any posts(eg. Merged Thread)

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -710,8 +710,8 @@ class ForumThreadView extends AbstractView {
         $thread_content = [];
 
         foreach ($threads as $thread) {
-            // Checks if thread ID is null. If so, skip this threads.
-            if ($thread["id"] == null) {
+            // Checks if thread ID is empty. If so, skip this threads.
+            if (empty($thread["id"])) {
                 continue;
             }
             $first_post = $this->core->getQueries()->getFirstPostForThread($thread["id"]);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
- Fixes #7955 
  - If a thread is queried in the Discussion Form using an invalid (a null or non-integer value) or non-existent thread id, a server error would be displayed prompting for the page to be refreshed.

### What is the new behavior?
Now, the thread id is checked when a thread is being retrieved to make sure that it and its corresponding thread exists.  If the thread id is invalid or the thread does not exist, a "fail" JSON response case will be rendered that says that the id is not valid.  

### Other information?
<!-- How did you test -->
I had two pages opened to the discussion forum.  One of these pages had the Inspector Console panel opened and the other with with the Inspector Network panel  opened.  In the Console, the following commands were entered: 
  - Commands that Rendered a "successful" JSON response case
    - window.socketClient.send({type: "new_thread", thread_id: "1"})
    - window.socketClient.send({type: "new_thread", thread_id: 3})
  - Commands that Rendered a "fail" JSON response case
    - window.socketClient.send({type: "new_thread", thread_id: "100"})
    - window.socketClient.send({type: "new_thread", thread_id: ""})
    - window.socketClient.send({type: "new_thread", thread_id: "thread id 1"})

After each command was entered, I checked the page with the Inspector Network panel opened to see if the "Error parsing new post" message was displayed onto the page and the command's corresponding request in the Inspector Network panel.  If a valid thread id was used in the command (the two commands under "Commands that Rendered a 'successful' JSON response case"), I checked if the request's preview had a line saying that the status was "success".  If an invalid or non-existent thread id was used (the commands under "Commands that Rendered a 'fail' JSON response case"), I check to see that the "Error parsing new post" message does not display and a line saying that the status was "fail" in the command's corresponding request's preview.  