### PR TITLE
[Refactor:Submission] Improve graded gradeable query

### DIFF
--- a/migration/migrator/migrations/course/20221026040934_add_gradeable_component_indexes.py
+++ b/migration/migrator/migrations/course/20221026040934_add_gradeable_component_indexes.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('CREATE INDEX IF NOT EXISTS gradeable_component_data_gd ON gradeable_component_data(gd_id)')
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('DROP INDEX IF EXISTS gradeable_component_data_gd')

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7215,7 +7215,7 @@ AND gc_id IN (
               ) AS goc ON goc.g_id=g.g_id AND goc.goc_{$submitter_type}={$submitter_type_ext}
 
               /* Join aggregate gradeable component data */
-              LEFT JOIN (
+              LEFT JOIN LATERAL (
                 SELECT
                   json_agg(in_gcd.gc_id) AS array_comp_id,
                   json_agg(gcd_score) AS array_score,
@@ -7257,7 +7257,7 @@ AND gc_id IN (
                   json_agg(uv.registration_type) AS array_verifier_registration_type,
                   in_gcd.gd_id,
                   ug.g_id
-                FROM gradeable_component_data in_gcd
+                FROM (SELECT * FROM gradeable_component_data WHERE gd_id=gd.gd_id) in_gcd
 
                   LEFT JOIN (
                     SELECT
@@ -7286,7 +7286,7 @@ AND gc_id IN (
                           user_id,
                           g_id
                         FROM gradeable_anon
-                      ) AS ga ON u.user_id=ga.user_id
+                      ) AS ga ON u.user_id=ga.user_id AND ga.g_id=g.g_id
                   ) AS ug ON ug.user_id=in_gcd.gcd_grader_id
                   LEFT JOIN (
                     SELECT u.*


### PR DESCRIPTION
### What is the current behavior?
Query for retrieving graded gradeables is slow; a query run on the "Gradeables" view in "sample" course took 1.218 seconds

### What is the new behavior?
Query time for retrieving graded gradeables has been improved - changed the join for gradeable_component_data to be a lateral join to allow for filtering before joins with gradeable/gradeable_data - when tested, query performance on the same view improved to 19.1 ms.

Added index on gradeable_component_data for gd_id - when tested, query performance on the same view improved to 9.01 ms.
