### PR TITLE
[Refactor:System] Remove Annotation Cache Removal

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -123,12 +123,6 @@ fi
 # create twig cache directory
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/twig
 
-# TODO: remove this. see #8404
-# clear old annotations cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/annotations" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/annotations"
-fi
-
 # clear old routes cache
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/routes" ]; then
     rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/routes"


### PR DESCRIPTION
### What is the current behavior?
The installation script deletes the cache annotation directory.
Closes #8404

### What is the new behavior?
The installation script no longer deletes that directory as it should definitely be gone now.
