### PR TITLE
[Feature:System] Vagrant libvirt + remodel box selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ composer.phar
 Pipfile
 Pipfile.lock
 .phpunit.result.cache
+
+.env

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,7 +149,8 @@ Vagrant.configure(2) do |config|
   config.vm.provider "parallels" do |prl, override|
     # Default box for parallels on arm64
     unless ENV.has_key?('VAGRANT_BOX')
-      if (`uname -m`.chomp == 'arm64' || `uname -m`.chomp == 'aarch64')
+      arch = `uname -m`.chomp
+      if (arch == 'arm64' || arch == 'aarch64')
         override.vm.box = "bento/ubuntu-20.04-arm64"
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,13 @@
 #   WORKER_PAIR=1 vagrant up
 #
 #
+# If you want to override the default image used for the virtual machines, you can set the
+# environment variable VAGRANT_BOX. See https://vagrantup.com/boxes/search for a list of
+# distributed boxes. For example:
+#
+# VAGRANT_BOX=ubuntu/focal64 vagrant up
+#
+#
 # If you want to install extra packages (such as rpi or matlab), you need to have the environment
 # variable EXTRA set. The easiest way to do this is doing:
 #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,6 +160,15 @@ Vagrant.configure(2) do |config|
     mount_folders(override, [])
   end
 
+  config.vm.provider "libvirt" do |libvirt, override|
+      libvirt.memory = 2048
+      libvirt.cpus = 2
+
+      libvirt.forward_ssh_port = true
+
+      mount_folders(override, [])
+  end
+
   config.vm.provision :shell, :inline => " sudo timedatectl set-timezone America/New_York", run: "once"
 
   if ARGV.include?('ssh')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,6 +71,11 @@ def mount_folders(config, mount_options)
 end
 
 Vagrant.configure(2) do |config|
+  # Optional plugin for reading from env file
+  if Vagrant.has_plugin?('vagrant-env')
+    config.env.enable
+  end
+
   # Default box
   config.vm.box = "bento/ubuntu-20.04"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,10 +54,10 @@ SCRIPT
 
 base_boxes = Hash[]
 
-# Should all be base Ubuntu 20.04 boxes
+# Should all be base Ubuntu boxes that use the same version
 base_boxes.default         = "bento/ubuntu-20.04"
 base_boxes[:arm_parallels] = "bento/ubuntu-20.04-arm64"
-base_boxes[:libvirt]       = "generic/2004"
+base_boxes[:libvirt]       = "generic/ubuntu2004"
 
 def mount_folders(config, mount_options)
   # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
@@ -83,13 +83,7 @@ Vagrant.configure(2) do |config|
     config.env.enable
   end
 
-  # Default box
-  config.vm.box = base_boxes.default
-
-  # Custom box
-  if ENV.has_key?('VAGRANT_BOX')
-    config.vm.box = ENV['VAGRANT_BOX']
-  end
+  config.vm.box = ENV.fetch('VAGRANT_BOX', base_boxes.default)
 
   mount_options = []
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,7 +78,6 @@ def mount_folders(config, mount_options)
 end
 
 Vagrant.configure(2) do |config|
-  # Optional plugin for reading from env file
   if Vagrant.has_plugin?('vagrant-env')
     config.env.enable
   end
@@ -153,7 +152,6 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "parallels" do |prl, override|
-    # Default box for parallels on arm64
     unless ENV.has_key?('VAGRANT_BOX')
       arch = `uname -m`.chomp
       if (arch == 'arm64' || arch == 'aarch64')
@@ -175,7 +173,6 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
-      # Default box with libvirt support
       unless ENV.has_key?('VAGRANT_BOX')
         override.vm.box = base_boxes[:libvirt]
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,13 @@ VERSION=$(lsb_release -sr | tr '[:upper:]' '[:lower:]')
 bash ${GIT_PATH}/.setup/install_worker.sh #{extra_command} 2>&1 | tee ${GIT_PATH}/.vagrant/install_worker.log
 SCRIPT
 
+base_boxes = Hash[]
+
+# Should all be base Ubuntu 20.04 boxes
+base_boxes.default         = "bento/ubuntu-20.04"
+base_boxes[:arm_parallels] = "bento/ubuntu-20.04-arm64"
+base_boxes[:libvirt]       = "generic/2004"
+
 def mount_folders(config, mount_options)
   # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
   # till post-provision (and this is mounted before provisioning), we want the group to be 'vagrant'
@@ -77,7 +84,7 @@ Vagrant.configure(2) do |config|
   end
 
   # Default box
-  config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box = base_boxes.default
 
   # Custom box
   if ENV.has_key?('VAGRANT_BOX')
@@ -156,7 +163,7 @@ Vagrant.configure(2) do |config|
     unless ENV.has_key?('VAGRANT_BOX')
       arch = `uname -m`.chomp
       if (arch == 'arm64' || arch == 'aarch64')
-        override.vm.box = "bento/ubuntu-20.04-arm64"
+        override.vm.box = base_boxes[:arm_parallels]
       end
     end
 
@@ -176,7 +183,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "libvirt" do |libvirt, override|
       # Default box with libvirt support
       unless ENV.has_key?('VAGRANT_BOX')
-        override.vm.box = "generic/ubuntu2004"
+        override.vm.box = base_boxes[:libvirt]
       end
 
       libvirt.memory = 2048


### PR DESCRIPTION
Currently, the Vagrant file is set to override boxes based on virtual machine. This is redundant because both virtual machines used for Submitty are configured to use the same box.

Also, a global variable is used to indicate running on an M1 Mac, which appends the string '-arm64' to the box name. This is not a universal naming convention and only works with the current `bento/ubuntu-20.04` box which has a `bento/ubuntu-20.04-arm64` counterpart that serves as an alternative box for parallels desktop on arm64.

There is also no existing way to override the default box specified in the Vagrant file without manually updating the file itself. This makes for a poor development experience as changes made to the box name in the Vagrant file cannot be committed without affecting other users as the Vagrant file is tracked by git.

---
**Changes**
* Added configuration for the libvirt provider to the Vagrantfile
* Remodeled box selection in the Vagrantfile to be more robust and allow for encapsulated provider-specific overrides, which are much more useful than the current vm-specific overrides
* Added support for the environment variable `VAGRANT_BOX` to override the default box used in the Vagrant file
* Added support for the `vagrant-env` plugin which allows reading from a `.env` file (also added to gitignore)