### PR TITLE
[Refactor:System] Reduce session handling overhead

### DIFF
--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -664,6 +664,13 @@ ALTER TABLE ONLY public.vcs_auth_tokens
 
 
 --
+-- Name: sessions_session_expires_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sessions_session_expires_idx ON public.sessions USING btree (session_expires);
+
+
+--
 -- Name: courses_users after_delete_sync_delete_user_cleanup; Type: TRIGGER; Schema: public; Owner: -
 --
 

--- a/migration/migrator/migrations/master/20221120163138_get_session_function.py
+++ b/migration/migrator/migrations/master/20221120163138_get_session_function.py
@@ -1,0 +1,25 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute("CREATE INDEX IF NOT EXISTS sessions_session_expires_idx ON sessions(session_expires);")
+
+
+def down(config, database):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute("DROP INDEX IF EXISTS sessions_session_expires_idx;")

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2985,7 +2985,8 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
      * @return array
      */
     public function getSession($session_id) {
-        $this->submitty_db->query("SELECT * FROM sessions WHERE session_id=?", [$session_id]);
+        // We only ever want to get sessions which aren't expired.  Don't rely upon other PHP code checking for this...
+        $this->submitty_db->query("SELECT * FROM sessions WHERE session_id=? AND session_expires > current_timestamp", [$session_id]);
         return $this->submitty_db->row();
     }
 
@@ -2999,7 +3000,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
     public function newSession($session_id, $user_id, $csrf_token) {
         $this->submitty_db->query(
             "INSERT INTO sessions (session_id, user_id, csrf_token, session_expires)
-                                   VALUES(?,?,?,current_timestamp + interval '336 hours')",
+                                   VALUES(?,?,?,current_timestamp + interval '14 days')",
             [$session_id, $user_id, $csrf_token]
         );
     }
@@ -3011,7 +3012,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
      */
     public function updateSessionExpiration($session_id) {
         $this->submitty_db->query(
-            "UPDATE sessions SET session_expires=(current_timestamp + interval '336 hours')
+            "UPDATE sessions SET session_expires=(current_timestamp + interval '14 days')
                                    WHERE session_id=?",
             [$session_id]
         );


### PR DESCRIPTION
### What is the current behavior?
Every single request to Submitty begins by checking the validity of a session token as follows:

1. Remove all expired sessions from the sessions table
    - This performs a sequential scan on the sessions table to search for expired sessions (!!)
2. Check the provided session token and ensure that it is valid
3. Update the expiration timestamp to expire two weeks from the time of page load

The delete and update operations are particularly expensive, which makes the page load time slower, and increases the load on the database server substantially when many users are attempting to access Submitty pages at one time.  These actions happen every single time a request is made, no matter how large.  This repetition of queries across page loads is unnecessary.

### What is the new behavior?
Removing expired sessions does not affect the functionality of Submitty in any way, beyond cluttering the sessions table of the database server.  It would be better to delete dead sessions via a cron job which runs periodically.  As a temporary fix, I have added an element of randomness such that the delete operation will only be triggered with a probability of 1/100.  This ensures that the sessions table is being cleared on a regular basis, while preventing a large wave of unnecessary queries when a large class tries to access Submitty at the same time.  Additionally, an index was added to the `session_expires` column to make the query for expired sessions more efficient when it does happen.

It is also unnecessary to update the expiration timestamp on every request.  If a user is clicking through 5 pages in rapid succession, it does not matter whether the expiration date is set to exactly two weeks from that point in time or not.  The update has been changed such that it only occurs when the expiration date is less than one week away.  If users are annoyed by the occasional logout if they do not access Submitty for a period of time, we can adjust this to log users out if the expiration date is less than 13 days away, such that the expiration date is at most updated once per day.

It is difficult to profile these changes in the development environment due to a lack of active sessions available, but it is believed that these changes will significantly improve the performance of Submitty in the production environment, particularly at peak load times.