### PR TITLE
[Feature:System] Add incremental build for tsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.xml
 /site/cypress/videos/
 /site/public/mjs/
 /site/report/
+/site/incremental_build/
 
 db_update.php
 .setup/data/random_users.txt

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -291,12 +291,18 @@ chown -R ${CGI_USER}:${CGI_USER} ${SUBMITTY_INSTALL_DIR}/site/cgi-bin
 chmod 540 ${SUBMITTY_INSTALL_DIR}/site/cgi-bin/*
 chmod 550 ${SUBMITTY_INSTALL_DIR}/site/cgi-bin/git-http-backend
 
+mkdir -p "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+chgrp "${PHP_USER}" "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+
 echo "Running esbuild"
 chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
+chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm run build"
 chmod a-x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a-x ${NODE_FOLDER}/typescript/bin/tsc
+chmod g-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+chmod -R u-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 
 chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs
 set_mjs_permission ${SUBMITTY_INSTALL_DIR}/site/public/mjs

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -3,6 +3,8 @@
     "compilerOptions": {
         "strict": true,
         "allowJs": true,
-        "noEmit": true
+        "noEmit": true,
+        "incremental": true,
+        "outDir": "incremental_build"
     }
 }


### PR DESCRIPTION
### What is the current behavior?
Right now tsc and esbuild are called for all typescript/mjs code. esbuild is pretty fast but tsc takes a lot of time since it has to typecheck all files from scratch.

### What is the new behavior?
Incremental building was added for tsc to speedup the typecheck time (Results listed below). This adds an `incremental_build` folder inside of `/usr/local/submitty/site` where any incremental build files get stored. This will help developers primarily so they don't have to wait as long for this script to finish.

### Other information?
This lists the time taken to run just a site install of Submitty:
- Before incremental: 21 seconds
- After incremental: 6 seconds

NOTE: You won't feel the effects of the speedup until you have run it at least once because it needs to create the first initial incremental build. After that all builds will be significantly faster.
