### PR TITLE
[SECURITY][Bugfix:RainbowGrades] Read API token instead of passing

### DIFF
--- a/sbin/auto_rainbow_grades.py
+++ b/sbin/auto_rainbow_grades.py
@@ -41,7 +41,6 @@ with open(config_file, 'r') as file:
     data = json.load(file)
     install_dir = data['submitty_install_dir']
     data_dir = data['submitty_data_dir']
-    host_name = data['submission_url']
 
 # Collect user information from configuration file
 users_config_file = os.path.join(install_dir, 'config', 'submitty_users.json')
@@ -182,9 +181,7 @@ else:
     cmd = [
         '{}/sbin/generate_grade_summaries.py'.format(install_dir),
         semester,
-        course,
-        host_name,
-        creds['token']
+        course
     ]
 
     # Call generate_grade_summaries.py script to generate grade summaries for the

--- a/sbin/generate_grade_summaries.py
+++ b/sbin/generate_grade_summaries.py
@@ -3,13 +3,41 @@
 Script to trigger the generate grade summaries.
 
 Usage:
-./generate_grade_summaries.py <semester> <course> <base_url> <token>
+./generate_grade_summaries.py <semester> <course>
 """
 
 import argparse
 import requests
+import os
+import json
 from sys import stderr
 
+# Get path to current file directory
+current_dir = os.path.dirname(__file__)
+
+# Collect submission url
+submitty_json_config = os.path.join(current_dir, '..', 'config', 'submitty.json')
+
+if not os.path.exists(submitty_json_config):
+    raise Exception('Unable to locate submitty.json configuration file')
+
+with open(submitty_json_config, 'r') as file:
+    data = json.load(file)
+    base_url = data['submission_url'].rstrip('/')
+    install_dir = data['submitty_install_dir']
+
+# Collect submitty admin token
+submitty_creds_file = os.path.join(install_dir, 'config', 'submitty_admin.json')
+
+if not os.path.exists(submitty_creds_file):
+    raise Exception('Unable to locate submitty_admin.json credentials file')
+
+# Load credentials out of admin file
+with open(submitty_creds_file, 'r') as file:
+    creds = json.load(file)
+
+if 'token' not in creds or not creds['token']:
+    raise Exception('Unable to read credentials from submitty_admin.json')
 
 def main():
     """Automatically call Generate Grade Summaries API."""
@@ -18,14 +46,11 @@ def main():
     )
     parser.add_argument('semester')
     parser.add_argument('course')
-    parser.add_argument('base_url')
-    parser.add_argument('token')
     args = parser.parse_args()
 
     semester = args.semester
     course = args.course
-    base_url = args.base_url.rstrip('/')
-    token = args.token
+    token = creds['token']
 
     try:
         grade_generation_response = requests.post(

--- a/sbin/generate_grade_summaries.py
+++ b/sbin/generate_grade_summaries.py
@@ -39,6 +39,7 @@ with open(submitty_creds_file, 'r') as file:
 if 'token' not in creds or not creds['token']:
     raise Exception('Unable to read credentials from submitty_admin.json')
 
+
 def main():
     """Automatically call Generate Grade Summaries API."""
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
### What is the current behavior?
Currently the submitty admin API token is passed from `auto_rainbow_grades.py` to `generate_grade_summaries.py` by arguments.

### What is the new behavior?
The submitty admin API token is read directly in `generate_grade_summaries.py`.

### Other information?
Tested locally and rainbow grades still builds when calling the `auto_rainbow_grades.py` script manually.
