### PR TITLE
[Bugfix:InstructorUI] Set confetti element display to `none` after finishing.

### DIFF
--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -163,23 +163,39 @@ function addConfetti() {
             return;
         }
 
-        update();
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        // Run each step of the animation for 9 seconds then hide the confetti.
+        let start = null;
+        function confettiStepAnimation(timestamp) {
+            if (!start) {
+                start = timestamp;
+            }
+            const progress = timestamp - start;
+            if (progress < 9000) {
+                update();
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        pieces.forEach((p) => {
-            ctx.save();
+                pieces.forEach((p) => {
+                    ctx.save();
 
-            ctx.fillStyle = p.color;
+                    ctx.fillStyle = p.color;
 
-            ctx.translate(p.x + p.size / 25, p.y + p.size / 2);
-            ctx.rotate(p.rotation);
+                    ctx.translate(p.x + p.size / 25, p.y + p.size / 2);
+                    ctx.rotate(p.rotation);
 
-            ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size);
+                    ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size);
 
-            ctx.restore();
-        });
+                    ctx.restore();
+                });
+                requestAnimationFrame(confettiStepAnimation);
+            }
+            else {
+                canvas.style.display = 'none';
+                cancelAnimationFrame(confettiStepAnimation);
+                is_drawing = false;
+            }
+        }
 
-        frame = requestAnimationFrame(draw);
+        frame = requestAnimationFrame(confettiStepAnimation);
     }
 
     function Piece (x, y) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The `display` property of the Confetti animation remained set to `block` after completion, forcing users to click twice - once to reset it to `none` and again to register the click. This fixes  #9091.

### What is the new behavior?
The `canvas` element which displays the confetti animation is now set to `none` after 9 seconds which is the time it takes for the animation to end.
### Other information?
I tested by opening the browser developer tools and seeing the property change back to `none` as soon as the animation ended and, my first click after animation ended would register correctly as well.
