### PR TITLE
[Bugfix:Forum] Grey Scrollbar Up Arrow at Top of Forum

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1101,7 +1101,9 @@ function dynamicScrollContentOnDemand(jElement, urlPattern, currentThreadId, cur
         const isTop = element.scrollTop < sensitivity;
         const isBottom = (element.scrollHeight - element.offsetHeight - element.scrollTop) < sensitivity;
         if (isTop) {
-            element.scrollTop = sensitivity;
+            if ($(element).data('prev_page') !== 0) {
+                element.scrollTop = sensitivity;
+            }
             dynamicScrollLoadPage(element,false);
         }
         else if (isBottom) {


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
 - If the scroll bar is at the upper end of the thread list, the up arrow on the scroll bar is not greyed out.
![image](https://user-images.githubusercontent.com/20442222/182418854-0c7307b0-8286-4c96-a473-767042c823fe.png)


### What is the new behavior?
 - If the scroll bar is at the upper end of the thread list, the up arrow on the scroll bar will now be greyed out.
![image](https://user-images.githubusercontent.com/20442222/182418903-5f9ac399-c684-4322-8c7f-951133b08694.png)


### Other information?
**How did you test**
 - Go to a "Discussion Forum" page (I tested in the Discussion Forum in "sample" course)
 - Scroll to the top of the thread list and check if the up arrow on the scrollbar is greyed out. 
 - Select a Forum Thread. Scroll to the top of the thread list and check if the up arrow on the scrollbar is greyed out. 
