### PR TITLE
[UI/UX:InstructorUI] Clarify poll edit confirmation

### DIFF
--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -163,7 +163,7 @@
         <span id="empty-response-error" class="red-message polls-submit-error" hidden>Please make sure all responses are filled in.<br/></span>
         <span id="file-size-error" class="red-message polls-submit-error" hidden>Please make sure to upload a file that does not exceed the maximum size.<br/></span>
         <a href="{{base_url}}" class="btn btn-danger">Cancel</a>
-        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : : 'Save' }} Poll </button>
+        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save' }} Poll </button>
     </form>
 </div>
 

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -163,7 +163,7 @@
         <span id="empty-response-error" class="red-message polls-submit-error" hidden>Please make sure all responses are filled in.<br/></span>
         <span id="file-size-error" class="red-message polls-submit-error" hidden>Please make sure to upload a file that does not exceed the maximum size.<br/></span>
         <a href="{{base_url}}" class="btn btn-danger">Cancel</a>
-        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save Changes' }} </button>
+        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save Poll' }} </button>
     </form>
 </div>
 

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -163,7 +163,7 @@
         <span id="empty-response-error" class="red-message polls-submit-error" hidden>Please make sure all responses are filled in.<br/></span>
         <span id="file-size-error" class="red-message polls-submit-error" hidden>Please make sure to upload a file that does not exceed the maximum size.<br/></span>
         <a href="{{base_url}}" class="btn btn-danger">Cancel</a>
-        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Edit' }} Poll</button>
+        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save changes' }} </button>
     </form>
 </div>
 

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -163,7 +163,7 @@
         <span id="empty-response-error" class="red-message polls-submit-error" hidden>Please make sure all responses are filled in.<br/></span>
         <span id="file-size-error" class="red-message polls-submit-error" hidden>Please make sure to upload a file that does not exceed the maximum size.<br/></span>
         <a href="{{base_url}}" class="btn btn-danger">Cancel</a>
-        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save' }} Poll </button>
+        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save' }} Poll</button>
     </form>
 </div>
 

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -163,7 +163,7 @@
         <span id="empty-response-error" class="red-message polls-submit-error" hidden>Please make sure all responses are filled in.<br/></span>
         <span id="file-size-error" class="red-message polls-submit-error" hidden>Please make sure to upload a file that does not exceed the maximum size.<br/></span>
         <a href="{{base_url}}" class="btn btn-danger">Cancel</a>
-        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save changes' }} </button>
+        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save Changes' }} </button>
     </form>
 </div>
 

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -163,7 +163,7 @@
         <span id="empty-response-error" class="red-message polls-submit-error" hidden>Please make sure all responses are filled in.<br/></span>
         <span id="file-size-error" class="red-message polls-submit-error" hidden>Please make sure to upload a file that does not exceed the maximum size.<br/></span>
         <a href="{{base_url}}" class="btn btn-danger">Cancel</a>
-        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : 'Save Poll' }} </button>
+        <button type="submit" id="poll-form-submit" class="btn btn-primary" {{ poll is null ? 'disabled' }}>{{ poll is null ? 'Add' : : 'Save' }} Poll </button>
     </form>
 </div>
 

--- a/site/cypress/e2e/polls.spec.js
+++ b/site/cypress/e2e/polls.spec.js
@@ -286,7 +286,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().click();
         cy.contains('Poll Cypress Test').siblings(':nth-child(1)').children().click();
         cy.url().should('include', 'sample/polls/editPoll');
-        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Edit Poll');
+        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Save Poll');
         cy.get('#student-histogram-release-setting').select('when_ended');
         cy.get('#student-histogram-release-setting').invoke('val').should('eq', 'when_ended');
         cy.get('#student-answer-release-setting').invoke('val').should('eq', 'never');

--- a/site/cypress/e2e/polls.spec.js
+++ b/site/cypress/e2e/polls.spec.js
@@ -286,7 +286,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().click();
         cy.contains('Poll Cypress Test').siblings(':nth-child(1)').children().click();
         cy.url().should('include', 'sample/polls/editPoll');
-        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Save Poll');
+        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Edit Poll');
         cy.get('#student-histogram-release-setting').select('when_ended');
         cy.get('#student-histogram-release-setting').invoke('val').should('eq', 'when_ended');
         cy.get('#student-answer-release-setting').invoke('val').should('eq', 'never');

--- a/site/cypress/e2e/polls.spec.js
+++ b/site/cypress/e2e/polls.spec.js
@@ -241,7 +241,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(1)').children().click();
         cy.url().should('include', 'sample/polls/editPoll');
-        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Save Poll');
+        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Edit Poll');
         cy.get('#poll-name').invoke('val').should('eq', 'Poll Cypress Test');
         cy.get('#poll-question').contains('Question goes here...?');
         cy.get('#poll-type-single-response-single-correct').should('not.be.checked');

--- a/site/cypress/e2e/polls.spec.js
+++ b/site/cypress/e2e/polls.spec.js
@@ -241,7 +241,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(1)').children().click();
         cy.url().should('include', 'sample/polls/editPoll');
-        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Edit Poll');
+        cy.get('#breadcrumbs > :nth-child(7) > span').should('have.text', 'Save Poll');
         cy.get('#poll-name').invoke('val').should('eq', 'Poll Cypress Test');
         cy.get('#poll-question').contains('Question goes here...?');
         cy.get('#poll-type-single-response-single-correct').should('not.be.checked');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
In the edit poll screen, edit is listed as the title as well as the button to save the changes, which can be misleading.

### What is the new behavior?
Change the confirmation button to save changes.

Fixes #9090
