### PR TITLE
[SYSADMIN ACTION][Bugfix:System] Add B flag to rewrite rule

### DIFF
--- a/.setup/apache/submitty.conf
+++ b/.setup/apache/submitty.conf
@@ -40,7 +40,7 @@
         Require all granted
 
         RewriteEngine On
-        
+
         # Routing Flexibility: Removes the trailing slash if it is supplied
         # Example: /courses/f21/csci1200/ -> /courses/f21/csci1200
         RewriteCond %{REQUEST_FILENAME} !-d
@@ -63,8 +63,8 @@
         # is valid and usable. In anycase, we rewrite everything up-to /index.php
         # to be the "url" parameter of the query, and then append whatever else we
         # had in the QUERY_STRING after it.
-        RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
-        RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
+        RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [B,NC,END]
+        RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [B,NC,END]
 
         # Allow Authorization header to pass which is used for passing the token
         # for API requests

--- a/.setup/apache/submitty.conf
+++ b/.setup/apache/submitty.conf
@@ -40,7 +40,7 @@
         Require all granted
 
         RewriteEngine On
-
+        
         # Routing Flexibility: Removes the trailing slash if it is supplied
         # Example: /courses/f21/csci1200/ -> /courses/f21/csci1200
         RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
### What is the current behavior?
We used rewrite rules without re-encoding special characters like spaces which when passed to PHP FPM, caused 403 errors.

### What is the new behavior?
Rewrite rules now re-encode special characters using the B flag.

### Other information?
This became necessary after a security patch update for Apache.

See https://submitty.org/sysadmin/installation/version_notes/v23.03.01
