### PR TITLE
[Feature:RainbowGrades] Add user_numeric_id to exported data

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -368,6 +368,7 @@ class ReportController extends AbstractController {
 
         $user_data = [];
         $user_data['user_id'] = $user->getId();
+        $user_data['user_numeric_id'] = $user->getNumericId();
         $user_data['legal_first_name'] = $user->getLegalFirstName();
         $user_data['preferred_first_name'] = $user->getPreferredFirstName();
         $user_data['legal_last_name'] = $user->getLegalLastName();

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7061,6 +7061,7 @@ WHERE current_state IN
         else {
             $submitter_data_inject = '
               u.user_id,
+              u.user_numeric_id,
               u.g_anon,
               u.user_firstname,
               u.user_preferred_firstname,

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -13,7 +13,7 @@ use Egulias\EmailValidator\Validation\RFCValidation;
  *
  * @method string getId()
  * @method void setId(string $id) Get the id of the loaded user
- * @method void getNumericId()
+ * @method string getNumericId()
  * @method void setNumericId(string $id)
  * @method string getPassword()
  * @method string getLegalFirstName() Get the first name of the loaded user


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The `user_numeric_id` column of the `users` table is not included in the grade summaries.

### What is the new behavior?
The `user_numeric_id` column is included in grade summaries data so it is written to the JSON files generated.

### Other information?
Closes #8552
