### PR TITLE
[Bugfix:Developer] Anon id migration fix

### DIFF
--- a/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
+++ b/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
@@ -37,19 +37,10 @@ def up(config, database, semester, course):
         database.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON gradeable_anon TO {}".format(db_info['database_course_user']))
 
     database.execute("""
-        DO
-        $do$
-        BEGIN
-        IF EXISTS (SELECT column_name
-                   FROM information_schema.columns
-                   WHERE table_name='users' and column_name='anon_id') THEN
-               INSERT INTO gradeable_anon (
-                    SELECT u.user_id, g_id, u.anon_id
-                    FROM gradeable g JOIN users u ON 1=1 WHERE NOT EXISTS (SELECT 1 FROM gradeable_anon WHERE user_id=u.user_id AND g_id=g.g_id) AND u.anon_id IS NOT NULL
-                );
-            END IF;
-        END
-        $do$
+        INSERT INTO gradeable_anon (
+            SELECT u.user_id, g_id, u.anon_id
+            FROM gradeable g JOIN users u ON 1=1 WHERE NOT EXISTS (SELECT 1 FROM gradeable_anon WHERE user_id=u.user_id AND g_id=g.g_id) AND u.anon_id IS NOT NULL
+        );
     """)
     database.execute("ALTER TABLE users DROP COLUMN IF EXISTS anon_id;")
 

--- a/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
+++ b/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
@@ -36,15 +36,22 @@ def up(config, database, semester, course):
         db_info = json.load(db_file, object_pairs_hook=OrderedDict)
         database.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON gradeable_anon TO {}".format(db_info['database_course_user']))
 
-    database.execute(
-        """
-        INSERT INTO gradeable_anon (
-            SELECT u.user_id, g_id, u.anon_id
-            FROM gradeable g JOIN users u ON 1=1 WHERE NOT EXISTS (SELECT 1 FROM gradeable_anon WHERE user_id=u.user_id AND g_id=g.g_id)
-        );
-        """
-    )
-    database.execute("ALTER TABLE users DROP COLUMN anon_id;")
+    database.execute("""
+        DO
+        $do$
+        BEGIN
+        IF EXISTS (SELECT column_name
+                   FROM information_schema.columns
+                   WHERE table_name='users' and column_name='anon_id') THEN
+               INSERT INTO gradeable_anon (
+                    SELECT u.user_id, g_id, u.anon_id
+                    FROM gradeable g JOIN users u ON 1=1 WHERE NOT EXISTS (SELECT 1 FROM gradeable_anon WHERE user_id=u.user_id AND g_id=g.g_id) AND u.anon_id IS NOT NULL
+                );
+            END IF;
+        END
+        $do$
+    """)
+    database.execute("ALTER TABLE users DROP COLUMN IF EXISTS anon_id;")
 
 def down(config, database, semester, course):
     """

--- a/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
+++ b/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
@@ -54,17 +54,4 @@ def up(config, database, semester, course):
     database.execute("ALTER TABLE users DROP COLUMN IF EXISTS anon_id;")
 
 def down(config, database, semester, course):
-    """
-    Run down migration (rollback).
-
-    :param config: Object holding configuration details about Submitty
-    :type config: migrator.config.Config
-    :param database: Object for interacting with given database for environment
-    :type database: migrator.db.Database
-    :param semester: Semester of the course being migrated
-    :type semester: str
-    :param course: Code of course being migrated
-    :type course: str
-    """
-    database.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS anon_id character varying(255);")
-    database.execute("UPDATE users u SET anon_id=(SELECT ga.anon_id FROM gradeable_anon ga WHERE ga.user_id=u.user_id LIMIT 1);")
+    pass

--- a/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
+++ b/migration/migrator/migrations/course/20220612122726_gradeable_specific_anon_ids.py
@@ -54,4 +54,17 @@ def up(config, database, semester, course):
     database.execute("ALTER TABLE users DROP COLUMN IF EXISTS anon_id;")
 
 def down(config, database, semester, course):
-    pass
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS anon_id character varying(255);")
+    database.execute("UPDATE users u SET anon_id=(SELECT ga.anon_id FROM gradeable_anon ga WHERE ga.user_id=u.user_id LIMIT 1);")

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -57,7 +57,7 @@ class Team extends AbstractModel {
         $this->invited_users = [];
         foreach ($details['users'] as $user_details) {
             //If we have user details, get user objects
-            if (array_key_exists('anon_id', $user_details)) {
+            if (array_key_exists('user_id', $user_details)) {
                 $user = new User($core, $user_details);
             }
             else {

--- a/site/tests/app/controllers/student/TeamControllerTester.php
+++ b/site/tests/app/controllers/student/TeamControllerTester.php
@@ -59,7 +59,12 @@ class TeamControllerTester extends BaseUnitTest {
             'users' => [
                 [
                     'state' => 1,
-                    'user_id' => 'test'
+                    'user_id' => 'test',
+                    'user_firstname' => 'User',
+                    'user_lastname' => 'One',
+                    'user_email' => 'user1@example.com',
+                    'user_email_secondary' => null,
+                    'user_email_secondary_notify' => false
                 ]
             ],
             'team_name' => null

--- a/site/tests/app/models/TeamTester.php
+++ b/site/tests/app/models/TeamTester.php
@@ -7,17 +7,7 @@ use tests\BaseUnitTest;
 
 class TeamTester extends BaseUnitTest {
     private $core;
-    public function setUp(): void {
-        $this->core = $this->createMockCore();
-    }
-
-    public function testTeamCreation() {
-        $details = [
-            'team_id' => 'test',
-            'team_name' => 'TEST NAME',
-            'registration_section' => 'test',
-            'rotating_section' => 0,
-            'users' => [
+    private $member_users = [
                 [
                     'state' => 1,
                     'user_id' => 'user1',
@@ -36,7 +26,19 @@ class TeamTester extends BaseUnitTest {
                     'user_email_secondary' => null,
                     'user_email_secondary_notify' => false
                 ]
-            ]
+    ];
+
+    public function setUp(): void {
+        $this->core = $this->createMockCore();
+    }
+
+    public function testTeamCreation() {
+        $details = [
+            'team_id' => 'test',
+            'team_name' => 'TEST NAME',
+            'registration_section' => 'test',
+            'rotating_section' => 0,
+            'users' => $this->member_users;
         ];
         $team = new Team($this->core, $details);
         $this->assertEquals($details['team_id'], $team->getId());
@@ -56,16 +58,7 @@ class TeamTester extends BaseUnitTest {
             'team_name' => null,
             'registration_section' => 'test',
             'rotating_section' => 0,
-            'users' => [
-                [
-                    'state' => 1,
-                    'user_id' => 'user1'
-                ],
-                [
-                    'state' => 0,
-                    'user_id' => 'user2'
-                ]
-            ]
+            'users' => $this->member_users
         ];
         $team = new Team($this->core, $details);
         $anon_id = "anon_id";

--- a/site/tests/app/models/TeamTester.php
+++ b/site/tests/app/models/TeamTester.php
@@ -21,7 +21,6 @@ class TeamTester extends BaseUnitTest {
                 [
                     'state' => 1,
                     'user_id' => 'user1',
-                    'anon_id' => 'anon1',
                     'user_firstname' => 'User',
                     'user_lastname' => 'One',
                     'user_email' => 'user1@example.com',
@@ -31,7 +30,6 @@ class TeamTester extends BaseUnitTest {
                 [
                     'state' => 0,
                     'user_id' => 'user2',
-                    'anon_id' => 'anon2',
                     'user_firstname' => 'User',
                     'user_lastname' => 'Two',
                     'user_email' => 'user2@example.com',

--- a/site/tests/app/models/TeamTester.php
+++ b/site/tests/app/models/TeamTester.php
@@ -38,7 +38,7 @@ class TeamTester extends BaseUnitTest {
             'team_name' => 'TEST NAME',
             'registration_section' => 'test',
             'rotating_section' => 0,
-            'users' => $this->member_users;
+            'users' => $this->member_users
         ];
         $team = new Team($this->core, $details);
         $this->assertEquals($details['team_id'], $team->getId());


### PR DESCRIPTION
### What is the current behavior?
#8002 was recently merged, `anon_id` column was removed from the users table and `setup_sample_courses.py` was modified to directly set `anon_id` in `gradeable_anon`. Accompanying migration extracted `anon_id` from users table to insert inside `gradeable_anon` but there may be users with null `anon_id` when migration runs, so running `submitty_install` currently throws an error.

### What is the new behavior?
A check has been added to move `anon_id` only if the column exists and is not null. An issue identified by Jerry (@Viyerelu23333) has also been fixed.