### PR TITLE
Added file size cap and file format criteria

### DIFF
--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -145,6 +145,11 @@ class UserProfileController extends AbstractController {
         else {
             $meta = explode('.', $_FILES['user_image']['name']);
             $extension = $meta[1];
+            $supported_ext = ["jpg", "jpeg", "gif", "png", "webp"];
+            $supp_mime_types = ["image/jpeg", "image/gif", "image/png", "image/webp"];
+            if (!(in_array($extension, $supported_ext) && in_array(mime_content_type($_FILES['user_image']['tmp_name']), $supp_mime_types))) {
+                return JsonResponse::getErrorResponse('File format not supported.');
+            }
 
             // Save image for user
             $result = $user->setDisplayImage($extension, $_FILES['user_image']['tmp_name']);

--- a/site/app/templates/EditProfilePhotoForm.twig
+++ b/site/app/templates/EditProfilePhotoForm.twig
@@ -17,7 +17,10 @@
         <label for="user-image-button">
         <h2>My Profile Photo</h2>
         </label>
-        <input type="file" name="user_image" id="user-image-button" accept="image/*">
+        <br>
+        <input type="file" name="user_image" id="user-image-button" accept=".jpg, .jpeg, .gif, .png, .webp">
+        <br>
+        <span>Maximum allowed file size: 20 MB | Supported file formats: JPG, GIF, PNG, WEBP</span>
     </div>
 {% endblock %}
 {% block form %}

--- a/site/public/js/user-profile.js
+++ b/site/public/js/user-profile.js
@@ -273,4 +273,10 @@ $(document).ready(function() {
     // Set time zone drop down boxes to the user's time zone (only after other JS has finished loading)
     let user_time_zone =  $('#time_zone_selector_label').data('user_time_zone');
     $('[value="' + user_time_zone + '"]').prop('selected', true);
+    $('#user-image-button').bind('change', function() {
+        if ((this.files[0].size/1048576)>20.0){
+            alert("Selected file's size exceeds 20 MB");
+            $('#user-image-button').val('');
+        }
+    });
 });


### PR DESCRIPTION
### What is the current behavior?
There is no client side limit on profile image size and a whole lot of unneeded file formats are supported opening doors for file inclusion and crafted SVGs.

### What is the new behavior?
A client side limit of 20MB has been imposed and only JPG, GIF, PNG and WEBP file formats are supported now.
