### PR TITLE
[Bugfix:Autograding] Success, information messages not shown

### DIFF
--- a/grading/main_validator.cpp
+++ b/grading/main_validator.cpp
@@ -199,7 +199,7 @@ double ValidateAutoCheck(const TestCase &my_testcase, int which_autocheck, nlohm
     }
 
     std::string fm = tcg.value("failure_message","");
-    if (!test_case_success) {
+    if (!test_case_success || show_message) {
       bool failure_message_already_added = false;
       if (FN==0) {
         for (int m = 0; m < messages.size(); m++) {

--- a/grading/main_validator.cpp
+++ b/grading/main_validator.cpp
@@ -214,7 +214,7 @@ double ValidateAutoCheck(const TestCase &my_testcase, int which_autocheck, nlohm
           autocheck_j["messages"].push_back(new_message);
         }
       }
-      if (fm != "" && !failure_message_already_added) {
+      if (fm != "" && !failure_message_already_added && !test_case_success) {
         nlohmann::json new_message;
         new_message["message"] = fm;
         new_message["type"] = "failure";

--- a/tests/integrationTests/tests/minimal_code_editing/validation/noise_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/noise_results.json
@@ -8,7 +8,13 @@
                     "actual_file": "test01/STDOUT.txt",
                     "description": "STDOUT.txt",
                     "difference_file": "test01/0_diff.json",
-                    "expected_file": "test_output/testassignment/fancy_hello_world.cpp"
+                    "expected_file": "test_output/testassignment/fancy_hello_world.cpp",
+                    "messages": [
+                        {
+                            "message": "Approx 76 characters added and/or deleted.  Character changes within allowed range.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 5,

--- a/tests/integrationTests/tests/minimal_code_editing/validation/tabs_results.json
+++ b/tests/integrationTests/tests/minimal_code_editing/validation/tabs_results.json
@@ -8,7 +8,13 @@
                     "actual_file": "test01/STDOUT.txt",
                     "description": "STDOUT.txt",
                     "difference_file": "test01/0_diff.json",
-                    "expected_file": "test_output/testassignment/fancy_hello_world.cpp"
+                    "expected_file": "test_output/testassignment/fancy_hello_world.cpp",
+                    "messages": [
+                        {
+                            "message": "Approx 99 characters added and/or deleted.  Character changes within allowed range.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 5,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_correct
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_correct
@@ -10,7 +10,13 @@
             "autochecks": [
                 {
                     "actual_file": "test02/STDOUT.txt",
-                    "description": "STDOUT.txt"
+                    "description": "STDOUT.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 8,
@@ -20,7 +26,13 @@
             "autochecks": [
                 {
                     "actual_file": "test03/STDOUT.txt",
-                    "description": "STDOUT.txt"
+                    "description": "STDOUT.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 6,
@@ -30,7 +42,13 @@
             "autochecks": [
                 {
                     "actual_file": "test04/STDOUT_0.txt",
-                    "description": "STDOUT_0.txt"
+                    "description": "STDOUT_0.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 },
                 {
                     "actual_file": "test04/STDOUT_1.txt",

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_not_random
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_not_random
@@ -10,7 +10,13 @@
             "autochecks": [
                 {
                     "actual_file": "test02/STDOUT.txt",
-                    "description": "STDOUT.txt"
+                    "description": "STDOUT.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 8,
@@ -20,7 +26,13 @@
             "autochecks": [
                 {
                     "actual_file": "test03/STDOUT.txt",
-                    "description": "STDOUT.txt"
+                    "description": "STDOUT.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 6,

--- a/tests/integrationTests/tests/python_custom_validation/validation/results.json_wrong_num
+++ b/tests/integrationTests/tests/python_custom_validation/validation/results.json_wrong_num
@@ -10,7 +10,13 @@
             "autochecks": [
                 {
                     "actual_file": "test02/STDOUT.txt",
-                    "description": "STDOUT.txt"
+                    "description": "STDOUT.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 }
             ],
             "points_awarded": 8,
@@ -36,7 +42,13 @@
             "autochecks": [
                 {
                     "actual_file": "test04/STDOUT_0.txt",
-                    "description": "STDOUT_0.txt"
+                    "description": "STDOUT_0.txt",
+                    "messages": [
+                        {
+                            "message": "Success: numbers summed correctly.",
+                            "type": "success"
+                        }
+                    ]
                 },
                 {
                     "actual_file": "test04/STDOUT_1.txt",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #5621 

### What is the new behavior?
Success and information messages shown when `show_messages: always` is set in config.json. Custom validator success and information messages shown.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
