### PR TITLE
[Bugfix:TAGrading] Remove Stack Trace in Team PDF Grading

### DIFF
--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -178,8 +178,13 @@ class PDFController extends AbstractController {
         for ($index = 1; $index < count($file_path_parts); $index++) {
             if ($index == 9) {
                 $user_id = $file_path_parts[$index];
-                $anon_id = $this->core->getQueries()->getUserFromAnon($user_id)[$user_id];
-                $anon_path = $anon_path . "/" . $anon_id;
+                if (empty($this->core->getQueries()->getUserFromAnon($user_id))) {
+                    $anon_path = $anon_path . "/" . $user_id;
+                }
+                else {
+                    $anon_id = $this->core->getQueries()->getUserFromAnon($user_id)[$user_id];
+                    $anon_path = $anon_path . "/" . $anon_id;
+                }
             }
             else {
                 $anon_path = $anon_path . "/" . $file_path_parts[$index];


### PR DESCRIPTION
### What is the current behavior?
Closes #8043
There is an unwanted stack trace in team PDF grading that should not be visible to the user.

### What is the new behavior?
Removes the stack trace in team PDF grading.