### PR TITLE
[Bugfix:Forum] Add required attribute to textareas

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -91,6 +91,7 @@
             "render_header" : render_markdown is defined and render_markdown ? render_markdown : false,
             "markdown_header_id" : "markdown_header_" ~ post_box_id,
             "min_height" : min_height,
+            "required" :  true,
             "textarea_maxlength" : post_content_limit is defined ? post_content_limit : null,
             "textarea_onkeydown" : "submitNearestForm(event,$(this))",
             "textarea_onpaste" : "pasteImageFromClipboard(event, $(this), " ~ post_box_id  ~ ")"

--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -84,7 +84,7 @@
             rows="10" cols="30"
             {# 524288 characters is the default max length for text input fields #}
             maxlength="{{ (no_maxlength|default(null) ? '524288' : (textarea_maxlength|default(null) ? textarea_maxlength :'5000'))}}"
-            {% if required %}
+            {% if required is defined and required %}
                 required
             {% endif %}
             {% if textarea_onchange is defined %}

--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -84,6 +84,9 @@
             rows="10" cols="30"
             {# 524288 characters is the default max length for text input fields #}
             maxlength="{{ (no_maxlength|default(null) ? '524288' : (textarea_maxlength|default(null) ? textarea_maxlength :'5000'))}}"
+            {% if required %}
+                required
+            {% endif %}
             {% if textarea_onchange is defined %}
                 onchange="{{ textarea_onchange }}"
             {% endif %}

--- a/site/public/templates/misc/MarkdownArea.twig
+++ b/site/public/templates/misc/MarkdownArea.twig
@@ -80,6 +80,9 @@
             rows="10" cols="30"
             {# 524288 characters is the default max length for text input fields #}
             maxlength="{{ (no_maxlength|default(null) ? '524288' : (textarea_maxlength|default(null) ? textarea_maxlength :'5000'))}}"
+            {% if required %}
+                required
+            {% endif %}
             {% if textarea_onchange is defined %}
                 onchange="{{ textarea_onchange }}"
             {% endif %}

--- a/site/public/templates/misc/MarkdownArea.twig
+++ b/site/public/templates/misc/MarkdownArea.twig
@@ -80,7 +80,7 @@
             rows="10" cols="30"
             {# 524288 characters is the default max length for text input fields #}
             maxlength="{{ (no_maxlength|default(null) ? '524288' : (textarea_maxlength|default(null) ? textarea_maxlength :'5000'))}}"
-            {% if required %}
+            {% if required is defined and required %}
                 required
             {% endif %}
             {% if textarea_onchange is defined %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Currently, whenever I try to post an empty post, Submitty makes a network request to the server which rejects the post due to the lack of text.

Fixes #8696

### What is the new behavior?

Textareas are required so some text has to be in them. This means that checking the post is not empty is done client side and saves a full network request.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
