### PR TITLE
[Bugfix:System] Fix database superuser check on workers

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -131,31 +131,33 @@ fi
 ################################################################################################################
 # VALIDATE DATABASE SUPERUSERS
 
-DATABASE_FILE="$CONF_DIR/database.json"
-DATABASE_HOST=$(jq -r '.database_host' $DATABASE_FILE)
-DATABASE_PORT=$(jq -r '.database_port' $DATABASE_FILE)
-GLOBAL_DBUSER=$(jq -r '.database_user' $DATABASE_FILE)
-GLOBAL_DBUSER_PASS=$(jq -r '.database_password' $DATABASE_FILE)
-COURSE_DBUSER=$(jq -r '.database_course_user' $DATABASE_FILE)
+if [ "${WORKER}" == 0 ]; then
+    DATABASE_FILE="$CONF_DIR/database.json"
+    DATABASE_HOST=$(jq -r '.database_host' $DATABASE_FILE)
+    DATABASE_PORT=$(jq -r '.database_port' $DATABASE_FILE)
+    GLOBAL_DBUSER=$(jq -r '.database_user' $DATABASE_FILE)
+    GLOBAL_DBUSER_PASS=$(jq -r '.database_password' $DATABASE_FILE)
+    COURSE_DBUSER=$(jq -r '.database_course_user' $DATABASE_FILE)
 
-DB_CONN="-h ${DATABASE_HOST} -U ${GLOBAL_DBUSER}"
-if [ ! -d "${DATABASE_HOST}" ]; then
-    DB_CONN="${DB_CONN} -p ${DATABASE_PORT}"
-fi
+    DB_CONN="-h ${DATABASE_HOST} -U ${GLOBAL_DBUSER}"
+    if [ ! -d "${DATABASE_HOST}" ]; then
+        DB_CONN="${DB_CONN} -p ${DATABASE_PORT}"
+    fi
 
 
-CHECK=`PGPASSWORD=${GLOBAL_DBUSER_PASS} psql ${DB_CONN} -d submitty -tAc "SELECT rolsuper FROM pg_authid WHERE rolname='$GLOBAL_DBUSER'"`
+    CHECK=`PGPASSWORD=${GLOBAL_DBUSER_PASS} psql ${DB_CONN} -d submitty -tAc "SELECT rolsuper FROM pg_authid WHERE rolname='$GLOBAL_DBUSER'"`
 
-if [ "$CHECK" == "f" ]; then
-    echo "ERROR: Database Superuser check failed! Master dbuser found to not be a superuser."
-    exit
-fi
+    if [ "$CHECK" == "f" ]; then
+        echo "ERROR: Database Superuser check failed! Master dbuser found to not be a superuser."
+        exit
+    fi
 
-CHECK=`PGPASSWORD=${GLOBAL_DBUSER_PASS} psql ${DB_CONN} -d submitty -tAc "SELECT rolsuper FROM pg_authid WHERE rolname='$COURSE_DBUSER'"`
+    CHECK=`PGPASSWORD=${GLOBAL_DBUSER_PASS} psql ${DB_CONN} -d submitty -tAc "SELECT rolsuper FROM pg_authid WHERE rolname='$COURSE_DBUSER'"`
 
-if [ "$CHECK" == "t" ]; then
-    echo "ERROR: Database Superuser check failed! Course dbuser found to be a superuser."
-    exit
+    if [ "$CHECK" == "t" ]; then
+        echo "ERROR: Database Superuser check failed! Course dbuser found to be a superuser."
+        exit
+    fi
 fi
 
 


### PR DESCRIPTION
### What is the current behavior?
If INSTALL_SUBMITTY_HELPER.sh is run on a worker it will look for a database.json file since https://github.com/Submitty/Submitty/pull/8031. The database.json file doesn't exist on worker machines so it will fail.

### What is the new behavior?
An if check was added to make sure that this code doesn't get executed on a worker.
