### PR TITLE
[Bugfix:Developer] Fix incorrect dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,5 +42,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "10:00"
-      open-pull-requests-limit: 15
-
+    open-pull-requests-limit: 15
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "[DevDependency] "


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `open-pull-requests-limit` key/value for the final block is incorrectly nested under `schedule`, and I'm seeing an error for some dependabot PRs due to it (e.g. https://github.com/Submitty/Submitty/pull/8839/checks?check_run_id=11226342389).

### What is the new behavior?

The `open-pull-requests-limit` has been moved to the appropriate level. I've also added the `labels` and `commit-message` block so that PRs opened for GH actions have the appropriate label and prefix.