### PR TITLE
[Bugfix:HelpQueue] Fix Empty Queues Not Showing

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6716,7 +6716,6 @@ LEFT JOIN (
     WHERE q.current_state IN ('waiting')
     GROUP BY q.queue_code
 ) AS ns ON ns.queue_code = qs.code
-WHERE qs.code = ns.queue_code
 ORDER BY id");
         return $this->course_db->rows();
     }


### PR DESCRIPTION
### What is the current behavior?
If a queue is empty, it will not get shown. This is due to a query having a WHERE clause that doesn't function when there is 0 students in a queue. This got added in #8585.

### What is the new behavior?
All queues are shown even if empty as expected. The WHERE clause has been removed.

### Other information?
Tested loading the page locally and hidden queues became visible.
