### PR TITLE
[Refactor:Submission] Reducing splitted jpg sizes

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -120,7 +120,8 @@ def main(args):
                     cover_writer.write(out)
 
                 # save cover image
-                page.save('{}.jpg'.format(cover_filename[:-4]), "JPEG", quality=20, optimize=True)
+                page.save('{}.jpg'.format(cover_filename[:-4]),
+                    "JPEG", quality=20, optimize=True)
 
                 id_index += 1
                 page_count = 1
@@ -149,7 +150,8 @@ def main(args):
                         cover_writer.write(out)
 
                     # save cover image
-                    page.save('{}.jpg'.format(cover_filename[:-4]), "JPEG", quality=20, optimize=True)
+                    page.save('{}.jpg'.format(cover_filename[:-4]),
+                        "JPEG", quality=20, optimize=True)
 
                 # add pages to current split_pdf
                 page_count += 1

--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -151,7 +151,7 @@ def main(args):
 
                     # save cover image
                     page.save('{}.jpg'.format(cover_filename[:-4]),
-                          "JPEG", quality=20, optimize=True)
+                              "JPEG", quality=20, optimize=True)
 
                 # add pages to current split_pdf
                 page_count += 1

--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -121,7 +121,7 @@ def main(args):
 
                 # save cover image
                 page.save('{}.jpg'.format(cover_filename[:-4]),
-                    "JPEG", quality=20, optimize=True)
+                          "JPEG", quality=20, optimize=True)
 
                 id_index += 1
                 page_count = 1
@@ -151,7 +151,7 @@ def main(args):
 
                     # save cover image
                     page.save('{}.jpg'.format(cover_filename[:-4]),
-                        "JPEG", quality=20, optimize=True)
+                          "JPEG", quality=20, optimize=True)
 
                 # add pages to current split_pdf
                 page_count += 1

--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -120,7 +120,7 @@ def main(args):
                     cover_writer.write(out)
 
                 # save cover image
-                page.save('{}.jpg'.format(cover_filename[:-4]), "JPEG", quality=100)
+                page.save('{}.jpg'.format(cover_filename[:-4]), "JPEG", quality=20, optimize=True)
 
                 id_index += 1
                 page_count = 1
@@ -128,7 +128,7 @@ def main(args):
 
                 # save page as image, start indexing at 1
                 page.save(prev_file[:-4] + '_' + str(page_count).zfill(3) + '.jpg',
-                          "JPEG", quality=100)
+                          "JPEG", quality=20, optimize=True)
 
             else:
                 # the first pdf page doesn't have a qr code
@@ -149,14 +149,14 @@ def main(args):
                         cover_writer.write(out)
 
                     # save cover image
-                    page.save('{}.jpg'.format(cover_filename[:-4]), "JPEG", quality=100)
+                    page.save('{}.jpg'.format(cover_filename[:-4]), "JPEG", quality=20, optimize=True)
 
                 # add pages to current split_pdf
                 page_count += 1
                 pdf_writer.add_page(pdfPages.pages[i])
                 # save page as image, start indexing at 1
                 page.save(prev_file[:-4] + '_' + str(page_count).zfill(3) + '.jpg',
-                          "JPEG", quality=100)
+                          "JPEG", quality=20, optimize=True)
 
             i += 1
 

--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_upload_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_upload_split.py
@@ -65,11 +65,11 @@ def main(args):
                 # save pdfs as images (start indexing at one)
                 # open the file after writing it
                 with open(output_filename, 'rb') as out:
-                    pdf_images = convert_from_bytes(out.read())
+                    pdf_images = convert_from_bytes(out.read(), dpi=200)
                     for k in range(len(pdf_images)):
                         pdf_images[k].save(output_filename[:-4] +
                                            '_' + str(k + 1).zfill(3) + '.jpg',
-                                           "JPEG", quality=100)
+                                           "JPEG", quality=20, optimize=True)
 
                 with open(cover_filename, 'wb') as out:
                     cover_writer.write(out)
@@ -78,9 +78,9 @@ def main(args):
 
                 with open(cover_filename, 'rb') as out:
                     # save cover as image
-                    pdf_images = convert_from_bytes(out.read())
+                    pdf_images = convert_from_bytes(out.read(), dpi=200)
                     pdf_images[0].save('{}.jpg'.format(cover_filename[:-4]),
-                                       "JPEG", quality=100)
+                                       "JPEG", quality=20, optimize=True)
 
             buff += "Finished splitting into " + str(int(total_pages/num)) + " files"
             logger.write_to_log(log_file_path, buff)


### PR DESCRIPTION
### What is the current behavior?
The splitted images for the uploaded pdfs in bulk submission currently take too much space.

### What is the new behavior?
The total size reduces to around 20% of the original total size.
