### PR TITLE
[Bugfix:TAGrading] Correct gradeable type on grading page

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -4,6 +4,8 @@ namespace app\controllers\grading;
 
 use app\libraries\DateUtils;
 use app\libraries\DiffViewer;
+use app\libraries\GradeableType;
+use app\libraries\response\RedirectResponse;
 use app\libraries\routers\AccessControl;
 use app\models\gradeable\Component;
 use app\models\gradeable\Gradeable;
@@ -848,6 +850,10 @@ class ElectronicGraderController extends AbstractController {
         if ($gradeable === false) {
             $this->core->addErrorMessage('Invalid Gradeable!');
             $this->core->redirect($this->core->buildCourseUrl());
+        }
+
+        if ($gradeable->getType() !== GradeableType::ELECTRONIC_FILE) {
+            return new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading']));
         }
 
         $gradeableUrl = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'details']);

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -2,7 +2,9 @@
 
 namespace app\controllers\grading;
 
+use app\libraries\GradeableType;
 use app\libraries\response\RedirectResponse;
+use app\libraries\response\ResponseInterface;
 use app\models\gradeable\GradedGradeable;
 use app\models\User;
 use app\controllers\AbstractController;
@@ -97,7 +99,7 @@ class SimpleGraderController extends AbstractController {
      * @param null|string $view
      * @param string $sort
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grading", methods={"GET"})
-     * @return MultiResponse
+     * @return ResponseInterface
      */
     public function gradePage($gradeable_id, $view = null, $sort = "section_subsection") {
         try {
@@ -107,6 +109,10 @@ class SimpleGraderController extends AbstractController {
             return MultiResponse::webOnlyResponse(
                 new WebResponse('Error', 'noGradeable')
             );
+        }
+
+        if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
+            return new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'details']));
         }
 
         //If you can see the page, you can grade the page


### PR DESCRIPTION
### What is the current behavior?
If you create an electronic gradeable, you can visit the numeric grade view of that gradeable which does not make sense. You can also attempt to do the reverse where you view a numeric gradeable as an electronic gradeable but it creates a frog robot error.
Fixes #8509

### What is the new behavior?
If you attempt to go to the wrong route for grading a gradeable, it will redirect you to the correct one.

### Other information?
Tested locally and it redirected properly.
