### PR TITLE
[SECURITY][Bugfix:Autograding] Prevent autograder from copying links

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -717,6 +717,8 @@ def pattern_copy(what, patterns, source, target, tmp_logs):
         print(what, " pattern copy ", patterns, " from ", source, " -> ", target, file=f)
         for pattern in patterns:
             for my_file in glob.glob(os.path.join(source, pattern), recursive=True):
+                if (os.path.islink(my_file)):
+                    continue
                 if (os.path.isfile(my_file)):
                     # grab the matched name
                     relpath = os.path.relpath(my_file, source)


### PR DESCRIPTION
### What is the current behavior?
If a symlink exists in the autograding directory, it will try to copy it when moving files around.

### What is the new behavior?
When copying files, symlinks will be ignored and left behind.

### Other information?
Autograding still works as expected with this change.
