### PR TITLE
[Bugfix:TAGrading] View/Download Annotations

### DIFF
--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -97,7 +97,7 @@ $( document ).ready(function() {
                                 {% if file.encoded_name in annotated_file_names %}
                                     <p style="text-align:center; vertical-align: middle; float: right; margin-bottom: 2em">
                                         <a class="btn btn-success key_to_click" style="margin-right:20px;" tabindex="0" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}&anon_path={{ file.anon_path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a>
-                                        <button class = 'btn btn-default key_to_click' onclick='downloadStudentAnnotations("{{ student_pdf_download_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}&anon_path={{ file.anon_path|url_encode }}", "{{file.path|url_encode}}", "annotated_pdfs")' aria-label="Download the file"> Download
+                                        <button class = 'btn btn-default key_to_click' onclick='downloadStudentAnnotations("{{ student_pdf_download_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}&anon_path={{ file.anon_path|url_encode }}&student_id={{ user_id }}", "{{file.path|url_encode}}", "annotated_pdfs")' aria-label="Download the file"> Download
                                         <i class="fas fa-download" title="Download the file"></i></button>
                                     </p>
                                     {% if loop.index != files|length %}

--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -23,37 +23,30 @@
 
 <script>
     window['csrfToken'] = "{{ csrfToken }}";
+    if(typeof annotations === "undefined") {
+        let annotations;
+    }
+
     try {
         for(let i = 0 ; i < localStorage.length; i++){
             if(localStorage.key(i).includes('annotations')){
                 localStorage.removeItem(localStorage.key(i));
             }
         }
-        let annotations = JSON.parse({{ annotation_jsons|json_encode|raw }});
-        for(let grader in annotations){
-            if(annotations[grader] !== ""){
-                if(grader === '{{ grader_id }}') {
-                    localStorage.setItem('{{ filename }}/' + grader +'/annotations', annotations[grader]);
-                }
-                else{
-                if (!window.GENERAL_INFORMATION.hidden_annotations) {
-                        window.GENERAL_INFORMATION.hidden_annotations = {};
-                    }
-                    window.GENERAL_INFORMATION.hidden_annotations[grader] = annotations[grader];
-                    localStorage.setItem('{{ filename }}/' + grader +'/annotations', '[]');
-                }
-            }
-        }
+        annotations = JSON.parse({{ annotation_jsons|json_encode|raw }});
     }
     catch (err) {
         console.error(err);
         alert("Can't fetch annotations");
     }
     {% if student_download is defined and student_download %}
+    loadAllAnnotations(annotations, "{{ filename }}");
     download_student("{{ gradeable_id }}", "{{ user_id }}", "{{ filename | e('js') }}", "{{ file_path | e('js') }}", "{{ pdf_url_base | e('js')}}" , "{{ rerender_annotated_pdf }}");
     {% elseif student_popup is defined and student_popup %}
+    loadAllAnnotations(annotations, "{{ filename }}");
     render_student("{{ gradeable_id }}", "{{ user_id }}", "{{ filename | e('js') }}", "{{ file_path | e('js') }}", "{{ pdf_url_base | e('js')}}");
     {% else %}
+    loadGraderAnnotations(annotations, "{{ filename }}", "{{ grader_id }}");
     render("{{ gradeable_id }}", "{{ user_id }}", "{{ grader_id }}", '{{ filename | e('js') }}', "{{ file_path | e('js') }}", {{ page_num }}, "{{ pdf_url_base | e('js')}}");
     {% endif %}
 

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -425,7 +425,7 @@ class AutoGradingView extends AbstractView {
         }
 
         $annotation_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotations', $gradeable->getId(), $id, $active_version);
-        $pdfs_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotated_pdfs', $gradeable->getId(), $id, $active_version);
+        $pdfs_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'submissions', $gradeable->getId(), $id, $active_version);
         $annotated_pdf_paths = [];
         $annotated_file_names = [];
         $annotation_paths = [];
@@ -435,7 +435,7 @@ class AutoGradingView extends AbstractView {
                 $pdf_id = explode("_", $file_info->getFilename())[0];
                 if (file_get_contents($file_info->getPathname()) !== "") {
                     $annotated_file_names[] = $pdf_id;
-                    $pdf_id = $pdf_id . '.pdf';
+                    //$pdf_id = $pdf_id . '.pdf';
                     if (is_dir($annotation_path) && count(scandir($annotation_path)) > 2) {
                         $target_file = scandir($annotation_path)[2];
                         $annotation_paths[$pdf_id] = FileUtils::joinPaths($annotation_path, $target_file);
@@ -482,6 +482,8 @@ class AutoGradingView extends AbstractView {
                 $grader_info[$user_name]["comment"] = $comment;
             }
         }
+
+        var_dump($uploaded_pdfs, $pdfs_path, $annotated_file_names, $annotation_paths, $annotated_pdf_paths);
         return $this->core->getOutput()->renderTwigTemplate('autograding/TAResults.twig', [
             'files' => $files,
             'been_ta_graded' => $ta_graded_gradeable->isComplete(),

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -425,7 +425,7 @@ class AutoGradingView extends AbstractView {
         }
 
         $annotation_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotations', $gradeable->getId(), $id, $active_version);
-        $pdfs_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'submissions', $gradeable->getId(), $id, $active_version);
+        $pdfs_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'annotated_pdfs', $gradeable->getId(), $id, $active_version);
         $annotated_pdf_paths = [];
         $annotated_file_names = [];
         $annotation_paths = [];
@@ -435,7 +435,7 @@ class AutoGradingView extends AbstractView {
                 $pdf_id = explode("_", $file_info->getFilename())[0];
                 if (file_get_contents($file_info->getPathname()) !== "") {
                     $annotated_file_names[] = $pdf_id;
-                    //$pdf_id = $pdf_id . '.pdf';
+                    $pdf_id = $pdf_id . '.pdf';
                     if (is_dir($annotation_path) && count(scandir($annotation_path)) > 2) {
                         $target_file = scandir($annotation_path)[2];
                         $annotation_paths[$pdf_id] = FileUtils::joinPaths($annotation_path, $target_file);
@@ -482,8 +482,6 @@ class AutoGradingView extends AbstractView {
                 $grader_info[$user_name]["comment"] = $comment;
             }
         }
-
-        var_dump($uploaded_pdfs, $pdfs_path, $annotated_file_names, $annotation_paths, $annotated_pdf_paths);
         return $this->core->getOutput()->renderTwigTemplate('autograding/TAResults.twig', [
             'files' => $files,
             'been_ta_graded' => $ta_graded_gradeable->isComplete(),

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -94,7 +94,6 @@ function download(gradeable_id, user_id, grader_id, file_name, file_path, page_n
                     cMapPacked: true,
                 }).promise.then((pdf) => {
                     const doc = new jspdf.jsPDF('p', 'mm');
-                    //console.log(gradeable_id, user_id, grader_id, file_name, file_path, page_num, url, rerender_pdf);
                     renderPageForDownload(pdf, doc, 1, pdf.numPages + 1, file_name);
                 });
             },
@@ -330,25 +329,25 @@ function loadPDFToolbar() {
 }
 
 function loadAllAnnotations(annotations, file_name) {
-    for (let grader in annotations) {
-        if(annotations[grader] !== "") {
-            localStorage.setItem(file_name + '/' + grader +'/annotations', annotations[grader]);
+    for (const grader in annotations) {
+        if (annotations[grader] !== "") {
+            localStorage.setItem(`${file_name}/${grader}/annotations`, annotations[grader]);
         }
     }
 }
 
 function loadGraderAnnotations(annotations, file_name, grader_id) {
-    for (let grader in annotations) {
+    for (const grader in annotations) {
         if (annotations[grader] !== "") {
             if (grader === grader_id) {
-                localStorage.setItem(file_name + '/' + grader +'/annotations', annotations[grader]);
+                localStorage.setItem(`${file_name}/${grader}/annotations`, annotations[grader]);
             }
             else {
                 if (!window.GENERAL_INFORMATION.hidden_annotations) {
                     window.GENERAL_INFORMATION.hidden_annotations = {};
                 }
                 window.GENERAL_INFORMATION.hidden_annotations[grader] = annotations[grader];
-                localStorage.setItem(file_name + '/' + grader +'/annotations', '[]');
+                localStorage.setItem(`${file_name}/${grader}/annotations`, '[]');
             }
         }
     }

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -330,7 +330,7 @@ function loadPDFToolbar() {
 
 function loadAllAnnotations(annotations, file_name) {
     for (const grader in annotations) {
-        if (annotations[grader] !== "") {
+        if (annotations[grader] !== '') {
             localStorage.setItem(`${file_name}/${grader}/annotations`, annotations[grader]);
         }
     }
@@ -338,7 +338,7 @@ function loadAllAnnotations(annotations, file_name) {
 
 function loadGraderAnnotations(annotations, file_name, grader_id) {
     for (const grader in annotations) {
-        if (annotations[grader] !== "") {
+        if (annotations[grader] !== '') {
             if (grader === grader_id) {
                 localStorage.setItem(`${file_name}/${grader}/annotations`, annotations[grader]);
             }

--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -1,5 +1,5 @@
 /* global PDFAnnotate, pdfjsLib, csrfToken, jspdf */
-/* exported render_student, download_student, loadPDFToolbar, toggleOtherAnnotations */
+/* exported render_student, download_student, loadPDFToolbar, toggleOtherAnnotations, loadAllAnnotations, loadGraderAnnotations */
 
 if (PDFAnnotate.default) {
     // eslint-disable-next-line no-global-assign
@@ -94,6 +94,7 @@ function download(gradeable_id, user_id, grader_id, file_name, file_path, page_n
                     cMapPacked: true,
                 }).promise.then((pdf) => {
                     const doc = new jspdf.jsPDF('p', 'mm');
+                    //console.log(gradeable_id, user_id, grader_id, file_name, file_path, page_num, url, rerender_pdf);
                     renderPageForDownload(pdf, doc, 1, pdf.numPages + 1, file_name);
                 });
             },
@@ -326,6 +327,31 @@ function loadPDFToolbar() {
     const init_text_size = document.getElementById('text_size_selector').value;
     localStorage.setItem('text/size', init_text_size);
     PDFAnnotate.UI.setText(init_text_size, init_color);
+}
+
+function loadAllAnnotations(annotations, file_name) {
+    for (let grader in annotations) {
+        if(annotations[grader] !== "") {
+            localStorage.setItem(file_name + '/' + grader +'/annotations', annotations[grader]);
+        }
+    }
+}
+
+function loadGraderAnnotations(annotations, file_name, grader_id) {
+    for (let grader in annotations) {
+        if (annotations[grader] !== "") {
+            if (grader === grader_id) {
+                localStorage.setItem(file_name + '/' + grader +'/annotations', annotations[grader]);
+            }
+            else {
+                if (!window.GENERAL_INFORMATION.hidden_annotations) {
+                    window.GENERAL_INFORMATION.hidden_annotations = {};
+                }
+                window.GENERAL_INFORMATION.hidden_annotations[grader] = annotations[grader];
+                localStorage.setItem(file_name + '/' + grader +'/annotations', '[]');
+            }
+        }
+    }
 }
 
 function toggleOtherAnnotations(hide_others) {


### PR DESCRIPTION
### What is the current behavior?
The view/download functionality for annotated pdfs does not function correctly when in the view grade and grading interface. Annotations created by one user can only be downloaded by the same user. The bug is brought up by #8018. 

### What is the new behavior?
All annotations can be viewed/downloaded. 
