### PR TITLE
[UI/UX:SubminiPolls] Enlarge Correct Answer Icon in Polls

### DIFF
--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -64,7 +64,7 @@
                                 "style": "display: inline"
                             } only %}
                             {% if option.isCorrect() and poll.isReleaseAnswer()%}
-                                <i class="fa-solid fa-square-check correct-tag"></i>
+                                <i class="fa-solid fa-square-check fa-lg correct-tag"></i>
                             {% endif %}
                             <br/>
                             <br/>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
![image](https://user-images.githubusercontent.com/123511202/226467929-df607350-68f4-42a6-86d1-b782e1898441.png)



### What is the new behavior?
**Increased the fa checkmark icon that appears when an option in poll marked correct by 33% without disrupting spacing.**
![image](https://user-images.githubusercontent.com/123511202/226467968-465a6e7c-3225-4566-b7d0-0dfb9e94fe8b.png)



### Other information?
