### PR TITLE
[Bugfix:Autograding] graphics schema for mouse motion

### DIFF
--- a/bin/json_schemas/complete_config_schema.json
+++ b/bin/json_schemas/complete_config_schema.json
@@ -915,22 +915,22 @@
                   "start_x" : {
                     "description" : "(Optional) An integer starting x position for the mouse in window coordinates. Values will be clamped to within the window’s size. Defaults to zero.",
                     "type" : "integer",
-                    "minimum" : 1
+                    "minimum" : 0
                   },
                   "start_y" : {
                     "description" : "(Optional) An integer starting y position for the mouse in window coordinates. Values will be clamped to within the window’s size. Defaults to zero.",
                     "type" : "integer",
-                    "minimum" : 1
+                    "minimum" : 0
                   },
                   "end_x" : {
                     "description" : "(Optional) An integer ending x position for the mouse in window coordinates. Values will be clamped to within the window’s size. Defaults to zero.",
                     "type" : "integer",
-                    "minimum" : 1
+                    "minimum" : 0
                   },
                   "end_y" : {
                     "description" : "(Optional) An integer ending y position for the mouse in window coordinates. Values will be clamped to within the window’s size. Defaults to zero.",
                     "type" : "integer",
-                    "minimum" : 1
+                    "minimum" : 0
                   },
                   "mouse_button" : {
                     "description" : "(Optional) left, middle, or right. The mouse button to be clicked. Defaults to left.",

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -758,9 +758,8 @@ void FormatGraphicsActions(nlohmann::json &testcases, nlohmann::json &whole_conf
         validate_integer(action, "end_y",   true,  0, 0);
 
         if(action["end_x"] == 0 && action["end_y"] == 0){
-          std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
+          std::cout << "WARNING: some movement expected in click and drag" << std::endl;
         }
-        assert(action["end_x"] != 0 || action["end_y"] != 0);
 
       }
       //Click and drag delta can have an optional mouse button, and must have and end_x and end_y.
@@ -772,10 +771,8 @@ void FormatGraphicsActions(nlohmann::json &testcases, nlohmann::json &whole_conf
         validate_integer(action, "end_y",   true,  -100000, 0);
 
         if(action["end_x"] == 0 && action["end_y"] == 0){
-          std::cout << "ERROR: some movement must be specified in click and drag" << std::endl;
+          std::cout << "WARNING: some movement expected in click and drag delta" << std::endl;
         }
-
-        assert(action["end_x"] != 0 || action["end_y"] != 0);
 
       }
       //Click has an optional mouse button.


### PR DESCRIPTION
### What is the new behavior?
The validation schema for the autograding config.json was incorrect for graphics action mouse motion.
