### PR TITLE
[Bugfix:Developer] Use version constants for config message

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -144,7 +144,7 @@ class Core {
                 $message = "Unable to access configuration file " . $course_json_path . " for " .
                   $semester . " " . $course . " please contact your system administrator.\n" .
                   "If this is a new course, the error might be solved by restarting php-fpm:\n" .
-                  "sudo service php7.4-fpm restart";
+                  "sudo service php".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION."-fpm restart";
                 $this->addErrorMessage($message);
             }
         }

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -144,7 +144,7 @@ class Core {
                 $message = "Unable to access configuration file " . $course_json_path . " for " .
                   $semester . " " . $course . " please contact your system administrator.\n" .
                   "If this is a new course, the error might be solved by restarting php-fpm:\n" .
-                  "sudo service php".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION."-fpm restart";
+                  "sudo service php" . PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "-fpm restart";
                 $this->addErrorMessage($message);
             }
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Right now, we hardcode the version of `php-fpm` that should be restarted as part of the config.json error message. Anytime we move to a new version of Ubuntu, this version string would need to be updated, and it's easy for us to miss doing that (e.g. we've been using Ubuntu 20.04 for most people for well over year and half or so, and the message was only just updated to be `php7.4-fpm` today in #8145.

### What is the new behavior?

Instead of hardcoding the version, we can just leverage the `PHP_MAJOR_VERSION` and `PHP_MINOR_VERSION` constants instead, and so the error message will give the appropriate service restart command for the version of PHP that's on the OS, useful for when we start testing / moving to Ubuntu 22.04 which ships with PHP 8.1.

### Other information? PHP_MINOR_VERSION
<!-- Is this a breaking change? -->
<!-- How did you test -->
