### PR TITLE
[Bugfix:TAGrading] Resolution change for downloaded pdf

### DIFF
--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -67,7 +67,10 @@
                 $("#viewer").css("padding-top", height);
             });
         });
-        offSetter.observe(document.querySelector(".sticky-file-info"));
+
+        if (document.querySelector(".sticky-file-info") !== null) {
+            offSetter.observe(document.querySelector(".sticky-file-info"));
+        }
     }
 
 </script>


### PR DESCRIPTION
### What is the current behavior?
When downloading the PDF in the grading interface, the resulted file will have a low resolution.

### What is the new behavior?
