### PR TITLE
[Bugfix:Developer] Fix invalid YAML in dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,8 @@ updates:
     directory: "/site"
     schedule:
       interval: "weekly"
-        day: "monday"
-        time: "10:00"
+      day: "monday"
+      time: "10:00"
     open-pull-requests-limit: 15
     labels:
       - dependencies
@@ -29,18 +29,18 @@ updates:
     directory: "/.setup/pip/"
     schedule:
       interval: "weekly"
-        day: "monday"
-        time: "10:00"
+      day: "monday"
+      time: "10:00"
     open-pull-requests-limit: 15
     labels:
       - dependencies
     commit-message:
       prefix: "[Dependency] "
   - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-        interval: "weekly"
-          day: "monday"
-          time: "10:00"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
       open-pull-requests-limit: 15
 


### PR DESCRIPTION
### What is the current behavior?
https://github.com/Submitty/Submitty/pull/8788 mistakenly added invalid YAML to the `dependabot.yml` file, which has been causing intermittent errors on various PRs since https://github.com/Submitty/Submitty/pull/8788 was merged.  It is unclear why the tests on the PR did not pick up the failure.

### What is the new behavior?
`dependabot.yml` now passes [this](https://jsonformatter.org/yaml-validator) online validator, which is suggested by GitHub.  
