### PR TITLE
[Bugfix:System] Turn on HTTP only for cookies

### DIFF
--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -105,16 +105,17 @@ class Utils {
      * @param string        $name name of the cookie
      * @param string|array  $data data of the cookie, if array, will json_encode it
      * @param int           $expire when should the cookie expire
+     * @param bool          $http_only toggle the http only flag on the cookie
      *
      * @return bool true if successfully able to set the cookie, else false
      */
-    public static function setCookie(string $name, $data, int $expire = 0): bool {
+    public static function setCookie(string $name, $data, int $expire = 0, bool $http_only = true): bool {
         if (is_array($data)) {
             $data = json_encode($data);
         }
         $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && $_SERVER['HTTPS'] !== 'off';
         $_COOKIE[$name] = $data;
-        return setcookie($name, $data, $expire, "/", "", $secure);
+        return setcookie($name, $data, $expire, "/", "", $secure, $http_only);
     }
 
     /**


### PR DESCRIPTION
### What is the current behavior?
The HTTP only flag is not set for cookies such as `submitty_session`.

### What is the new behavior?
All cookies that use the `Utils::setCookie` function will now default to being HTTP only. This flag will tell browsers to not allow the cookie to be readable by JavaScript. All other cookies not set by this function should not be effected.

### Other information?
A quick local testing worked fine but I want to see how the tests perform. All current cookies will not be set to HTTP Only automatically, but within a week all `submitty_session` cookies will get set again with this new flag.
