### PR TITLE
[Refactor:System] Add index to user_registration table

### DIFF
--- a/migration/migrator/migrations/course/20221104203732_grading_registration_index.py
+++ b/migration/migrator/migrations/course/20221104203732_grading_registration_index.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("CREATE INDEX grading_registration_user_id_index ON grading_registration (user_id);")
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("DROP INDEX grading_registration_user_id_index;")


### PR DESCRIPTION
### What is the current behavior?
When creating a `User` model, the `user_registration` table is queried.  Since there is currently no index on the `user_id` column, this query is slow.  Since this query is run on nearly every page load, optimizations have the potential to make a significant impact.

### What is the new behavior?
An index was added to the `user_id` column of the `user_registration` table for more efficient lookup.
