### PR TITLE
[Feature:System] Worker Update Excluding List

### DIFF
--- a/.setup/worker_rsync_exclude.txt
+++ b/.setup/worker_rsync_exclude.txt
@@ -1,0 +1,7 @@
+.github
+.vagrant
+.setup/data
+site
+sample_files
+more_autograding_examples
+tests

--- a/sbin/shipper_utils/update_and_install_workers.py
+++ b/sbin/shipper_utils/update_and_install_workers.py
@@ -140,13 +140,14 @@ def copy_code_to_worker(worker, user, host, submitty_repository):
     local_directory = submitty_repository
     remote_host = '{0}@{1}'.format(user, host)
     foreign_directory = submitty_repository
+    rsync_exclude = os.path.join(submitty_repository, ".setup", "worker_rsync_exclude.txt")
 
     # rsync the file
     print(f"performing rsync to {worker}...")
     # If this becomes too slow, we can exculde directories using --exclude.
     # e.g. --exclude=.git --exclude=.setup/data --exclude=site
-    command = "rsync -a --no-perms --no-o --omit-dir-times --no-g {0}/ {1}:{2}".format(
-              local_directory, remote_host, foreign_directory).split()
+    command = "rsync -a --exclude-from={3} --no-perms --no-o --omit-dir-times --no-g {0}/ {1}:{2}".format(
+              local_directory, remote_host, foreign_directory, rsync_exclude).split()
     res = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                          check=True, universal_newlines=True)
     if res.returncode != 0:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

All GIT_CHECKOUT folder is copied to workers.  If the vagrant is not carefully configured, `.vagrant` which contains VHD may also be copied.

### What is the new behavior?

When the primary machine syncs folders to the workers, it will read `.setup/worker_rsync_exclude.txt` and avoid copying these files/folders.

### Other information?
Tested with the procedure below:
1. Clear the worker's `/usr/local/submitty/GIT_CHECKOUT`
2. `INSTALL_SUBMITTY` on primary machine
3. Check the excluded files in the worker
