### PR TITLE
[Bugfix:CourseMaterials] Unwanted deletion

### DIFF
--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -383,12 +383,8 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
             ->method('findOneBy')
             ->withConsecutive([['path' => $this->upload_path . "/" . $name]], [['id' => $course_material->getId()]])
             ->willReturnOnConsecutiveCalls(null, $course_material);
-        $repository
-            ->expects($this->once())
-            ->method('findAll')
-            ->willReturn([$course_material]);
         $this->core->getCourseEntityManager()
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(2))
             ->method('getRepository')
             ->with(CourseMaterial::class)
             ->willReturn($repository);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Deleting a folder (suppose A) also deletes the files present inside the same folder as folder A (but outside folder A) that begin with the same character(s) (e.g. ABC.pdf) from the database.

#### To reproduce on the main branch:

1. Navigate to course materials page of 'Sample' course.
2. Delete the folder named 'words'.
3. Observe that the file 'words_1463.pdf' (in the outermost directory) also gets deleted.

### What is the new behavior?
When a folder is deleted, only the database records of that folder and the files inside it are deleted.
