### PR TITLE
[Bugfix:Submission] grade inqueries on team gradeables

### DIFF
--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -12,14 +12,12 @@ use app\libraries\response\WebResponse;
 use RuntimeException;
 use Symfony\Component\Routing\Annotation\Route;
 
-class GradeInquiryController extends AbstractController
-{
+class GradeInquiryController extends AbstractController {
     /**
      * @param                                                                              string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/new", methods={"POST"})
      */
-    public function requestGradeInquiry($gradeable_id)
-    {
+    public function requestGradeInquiry($gradeable_id) {
         $content = $_POST['replyTextArea'] ?? '';
         $submitter_id = $_POST['submitter_id'] ?? '';
         $gc_id = $_POST['gc_id'] == 0 ? null : intval($_POST['gc_id']);
@@ -80,8 +78,7 @@ class GradeInquiryController extends AbstractController
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/post", methods={"POST"})
      * @return                                                                              MultiResponse|JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function makeGradeInquiryPost($gradeable_id)
-    {
+    public function makeGradeInquiryPost($gradeable_id) {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
         $submitter_id = $_POST['submitter_id'] ?? '';
         $gc_id = $_POST['gc_id'] == 0 ? null : intval($_POST['gc_id']);
@@ -153,8 +150,7 @@ class GradeInquiryController extends AbstractController
      * @param                                                                                 string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/single", methods={"POST"})
      */
-    public function getSingleGradeInquiryPost($gradeable_id)
-    {
+    public function getSingleGradeInquiryPost($gradeable_id) {
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         //TODO: look into why these aren't getting sent by websockets
@@ -217,8 +213,7 @@ class GradeInquiryController extends AbstractController
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/toggle_status", methods={"POST"})
      * @return                                                                                       JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function changeGradeInquiryStatus($gradeable_id)
-    {
+    public function changeGradeInquiryStatus($gradeable_id) {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
         $submitter_id = $_POST['submitter_id'] ?? '';
         $gc_id = $_POST['gc_id'] == 0 ? null : intval($_POST['gc_id']);
@@ -293,8 +288,7 @@ class GradeInquiryController extends AbstractController
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/discussion", methods={"POST"})
      * @return                                                                                    MultiResponse
      */
-    public function getGradeInquiryDiscussion($gradeable_id)
-    {
+    public function getGradeInquiryDiscussion($gradeable_id) {
         $submitter_id = $_POST['submitter_id'];
 
         $gradeable = $this->tryGetGradeable($gradeable_id);
@@ -321,8 +315,7 @@ class GradeInquiryController extends AbstractController
      * @param string          $type
      * @param int|null        $gc_id
      */
-    private function notifyGradeInquiryEvent(GradedGradeable $graded_gradeable, $gradeable_id, $content, $type, $gc_id)
-    {
+    private function notifyGradeInquiryEvent(GradedGradeable $graded_gradeable, $gradeable_id, $content, $type, $gc_id) {
         $component = "";
         $component_title = "";
         $component_string = "";

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class GradeInquiryController extends AbstractController {
     /**
-     * @param                                                                              string $gradeable_id
+     * @param string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/new", methods={"POST"})
      */
     public function requestGradeInquiry($gradeable_id) {
@@ -74,9 +74,9 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param                                                                               string $gradeable_id
+     * @param string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/post", methods={"POST"})
-     * @return                                                                              MultiResponse|JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
+     * @return MultiResponse|JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
      */
     public function makeGradeInquiryPost($gradeable_id) {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
@@ -147,7 +147,7 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param                                                                                 string $gradeable_id
+     * @param string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/single", methods={"POST"})
      */
     public function getSingleGradeInquiryPost($gradeable_id) {
@@ -209,9 +209,9 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param                                                                                        string $gradeable_id
+     * @param string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/toggle_status", methods={"POST"})
-     * @return                                                                                       JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
+     * @return JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
      */
     public function changeGradeInquiryStatus($gradeable_id) {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
@@ -284,9 +284,9 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param                                                                                     string $gradeable_id
+     * @param string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/discussion", methods={"POST"})
-     * @return                                                                                    MultiResponse
+     * @return MultiResponse
      */
     public function getGradeInquiryDiscussion($gradeable_id) {
         $submitter_id = $_POST['submitter_id'];

--- a/site/app/controllers/student/GradeInquiryController.php
+++ b/site/app/controllers/student/GradeInquiryController.php
@@ -12,18 +12,20 @@ use app\libraries\response\WebResponse;
 use RuntimeException;
 use Symfony\Component\Routing\Annotation\Route;
 
-class GradeInquiryController extends AbstractController {
+class GradeInquiryController extends AbstractController
+{
     /**
-     * @param string $gradeable_id
+     * @param                                                                              string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/new", methods={"POST"})
      */
-    public function requestGradeInquiry($gradeable_id) {
+    public function requestGradeInquiry($gradeable_id)
+    {
         $content = $_POST['replyTextArea'] ?? '';
         $submitter_id = $_POST['submitter_id'] ?? '';
         $gc_id = $_POST['gc_id'] == 0 ? null : intval($_POST['gc_id']);
 
         $user = $this->core->getUser();
-        $submitter = $this->core->getQueries()->getUserById($submitter_id);
+        $submitter = $this->core->getQueries()->getSubmitterById($submitter_id);
 
         if ($submitter === null) {
             return JsonResponse::getFailResponse("Failed to get submitter");
@@ -45,7 +47,7 @@ class GradeInquiryController extends AbstractController {
             return JsonResponse::getFailResponse("No graded gradeable found for submitter");
         }
 
-        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]) && ($submitter_id === $user->getId() || $user->accessGrading() );
+        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]) && $user->accessGrading();
         if (!($graded_gradeable->getSubmitter()->hasUser($user) || $can_inquiry)) {
             return MultiResponse::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Insufficient permissions to request regrade')
@@ -74,15 +76,16 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param string $gradeable_id
+     * @param                                                                               string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/post", methods={"POST"})
-     * @return MultiResponse|JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
+     * @return                                                                              MultiResponse|JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function makeGradeInquiryPost($gradeable_id) {
+    public function makeGradeInquiryPost($gradeable_id)
+    {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
         $submitter_id = $_POST['submitter_id'] ?? '';
         $gc_id = $_POST['gc_id'] == 0 ? null : intval($_POST['gc_id']);
-        $submitter = $this->core->getQueries()->getUserById($submitter_id);
+        $submitter = $this->core->getQueries()->getSubmitterById($submitter_id);
 
         if ($submitter === null) {
             return JsonResponse::getFailResponse("Failed to get submitter");
@@ -109,7 +112,7 @@ class GradeInquiryController extends AbstractController {
         $can_inquiry = $this->core->getAccess()->canI(
             "grading.electronic.grade_inquiry",
             ['graded_gradeable' => $graded_gradeable]
-        ) && ($submitter_id === $user->getId() || $user->accessFullGrading());
+        ) && $user->accessFullGrading();
         if (!($graded_gradeable->getSubmitter()->hasUser($user) || $can_inquiry)) {
             return MultiResponse::JsonOnlyResponse(
                 JsonResponse::getFailResponse('Insufficient permissions to make grade inquiry post')
@@ -147,10 +150,11 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param string $gradeable_id
+     * @param                                                                                 string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/single", methods={"POST"})
      */
-    public function getSingleGradeInquiryPost($gradeable_id) {
+    public function getSingleGradeInquiryPost($gradeable_id)
+    {
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         //TODO: look into why these aren't getting sent by websockets
@@ -176,7 +180,7 @@ class GradeInquiryController extends AbstractController {
             return "";
         }
 
-        $submitter = $this->core->getQueries()->getUserById($submitter_id);
+        $submitter = $this->core->getQueries()->getSubmitterById($submitter_id);
         if ($submitter === null) {
             return "";
         }
@@ -185,7 +189,7 @@ class GradeInquiryController extends AbstractController {
         $can_inquiry = $this->core->getAccess()->canI(
             "grading.electronic.grade_inquiry",
             ['graded_gradeable' => $graded_gradeable]
-        ) && ($submitter_id === $user->getId() || $user->accessGrading() );
+        ) && $user->accessGrading();
         if (!($graded_gradeable->getSubmitter()->hasUser($user) || $can_inquiry)) {
             return "";
         }
@@ -209,11 +213,12 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param string $gradeable_id
+     * @param                                                                                        string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/toggle_status", methods={"POST"})
-     * @return JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
+     * @return                                                                                       JsonResponse|null null is for tryGetGradeable and tryGetGradedGradeable
      */
-    public function changeGradeInquiryStatus($gradeable_id) {
+    public function changeGradeInquiryStatus($gradeable_id)
+    {
         $content = str_replace("\r", "", $_POST['replyTextArea']);
         $submitter_id = $_POST['submitter_id'] ?? '';
         $gc_id = $_POST['gc_id'] == 0 ? null : intval($_POST['gc_id']);
@@ -234,12 +239,12 @@ class GradeInquiryController extends AbstractController {
             return JsonResponse::getFailResponse('Submitter has not made a grade inquiry');
         }
 
-        $submitter = $this->core->getQueries()->getUserById($submitter_id);
+        $submitter = $this->core->getQueries()->getSubmitterById($submitter_id);
         if ($submitter === null) {
             return JsonResponse::getFailResponse("Failed to get submitter");
         }
 
-        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]) && ($submitter_id === $user->getId() || $user->accessGrading() );
+        $can_inquiry = $this->core->getAccess()->canI("grading.electronic.grade_inquiry", ['graded_gradeable' => $graded_gradeable]) && $user->accessGrading();
         if (!($graded_gradeable->getSubmitter()->hasUser($user) || $can_inquiry)) {
             return JsonResponse::getFailResponse('Insufficient permissions to change grade inquiry status');
         }
@@ -268,10 +273,12 @@ class GradeInquiryController extends AbstractController {
             $new_discussion = $this->core->getOutput()->renderTemplate('submission\Homework', 'showRegradeDiscussion', $graded_gradeable, $can_inquiry);
 
             $this->notifyGradeInquiryEvent($graded_gradeable, $gradeable_id, $content, $type, $gc_id);
-            return JsonResponse::getSuccessResponse([
+            return JsonResponse::getSuccessResponse(
+                [
                 'type' => 'toggle_status',
                 'new_discussion' => $new_discussion
-            ]);
+                ]
+            );
         }
         catch (\InvalidArgumentException $e) {
             return JsonResponse::getFailResponse($e->getMessage());
@@ -282,11 +289,12 @@ class GradeInquiryController extends AbstractController {
     }
 
     /**
-     * @param string $gradeable_id
+     * @param                                                                                     string $gradeable_id
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grade_inquiry/discussion", methods={"POST"})
-     * @return MultiResponse
+     * @return                                                                                    MultiResponse
      */
-    public function getGradeInquiryDiscussion($gradeable_id) {
+    public function getGradeInquiryDiscussion($gradeable_id)
+    {
         $submitter_id = $_POST['submitter_id'];
 
         $gradeable = $this->tryGetGradeable($gradeable_id);
@@ -306,13 +314,15 @@ class GradeInquiryController extends AbstractController {
 
     /**
      * Helper function to create notification/email content and aggregate recipients
+     *
      * @param GradedGradeable $graded_gradeable
-     * @param string $gradeable_id
-     * @param string $content
-     * @param string $type
-     * @param int|null $gc_id
+     * @param string          $gradeable_id
+     * @param string          $content
+     * @param string          $type
+     * @param int|null        $gc_id
      */
-    private function notifyGradeInquiryEvent(GradedGradeable $graded_gradeable, $gradeable_id, $content, $type, $gc_id) {
+    private function notifyGradeInquiryEvent(GradedGradeable $graded_gradeable, $gradeable_id, $content, $type, $gc_id)
+    {
         $component = "";
         $component_title = "";
         $component_string = "";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant

### What is the current behavior?
Grade inquiries assume only a single user can make a grade inquery, the submitter_id was used to try and get the submitter which doesn't work when the 'submitter' is a team. In that case, the team_id would always return a bad submitter preventing any grade inquiry functionality  

### What is the new behavior?
Grade inquiry controller now uses the `getSubmitterById` function instead of `getUserById`, this allows grade inquiries to handle submissions by both teams and individuals. Also removed a duplicate check when seeing if there's a fast path to allowing a grade inquiry option, the `graded_gradeable->getSubmitter()->hasUser($user) ` was already checking if the given user's team or user id was part of the graded_gradeable submitter(s)

### Other information?
Tested opening and replying to grade inquiries and their websocket functionality. 
