### PR TITLE
[Feature:System] Access control caching

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -136,6 +136,13 @@ fi
 # create routes cache directory
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/routes
 
+# clear old access control cache
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/access_control" ]; then
+    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/access_control"
+fi
+# create access control cache directory
+mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/access_control
+
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/public/mjs" ]; then
     rm -r "${SUBMITTY_INSTALL_DIR}/site/public/mjs"
 fi

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -6,6 +6,7 @@ use app\libraries\response\RedirectResponse;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\JsonResponse;
 use app\libraries\response\WebResponse;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
@@ -47,8 +48,15 @@ class WebRouter {
         $cache_path = FileUtils::joinPaths(dirname(__DIR__, 3), 'cache', 'routes');
         $cache = new FilesystemAdapter("", 0, $cache_path);
 
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $this->reader = new AnnotationReader();
+        $access_control_cache_path = FileUtils::joinPaths(dirname(__DIR__, 3), 'cache', 'access_control');
+        $ac_cache = new FilesystemAdapter("", 0, $access_control_cache_path);
+
+        $this->reader = new PsrCachedReader(
+            new AnnotationReader(),
+            $ac_cache,
+            $this->core->getConfig()->isDebug()
+        );
+
         // This will fetch the cache for routes. If it doesn't find it then it will
         // compile them, set the cache, and set compiledRoutes to that.
         $compiledRoutes = $cache->get('routes', function (ItemInterface $item) {

--- a/site/app/libraries/routers/WebRouter.php
+++ b/site/app/libraries/routers/WebRouter.php
@@ -29,7 +29,7 @@ class WebRouter {
     /** @var Request  */
     protected $request;
 
-    /** @var AnnotationReader */
+    /** @var PsrCachedReader */
     protected $reader;
 
     /** @var array */


### PR DESCRIPTION
### What is the current behavior?
Every request, the access control annotations for the target route have to be read and parsed.

### What is the new behavior?
The annotation reader is wrapped in a cache so it won't have to spend time parsing annotations per request.
