### PR TITLE
[Feature:System] cleanup old emails from Database

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -887,7 +887,7 @@ done
 #############################################################################
 # Cleanup Old Email
 
-"${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 1000
+"${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 10000
 
 
 #############################################################################

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -891,8 +891,9 @@ done
 # receipts that were successfully sent at least 360 days ago, with no
 # errors, and delete them from the table.  A maximum of 10,000 email
 # receipts will be deleted.
-"${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 10000
-
+if [ "${WORKER}" == 0 ]; then
+    "${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 10000
+fi
 
 #############################################################################
 # If the migrations have indicated that it is necessary to rebuild all

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -888,9 +888,9 @@ done
 # Cleanup Old Email
 
 # Will scan the emails table in the main Submitty database for email
-# receipts that were successfully sent (with no errors) and delete
-# them from the table.  A maximum of 10,000 email receipts will be
-# deleted.
+# receipts that were successfully sent at least 360 days ago, with no
+# errors, and delete them from the table.  A maximum of 10,000 email
+# receipts will be deleted.
 "${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 10000
 
 

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -885,6 +885,12 @@ done
 
 
 #############################################################################
+# Cleanup Old Email
+
+"${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 1000
+
+
+#############################################################################
 # If the migrations have indicated that it is necessary to rebuild all
 # existing gradeables, do so.
 

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -887,6 +887,10 @@ done
 #############################################################################
 # Cleanup Old Email
 
+# Will scan the emails table in the main Submitty database for email
+# receipts that were successfully sent (with no errors) and delete
+# them from the table.  A maximum of 10,000 email receipts will be
+# deleted.
 "${SUBMITTY_INSTALL_DIR}/sbin/cleanup_old_email.py" 360 10000
 
 

--- a/.setup/install_submitty/install_bin.sh
+++ b/.setup/install_submitty/install_bin.sh
@@ -70,7 +70,7 @@ chmod 550 ${SUBMITTY_INSTALL_DIR}/sbin/authentication.py
 chmod 555 ${SUBMITTY_INSTALL_DIR}/sbin/killall.py
 
 # DAEMON_USER only things in sbin
-array=( auto_rainbow_grades.py auto_rainbow_scheduler.py build_config_upload.py send_email.py generate_grade_summaries.py submitty_daemon_jobs)
+array=( auto_rainbow_grades.py auto_rainbow_scheduler.py build_config_upload.py send_email.py cleanup_old_email.py generate_grade_summaries.py submitty_daemon_jobs)
 for i in "${array[@]}"; do
     chown -R root:"${DAEMON_GROUP}" ${SUBMITTY_INSTALL_DIR}/sbin/${i}
     chmod -R 750 ${SUBMITTY_INSTALL_DIR}/sbin/${i}

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -21,7 +21,7 @@
 cryptography==3.3.2
 
 # For QR bulk upload
-#opencv-python==3.4.9.33
+opencv-python==3.4.9.33
 
 # jsonschema & jsonref & pytz & tzlocal
 pytz==2021.3 # Submitty-util specific.
@@ -57,5 +57,5 @@ numpy==1.19.5
 
 # python libraries for OCR for digit recognition
 # newer versions are not supported on 18.04
-#onnx==1.9.0
-#onnxruntime==1.3.0
+onnx==1.9.0
+onnxruntime==1.3.0

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -21,7 +21,7 @@
 cryptography==3.3.2
 
 # For QR bulk upload
-opencv-python==3.4.9.33
+#opencv-python==3.4.9.33
 
 # jsonschema & jsonref & pytz & tzlocal
 pytz==2021.3 # Submitty-util specific.
@@ -57,5 +57,5 @@ numpy==1.19.5
 
 # python libraries for OCR for digit recognition
 # newer versions are not supported on 18.04
-onnx==1.9.0
-onnxruntime==1.3.0
+#onnx==1.9.0
+#onnxruntime==1.3.0

--- a/sbin/cleanup_old_email.py
+++ b/sbin/cleanup_old_email.py
@@ -114,7 +114,7 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
     print(f"email to delete after count: {after}")
 
     print(f"deleted email count {before-after}\n")
-    
+
 
 def main():
     try:

--- a/sbin/cleanup_old_email.py
+++ b/sbin/cleanup_old_email.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+"""
+Cleanup old email from main Submitty database emails table.
+
+This script takes 2 optional arguments:
+ - the number of days of sent email records to preserve (default 360)
+ - the maximum number of emails to delete per call to this script (default 1,000)
+"""
+
+import json
+import os
+import datetime
+from sqlalchemy import create_engine, MetaData, Table, bindparam, text
+import sys
+import psutil
+
+
+try:
+    CONFIG_PATH = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), '..', 'config')
+    with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
+        SUBMITTY_CONFIG = json.load(open_file)
+    with open(os.path.join(CONFIG_PATH, 'database.json')) as open_file:
+        DATABASE_CONFIG = json.load(open_file)
+
+        
+except Exception as config_fail_error:
+    print("[{}] ERROR: CORE SUBMITTY CONFIGURATION ERROR {}".format(
+        str(datetime.datetime.now()), str(config_fail_error)))
+    sys.exit(1)
+
+
+DATA_DIR_PATH = SUBMITTY_CONFIG['submitty_data_dir']
+EMAIL_LOG_PATH = os.path.join(DATA_DIR_PATH, "logs", "emails")
+TODAY = datetime.datetime.now()
+LOG_FILE = open(os.path.join(
+    EMAIL_LOG_PATH, "{:04d}{:02d}{:02d}.txt".format(TODAY.year, TODAY.month,
+                                                    TODAY.day)), 'a')
+
+
+try:
+    DB_HOST = DATABASE_CONFIG['database_host']
+    DB_USER = DATABASE_CONFIG['database_user']
+    DB_PASSWORD = DATABASE_CONFIG['database_password']
+
+except Exception as config_fail_error:
+    e = "[{}] ERROR: Database Configuration Failed {}".format(
+        str(datetime.datetime.now()), str(config_fail_error))
+    LOG_FILE.write(e+"\n")
+    print(e)
+    sys.exit(1)
+
+
+def setup_db():
+    """Set up a connection with the submitty database."""
+    db_name = "submitty"
+    # If using a UNIX socket, have to specify a slightly different connection string
+    if os.path.isdir(DB_HOST):
+        conn_string = "postgresql://{}:{}@/{}?host={}".format(
+            DB_USER, DB_PASSWORD, db_name, DB_HOST)
+    else:
+        conn_string = "postgresql://{}:{}@{}/{}".format(
+            DB_USER, DB_PASSWORD, DB_HOST, db_name)
+
+    engine = create_engine(conn_string)
+    db = engine.connect()
+    metadata = MetaData(bind=db)
+    return db, metadata
+
+
+def delete_old_emails(db, days_to_preserve, maximum_to_delete):
+    """Collect the emails to be deleted and information about errors and unsent email."""
+    
+    query  = """SELECT count(*) FROM emails;"""
+    result = db.execute(text(query))
+    for row in result:
+        print(f"total email count: {row[0]}")
+
+    query  = """SELECT count(*) FROM emails where error != '';"""
+    result = db.execute(text(query))
+    for row in result:
+        error_count = row[0]
+        print(f"error email count: {row[0]}")
+
+    if error_count > 0:
+        print (f"WARNING: {error_count} unsent emails in database WITH ERRORS.")
+        
+    query  = """SELECT count(*) FROM emails where sent is NULL AND error = '';"""
+    result = db.execute(text(query))
+    for row in result:
+        unsent_count = row[0]
+        print(f"unsent email count: {row[0]}")
+
+    if unsent_count > 0:
+        print (f"WARNING: {unsent_count} UNSENT emails in database without errors.")
+        
+    last_week = str(TODAY - datetime.timedelta(days=days_to_preserve))
+    
+    query  = """SELECT count(*) FROM emails WHERE sent is not NULL AND sent < :format AND error = '';"""
+    result = db.execute(text(query), format=last_week)
+    for row in result:
+        before = row[0]
+        print(f"email to delete before count: {row[0]}")
+
+    if before == 0:
+        print("Nothing to delete, exiting\n")
+        return
+        
+    query  = """delete from emails WHERE ctid in (select ctid from emails where sent is not NULL AND sent < :format AND error = '' LIMIT :foo);"""
+    result = db.execute(text(query), format=last_week, foo=str(maximum_to_delete))
+        
+    query  = """SELECT count(*) FROM emails WHERE sent is not NULL AND sent < :format AND error = '';"""
+    result = db.execute(text(query), format=last_week)
+    for row in result:
+        after = row[0]
+        print(f"email to delete after count: {row[0]}")
+
+    print(f"deleted email count {before-after}\n")
+
+
+def main():
+    try:
+        db, metadata = setup_db()
+
+        print ("\nChecking Submitty Database Emails Table")
+        
+        days_to_preserve = 360
+        if len(sys.argv) > 1:
+            days_to_preserve = int(sys.argv[1])
+        if (days_to_preserve < 7):
+            print("ERROR: Should preserve at least 1 week of email")
+            return
+        print(f"preserving {days_to_preserve} days of email")
+            
+        maximum_to_delete = 1000
+        if len(sys.argv) > 2:
+            maximum_to_delete = int(sys.argv[2])
+        if (maximum_to_delete < 10 or maximum_to_delete > 10000):
+            print("ERROR: maximum to delete should be between 10 and 10000")
+            return
+        print(f"deleting at most {maximum_to_delete} emails")
+        
+        delete_old_emails(db,days_to_preserve,maximum_to_delete)
+
+    except Exception as email_send_error:
+        e = "[{}] Error Sending Email: {}".format(
+            str(datetime.datetime.now()), str(email_send_error))
+        LOG_FILE.write(e+"\n")
+        print(e)
+
+
+if __name__ == "__main__":
+    main()

--- a/sbin/cleanup_old_email.py
+++ b/sbin/cleanup_old_email.py
@@ -83,7 +83,7 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
         print(f"error email count: {row[0]}")
 
     if error_count > 0:
-        print (f"WARNING: {error_count} unsent emails in database WITH ERRORS.")
+        print(f"WARNING: {error_count} unsent emails in database WITH ERRORS.")
 
     query = """SELECT count(*) FROM emails where sent is NULL AND error = '';"""
     result = db.execute(text(query))
@@ -96,7 +96,7 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
 
     last_week = str(TODAY - datetime.timedelta(days=days_to_preserve))
 
-    query = """SELECT count(*) FROM emails WHERE sent is not NULL 
+    query = """SELECT count(*) FROM emails WHERE sent is not NULL
     AND sent < :format AND error = '';"""
     result = db.execute(text(query), format=last_week)
     for row in result:
@@ -107,11 +107,11 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
         print("Nothing to delete, exiting\n")
         return
 
-    query = """delete from emails WHERE ctid in (select ctid from emails 
+    query = """delete from emails WHERE ctid in (select ctid from emails
     where sent is not NULL AND sent < :format AND error = '' LIMIT :foo);"""
     result = db.execute(text(query), format=last_week, foo=str(maximum_to_delete))
 
-    query = """SELECT count(*) FROM emails WHERE sent is not NULL 
+    query = """SELECT count(*) FROM emails WHERE sent is not NULL
     AND sent < :format AND error = '';"""
     result = db.execute(text(query), format=last_week)
     for row in result:
@@ -138,8 +138,8 @@ def main():
         maximum_to_delete = 1000
         if len(sys.argv) > 2:
             maximum_to_delete = int(sys.argv[2])
-        if (maximum_to_delete < 10 or maximum_to_delete > 10000):
-            print("ERROR: maximum to delete should be between 10 and 10000")
+        if (maximum_to_delete < 10 or maximum_to_delete > 100000):
+            print("ERROR: maximum to delete should be between 10 and 100000")
             return
         print(f"deleting at most {maximum_to_delete} emails")
 

--- a/sbin/cleanup_old_email.py
+++ b/sbin/cleanup_old_email.py
@@ -143,7 +143,7 @@ def main():
             return
         print(f"deleting at most {maximum_to_delete} emails")
 
-        delete_old_emails(db, days_to_preserve,m aximum_to_delete)
+        delete_old_emails(db, days_to_preserve, maximum_to_delete)
 
     except Exception as email_send_error:
         e = "[{}] Error Sending Email: {}".format(

--- a/sbin/cleanup_old_email.py
+++ b/sbin/cleanup_old_email.py
@@ -73,23 +73,20 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
 
     query = """SELECT count(*) FROM emails;"""
     result = db.execute(text(query))
-    for row in result:
-        print(f"total email count: {row[0]}")
+    print(f"total email count: {result.fetchone()[0]}")
 
     query = """SELECT count(*) FROM emails where error != '';"""
     result = db.execute(text(query))
-    for row in result:
-        error_count = row[0]
-        print(f"error email count: {row[0]}")
+    error_count = result.fetchone()[0]
+    print(f"error email count: {error_count}")
 
     if error_count > 0:
         print(f"WARNING: {error_count} unsent emails in database WITH ERRORS.")
 
     query = """SELECT count(*) FROM emails where sent is NULL AND error = '';"""
     result = db.execute(text(query))
-    for row in result:
-        unsent_count = row[0]
-        print(f"unsent email count: {row[0]}")
+    unsent_count = result.fetchone()[0]
+    print(f"unsent email count: {unsent_count}")
 
     if unsent_count > 0:
         print(f"WARNING: {unsent_count} UNSENT emails in database without errors.")
@@ -99,9 +96,8 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
     query = """SELECT count(*) FROM emails WHERE sent is not NULL
     AND sent < :format AND error = '';"""
     result = db.execute(text(query), format=last_week)
-    for row in result:
-        before = row[0]
-        print(f"email to delete before count: {row[0]}")
+    before = result.fetchone()[0]
+    print(f"email to delete before count: {before}")
 
     if before == 0:
         print("Nothing to delete, exiting\n")
@@ -114,12 +110,11 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
     query = """SELECT count(*) FROM emails WHERE sent is not NULL
     AND sent < :format AND error = '';"""
     result = db.execute(text(query), format=last_week)
-    for row in result:
-        after = row[0]
-        print(f"email to delete after count: {row[0]}")
+    after = result.fetchone()[0]
+    print(f"email to delete after count: {after}")
 
     print(f"deleted email count {before-after}\n")
-
+    
 
 def main():
     try:

--- a/sbin/cleanup_old_email.py
+++ b/sbin/cleanup_old_email.py
@@ -11,9 +11,8 @@ This script takes 2 optional arguments:
 import json
 import os
 import datetime
-from sqlalchemy import create_engine, MetaData, Table, bindparam, text
+from sqlalchemy import create_engine, MetaData, text
 import sys
-import psutil
 
 
 try:
@@ -24,7 +23,7 @@ try:
     with open(os.path.join(CONFIG_PATH, 'database.json')) as open_file:
         DATABASE_CONFIG = json.load(open_file)
 
-        
+
 except Exception as config_fail_error:
     print("[{}] ERROR: CORE SUBMITTY CONFIGURATION ERROR {}".format(
         str(datetime.datetime.now()), str(config_fail_error)))
@@ -71,13 +70,13 @@ def setup_db():
 
 def delete_old_emails(db, days_to_preserve, maximum_to_delete):
     """Collect the emails to be deleted and information about errors and unsent email."""
-    
-    query  = """SELECT count(*) FROM emails;"""
+
+    query = """SELECT count(*) FROM emails;"""
     result = db.execute(text(query))
     for row in result:
         print(f"total email count: {row[0]}")
 
-    query  = """SELECT count(*) FROM emails where error != '';"""
+    query = """SELECT count(*) FROM emails where error != '';"""
     result = db.execute(text(query))
     for row in result:
         error_count = row[0]
@@ -85,19 +84,20 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
 
     if error_count > 0:
         print (f"WARNING: {error_count} unsent emails in database WITH ERRORS.")
-        
-    query  = """SELECT count(*) FROM emails where sent is NULL AND error = '';"""
+
+    query = """SELECT count(*) FROM emails where sent is NULL AND error = '';"""
     result = db.execute(text(query))
     for row in result:
         unsent_count = row[0]
         print(f"unsent email count: {row[0]}")
 
     if unsent_count > 0:
-        print (f"WARNING: {unsent_count} UNSENT emails in database without errors.")
-        
+        print(f"WARNING: {unsent_count} UNSENT emails in database without errors.")
+
     last_week = str(TODAY - datetime.timedelta(days=days_to_preserve))
-    
-    query  = """SELECT count(*) FROM emails WHERE sent is not NULL AND sent < :format AND error = '';"""
+
+    query = """SELECT count(*) FROM emails WHERE sent is not NULL 
+    AND sent < :format AND error = '';"""
     result = db.execute(text(query), format=last_week)
     for row in result:
         before = row[0]
@@ -106,11 +106,13 @@ def delete_old_emails(db, days_to_preserve, maximum_to_delete):
     if before == 0:
         print("Nothing to delete, exiting\n")
         return
-        
-    query  = """delete from emails WHERE ctid in (select ctid from emails where sent is not NULL AND sent < :format AND error = '' LIMIT :foo);"""
+
+    query = """delete from emails WHERE ctid in (select ctid from emails 
+    where sent is not NULL AND sent < :format AND error = '' LIMIT :foo);"""
     result = db.execute(text(query), format=last_week, foo=str(maximum_to_delete))
-        
-    query  = """SELECT count(*) FROM emails WHERE sent is not NULL AND sent < :format AND error = '';"""
+
+    query = """SELECT count(*) FROM emails WHERE sent is not NULL 
+    AND sent < :format AND error = '';"""
     result = db.execute(text(query), format=last_week)
     for row in result:
         after = row[0]
@@ -123,8 +125,8 @@ def main():
     try:
         db, metadata = setup_db()
 
-        print ("\nChecking Submitty Database Emails Table")
-        
+        print("\nChecking Submitty Database Emails Table")
+
         days_to_preserve = 360
         if len(sys.argv) > 1:
             days_to_preserve = int(sys.argv[1])
@@ -132,7 +134,7 @@ def main():
             print("ERROR: Should preserve at least 1 week of email")
             return
         print(f"preserving {days_to_preserve} days of email")
-            
+
         maximum_to_delete = 1000
         if len(sys.argv) > 2:
             maximum_to_delete = int(sys.argv[2])
@@ -140,8 +142,8 @@ def main():
             print("ERROR: maximum to delete should be between 10 and 10000")
             return
         print(f"deleting at most {maximum_to_delete} emails")
-        
-        delete_old_emails(db,days_to_preserve,maximum_to_delete)
+
+        delete_old_emails(db, days_to_preserve,m aximum_to_delete)
 
     except Exception as email_send_error:
         e = "[{}] Error Sending Email: {}".format(


### PR DESCRIPTION
### What is the current behavior?
Old emails, that have been successfully sent without error, are accumulating in the emails table of the main database.

### What is the new behavior?
This PR adds a sbin/cleanup_old_emails.py script that will purge the oldest emails that didn't have any error and were successfully sent.

This script takes 2 optional arguments:
 - the number of days of sent email records to preserve (default 360)
 - the maximum number of emails to delete per call to this script (default 10,000)

This script is called from the INSTALL_SUBMITTY.sh script.

Closes #3326
