### PR TITLE
[Feature:InstructorUI] Add note for Grades Released Date

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -59,6 +59,12 @@
         <div id="release_date_container" class="release_date_date" {{ gradeable.hasReleaseDate() ? '' : 'hidden' }}>
             <input name="grade_released_date" id="date_released" class="date_picker" type="text" value="{{ gradeable.getGradeReleasedDate()|date(date_format, timezone_string) }}">
             <label for="date_released">Grades Released Date (grades will be visible to students)</label>
+        
+            <br />
+
+            <p style="max-width:600px;" id="checkpoint-numeric-gradeables-message">
+                Note: Released Grades for checkpoint and numeric gradeables are available to students only through Rainbow Grades.
+            </p>
         </div>
     </div>
     <br />

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -162,6 +162,10 @@ table#grader-history td {
     text-align: center;
 }
 
+#checkpoint-numeric-gradeables-message {
+    font-style: italic;
+}
+
 #late-days-message {
     font-style: italic;
 }


### PR DESCRIPTION
Closes #8403 

Added the following note under Grades Released Date on the Edit Gradeable page:
"Note: Released Grades for checkpoint and numeric gradeables are available to students only through Rainbow Grades."