### PR TITLE
[Feature:System] Expand Logical Volume on Setup

### DIFF
--- a/.setup/vagrant/setup_vagrant.sh
+++ b/.setup/vagrant/setup_vagrant.sh
@@ -14,8 +14,13 @@ if [ -x "$(command -v pip3)" ]; then
     python3 ${SUBMITTY_REPOSITORY}/.setup/bin/reset_system.py
 fi
 
-sudo bash ${SUBMITTY_REPOSITORY}/.setup/install_system.sh --vagrant ${@}
-if [ $? -ne 0 ]; then
+# Expand the default logical volume for Ubuntu
+lvresize -l +100%FREE /dev/mapper/ubuntu--vg-ubuntu--lv
+resize2fs /dev/mapper/ubuntu--vg-ubuntu--lv
+
+# Start installation
+# shellcheck disable=2068
+if ! sudo bash ${SUBMITTY_REPOSITORY}/.setup/install_system.sh --vagrant ${@}; then
     DISTRO=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
     VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
     >&2 echo -e "

--- a/.shellcheckignore
+++ b/.shellcheckignore
@@ -13,7 +13,6 @@ tests/**/*.sh
 .setup/vagrant/db_users.sh
 .setup/install_submitty/install_bin.sh
 .setup/install_submitty/install_site.sh
-.setup/vagrant/setup_vagrant.sh
 .setup/vagrant/setup_ldap.sh
 .setup/update_system.sh
 .setup/bin/recreate_sample_courses.sh


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

Closes #8483 

### What is the current behavior?
Ubuntu server by default uses logical volume with ~31 GiB.  This applies to the vagrant VM.

### What is the new behavior?
When vagrant initializes Ubuntu server, it also expands the LV to ~62 GiB.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested with `vagrant destroy` and `NO_SUBMISSIONS=1 vagrant up`.
