### PR TITLE
[Bugfix:System] Course Database Password Assignment

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -708,6 +708,7 @@ fi
 # Create and setup database for non-workers
 if [ ${WORKER} == 0 ]; then
     dbuser_password=`cat ${SUBMITTY_INSTALL_DIR}/.setup/submitty_conf.json | jq .database_password | tr -d '"'`
+    dbcourse_user_password=`cat ${SUBMITTY_INSTALL_DIR}/.setup/submitty_conf.json | jq .database_course_password | tr -d '"'`
 
     # create the submitty_dbuser role in postgres (if it does not yet exist)
     # SUPERUSER privilege is required to use dblink extension (needed for data sync between master and course DBs).


### PR DESCRIPTION
### What is the current behavior?
If the install system script is run, the course database user password won't get set properly as the variable isn't defined.

### What is the new behavior?
The variable is now defined so the password gets set to the right value rather than just an empty string.
