### PR TITLE
[Bugfix:System] Make doctrine proxy classes upon install

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -144,6 +144,16 @@ fi
 # create access control cache directory
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/access_control
 
+# clear old doctrine proxy classes
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/doctrine-proxy" ]; then
+    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/doctrine-proxy"
+fi
+# create doctrine proxy classes directory
+mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/doctrine-proxy
+
+# create doctrine proxy classes
+php "${SUBMITTY_INSTALL_DIR}/sbin/doctrine.php" "orm:generate-proxies"
+
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/public/mjs" ]; then
     rm -r "${SUBMITTY_INSTALL_DIR}/site/public/mjs"
 fi

--- a/sbin/doctrine.php
+++ b/sbin/doctrine.php
@@ -1,0 +1,26 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This script runs the Doctrine console
+ *
+ * Trying to perform interactions on course databases
+ * through this will fail
+ *
+ * Usage (this will show commands): ./doctrine.php
+ */
+
+require_once __DIR__ . "/../site/vendor/autoload.php";
+
+use app\libraries\Core;
+use Doctrine\ORM\Tools\Console\ConsoleRunner;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+
+$core = new Core();
+
+$core->loadMasterConfig();
+$core->loadMasterDatabase();
+
+ConsoleRunner::run(
+    new SingleManagerProvider($core->getSubmittyEntityManager())
+);

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -181,7 +181,7 @@ class Core {
         $config = ORMSetup::createAnnotationMetadataConfiguration(
             [FileUtils::joinPaths(__DIR__, '..', 'entities')],
             $this->config->isDebug(),
-            null,
+            FileUtils::joinPaths(dirname(__DIR__, 2), 'cache', 'doctrine-proxy'),
             $cache
         );
 


### PR DESCRIPTION
### What is the current behavior?
Currently Doctrine proxy classes get generated while the code is running if we are in debug mode. If it's in production mode then it is expected the proxy classes are made which never happens. This leads to white screen errors on a couple pages after PR #6708.

### What is the new behavior?
* A new directory inside the cache directory is created for these proxy classes
* A doctrine php executable was added which will make the proxy classes
* The installation script will clear the proxy classes directory and regenerate the proxy classes during each install

### Other information?
Tested on a mock production server and it works as expected.
