### PR TITLE
[Bugfix:System] Fix ordering on SAML management page

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -8092,7 +8092,7 @@ ORDER BY
     public function getProxyMappedUsers(): array {
         $this->submitty_db->query("
             SELECT id, user_id, saml_id, active FROM saml_mapped_users
-                WHERE saml_id != user_id;
+                WHERE saml_id != user_id ORDER BY saml_id, user_id;
         ");
         return $this->submitty_db->rows();
     }


### PR DESCRIPTION
### What is the current behavior?
There is no guaranteed order of proxy users on the SAML management page.

### What is the new behavior?
The list of users is now sorted by SAML ID then by Submitty ID.

Partially resolves #8166