### PR TITLE
[Bugfix:Forum] Remove dead code causing JS syntax issue

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -2,28 +2,13 @@
 
 {% if show_more is defined and show_more %}
 	<script>
-
 		$(document).ready(function() {
 		    let filterOption = '{{ more_data[0]["filter_option"] }}';
 		    if (filterOption) {
                 $('#' + filterOption).parent().removeClass("active");
                 $('#' + filterOption).addClass("active");
             }
-			let del = $('#delete');
-			let merge  = $('#merge_thread');
-
-			let deleteActive = typeof del[0] !== typeof undefined && del[0].hasAttribute('class') && del.attr('class').includes('active');
-			let deleteMerge  = merge[0].hasAttribute('class')  && merge.attr('class').includes('active');
-
-			if(('{{ more_data[0]["filter_option"] }}' === 'tree' && !deleteActive && !deleteMerge) || {{is_full_threads_page is defined ? is_full_threads_page : ''}}) {
-				$('#dropdownLabel').removeClass("active");
-			}
-			else {
-				$('#dropdownLabel').addClass("active");
-			}
-
 		 });
-
 	</script>
 {% endif %}
 


### PR DESCRIPTION
### What is the current behavior?
When viewing a forum with merged threads in anything but the wide view, the Twig variable `is_full_threads_page` is left undefined, which results in a JS syntax error due to the ternary expression on line 18.

### What is the new behavior?
The `dropdownLabel` ID does not appear anywhere in the codebase except for this location, so I have removed all of the related logic, including the buggy line.