### PR TITLE
[UI/UX:CourseMaterials] Text tweak in upload form

### DIFF
--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -59,7 +59,7 @@
             <input id="hide-materials-checkbox" type="checkbox" value="off" onchange="toggleHideMaterialsWarning()"/>
             Hide from students (Note: If checked, students will not be able to see course materials, but can still access them via the URL)
             <span id="upload-form-hide-warning" class="red-message full-width" style="display: none;">
-                Warning: Students can view the hidden course material by guessing the corresponding course material ID (a number), it is recommended to use the release date feature to keep students from accessing course materials.
+                Warning: Students can view the hidden course material by guessing the corresponding course material ID (a simple number).  It is recommended to instead use the release date feature if it is necessary to prevent students from accessing course materials.
             </span>
         </label>
         <script>

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -57,7 +57,8 @@
         </label>
         <label>
             <input id="hide-materials-checkbox" type="checkbox" value="off" onchange="toggleHideMaterialsWarning()"/>
-            Hide from students (Note: If checked, students will not be able to see course materials, but can still access them via the URL)
+            Hide from Students<br>
+            <em>Note: Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL.</em>
             <span id="upload-form-hide-warning" class="red-message full-width" style="display: none;">
                 Warning: Students can view the hidden course material by guessing the corresponding course material ID (a simple number).  It is recommended to instead use the release date feature if it is necessary to prevent students from accessing course materials.
             </span>


### PR DESCRIPTION
### What is the current behavior?
Text was left unchanged in upload course materials form in #8150.

### What is the new behavior?
It has been tweaked to be consistent with edit course material form and edit folder form.