### PR TITLE
[Bugfix:System] SAML Add Proxy User Fix

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -357,6 +357,9 @@ class UsersController extends AbstractController {
         else {
             if ($this->core->getQueries()->getSubmittyUser($_POST['user_id']) === null) {
                 $this->core->getQueries()->insertSubmittyUser($user);
+                if ($authentication instanceof SamlAuthentication) {
+                    $this->core->getQueries()->insertSamlMapping($_POST['user_id'], $_POST['user_id']);
+                }
                 $this->core->addSuccessMessage("Added a new user {$user->getId()} to Submitty");
                 $this->core->getQueries()->insertCourseUser($user, $semester, $course);
                 $this->core->addSuccessMessage("New Submitty user '{$user->getId()}' added");
@@ -815,6 +818,9 @@ class UsersController extends AbstractController {
                         //User must first exist in Submitty before being enrolled to a course.
                         if (is_null($this->core->getQueries()->getSubmittyUser($user->getId()))) {
                             $this->core->getQueries()->insertSubmittyUser($user);
+                            if ($this->core->getAuthentication() instanceof SamlAuthentication) {
+                                $this->core->getQueries()->insertSamlMapping($user->getId(), $user->getId());
+                            }
                         }
                         $this->core->getQueries()->insertCourseUser($user, $semester, $course);
                         break;

--- a/site/app/controllers/superuser/SamlManagerController.php
+++ b/site/app/controllers/superuser/SamlManagerController.php
@@ -63,6 +63,10 @@ class SamlManagerController extends AbstractController {
             $this->core->addErrorMessage("User ID already exists.");
             return new RedirectResponse($return_url);
         }
+        if (empty(trim($_POST['user_numeric_id']))) {
+            $this->core->addErrorMessage("Numeric ID can't be empty.");
+            return new RedirectResponse($return_url);
+        }
         $auth->setValidUsernames([$user_id]);
         if ($auth->isValidUsername($user_id)) {
             $this->core->addErrorMessage("User ID is a valid SAML username and cannot be used for a proxy user.");

--- a/site/app/templates/superuser/NewProxyUser.twig
+++ b/site/app/templates/superuser/NewProxyUser.twig
@@ -6,7 +6,7 @@
     <label for="form-user-id">User ID:</label>
     <input type="text" id="form-user-id" placeholder="(Required)" name="user_id"><br>
     <label for="form-user-num-id">User Numeric ID:</label>
-    <input type="text" id="form-user-num-id" placeholder="(Optional)" name="user_numeric_id"><br>
+    <input type="text" id="form-user-num-id" placeholder="(Required)" name="user_numeric_id"><br>
     <label for="form-user-first-name">User First Name:</label>
     <input type="text" id="form-user-first-name" placeholder="(Required)" name="user_first_name"><br>
     <label for="form-user-last-name">User Last Name:</label>


### PR DESCRIPTION
### What is the current behavior?
If you try to add a proxy user from the SAML management page, it will fail. Also it marks numeric ID as optional when it is required.

### What is the new behavior?
I made sure both IDs get checked for valid usernames in SAML before doing the check preventing new users from being added. I also marked numeric IDs as required on the page.

### Other information?
Tested locally and it now works.
