### PR TITLE
[Bugfix:TAGrading] Add check to delete attachments

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -117,4 +117,5 @@ Matt Raneri
 Chris Reed  
 Zachary Wimer  
 Fu Chai
+Asher Gottlieb
 For their bug reports of specific security vulnerabilities :)  

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1124,6 +1124,11 @@ class ElectronicGraderController extends AbstractController {
             return;
         }
 
+        if (strpos($_POST['attachment'], "..") !== false) {
+            $this->core->getOutput()->renderJsonFail('Invalid path.');
+            return;
+        }
+
         $attachment_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'attachments', $gradeable->getId(), $submitter_id, $grader->getId(), $_POST["attachment"]);
         if (is_file($attachment_path)) {
             if (@unlink($attachment_path)) {


### PR DESCRIPTION
### What is the current behavior?
Files from the incorrect directory could get deleted when deleting attachments.

### What is the new behavior?
An extra check has been put in place to ensure this won't happen.

### Other information?
Thanks to Asher for reporting this
