### PR TITLE
[Bugfix:System] sync registration type, main->course db

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -739,9 +739,9 @@ CREATE TABLE public.electronic_gradeable (
     eg_max_team_size integer NOT NULL,
     eg_team_lock_date timestamp(6) with time zone NOT NULL,
     eg_use_ta_grading boolean NOT NULL,
+    eg_student_download boolean DEFAULT false NOT NULL,
     eg_student_view boolean NOT NULL,
     eg_student_view_after_grades boolean DEFAULT false NOT NULL,
-    eg_student_download boolean DEFAULT true NOT NULL,
     eg_student_submit boolean NOT NULL,
     eg_submission_open_date timestamp(6) with time zone NOT NULL,
     eg_submission_due_date timestamp(6) with time zone NOT NULL,
@@ -2326,6 +2326,13 @@ CREATE INDEX forum_posts_history_edit_timestamp_index ON public.forum_posts_hist
 --
 
 CREATE INDEX forum_posts_history_post_id_index ON public.forum_posts_history USING btree (post_id);
+
+
+--
+-- Name: gradeable_component_data_gd; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX gradeable_component_data_gd ON public.gradeable_component_data USING btree (gd_id);
 
 
 --

--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -336,8 +336,8 @@ CREATE TABLE public.courses_users (
     registration_section character varying(255),
     registration_type character varying(255) DEFAULT 'graded'::character varying,
     manual_registration boolean DEFAULT false,
-    CONSTRAINT users_user_group_check CHECK (((user_group >= 1) AND (user_group <= 4))),
-    CONSTRAINT check_registration_type CHECK (registration_type::TEXT = ANY (ARRAY['graded'::character varying::text, 'audit'::character varying::text, 'withdrawn'::character varying::text, 'staff'::character varying::text]))
+    CONSTRAINT check_registration_type CHECK (((registration_type)::text = ANY (ARRAY[('graded'::character varying)::text, ('audit'::character varying)::text, ('withdrawn'::character varying)::text, ('staff'::character varying)::text]))),
+    CONSTRAINT users_user_group_check CHECK (((user_group >= 1) AND (user_group <= 4)))
 );
 
 
@@ -794,3 +794,4 @@ ALTER TABLE ONLY public.vcs_auth_tokens
 --
 -- PostgreSQL database dump complete
 --
+

--- a/migration/migrator/migrations/master/20221028192745_registration_section_main_to_course.py
+++ b/migration/migrator/migrations/master/20221028192745_registration_section_main_to_course.py
@@ -1,0 +1,27 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute("""
+UPDATE courses_users SET registration_type=registration_type;
+    """)
+
+
+def down(config, database):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    pass


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Edits to registration type used to be made in the course database and were not updated automatically in the main database. This left different data in both the main and course databases if the registration type was changed for any user.

### What is the new behavior?
This adds a migration that fires the trigger to copy the data from the main database into the course databases so that the data is consistent in both.

### Other information?
Tested by manually editing users' registration type in course databases and checking that the data in the main database gets copied to replace the changed values when running the migration.
