### PR TITLE
[Feature:TAGrading] "Graded by" display name change

### DIFF
--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -383,7 +383,7 @@ class AutoGradingView extends AbstractView {
                 'custom_mark_score' => $container->getScore(),
                 'comment' => $container->getComment(),
                 'graders' => array_map(function (User $grader) {
-                    return $grader->getDisplayedLastName();
+                    return ($grader->getDisplayedFirstName() . ' ' . $grader->getDisplayedLastName());
                 }, $container->getVisibleGraders()),
                 'marks' => $component_marks,
             ];

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -383,7 +383,8 @@ class AutoGradingView extends AbstractView {
                 'custom_mark_score' => $container->getScore(),
                 'comment' => $container->getComment(),
                 'graders' => array_map(function (User $grader) {
-                    return ($grader->getDisplayedFirstName() . ' ' . $grader->getDisplayedLastName());
+                    //Preferred first name, preffered last name initial for full access graders
+                    return $grader->getDisplayedFirstName() . ' ' . $grader->getDisplayedLastName()[0];
                 }, $container->getVisibleGraders()),
                 'marks' => $component_marks,
             ];

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -383,7 +383,7 @@ class AutoGradingView extends AbstractView {
                 'custom_mark_score' => $container->getScore(),
                 'comment' => $container->getComment(),
                 'graders' => array_map(function (User $grader) {
-                    //Preferred first name, preffered last name initial for full access graders
+                    //Preferred first name, preferred last name initial for full access graders
                     return $grader->getDisplayedFirstName() . ' ' . $grader->getDisplayedLastName()[0];
                 }, $container->getVisibleGraders()),
                 'marks' => $component_marks,


### PR DESCRIPTION
### What is the new behavior?
The "Graded by" display name is now "Preferredfirstname Preferredlastname" instead of just "Preferredlastname."

Closes #8431 
