### PR TITLE
[SECURITY][Bugfix:CourseMaterials] Treat name as text on delete form

### DIFF
--- a/site/public/css/course-materials.css
+++ b/site/public/css/course-materials.css
@@ -40,3 +40,7 @@ a.popout-item > .fas:hover {
 .partial-checkbox:checked {
     background-color: var(--standard-medium-gray) !important;
 }
+
+.delete-course-material-message {
+    font-weight: bold;
+}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -171,8 +171,7 @@ function newDeleteCourseMaterialForm(id, file_name) {
 
     $('.popup-form').css('display', 'none');
     var form = $("#delete-course-material-form");
-    $('.delete-course-material-message', form).html('');
-    $('.delete-course-material-message', form).append('<b>'+file_name+'</b>');
+    $('.delete-course-material-message', form).text(file_name);
     $('[name="delete-confirmation"]', form).attr('action', url);
     form.css("display", "block");
     captureTabInModal("delete-course-material-form");


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The material name provided by an instructor may contain XSS payload which will get executed when a user tries to delete that particular course material.

### What is the new behavior?
The user provided file name is treated as text instead of HTML, thereby preventing execution.

### Other information?
Thanks @cjreed121 for finding this vulnerability.
