### PR TITLE
[UI/UX:CourseMaterials] Change course materials icon

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -172,7 +172,7 @@ class GlobalController extends AbstractController {
             $sidebar_buttons[] = new NavButton($this->core, [
                 "href" => $this->core->buildCourseUrl(['course_materials']),
                 "title" => "Course Materials",
-                "icon" => "fa-copy"
+                "icon" => "fa-file"
             ]);
         }
 


### PR DESCRIPTION
### What is the current behavior?
#8362 changed the style of the `fa-copy` icon as part of the addition of a new "sharp" family of icons.  The new copy icon looks like [this](https://fontawesome.com/icons/copy?s=solid&f=classic), which is a change from the "two documents" style which existed previously. 

### What is the new behavior?
The previous "two documents" look does not appear anywhere in the current set of FA free icons so I have replaced the course materials icon with a single "file" icon (see screenshot for the new look).  Other possibilities for the replacement icon are [`fa-folder`](https://fontawesome.com/icons/folder?f=classic&s=solid) and [`fa-folder-open`](https://fontawesome.com/icons/folder-open?f=classic&s=solid).

![image](https://user-images.githubusercontent.com/16820599/189925114-9ded60ab-27f1-4735-a0cd-0d58b485804c.png)

