### PR TITLE
[Refactor:SubminiPolls] Simplify repetitive queries

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5315,22 +5315,6 @@ AND gc_id IN (
     }
 
     /**
-     * Gets user or team submitters by id
-     *
-     * @param  string[] $ids User or team ids
-     * @return Submitter[]
-     */
-    public function getSubmittersById(array $ids) {
-        //Get Submitter for each id in ids
-        return array_map(
-            function ($id) {
-                return $this->getSubmitterById($id);
-            },
-            $ids
-        );
-    }
-
-    /**
      * Gets a single GradedGradeable associated with the provided gradeable and
      *  user/team.  Note: The user's team for this gradeable will be retrived if provided
      *
@@ -7731,68 +7715,61 @@ AND gc_id IN (
         $this->course_db->query("UPDATE polls SET status = 'open' where poll_id = ?", [$poll_id]);
     }
 
-    public function getPolls() {
+    public function getPolls(): array {
         $polls = [];
         $this->course_db->query("SELECT * from polls order by poll_id ASC");
         $polls_rows = $this->course_db->rows();
-        $user = $this->core->getUser()->getId();
 
         foreach ($polls_rows as $row) {
-            $polls[] = $this->getPoll($row["poll_id"]);
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"]);
         }
 
         return $polls;
     }
 
-    public function getTodaysPolls() {
+    public function getTodaysPolls(): array {
         $polls = [];
         $this->course_db->query("SELECT * from polls where release_date = ? order by name", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
-        $user = $this->core->getUser()->getId();
 
         foreach ($polls_rows as $row) {
-            $polls[] = $this->getPoll($row["poll_id"]);
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"]);
         }
 
         return $polls;
     }
 
-    public function getOlderPolls() {
+    public function getOlderPolls(): array {
         $polls = [];
         $this->course_db->query("SELECT * from polls where release_date < ? order by release_date DESC, name ASC", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
-        $user = $this->core->getUser()->getId();
 
         foreach ($polls_rows as $row) {
-            $polls[] = $this->getPoll($row["poll_id"]);
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"]);
         }
 
         return $polls;
     }
 
-    public function getFuturePolls() {
+    public function getFuturePolls(): array {
         $polls = [];
         $this->course_db->query("SELECT * from polls where release_date > ? order by release_date ASC, name ASC", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
-        $user = $this->core->getUser()->getId();
 
         foreach ($polls_rows as $row) {
-            $polls[] = $this->getPoll($row["poll_id"]);
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"]);
         }
 
         return $polls;
     }
 
-    public function getPoll($poll_id) {
+    public function getPoll($poll_id): ?PollModel {
         $this->course_db->query("SELECT * from polls where poll_id = ?", [$poll_id]);
-        $row = $this->course_db->rows();
-        $user = $this->core->getUser()->getId();
+        $row = $this->course_db->row();
         if (count($row) <= 0) {
             return null;
         }
-        $row = $row[0];
-        $responses = $this->getResponses($row["poll_id"]);
-        return new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $responses, $this->getAnswers($poll_id), $row["status"], $this->getUserResponses($row["poll_id"]), $row["release_date"], $row["image_path"], $row["release_histogram"]);
+        return new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"]);
     }
 
     public function getResponses($poll_id) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7811,12 +7811,12 @@ ORDER BY
 
             foreach ($polls_rows as $row) {
                 $answers = [];
-                foreach ($row['responses'] as $r) {
+                foreach (json_decode($row['responses'], true) as $r) {
                     if ($r['correct'] === true) {
                         $answers[] = $r['poll_id'];
                     }
                 }
-                $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']], $answers, $row['responses']);
+                $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']], $answers, json_decode($row['responses'], true));
             }
         }
         else {
@@ -7835,13 +7835,29 @@ ORDER BY
 
     public function getTodaysPolls(): array {
         $polls = [];
-        $this->course_db->query("SELECT * from polls where release_date = ? order by name", [date("Y-m-d")]);
+        $this->course_db->query("
+SELECT
+    p.*,
+    json_agg(po1) AS responses
+FROM polls p
+LEFT JOIN poll_options po1 ON po1.poll_id = p.poll_id
+WHERE p.release_date = ?
+GROUP BY p.poll_id
+ORDER BY
+    p.name ASC
+        ", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
 
         $num_responses = $this->getNumResponsesAllPolls();
 
         foreach ($polls_rows as $row) {
-            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']]);
+            $answers = [];
+            foreach (json_decode($row['responses'], true) as $r) {
+                if ($r['correct'] === true) {
+                    $answers[] = $r['poll_id'];
+                }
+            }
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']], $answers, json_decode($row['responses'], true));
         }
 
         return $polls;
@@ -7849,13 +7865,29 @@ ORDER BY
 
     public function getOlderPolls(): array {
         $polls = [];
-        $this->course_db->query("SELECT * from polls where release_date < ? order by release_date DESC, name ASC", [date("Y-m-d")]);
+        $this->course_db->query("
+SELECT
+    p.*,
+    json_agg(po1) AS responses
+FROM polls p
+LEFT JOIN poll_options po1 ON po1.poll_id = p.poll_id
+WHERE p.release_date < ?
+GROUP BY p.poll_id
+ORDER BY
+    p.name ASC
+        ", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
 
         $num_responses = $this->getNumResponsesAllPolls();
 
         foreach ($polls_rows as $row) {
-            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']]);
+            $answers = [];
+            foreach (json_decode($row['responses'], true) as $r) {
+                if ($r['correct'] === true) {
+                    $answers[] = $r['poll_id'];
+                }
+            }
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']], $answers, json_decode($row['responses'], true));
         }
 
         return $polls;
@@ -7863,13 +7895,29 @@ ORDER BY
 
     public function getFuturePolls(): array {
         $polls = [];
-        $this->course_db->query("SELECT * from polls where release_date > ? order by release_date ASC, name ASC", [date("Y-m-d")]);
+        $this->course_db->query("
+SELECT
+    p.*,
+    json_agg(po1) AS responses
+FROM polls p
+LEFT JOIN poll_options po1 ON po1.poll_id = p.poll_id
+WHERE p.release_date > ?
+GROUP BY p.poll_id
+ORDER BY
+    p.name ASC
+        ", [date("Y-m-d")]);
         $polls_rows = $this->course_db->rows();
 
         $num_responses = $this->getNumResponsesAllPolls();
 
         foreach ($polls_rows as $row) {
-            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']]);
+            $answers = [];
+            foreach (json_decode($row['responses'], true) as $r) {
+                if ($r['correct'] === true) {
+                    $answers[] = $r['poll_id'];
+                }
+            }
+            $polls[] = new PollModel($this->core, $row["poll_id"], $row["name"], $row["question"], $row["question_type"], $row["status"], $row["release_date"], $row["image_path"], $row["release_histogram"], $num_responses[$row['poll_id']], $answers, json_decode($row['responses'], true));
         }
 
         return $polls;

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5315,6 +5315,22 @@ AND gc_id IN (
     }
 
     /**
+     * Gets user or team submitters by id
+     *
+     * @param  string[] $ids User or team ids
+     * @return Submitter[]
+     */
+    public function getSubmittersById(array $ids) {
+        //Get Submitter for each id in ids
+        return array_map(
+            function ($id) {
+                return $this->getSubmitterById($id);
+            },
+            $ids
+        );
+    }
+
+    /**
      * Gets a single GradedGradeable associated with the provided gradeable and
      *  user/team.  Note: The user's team for this gradeable will be retrived if provided
      *

--- a/site/app/models/PollModel.php
+++ b/site/app/models/PollModel.php
@@ -12,6 +12,7 @@ use app\libraries\Core;
  * @method string getName()
  * @method string getQuestion()
  * @method string getQuestionType()
+ * @method int getNumResponses()
  * @method string|null getImagePath()
  */
 class PollModel extends AbstractModel {
@@ -24,6 +25,8 @@ class PollModel extends AbstractModel {
     /** @prop-read string */
     protected $question_type;
     protected $responses;
+    /** @prop-read int */
+    protected $num_responses;
     /** @prop-read array */
     protected $answers;
     /** @prop-read array */
@@ -35,7 +38,21 @@ class PollModel extends AbstractModel {
     /** @prop-read string */
     protected $release_histogram;
 
-    public function __construct(Core $core, $id, $name, $question, $question_type, $status, $release_date, $image_path, $release_histogram) {
+    public function __construct(
+        Core $core,
+        int $id,
+        string $name,
+        string $question,
+        string $question_type,
+        string $status,
+        string $release_date,
+        ?string $image_path,
+        string $release_histogram,
+        int $num_responses,
+        ?array $answers = null,
+        ?array $responses = null,
+        ?array $user_responses = null
+    ) {
         parent::__construct($core);
         $this->id = $id;
         $this->name = $name;
@@ -45,11 +62,15 @@ class PollModel extends AbstractModel {
         $this->release_date = $release_date;
         $this->image_path = $image_path;
         $this->release_histogram = $release_histogram;
+        $this->num_responses = $num_responses;
+        $this->answers = $answers;
+        $this->responses = $responses;
+        $this->user_responses = $user_responses;
     }
 
     public function getResponses() {
         // If this is the first time the responses have been queried, make a DB query.  Otherwise use the existing data.
-        if (!isset($this->responses)) {
+        if ($this->responses === null) {
             $this->responses = $this->core->getQueries()->getResponses($this->getId());
         }
         return array_keys($this->responses);
@@ -57,7 +78,7 @@ class PollModel extends AbstractModel {
 
     public function getAnswers() {
         // If this is the first time the answers have been queried, make a DB query.  Otherwise use the existing data.
-        if (!isset($this->answers)) {
+        if ($this->answers === null) {
             $this->answers = $this->core->getQueries()->getAnswers($this->getId());
         }
         return $this->answers;
@@ -77,7 +98,7 @@ class PollModel extends AbstractModel {
 
     public function getUserResponses() {
         // Only fetch the responses if they are needed, and cache the result
-        if (!isset($this->user_responses)) {
+        if ($this->user_responses === null) {
             $this->user_responses = $this->core->getQueries()->getUserResponses($this->id);
         }
         return $this->user_responses;

--- a/site/app/models/PollModel.php
+++ b/site/app/models/PollModel.php
@@ -108,43 +108,45 @@ class PollModel extends AbstractModel {
         if ($this->user_responses === null) {
             $this->user_responses = $this->core->getQueries()->getUserResponses($this->id);
         }
-        if (!isset($this->user_responses[$user_id][0])) {
+        if (!isset($this->user_responses[$user_id]) || count($this->user_responses[$user_id]) === 0) {
             return null;
         }
 
         return $this->user_responses[$user_id];
     }
 
-    public function getResponseString($response_id) {
+    public function getResponseString($response_id): string {
         // If this is the first time the responses have been queried, make a DB query.  Otherwise use the existing data.
         if ($this->responses === null) {
             $this->responses = $this->core->getQueries()->getResponses($this->getId());
         }
-        if (isset($this->responses[$response_id])) {
-            return $this->responses[$response_id];
+        foreach ($this->responses as $r) {
+            if ($r['option_id'] === $response_id) {
+                return $r['response'];
+            }
         }
         return "No Response";
     }
 
-    public function getAllResponsesString($response_id) {
+    public function getAllResponsesString($response_id): string {
         // If this is the first time the responses have been queried, make a DB query.  Otherwise use the existing data.
         if ($this->responses === null) {
             $this->responses = $this->core->getQueries()->getResponses($this->getId());
         }
-        if (count($this->responses) == 1) {
-            return $this->responses[$response_id[0]];
+        if (count($this->responses) === 1) {
+            return $this->getResponseString($response_id);
         }
         else {
             $ret_string = "";
             $first_answer = true;
-            foreach ($this->responses as $id => $response) {
-                if (in_array($id, $response_id)) {
+            foreach ($this->responses as $response) {
+                if (in_array($response['option_id'], $response_id)) {
                     if (!$first_answer) {
-                        $ret_string .= ", " . $response;
+                        $ret_string .= ", " . $response['response'];
                     }
                     else {
                         $first_answer = false;
-                        $ret_string .= $response;
+                        $ret_string .= $response['response'];
                     }
                 }
             }

--- a/site/app/models/PollModel.php
+++ b/site/app/models/PollModel.php
@@ -12,8 +12,6 @@ use app\libraries\Core;
  * @method string getName()
  * @method string getQuestion()
  * @method string getQuestionType()
- * @method array getAnswers()
- * @method array getUserResponses()
  * @method string|null getImagePath()
  */
 class PollModel extends AbstractModel {
@@ -77,12 +75,15 @@ class PollModel extends AbstractModel {
         return $this->status == "ended";
     }
 
-    public function getUserResponse($user_id) {
+    public function getUserResponses() {
         // Only fetch the responses if they are needed, and cache the result
         if (!isset($this->user_responses)) {
             $this->user_responses = $this->core->getQueries()->getUserResponses($this->id);
         }
+        return $this->user_responses;
+    }
 
+    public function getUserResponse($user_id) {
         if (!isset($this->user_responses[$user_id][0])) {
             return null;
         }

--- a/site/app/models/PollModel.php
+++ b/site/app/models/PollModel.php
@@ -105,6 +105,9 @@ class PollModel extends AbstractModel {
     }
 
     public function getUserResponse($user_id) {
+        if ($this->user_responses === null) {
+            $this->user_responses = $this->core->getQueries()->getUserResponses($this->id);
+        }
         if (!isset($this->user_responses[$user_id][0])) {
             return null;
         }
@@ -113,6 +116,10 @@ class PollModel extends AbstractModel {
     }
 
     public function getResponseString($response_id) {
+        // If this is the first time the responses have been queried, make a DB query.  Otherwise use the existing data.
+        if ($this->responses === null) {
+            $this->responses = $this->core->getQueries()->getResponses($this->getId());
+        }
         if (isset($this->responses[$response_id])) {
             return $this->responses[$response_id];
         }
@@ -120,6 +127,10 @@ class PollModel extends AbstractModel {
     }
 
     public function getAllResponsesString($response_id) {
+        // If this is the first time the responses have been queried, make a DB query.  Otherwise use the existing data.
+        if ($this->responses === null) {
+            $this->responses = $this->core->getQueries()->getResponses($this->getId());
+        }
         if (count($this->responses) == 1) {
             return $this->responses[$response_id[0]];
         }

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -55,7 +55,7 @@
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getId() }}_view_results" aria-label="label" onclick='updatePollAcceptingAnswers("{{ poll.getId() }}", "{{ base_url }}")' {{ poll.isOpen ? 'checked' : ''}}>
                         </td>
-                        <td id="poll_{{ poll.getId() }}_responses"> {{ poll.getUserResponses()|length }} </td>
+                        <td id="poll_{{ poll.getId() }}_responses"> {{ poll.getNumResponses() }} </td>
                         <td>
                             <a href="{{base_url}}/viewPoll/{{ poll.getId() }}" class="btn btn-primary">
                                 {% if poll.isHistogramAvailable() %}
@@ -126,7 +126,7 @@
                         <td>
                             <input type="checkbox" id="poll_{{ poll.getId() }}_view_results" aria-label="label" onclick='updatePollAcceptingAnswers("{{ poll.getId() }}", "{{ base_url }}")' {{ poll.isOpen ? 'checked' : ''}}>
                         </td>
-                        <td id="poll_{{ poll.getId() }}_responses"> {{ poll.getUserResponses()|length }} </td>
+                        <td id="poll_{{ poll.getId() }}_responses"> {{ poll.getNumResponses() }} </td>
                         <td>
                             <a href="{{base_url}}/viewPoll/{{ poll.getId() }}" class="btn btn-primary">
                                 {% if poll.isHistogramAvailable() %}
@@ -186,7 +186,7 @@
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() }} </td>
-                        <td id="poll_{{ poll.getId() }}_responses"> {{ poll.getUserResponses()|length }} </td>
+                        <td id="poll_{{ poll.getId() }}_responses"> {{ poll.getNumResponses() }} </td>
                         <td>
                             <a href="{{base_url}}/viewPoll/{{ poll.getId() }}" class="btn btn-primary">
                                 {% if poll.isHistogramAvailable() %}

--- a/site/tests/app/libraries/PollUtilsTester.php
+++ b/site/tests/app/libraries/PollUtilsTester.php
@@ -2,7 +2,6 @@
 
 namespace tests\app\libraries;
 
-use app\libraries\Core;
 use app\libraries\PollUtils;
 use app\models\PollModel;
 

--- a/site/tests/app/libraries/PollUtilsTester.php
+++ b/site/tests/app/libraries/PollUtilsTester.php
@@ -6,13 +6,10 @@ use app\libraries\Core;
 use app\libraries\PollUtils;
 use app\models\PollModel;
 
-class PollUtilsTester extends \PHPUnit\Framework\TestCase {
+class PollUtilsTester extends \tests\BaseUnitTest {
     use \phpmock\phpunit\PHPMock;
 
-    private $core;
-
     public function setUp(): void {
-        $this->core = new Core();
     }
 
     public function tearDown(): void {
@@ -27,9 +24,51 @@ class PollUtilsTester extends \PHPUnit\Framework\TestCase {
 
     public function testExportDataWithNonEmptyPolls() {
         $polls = [
-            new PollModel($this->core, 0, "Poll #1", "Is this the first poll?", "single-response", "closed", "2020-01-11", null, "never"),
-            new PollModel($this->core, 1, "Poll #2", "Is this the second poll?", "single-response", "open", "2020-01-12", null, "always"),
-            new PollModel($this->core, 2, "Poll #3", "Is this the fourth poll?", "multiple-response", "ended", "2020-01-13", null, "when_ended"),
+            new PollModel(
+                $this->createMockCore([],[],[
+                    "getResponses" => ["Yes", "No", "Maybe"],
+                    "getAnswers" => [0, 2],
+                    "getUserResponses" => ["bitdiddle" => 0, "aphacker" => 1]
+                ]),
+                0,
+                "Poll #1",
+                "Is this the first poll?",
+                "single-response",
+                "closed",
+                "2020-01-11",
+                null,
+                "never"
+            ),
+            new PollModel(
+                $this->createMockCore([],[],[
+                    "getResponses" => ["Yes", "No", "Definitely not"],
+                    "getAnswers" => [0],
+                    "getUserResponses" => ["bitdiddle" => 2, "aphacker" => 0]
+                ]),
+                1,
+                "Poll #2",
+                "Is this the second poll?",
+                "single-response",
+                "open",
+                "2020-01-12",
+                null,
+                "always"
+            ),
+            new PollModel(
+                $this->createMockCore([],[],[
+                    "getResponses" => ["Yes", "No", "Maybe"],
+                    "getAnswers" => [1],
+                    "getUserResponses" => ["bitdiddle" => 1, "aphacker" => 2]
+                ]),
+                2,
+                "Poll #3",
+                "Is this the fourth poll?",
+                "multiple-response",
+                "ended",
+                "2020-01-13",
+                null,
+                "when_ended"
+            ),
         ];
         $expected_data = [
             [

--- a/site/tests/app/libraries/PollUtilsTester.php
+++ b/site/tests/app/libraries/PollUtilsTester.php
@@ -25,7 +25,7 @@ class PollUtilsTester extends \tests\BaseUnitTest {
     public function testExportDataWithNonEmptyPolls() {
         $polls = [
             new PollModel(
-                $this->createMockCore([],[],[
+                $this->createMockCore([], [], [
                     "getResponses" => ["Yes", "No", "Maybe"],
                     "getAnswers" => [0, 2],
                     "getUserResponses" => ["bitdiddle" => 0, "aphacker" => 1]
@@ -40,7 +40,7 @@ class PollUtilsTester extends \tests\BaseUnitTest {
                 "never"
             ),
             new PollModel(
-                $this->createMockCore([],[],[
+                $this->createMockCore([], [], [
                     "getResponses" => ["Yes", "No", "Definitely not"],
                     "getAnswers" => [0],
                     "getUserResponses" => ["bitdiddle" => 2, "aphacker" => 0]
@@ -55,7 +55,7 @@ class PollUtilsTester extends \tests\BaseUnitTest {
                 "always"
             ),
             new PollModel(
-                $this->createMockCore([],[],[
+                $this->createMockCore([], [], [
                     "getResponses" => ["Yes", "No", "Maybe"],
                     "getAnswers" => [1],
                     "getUserResponses" => ["bitdiddle" => 1, "aphacker" => 2]

--- a/site/tests/app/libraries/PollUtilsTester.php
+++ b/site/tests/app/libraries/PollUtilsTester.php
@@ -27,9 +27,9 @@ class PollUtilsTester extends \PHPUnit\Framework\TestCase {
 
     public function testExportDataWithNonEmptyPolls() {
         $polls = [
-            new PollModel($this->core, 0, "Poll #1", "Is this the first poll?", "single-response", ["Yes", "No", "Maybe"], [0, 2], "closed", ["bitdiddle" => 0, "aphacker" => 1], "2020-01-11", null, "never"),
-            new PollModel($this->core, 1, "Poll #2", "Is this the second poll?", "single-response", ["Yes", "No", "Definitely not"], [0], "open", ["bitdiddle" => 2, "aphacker" => 0], "2020-01-12", null, "always"),
-            new PollModel($this->core, 2, "Poll #3", "Is this the fourth poll?", "multilple-response", ["Yes", "No", "Maybe"], [1], "ended", ["bitdiddle" => 1, "aphacker" => 2], "2020-01-13", null, "when_ended"),
+            new PollModel($this->core, 0, "Poll #1", "Is this the first poll?", "single-response", "closed", "2020-01-11", null, "never"),
+            new PollModel($this->core, 1, "Poll #2", "Is this the second poll?", "single-response", "open", "2020-01-12", null, "always"),
+            new PollModel($this->core, 2, "Poll #3", "Is this the fourth poll?", "multiple-response", "ended", "2020-01-13", null, "when_ended"),
         ];
         $expected_data = [
             [
@@ -60,7 +60,7 @@ class PollUtilsTester extends \PHPUnit\Framework\TestCase {
                 "id" => 2,
                 "name" => "Poll #3",
                 "question" => "Is this the fourth poll?",
-                "question_type" => "multilple-response",
+                "question_type" => "multiple-response",
                 "responses" => ["Yes", "No", "Maybe"],
                 "correct_responses" => [1],
                 "release_date" => "2020-01-13",

--- a/site/tests/app/models/PollModelTester.php
+++ b/site/tests/app/models/PollModelTester.php
@@ -5,51 +5,52 @@ namespace tests\app\models;
 use app\libraries\Core;
 use app\models\PollModel;
 
-class PollModelTester extends \PHPUnit\Framework\TestCase {
-    private $core;
+class PollModelTester extends \tests\BaseUnitTest {
     private $my_polls;
 
     public function setUp(): void {
-        $this->core = new Core();
         $this->my_polls = [
             0 => new PollModel(
-                $this->core,                                       // core
+                $this->createMockCore([],[],[
+                    "getResponses" => [0 => "Yes", 1 => "No", 2 => "Maybe"],
+                    "getAnswers" => [0 => 0],
+                    "getUserResponses" => ["bitdiddle" => [0 => 1], "aphacker" => [0 => 1]]
+                ]),                                       // core
                 0,                                                 // id
                 "Poll #1",                                         // name
                 "Is this the first poll?",                         // question
                 "single-response-single-correct",                  // question_type
-                [0 => "Yes", 1 => "No", 2 => "Maybe"],             // responses
-                [0 => 0],                                          // asnwers
                 "closed",                                          // status
-                ["bitdiddle" => [0 => 1], "aphacker" => [0 => 1]], // user_responses
                 "2021-01-11",                                      // release_date
                 null,                                              // image path
                 "never"                                            // student histogram release setting
             ),
             1 => new PollModel(
-                $this->core,
+                $this->createMockCore([],[],[
+                    "getResponses" => [0 => "Absolutely", 1 => "No", 2 => "Perhaps"],
+                    "getAnswers" => [0 => 1, 1 => 2],
+                    "getUserResponses" => ["bitdiddle" => [0 => 2], "aphacker" => [0 => 0]]
+                ]),
                 1,
                 "Poll #2",
                 "Is this the first poll?",
                 "single-response-multiple-correct",
-                [0 => "Absolutely", 1 => "No", 2 => "Perhaps"],
-                [0 => 1, 1 => 2],
                 "open",
-                ["bitdiddle" => [0 => 2], "aphacker" => [0 => 0]],
                 "9999-12-31",
                 null,
                 "always"
             ),
             2 => new PollModel(
-                $this->core,
+                $this->createMockCore([],[],[
+                    "getResponses" => [0 => "Red", 1 => "Blue", 2 => "Yellow", 3 => "Green"],
+                    "getAnswers" => [0 => 0, 1 => 1, 2 => 2, 3 => 3],
+                    "getUserResponses" => ["bitdiddle" => [0 => 0, 1 => 2, 2 => 3], "aphacker" => [0 => 1, 1 => 3]]
+                ]),
                 2,
                 "Poll #3",
                 "What is your favorite color?",
                 "multiple-response-survey",
-                [0 => "Red", 1 => "Blue", 2 => "Yellow", 3 => "Green"],
-                [0 => 0, 1 => 1, 2 => 2, 3 => 3],
                 "ended",
-                ["bitdiddle" => [0 => 0, 1 => 2, 2 => 3], "aphacker" => [0 => 1, 1 => 3]],
                 date("Y-m-d"),
                 "/var/local/submitty/courses/s21/sample/uploads/polls/poll_image_3_colors.png",
                 "when_ended"
@@ -86,7 +87,6 @@ class PollModelTester extends \PHPUnit\Framework\TestCase {
 
     public function testResponses(): void {
         $this->assertEquals($this->my_polls[0]->getResponses(), [0 => 0, 1 => 1, 2 => 2]);
-        $this->assertEquals($this->my_polls[0]->getResponsesWithKeys(), [0 => "Yes", 1 => "No", 2 => "Maybe"]);
         $this->assertEquals($this->my_polls[0]->getResponseString(0), "Yes");
         $this->assertEquals($this->my_polls[0]->getResponseString(1), "No");
         $this->assertEquals($this->my_polls[0]->getResponseString(2), "Maybe");
@@ -100,7 +100,6 @@ class PollModelTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($this->my_polls[0]->getAllResponsesString([0 => 2]), "Maybe");
 
         $this->assertEquals($this->my_polls[1]->getResponses(), [0 => 0, 1 => 1, 2 => 2]);
-        $this->assertEquals($this->my_polls[1]->getResponsesWithKeys(), [0 => "Absolutely", 1 => "No", 2 => "Perhaps"]);
         $this->assertEquals($this->my_polls[1]->getResponseString(0), "Absolutely");
         $this->assertEquals($this->my_polls[1]->getResponseString(1), "No");
         $this->assertEquals($this->my_polls[1]->getResponseString(2), "Perhaps");
@@ -114,7 +113,6 @@ class PollModelTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($this->my_polls[1]->getAllResponsesString([0 => 2]), "Perhaps");
 
         $this->assertEquals($this->my_polls[2]->getResponses(), [0 => 0, 1 => 1, 2 => 2, 3 => 3]);
-        $this->assertEquals($this->my_polls[2]->getResponsesWithKeys(), [0 => "Red", 1 => "Blue", 2 => "Yellow", 3 => "Green"]);
         $this->assertEquals($this->my_polls[2]->getResponseString(0), "Red");
         $this->assertEquals($this->my_polls[2]->getResponseString(1), "Blue");
         $this->assertEquals($this->my_polls[2]->getResponseString(2), "Yellow");

--- a/site/tests/app/models/PollModelTester.php
+++ b/site/tests/app/models/PollModelTester.php
@@ -2,7 +2,6 @@
 
 namespace tests\app\models;
 
-use app\libraries\Core;
 use app\models\PollModel;
 
 class PollModelTester extends \tests\BaseUnitTest {
@@ -11,7 +10,7 @@ class PollModelTester extends \tests\BaseUnitTest {
     public function setUp(): void {
         $this->my_polls = [
             0 => new PollModel(
-                $this->createMockCore([],[],[
+                $this->createMockCore([], [], [
                     "getResponses" => [0 => "Yes", 1 => "No", 2 => "Maybe"],
                     "getAnswers" => [0 => 0],
                     "getUserResponses" => ["bitdiddle" => [0 => 1], "aphacker" => [0 => 1]]
@@ -26,7 +25,7 @@ class PollModelTester extends \tests\BaseUnitTest {
                 "never"                                            // student histogram release setting
             ),
             1 => new PollModel(
-                $this->createMockCore([],[],[
+                $this->createMockCore([], [], [
                     "getResponses" => [0 => "Absolutely", 1 => "No", 2 => "Perhaps"],
                     "getAnswers" => [0 => 1, 1 => 2],
                     "getUserResponses" => ["bitdiddle" => [0 => 2], "aphacker" => [0 => 0]]
@@ -41,7 +40,7 @@ class PollModelTester extends \tests\BaseUnitTest {
                 "always"
             ),
             2 => new PollModel(
-                $this->createMockCore([],[],[
+                $this->createMockCore([], [], [
                     "getResponses" => [0 => "Red", 1 => "Blue", 2 => "Yellow", 3 => "Green"],
                     "getAnswers" => [0 => 0, 1 => 1, 2 => 2, 3 => 3],
                     "getUserResponses" => ["bitdiddle" => [0 => 0, 1 => 2, 2 => 3], "aphacker" => [0 => 1, 1 => 3]]


### PR DESCRIPTION
### What is the current behavior?
The main polls page currently makes 4n queries for n polls in a given course.  In addition, each of the responses is loaded each time.  For a moderately-sized class which uses polls regularly such as Data Structures at RPI, this corresponds to roughly 50,000 (yes, fifty thousand) individual queries being executed in the span of a few minutes, which puts a significant strain on the database server. 

### What is the new behavior?
The polls model has been refactored to lazily load data for improved performance if those data are not needed.  Data is also queried in aggregate instead of creating a large number of small queries.  In a local test with 10 polls, the average load time dropped from 0.33 seconds to 0.24 seconds.