### PR TITLE
[Bugfix:System] Fix Incremental Build Permissions

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -298,6 +298,7 @@ echo "Running esbuild"
 chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
 chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+chmod -R u+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm run build"
 chmod a-x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a-x ${NODE_FOLDER}/typescript/bin/tsc


### PR DESCRIPTION
### What is the current behavior?
When installing the site, the permissions may not be correct on the incremental_build folder for typescript compilation. This causes the site JS files to not get properly built.

### What is the new behavior?
This PR ensures that the PHP user has proper permission to write to any file previous created.

### Other information?
Tested it locally and it fixed the problem for me.
