### PR TITLE
[Bugfix:HelpQueue] Removing students causes PHP error

### DIFF
--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -285,10 +285,10 @@ class OfficeHoursQueueModel extends AbstractModel {
         }
 
         $user_info = [];
-        $user_info["user_firstname"] = $query_row["remover_firstname"];
-        $user_info["user_preferred_firstname"] = $query_row["remover_preferred_firstname"];
-        $user_info["user_lastname"] = $query_row["remover_lastname"];
-        $user_info["user_preferred_lastname"] = $query_row["remover_preferred_lastname"];
+        $user_info["user_givenname"] = $query_row["remover_givenname"];
+        $user_info["user_preferred_givenname"] = $query_row["remover_preferred_givenname"];
+        $user_info["user_familyname"] = $query_row["remover_familyname"];
+        $user_info["user_preferred_familyname"] = $query_row["remover_preferred_familyname"];
         $user_info["user_id"] = $query_row["remover_id"];
         $user_info["user_email"] = $query_row["remover_email"];
         $user_info["user_email_secondary"] = $query_row["remover_email_secondary"];


### PR DESCRIPTION
### What is the current behavior?
https://github.com/Submitty/Submitty/pull/8786 missed one location where strings were not updated to use the given/family name convention.  This results in a PHP error when users are removed from the help queue.  The error does not affect the majority of the page rendering, and will not be displayed on production (although it will still show up in the log of course).

### What is the new behavior?
The strings have been updated to fix the PHP error.

Note: do not merge until tests pass.
