### PR TITLE
[Bugfix:Developer] Update minimum PHP version for composer

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -2,7 +2,7 @@
   "name": "submitty/submitty",
   "config": {
     "platform": {
-      "php": "7.2"
+      "php": "7.4"
     },
     "sort-packages": true,
     "allow-plugins": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant: https://github.com/Submitty/submitty.github.io/pull/440

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

We had set the `config.platform.php` value in the `composer.json` file to 7.2 so that no matter what version of PHP the host system was using, it would only try to use packages that were 7.2 compatible. Given that we've dropped Ubuntu 18.04 and our new minimum version is 7.4, we can bump the value.

### What is the new behavior?

Set the value of `config.platform.php` to 7.4 to match our new minimum supported version. This will allow installing and updating packages to versions that did not support 7.2 (e.g. phpunit 9.x or twig 3.x). 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Vagrant up run: https://github.com/Submitty/Submitty/actions/runs/2611293412