### PR TITLE
[UI/UX:InstructorUI] arrowkey navigation fixed

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -872,6 +872,20 @@ function setupSimpleGrading(action) {
         registerKeyHandler({ name: 'Cycle Row Value', code: 'KeyF', options: {score: null} }, keySetCurrentRow);
     }
 
+    // make sure to show focused cell when covered by student info
+    $('.scrollable-table td[class^="option-"] > .cell-grade').on('focus', function() {
+        const lastInfoBox = $(this).parent().parent().children('td:not([class^="option-"])').last();
+        const boxRect = lastInfoBox[0].getBoundingClientRect();
+        const inputRect = $(this).parent()[0].getBoundingClientRect();
+
+        const diff = boxRect.right - inputRect.left;
+        if (diff < 0) {
+            return;
+        }
+
+        $('.scrollable-table')[0].scrollLeft -= diff;
+    });
+
     // when pressing enter in the search bar, go to the corresponding element
     $('#student-search-input').on('keyup', function(event) {
         if (event.code === 'Enter') { // Enter


### PR DESCRIPTION
fixes #8852 
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When using arrow keys to navigate through the input boxes on the grading page, there will be a display error.
if press the right arrow key all the way to the right, then press the left arrow key to navigate back will cause a display error.
![image](https://user-images.githubusercontent.com/114595115/219805251-da2122f2-f666-4b14-b37b-31b3620bd2aa.png)
student information will block some of the input boxes.
### What is the new behavior?
If using arrow key navigation & reaches the first element in the table, the table will scroll to right, exposes the part that was been blocked
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
To test
Steps to test the behavior:

1. Open grading on a numeric/text input gradeable (which has enough columns to horizontally overflow the screen)

2. Select one of the boxes and use the arrow keys to navigate all the way to the right

3. Attempt to use the arrow keys to navigate all the way to the left
