### PR TITLE
[Feature:Autograding] Max Submission Size String

### DIFF
--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -32,16 +32,18 @@ uint64_t parse_file_size(std::string size_str) {
   // Accepted units, all Bs could be omitted:
   //    Base 1000: B, KB,  MB,  GB,  TB   (SI)
   //    Base 1024: B, KiB, MiB, GiB, TiB  (IEC-i)
-  const std::regex accepted { "[1-9]\\d*([kmgt]i?)?b?" };
+  const std::regex accepted { "\\d+([kmgt]i?)?b?" };
   // check if it is well formatted
   if (!std::regex_match(size_str, accepted)) {
     std::cout << "Got string: " << size_str << std::endl;
-    throw std::invalid_argument("Wrong format: accepted format is [1-9]\\d*([KMGT]i?)?B?");
+    throw std::invalid_argument("Wrong format: accepted format is \\d+([KMGT]i?)?B?");
   }
 
   // Extract numeric file size, will cause exception if the number is larger than 64-bit
   size_t unit_begin  = 0;
   uint64_t file_size = std::stoull(size_str, &unit_begin);
+  if (!file_size)
+    throw std::invalid_argument("Wrong file size: 0 byte");
 
   // Parse the units
   const std::string suffices { "bkmgt" };

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -1890,24 +1890,3 @@ nlohmann::json ValidateANotebook(const nlohmann::json& notebook, const nlohmann:
     }
     return complete;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -32,21 +32,16 @@ uint64_t parse_file_size(std::string size_str) {
   // Accepted units, all Bs could be omitted:
   //    Base 1000: B, KB,  MB,  GB,  TB   (SI)
   //    Base 1024: B, KiB, MiB, GiB, TiB  (IEC-i)
-  const std::regex accepted { "\\d+([kmgt]i?)?b?" };
+  const std::regex accepted { "[1-9]\\d*([kmgt]i?)?b?" };
+  // check if it is well formatted
+  if (!std::regex_match(size_str, accepted)) {
+    std::cout << "Got string: " << size_str << std::endl;
+    throw std::invalid_argument("Wrong format: accepted format is [1-9]\\d*([KMGT]i?)?B?");
+  }
 
   // Extract numeric file size, will cause exception if the number is larger than 64-bit
   size_t unit_begin  = 0;
   uint64_t file_size = std::stoull(size_str, &unit_begin);
-  // check if it is 0
-  if (file_size == 0) {
-    std::cout << "Got parsed value " << file_size << " from string: " << size_str << std::endl;
-    throw std::invalid_argument("Wrong file size");
-  }
-  // check if it is well formatted
-  if (!std::regex_match(size_str, accepted)) {
-    std::cout << "Got string " << size_str << std::endl;
-    throw std::invalid_argument("Wrong format: accepted format is \\d+([KMGT]i?)?B?");
-  }
 
   // Parse the units
   const std::string suffices { "bkmgt" };
@@ -61,9 +56,9 @@ uint64_t parse_file_size(std::string size_str) {
   // Return the multiplied size, throw if overflowed
   uint64_t multiplier  = static_cast<uint64_t>(std::pow(base, power));
   uint64_t parsed_size = file_size * multiplier;
-  if (file_size != parsed_size / multiplier) {
+  if (file_size != parsed_size / multiplier)
     throw std::overflow_error("Total file size overflowed");
-  }
+
   return parsed_size;
 }
 

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -22,7 +22,7 @@ void json_set_default(nlohmann::json &whole_config, std::string field, const T& 
 
 uint64_t parse_file_size(std::string size_str) {
   // Trim whitespaces
-  size_str.erase(remove_if(size_str.begin(), size_str.end(), isspace), size_str.end());
+  size_str.erase(std::remove_if(size_str.begin(), size_str.end(), isspace), size_str.end());
 
   // Convert string to lowercase, note that it cannot handle UTF-8 characters
   for (char& c : size_str)
@@ -32,7 +32,7 @@ uint64_t parse_file_size(std::string size_str) {
   size_t unit_begin = 0;
   uint64_t file_size = std::stoull(size_str, &unit_begin);
   // check if it is 0 or contains invalid chars     ====whitelist====
-  if (file_size == 0 || size_str.find_first_not_of("01234567890bkmgti") == std::string::npos) {
+  if (file_size == 0 || size_str.find_first_not_of("01234567890bkmgti") != std::string::npos) {
     std::cout << "Got parsed value " << file_size << " from string: " << size_str << std::endl;
     throw std::invalid_argument("Wrong file size");
   }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -44,6 +44,7 @@ uint64_t parse_file_size(std::string size_str) {
   }
   // check if it is well formatted
   if (!std::regex_match(size_str, accepted)) {
+    std::cout << "Got string " << size_str << std::endl;
     throw std::invalid_argument("Wrong format: accepted format is \\d+([KMGT]i?)?B?");
   }
 
@@ -51,7 +52,8 @@ uint64_t parse_file_size(std::string size_str) {
   const std::string suffices { "bkmgt" };
   size_t power = 0;
   size_t base  = 1000;
-  power = suffices.find(size_str[unit_begin]);
+  if ((power = suffices.find(size_str[unit_begin])) == std::string::npos)
+    power = 0; // Handle empty unit, treat as byte
   assert(power < 5);
   if (size_str.size() - unit_begin >= 2 && size_str[unit_begin + 1] == 'i')
     base = 1024;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

Closes #5712 

### What is the current behavior?
The issue was fixed in #6815.

### What is the new behavior?
This PR adds a new parser for stringified `max_submission_size`.

### Other information?
- Accepted format: `"\d+ ?([KMGT]i?)B?"`
  - `SI` format (`KB, K`) will be converted using base 1000
  - `IEC-i` format (`KiB, Ki`) will be converted using base 1024
- Testing
  - Manually compile the `configure.out` using `g++`, follow `INSTALL_SUBMITTY_HELPER.sh#L522-568`
  - Run the `configure.out`
  - Use `grep` to parse the output (`jq` cannot deal with `uint64_t`)
  - See details below
- Examples
  - `2333` will not be parsed, and stays as numeric `2333`
  - `"2333"` will be parsed as byte, to numeric `2333`
  - `"233 kib"` will be parsed as IEC-i `Kibibyte`, `238592`
  - `"233 mb"` will be parsed as SI `Megabyte`, `233000000`
  - `"-233k"` will cause `invalid_argument("Wrong format")`
  - `"99999990ti"` will cause `overflow_error()`

<details>

```bash
cd ${SUBMITTY_INSTALL_DIR}
# Manually compile the `configure.out`
GRADINGCODE="${SUBMITTY_INSTALL_DIR}/src/grading"
JSONCODE="${SUBMITTY_INSTALL_DIR}/vendor/include"
g++ "${GRADINGCODE}/main_configure.cpp" \
    "${GRADINGCODE}/load_config_json.cpp" \
    "${GRADINGCODE}/execute.cpp" \
    "${GRADINGCODE}/TestCase.cpp" \
    "${GRADINGCODE}/error_message.cpp" \
    "${GRADINGCODE}/window_utils.cpp" \
    "${GRADINGCODE}/dispatch.cpp" \
    "${GRADINGCODE}/change.cpp" \
    "${GRADINGCODE}/difference.cpp" \
    "${GRADINGCODE}/tokenSearch.cpp" \
    "${GRADINGCODE}/tokens.cpp" \
    "${GRADINGCODE}/clean.cpp" \
    "${GRADINGCODE}/execute_limits.cpp" \
    "${GRADINGCODE}/seccomp_functions.cpp" \
    "${GRADINGCODE}/empty_custom_function.cpp" \
    "-I${JSONCODE}" \
    -pthread -std=c++11 -lseccomp -o "${SUBMITTY_INSTALL_DIR}/bin/configure.out"

# Run the `configure.out` and get output
./bin/configure.out more_autograding_examples/c_failure_messages/config/config.json ./config_out.json c_failure_messages \
&& grep "max_submission_size" config_out.json
```

</details>