### PR TITLE
[Bugfix:Submission] Generate team anon id on creation

### DIFF
--- a/migration/migrator/migrations/course/20230111115942_create_missing_gradeable_team_anon_ids.py
+++ b/migration/migrator/migrations/course/20230111115942_create_missing_gradeable_team_anon_ids.py
@@ -1,0 +1,47 @@
+"""Migration for a given Submitty course database."""
+import random
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+    anon_ids_raw = database.execute("SELECT anon_id FROM gradeable_teams")
+    anon_ids = set()
+    for anon_id in anon_ids_raw:
+        anon_ids.add(anon_id[0])
+    rows = database.execute('SELECT team_id FROM gradeable_teams WHERE anon_id IS NULL')
+    anon_id = None
+    for row in rows:
+        while anon_id is None or anon_id in anon_ids:
+            anon_id = ""
+            for i in range(15):
+                anon_id += alpha[random.randrange(len(alpha))]
+        print(row[0], anon_id)
+        database.execute("UPDATE gradeable_teams SET anon_id='{}' WHERE team_id='{}'".format(anon_id, row[0]))
+    pass
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass

--- a/migration/migrator/migrations/course/20230111115942_create_missing_gradeable_team_anon_ids.py
+++ b/migration/migrator/migrations/course/20230111115942_create_missing_gradeable_team_anon_ids.py
@@ -26,9 +26,7 @@ def up(config, database, semester, course):
             anon_id = ""
             for i in range(15):
                 anon_id += alpha[random.randrange(len(alpha))]
-        print(row[0], anon_id)
         database.execute("UPDATE gradeable_teams SET anon_id='{}' WHERE team_id='{}'".format(anon_id, row[0]))
-    pass
 
 
 def down(config, database, semester, course):

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -3144,6 +3144,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
         $params = [$team_id, $g_id, $registration_section, $rotating_section, $team_name];
         $this->course_db->query("INSERT INTO gradeable_teams (team_id, g_id, registration_section, rotating_section, team_name) VALUES(?,?,?,?,?)", $params);
         $this->course_db->query("INSERT INTO teams (team_id, user_id, state) VALUES(?,?,1)", [$team_id, $user_id]);
+        $this->core->getQueries()->getTeamById($team_id)->getAnonId();
         return $team_id;
     }
 


### PR DESCRIPTION
### What is the current behavior?
When creating a team for a gradeable, an anon_id is not automatically generated for it (generated when getAnonId).

### What is the new behavior?
When creating a team for a gradeable, an anon_id is automatically generated as part of the creation process.

A migration has been added to fix cases in the database where an anon_id was not generated for a team (when creating teams using the bulk-upload interface).