### PR TITLE
[SECURITY][Bugfix:Forum] Enforce max nesting level

### DIFF
--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -151,7 +151,7 @@ HTML;
         $environment->addInlineRenderer(Code::class, new CustomCodeInlineRenderer());
         $environment->mergeConfig([]);
 
-        $converter = new CommonMarkConverter(['html_input' => 'escape', 'allow_unsafe_links' => false], $environment);
+        $converter = new CommonMarkConverter(['html_input' => 'escape', 'allow_unsafe_links' => false, 'max_nesting_level' => 10], $environment);
         $engine = new PHPLeagueCommonMarkEngine($converter);
         $this->twig->addExtension(new MarkdownExtension($engine));
     }


### PR DESCRIPTION
### What is the current behavior?
Max nesting level hasn't been enforced for Markdown. It was identified that this can make a discussion forum thread inaccessible for everyone. At the very least, this can make pages slow to load.

### What is the new behavior?
The issue has been fixed.
