### PR TITLE
[Bugfix:TAGrading] Display "Note to Student" in TA grading

### DIFF
--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -212,8 +212,6 @@ function renderGradingComponent(grader_id, component, graded_component, grading_
         graded_component = prepGradedComponent(component, graded_component);
         if (is_student) {
             component.ta_comment = "";
-        } else {
-            component.student_comment = "";
         }
         // TODO: i don't think this is async
         resolve(Twig.twig({ref: "GradingComponent"}).render({


### PR DESCRIPTION
### What is the current behavior?
The TA grading rubric does not display the note to students, only the note to TAs.

Fixes #8382 

### What is the new behavior?
The TA grading rubric now displays both the student and TA notes when both are filled in.

### Other information?
Testing was done by filling in the student note only, TA note only, and both the student and TA notes and making sure the note(s) are displayed accordingly.
