### PR TITLE
[Bugfix:CourseMaterials] Remove null hidden from student

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -656,7 +656,7 @@ CREATE TABLE public.course_materials (
     path character varying(255),
     type smallint NOT NULL,
     release_date timestamp with time zone,
-    hidden_from_students boolean,
+    hidden_from_students boolean NOT NULL,
     priority double precision NOT NULL,
     url text,
     url_title character varying(255)

--- a/migration/migrator/migrations/course/20220917193129_course_materials_remove_null_hidden.py
+++ b/migration/migrator/migrations/course/20220917193129_course_materials_remove_null_hidden.py
@@ -1,0 +1,37 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("UPDATE course_materials SET hidden_from_students = false WHERE hidden_from_students IS NULL AND type = 2;")
+    database.execute("""
+        ALTER TABLE course_materials
+            ALTER COLUMN hidden_from_students SET NOT NULL;
+    """)
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass


### PR DESCRIPTION
### What is the current behavior?
Null values are allowed in the `hidden_from_students` column in course materials. A recent change has made it so the page expects that this column has a non-null value.

### What is the new behavior?
This PR adds a migration to set all folders which would have the null values to have the value false. It also adds a database constraint to ensure this value is never null again.
