### PR TITLE
[SECURITY][Bugfix:TAGrading] Peer grading access control

### DIFF
--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -406,11 +406,6 @@ parameters:
 			path: app/libraries/Access.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/libraries/Access.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 2
 			path: app/libraries/Access.php

--- a/site/tests/app/libraries/AccessTester.php
+++ b/site/tests/app/libraries/AccessTester.php
@@ -67,27 +67,15 @@ class AccessTester extends BaseUnitTest {
         $gg3->method("getSubmitter")->willReturn($su3);
         $gg3->method("getGradeable")->willReturn($g3);
 
-        /*
-        NOTE: ALL tests seem to be true
-        self::assertFalse($this->access->isGradeableInStudentPeerAssignment($gg1, $user1));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($gg2, $user1));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($gg3, $user1));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($gg1, $user2));
-        self::assertFalse($this->access->isGradeableInStudentPeerAssignment($gg2, $user2));
-        self::assertFalse($this->access->isGradeableInStudentPeerAssignment($gg3, $user2));
-        self::assertFalse($this->access->isGradeableInStudentPeerAssignment($gg1, $user3));
-        self::assertFalse($this->access->isGradeableInStudentPeerAssignment($gg2, $user3));
-        self::assertFalse($this->access->isGradeableInStudentPeerAssignment($gg3, $user3));
-        */
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g1, $user1));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g2, $user1));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g3, $user1));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g1, $user2));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g2, $user2));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g3, $user2));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g1, $user3));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g2, $user3));
-        self::assertTrue($this->access->isGradeableInStudentPeerAssignment($g3, $user3));
+        self::assertFalse($this->access->isGradedGradeableInPeerAssignment($g1, $gg1, $user1));
+        self::assertTrue($this->access->isGradedGradeableInPeerAssignment($g2, $gg2, $user1));
+        self::assertTrue($this->access->isGradedGradeableInPeerAssignment($g3, $gg3, $user1));
+        self::assertTrue($this->access->isGradedGradeableInPeerAssignment($g1, $gg1, $user2));
+        self::assertFalse($this->access->isGradedGradeableInPeerAssignment($g2, $gg2, $user2));
+        self::assertFalse($this->access->isGradedGradeableInPeerAssignment($g3, $gg3, $user2));
+        self::assertFalse($this->access->isGradedGradeableInPeerAssignment($g1, $gg1, $user3));
+        self::assertFalse($this->access->isGradedGradeableInPeerAssignment($g2, $gg2, $user3));
+        self::assertFalse($this->access->isGradedGradeableInPeerAssignment($g3, $gg3, $user3));
     }
 
     public function checkGroupPrivilegeProvider() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?

Fixes #8303
Peer graders can grade unassigned students if anonymous id of the student to grade is known.

### What is the new behavior?

Peer graders can only grade students assigned to them; "you don't have access..." error page is shown if they try to grade unassigned students.