### PR TITLE
[Bugfix:Autograding] Fix for worker installation failure

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -196,6 +196,10 @@ DAEMON_GID=$(jq -r '.daemon_gid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.
 PHP_USER=$(jq -r '.php_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 CGI_USER=$(jq -r '.cgi_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 DAEMONPHP_GROUP=$(jq -r '.daemonphp_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
+
+echo ====== DAEMONPHP_GROUP = ${DAEMONPHP_GROUP}
+sleep 5
+
 DAEMONCGI_GROUP=$(jq -r '.daemoncgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 SUPERVISOR_USER=$(jq -r '.supervisor_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -185,13 +185,12 @@ popd > /dev/null
 # (eventually will remove these from the /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh script)
 
 SUBMITTY_DATA_DIR=$(jq -r '.submitty_data_dir' "${SUBMITTY_INSTALL_DIR}/config/submitty.json")
-
+# Worker does not need course builders so just use root
 if [ "${WORKER}" == 0 ]; then
     COURSE_BUILDERS_GROUP=$(jq -r '.course_builders_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 else
     COURSE_BUILDERS_GROUP=root
 fi
-
 NUM_UNTRUSTED=$(jq -r '.num_untrusted' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 FIRST_UNTRUSTED_UID=$(jq -r '.first_untrusted_uid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 FIRST_UNTRUSTED_GID=$(jq -r '.first_untrusted_gid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
@@ -201,13 +200,12 @@ DAEMON_UID=$(jq -r '.daemon_uid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.
 DAEMON_GID=$(jq -r '.daemon_gid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 PHP_USER=$(jq -r '.php_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 CGI_USER=$(jq -r '.cgi_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
-
+# Worker does not need daemon PHP so just use root
 if [ "${WORKER}" == 0 ]; then
     DAEMONPHP_GROUP=$(jq -r '.daemonphp_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 else
     DAEMONPHP_GROUP=root
 fi
-
 DAEMONCGI_GROUP=$(jq -r '.daemoncgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 SUPERVISOR_USER=$(jq -r '.supervisor_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 
@@ -323,40 +321,21 @@ if [ "${WORKER}" == 0 ]; then
 fi
 # ------------------------------------------------------------------------
 
-echo ============== MADE DIRS ==================
-echo ============== COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
-echo ============== SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
-echo ============== DAEMON_USER = ${DAEMON_USER}
-echo  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"
-echo ===========================================
-
 # set the permissions of these directories
 chown  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"
-echo ====== CHOWN DONE ======
 chmod  751                                            "${SUBMITTY_DATA_DIR}"
-echo ====== CHMOD DONE ======
 
 #Set up courses and version control ownership if not in worker mode
 if [ "${WORKER}" == 0 ]; then
-    echo ============= CHOWN courses =========
     chown  "root:${COURSE_BUILDERS_GROUP}"            "${SUBMITTY_DATA_DIR}/courses"
     chmod  751                                        "${SUBMITTY_DATA_DIR}/courses"
-    echo ============= CHOWN user_data ===========
     chown  "${PHP_USER}:${PHP_USER}"                  "${SUBMITTY_DATA_DIR}/user_data"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/user_data"
-    echo ============= CHOWN vcs =============
     chown  "root:${DAEMONCGI_GROUP}"                  "${SUBMITTY_DATA_DIR}/vcs"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs"
-    echo ============= CHOWN vcs/git ============
     chown  "root:${DAEMONCGI_GROUP}"                  "${SUBMITTY_DATA_DIR}/vcs/git"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs/git"
 fi
-
-echo ======= MORE STUFF FOR BOTH =====
-echo === COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
-echo === SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
-echo === DAEMON_USER = ${DAEMON_USER}
-echo === DAEMONPHP_GROUP = ${DAEMONPHP_GROUP}
 
 # ------------------------------------------------------------------------
 # Set owner/group of the top level logs directory
@@ -364,8 +343,6 @@ chown "root:${COURSE_BUILDERS_GROUP}"                   "${SUBMITTY_DATA_DIR}/lo
 # Set owner/group for logs directories that exist on both primary & work machines
 chown  -R "${DAEMON_USER}":"${DAEMONPHP_GROUP}"         "${SUBMITTY_DATA_DIR}/logs/autograding"
 chown  -R "${DAEMON_USER}":"${DAEMONPHP_GROUP}"         "${SUBMITTY_DATA_DIR}/logs/autograding_stack_traces"
-
-echo ====================================
 
 # Set owner/group for logs directories that exist only on the primary machine
 if [ "${WORKER}" == 0 ]; then

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -341,6 +341,9 @@ if [ "${WORKER}" == 0 ]; then
 fi
 
 echo ======= MORE STUFF FOR BOTH =====
+echo === COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
+echo === SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
+echo === DAEMON_USER = ${DAEMON_USER}
 
 # ------------------------------------------------------------------------
 # Set owner/group of the top level logs directory

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -344,6 +344,7 @@ echo ======= MORE STUFF FOR BOTH =====
 echo === COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
 echo === SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
 echo === DAEMON_USER = ${DAEMON_USER}
+echo === DAEMONPHP_GROUP = ${DAEMONPHP_GROUP}
 
 # ------------------------------------------------------------------------
 # Set owner/group of the top level logs directory

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -313,6 +313,7 @@ fi
 
 echo ============== MADE DIRS ==================
 echo ============== COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
+echo ============== SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
 
 # set the permissions of these directories
 chown  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -319,12 +319,16 @@ chmod  751                                            "${SUBMITTY_DATA_DIR}"
 
 #Set up courses and version control ownership if not in worker mode
 if [ "${WORKER}" == 0 ]; then
+    echo ============= CHOWN courses =========
     chown  "root:${COURSE_BUILDERS_GROUP}"            "${SUBMITTY_DATA_DIR}/courses"
     chmod  751                                        "${SUBMITTY_DATA_DIR}/courses"
+    echo ============= CHOWN user_data ===========
     chown  "${PHP_USER}:${PHP_USER}"                  "${SUBMITTY_DATA_DIR}/user_data"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/user_data"
+    echo ============= CHOWN vcs =============
     chown  "root:${DAEMONCGI_GROUP}"                  "${SUBMITTY_DATA_DIR}/vcs"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs"
+    echo ============= CHOWN vcs/git ============
     chown  "root:${DAEMONCGI_GROUP}"                  "${SUBMITTY_DATA_DIR}/vcs/git"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs/git"
 fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -314,6 +314,7 @@ fi
 echo ============== MADE DIRS ==================
 echo ============== COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
 echo ============== SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
+echo ============== DAEMON_USER = ${DAEMON_USER}
 echo  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"
 echo ===========================================
 

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -340,12 +340,16 @@ if [ "${WORKER}" == 0 ]; then
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs/git"
 fi
 
+echo ======= MORE STUFF FOR BOTH =====
+
 # ------------------------------------------------------------------------
 # Set owner/group of the top level logs directory
 chown "root:${COURSE_BUILDERS_GROUP}"                   "${SUBMITTY_DATA_DIR}/logs"
 # Set owner/group for logs directories that exist on both primary & work machines
 chown  -R "${DAEMON_USER}":"${DAEMONPHP_GROUP}"         "${SUBMITTY_DATA_DIR}/logs/autograding"
 chown  -R "${DAEMON_USER}":"${DAEMONPHP_GROUP}"         "${SUBMITTY_DATA_DIR}/logs/autograding_stack_traces"
+
+echo ====================================
 
 # Set owner/group for logs directories that exist only on the primary machine
 if [ "${WORKER}" == 0 ]; then

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -314,6 +314,8 @@ fi
 echo ============== MADE DIRS ==================
 echo ============== COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
 echo ============== SUBMITTY_DATA_DIR = ${SUBMITTY_DATA_DIR}
+echo  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"
+echo ===========================================
 
 # set the permissions of these directories
 chown  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -311,6 +311,8 @@ if [ "${WORKER}" == 0 ]; then
 fi
 # ------------------------------------------------------------------------
 
+echo ============== MADE DIRS ==================
+
 # set the permissions of these directories
 chown  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"
 chmod  751                                            "${SUBMITTY_DATA_DIR}"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -185,7 +185,13 @@ popd > /dev/null
 # (eventually will remove these from the /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh script)
 
 SUBMITTY_DATA_DIR=$(jq -r '.submitty_data_dir' "${SUBMITTY_INSTALL_DIR}/config/submitty.json")
-COURSE_BUILDERS_GROUP=$(jq -r '.course_builders_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
+
+if [ "${WORKER}" == 0 ]; then
+    COURSE_BUILDERS_GROUP=$(jq -r '.course_builders_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
+else
+    COURSE_BUILDERS_GROUP=root
+fi
+
 NUM_UNTRUSTED=$(jq -r '.num_untrusted' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 FIRST_UNTRUSTED_UID=$(jq -r '.first_untrusted_uid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 FIRST_UNTRUSTED_GID=$(jq -r '.first_untrusted_gid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
@@ -195,10 +201,12 @@ DAEMON_UID=$(jq -r '.daemon_uid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.
 DAEMON_GID=$(jq -r '.daemon_gid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 PHP_USER=$(jq -r '.php_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 CGI_USER=$(jq -r '.cgi_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
-DAEMONPHP_GROUP=$(jq -r '.daemonphp_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 
-echo ====== DAEMONPHP_GROUP = ${DAEMONPHP_GROUP}
-sleep 5
+if [ "${WORKER}" == 0 ]; then
+    DAEMONPHP_GROUP=$(jq -r '.daemonphp_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
+else
+    DAEMONPHP_GROUP=root
+fi
 
 DAEMONCGI_GROUP=$(jq -r '.daemoncgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 SUPERVISOR_USER=$(jq -r '.supervisor_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -320,7 +320,9 @@ echo ===========================================
 
 # set the permissions of these directories
 chown  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"
+echo ====== CHOWN DONE ======
 chmod  751                                            "${SUBMITTY_DATA_DIR}"
+echo ====== CHMOD DONE ======
 
 #Set up courses and version control ownership if not in worker mode
 if [ "${WORKER}" == 0 ]; then

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -200,11 +200,11 @@ DAEMON_UID=$(jq -r '.daemon_uid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.
 DAEMON_GID=$(jq -r '.daemon_gid' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 PHP_USER=$(jq -r '.php_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 CGI_USER=$(jq -r '.cgi_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
-# Worker does not need daemon PHP so just use root
+# Worker does not have daemon PHP so just use daemon group
 if [ "${WORKER}" == 0 ]; then
     DAEMONPHP_GROUP=$(jq -r '.daemonphp_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 else
-    DAEMONPHP_GROUP=root
+    DAEMONPHP_GROUP=${DAEMON_GROUP}
 fi
 DAEMONCGI_GROUP=$(jq -r '.daemoncgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 SUPERVISOR_USER=$(jq -r '.supervisor_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -312,6 +312,7 @@ fi
 # ------------------------------------------------------------------------
 
 echo ============== MADE DIRS ==================
+echo ============== COURSE_BUILDERS_GROUP = ${COURSE_BUILDERS_GROUP}
 
 # set the permissions of these directories
 chown  "root:${COURSE_BUILDERS_GROUP}"                "${SUBMITTY_DATA_DIR}"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -204,7 +204,7 @@ CGI_USER=$(jq -r '.cgi_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json
 if [ "${WORKER}" == 0 ]; then
     DAEMONPHP_GROUP=$(jq -r '.daemonphp_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 else
-    DAEMONPHP_GROUP=${DAEMON_GROUP}
+    DAEMONPHP_GROUP="${DAEMON_GROUP}"
 fi
 DAEMONCGI_GROUP=$(jq -r '.daemoncgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 SUPERVISOR_USER=$(jq -r '.supervisor_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -110,7 +110,7 @@ def run_commands_on_worker(user, host, commands, operation='unspecified operatio
             success = True
             for command in commands:
                 print(f'{host}: performing {command}')
-                (_, stdout, _) = target_connection.exec_command(command, timeout=600)
+                (_, stdout, _) = target_connection.exec_command(command, timeout=60)
                 print(stdout.read().decode('ascii'))
                 status = int(stdout.channel.recv_exit_status())
                 if status != 0:

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -110,7 +110,7 @@ def run_commands_on_worker(user, host, commands, operation='unspecified operatio
             success = True
             for command in commands:
                 print(f'{host}: performing {command}')
-                (_, stdout, _) = target_connection.exec_command(command, timeout=60)
+                (_, stdout, _) = target_connection.exec_command(command, timeout=600)
                 print(stdout.read().decode('ascii'))
                 status = int(stdout.channel.recv_exit_status())
                 if status != 0:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Worker installation fails on a `chown` command due to not having the group specified which is only used on the primary machine.

### What is the new behavior?
These issues were fixed and the installation was tested to complete successfully now.

### Other information?
Closes #8056 
