### PR TITLE
[Bugfix:System] Create the course only if the term exists

### DIFF
--- a/sbin/create_course.sh
+++ b/sbin/create_course.sh
@@ -117,6 +117,13 @@ fi
 #       additional instructors and/or head TAs who need read/write
 #       access to these files
 
+TERM_EXISTS=$(PGPASSWORD=${DATABASE_PASS} psql ${CONN_STRING} -d submitty -AXtc "SELECT COUNT(*) FROM terms WHERE term_id='${semester}'")
+
+if [[ "$TERM_EXISTS" -eq "0" ]] ; then
+    echo "ERROR: Provided term ${semester} doesn't exist."
+    echo "       To fix, try creating the term first by running 'create_term.sh'."
+    exit
+fi
 
 # FIXME: add some error checking on the $semester and $course
 #        variables


### PR DESCRIPTION
### What is the current behavior?
Fixes #7214, running `create_course.sh` with an invalid term creates the course even after failing to link it to a term, running `create_course.sh` after creating the term suggests that the course is already set up and doesn't link the term with the course.

### What is the new behavior?
Providing an invalid term doesn't create the course and throws an error suggesting to create the term first.