### PR TITLE
[Testing:Developer] Modified folder edit form tests

### DIFF
--- a/site/cypress/integration/courseMaterials.spec.js
+++ b/site/cypress/integration/courseMaterials.spec.js
@@ -416,7 +416,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('.fa-trash').first().click();
         cy.get('.btn-danger').click();
 
-        cy.get('.file-viewer').should('not.exist');
+        cy.get('.file-viewer').should('have.length', 6);
     });
 
     it('Should release course materials in folder by date', () => {
@@ -443,7 +443,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.login('aphacker');
         cy.visit(['sample', 'course_materials']);
 
-        cy.get('.file-viewer').should('have.length', 0);
+        cy.get('.file-viewer').should('have.length', 6);
 
         cy.visit('/');
         cy.logout();
@@ -470,7 +470,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.login('aphacker');
         cy.visit(['sample', 'course_materials']);
 
-        cy.get('.file-viewer').should('have.length', 2);
+        cy.get('.file-viewer').should('have.length', 8);
 
         cy.logout();
         cy.login();
@@ -480,7 +480,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('.fa-trash').first().click();
         cy.get('.btn-danger').click();
 
-        cy.get('.file-viewer').should('not.exist');
+        cy.get('.file-viewer').should('have.length', 6);
     });
 
     it('Should restrict course materials in folder', () => {
@@ -525,13 +525,13 @@ describe('Test cases revolving around course material uploading and access contr
         cy.login('aphacker');
         cy.visit(['sample', 'course_materials']);
 
-        cy.get('.file-viewer').should('have.length', 2);
+        cy.get('.file-viewer').should('have.length', 8);
 
         // Check that a student not in section 1 cannot view the files
         cy.logout();
         cy.login('browna');
         cy.visit(['sample', 'course_materials']);
-        cy.get('.file-viewer').should('not.exist');
+        cy.get('.file-viewer').should('have.length', 6);
 
         const fileTgt = buildUrl(['sample', 'course_material', 'a', 'file1.txt']);
 
@@ -546,7 +546,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('.fa-trash').first().click();
         cy.get('.btn-danger').click();
 
-        cy.get('.file-viewer').should('not.exist');
+        cy.get('.file-viewer').should('have.length', 6);
     });
 
     it('Should hide course materials in folder visually', () => {
@@ -588,7 +588,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.logout();
         cy.login('aphacker');
         cy.visit(['sample', 'course_materials']);
-        cy.get('.file-viewer').should('not.exist');
+        cy.get('.file-viewer').should('have.length', 6);
 
         // Check that a student can view the files through a URL
         const fileTgt = buildUrl(['sample', 'course_material', 'a', 'file1.txt']);
@@ -604,7 +604,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('.fa-trash').first().click();
         cy.get('.btn-danger').click();
 
-        cy.get('.file-viewer').should('not.exist');
+        cy.get('.file-viewer').should('have.length', 6);
     });
 
     it('Should sort course materials folder and preserve uploaded links', () => {


### PR DESCRIPTION
### What is the current behavior?
#8083 was recently merged, it added some tests that assumed course materials page to be empty but CI tests have sample course materials after #8122 was merged; therefore, Cypress tests fail currently.

### What is the new behavior?
Tests have been modified to work correctly in the presence of sample course materials.

Additional information:
To test locally, delete all the course materials in "sample" course and upload [sample_course_materials.zip](https://github.com/Submitty/Submitty/files/9122623/sample_course_materials.zip) with "Unzip" checked and remember to set the release date to a past date.
