### PR TITLE
[Bugfix:Submission] Pause Confetti Animation

### DIFF
--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -159,6 +159,7 @@ function addConfetti() {
 
         // Stop the confetti animation if the page is not visible
         if (document.visibilityState === 'hidden') {
+            cancelAnimationFrame(frame);
             return;
         }
 

--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -22,6 +22,14 @@ function addConfetti() {
         }
     });
 
+    // Resume confetti animation when window is visible again
+    window.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && is_drawing) {
+            lastUpdateTime = Date.now();
+            draw();
+        }
+    });
+
     canvas.width  = window.innerWidth;
     const body = document.body;
     const html = document.documentElement;
@@ -38,6 +46,8 @@ function addConfetti() {
     const max_times = 250;
     const size_const = 10;
     const gravity_const = 0.25;
+
+    let is_drawing = false;
 
     const date_box = document.getElementById('submission_timestamp');
     let submission_date = '';
@@ -141,6 +151,14 @@ function addConfetti() {
 
         if (canvas.style.display === 'none') {
             cancelAnimationFrame(frame);
+            is_drawing = false;
+            return;
+        }
+
+        is_drawing = true;
+
+        // Stop the confetti animation if the page is not visible
+        if (document.visibilityState === 'hidden') {
             return;
         }
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
 - Fixes #8213 
   - When the user plays the confetti animation and switches off of the gradeable submission page's tab, the confetti bunches up and is dropped at once when the user returns to the submission page's tab.

### What is the new behavior?
 - When the user switches off of the gradeable submission page, the confetti animation will be paused. Upon returning to the submission page, the confetti animation will be resumed.

### Other information?
**How did you test**
 1. On a gradeable that received a perfect score on the auto-grading, select "Autograding Total" to play the confetti animation.
 2. Change to a different tab and wait for a few seconds.
 3. Return to the submission page's tab and see if the confetti does not bunch up and the animation resumes.
 4. Play the confetti animation again.
 5. Minimize the browser and wait for a few seconds. 
 6. Return to the submission page's tab and see if the confetti does not bunch up and the animation resumes.
 7. Play the confetti animation again.
 8. Switch to a different application, covering up the browser so that the browser is not visible, and wait for a few seconds.
 9. Return to the submission page's tab and see if the confetti does not bunch up and the animation resumes.