### PR TITLE
Adds code to auto open attachments

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -109,6 +109,16 @@
 
         <div id="{{ post_attachment.params.well_id }}" class="attachment-well well well-lg"></div>
 
+        {# Checks whether the page is on TA grading or the Discussion forum and opens attachments based off that#}
+        <script>
+            function openAttachments() {
+                if ( window.location.pathname == '/courses/s23/hashtag8471/gradeable/hw01/grading/grade') {
+                    document.getElementById("{{ post_attachment.params.button_id }}").click();
+                }
+            }
+            window.onload=openAttachments();
+        </script>
+
     {% endif %}
 
     {% set offset = offset + 30 %}


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Looks to fix issue #8818, currently attachments don't open automatically in the TA discussion forum panel.

### What is the new behavior?
The attachments now open automatically in the TA discussion forum panel.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I logged in as an instructor, made a thread on the discussion forum and created a homework. I linked the homework to the discussion forum thread and then went into TA grading to check whether the attachments were opening or not.