### PR TITLE
[Bugfix:System] Handle array while formatting query

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -314,20 +314,4 @@ class Utils {
     public static function escapeDoubleQuotes(string $str): ?string {
         return preg_replace('["]', '\"', $str);
     }
-
-    /**
-     * Separate an array containing strings and/or numbers using commas, with strings enclosed in single quotes
-     *
-     * @param array $arr
-     * @return string Comma-separated string
-     */
-    public static function arrayToCommaSepString(array $arr): string {
-        $result = "";
-        $sep = "";
-        foreach ($arr as $elem) {
-            $result .= is_numeric($elem) ? "{$sep}{$elem}" : "{$sep}'{$elem}'";
-            $sep = ", ";
-        }
-        return $result;
-    }
 }

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -314,4 +314,20 @@ class Utils {
     public static function escapeDoubleQuotes(string $str): ?string {
         return preg_replace('["]', '\"', $str);
     }
+
+    /**
+     * Separate an array containing strings and/or numbers using commas, with strings enclosed in single quotes
+     *
+     * @param array $arr
+     * @return string Comma-separated string
+     */
+    public static function arrayToCommaSepString(array $arr): string {
+        $result = "";
+        $sep = "";
+        foreach ($arr as $elem) {
+            $result .= is_numeric($elem) ? "{$sep}{$elem}" : "{$sep}'{$elem}'";
+            $sep = ", ";
+        }
+        return $result;
+    }
 }

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -18,6 +18,29 @@ class DatabaseUtils {
             }
             if (is_array($param)) {
                 $str_param = json_encode($param);
+
+                /*
+                // in case queries with json function calls are not formatted properly
+                $json_functions = ["json_array_length", "json_array_elements", "json_array_elements_text"];
+                $function_call = false;
+                $qmark_info = [];
+                preg_match('/\?/', $sql, $qmark_info, PREG_OFFSET_CAPTURE);
+                foreach ($json_functions as $json_func) {
+                    $func_name_offset = $qmark_info[0][1]-strlen($json_func)-1;
+                    if ($func_name_offset >= 0 && substr($sql, $func_name_offset, strlen($json_func)) === $json_func) {
+                        $function_call = true;
+                        break;
+                    }
+                }
+                if ($function_call) {
+                    $param = "'{$str_param}'";
+                }
+                else {
+                    $param = substr($str_param, 1, strlen($str_param) - 2);
+                }
+                */
+
+                // remove square brackets
                 $param = substr($str_param, 1, strlen($str_param) - 2);
             }
             elseif (!is_numeric($param)) {

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace app\libraries\database;
 
 use app\libraries\DateUtils;
-use app\libraries\Utils;
 
 class DatabaseUtils {
     public static function formatQuery(string $sql, ?array $params): string {
@@ -18,7 +17,7 @@ class DatabaseUtils {
                 $param = DateUtils::dateTimeToString($param);
             }
             if (gettype($param) === "array") {
-                $param = Utils::arrayToCommaSepString($param);
+                $param = json_encode($param);
             }
             elseif (!is_numeric($param)) {
                 $param = "'{$param}'";

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace app\libraries\database;
 
 use app\libraries\DateUtils;
+use app\libraries\Utils;
 
 class DatabaseUtils {
     public static function formatQuery(string $sql, ?array $params): string {
@@ -16,7 +17,13 @@ class DatabaseUtils {
             if ($param instanceof \DateTime) {
                 $param = DateUtils::dateTimeToString($param);
             }
-            $sql = preg_replace('/\?/', is_numeric($param) ? $param : "'{$param}'", $sql, 1);
+            if (gettype($param) === "array") {
+                $param = Utils::arrayToCommaSepString($param);
+            }
+            elseif (!is_numeric($param)) {
+                $param = "'{$param}'";
+            }
+            $sql = preg_replace('/\?/', $param, $sql, 1);
         }
         return $sql;
     }

--- a/site/app/libraries/database/DatabaseUtils.php
+++ b/site/app/libraries/database/DatabaseUtils.php
@@ -16,8 +16,9 @@ class DatabaseUtils {
             if ($param instanceof \DateTime) {
                 $param = DateUtils::dateTimeToString($param);
             }
-            if (gettype($param) === "array") {
-                $param = json_encode($param);
+            if (is_array($param)) {
+                $str_param = json_encode($param);
+                $param = substr($str_param, 1, strlen($str_param) - 2);
             }
             elseif (!is_numeric($param)) {
                 $param = "'{$param}'";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
`formatQuery` function in `site/app/libraries/database/DatabaseUtils.php` throws an error if `$param` is an array.

### What is the new behavior?
`formatQuery` function can now handle an array (`$param`) inside `$params`.

### Other information?
This issue was discovered while working on #8615 where the following query is generated:

`SELECT t0.id AS id_1, t0.path AS path_2, t0.type AS type_3, t0.release_date AS release_date_4, t0.hidden_from_students AS hidden_from_students_5, t0.priority AS priority_6, t0.url AS url_7, t0.url_title AS url_title_8, t9.id AS id_10, t9.user_id AS user_id_11, t9.timestamp AS timestamp_12, t9.course_material_id AS course_material_id_13, t14.section_id AS section_id_15, t14.course_material_id AS course_material_id_16 FROM course_materials t0 LEFT JOIN course_materials_access t9 ON t9.course_material_id = t0.id LEFT JOIN course_materials_sections t14 ON t14.course_material_id = t0.id WHERE t0.path IN (?)`

Here, the relevant portion is at the last i.e. `WHERE t0.path IN (?)`. This is possibly generated by Doctrine's `findBy` call [here](https://github.com/Submitty/Submitty/blob/8fa2ce8e37d1a270bc3a151a0f65ab5af8e1a7e7/site/app/controllers/course/CourseMaterialsController.php#L800).

The error was encountered while trying to upload a material, see screenshot:
![StackTrace](https://user-images.githubusercontent.com/51257141/207940557-5fe971d0-ba09-4a6b-8f99-1b0f0350dd12.png)

As can be observed in the above screenshot, this issue probably stayed hidden until recently a PR related to DB performance warning was merged.
