### PR TITLE
[Testing:System] Update CI to use PHP 7.4

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -11,7 +11,7 @@ env:
   SUBMITTY_INSTALL_DIR: /usr/local/submitty
   SUBMITTY_REPOSITORY: /usr/local/submitty/GIT_CHECKOUT/Submitty
   POSTGRES_HOST: localhost
-  PHP_VER: 7.2
+  PHP_VER: 7.4
   NODE_VERSION: 16
   PYTHON_VERSION: 3.8
 

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -895,7 +895,7 @@ class ForumThreadView extends AbstractView {
             foreach ($result[1] as $url) {
                 $decoded_url = filter_var(trim(strip_tags(html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8'))), FILTER_SANITIZE_URL);
                 $parsed_url = parse_url($decoded_url, PHP_URL_SCHEME);
-                if (filter_var($decoded_url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== false && in_array($parsed_url, $accepted_schemes, true)) {
+                if (filter_var($decoded_url, FILTER_VALIDATE_URL) !== false && in_array($parsed_url, $accepted_schemes, true)) {
                     $pre_post = preg_replace('#\&lbrack;url&equals;(.*?)&rsqb;(.*?)(&lbrack;&sol;url&rsqb;)#', '<a href="' . htmlspecialchars($decoded_url, ENT_QUOTES) . '" target="_blank" rel="noopener nofollow">' . $result[2][$pos] . '</a>', $post_content, 1);
                 }
                 else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Recently, the minimum PHP version for composer was upgraded to `7.4`. Installing `PHP 7.4` dependencies now causes `php-lint` and `php-unit` to fail. Also, `php-lint` fails due to usage of deprecated flags.
See [this workflow run](https://github.com/Submitty/Submitty/runs/8003796747?check_suite_focus=true) and [this one](https://github.com/Submitty/Submitty/runs/8003849332?check_suite_focus=true) (for flags).

### What is the new behavior?
PHP version for CI has been updated to `7.4` and usage of deprecated `FILTER_FLAG_SCHEME_REQUIRED` and `FILTER_FLAG_HOST_REQUIRED` has been removed (see [https://stackoverflow.com/a/45240693](https://stackoverflow.com/a/45240693)).
