### PR TITLE
[Feature:RainbowGrades] Registration type in grade summaries

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -374,6 +374,7 @@ class ReportController extends AbstractController {
         $user_data['preferred_last_name'] = $user->getPreferredLastName();
         $user_data['registration_section'] = $user->getRegistrationSection();
         $user_data['rotating_section'] = $user->getRotatingSection();
+        $user_data['registration_type'] = $user->getRegistrationType();
         $user_data['default_allowed_late_days'] = $this->core->getConfig()->getDefaultStudentLateDays();
         $user_data['last_update'] = date("l, F j, Y");
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7004,7 +7004,9 @@ AND gc_id IN (
               u.manual_registration,
               u.last_updated,
               u.grading_registration_sections,
-              u.registration_section, u.rotating_section,
+              u.registration_section,
+              u.rotating_section,
+              u.registration_type,
               ldeu.late_day_exceptions,
               u.registration_subsection';
             $submitter_inject = '
@@ -7081,6 +7083,7 @@ AND gc_id IN (
               gcd.array_grader_last_updated,
               gcd.array_grader_registration_section,
               gcd.array_grader_rotating_section,
+              gcd.array_grader_registration_type,
               gcd.array_grader_grading_registration_sections,
 
               /* Aggregate Gradeable Component Data (versions) */
@@ -7155,6 +7158,7 @@ AND gc_id IN (
                   json_agg(ug.last_updated) AS array_grader_last_updated,
                   json_agg(ug.registration_section) AS array_grader_registration_section,
                   json_agg(ug.rotating_section) AS array_grader_rotating_section,
+                  json_agg(ug.registration_type) AS array_grader_registration_type,
                   json_agg(ug.grading_registration_sections) AS array_grader_grading_registration_sections,
                   in_gcd.gd_id
                 FROM gradeable_component_data in_gcd
@@ -7316,6 +7320,7 @@ AND gc_id IN (
                 'last_updated',
                 'registration_section',
                 'rotating_section',
+                'registration_type',
                 'grading_registration_sections'
             ];
             $comp_array_properties = [

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -218,8 +218,8 @@ class User extends AbstractModel {
             $this->setRegistrationSubsection($details['registration_subsection']);
         }
 
-        $default_registration_type = $this->group == 4 ? 'graded' : 'staff';
-        $this->registration_type = $details['registration_type'] ?? $default_registration_type;
+        // Use registration type data for students group (defaulting to 'graded') and 'staff' for staff groups
+        $this->registration_type = $this->group == 4 ? ($details['registration_type'] ?? 'graded') : 'staff';
     }
 
     /**

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -218,8 +218,8 @@ class User extends AbstractModel {
             $this->setRegistrationSubsection($details['registration_subsection']);
         }
 
-        // Use registration type data for students group (defaulting to 'graded') and 'staff' for staff groups
-        $this->registration_type = $this->group == 4 ? ($details['registration_type'] ?? 'graded') : 'staff';
+        // Use registration type data or default to "graded" for students and "staff" for others
+        $this->registration_type = $details['registration_type'] ?? ($this->group == 4 ? 'graded' : 'staff');
     }
 
     /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The grade summaries for rainbow grades do not include registration type.
Closes #7474

### What is the new behavior?
The JSON files used by rainbow grades now have the registration type included.

### Other information?
I tested by setting various registration types in the sample course. Then after generating the grade summaries, checking the JSON files to see that the correct "registration_type" property is set.
