### PR TITLE
Add leading 0 to exam page file

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -687,7 +687,7 @@ class SubmissionController extends AbstractController {
         $i = 1;
         foreach ($image_files as $image) {
             // copy over the uploaded image
-            if (!@copy($image, FileUtils::joinPaths($version_path, "upload_page_" . $i . "." . $image_extension))) {
+            if (!@copy($image, FileUtils::joinPaths($version_path, "upload_page_" . str_pad($i, 2, "0", STR_PAD_LEFT) . "." . $image_extension))) {
                 return $this->uploadResult("Failed to copy uploaded image {$image} to current submission.", false);
             }
             if (!@unlink($image)) {


### PR DESCRIPTION
No documentation update is necessary. A leading 0 has been added on the exam page file name in order to get them ordered.

 #8430  issue must be solved with this pull request

