### PR TITLE
[Bugfix:System] Fix LDAP install on vagrant

### DIFF
--- a/.setup/distro_setup/setup_distro.sh
+++ b/.setup/distro_setup/setup_distro.sh
@@ -41,7 +41,7 @@ fi
 
 # SEE GITHUB ISSUE #7885 - https://github.com/Submitty/Submitty/issues/7885
 
-if [ ${VAGRANT} == 1] && [ ${UTM_ARM} == 0]; then
+if [ "${VAGRANT}" == 1 ] && [ "${UTM_ARM}" == 0 ]; then
     # Ubuntu/Debian share this stuff, CentOS does not
     if [ -d /etc/update-motd.d ]; then
         chmod -x /etc/update-motd.d/*
@@ -101,16 +101,4 @@ ${DATABASE_LINE}
 ############################################################
 " > /etc/motd
     chmod 644 /etc/motd
-
-    # setup up LDAP stuff
-    echo "" >> /etc/ldap/ldap.conf
-    echo "BASE   dc=vagrant,dc=local" >> /etc/ldap/ldap.conf
-    echo "URI    ldap://localhost" >> /etc/ldap/ldap.conf
-
-    echo -e "dn: ou=users,dc=vagrant,dc=local
-objectClass: organizationalUnit
-objectClass: top
-ou: users" > /tmp/base.ldif
-    ldapadd -x -w root_password -D "cn=admin,dc=vagrant,dc=local" -f /tmp/base.ldif
-    rm -f /tmp/base.ldif
 fi

--- a/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/20.04/setup_distro.sh
@@ -109,21 +109,10 @@ apt-get install git -y
 # Install OpenLDAP for testing on Vagrant
 if [ ${VAGRANT} == 1 ]; then
     apt-get install -qqy php-ldap
-    echo 'slapd/root_password password password' | debconf-set-selections &&\
-        echo 'slapd/root_password_again password password' | debconf-set-selections && \
-        DEBIAN_FRONTEND=noninteractive apt-get install -qqy slapd ldap-utils
 
-    echo "slapd slapd/no_configuration boolean false" | debconf-set-selections
-    echo "slapd slapd/domain string vagrant.local" | debconf-set-selections
-    echo "slapd shared/organization string 'Vagrant LDAP'" | debconf-set-selections
-    echo "slapd slapd/password1 password root_password" | debconf-set-selections
-    echo "slapd slapd/password2 password root_password" | debconf-set-selections
-    echo "slapd slapd/backend select HDB" | debconf-set-selections
-    echo "slapd slapd/purge_database boolean true" | debconf-set-selections
-    echo "slapd slapd/allow_ldap_v2 boolean false" | debconf-set-selections
-    echo "slapd slapd/move_old_database boolean true" | debconf-set-selections
+    CUR_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-    dpkg-reconfigure -f noninteractive slapd
+    source "$CUR_DIR/../../../vagrant/setup_ldap.sh"
 fi
 
 # Install SAML IdP docker container for testing

--- a/.setup/testing/setup_ldap.sh
+++ b/.setup/testing/setup_ldap.sh
@@ -2,29 +2,9 @@
 
 set -ev
 
-echo 'slapd/root_password password password' | debconf-set-selections &&\
-    echo 'slapd/root_password_again password password' | debconf-set-selections && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qqy slapd ldap-utils
-echo "slapd slapd/no_configuration boolean false" | debconf-set-selections
-echo "slapd slapd/domain string vagrant.local" | debconf-set-selections
-echo "slapd shared/organization string 'Vagrant LDAP'" | debconf-set-selections
-echo "slapd slapd/password1 password root_password" | debconf-set-selections
-echo "slapd slapd/password2 password root_password" | debconf-set-selections
-echo "slapd slapd/backend select HDB" | debconf-set-selections
-echo "slapd slapd/purge_database boolean true" | debconf-set-selections
-echo "slapd slapd/allow_ldap_v2 boolean false" | debconf-set-selections
-echo "slapd slapd/move_old_database boolean true" | debconf-set-selections
-dpkg-reconfigure -f noninteractive slapd
-echo "" >> /etc/ldap/ldap.conf
-echo "BASE   dc=vagrant,dc=local" >> /etc/ldap/ldap.conf
-echo "URI    ldap://localhost" >> /etc/ldap/ldap.conf
+CUR_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo -e "dn: ou=users,dc=vagrant,dc=local
-objectClass: organizationalUnit
-objectClass: top
-ou: users" > /tmp/base.ldif
-ldapadd -x -w root_password -D "cn=admin,dc=vagrant,dc=local" -f /tmp/base.ldif
-rm -f /tmp/base.ldif
+source "$CUR_DIR/../vagrant/setup_ldap.sh"
 
 sed -i -e 's/"url": ""/"url": "ldap:\/\/localhost"/g' /usr/local/submitty/config/authentication.json
 sed -i -e 's/"uid": ""/"uid": "uid"/g' /usr/local/submitty/config/authentication.json

--- a/.setup/vagrant/setup_ldap.sh
+++ b/.setup/vagrant/setup_ldap.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+echo 'slapd/root_password password password' | debconf-set-selections &&\
+    echo 'slapd/root_password_again password password' | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qqy slapd ldap-utils
+echo "slapd slapd/no_configuration boolean false" | debconf-set-selections
+echo "slapd slapd/domain string vagrant.local" | debconf-set-selections
+echo "slapd shared/organization string 'Vagrant LDAP'" | debconf-set-selections
+echo "slapd slapd/password1 password root_password" | debconf-set-selections
+echo "slapd slapd/password2 password root_password" | debconf-set-selections
+echo "slapd slapd/backend select HDB" | debconf-set-selections
+echo "slapd slapd/purge_database boolean true" | debconf-set-selections
+echo "slapd slapd/allow_ldap_v2 boolean false" | debconf-set-selections
+echo "slapd slapd/move_old_database boolean true" | debconf-set-selections
+dpkg-reconfigure -f noninteractive slapd
+echo "" >> /etc/ldap/ldap.conf
+echo "BASE   dc=vagrant,dc=local" >> /etc/ldap/ldap.conf
+echo "URI    ldap://localhost" >> /etc/ldap/ldap.conf
+
+echo -e "dn: ou=users,dc=vagrant,dc=local
+objectClass: organizationalUnit
+objectClass: top
+ou: users" > /tmp/base.ldif
+ldapadd -x -w root_password -D "cn=admin,dc=vagrant,dc=local" -f /tmp/base.ldif
+rm -f /tmp/base.ldif


### PR DESCRIPTION
### What is the current behavior?
When the vagrant system is installed, LDAP doesn't get fully set up because it is missing a couple commands. So when the setup_sample_courses script tries to add the users it fails on them and there are then 0 ldap users. There was also a bash syntax error from #6815.

### What is the new behavior?
The testing LDAP and vagrant LDAP now use the same script and it works locally. This should also help us detect problems like this earlier for LDAP. The bash syntax issue has been fixed.

### Other information?
I tested locally with LDAP and SAML and they both worked.
