### PR TITLE
[Bugfix:System] Update Docker Hub API to v2

### DIFF
--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -91,7 +91,7 @@ class DockerInterfaceController extends AbstractController {
 
         $image_arr = explode(":", $_POST['image']);
         // ping the dockerhub API to check if docker exists
-        $url = "https://registry.hub.docker.com/v1/repositories/" . $image_arr[0] . "/tags";
+        $url = "https://registry.hub.docker.com/v2/repositories/" . $image_arr[0] . "/tags";
         $tag = $image_arr[1];
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
@@ -102,11 +102,13 @@ class DockerInterfaceController extends AbstractController {
         if (curl_errno($ch) || $http_code !== 200) {
             return JsonResponse::getErrorResponse($image_arr[0] . ' not found on DockerHub');
         }
-        $return_json = json_decode($return_str);
+        $return_json = (array) json_decode($return_str);
+        if (!isset($return_json['results'])) {
+            return JsonResponse::getFailResponse($_POST['image'] . ' not found on DockerHub');
+        }
         $found = false;
-
-        foreach ($return_json as $image) {
-            if ($image->name == $tag) {
+        foreach ($return_json['results'] as $result) {
+            if ($result->name === $tag) {
                 $found = true;
                 break;
             }


### PR DESCRIPTION
### What is the current behavior?
We rely on the Docker Hub API version 1 to check if an image is valid. The API has been marked as deprecated and thus does not work anymore.

### What is the new behavior?
The Docker interface page uses Docker Hub API version 2 now.

