### PR TITLE
[Bugfix:Plagiarism] Support viewing versions with no matches

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -253,7 +253,9 @@ class PlagiarismController extends AbstractController {
         $ranking = preg_split('/\R/', $content);
         $ranking_array = [];
         foreach ($ranking as $row) {
-            $ranking_array[] = preg_split('/\s+/', $row);
+            if (strlen(trim($row)) !== 0) { // filter out whitespace-only rows
+                $ranking_array[] = preg_split('/\s+/', $row);
+            }
         }
         return $ranking_array;
     }
@@ -1585,6 +1587,11 @@ class PlagiarismController extends AbstractController {
         }
         catch (Exception $e) {
             return JsonResponse::getErrorResponse($e->getMessage());
+        }
+
+        // If there were no matches for this version, show nothing in the right dropdown
+        if (count($ranking) === 0) {
+            return JsonResponse::getSuccessResponse([]);
         }
 
         $is_team_assignment = $this->core->getQueries()->getGradeableConfig($gradeable_id)->isTeamAssignment();

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -264,9 +264,13 @@ function loadUser2DropdownList(state) {
     // eslint-disable-next-line no-undef
     const url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'match'])}?user_id_1=${state.user_1_selected.user_id}&version_user_1=${state.user_1_selected.version}`;
     requestAjaxData(url, (data) => {
-
         state.user_2_dropdown_list = data;
         state.user_2_selected = data[0];
+
+        // No matches for this user+version pair
+        if (data.length === 0) {
+            state.user_2_selected = [];
+        }
 
         refreshUser2Dropdown(state);
         loadConcatenatedFileForEditor(state, 2);
@@ -286,7 +290,12 @@ function loadConcatenatedFileForEditor(state, editor) {
         // eslint-disable-next-line no-undef
         url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'concat'])}?user_id=${state.user_1_selected.user_id}&version=${state.user_1_selected.version}`;
     }
-    else {
+    else { // editor 2
+        if (state.user_2_selected.length === 0) {
+            state.editor2.getDoc().setValue('No matches for this submission');
+            state.editor2.refresh();
+            return;
+        }
         // eslint-disable-next-line no-undef
         url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'concat'])}?user_id=${state.user_2_selected.user_id}&version=${state.user_2_selected.version}&source_gradeable=${state.user_2_selected.source_gradeable}`;
     }
@@ -321,6 +330,12 @@ function colorRefreshAfterConcatLoad(state) {
 
 
 function loadColorInfo(state) {
+    if (state.user_2_selected.length === 0) {
+        state.color_info = [];
+        colorRefreshAfterConcatLoad(state);
+        return;
+    }
+
     // eslint-disable-next-line no-undef
     const url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'colorinfo'])}?user_id_1=${state.user_1_selected.user_id}&version_user_1=${state.user_1_selected.version}&user_id_2=${state.user_2_selected.user_id}&version_user_2=${state.user_2_selected.version}&source_gradeable_user_2=${state.user_2_selected.source_gradeable}`;
     requestAjaxData(url, (data) => {


### PR DESCRIPTION
### What is the current behavior?
It is currently possible to try to switch to any version for a user as long as that user has at least one match on at least one version.  An error is currently displayed when a user attempts to navigate to a version which has no matches. 

### What is the new behavior?
It is now possible to view versions with no matches in the left panel without errors appearing.  A notice is displayed in the right panel indicating that there are no matches as seen in the following screenshot:
![image](https://user-images.githubusercontent.com/16820599/194731541-70cdea99-b812-4aa4-b36b-38e183b134b2.png)
