### PR TITLE
[Bugfix:RainbowGrades] Fix Web Customization

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -143,7 +143,7 @@ class RainbowCustomization extends AbstractModel {
                     if ($j_index >= count($json_bucket->ids)) {
                         $c_gradeable['override_max'] = $c_gradeable['max_score'];
                     }
-                    else if ($c_gradeable['max_score'] !== (float) $json_bucket->ids[$j_index]->max) {
+                    elseif ($c_gradeable['max_score'] !== (float) $json_bucket->ids[$j_index]->max) {
                         $c_gradeable['override'] = true;
                         $c_gradeable['override_max'] = $json_bucket->ids[$j_index]->max;
                     }

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -140,7 +140,10 @@ class RainbowCustomization extends AbstractModel {
                 //loop through all gradeables in bucket and compare them
                 $j_index = 0;
                 foreach ($this->customization_data[$c_bucket] as &$c_gradeable) {
-                    if ($c_gradeable['max_score'] !== (float) $json_bucket->ids[$j_index]->max) {
+                    if ($j_index >= count($json_bucket->ids)) {
+                        $c_gradeable['override_max'] = $c_gradeable['max_score'];
+                    }
+                    else if ($c_gradeable['max_score'] !== (float) $json_bucket->ids[$j_index]->max) {
                         $c_gradeable['override'] = true;
                         $c_gradeable['override_max'] = $json_bucket->ids[$j_index]->max;
                     }


### PR DESCRIPTION
### What is the current behavior?
It is possible for null values to end up in the generated customization.json file. This happens when a new gradeable is created and does not exist in the current customization.json. The page also throws a lot of errors in this case when in debug mode.

### What is the new behavior?
The errors on the page are now gone. The default override value is now set to the same value as the current max score which will prevent these null values.
