### PR TITLE
[Refactor:Developer] Fix deprecation warnings for JWT lib

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -475,7 +475,7 @@ class Core {
                     $user_id,
                     $persistent_cookie
                 );
-                return Utils::setCookie('submitty_session', (string) $token, $token->claims()->get('expire_time'));
+                return Utils::setCookie('submitty_session', $token->toString(), $token->claims()->get('expire_time'));
             }
         }
         catch (\Exception $e) {
@@ -501,9 +501,9 @@ class Core {
         try {
             if ($this->authentication->authenticate()) {
                 $this->database_queries->refreshUserApiKey($user_id);
-                return (string) TokenManager::generateApiToken(
+                return TokenManager::generateApiToken(
                     $this->database_queries->getSubmittyUserApiKey($user_id)
-                );
+                )->toString();
             }
         }
         catch (\Exception $e) {
@@ -773,10 +773,10 @@ class Core {
                     if ($expire_time > 0) {
                         Utils::setCookie(
                             $cookie_key,
-                            (string) TokenManager::generateSessionToken(
+                            TokenManager::generateSessionToken(
                                 $session_id,
                                 $token->claims()->get('sub')
-                            ),
+                            )->toString(),
                             $expire_time
                         );
                     }

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -424,14 +424,6 @@ parameters:
 			path: app/libraries/Access.php
 
 		-
-			message: """
-				#^Casting class Lcobucci\\\\JWT\\\\Token to string is deprecated\\.\\:
-				This method has been removed from the interface in v4\\.0$#
-			"""
-			count: 3
-			path: app/libraries/Core.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 2
 			path: app/libraries/Core.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We use `(string) Lcobucci\JWT\Token` in a handful of places which is deprecated, and the suggestion is to use the `toString()` method instead.

### What is the new behavior?

Use the `toString()` method.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Should have no impact on behavior as `(string)` cast calls `toString()` under the hood.
