### PR TITLE
[Bugfix:CourseMaterials] Editing Folder Nulls Links

### DIFF
--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -303,7 +303,7 @@ class CourseMaterialsController extends AbstractController {
                     $this->recursiveEditFolder($course_materials, $course_material);
                 }
                 else {
-                    $_POST['requested_path'] = $course_material->getPath();
+                    $_POST['id'] = $course_material->getId();
                     $this->ajaxEditCourseMaterialsFiles(false);
                 }
             }

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -152,7 +152,7 @@
                 </a>
                 <a onclick="downloadCourseMaterialZip('{{ folder_ids[folder_path] }}')" aria-label="Download the folder: {{ name }}" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the folder"></i></a>
                 {% if user_group == 1 %}
-                    <a class="key_to_click" tabindex="0" onclick='newEditCourseMaterialsFolderForm("{{ folder_path }}", "{{ directory_priorities[folder_path] }}")'> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
+                    <a class="key_to_click" tabindex="0" onclick='newEditCourseMaterialsFolderForm("{{ folder_ids[folder_path] }}", "{{ directory_priorities[folder_path] }}")'> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
                     <a class="key_to_click" tabindex="0" onclick='newDeleteCourseMaterialForm("{{ folder_ids[folder_path]  }}", "{{ name }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
                     <a onclick='setFolderRelease("{{ folder_path }}","","{{ id }}","{{ folder_ids[folder_path] }}")' class="btn btn-primary key_to_click" tabindex="0">Set Folder Release Date</a>
                 {% endif %}

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -139,6 +139,6 @@
 {% endblock %}
 {% block buttons %}
     {{ block('close_button') }}
-    <input class="btn btn-primary" id="submit-folder-edit" type="submit" value="Submit Sort Change" onclick = "submitFolderEdit(false);"/>
-    <input class="btn btn-primary" id="submit-folder-edit-full" type="submit" value="Submit Full Update" disabled onclick="submitFolderEdit(true);">
+    <input class="btn btn-primary" id="submit-folder-edit" type="submit" value="Set Folder Sorting Rank" onclick = "submitFolderEdit(false);"/>
+    <input class="btn btn-primary" id="submit-folder-edit-full" type="submit" value="Apply Recursive Updates" disabled onclick="submitFolderEdit(true);">
 {% endblock %}

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -1288,8 +1288,12 @@ function handleEditCourseMaterials(csrf_token, hide_from_students, id, sectionsE
     formData.append('release_time',cmTime);
     formData.append('sort_priority',priority);
     formData.append('sections_lock', sections_lock);
-    formData.append('link_url', link_url);
-    formData.append('link_title', link_title);
+    if(link_url != null) {
+        formData.append('link_url', link_url);
+    }
+    if(link_title != null) {
+        formData.append('link_title', link_title);
+    }
     if (folderUpdate != null) {
         formData.append('folder_update', folderUpdate);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
 - Fixes #8085 
    - If a folder that contains a link is edited with a "Recursive Update", the link's Title and URL will both be set to null.

### What is the new behavior?
 - If a folder that contains a link is edited, the link's Title and URL will not be set to null. 

### Other information?
**How did you test**
 1. As an Instructor, created a Course Materials folder and added a link and a subfolder that contained another link
 2. Select the main folder and made the following edits to the folder one at a time: 
     - Restricted Course Materials to some section
     - Changed the time to release the files
     - Hid the Course Materials from students
 3. Check after each edit if either of the links had their Title and/or URL set to null