### PR TITLE
[Bugfix:System] Change Signal for untrusted_execute

### DIFF
--- a/.setup/untrusted_execute.c
+++ b/.setup/untrusted_execute.c
@@ -29,14 +29,14 @@ change permissions & set suid: (must be root)
 int main(int argc, char* argv[]) {
   /* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
   /* Retrieve the PID from the parent process .  If the program fails internally,
-     then it sends SIGCHLD to the PID.  Make sure they match to the Python runner
+     then it sends SIGUSR2 to the PID.  Make sure they match to the Python runner
      at `autograder/autograder/execution_environment/jailed_sandbox.py`           */
 
   // Parent PID to send the signal on program error
   pid_t error_notify = getppid();
 
   // Defines the signal to send.
-  int   error_signal = SIGCHLD;
+  int   error_signal = SIGUSR2;
 
 
   /* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */

--- a/autograder/autograder/execution_environments/jailed_sandbox.py
+++ b/autograder/autograder/execution_environments/jailed_sandbox.py
@@ -96,7 +96,7 @@ class JailedSandbox(secure_execution_environment.SecureExecutionEnvironment):
             ]
 
         # Make sure the signal matches to .setup/untrusted_execute.c
-        signal.signal(signal.SIGCHLD, self._handle_error_signal)
+        signal.signal(signal.SIGUSR2, self._handle_error_signal)
 
         success = False
         try:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

Untrusted execute will throw `SIGCHLD` if it encounters any internal errors.

`SIGCHLD` is also used in `waitpid` and will cause excessive unrelated error logs in student's submission result.  If the system load is high enough, this might fail the autograding process.

### What is the new behavior?

Untrusted execute will throw `SIGUSR2` if it encounters any internal errors.

### Other information?

`SIGUSR2`'s default behavior (without handling) is stopping the target process, which might be dangerous.

Tested with ~2000 sample submissions, and it probably should work...

This could be tested through 
```bash
trap "echo got sigusr2" SIGUSR2         # capture SIGUSR2
chmod 777 sbin/untrusted_execute        # force error for untrusted_execute
./untrusted_execute                     # should get SIGUSR2
sudo su submitty_daemon -c './untrusted_execute untrusted01 "/usr/bin/true"'
                                        # this should write 'BAD USER...User defined signal 2'
chmod 4550 sbin/untrusted_execute       # revert to original state
trap "-" SIGUSR2                        # revert SIGUSR2 to default behavior
```
The code above is just a proof of concept, please also test in your VM... 

1. Make a submission
2. See the autograding details, `meta_log.txt` and `/var/local/submitty/logs/autograding` should not have `ERROR: untrusted_execute ...`
3. Run `chmod 777 sbin/untrusted_execute` in `bash`
4. Regrade the submission, `meta_log.txt` and `/var/local/submitty/logs/autograding` should have few entries with `ERROR: untrusted_execute ...`
5. Run `chmod 4550 sbin/untrusted_execute` to recover the original state