### PR TITLE
[Refactor:System] Add index to notifications table

### DIFF
--- a/migration/migrator/migrations/course/20221104210520_notifications_index.py
+++ b/migration/migrator/migrations/course/20221104210520_notifications_index.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("CREATE INDEX notifications_to_user_id_index ON notifications (to_user_id);")
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("DROP INDEX notifications_to_user_id_index;")


### PR DESCRIPTION
### What is the current behavior?
Multiple queries currently select notifications by the person each notification was sent to.  In particular, the notifications badge on the sidebar makes this query every time a course page is loaded.  Since the notifications table is quite large (potentially on the order of tens of thousands of rows or more for large classes), this can easily create a significant slowdown.

### What is the new behavior?
This PR simply adds an index to the `to_user_id` column of the `notifications` table, to allow more efficient querying of notifications by user to which it was sent.