### PR TITLE
[Bugfix:CourseMaterials] Link fields in non-link materials

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -321,11 +321,9 @@ function newEditCourseMaterialsForm(tag) {
         $("#all-sections-showing-yes", form).prop('checked',false);
         $("#all-sections-showing-no", form).prop('checked',true);
     }
+    const title_label = $("#edit-url-title-label", form);
+    const url_label = $("#edit-url-url-label", form);
     if (is_link === 1) {
-        const title_label = $("#edit-url-title-label", form);
-        const url_label = $("#edit-url-url-label", form);
-        title_label.prop('hidden', false);
-        url_label.prop('hidden', false);
         title_label.css('display', 'block');
         url_label.css('display', 'block');
         const title = $("#edit-url-title");
@@ -334,6 +332,14 @@ function newEditCourseMaterialsForm(tag) {
         const url = $("#edit-url-url");
         url.prop('disabled', false);
         url.val(link_url);
+    }
+    else {
+        if (title_label.css('display') !== 'none') {
+            title_label.css('display', 'none');
+        }
+        if (url_label.css('display') !== 'none') {
+            url_label.css('display', 'none');
+        }
     }
     $("#material-edit-form", form).attr('data-id', id);
     $("#edit-picker", form).attr('value', release_time);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Link title and link URL input fields show up in edit course material popup of materials that are not links.

#### Steps to reproduce:

1. Create a link in course materials of 'Sample' course.
2. Open the edit course material popup of the link (by clicking on pencil icon), close it without making any edits.
3. Now open edit course material popup of a file (e.g. words_1463.pdf).
4. Notice that link title and link URL input fields are still there in the popup.

### What is the new behavior?
Link related input fields don't show up in edit material popup of materials that are not links.
