### PR TITLE
[Bugfix:System] SysadminTools preferred_name_logging

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -793,13 +793,18 @@ if [ ${VAGRANT} == 1 ] && [ ${WORKER} == 0 ]; then
     systemctl enable nullsmtpd
 fi
 
-# Setup preferred_name_logging
-echo -e "Setup preferred name logging."
 
-# Copy preferred_name_logging.php to sbin
-rsync -qt ${SUBMITTY_REPOSITORY}/../SysadminTools/preferred_name_logging/preferred_name_logging.php ${SUBMITTY_INSTALL_DIR}/sbin
-chown root:${DAEMON_GROUP} ${SUBMITTY_INSTALL_DIR}/sbin/preferred_name_logging.php
-chmod 0550 ${SUBMITTY_INSTALL_DIR}/sbin/preferred_name_logging.php
+
+
+## Setup preferred_name_logging
+#echo -e "Setup preferred name logging."
+
+## Copy preferred_name_logging.php to sbin
+#rsync -qt ${SUBMITTY_REPOSITORY}/../SysadminTools/preferred_name_logging/preferred_name_logging.php ${SUBMITTY_INSTALL_#DIR}/sbin
+#chown root:${DAEMON_GROUP} ${SUBMITTY_INSTALL_DIR}/sbin/preferred_name_logging.php
+#chmod 0550 ${SUBMITTY_INSTALL_DIR}/sbin/preferred_name_logging.php
+
+
 
 # Backup and adjust/overwrite Postgresql's configuration
 if [ ${WORKER} == 0 ]; then


### PR DESCRIPTION
The preferred_name_logging.php script was removed in PR:
https://github.com/Submitty/SysadminTools/pull/23
But the install_system.sh script was not updated at that time

NOTE:  I believe we did not catch this error because we did not name a release for the SysadminTools repo, so most people did not get the update.

This PR comments out the installation.  But we need to modify the installation to correctly install the newer version.   Just opened issue #8778 