### PR TITLE
[Refactor:TAGrading] Simplify getAnonPath function

### DIFF
--- a/site/app/controllers/pdf/PDFController.php
+++ b/site/app/controllers/pdf/PDFController.php
@@ -176,15 +176,10 @@ class PDFController extends AbstractController {
         $file_path_parts = explode("/", $file_path);
         $anon_path = "";
         for ($index = 1; $index < count($file_path_parts); $index++) {
-            if ($index == 9) {
+            if ($index === 9) {
                 $user_id = $file_path_parts[$index];
-                if (empty($this->core->getQueries()->getUserFromAnon($user_id))) {
-                    $anon_path = $anon_path . "/" . $user_id;
-                }
-                else {
-                    $anon_id = $this->core->getQueries()->getUserFromAnon($user_id)[$user_id];
-                    $anon_path = $anon_path . "/" . $anon_id;
-                }
+                $anon_ids = $this->core->getQueries()->getUserFromAnon($user_id);
+                $anon_path .= "/" . (empty($anon_ids) ? $user_id : $anon_ids[$user_id]);
             }
             else {
                 $anon_path = $anon_path . "/" . $file_path_parts[$index];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

If using anonymous IDs for finding PDF path, then the `getUserFromAnon` query function will be executed twice for each path part. The second query was added as part of the fix in #8061.

### What is the new behavior?

`getUserFromAnon` is only ever executed once per path part. Additionally, took advantage of using the string concat operator with equality to simplify the if branches down to a single line.