### PR TITLE
[Testing:Developer] Update GH Workflow to use new env files

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                 node-version: ${{ env.NODE_VERSION }}
             - name: Cache Node Modules
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -49,7 +49,7 @@ jobs:
               with:
                 node-version: ${{ env.NODE_VERSION }}
             - name: Cache Node Modules
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -73,7 +73,7 @@ jobs:
               with:
                 node-version: ${{ env.NODE_VERSION }}
             - name: Cache Node Modules
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -100,9 +100,9 @@ jobs:
                 php-version: ${{ env.PHP_VER }}
             - name: Cache Composer
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
             - name: Install Composer
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -137,9 +137,9 @@ jobs:
               coverage: pcov
           - name: Cache Composer
             id: composer-cache
-            run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+            run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           - name: Install Composer
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
                 path: ${{ steps.composer-cache.outputs.dir }}
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -164,7 +164,7 @@ jobs:
           with:
             python-version: ${{ env.PYTHON_VERSION }}
         - name: Cache Pip
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.cache/pip
             key: ${{ runner.os }}-${{ github.job }}-pip-${{ github.sha }}
@@ -186,7 +186,7 @@ jobs:
           with:
             python-version: ${{ env.PYTHON_VERSION }}
         - name: Cache Pip
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.cache/pip
             key: ${{ runner.os }}-${{ github.job }}-pip-${{ hashFiles('**/system_requirements.txt') }}
@@ -320,7 +320,7 @@ jobs:
               sudo timedatectl set-timezone America/New_York
 
           - name: Cache pip
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: ~/.cache/pip
               key: ${{ runner.os }}-${{ github.job }}-pip-${{ hashFiles('**/system_requirements.txt') }}
@@ -348,9 +348,9 @@ jobs:
             id: composer-cache
             run: |
               cd ${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT/Submitty/site
-              echo "::set-output name=dir::$(composer config cache-files-dir)"
+              echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           - name: Install composer Cache
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: ${{ steps.composer-cache.outputs.dir }}
               key: ${{ runner.os }}-php-composer-${{ hashFiles('**/composer.lock') }}
@@ -484,7 +484,7 @@ jobs:
 
           # TODO: Remove this block after upgrading jsPDF
           - name: Cache Node Modules
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: ~/.npm
               key: ${{ runner.os }}-cache-node-modules-dev-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Updated the Submitty CI Github Workflow, moving away from the use of `::set-output` and `::save-state`, which have been deprecated by GitHub since October 2022 and will no longer function starting in May 2023 as outlined in [this article](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

* All usage of `::set-output` has been refactored to write to the new `$GITHUB_OUTPUT` file.
* The outdated dependency `actions/cache@v2` has been updated to `actions/cache@v3`.