### PR TITLE
[Feature:InstructorUI] Added registration section to home page

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4083,7 +4083,7 @@ SQL;
         }
 
         $query = <<<SQL
-SELECT t.name AS term_name, u.semester, u.course, u.user_group
+SELECT t.name AS term_name, u.semester, u.course, u.user_group, u.registration_section
 FROM courses_users u
 INNER JOIN courses c ON u.course=c.course AND u.semester=c.semester
 INNER JOIN terms t ON u.semester=t.term_id

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -25,6 +25,8 @@ class Course extends AbstractModel {
     protected $display_name;
     /** @property int $user_group used to rank courses in homepage view. */
     protected $user_group;
+    /** @property string $registration_section for homepage view */
+    protected $registration_section;
 
     /**
      * Course constructor.
@@ -39,6 +41,7 @@ class Course extends AbstractModel {
         $this->title = $details['course'];
         $this->display_name = "";
         $this->user_group = $details['user_group'] ?? 3;
+        $this->registration_section = $details['registration_section'] ?? NULL;
     }
 
     public function loadDisplayName() {
@@ -74,7 +77,8 @@ class Course extends AbstractModel {
             "title" => $this->title,
             "display_name" => $this->display_name,
             "display_semester" => $this->semester_name,
-            "user_group" => $this->user_group
+            "user_group" => $this->user_group,
+            "registration_section" => $this->registration_section
         ];
     }
 }

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -41,7 +41,7 @@ class Course extends AbstractModel {
         $this->title = $details['course'];
         $this->display_name = "";
         $this->user_group = $details['user_group'] ?? 3;
-        $this->registration_section = $details['registration_section'] ?? NULL;
+        $this->registration_section = $details['registration_section'] ?? null;
     }
 
     public function loadDisplayName() {

--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -21,7 +21,9 @@
                             {% if course['display_name'] != "" %}
                                 {{ course['display_name'] }} &nbsp; &nbsp;
                             {% endif %}
-                            (Section {{ course['registration_section'] ?? "NULL" }})
+                            {% if course['registration_section'] != null %}
+                                (Section {{ course['registration_section'] }})
+                            {% endif %}
                             {{ user.accessAdmin() }}
                         </a>
                     </li>

--- a/site/app/templates/HomePage.twig
+++ b/site/app/templates/HomePage.twig
@@ -19,8 +19,9 @@
                             {{ course['display_semester'] }} &nbsp; &nbsp;
                             {{ course['title'] | upper }} &nbsp; &nbsp;
                             {% if course['display_name'] != "" %}
-                                {{ course['display_name'] }}
+                                {{ course['display_name'] }} &nbsp; &nbsp;
                             {% endif %}
+                            (Section {{ course['registration_section'] ?? "NULL" }})
                             {{ user.accessAdmin() }}
                         </a>
                     </li>

--- a/site/tests/app/models/CourseTester.php
+++ b/site/tests/app/models/CourseTester.php
@@ -29,7 +29,8 @@ class CourseTester extends BaseUnitTest {
             'title' => 'csci1000',
             'display_name' => '',
             'user_group' => 1,
-            'modified' => false
+            'modified' => false,
+            'registration_section' => null
         ];
         $this->assertEquals($array, $course->toArray());
     }
@@ -55,7 +56,8 @@ class CourseTester extends BaseUnitTest {
                 'title' => 'csci1000',
                 'display_name' => 'Test Course',
                 'user_group' => 3,
-                'modified' => false
+                'modified' => false,
+                'registration_section' => null
             ];
             $this->assertEquals($array, $course->toArray());
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The home page does not list registration sections.

### What is the new behavior?
Registration sections are now listed on the home page. Below are examples of how they appear:

On desktop:
![image](https://user-images.githubusercontent.com/13438573/173721887-45a519c2-a24a-431d-85d4-935c383bf7b8.png)

On mobile:
![image](https://user-images.githubusercontent.com/13438573/173721990-e13999ea-f449-4741-bd1a-7b52375b32f8.png)

The section information is not displayed for users in the NULL section (most likely the course staff).

### Other information?
Closes #7248 