### PR TITLE
Links (anchor tag) replaced by buttons (button tag) for non-navigation buttons 

### DIFF
--- a/site/app/templates/admin/users/StudentList.twig
+++ b/site/app/templates/admin/users/StudentList.twig
@@ -56,7 +56,7 @@
                                 <form method="post" action="{{ view_grades_url }}">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
                                     <input type="hidden" name="student_id" value="{{ student.getId() }}"/>
-                                    <a onclick="$(this).parent().submit();"><i class="fas fa-chart-line"></i></a>
+                                    <button onclick="$(this).parent().submit();"><i class="fas fa-chart-line"></i></button>
                                 </form>
                             </td>
                             <td>{{ student.getRegistrationType() }}</td>

--- a/site/app/templates/autograding/Attachments.twig
+++ b/site/app/templates/autograding/Attachments.twig
@@ -5,9 +5,9 @@
             <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
             {{ file.name }}</a> &nbsp;
         <a id = 'open_file_{{ file.name|url_encode }}' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
-        <a onclick='downloadFile("{{ file.path|url_encode }}", "attachments")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
+        <button onclick='downloadFile("{{ file.path|url_encode }}", "attachments")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></button>
         {% if can_modify %}
-        <a onclick='deleteAttachment(this, "{{ file.name|url_encode }}")' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></a>
+        <button onclick='deleteAttachment(this, "{{ file.name|url_encode }}")' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></button>
         {% endif %}
     </div>
     <div id="file_viewer_{{ id }}" data-file_name="{{ file.name }}" data-file_url="{{ file.path }}"></div>

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -8,14 +8,14 @@
 
     <div class="action-buttons" style="float: right; margin-bottom: 20px;">
         {# button to open all of the subfolders and cookie it#}            
-        <a onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary key_to_click" tabindex="0">Open/Close All Folders</a>
+        <button onclick='setCookie("foldersOpen",openAllDivForCourseMaterials());' class="btn btn-primary key_to_click" tabindex="0">Open/Close All Folders</button>
         {% if user_group == 1 %}
             {# button to set the release dates of all files in the page/course materials #}
             <a
                     onclick='openSetAllRelease()'
                     class="btn btn-primary key_to_click {% if not materials_exist %}disabled{% endif %}"
                     tabindex="0">Set All Release Dates</a>
-            <a onclick="newUploadCourseMaterialsForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Course Materials</a>
+            <button onclick="newUploadCourseMaterialsForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Course Materials</button>
         {% endif %}
     </div>
     <h1>Course Materials</h1>
@@ -163,11 +163,11 @@
                     <span  class="fas fa-folder open-all-folder" style="vertical-align: text-top; font-size: 20px"></span>
                     {{ name }}
                 </a>
-                <a onclick="downloadCourseMaterialZip('{{ folder_ids[folder_path] }}')" aria-label="Download the folder: {{ name }}" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the folder"></i></a>
+                <button onclick="downloadCourseMaterialZip('{{ folder_ids[folder_path] }}')" aria-label="Download the folder: {{ name }}" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the folder"></i></button>
                 {% if user_group == 1 %}
                     <a class="key_to_click" tabindex="0" onclick='newEditCourseMaterialsFolderForm(this)' data-id="{{ folder_ids[folder_path] }}" data-priority="{{ directory_priorities[folder_path] }}"> <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
                     <a class="key_to_click" tabindex="0" onclick='newDeleteCourseMaterialForm("{{ folder_ids[folder_path]  }}", "{{ name }}");'> <i class="fas fa-trash" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i></a>
-                    <a onclick='setFolderRelease("{{ folder_path }}","","{{ id }}","{{ folder_ids[folder_path] }}")' class="btn btn-primary key_to_click" tabindex="0">Set Folder Release Date</a>
+                    <button onclick='setFolderRelease("{{ folder_path }}","","{{ id }}","{{ folder_ids[folder_path] }}")' class="btn btn-primary key_to_click" tabindex="0">Set Folder Release Date</button>
                 {% endif %}
                 {% if not seen[folder_path] %}
                     <span class="badge course-material-badge" >NEW</span>

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -6,7 +6,7 @@
             {% elseif has_sections %}
                 <a class="btn btn-primary" tabindex="0" href="{{ student_photos_url ~ '?view=all' }}">View All Sections</a>
             {% endif %}
-            <a onclick="newUploadImagesForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Student Photos</a>
+            <button onclick="newUploadImagesForm()" class="btn btn-primary key_to_click" tabindex="0">Upload Student Photos</button>
         </div>
     {% endif %}
     <h1>Student Photos</h1>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -547,7 +547,7 @@
 {% macro render_column_team_edit(context, section, graded_gradeable, index, team_edit_onclick, column, edited_past_lock_date) %}
     <td>
         <div>
-            <a onclick="{{ team_edit_onclick }}" title="Edit Team" aria-label="Edit Team" class="key_to_click" tabindex="0"><i class="fas fa-pencil-alt"></i></a>
+            <button onclick="{{ team_edit_onclick }}" title="Edit Team" aria-label="Edit Team" class="key_to_click" tabindex="0"><i class="fas fa-pencil-alt"></i></button>
             {% if edited_past_lock_date %}
                 <div style="display:inline-block;" title="Edited Past Lock Date" aria-label="Edited Past Lock Date"><i class="fas fa-exclamation red-message"></i></div>
             {% endif %}

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -77,8 +77,8 @@
                 <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
                 {{ dir }}</a> &nbsp;
             <a id = 'open_file_{{ dir|url_encode }}' onclick='popOutSubmittedFile("{{ dir|url_encode }}", "{{ path|url_encode }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
-            <a onclick='viewFileFullPanel("{{ dir|url_encode|e('js') }}", "{{ path|url_encode|e('js') }}")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></a>
-            <a onclick='downloadFile("{{ path|url_encode }}", "{{ title }}")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
+            <button onclick='viewFileFullPanel("{{ dir|url_encode|e('js') }}", "{{ path|url_encode|e('js') }}")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></button>
+            <button onclick='downloadFile("{{ path|url_encode }}", "{{ title }}")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></button>
         </div>
         <div id="file_viewer_{{ id }}" style="margin-left:{{ indent * -15 }}px" data-file_name="{{ dir }}" data-file_url="{{ path }}"></div>
     </div>

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -242,9 +242,9 @@
                                         {{ file.name }}</a> &nbsp;
                                     <a id = 'open_file_{{ file.name|url_encode }}' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
                                     {% if is_grader_view %}
-                                    <a onclick='viewFileFullPanel("{{ file.name|url_encode|e('js') }}", "{{ file.path|url_encode|e('js') }}", 0, "notebook")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></a>
+                                    <button onclick='viewFileFullPanel("{{ file.name|url_encode|e('js') }}", "{{ file.path|url_encode|e('js') }}", 0, "notebook")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></button>
                                     {% endif %}
-                                    <a onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
+                                    <button onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></button>
                                 </div>
                                 <div id="file_viewer_{{ id }}" data-file_name="{{ file.name }}" data-file_url="{{ file.path }}"></div>
                             </div>

--- a/site/app/templates/plagiarism/DeletePlagiarismResultsAndConfig.twig
+++ b/site/app/templates/plagiarism/DeletePlagiarismResultsAndConfig.twig
@@ -11,7 +11,7 @@
                     Are you sure you wish to delete Plagiarism Results for "<div style="display: inline;" name="gradeable_title"></div>"?
                     <div class="form-buttons">
                         <div class="form-button-container">
-                            <a onclick="$('#delete-plagiarism-result-and-config-form').css('display', 'none');" class="btn btn-default">Cancel</a>
+                            <button onclick="$('#delete-plagiarism-result-and-config-form').css('display', 'none');" class="btn btn-default">Cancel</button>
                             <input id="submit-form" class="btn btn-danger" type="submit" value="Delete" />
                         </div>
                     </div>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1165,7 +1165,7 @@ function refreshOnResponseOverriddenGrades(json) {
     }
     else {
         json['data']['users'].forEach(function(elem){
-            let delete_button = "<a onclick=\"deleteOverriddenGrades('" + elem['user_id'] + "', '" + json['data']['gradeable_id'] + "');\"><i class='fas fa-trash'></i></a>"
+            let delete_button = "<button onclick=\"deleteOverriddenGrades('" + elem['user_id'] + "', '" + json['data']['gradeable_id'] + "');\"><i class='fas fa-trash'></i></button>"
             let bits = ['<tr><td class="align-left">' + elem['user_id'], elem['user_givenname'], elem['user_familyname'], elem['marks'], elem['comment'], delete_button + '</td></tr>'];
             $('#grade-override-table').append(bits.join('</td><td class="align-left">'));
         });

--- a/site/public/templates/grading/Attachments.twig
+++ b/site/public/templates/grading/Attachments.twig
@@ -5,9 +5,9 @@
             <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
             {{ file.name }}</a> &nbsp;
         <a id = 'open_file_{{ file.name|url_encode }}' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
-        <a onclick='downloadFile("{{ file.path|url_encode }}", "attachments")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
+        <button onclick='downloadFile("{{ file.path|url_encode }}", "attachments")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></button>
         {% if can_modify %}
-        <a onclick='deleteAttachment(this, "{{ file.name|url_encode }}")' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></a>
+        <button onclick='deleteAttachment(this, "{{ file.name|url_encode }}")' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></button>
         {% endif %}
     </div>
     <div id="file_viewer_{{ id }}" data-file_name="{{ file.name }}" data-file_url="{{ file.path }}"></div>


### PR DESCRIPTION
Pull request for Issue#7819

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
A number of places throughout Submitty use anchor tags and are stylized as buttons but do not perform navigation and instead rely on an onclick event. This can confuse screen readers which might interpret the element as a link.

### What is the new behavior?
The button tag is now used for elements that do an action without changing the page. The button tag also automatically fires onclick when a key is pressed on the keyboard, eliminating the need for the key to click class to be used everywhere.

### Other Information
-The original issue has some articles listed for the support of the above statements.
-The PR#7863 had no progress since Oct 30, 2022 and had some problems unfixed.
-Thank you @immortalcodes for mentioning the specific lines of code that contained the bugs.
