### PR TITLE
[Bugfix:Autograding] Fix BadZipError

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -499,8 +499,8 @@ def unpack_job(
         fd1, local_done_queue_file = tempfile.mkstemp()
         fd2, local_results_zip = tempfile.mkstemp()
         copy_files(config, which_machine, [
-            (target_done_queue_file, local_done_queue_file),
-            (target_results_zip, local_results_zip)
+            (target_results_zip, local_results_zip),
+            (target_done_queue_file, local_done_queue_file)
         ], CopyDirection.PULL)
     except (socket.timeout, TimeoutError, FileNotFoundError):
         # These are expected error cases, so we clean up on our end and return a `WAITING` status.

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -424,8 +424,6 @@ def prepare_job(
         os.remove(autograding_zip_tmp)
         os.remove(submission_zip_tmp)
         os.remove(todo_queue_file_tmp)
-        if host != 'localhost':
-            os.remove(todo_queue_file)
 
     # log completion of job preparation
     obj = packer_unpacker.load_queue_file_obj(config, JOB_ID, next_directory, next_to_grade)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

Closes #8280 

### What is the current behavior?

When bulk regrading, there are `BadZipError`s from the worker, and `FileNotFoundError` from the shipper.

#### The error

Workers read the queue file in `autograding_TODO` before starting the grading process.  

The shipper writes the queue file to the `TODO` folder directly if the worker is `localhost`.

Workers in the primary machine may start grading before the autograding/submission zip files are copied.

### What is the new behavior?

When autograding, there should be no `BadZipError` or `FileNotFoundError`.

Instead of dumping the queue file to the `TODO` folder, shipper will write the queue file to `/tmp` and copy it after the zip files are copied.

`copy_files()` of the shipper will append `_COPYING` to the file names when copying, after they are copied, they will be changed back to the original name.

### Other information?
