### PR TITLE
[Bugfix:SubminiPolls] Broken poll export for rainbow grades

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -402,7 +402,7 @@ class ReportController extends AbstractController {
                 if (!array_key_exists($response->getStudentId(), $responses)) {
                     $responses[$response->getStudentId()] = [];
                 }
-                $responses[$response->getStudentId()][] = $response->getOption()->getId();
+                $responses[$response->getStudentId()][] = $response->getOption()->getOrderId();
             }
 
             $polls_data[] = [

--- a/site/app/libraries/PollUtils.php
+++ b/site/app/libraries/PollUtils.php
@@ -16,6 +16,7 @@ class PollUtils {
         $export_data = [];
         foreach ($polls as $poll) {
             $poll_data = [
+                'id' => $poll->getId(),
                 'name' => $poll->getName(),
                 'question' => $poll->getQuestion(),
                 'question_type' => $poll->getQuestionType(),

--- a/site/tests/app/libraries/PollUtilsTester.php
+++ b/site/tests/app/libraries/PollUtilsTester.php
@@ -95,6 +95,7 @@ class PollUtilsTester extends \PHPUnit\Framework\TestCase {
 
         $expected_data = [
             [
+                "id" => 0,
                 "name" => "Poll #1",
                 "question" => "Is this the first poll?",
                 "question_type" => "single-response",
@@ -106,6 +107,7 @@ class PollUtilsTester extends \PHPUnit\Framework\TestCase {
                 "release_histogram" => "never"
             ],
             [
+                "id" => 1,
                 "name" => "Poll #2",
                 "question" => "Is this the second poll?",
                 "question_type" => "single-response",
@@ -117,6 +119,7 @@ class PollUtilsTester extends \PHPUnit\Framework\TestCase {
                 "release_histogram" => "always"
             ],
             [
+                "id" => 2,
                 "name" => "Poll #3",
                 "question" => "Is this the fourth poll?",
                 "question_type" => "multiple-response",


### PR DESCRIPTION
### What is the current behavior?
The poll export functionality during the Grade Reports generation process currently produces files which do not contain enough data to associate student responses with the polls the students responded to.

### What is the new behavior?
A missing `id` field was added to `poll_questions.json` and the numeric identifier for each response in `poll_responses.json` was switched to `order_id` from `option_id`.

Both of these changes fix bugs introduced by https://github.com/Submitty/Submitty/pull/6708.