### PR TITLE
[Documentation:Developer] Remove hack step from UTM README

### DIFF
--- a/README_utm_arm.txt
+++ b/README_utm_arm.txt
@@ -157,17 +157,7 @@ On an M1 Mac laptop, we cannot use virtual box, so follow these instructions ins
    sudo umount /usr/local/submitty/GIT_CHECKOUT
 
 
-9. TEMPORARY HACK STEP
-
-   open .setup/pip/system_requirements.txt
-   comment out the opencv and onnx version installations (compilation from scratch fails)
-
-    #opencv-python==3.4.10.37
-    #onnxruntime==1.8.1
-    #onnx==1.9.0
-
-
-10. Do Submitty system setup and installation:
+9. Do Submitty system setup and installation:
 
     On the guest machine:
 
@@ -181,13 +171,11 @@ On an M1 Mac laptop, we cannot use virtual box, so follow these instructions ins
     sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/recreate_sample_courses.sh
 
 
-11. After installation, to fix opencv & onnx:
+10. After installation, to fix opencv & onnx:
 
-    sudo pip install opencv-python
-    sudo pip install onnxruntime
     sudo apt install libgl1-mesa-glx
 
 
-12. When finished, access the Submitty website from a browser on your host machine:
+11. When finished, access the Submitty website from a browser on your host machine:
 
     http://localhost:1511/


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When setting up the VM using UTM, it was necessary to "hack" what dependencies got installed as the old versions of those dependencies were not compatible with arm64 architecture.

### What is the new behavior?

Now that we've moved to Ubuntu 20.04, and so can better support installation of newer versions of these dependencies which have arm64 support, it's no longer necessary to run the hack step that was listed in the UTM README. As such, they've been removed.

I'm not sure if `libgl1-mesa-glx` is still something that's required to be installed or not though.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

I'm not sure who other than @bmcutler has used these instructions.