### PR TITLE
[Bugfix:CourseMaterials] Remove redundant folders 

### DIFF
--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -145,7 +145,7 @@ class CourseMaterialsController extends AbstractController {
             FileUtils::getTopEmptyDir($path, $base_path, $empty_folders);
             if (count($empty_folders) > 0) {
                 foreach ($empty_folders as $folder) {
-                    $success = $success & rmdir($folder);
+                    $success = $success && rmdir($folder);
                     if ($success === false) {
                         break;
                     }

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -137,7 +137,7 @@ class CourseMaterialsController extends AbstractController {
         else {
             $success = unlink($path);
         }
-        $base_path = $this->core->getConfig()->getCoursePath() . "/uploads/course_materials";
+        $base_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "course_materials");
         // delete the topmost parent folder that's empty (contains no files)
         if (pathinfo($path, PATHINFO_DIRNAME) !== $base_path) {
             $empty_folders = [];
@@ -145,12 +145,6 @@ class CourseMaterialsController extends AbstractController {
             if (count($empty_folders) > 0) {
                 $path = $empty_folders[0];
                 $success = $success && FileUtils::recursiveRmdir($path);
-                foreach ($all_files as $file) {
-                    if (str_starts_with($file->getPath(), $path)) {
-                        $this->core->getCourseEntityManager()->remove($file);
-                    }
-                }
-                $this->core->getCourseEntityManager()->flush();
             }
         }
         if ($success) {

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -145,6 +145,12 @@ class CourseMaterialsController extends AbstractController {
             if (count($empty_folders) > 0) {
                 $path = $empty_folders[0];
                 $success = $success && FileUtils::recursiveRmdir($path);
+                foreach ($all_files as $file) {
+                    if (str_starts_with($file->getPath(), $path)) {
+                        $this->core->getCourseEntityManager()->remove($file);
+                    }
+                }
+                $this->core->getCourseEntityManager()->flush();
             }
         }
         if ($success) {

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -138,19 +138,13 @@ class CourseMaterialsController extends AbstractController {
             $success = unlink($path);
         }
         $base_path = $this->core->getConfig()->getCoursePath() . "/uploads/course_materials";
-        /* delete the topmost parent folder that's empty (contains no files), doing that requires the
-        ** subdirectories to be deleted first */
+        // delete the topmost parent folder that's empty (contains no files)
         if (pathinfo($path, PATHINFO_DIRNAME) !== $base_path) {
             $empty_folders = [];
             FileUtils::getTopEmptyDir($path, $base_path, $empty_folders);
             if (count($empty_folders) > 0) {
-                foreach ($empty_folders as $folder) {
-                    $success = $success && rmdir($folder);
-                    if ($success === false) {
-                        break;
-                    }
-                }
-                $path = $empty_folders[count($empty_folders) - 1];
+                $path = $empty_folders[0];
+                $success = $success && FileUtils::recursiveRmdir($path);
                 foreach ($all_files as $file) {
                     if (str_starts_with($file->getPath(), $path)) {
                         $this->core->getCourseEntityManager()->remove($file);

--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -150,7 +150,7 @@ class CourseMaterialsController extends AbstractController {
                         break;
                     }
                 }
-                $path = $empty_folders[count($empty_folders)-1];
+                $path = $empty_folders[count($empty_folders) - 1];
                 foreach ($all_files as $file) {
                     if (str_starts_with($file->getPath(), $path)) {
                         $this->core->getCourseEntityManager()->remove($file);

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -725,8 +725,8 @@ class FileUtils {
      * @param string $path Absolute path to file or directory
      * @param string $base_path Recursion is stopped at this path i.e. this path isn't included in empty dirs
      * @param array $results An array passed by reference will be populated if an empty dir is found. The array is
-     * populated as per the hierarchy i.e. at the end of execution the first element (if any) of the array will be the 
-     * the innermost empty directory and the last element (if any) will be the topmost empty directory 
+     * populated as per the hierarchy i.e. at the end of execution the first element (if any) of the array will be the
+     * the innermost empty directory and the last element (if any) will be the topmost empty directory
      * If immediate parent directory is not empty, the array will remain empty
      * @return void
      */
@@ -737,8 +737,8 @@ class FileUtils {
         }
         $has_file = false;
         $entities = []; // dirs or files
-        FileUtils::getDirContents($parent_dir, $entities); 
-        foreach($entities as $entity) {
+        FileUtils::getDirContents($parent_dir, $entities);
+        foreach ($entities as $entity) {
             if (is_file($entity)) {
                 $has_file = true;
                 break;

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -719,14 +719,14 @@ class FileUtils {
     }
 
     /**
-     * Given a path, searches for the topmost directory that's empty, empty means having no files but there can be
+     * Given a path, searches for the topmost directory that's empty, here empty means having no files but there can be
      * empty subdirectories inside that directory
      *
      * @param string $path Absolute path to file or directory
      * @param string $base_path Recursion is stopped at this path i.e. this path isn't included in empty dirs
      * @param array $results An array passed by reference will be populated if an empty dir is found. The array is
-     * populated as per the hierarchy i.e. at the end of execution the first element (if any) of the array will be the
-     * the innermost empty directory and the last element (if any) will be the topmost empty directory
+     * populated as per the hierarchy i.e. at the end of execution the first element (if any) of the array will be
+     * the outermost empty directory and the last element (if any) will be the innermost empty directory
      * If immediate parent directory is not empty, the array will remain empty
      * @return void
      */
@@ -745,8 +745,8 @@ class FileUtils {
             }
         }
         if ($has_file == false) {
-            $results[] = $parent_dir;
             FileUtils::getTopEmptyDir($parent_dir, $base_path, $results);
+            $results[] = $parent_dir;
         }
     }
 }

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -717,4 +717,36 @@ class FileUtils {
             }
         }
     }
+
+    /**
+     * Given a path, searches for the topmost directory that's empty, empty means having no files but there can be
+     * empty subdirectories inside that directory
+     *
+     * @param string $path Absolute path to file or directory
+     * @param string $base_path Recursion is stopped at this path i.e. this path isn't included in empty dirs
+     * @param array $results An array passed by reference will be populated if an empty dir is found. The array is
+     * populated as per the hierarchy i.e. at the end of execution the first element (if any) of the array will be the 
+     * the innermost empty directory and the last element (if any) will be the topmost empty directory 
+     * If immediate parent directory is not empty, the array will remain empty
+     * @return void
+     */
+    public static function getTopEmptyDir(string $path, string $base_path, &$results = []): void {
+        $parent_dir = pathinfo($path, PATHINFO_DIRNAME);
+        if (!((str_starts_with($parent_dir, $base_path)) && $parent_dir != $base_path)) {
+            return;
+        }
+        $has_file = false;
+        $entities = []; // dirs or files
+        FileUtils::getDirContents($parent_dir, $entities); 
+        foreach($entities as $entity) {
+            if (is_file($entity)) {
+                $has_file = true;
+                break;
+            }
+        }
+        if ($has_file == false) {
+            $results[] = $parent_dir;
+            FileUtils::getTopEmptyDir($parent_dir, $base_path, $results);
+        }
+    }
 }


### PR DESCRIPTION
### What is the current behavior?
The folders that have no files in the course materials page are not shown in the frontend but they persist inside the filesystem.

Steps to reproduce:
1.) Create a folder by specifying an optional subdirectory such as "outer" in "Upload Course Materials" and upload a file inside it.
2.) Delete that file using the interface, the folder will no more be shown as it has no files.
3.) Go to the relevant course_materials folder in the system e.g. `/var/local/submitty/courses/s22/blank/uploads/course_materials`
4.) See that the folder that was invisible on the interface is still there in the system.

### What is the new behavior?
The redundant empty folders are removed from the file system and also removed using entity manager. This also applies to nested folders such as outer/inner/file.txt. This prevents long empty folder trees from existing in the course materials.

### Other information?
Note for the reviewer: I've tested but it's easy to overlook a special case. So please test for various scenarios especially involving nested folders.
