### PR TITLE
[Refactor:System] Cache Symfony routes

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -123,6 +123,12 @@ fi
 # create twig cache directory
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/twig
 
+# TODO: remove this. see #8404
+# clear old annotations cache
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/annotations" ]; then
+    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/annotations"
+fi
+
 # clear old routes cache
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/routes" ]; then
     rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/routes"

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -123,11 +123,11 @@ fi
 # create twig cache directory
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/twig
 
-# clear old annotation cache
+# clear old routes cache
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/routes" ]; then
     rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/routes"
 fi
-# create annotation cache directory
+# create routes cache directory
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/routes
 
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/public/mjs" ]; then

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -124,11 +124,11 @@ fi
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/twig
 
 # clear old annotation cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/annotations" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/annotations"
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/routes" ]; then
+    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/routes"
 fi
 # create annotation cache directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/annotations
+mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/routes
 
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/public/mjs" ]; then
     rm -r "${SUBMITTY_INSTALL_DIR}/site/public/mjs"


### PR DESCRIPTION
### What is the current behavior?
Currently only the annotations get cached in WebRouter. This still leaves a huge performance bottleneck as it has to collect all the routes every request.

### What is the new behavior?
The annotation cache has been swapped out for a route cache. The annotations don't need to be cached since we only fetch them once per install when we need to update our route cache. This greatly improves performance per request which is noted below.

Note about debug mode: You'll see we don't rely upon debug mode for the cache anymore. I tried implementing this but it made the debug mode noticeably slower. Most developers use code watcher and will be running install_site each code change, thus clearing the route cache. This may effect PHPStorm users which I use but a quick run of install_site when editing routes is not an issue especially given the performance benefits we are looking at.

### Other information?
xdebug profile before:
![image](https://user-images.githubusercontent.com/55092742/190862027-5737c78c-d493-4808-adac-af8d648f0422.png)

xdebug profile after:
![image](https://user-images.githubusercontent.com/55092742/190862051-9f6a2e75-0848-47b0-a0f0-909b0ab0ae21.png)

Using Apache Bench, the requests/sec were about 10-20 before and are now 50+.

The compiled url matcher and matcher dumper can be found in the docs here: https://symfony.com/doc/4.4/create_framework/routing.html