### PR TITLE
[Refactor:TAGrading] Grading page performance

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -2329,6 +2329,13 @@ CREATE INDEX forum_posts_history_post_id_index ON public.forum_posts_history USI
 
 
 --
+-- Name: gradeable_allowed_minutes_override_g_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX gradeable_allowed_minutes_override_g_id_idx ON public.gradeable_allowed_minutes_override USING btree (g_id);
+
+
+--
 -- Name: gradeable_component_data_gd; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2343,6 +2350,13 @@ CREATE INDEX gradeable_component_data_no_grader_index ON public.gradeable_compon
 
 
 --
+-- Name: gradeable_component_mark_data_gcm_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX gradeable_component_mark_data_gcm_id_idx ON public.gradeable_component_mark_data USING btree (gcm_id);
+
+
+--
 -- Name: gradeable_team_unique; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2354,6 +2368,13 @@ CREATE UNIQUE INDEX gradeable_team_unique ON public.regrade_requests USING btree
 --
 
 CREATE UNIQUE INDEX gradeable_user_unique ON public.regrade_requests USING btree (user_id, g_id) WHERE (gc_id IS NULL);
+
+
+--
+-- Name: grading_registration_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX grading_registration_user_id_idx ON public.grading_registration USING btree (user_id);
 
 
 --

--- a/migration/migrator/migrations/course/20221207220918_gradeable_allowed_minutes_index.py
+++ b/migration/migrator/migrations/course/20221207220918_gradeable_allowed_minutes_index.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('CREATE INDEX IF NOT EXISTS gradeable_allowed_minutes_override_g_id_idx ON gradeable_allowed_minutes_override(g_id)')
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('DROP INDEX IF EXISTS gradeable_allowed_minutes_override_g_id_idx')

--- a/migration/migrator/migrations/course/20221207223331_gradeable_component_mark_data_gcm_id_index.py
+++ b/migration/migrator/migrations/course/20221207223331_gradeable_component_mark_data_gcm_id_index.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('CREATE INDEX IF NOT EXISTS gradeable_component_mark_data_gcm_id_idx ON gradeable_component_mark_data(gcm_id)')
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('DROP INDEX IF EXISTS gradeable_component_mark_data_gcm_id_idx')

--- a/migration/migrator/migrations/course/20221208001513_grading_registration_user_id_index.py
+++ b/migration/migrator/migrations/course/20221208001513_grading_registration_user_id_index.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('CREATE INDEX IF NOT EXISTS grading_registration_user_id_idx ON grading_registration(user_id)')
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute('DROP INDEX IF EXISTS grading_registration_user_id_idx')

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -929,7 +929,10 @@ class ElectronicGraderController extends AbstractController {
         }
 
         $graded_gradeables = [];
-        $user_ids = $this->core->getQueries()->getUsersOnTeamsForGradeable($gradeable); // Collect user ids so we know who isn't on a team
+        if ($gradeable->isTeamAssignment()) {
+            $user_ids = $this->core->getQueries()->getUsersOnTeamsForGradeable($gradeable);
+            // Collect user ids so we know who isn't on a team
+        }
         /** @var GradedGradeable $g */
         foreach ($order->getSortedGradedGradeables() as $g) {
             $graded_gradeables[] = $g;

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -929,6 +929,7 @@ class ElectronicGraderController extends AbstractController {
         }
 
         $graded_gradeables = [];
+        $user_ids = [];
         if ($gradeable->isTeamAssignment()) {
             $user_ids = $this->core->getQueries()->getUsersOnTeamsForGradeable($gradeable);
             // Collect user ids so we know who isn't on a team

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1623,7 +1623,6 @@ class ElectronicGraderController extends AbstractController {
             }
 
             // Get the graded gradeable for the $from user
-            $from_graded_gradeable = false;
             $id_from_anon = $this->core->getQueries()->getSubmitterIdFromAnonId($from, $gradeable_id);
             if ($blind_grading !== "unblind" || $anon_mode) {
                 $from_graded_gradeable = $this->tryGetGradedGradeable($gradeable, $id_from_anon, false);
@@ -1788,7 +1787,7 @@ class ElectronicGraderController extends AbstractController {
             $late_days_user = $graded_gradeable->getSubmitter()->getUser();
         }
 
-        $ldi = LateDays::fromUser($this->core, $late_days_user)->getLateDayInfoByGradeable($gradeable);
+        $ldi = (new LateDays($this->core, $late_days_user, [$graded_gradeable]))->getLateDayInfoByGradeable($gradeable);
         if ($ldi === null) {
             $late_status = LateDayInfo::STATUS_GOOD;  // Assume its good
         }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6340,20 +6340,14 @@ AND gc_id IN (
             SELECT ids.id, (CASE WHEN m IS NULL THEN 0 ELSE m END) AS max
             FROM (VALUES $id_placeholders) ids(id)
             LEFT JOIN (
-              (SELECT user_id AS id, active_version as m
+              SELECT COALESCE(user_id, team_id) AS id, active_version as m
               FROM electronic_gradeable_version
-              WHERE g_id = ? AND user_id IS NOT NULL)
-
-              UNION
-
-              (SELECT team_id AS id, active_version as m
-              FROM electronic_gradeable_version
-              WHERE g_id = ? AND team_id IS NOT NULL)
+              WHERE g_id = ? AND (user_id IS NOT NULL OR team_id IS NOT NULL)
             ) AS versions
             ON versions.id = ids.id
         ";
 
-        $params = array_merge($submitter_ids, [$gradeable->getId(), $gradeable->getId()]);
+        $params = array_merge($submitter_ids, [$gradeable->getId()]);
 
         $this->course_db->query($query, $params);
         $versions = [];

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -35,8 +35,8 @@ class Team extends AbstractModel {
     protected $member_list;
     /** @var array $assignment_settings */
     protected $assignment_settings;
-    /** @var ?string $anon_id */
-    protected $anon_id = null;
+    /** @var string $anon_id */
+    protected $anon_id;
     /** @prop @var string The name of the team */
     protected $team_name;
 
@@ -86,13 +86,7 @@ class Team extends AbstractModel {
      * @return string
      */
     public function getAnonId() {
-        if ($this->anon_id !== null) {
-            // used the cached anon_id if we have it
-            return $this->anon_id;
-        }
-
-        $temp = $this->core->getQueries()->getTeamAnonId($this->getId());
-        if (empty($temp) || $temp[$this->getId()] === null) {
+        if (empty($this->core->getQueries()->getTeamAnonId($this->getId())) || $this->core->getQueries()->getTeamAnonId($this->getId())[$this->getId()] === null) {
             $alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             $anon_ids = $this->core->getQueries()->getAllAnonIds();
             $alpha_length = strlen($alpha) - 1;
@@ -109,11 +103,7 @@ class Team extends AbstractModel {
             $this->anon_id = $random;
             $this->core->getQueries()->updateTeamAnonId($this->getId(), $random);
         }
-        else {
-            $this->anon_id = $temp[$this->getId()];
-        }
-
-        return $this->anon_id;
+        return $this->core->getQueries()->getTeamAnonId($this->getId())[$this->getId()];
     }
 
     /**

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -35,8 +35,8 @@ class Team extends AbstractModel {
     protected $member_list;
     /** @var array $assignment_settings */
     protected $assignment_settings;
-    /** @var string $anon_id */
-    protected $anon_id;
+    /** @var ?string $anon_id */
+    protected $anon_id = null;
     /** @prop @var string The name of the team */
     protected $team_name;
 
@@ -86,7 +86,13 @@ class Team extends AbstractModel {
      * @return string
      */
     public function getAnonId() {
-        if (empty($this->core->getQueries()->getTeamAnonId($this->getId())) || $this->core->getQueries()->getTeamAnonId($this->getId())[$this->getId()] === null) {
+        if ($this->anon_id !== null) {
+            // used the cached anon_id if we have it
+            return $this->anon_id;
+        }
+
+        $temp = $this->core->getQueries()->getTeamAnonId($this->getId());
+        if (empty($temp) || $temp[$this->getId()] === null) {
             $alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             $anon_ids = $this->core->getQueries()->getAllAnonIds();
             $alpha_length = strlen($alpha) - 1;
@@ -103,7 +109,11 @@ class Team extends AbstractModel {
             $this->anon_id = $random;
             $this->core->getQueries()->updateTeamAnonId($this->getId(), $random);
         }
-        return $this->core->getQueries()->getTeamAnonId($this->getId())[$this->getId()];
+        else {
+            $this->anon_id = $temp[$this->getId()];
+        }
+
+        return $this->anon_id;
     }
 
     /**

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -152,6 +152,9 @@ class User extends AbstractModel {
     /** @prop @var string The display_image_state string which can be used to instantiate a DisplayImage object */
     protected $display_image_state;
 
+    /** @var array A cache of [gradeable id] => [anon id] */
+    private $anon_id_by_gradeable = [];
+
     /**
      * User constructor.
      *
@@ -462,7 +465,13 @@ class User extends AbstractModel {
         if ($g_id === "") {
             return "";
         }
-        $anon_id = $this->core->getQueries()->getAnonId($this->id, $g_id);
+        if (array_key_exists($g_id, $this->anon_id_by_gradeable)) {
+            $anon_id = $this->anon_id_by_gradeable[$g_id];
+        }
+        else {
+            $anon_id = $this->core->getQueries()->getAnonId($this->id, $g_id);
+            $this->anon_id_by_gradeable[$g_id] = $anon_id;
+        }
         $anon_id = empty($anon_id) ? null : $anon_id[$this->getId()];
         if ($anon_id === null) {
             $alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -470,9 +470,9 @@ class User extends AbstractModel {
         }
         else {
             $anon_id = $this->core->getQueries()->getAnonId($this->id, $g_id);
+            $anon_id = empty($anon_id) ? null : $anon_id[$this->getId()];
             $this->anon_id_by_gradeable[$g_id] = $anon_id;
         }
-        $anon_id = empty($anon_id) ? null : $anon_id[$this->getId()];
         if ($anon_id === null) {
             $alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             $anon_ids = $this->core->getQueries()->getAllAnonIdsByGradeable($g_id);

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -59,7 +59,7 @@
                         <h4>No Submission</h4>
                     {% endif %}
                 </div>
-                {% for student_anon_id in student_anon_ids %}
+                {% for student_anon_id in student_anon_ids and gradeable.hasPeerComponent() %}
                     {% if gradeable.getPeerFeedback(grader_id, student_anon_id) != 'No response' %}
                         <div class="box component peer-border">
                             Peer Feedback: {{gradeable.getPeerFeedback(grader_id, student_anon_id)}}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1447,14 +1447,15 @@ HTML;
         $return = "";
         $student_anon_ids = [];
         $gradeable = $graded_gradeable->getGradeable();
-        if ($gradeable->isTeamAssignment()) {
-            $team = $this->core->getQueries()->getTeamById($graded_gradeable->getSubmitter()->getId());
-            foreach ($team->getMemberUsers() as $user) {
-                $student_anon_ids[] = $user->getAnonId($gradeable->getId());
+        if ($gradeable->hasPeerComponent()) {
+            if ($gradeable->isTeamAssignment()) {
+                $team = $this->core->getQueries()->getTeamById($graded_gradeable->getSubmitter()->getId());
+                foreach ($team->getMemberUsers() as $user) {
+                    $student_anon_ids[] = $user->getAnonId($gradeable->getId());
+                }
+            } else {
+                $student_anon_ids[] = $graded_gradeable->getSubmitter()->getAnonId($graded_gradeable->getGradeableId());
             }
-        }
-        else {
-            $student_anon_ids[] = $graded_gradeable->getSubmitter()->getAnonId($graded_gradeable->getGradeableId());
         }
         // Disable grading if the requested version isn't the active one
         $grading_disabled = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion() == 0

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1447,16 +1447,14 @@ HTML;
         $return = "";
         $student_anon_ids = [];
         $gradeable = $graded_gradeable->getGradeable();
-        if ($gradeable->hasPeerComponent()) {
-            if ($gradeable->isTeamAssignment()) {
-                $team = $this->core->getQueries()->getTeamById($graded_gradeable->getSubmitter()->getId());
-                foreach ($team->getMemberUsers() as $user) {
-                    $student_anon_ids[] = $user->getAnonId($gradeable->getId());
-                }
+        if ($gradeable->isTeamAssignment()) {
+            $team = $this->core->getQueries()->getTeamById($graded_gradeable->getSubmitter()->getId());
+            foreach ($team->getMemberUsers() as $user) {
+                $student_anon_ids[] = $user->getAnonId($gradeable->getId());
             }
-            else {
-                $student_anon_ids[] = $graded_gradeable->getSubmitter()->getAnonId($graded_gradeable->getGradeableId());
-            }
+        }
+        else {
+            $student_anon_ids[] = $graded_gradeable->getSubmitter()->getAnonId($graded_gradeable->getGradeableId());
         }
         // Disable grading if the requested version isn't the active one
         $grading_disabled = $graded_gradeable->getAutoGradedGradeable()->getActiveVersion() == 0

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1453,7 +1453,8 @@ HTML;
                 foreach ($team->getMemberUsers() as $user) {
                     $student_anon_ids[] = $user->getAnonId($gradeable->getId());
                 }
-            } else {
+            }
+            else {
                 $student_anon_ids[] = $graded_gradeable->getSubmitter()->getAnonId($graded_gradeable->getGradeableId());
             }
         }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -10,7 +10,6 @@ use app\models\gradeable\Gradeable;
 use app\models\gradeable\AutoGradedVersion;
 use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\LateDayInfo;
-use app\models\gradeable\LateDays;
 use app\models\gradeable\RegradeRequest;
 use app\models\SimpleStat;
 use app\models\Team;

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -10,6 +10,7 @@ use app\models\gradeable\Gradeable;
 use app\models\gradeable\AutoGradedVersion;
 use app\models\gradeable\GradedGradeable;
 use app\models\gradeable\LateDayInfo;
+use app\models\gradeable\LateDays;
 use app\models\gradeable\RegradeRequest;
 use app\models\SimpleStat;
 use app\models\Team;
@@ -35,6 +36,8 @@ class ElectronicGraderView extends AbstractView {
      * @param int $submissions_in_queue
      * @return string
      */
+
+    private $user_id_to_User_cache = [];
 
     public function statusPage(
         Gradeable $gradeable,
@@ -1261,7 +1264,10 @@ HTML;
         for ($index = 1; $index < count($file_path_parts); $index++) {
             if ($index == 9) {
                 $user_id[] = $file_path_parts[$index];
-                $user_or_team = $this->core->getQueries()->getUsersOrTeamsById($user_id)[$user_id[0]];
+                if (!array_key_exists($user_id[0], $this->user_id_to_User_cache)) {
+                    $this->user_id_to_User_cache[$user_id[0]] = $this->core->getQueries()->getUsersOrTeamsById($user_id)[$user_id[0]];
+                }
+                $user_or_team = $this->user_id_to_User_cache[$user_id[0]];
                 $anon_id = $user_or_team->getAnonId($g_id);
                 $anon_path = $anon_path . "/" . $anon_id;
             }


### PR DESCRIPTION
### What is the current behavior?
The individual grading page currently makes in excess of 100 database queries for most gradeable+student combinations.  This causes the grading page to be one of the slowest pages across the entire Submitty website.  This slowness is detrimental to those who use this interface to grade hundreds of students per week.

### What is the new behavior?

This PR reduces the number of queries from more than 100 to roughly 60 queries on the grading page, with further improvements expected in future PRs.

Repetitive queries were simplified in several places.  Additionally, several new indices were added to improve query lookup time for some of the more important queries.  Since many of these changes affect queries which are run on other pages such as the gradeables page and grading index page, these changes should also benefit the query performance on those pages as well.