### PR TITLE
[Refactor:TAGrading] Speedup Details Page

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -935,7 +935,19 @@ class ElectronicGraderController extends AbstractController {
         $show_export_teams_button = $show_edit_teams && (count($all_teams) == count($empty_teams));
         $past_grade_start_date = $gradeable->getDates()['grade_start_date'] < $this->core->getDateTimeNow();
 
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode);
+        $rawOverrides = $this->core->getQueries()->getRawUsersWithOverriddenGrades($gradeable->getId());
+        $overrides = [];
+        foreach ($rawOverrides as $o) {
+            $overrides[] = $o['user_id'];
+        }
+
+        $rawAnonIds = $this->core->getQueries()->getAllAnonIdsByGradeableWithUserIds($gradeable->getId());
+        $anon_ids = [];
+        foreach ($rawAnonIds as $anon) {
+            $anon_ids[$anon['user_id']] = $anon['anon_id'];
+        }
+
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode, $overrides, $anon_ids);
 
         if ($show_edit_teams) {
             $all_reg_sections = $this->core->getQueries()->getRegistrationSections();

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -941,10 +941,15 @@ class ElectronicGraderController extends AbstractController {
             $overrides[] = $o['user_id'];
         }
 
-        $rawAnonIds = $this->core->getQueries()->getAllAnonIdsByGradeableWithUserIds($gradeable->getId());
+        if ($gradeable->isTeamAssignment()) {
+            $rawAnonIds = $this->core->getQueries()->getAllTeamAnonIdsByGradeable($gradeable->getId());
+        }
+        else {
+            $rawAnonIds = $this->core->getQueries()->getAllAnonIdsByGradeableWithUserIds($gradeable->getId());
+        }
         $anon_ids = [];
         foreach ($rawAnonIds as $anon) {
-            $anon_ids[$anon['user_id']] = $anon['anon_id'];
+            $anon_ids[$anon[$gradeable->isTeamAssignment() ? 'team_id' : 'user_id']] = $anon['anon_id'];
         }
 
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode, $overrides, $anon_ids);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4465,6 +4465,11 @@ AND gc_id IN (
         return $this->course_db->rows();
     }
 
+    public function getAllTeamAnonIdsByGradeable($g_id) {
+        $this->course_db->query("SELECT team_id, anon_id FROM gradeable_teams WHERE g_id=?", [$g_id]);
+        return $this->course_db->rows();
+    }
+
     /**
      * Get gradeable-specific user anon_id
      *

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3724,6 +3724,20 @@ ORDER BY gt.{$section_key}",
      * @return SimpleGradeOverriddenUser[]
      */
     public function getUsersWithOverriddenGrades($gradeable_id) {
+        $return = [];
+        foreach ($this->getRawUsersWIthOverriddenGrades($gradeable_id) as $row) {
+            $return[] = new SimpleGradeOverriddenUser($this->core, $row);
+        }
+        return $return;
+    }
+
+    /**
+     * Return an array of users with overridden Grades
+     *
+     * @param  string $gradeable_id
+     * @return array
+     */
+    public function getRawUsersWithOverriddenGrades(string $gradeable_id) {
         $this->course_db->query(
             "
         SELECT u.user_id, user_firstname,
@@ -3736,12 +3750,7 @@ ORDER BY gt.{$section_key}",
         ORDER BY user_email ASC;",
             [$gradeable_id]
         );
-
-        $return = [];
-        foreach ($this->course_db->rows() as $row) {
-            $return[] = new SimpleGradeOverriddenUser($this->core, $row);
-        }
-        return $return;
+        return $this->course_db->rows();
     }
 
     /**
@@ -4448,6 +4457,11 @@ AND gc_id IN (
 
     public function getAllAnonIdsByGradeable($g_id) {
         $this->course_db->query("SELECT anon_id FROM gradeable_anon WHERE g_id=?", [$g_id]);
+        return $this->course_db->rows();
+    }
+
+    public function getAllAnonIdsByGradeableWithUserIds($g_id) {
+        $this->course_db->query("SELECT anon_id, user_id FROM gradeable_anon WHERE g_id=?", [$g_id]);
         return $this->course_db->rows();
     }
 

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -174,7 +174,7 @@
                 <tbody class="details-content panel-content-active">
                     {% if section.rows is defined %}
                         {% for info in section.rows %}
-                            {{ _self.render_student(_context, section, info.graded_gradeable, loop.index, info, columns, team_gradeable_view_history) }}
+                            {{ _self.render_student(_context, section, info.graded_gradeable, loop.index, info, columns, team_gradeable_view_history, overrides, anon_ids) }}
                         {% endfor %}
                     {% endif %}
                     {% if section.teamless_users is defined %}
@@ -219,7 +219,7 @@
     </table>
 </div>
 
-{% macro render_student(context, section, graded_gradeable, index, info, columns, team_gradeable_view_history) %}
+{% macro render_student(context, section, graded_gradeable, index, info, columns, team_gradeable_view_history, overrides, anon_ids) %}
     <tr
         {% if not graded_gradeable.getSubmitter().isTeam() and graded_gradeable.getSubmitter().getUser().accessGrading() %}
             style='background: #7bd0f7;'
@@ -239,9 +239,9 @@
             {% elseif column.function == "graded_questions" %}
                 {{ _self.render_column_graded_questions(context, section, graded_gradeable, index, info, column) }}
             {% elseif column.function == "grading" %}
-                {{ _self.render_column_grading(context, section, graded_gradeable, index, info, column) }}
+                {{ _self.render_column_grading(context, section, graded_gradeable, index, info, column, overrides, anon_ids) }}
             {% elseif column.function == "grading_blind" %}
-                {{ _self.render_column_grading_blind(context, section, graded_gradeable, index, info, column) }}
+                {{ _self.render_column_grading_blind(context, section, graded_gradeable, index, info, column, overrides, anon_ids) }}
             {% elseif column.function == "grading_blind" %}
                 {{ _self.render_column_grading_peer(context, section, graded_gradeable, index, info, column) }}
             {% elseif column.function == "index" %}
@@ -261,9 +261,9 @@
             {% elseif column.function == "user_first" %}
                 {{ _self.render_column_user_first(context, section, graded_gradeable, index, info, column) }}
             {% elseif column.function == "user_id" %}
-                {{ _self.render_column_user_id(context, section, graded_gradeable, index, info, column) }}
+                {{ _self.render_column_user_id(context, section, graded_gradeable, index, info, column, anon_ids) }}
             {% elseif column.function == "user_id_anon" %}
-                {{ _self.render_column_user_id_anon(context, section, graded_gradeable, index, info, column) }}
+                {{ _self.render_column_user_id_anon(context, section, graded_gradeable, index, info, column, anon_ids) }}
             {% elseif column.function == "team_members_anon" %}
                 {{ _self.render_column_team_members_anon(context, section, graded_gradeable, index, info, column) }}
             {% elseif column.function == "user_last" %}
@@ -420,9 +420,9 @@
 {% endmacro %}
 
 {# Grading Button #}
-{% macro render_column_grading(context, section, graded_gradeable, index, info, column) %}
+{% macro render_column_grading(context, section, graded_gradeable, index, info, column, overrides, anon_ids) %}
     {% set badge_count = 0 %}
-    {% if  graded_gradeable.hasOverriddenGrades() %}
+    {% if  graded_gradeable.getSubmitter().getId() in overrides %}
         {% set contents = "Overridden" %}
         {% set btn_class = "btn-default" %}
     {% elseif not graded_gradeable.getAutoGradedGradeable().hasSubmission() %}
@@ -461,7 +461,7 @@
         {% set badge_count = graded_gradeable.getActiveGradeInquiryCount()  %}
     {%  endif %}
     <td style="text-align: center;">
-        <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId(graded_gradeable.getGradeableId()) }}&sort={{ context.sort }}&direction={{ context.direction }}">
+        <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ anon_ids[graded_gradeable.getSubmitter().getId()] }}&sort={{ context.sort }}&direction={{ context.direction }}">
             {{ contents }}
             {% if badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
                 <span class="notification-badge">{{ badge_count }}</span>
@@ -471,8 +471,8 @@
 {% endmacro %}
 
 {# Grading Button (peer) TODO: fix this for peer grading support #}
-{% macro render_column_grading_blind(context, section, graded_gradeable, index, info, column) %}
-    {% if  graded_gradeable.hasOverriddenGrades() %}
+{% macro render_column_grading_blind(context, section, graded_gradeable, index, info, column, overrides, anon_ids) %}
+    {% if  graded_gradeable.getSubmitter().getId() in overrides %}
         {% set contents = "Overridden" %}
         {% set btn_class = "btn-default" %}
     {% elseif not graded_gradeable.getAutoGradedGradeable().hasSubmission() %}
@@ -511,7 +511,7 @@
         {% set badge_count = graded_gradeable.getActiveGradeInquiryCount()  %}
     {%  endif %}
     <td>
-        <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ graded_gradeable.getSubmitter().getAnonId(graded_gradeable.getGradeableId()) }}&sort={{ context.sort }}&direction={{ context.direction }}">
+        <a class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ anon_ids[graded_gradeable.getSubmitter().getId()] }}&sort={{ context.sort }}&direction={{ context.direction }}">
             {{ contents }}
             {% if badge_count is defined and badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
                 <span class="notification-badge">{{ badge_count }}</span>
@@ -624,18 +624,18 @@
 {% endmacro %}
 
 {# Anonymous ID #}
-{% macro render_column_user_id_anon(context, section, graded_gradeable, index, info, column) %}
-    <td>{{ graded_gradeable.getSubmitter().getUser().getAnonId(graded_gradeable.getGradeableId()) }}</td>
+{% macro render_column_user_id_anon(context, section, graded_gradeable, index, info, column, anon_ids) %}
+    <td>{{ anon_ids[graded_gradeable.getSubmitter().getId()] }}</td>
 {% endmacro %}
 
-{% macro render_column_team_members_anon(context, section, graded_gradeable, index, info, column) %}
+{% macro render_column_team_members_anon(context, section, graded_gradeable, index, info, column, anon_ids) %}
     <td>
         {% if not graded_gradeable.getGradeable().isTeamAssignment() %}
-            {{ graded_gradeable.getSubmitter().getUser().getAnonId(graded_gradeable.getGradeableId()) }}
+            {{ anon_ids[graded_gradeable.getSubmitter().getId()] }}
         {% else %}
             {%- for member in graded_gradeable.getSubmitter().getTeam().getMemberUsersSorted() -%}
                 {%- if loop.index != 1 -%}, {% endif -%}
-                {{- member.getAnonId(graded_gradeable.getGradeableId()) -}}
+                {{- anon_ids[member.getId()] -}}
             {%- endfor -%}
         {% endif %}
     <div style="font-style: italic; display: inline; color: grey;">
@@ -643,7 +643,7 @@
             {%- for member in graded_gradeable.getSubmitter().getTeam().getInvitedUsers() -%}
                 {%- if loop.index == 1 -%}Pending: {% endif -%}
                 {%- if loop.index != 1 -%}, {% endif -%}
-                {{- member.getAnonId(graded_gradeable.getGradeableId()) -}}
+                {{- anon_ids[member.getId()] -}}
             {%- endfor -%}
         {% endif %}
     </div>

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -440,7 +440,7 @@ HTML;
      * @param bool $show_edit_teams
      * @return string
      */
-    public function detailsPage(Gradeable $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode) {
+    public function detailsPage(Gradeable $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode, $overrides, $anon_ids) {
         $peer = false;
         if ($gradeable->hasPeerComponent() && $this->core->getUser()->getGroup() === User::GROUP_STUDENT) {
             $peer = true;
@@ -826,7 +826,9 @@ HTML;
             "is_instructor" => $this->core->getUser()->getGroup() === User::GROUP_INSTRUCTOR,
             "is_student" => $this->core->getUser()->getGroup() === User::GROUP_STUDENT,
             "message" => $message,
-            "message_warning" => $message_warning
+            "message_warning" => $message_warning,
+            "overrides" => $overrides,
+            "anon_ids" => $anon_ids
         ]);
     }
 


### PR DESCRIPTION
### What is the current behavior?
Currently when loading the details page for an electronic gradeable there is 2 n-length queries. When a course has a lot of users this slows down the page a lot.

### What is the new behavior?
Both n-length queries have been reduced down to single-length queries instead.

### Other information?
I tested on a mock production server (around 800 users) where the page load time was initially 2.7 seconds and is now 0.9 seconds.
