### PR TITLE
[Refactor:TAGrading] PDF console errors

### DIFF
--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -67,17 +67,14 @@
     same could not be achived through CSS as it cause the tools to hide when moved right in panel.
     This has been done taking care of resizing of panel ,platform(device),overlapping and scrolling of panels */
 
-    try {
+    if(typeof offSetter === "undefined") {
         const offSetter = new ResizeObserver(entries => {
             entries.forEach(entry => {
                 let height = $(".sticky-file-info").outerHeight();
-                $("#viewer").css("paddingTop", height);
+                $("#viewer").css("padding-top", height);
             });
         });
         offSetter.observe(document.querySelector(".sticky-file-info"));
-    }
-    catch (e) {
-        // Prevent defining the variable again
     }
 
 </script>

--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -67,12 +67,17 @@
     same could not be achived through CSS as it cause the tools to hide when moved right in panel.
     This has been done taking care of resizing of panel ,platform(device),overlapping and scrolling of panels */
 
-    const offSetter = new ResizeObserver(entries => {
-        entries.forEach(entry => {
-            let height = $(".sticky-file-info").outerHeight();
-            $("#viewer").css("paddingTop", height);
+    try {
+        const offSetter = new ResizeObserver(entries => {
+            entries.forEach(entry => {
+                let height = $(".sticky-file-info").outerHeight();
+                $("#viewer").css("paddingTop", height);
+            });
         });
-    });
-    offSetter.observe(document.querySelector(".sticky-file-info"));
+        offSetter.observe(document.querySelector(".sticky-file-info"));
+    }
+    catch (e) {
+        // Prevent defining the variable again
+    }
 
 </script>

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -97,7 +97,7 @@ Required Parameters:
         $(document).ready(function(){
             $('.overall-comment-other').each(function() {
                 const content = $(this).html().trim();
-                const url = buildURL(["markdown"]);
+                const url = buildUrl(["markdown"]);
                 renderMarkdown($(this), url, content);
             });
         });
@@ -114,5 +114,3 @@ Required Parameters:
       });
     </script>
 </div>
-
-


### PR DESCRIPTION
### What is the current behavior?
In the grading interface, there are console errors related to already defined identifiers when trying to view multiple pdfs in a session. This prevents later pdfs from loading.
There are also warning related to undefined variables.

### What is the new behavior?
Removes the corresponding console errors and users can view multiple pdfs in a session.