### PR TITLE
[Bugfix:Plagiarism] Handle no user for matching user ID

### DIFF
--- a/site/app/controllers/admin/PlagiarismController.php
+++ b/site/app/controllers/admin/PlagiarismController.php
@@ -1625,7 +1625,7 @@ class PlagiarismController extends AbstractController {
         $return = [];
         foreach ($ranking as $item) {
             $display_name = "";
-            if (!$is_team_assignment) {
+            if (!$is_team_assignment && array_key_exists($item[0], $user_ids_and_names)) {
                 $display_name = "{$user_ids_and_names[$item[0]]->getDisplayedGivenName()} {$user_ids_and_names[$item[0]]->getDisplayedFamilyName()}";
             }
             $temp = [


### PR DESCRIPTION
### What is the current behavior?
If no user exists in the system, even though that userid has submissions being analyzed, the plagiarism results page will fail to load because it can't query the user's name.

### What is the new behavior?
If the specified user's name is not available, simply show the user ID, just like we do for team gradeables.
