### PR TITLE
[Feature:Autograding] Rename meta_log.txt to container_log.txt

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -175,8 +175,8 @@ def just_write_grade_history(json_file, assignment_deadline, submission_time, se
 # ==================================================================================
 
 
-def log_container_meta(log_path, event="", name="", container="", time=0):
-    """ Given a log file, create or append container meta data to a log file. """
+def log_container(log_path, event="", name="", container="", time=0):
+    """ Given a log file, create or append container details. """
 
     now = dateutils.get_current_time()
     easy_to_read_date = dateutils.write_submitty_date(now, True)

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -19,7 +19,7 @@ class Container():
     can be made up of 1 or more containers.
     """
     def __init__(self, container_info, untrusted_user, testcase_directory, more_than_one,
-                 is_test_environment, log_function, log_meta):
+                 is_test_environment, log_function, log_container):
         self.name = container_info['container_name']
 
         # If there are multiple containers, each gets its own directory under
@@ -45,7 +45,7 @@ class Container():
         # This will be populated later
         self.return_code = None
         self.log_function = log_function
-        self.log_meta = log_meta
+        self.log_container = log_container
         self.container = None
         # A socket for communication with the container.
         self.socket = None
@@ -63,7 +63,7 @@ class Container():
     def create(self, execution_script, arguments, more_than_one):
         """ Create (but don't start) this container. """
         container_create_time = timer()
-        self.log_meta('CREATE BEGIN', self.full_name)
+        self.log_container('CREATE BEGIN', self.full_name)
 
         client = docker.from_env(timeout=60)
 
@@ -119,7 +119,7 @@ class Container():
             client.close()
             raise
 
-        self.log_meta(
+        self.log_container(
             'CREATE END',
             self.full_name,
             self.container.short_id,
@@ -129,13 +129,13 @@ class Container():
 
     def start(self, logfile):
         container_start_time = timer()
-        self.log_meta('START BEGIN', self.full_name, self.container.short_id)
+        self.log_container('START BEGIN', self.full_name, self.container.short_id)
 
         self.container.start()
         self.socket = self.container.attach_socket(params={'stdin': 1, 'stream': 1})
 
         self.container_grading_time = timer()
-        self.log_meta(
+        self.log_container(
             'START END',
             self.full_name,
             self.container.short_id,
@@ -170,7 +170,7 @@ class Container():
             f'{dateutils.get_current_time()} docker container '
             f'{self.container.short_id} destroyed'
         )
-        self.log_meta(
+        self.log_container(
             'DESTROY',
             self.full_name,
             self.container.short_id, timer() - self.container_grading_time
@@ -222,7 +222,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                         greater_than_one,
                         self.is_test_environment,
                         self.log_message,
-                        self.log_container_meta
+                        self.log_container
                     )
                 )
         else:
@@ -243,7 +243,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                     False,
                     self.is_test_environment,
                     self.log_message,
-                    self.log_container_meta
+                    self.log_container
                 )
             )
         self.containers = containers
@@ -275,7 +275,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                     greater_than_one_solution_container,
                     self.is_test_environment,
                     self.log_message,
-                    self.log_container_meta
+                    self.log_container
                 )
             )
         self.solution_containers = solution_containers
@@ -757,7 +757,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             False,
             self.is_test_environment,
             self.log_message,
-            self.log_container_meta
+            self.log_container
         )
         execution_script = os.path.join(container.directory, executable)
         try:

--- a/autograder/autograder/execution_environments/jailed_sandbox.py
+++ b/autograder/autograder/execution_environments/jailed_sandbox.py
@@ -22,11 +22,11 @@ class JailedSandbox(secure_execution_environment.SecureExecutionEnvironment):
 
     def _handle_error_signal(self, _signum, _frame):
         """
-        Leave a message at logs/autograding and meta_log.txt when it receives an error signal
+        Leave a message at logs/autograding and container_log.txt when it receives an error signal
         from untrusted_execute.
         """
         self.log_message("ERROR: untrusted_execute reported an error")
-        self.log_container_meta("ERROR: untrusted_execute reported an error")
+        self.log_container("ERROR: untrusted_execute reported an error")
 
     def setup_for_archival(self, overall_log):
         """

--- a/autograder/autograder/execution_environments/secure_execution_environment.py
+++ b/autograder/autograder/execution_environments/secure_execution_environment.py
@@ -487,7 +487,7 @@ class SecureExecutionEnvironment():
             trace=trace
         )
 
-    def log_container_meta(self, event, name='', container='', time=0):
+    def log_container(self, event, name='', container='', time=0):
         """ A useful wrapper for the atuograding_utils.log_message function. """
-        log_path = os.path.join(self.tmp_logs, 'meta_log.txt')
-        autograding_utils.log_container_meta(log_path, event, name, container, time)
+        log_path = os.path.join(self.tmp_logs, 'container_log.txt')
+        autograding_utils.log_container(log_path, event, name, container, time)

--- a/autograder/autograder/testcase.py
+++ b/autograder/autograder/testcase.py
@@ -84,7 +84,7 @@ class Testcase():
         testcase type.
         """
         if self.type in ['Compilation', 'FileCheck']:
-            self.secure_environment.log_container_meta("", "", "AUTOGRADING BEGIN", 0)
+            self.secure_environment.log_container("", "", "AUTOGRADING BEGIN", 0)
             success = self._run_compilation()
         else:
             success = self._run_execution()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Docker container info is logged to a file called `meta_log.txt`

### What is the new behavior?
The file is now named `container_log.txt` and the names of some functions and variables have been updated similarly.

### Other information?
