### PR TITLE
[Refactor:Plagiarism] Improve JSON parse error logging

### DIFF
--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -345,6 +345,7 @@ function requestAjaxData(url, f, es) {
                 data = JSON.parse(data);
             }
             catch (e) {
+                console.log(url);
                 console.log(data);
                 throw e;
             }

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -341,7 +341,13 @@ function requestAjaxData(url, f, es) {
     $.ajax({
         url: url,
         success: function(data) {
-            data = JSON.parse(data);
+            try {
+                data = JSON.parse(data);
+            }
+            catch (e) {
+                console.log(data);
+                throw e;
+            }
             if (data.status !== 'success') {
                 alert(data.message);
                 return;


### PR DESCRIPTION
### What is the current behavior?
JSON parsing errors are a common symptom of issues with the plagiarism results interface, but are difficult to debug when the route and corresponding response data are not available.  These types of errors are often reported in the production environment, but are much more difficult to track down in the development environment.

### What is the new behavior?
This PR adds a few logging commands which print out the relevant route and response when a parsing issue occurs.  The exception is then re-thrown so it is visible in the console and will cause testing tools like Cypress to fail if it occurs.