### PR TITLE
[Bugfix:Submission] Fixes gradeable relocking

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1133,7 +1133,7 @@ class AdminGradeableController extends AbstractController {
                             $gradeable->setDependsOnPoints(0);
                         }
                         else {
-                            if ($depends_on_points < 0 || ($depends_on_points > $temp_gradeable->getDependsOnPoints() && $temp_gradeable->getDependsOnPoints() != null)) {
+                            if ($depends_on_points < 0 || ($depends_on_points > $temp_gradeable->getDependsOnPoints() && $temp_gradeable->getDependsOnPoints() !== null)) {
                                 $errors['depends_on_points'] = "Invalid depends on points!";
                             }
                         }

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1133,7 +1133,7 @@ class AdminGradeableController extends AbstractController {
                             $gradeable->setDependsOnPoints(0);
                         }
                         else {
-                            if ($depends_on_points < 0 || $depends_on_points > $temp_gradeable->getDependsOnPoints()) {
+                            if ($depends_on_points < 0 || ($depends_on_points > $temp_gradeable->getDependsOnPoints() && $temp_gradeable->getDependsOnPoints() != null)) {
                                 $errors['depends_on_points'] = "Invalid depends on points!";
                             }
                         }

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -223,7 +223,7 @@ $(document).ready(function () {
             }
             data[val.name] = $(val).val();
         };
-        if (data['depends_on'] != null){
+        if (data['depends_on'] != null) {
             data['depends_on_points'] = points;
         }
         else if (data['depends_on_points'] != null) {

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -226,7 +226,7 @@ $(document).ready(function () {
         if (data['depends_on'] !== null) {
             data['depends_on_points'] == points;
         }
-        else if (data['depends_on_points'] != null) {
+        else if (data['depends_on_points'] !== null) {
             data['depends_on'] = gradeable;
         }
 

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -223,8 +223,8 @@ $(document).ready(function () {
             }
             data[val.name] = $(val).val();
         };
-        if (data['depends_on'] != null) {
-            data['depends_on_points'] = points;
+        if (data['depends_on'] !== null) {
+            data['depends_on_points'] == points;
         }
         else if (data['depends_on_points'] != null) {
             data['depends_on'] = gradeable;

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -224,7 +224,7 @@ $(document).ready(function () {
             data[val.name] = $(val).val();
         };
         if (data['depends_on'] !== null) {
-            data['depends_on_points'] == points;
+            data['depends_on_points'] = points;
         }
         else if (data['depends_on_points'] !== null) {
             data['depends_on'] = gradeable;

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -223,6 +223,12 @@ $(document).ready(function () {
             }
             data[val.name] = $(val).val();
         };
+        if (data['depends_on'] != null){
+            data['depends_on_points'] = points;
+        }
+        else if (data['depends_on_points'] != null) {
+            data['depends_on'] = gradeable;
+        }
 
         // If its date-related, then submit all date data
         if ($('#gradeable-dates').find('input[name="' + this.name + '"]:enabled').length > 0


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #9037 The gradeable was not being re locked. it was though to be only limited to that but since the page change only sended depend_on or depend_on_points at a time the locking function wasn't working. 

### What is the new behavior?
Both the data values are send at the same time and the depend_on_point also get checked for null value in the controller.
Below is a gif of the implementation working

![RelockingFixed](https://user-images.githubusercontent.com/34577232/225397713-4d23adac-f866-47e7-8090-5df268e5700d.gif)
