### PR TITLE
[Bugfix:SubminiPolls] Fix Viewpoll Image

### DIFF
--- a/site/app/templates/polls/ViewPollPage.twig
+++ b/site/app/templates/polls/ViewPollPage.twig
@@ -13,6 +13,11 @@
             {% include "misc/Markdown.twig" with {
                 "content": poll.getQuestion(),
             } only %}
+            {% if file_data is not null %}
+                <br/>
+                <img src="{{ file_data }}">
+                <br/>
+            {% endif %}
             <form method="post" action="{{ base_url }}/submitResponse">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                 <input type="hidden" name="poll_id" value="{{ poll.getId() }}"/>

--- a/site/public/css/polls.css
+++ b/site/public/css/polls.css
@@ -83,6 +83,10 @@ form {
     max-width: 73%;
 }
 
+.poll-view-wrapper.info-wrapper img {
+    width: 100%;
+}
+
 .poll-view-wrapper.histogram-wrapper {
     flex: 2 1 0;
 }


### PR DESCRIPTION
### What is the current behavior?

Closes #8020 

`ViewPollPage.twig` could not show the image attachment.

### What is the new behavior?

`ViewPollPage.twig` could show the image attachment.
