### PR TITLE
[Refactor:Developer] Use official bento arm64 vagrant image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,11 +52,10 @@ VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 bash ${GIT_PATH}/.setup/install_worker.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker.log
 SCRIPT
 
-# Bento does not yet make available ARM64 compatible boxes, so we need to use an alternative box that's built from bento's sources
-ubuntu_2004_box = if Vagrant::Util::Platform.darwin? && (`uname -m`.chomp == "arm64" || (`sysctl -n machdep.cpu.brand_string`.chomp.include? 'M1'))
-  'jeffnoxon/ubuntu-20.04-arm64'
+box_extra = if Vagrant::Util::Platform.darwin? && (`uname -m`.chomp == "arm64" || (`sysctl -n machdep.cpu.brand_string`.chomp.include? 'M1'))
+  '-arm64'
 else
-  'bento/ubuntu-20.04'
+  ''
 end
 
 def mount_folders(config, mount_options)
@@ -86,7 +85,7 @@ Vagrant.configure(2) do |config|
   # so that when we do "vagrant up", it doesn't spin up those machines.
 
   config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
-    ubuntu.vm.box = ubuntu_2004_box
+    ubuntu.vm.box = "bento/ubuntu-20.04#{box_extra}"
     # If this IP address changes, it must be changed in install_system.sh and
     # CONFIGURE_SUBMITTY.py to allow the ssh connection
     ubuntu.vm.network "private_network", ip: "172.18.2.8"
@@ -96,7 +95,7 @@ Vagrant.configure(2) do |config|
 
   # Our primary development target, RPI uses it as of Fall 2021
   config.vm.define 'ubuntu-20.04', primary: true do |ubuntu|
-    ubuntu.vm.box = ubuntu_2004_box
+    ubuntu.vm.box = "bento/ubuntu-20.04#{box_extra}"
     ubuntu.vm.network 'forwarded_port', guest: 1511, host: 1511   # site
     ubuntu.vm.network 'forwarded_port', guest: 8443, host: 8443   # Websockets
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: 16442  # database


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The Vagrantfile uses a random user's generated box image to support arm64 architectures, as at the time, bento project had not yet release their own official version of it.

### What is the new behavior?

Bento now releases `arm64` versions of their images, and so we can switch back to using those, and so should have image compatibility between the `x86_64` and `arm64` images and how they function.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

I ran `vagrant up` on a M1 mac to validate that the image works on arm64 architectures. Running https://github.com/Submitty/Submitty/actions/runs/2607599868 to validate nothing broke with `x86_64` OSes.

GitHub does not offer an `arm64` compatible machine, so we cannot add to our vagrant up matrix nightly testing of the arm64 variant, and just have to rely on regular testing of end users.