### PR TITLE
[Dependency] Set composer.lock platform version to PHP version

### DIFF
--- a/site/composer.lock
+++ b/site/composer.lock
@@ -6802,7 +6802,7 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2"
+        "php": "7.4"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
Somehow the platform version had gotten out of sync between `composer.json` and `composer.lock`. Even though the platform version is `7.4` in the `composer.json` it was `7.2` in the `composer.lock`. This caused dependencies to think an older version of PHP was installed when it was actually bumped up recently.

This is causing recent dependabot upgrade PRs for PHP dependencies to fail since it cannot no longer perform composer installs on CI

### What is the new behavior?
Manually edited composer.json to have matching platforms

### Other information?
For developers, the platform config might be convenient but for CI since we control the version everytime maybe we can just ignore platform dependent requirements in the future in the github workflow. Or maybe there isn't a need for the platform config anymore?

More information here
https://getcomposer.org/doc/06-config.md#platform
