### PR TITLE
[Bugfix:TAGrading] Fixed regrade button for Git gradeables

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -987,7 +987,7 @@ class SubmissionController extends AbstractController {
                     "semester" => $this->core->getConfig()->getSemester(),
                     "team" => $team_id,
                     "user" => $user_id,
-                    "vcs_checkout" => false,
+                    "vcs_checkout" => $gradeable->isVcs(),
                     "version" => $active_version,
                     "who" => $who_id
                 ];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Regrading a Git gradeable through the web interface does not work.

### What is the new behavior?
The queue files are now created with the proper information to indicate it is a VCS gradeable so the web interface works.

### Other information?
Tested with a sample Git gradeable using one of the autograding example configs. Closes #8758.
