### PR TITLE
[Bugfix:Autograding] Mermaid Sequence Diagram Fix

### DIFF
--- a/grading/python/submitty_router.py
+++ b/grading/python/submitty_router.py
@@ -111,7 +111,7 @@ class submitty_router():
         outfile.write(f'{start}: {message}\n')
       else:
         str_lines = [str(x) for x in message_lines ]
-        outfile.write(f'{start}: {"<br>".join(str_lines)}\n')
+        outfile.write(f'{start}: {"<br/>".join(str_lines)}\n')
 
       if diagram_label is not None and obj['diagram_label'].strip() != '':
         outfile.write(f'Note over {sender},{recipient}: {diagram_label}\n')

--- a/grading/python/submitty_router.py
+++ b/grading/python/submitty_router.py
@@ -111,7 +111,7 @@ class submitty_router():
         outfile.write(f'{start}: {message}\n')
       else:
         str_lines = [str(x) for x in message_lines ]
-        outfile.write(f'{start}: {"<br/>".join(str_lines)}\n')
+        outfile.write(f'{start}: {"<br>".join(str_lines)}\n')
 
       if diagram_label is not None and obj['diagram_label'].strip() != '':
         outfile.write(f'Note over {sender},{recipient}: {diagram_label}\n')

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -125,6 +125,7 @@
                   "useMaxWidth" : false
                 };
                 mermaid.initialize(config);
+                // TODO: This is a TEMPERARY fix, use callback
                 setTimeout(() => {mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");}, 200);
               </script>
             {% endif %}

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -125,7 +125,7 @@
                   "useMaxWidth" : false
                 };
                 mermaid.initialize(config);
-                // TODO: This is a TEMPERARY fix, use callback
+                // TODO: This is a TEMPORARY fix, use callback
                 setTimeout(() => {mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");}, 200);
               </script>
             {% endif %}

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -125,8 +125,9 @@
                   "useMaxWidth" : false
                 };
                 mermaid.initialize(config);
-                // TODO: This is a TEMPORARY fix, use callback
-                setTimeout(() => {mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");}, 200);
+                $( document ).ready(function() {
+                    mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");
+                });
               </script>
             {% endif %}
         </div>

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -125,7 +125,7 @@
                   "useMaxWidth" : false
                 };
                 mermaid.initialize(config);
-                mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");
+                setTimeout(() => {mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");}, 200);
               </script>
             {% endif %}
         </div>


### PR DESCRIPTION
### What is the current behavior?
The mermaid sequence diagrams for network gradeables have messages overlapping with each other most likely due to broken y values for the elements in the SVG.

### What is the new behavior?
The messages in the mermaid sequence diagrams now have line breaks and other elements have correct y values.
![image](https://user-images.githubusercontent.com/79226246/176240334-3b059e8b-68ad-4e39-8eae-9ac7700e4c19.png)

### Other information?
This is a temporary fix by adding delays.