### PR TITLE
[Bugfix:CourseMaterials] Open/Close All Folders for Students

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -17,6 +17,10 @@
                     tabindex="0">Set All Release Dates</a>
             <a onclick="newUploadCourseMaterialsForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Course Materials</a>
         </div>
+    {% elseif user_group < 4 or ( not course_material.isHiddenFromStudents and (course_material.isSectionAllowed(user_section)) ) %}
+        <div class="action-buttons" style="float: right; margin-bottom: 20px;">
+            <a onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary key_to_click" tabindex="0">Open/Close All Folders</a>
+        </div>
     {% endif %}
     <h1>Course Materials</h1>
     {% if user_group==1 %}

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -9,7 +9,7 @@
     {% if user_group == 1 %}
         <div class="action-buttons" style="float: right; margin-bottom: 20px;">
             {# button to open all of the subfolders and cookie it#}
-            <a onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary key_to_click" tabindex="0">Open/Close All Folders</a>
+            <a onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary key_to_click" tabindex="0">Open/Close All Folder</a>
             {# button to set the release dates of all files in the page/course materials #}
             <a
                     onclick='openSetAllRelease()'


### PR DESCRIPTION
### **What is the current behavior?**

Closes #8420
Currently there is a button "Open/Close All Folders" for teachers on the course materials page which expands all folders. However, this button is missing for students.

### **What is the new behavior?**

Adds the "Open/Close All Folders" button for students with the same functionality.

