### PR TITLE
[Bugfix:SubminiPolls] Poll visibility

### DIFF
--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -62,7 +62,7 @@ class PollController extends AbstractController {
 
     /**
      * @Route("/courses/{_semester}/{_course}/polls/viewPoll/{poll_id}", methods={"GET"}, requirements={"poll_id": "\d*", })
-     * @return MultiResponse
+     * @return MultiResponse|RedirectResponse
      */
     public function viewPoll($poll_id) {
         if (!isset($poll_id)) {
@@ -80,9 +80,7 @@ class PollController extends AbstractController {
         }
         if ($poll->isClosed() && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Poll is currently closed");
-            return MultiResponse::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['polls']))
-            );
+            return new RedirectResponse($this->core->buildCourseUrl(['polls']));
         }
         return MultiResponse::webOnlyResponse(
             new WebResponse(

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -80,9 +80,7 @@ class PollController extends AbstractController {
         }
         if ($poll->isClosed() && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Poll is currently closed");
-            return MultiResponse::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['polls']))
-            );
+            return new RedirectResponse($this->core->buildCourseUrl(['polls']));
         }
         return MultiResponse::webOnlyResponse(
             new WebResponse(

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -80,7 +80,9 @@ class PollController extends AbstractController {
         }
         if ($poll->isClosed() && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Poll is currently closed");
-            return new RedirectResponse($this->core->buildCourseUrl(['polls']));
+            return MultiResponse::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildCourseUrl(['polls']))
+            );
         }
         return MultiResponse::webOnlyResponse(
             new WebResponse(

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -78,7 +78,7 @@ class PollController extends AbstractController {
                 new RedirectResponse($this->core->buildCourseUrl(['polls']))
             );
         }
-        if ($poll->isClosed()) {
+        if ($poll->isClosed() && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Poll is currently closed");
             return MultiResponse::RedirectOnlyResponse(
                 new RedirectResponse($this->core->buildCourseUrl(['polls']))

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -78,6 +78,12 @@ class PollController extends AbstractController {
                 new RedirectResponse($this->core->buildCourseUrl(['polls']))
             );
         }
+        if ($poll->isClosed()) {
+            $this->core->addErrorMessage("Poll is currently closed");
+            return MultiResponse::RedirectOnlyResponse(
+                new RedirectResponse($this->core->buildCourseUrl(['polls']))
+            );
+        }
         return MultiResponse::webOnlyResponse(
             new WebResponse(
                 'Poll',


### PR DESCRIPTION
### What is the current behavior?
Currently students can be able to see closed polls using URL manipulation
Closes #8668 

### What is the new behavior?
When polls are closed, students will no longer be able to see it.

### Other information?
The wording for Submini Polls are kinda confusing. "Closed poll" means a poll that is not visible while "ended poll" means a poll that is no longer accepting submissions (but visible)