### PR TITLE
[Bugfix:TAGrading] Peer grading sever error

### DIFF
--- a/site/app/templates/grading/electronic/EditPeerComponentsForm.twig
+++ b/site/app/templates/grading/electronic/EditPeerComponentsForm.twig
@@ -37,7 +37,8 @@
 			        {% for mark in component.marks %}
 		                <div class="row">
 		                    <div class="col-no-gutters indicator">
-		                    	{% if peer_details.marks_assigned is defined and mark in peer_details.marks_assigned[component.id][peer] %}
+		                    	{% if peer_details.marks_assigned is defined and 
+		                    		peer_details.marks_assigned[component.id][peer] is defined and mark in peer_details.marks_assigned[component.id][peer] %}
 		                        	<i class="far fa-check-square fa-1g"></i>
 		                        {% else %}
 		                        	<i class="far fa-square fa-1g"></i>


### PR DESCRIPTION
### What is the current behavior?
Closes #8091
In peer gradeables, a grader will get a server error when trying to grade a student who has already been graded by other peers.

### What is the new behavior?
Removes the server error.