### PR TITLE
[Bugfix:Developer] Update config.json error message

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -144,7 +144,7 @@ class Core {
                 $message = "Unable to access configuration file " . $course_json_path . " for " .
                   $semester . " " . $course . " please contact your system administrator.\n" .
                   "If this is a new course, the error might be solved by restarting php-fpm:\n" .
-                  "sudo service php7.2-fpm restart";
+                  "sudo service php7.4-fpm restart";
                 $this->addErrorMessage($message);
             }
         }


### PR DESCRIPTION
### What is the current behavior?
If a course's `config.json` file is inaccessible then an error message is shown recommending to restart `php-fpm` using the command `sudo service php7.2-fpm restart`.

### What is the new behavior?
Support for `php7.2` was dropped, so the command has been changed to `sudo service php7.4-fpm restart`.

### Other information?
The old error message was misguiding at times because running the advised command would result in error `Failed to restart php7.2-fpm.service: Unit php7.2-fpm.service not found.`
