### PR TITLE
[Feature:Autograding] Config option to keep `.git`

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1010,9 +1010,25 @@ def checkout_vcs_repo(config, my_file):
                 "credentials.\n",
                 file=f)
 
-    # remove the .git directory (storing full history and metafiles)
-    git_path = os.path.join(checkout_path, ".git")
-    shutil.rmtree(git_path, ignore_errors=True)
+    form_json_file = os.path.join(course_dir, 'config', 'form', f'form_{obj["gradeable"]}.json')
+    with open(form_json_file, 'r') as fj:
+        form_json = json.load(fj)
+    gradeable_json_file = os.path.join(form_json["config_path"], "config.json")
+    with open(gradeable_json_file, 'r') as gj:
+        gradeable_json = json.load(gj)
+
+    try:
+        # We explicitly compare equality with True because otherwise,
+        # Python might implicitly coerce a “truthy” value
+        # (such as any non-empty string, including the string "False")
+        # to True in an if statement
+        keep_git_directory = gradeable_json["keep_git_directory"] is True
+    except KeyError:
+        keep_git_directory = False
+    if not keep_git_directory:
+        # remove the .git directory (storing full history and metafiles)
+        git_path = os.path.join(checkout_path, ".git")
+        shutil.rmtree(git_path, ignore_errors=True)
 
     # calculate total file size, and remove symlinks
     (checkout_size, checkout_included_symlinks) = calculate_size_cleanup_symlinks(checkout_path)

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1010,20 +1010,23 @@ def checkout_vcs_repo(config, my_file):
                 "credentials.\n",
                 file=f)
 
-    form_json_file = os.path.join(course_dir, 'config', 'form', f'form_{obj["gradeable"]}.json')
-    with open(form_json_file, 'r') as fj:
-        form_json = json.load(fj)
-    gradeable_json_file = os.path.join(form_json["config_path"], "config.json")
-    with open(gradeable_json_file, 'r') as gj:
-        gradeable_json = json.load(gj)
+    gradeable_config_json_file = os.path.join(
+        course_path,
+        'config',
+        'complete_config',
+        f'complete_config_{obj["gradeable"]}.json'
+    )
 
     try:
+        with open(gradeable_config_json_file, 'r') as gcj:
+            gradeable_config_json = json.load(gcj)
+
         # We explicitly compare equality with True because otherwise,
         # Python might implicitly coerce a “truthy” value
         # (such as any non-empty string, including the string "False")
         # to True in an if statement
-        keep_git_directory = gradeable_json["keep_git_directory"] is True
-    except KeyError:
+        keep_git_directory = gradeable_config_json["keep_git_directory"] is True
+    except (FileNotFoundError, KeyError):
         keep_git_directory = False
     if not keep_git_directory:
         # remove the .git directory (storing full history and metafiles)

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1011,7 +1011,7 @@ def checkout_vcs_repo(config, my_file):
                 file=f)
 
     gradeable_config_json_file = os.path.join(
-        course_path,
+        course_dir,
         'config',
         'complete_config',
         f'complete_config_{obj["gradeable"]}.json'

--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -515,6 +515,10 @@
             }
           }
         }
+      },
+      "keep_git_directory": {
+        "type": "boolean",
+        "description": "Specifies whether the .git directory should be copied into the temporary workspace for a custom validation script"
       }
   },
   "definitions" : {

--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -518,7 +518,7 @@
       },
       "keep_git_directory": {
         "type": "boolean",
-        "description": "Specifies whether the .git directory should be copied into the temporary workspace for a custom validation script"
+        "description": "Specifies whether the .git directory should be kept on clone into the student's checkout submission. Defaults to false."
       }
   },
   "definitions" : {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Documentation has been updated/added if relevant _(will be submitted as a separate pull request to the documentation repository)_

### What is the current behavior?
Submitty automatically deletes the `.git` directory while copying the current state of a student’s VCS submission to the temporary auto-grading workspace when a student clicks the “Grade My Repository” button.

### What is the new behavior?
Submitty automatically deletes the `.git` directory while copying the current state of a student’s VCS submission to the temporary auto-grading workspace when a student clicks the “Grade My Repository” button unless the auto-grading configuration’s `config.json` file has the `"keep_git_directory"` field set to the Boolean `true` at the root of the JSON object.

Any value other than `true`—including the string `"true"`—is implicitly coerced to `false`. Furthermore, in the absence of the JSON field, the current behavior is maintained. In other words, the default behavior remains to delete the `.git` directory, but there’s now an option to override that behavior for a specific auto-grading configuration.

### Other information?
This is not a breaking change because it relies on an entirely new, optional auto-grading configuration JSON field to change the current behavior. No existing auto-grading configuration should include this field because until now, it was invalid. Auto-grading configurations that continue not to include this field will continue to observe the same behavior as before.

I and @cjreed121 tested the change with a local development Submitty installation.

This change supports the needs of CSCI-2961 Rensselaer Center for Open Source in first few weeks of the Spring ’23 semester. We’re working on an auto-grading configuration with a custom validation script to grade the structure and commit history of students’ Git repositories, which needs to interact with the `.git` directory directly. This is part of an initiative to ensure that all RCOS students have baseline Git skills at the start of the semester. As such, we would greatly appreciate a timely deployment to submitty.cs.rpi.edu!