### PR TITLE
[Refactor:TAGrading] Fetch Verified Grader Eagerly

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7152,6 +7152,21 @@ AND gc_id IN (
               gcd.array_grader_rotating_section,
               gcd.array_grader_registration_type,
               gcd.array_grader_grading_registration_sections,
+              
+              /* Aggregate Gradeable Component Verifier Data */
+              gcd.array_verifier_user_id,
+              gcd.array_verifier_user_firstname,
+              gcd.array_verifier_user_preferred_firstname,
+              gcd.array_verifier_user_lastname,
+              gcd.array_verifier_user_email,
+              gcd.array_verifier_user_email_secondary,
+              gcd.array_verifier_user_email_secondary_notify,
+              gcd.array_verifier_user_group,
+              gcd.array_verifier_manual_registration,
+              gcd.array_verifier_last_updated,
+              gcd.array_verifier_registration_section,
+              gcd.array_verifier_rotating_section,
+              gcd.array_verifier_registration_type,
 
               /* Aggregate Gradeable Component Data (versions) */
               egd.array_version,
@@ -7227,6 +7242,19 @@ AND gc_id IN (
                   json_agg(ug.rotating_section) AS array_grader_rotating_section,
                   json_agg(ug.registration_type) AS array_grader_registration_type,
                   json_agg(ug.grading_registration_sections) AS array_grader_grading_registration_sections,
+                  json_agg(uv.user_id) AS array_verifier_user_id,
+                  json_agg(uv.user_firstname) AS array_verifier_user_firstname,
+                  json_agg(uv.user_preferred_firstname) AS array_verifier_user_preferred_firstname,
+                  json_agg(uv.user_lastname) AS array_verifier_user_lastname,
+                  json_agg(uv.user_email) AS array_verifier_user_email,
+                  json_agg(uv.user_email_secondary) AS array_verifier_user_email_secondary,
+                  json_agg(uv.user_email_secondary_notify) AS array_verifier_user_email_secondary_notify,
+                  json_agg(uv.user_group) AS array_verifier_user_group,
+                  json_agg(uv.manual_registration) AS array_verifier_manual_registration,
+                  json_agg(uv.last_updated) AS array_verifier_last_updated,
+                  json_agg(uv.registration_section) AS array_verifier_registration_section,
+                  json_agg(uv.rotating_section) AS array_verifier_rotating_section,
+                  json_agg(uv.registration_type) AS array_verifier_registration_type,
                   in_gcd.gd_id,
                   ug.g_id
                 FROM gradeable_component_data in_gcd
@@ -7260,6 +7288,10 @@ AND gc_id IN (
                         FROM gradeable_anon
                       ) AS ga ON u.user_id=ga.user_id
                   ) AS ug ON ug.user_id=in_gcd.gcd_grader_id
+                  LEFT JOIN (
+                    SELECT u.*
+                    FROM users u
+                  ) AS uv ON uv.user_id=in_gcd.gcd_verifier_id
                 GROUP BY in_gcd.gd_id, ug.g_id
               ) AS gcd ON gcd.gd_id=gd.gd_id AND gcd.g_id=g.g_id
 
@@ -7429,9 +7461,18 @@ AND gc_id IN (
                             return 'grader_' . $elem;
                         },
                         $user_properties
+                    ),
+                    array_map(
+                        function ($elem) {
+                            return 'verifier_' . $elem;
+                        },
+                        $user_properties
                     )
                 ) as $property
             ) {
+                if (in_array($property, ['verifier_anon_id', 'verifier_grading_registration_sections'], true)) {
+                    continue;
+                }
                 $db_row_split[$property] = json_decode($row['array_' . $property]);
             }
 
@@ -7454,13 +7495,26 @@ AND gc_id IN (
                     // Create the grader user
                     $grader = new User($this->core, $user_array);
 
+                    // Transpose the verifier if it exists
+                    $verifier = null;
+                    $verifier_array = [];
+                    if (isset($db_row_split['verifier_user_id'][$i])) {
+                        foreach ($user_properties as $property) {
+                            if (isset($db_row_split['verifier' . $property][$i])) {
+                                $verifier_array[$property] = $db_row_split['verifier' . $property][$i];
+                            }
+                        }
+                        $verifier = new User($this->core, $verifier_array);
+                    }
+
                     // Create the component
                     $graded_component = new GradedComponent(
                         $this->core,
                         $ta_graded_gradeable,
                         $gradeable->getComponent($db_row_split['comp_id'][$i]),
                         $grader,
-                        $comp_array
+                        $comp_array,
+                        $verifier
                     );
 
                     $graded_component->setMarkIdsFromDb($db_row_split['mark_id'][$i] ?? []);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7466,13 +7466,13 @@ AND gc_id IN (
                         function ($elem) {
                             return 'verifier_' . $elem;
                         },
-                        $user_properties
+                        array_diff(
+                            $user_properties,
+                            ['anon_id', 'grading_registration_sections']
+                        )
                     )
                 ) as $property
             ) {
-                if (in_array($property, ['verifier_anon_id', 'verifier_grading_registration_sections'], true)) {
-                    continue;
-                }
                 $db_row_split[$property] = json_decode($row['array_' . $property]);
             }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7498,10 +7498,10 @@ AND gc_id IN (
                     // Transpose the verifier if it exists
                     $verifier = null;
                     $verifier_array = [];
-                    if (isset($db_row_split['verifier_user_id'][$i])) {
+                    if (isset($db_row_split['verifier_user_id'][$i]) && $db_row_split['verifier_user_id'][$i] !== null) {
                         foreach ($user_properties as $property) {
-                            if (isset($db_row_split['verifier' . $property][$i])) {
-                                $verifier_array[$property] = $db_row_split['verifier' . $property][$i];
+                            if (isset($db_row_split['verifier_' . $property][$i])) {
+                                $verifier_array[$property] = $db_row_split['verifier_' . $property][$i];
                             }
                         }
                         $verifier = new User($this->core, $verifier_array);

--- a/site/app/models/gradeable/GradedComponent.php
+++ b/site/app/models/gradeable/GradedComponent.php
@@ -75,7 +75,7 @@ class GradedComponent extends AbstractModel {
      * @param array $details any remaining properties
      * @throws \InvalidArgumentException if any of the details are invalid, or the component/grader are null
      */
-    public function __construct(Core $core, TaGradedGradeable $ta_graded_gradeable, Component $component, User $grader, array $details) {
+    public function __construct(Core $core, TaGradedGradeable $ta_graded_gradeable, Component $component, User $grader, array $details, User $verifier = null) {
         parent::__construct($core);
 
         if ($ta_graded_gradeable === null) {
@@ -89,9 +89,7 @@ class GradedComponent extends AbstractModel {
         $this->setGradedVersion($details['graded_version'] ?? 0);
         $this->setGradeTime($details['grade_time'] ?? $this->core->getDateTimeNow());
         $this->verifier_id = $details['verifier_id'] ?? '';
-        if ($this->verifier_id !== '') {
-            $this->verifier = $this->core->getQueries()->getUserById($this->verifier_id);
-        }
+        $this->verifier = $verifier;
         $this->setVerifyTime($details['verify_time'] ?? '');
         // assign the default score if its not electronic (or rather not a custom mark)
         if ($component->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE) {


### PR DESCRIPTION
### What is the current behavior?
Every time a GradedComponent is created, if a verifier_id exists it fetches the database for the verifier User. In a gradeable with a lot of verified marks this can get very expensive.

### What is the new behavior?
The verifier user was added to our GradedGradeable query so that info can get picked up there if it exists.

### Other information?
I tested this and I could still verify graders and see that marks were verified.
