### PR TITLE
[Bugfix:System] Fix vagrant SSH freeze

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,6 +82,11 @@ Vagrant.configure(2) do |config|
   # The time in seconds that Vagrant will wait for the machine to boot and be accessible. 
   config.vm.boot_timeout = 600
 
+  config.vm.provider :virtualbox do |v|
+    v.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    v.customize ["modifyvm", :id, "--uartmode1", "file", File::NULL]
+  end 
+
   # Specify the various machines that we might develop on. After defining a name, we
   # can specify if the vm is our "primary" one (if we don't specify a VM, it'll use
   # that one) as well as making sure all non-primary ones have "autostart: false" set


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There was a bug where if you were trying to install Submitty it would freeze at 'SSH auth method: private key' and time out. This was commonly seen on Windows devices but also could have stemmed from a problem with the Ubuntu box. 
### What is the new behavior?
After modifying the vagrant file and adding some instructions regarding the serial ports, the installation was able to continue. 
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Further bug and solution descriptions can be found here:
https://bugs.launchpad.net/cloud-images/+bug/1829625
https://github.com/hashicorp/vagrant/issues/11890