### PR TITLE
[Bugfix:Submission] Student view pdf for bulk

### DIFF
--- a/more_autograding_examples/pdf_exam/config/config.json
+++ b/more_autograding_examples/pdf_exam/config/config.json
@@ -13,6 +13,6 @@
     // don't show students the version # or the submitted files box
     // (they can still view and download pdf files from the active
     // submission when manual TA grading is released)
-    "hide_submitted_files" : true,
-    "hide_version_and_test_details" : true
+    "hide_submitted_files" : false,
+    "hide_version_and_test_details" : false
 }


### PR DESCRIPTION
### What is the current behavior?
Students cannot see uploaded pdfs when bulk upload gradeable grades are released. 

### What is the new behavior?
Students now have access to uploaded pdfs for bulk submission.

### Other information?
This is a temporary fix for #8437.
