### PR TITLE
[Bugfix:Submission] Adding and deleting users

### DIFF
--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -171,7 +171,9 @@ DECLARE
     query_string TEXT;
 BEGIN
     db_conn := format('dbname=submitty_%s_%s', OLD.semester, OLD.course);
-    query_string := 'DELETE FROM users WHERE user_id = ' || quote_literal(OLD.user_id);
+    -- Need to delete anon_id entry from gradeable_anon otherwise foreign key constraint will be violated and execution will fail
+    query_string := 'DELETE FROM gradeable_anon WHERE user_id = ' || quote_literal(OLD.user_id) || '; '
+                    || 'DELETE FROM users WHERE user_id = ' || quote_literal(OLD.user_id);
     -- Need to make sure that query_string was set properly as dblink_exec will happily take a null and then do nothing
     IF query_string IS NULL THEN
         RAISE EXCEPTION 'query_string error in trigger function sync_delete_user()';

--- a/migration/migrator/migrations/course/20220828143054_add_user_anon_trigger.py
+++ b/migration/migrator/migrations/course/20220828143054_add_user_anon_trigger.py
@@ -1,0 +1,84 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    # random_string function taken from Szymon Lipiński's answer (https://stackoverflow.com/a/3972983)
+    database.execute("""
+    CREATE OR REPLACE FUNCTION random_string(length integer) RETURNS TEXT AS $$
+        DECLARE
+            chars text[] := '{0,1,2,3,4,5,6,7,8,9,A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z}';
+            result text := '';
+            i integer := 0;
+        BEGIN
+            IF length < 0 THEN
+                raise exception 'Given length cannot be less than 0';
+            END IF;
+            FOR i IN 1..length LOOP
+                result := result || chars[1+random()*(array_length(chars, 1)-1)];
+            END LOOP;
+            RETURN result;
+        END;
+    $$ LANGUAGE PLPGSQL;
+    """)
+
+    database.execute("""
+    INSERT INTO gradeable_anon (
+        SELECT user_id, g_id, random_string(15)
+        FROM users u JOIN gradeable g ON 1=1 WHERE NOT EXISTS (SELECT 1 FROM gradeable_anon WHERE user_id=u.user_id AND g_id=g.g_id)
+    )
+    """)
+
+    database.execute("""
+    CREATE OR REPLACE FUNCTION add_course_user() RETURNS trigger AS $$
+        DECLARE
+            temp_row RECORD;
+            random_str TEXT;
+            num_rows INT;
+        BEGIN
+            FOR temp_row IN SELECT g_id FROM gradeable LOOP
+                LOOP
+                    random_str = random_string(15);
+                    PERFORM 1 FROM gradeable_anon
+                    WHERE g_id=temp_row.g_id AND anon_id=random_str;
+                    GET DIAGNOSTICS num_rows = ROW_COUNT;
+                    IF num_rows = 0 THEN
+                        EXIT;
+                    END IF;
+                END LOOP;
+                INSERT INTO gradeable_anon (
+                    SELECT NEW.user_id, temp_row.g_id, random_str
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM gradeable_anon
+                        WHERE user_id=NEW.user_id AND g_id=temp_row.g_id
+                    )
+                );
+            END LOOP;
+            RETURN NULL;
+        END;
+    $$ LANGUAGE PLPGSQL;""")
+
+    database.execute("""
+    CREATE TRIGGER add_course_user AFTER INSERT OR UPDATE ON users
+        FOR EACH ROW EXECUTE PROCEDURE add_course_user();
+    """)
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+    """
+    database.execute("DROP FUNCTION IF EXISTS random_string;")
+    database.execute("DROP TRIGGER IF EXISTS add_course_user ON users;")
+    database.execute("DROP FUNCTION IF EXISTS add_course_user;")

--- a/migration/migrator/migrations/master/20220827110746_trigger_update_delete_user.py
+++ b/migration/migrator/migrations/master/20220827110746_trigger_update_delete_user.py
@@ -1,0 +1,78 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute("""
+CREATE OR REPLACE FUNCTION sync_delete_user() RETURNS TRIGGER AS $$
+-- BEFORE DELETE trigger function to DELETE users from course DB.
+DECLARE
+    db_conn VARCHAR;
+    query_string TEXT;
+BEGIN
+    db_conn := format('dbname=submitty_%s_%s', OLD.semester, OLD.course);
+    -- Need to delete anon_id entry from gradeable_anon otherwise foreign key constraint will be violated and execution will fail
+    query_string := 'DELETE FROM gradeable_anon WHERE user_id = ' || quote_literal(OLD.user_id) || '; '
+                    || 'DELETE FROM users WHERE user_id = ' || quote_literal(OLD.user_id);
+    -- Need to make sure that query_string was set properly as dblink_exec will happily take a null and then do nothing
+    IF query_string IS NULL THEN
+        RAISE EXCEPTION 'query_string error in trigger function sync_delete_user()';
+    END IF;
+    PERFORM dblink_exec(db_conn, query_string);
+
+    -- All done.  As this is a BEFORE DELETE trigger, RETURN OLD allows original triggering DELETE query to proceed.
+    RETURN OLD;
+
+-- Trying to delete a user with existing data (via foreign keys) will raise an integrity constraint violation exception.
+-- We should catch this exception and stop execution with no rows processed.
+-- No rows processed will indicate that deletion had an error and did not occur.
+EXCEPTION WHEN integrity_constraint_violation THEN
+    -- Show that an exception occurred, and what was the exception.
+    RAISE NOTICE 'User ''%'' still has existing data in course DB ''%''', OLD.user_id, substring(db_conn FROM 8);
+    RAISE NOTICE '%', SQLERRM;
+    -- Return NULL so we do not proceed with original triggering DELETE query.
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;""")
+
+
+def down(config, database):
+    """
+    Run down migration (rollback).
+    """
+    database.execute("""
+CREATE OR REPLACE FUNCTION sync_delete_user() RETURNS TRIGGER AS $$
+-- BEFORE DELETE trigger function to DELETE users from course DB.
+DECLARE
+    db_conn VARCHAR;
+    query_string TEXT;
+BEGIN
+    db_conn := format('dbname=submitty_%s_%s', OLD.semester, OLD.course);
+    query_string := 'DELETE FROM users WHERE user_id = ' || quote_literal(OLD.user_id);
+    -- Need to make sure that query_string was set properly as dblink_exec will happily take a null and then do nothing
+    IF query_string IS NULL THEN
+        RAISE EXCEPTION 'query_string error in trigger function sync_delete_user()';
+    END IF;
+    PERFORM dblink_exec(db_conn, query_string);
+
+    -- All done.  As this is a BEFORE DELETE trigger, RETURN OLD allows original triggering DELETE query to proceed.
+    RETURN OLD;
+
+-- Trying to delete a user with existing data (via foreign keys) will raise an integrity constraint violation exception.
+-- We should catch this exception and stop execution with no rows processed.
+-- No rows processed will indicate that deletion had an error and did not occur.
+EXCEPTION WHEN integrity_constraint_violation THEN
+    -- Show that an exception occurred, and what was the exception.
+    RAISE NOTICE 'User ''%'' still has existing data in course DB ''%''', OLD.user_id, substring(db_conn FROM 8);
+    RAISE NOTICE '%', SQLERRM;
+    -- Return NULL so we do not proceed with original triggering DELETE query.
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;""")

--- a/sbin/adduser_course.py
+++ b/sbin/adduser_course.py
@@ -7,8 +7,6 @@ will be an instructor.
 
 import argparse
 import json
-import random
-import string
 from os import path
 import sys
 from sqlalchemy import create_engine, MetaData, Table, bindparam, and_
@@ -22,8 +20,6 @@ DATABASE_HOST = DATABASE_DETAILS['database_host']
 DATABASE_PORT = DATABASE_DETAILS['database_port']
 DATABASE_USER = DATABASE_DETAILS['database_user']
 DATABASE_PASS = DATABASE_DETAILS['database_password']
-DATABASE_COURSE_USER = DATABASE_DETAILS['database_course_user']
-DATABASE_COURSE_PASS = DATABASE_DETAILS['database_course_password']
 
 
 def parse_args():
@@ -110,46 +106,6 @@ def main():
             b_user_id=user_id,
             registration_section=registration_section
         )
-
-    # function taken from setup_sample_courses
-    def generate_random_user_id(length=15):
-        pick_from = string.ascii_lowercase + string.ascii_uppercase + string.digits
-        return ''.join(random.choice(pick_from) for _ in range(length))
-
-    course_conn_str = db_utils.generate_connect_string(
-        DATABASE_HOST,
-        DATABASE_PORT,
-        f"submitty_{semester}_{course}",
-        DATABASE_COURSE_USER,
-        DATABASE_COURSE_PASS,
-    )
-
-    course_engine = create_engine(course_conn_str)
-    course_connection = course_engine.connect()
-    course_metadata = MetaData(bind=course_engine)
-    gradeable_table = Table('gradeable', course_metadata, autoload=True)
-    g_anon_table = Table('gradeable_anon', course_metadata, autoload=True)
-    select = gradeable_table.select()
-    rows = course_connection.execute(select).fetchall()
-    for gradeable in rows:
-        g_id = gradeable['g_id']
-        select = g_anon_table.select().where(and_(
-            g_anon_table.c.user_id == bindparam('user_id'),
-            g_anon_table.c.g_id == bindparam('g_id')
-        ))
-        row = course_connection.execute(
-            select,
-            user_id=user_id,
-            g_id=g_id
-        ).fetchone()
-        if row is None:
-            query = g_anon_table.insert()
-            course_connection.execute(
-                query,
-                user_id=user_id,
-                g_id=g_id,
-                anon_id=generate_random_user_id()
-            )
 
 
 if __name__ == '__main__':

--- a/sbin/anonymize.py
+++ b/sbin/anonymize.py
@@ -88,7 +88,7 @@ def main():
                 if row['anon_id'] == '':
                     users_to_update.append(row['user_id'])
                     user_id = row['user_id']
-                    print (f"  Need to update: {user_id} for gradeable: {gradeable_id}")
+                    print(f"  Need to update: {user_id} for gradeable: {gradeable_id}")
             for row in user_rows:
                 user_id = row["user_id"]
                 if (user_id not in existing_user_ids) or (user_id in users_to_update):
@@ -100,7 +100,7 @@ def main():
                         new_row = {'user_id': user_id, 'g_id': gradeable_id, 'anon_id': anon}
                         insert = gradeable_anon.insert().values(new_row)
                         conn.execute(insert)
-                        print (f"  Insert user: {user_id} for gradeable: {gradeable_id}")
+                        print(f"  Insert user: {user_id} for gradeable: {gradeable_id}")
                         num_rows += 1
                     elif user_id in users_to_update:
                         new_info = {'anon_id': anon}
@@ -108,7 +108,7 @@ def main():
                             gradeable_anon.c.user_id == bindparam('b_user_id'),
                             gradeable_anon.c.g_id == bindparam('b_g_id')
                         )
-                        print (f"  Update: {user_id} for gradeable: {gradeable_id}")
+                        print(f"  Update: {user_id} for gradeable: {gradeable_id}")
                         conn.execute(update, b_user_id=user_id, b_g_id=gradeable_id)
                         num_rows += 1
         conn.close()

--- a/sbin/anonymize.py
+++ b/sbin/anonymize.py
@@ -87,6 +87,8 @@ def main():
                 anon_ids.append(row['anon_id'])
                 if row['anon_id'] == '':
                     users_to_update.append(row['user_id'])
+                    user_id = row['user_id']
+                    print (f"Need to update: {user_id}")
             for row in user_rows:
                 user_id = row["user_id"]
                 if (user_id not in existing_user_ids) or (user_id in users_to_update):
@@ -98,6 +100,7 @@ def main():
                         new_row = {'user_id': user_id, 'g_id': gradeable_id, 'anon_id': anon}
                         insert = gradeable_anon.insert().values(new_row)
                         conn.execute(insert)
+                        print (f"Need to insert user: {user_id}")
                         num_rows += 1
                     elif user_id in users_to_update:
                         new_info = {'anon_id': anon}
@@ -105,6 +108,7 @@ def main():
                             gradeable_anon.c.user_id == bindparam('b_user_id'),
                             gradeable_anon.c.g_id == bindparam('b_g_id')
                         )
+                        print (f"Need to update user: {user_id}")
                         conn.execute(update, b_user_id=user_id, b_g_id=gradeable_id)
                         num_rows += 1
         conn.close()

--- a/sbin/anonymize.py
+++ b/sbin/anonymize.py
@@ -23,8 +23,8 @@ def main():
     CONFIG_PATH = path.join(path.dirname(path.realpath(__file__)), '..', 'config')
     with open(path.join(CONFIG_PATH, 'database.json')) as open_file:
         DATABASE_DETAILS = json.load(open_file)
-    #COURSE = input("Course: ")
-    #SEMESTER = input("Semester: ")
+    # COURSE = input("Course: ")
+    # SEMESTER = input("Semester: ")
     DATABASE_HOST = DATABASE_DETAILS['database_host']
     DATABASE_PORT = DATABASE_DETAILS['database_port']
     DB_USER = DATABASE_DETAILS['database_user']
@@ -75,7 +75,9 @@ def main():
         print("Performing anonymization...\n")
         for g_row in gradeable_rows:
             gradeable_id = g_row["g_id"]
-            select = gradeable_anon.select().where(gradeable_anon.c.g_id == bindparam('gradeable_id'))
+            select = gradeable_anon.select().where(
+                gradeable_anon.c.g_id == bindparam('gradeable_id')
+            )
             existing_rows = conn.execute(select, gradeable_id=gradeable_id)
             existing_user_ids = []
             anon_ids = []

--- a/sbin/anonymize.py
+++ b/sbin/anonymize.py
@@ -72,7 +72,7 @@ def main():
         gradeable_rows = conn.execute(g_select)
 
         gradeable_anon = Table("gradeable_anon", metadata, autoload=True)
-        print("Performing anonymization...\n")
+        print("Performing anonymization...")
         for g_row in gradeable_rows:
             gradeable_id = g_row["g_id"]
             select = gradeable_anon.select().where(
@@ -88,7 +88,7 @@ def main():
                 if row['anon_id'] == '':
                     users_to_update.append(row['user_id'])
                     user_id = row['user_id']
-                    print (f"Need to update: {user_id}")
+                    print (f"  Need to update: {user_id} for gradeable: {gradeable_id}")
             for row in user_rows:
                 user_id = row["user_id"]
                 if (user_id not in existing_user_ids) or (user_id in users_to_update):
@@ -100,7 +100,7 @@ def main():
                         new_row = {'user_id': user_id, 'g_id': gradeable_id, 'anon_id': anon}
                         insert = gradeable_anon.insert().values(new_row)
                         conn.execute(insert)
-                        print (f"Need to insert user: {user_id}")
+                        print (f"  Insert user: {user_id} for gradeable: {gradeable_id}")
                         num_rows += 1
                     elif user_id in users_to_update:
                         new_info = {'anon_id': anon}
@@ -108,10 +108,11 @@ def main():
                             gradeable_anon.c.user_id == bindparam('b_user_id'),
                             gradeable_anon.c.g_id == bindparam('b_g_id')
                         )
-                        print (f"Need to update user: {user_id}")
+                        print (f"  Update: {user_id} for gradeable: {gradeable_id}")
                         conn.execute(update, b_user_id=user_id, b_g_id=gradeable_id)
                         num_rows += 1
         conn.close()
+        print("...done\n")
     db_conn.close()
     print(f"Rows created/updated: {num_rows}\n")
 

--- a/sbin/anonymize.py
+++ b/sbin/anonymize.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+This script can be used to assign gradeable-specific anonymous ids
+to the members of a course that don't already have anon ids.
+"""
+
+from sqlalchemy import create_engine, Table, MetaData, bindparam
+import string
+import random
+import json
+from os import path
+
+from submitty_utils import db_utils
+
+
+# function taken from setup_sample_courses
+def generate_random_user_id(length=15):
+    pick_from = string.ascii_lowercase + string.ascii_uppercase + string.digits
+    return ''.join(random.choice(pick_from) for _ in range(length))
+
+
+def main():
+    CONFIG_PATH = path.join(path.dirname(path.realpath(__file__)), '..', 'config')
+    with open(path.join(CONFIG_PATH, 'database.json')) as open_file:
+        DATABASE_DETAILS = json.load(open_file)
+    COURSE = input("Course: ")
+    SEMESTER = input("Semester: ")
+    DATABASE_HOST = DATABASE_DETAILS['database_host']
+    DATABASE_PORT = DATABASE_DETAILS['database_port']
+    DB_COURSE_USER = DATABASE_DETAILS['database_course_user']
+    DB_COURSE_PASS = DATABASE_DETAILS['database_course_password']
+
+    course_conn_str = db_utils.generate_connect_string(
+        DATABASE_HOST,
+        DATABASE_PORT,
+        f"submitty_{SEMESTER}_{COURSE}",
+        DB_COURSE_USER,
+        DB_COURSE_PASS,
+    )
+
+    course_engine = create_engine(course_conn_str)
+    conn = course_engine.connect()
+    metadata = MetaData(bind=course_engine)
+
+    users = Table("users", metadata, autoload=True)
+    user_select = users.select()
+    user_rows_obj = conn.execute(user_select)
+    user_rows = list(user_rows_obj)
+
+    gradeable = Table("gradeable", metadata, autoload=True)
+    g_select = gradeable.select()
+    gradeable_rows = conn.execute(g_select)
+
+    num_rows = 0
+    gradeable_anon = Table("gradeable_anon", metadata, autoload=True)
+    print("\nPerforming anonymization...")
+    for g_row in gradeable_rows:
+        gradeable_id = g_row["g_id"]
+        select = gradeable_anon.select().where(gradeable_anon.c.g_id == bindparam('gradeable_id'))
+        existing_rows = conn.execute(select, gradeable_id=gradeable_id)
+        existing_user_ids = []
+        anon_ids = []
+        users_to_update = []
+        for row in existing_rows:
+            existing_user_ids.append(row['user_id'])
+            anon_ids.append(row['anon_id'])
+            if row['anon_id'] == '':
+                users_to_update.append(row['user_id'])
+        for row in user_rows:
+            user_id = row["user_id"]
+            if (user_id not in existing_user_ids) or (user_id in users_to_update):
+                anon = generate_random_user_id()
+                while (anon in anon_ids):
+                    anon = generate_random_user_id()
+                anon_ids.append(anon)
+                if user_id not in existing_user_ids:
+                    new_row = {'user_id': user_id, 'g_id': gradeable_id, 'anon_id': anon}
+                    insert = gradeable_anon.insert().values(new_row)
+                    conn.execute(insert)
+                    num_rows += 1
+                elif user_id in users_to_update:
+                    new_info = {'anon_id': anon}
+                    update = gradeable_anon.update(values=new_info).where(
+                        gradeable_anon.c.user_id == bindparam('b_user_id'),
+                        gradeable_anon.c.g_id == bindparam('b_g_id')
+                    )
+                    conn.execute(update, b_user_id=user_id, b_g_id=gradeable_id)
+                    num_rows += 1
+    conn.close()
+    print(f"\nRows created/updated: {num_rows}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1045,7 +1045,6 @@ VALUES (?,?,?,?,?,?)",
         $params = [$user->getRotatingSection(), $user->getRegistrationSubsection(), $user->getRegistrationType(), $user->getId()];
         $this->course_db->query("UPDATE users SET rotating_section=?, registration_subsection=?, registration_type=? WHERE user_id=?", $params);
         $this->updateGradingRegistration($user->getId(), $user->getGroup(), $user->getGradingRegistrationSections());
-        $this->insertAnonIdForExistingGradeables($user);
     }
 
     /**
@@ -1098,7 +1097,6 @@ WHERE semester=? AND course=? AND user_id=?",
             $params = [$user->getRotatingSection(), $user->getRegistrationSubsection(), $user->getRegistrationType(), $user->getId()];
             $this->course_db->query("UPDATE users SET rotating_section=?, registration_subsection=?, registration_type=? WHERE user_id=?", $params);
             $this->updateGradingRegistration($user->getId(), $user->getGroup(), $user->getGradingRegistrationSections());
-            $this->insertAnonIdForExistingGradeables($user);
         }
     }
 
@@ -4443,12 +4441,7 @@ AND gc_id IN (
                 continue;
             }
             $params = [$user_id, $g_id, $anon_id];
-            $this->course_db->query(
-                "INSERT INTO gradeable_anon(user_id, g_id, anon_id)
-                VALUES (?, ?, ?)
-                ON CONFLICT DO NOTHING",
-                $params
-            );
+            $this->course_db->query("INSERT INTO gradeable_anon(user_id, g_id, anon_id) VALUES (?, ?, ?) ON CONFLICT DO NOTHING", $params);
         }
     }
 
@@ -4523,12 +4516,6 @@ AND gc_id IN (
         return $this->getUserFromAnon($anon_id, $g_id)[$anon_id] ??
             $this->getTeamIdFromAnonId($anon_id)[$anon_id] ??
                 null;
-    }
-
-    private function insertAnonIdForExistingGradeables(User $user) {
-        foreach ($this->getAllGradeablesIds() as $row) {
-            $this->insertGradeableAnonId($user->getId(), $row['g_id'], $user->getAnonId($row['g_id']));
-        }
     }
 
     // NOTIFICATION/EMAIL QUERIES


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

If a student is added to a course after one or more gradeables have been created, the student will not have an anon id for that gradeable, this causes several bugs.

### What is the new behavior?
Whenever a user is created, `gradeable_anon` is populated with anon ids for existing gradeables.

Another issue related to deleting a user was identified:
![delete_user](https://user-images.githubusercontent.com/51257141/187048941-7721783b-f28d-482e-9f8f-0f11e2211af7.jpg)

It is impossible to delete a user even though they didn't have any record of interactions; to fix this, a migration has been created, the function isn't new, a minor change in an already existing function has been done.

A migration has been added that adds the missing anon ids, the same migration also adds a trigger to automatically insert required rows in `gradeable_anon` table whenever insertion happens in `users` (course) table.

Running the migration is all that is needed, but for insurance, `anonymize.py` has been added, this is not to be confused with the script that existed before PR 8002 as most of it has been modified.

### Other information?

Fixes #8338 
This is another one in the series of bugs introduced by #8002, hopefully this string ends with this PR.
