### PR TITLE
[Bugfix:Forum] "New" Color on Old Forum Threads

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -743,7 +743,6 @@ class ForumThreadView extends AbstractView {
                     $thread_id_p = $thread["id"];
                 }
             }
-
             $isNewThread = !$this->core->getQueries()->viewedThread($current_user, $thread["id"]) && $current_user != $thread['created_by'];
             if ($isNewThread) {
                 $class .= " new_thread";

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -743,7 +743,7 @@ class ForumThreadView extends AbstractView {
                     $thread_id_p = $thread["id"];
                 }
             }
-            if (!$this->core->getQueries()->viewedThread($current_user, $thread["id"]) && $current_user != $thread['created_by']) {
+            if (!$this->core->getQueries()->viewedThread($current_user, $thread["id"])) {
                 $class .= " new_thread";
             }
             if ($thread["deleted"]) {

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -743,7 +743,7 @@ class ForumThreadView extends AbstractView {
                     $thread_id_p = $thread["id"];
                 }
             }
-            $isNewThread = !$this->core->getQueries()->viewedThread($current_user, $thread["id"]) && $current_user != $thread['created_by'];
+            $isNewThread = !$this->core->getQueries()->viewedThread($current_user, $thread["id"]);
             if ($isNewThread) {
                 $class .= " new_thread";
             }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #8990. Originally if new posts were added to a thread, the creator of that thread would see the thread color as being white instead of blue.
<img width="960" alt="2023-03-07" src="https://user-images.githubusercontent.com/117249183/223510786-939488f4-2a7a-42ef-a9bc-59a7c65071a4.png">


### What is the new behavior?
Now, for new posts that were added to a thread, the creator of that thread would see the thread color as being blue.
<img width="960" alt="2023-03-07 (1)" src="https://user-images.githubusercontent.com/117249183/223510867-992bb8d7-c33d-47e9-bcf2-70ff10f8e620.png">


### Other information?
For an example to see how the change works. If an instructor makes a thread about "Homework Three" and students start to add new posts about this thread that the instructor has seen yet, "Homework Three" would originally be white but is now blue.
