### PR TITLE
[SECURITY][Bugfix:Forum] Fix Forum Links and Deletion

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -116,4 +116,5 @@ Toshi Piazza
 Matt Raneri  
 Chris Reed  
 Zachary Wimer  
+Fu Chai
 For their bug reports of specific security vulnerabilities :)  

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -574,6 +574,9 @@ class ForumController extends AbstractController {
         if (!$this->core->getAccess()->canI("forum.modify_post", ['post_author' => $post['author_user_id']])) {
                 return $this->core->getOutput()->renderJsonFail('You do not have permissions to do that.');
         }
+        if ($post['thread_id'] !== intval($_POST['thread_id'])) {
+            return $this->core->getOutput()->renderJsonFail("You do not have permission to do that.");
+        }
         if (!empty($_POST['edit_thread_id']) && $this->core->getQueries()->isThreadLocked($_POST['edit_thread_id']) && !$this->core->getUser()->accessAdmin()) {
             return $this->core->getOutput()->renderJsonFail('Thread is locked');
         }

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -151,7 +151,7 @@ HTML;
         $environment->addInlineRenderer(Code::class, new CustomCodeInlineRenderer());
         $environment->mergeConfig([]);
 
-        $converter = new CommonMarkConverter(['html_input' => 'escape'], $environment);
+        $converter = new CommonMarkConverter(['html_input' => 'escape', 'allow_unsafe_links' => false], $environment);
         $engine = new PHPLeagueCommonMarkEngine($converter);
         $this->twig->addExtension(new MarkdownExtension($engine));
     }


### PR DESCRIPTION
### What is the current behavior?
Threads/posts could be deleted by a different user. Also it is possible to create links that could lead to XSS.

### What is the new behavior?
Threads/posts can only be deleted by the author or an authorized user. Links are checked in the markdown renderer so XSS is not possible.

### Other information?
Thanks Fu (@richcfno1) for pointing these out.
