### PR TITLE
[Bugfix:Autograding] stop confetti automatically

### DIFF
--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -33,14 +33,13 @@ function addConfetti() {
     canvas.width  = window.innerWidth;
     const body = document.body;
     const html = document.documentElement;
-    canvas.height = Math.max( body.scrollHeight, body.offsetHeight,
-        html.clientHeight, html.scrollHeight, html.offsetHeight );
+    canvas.height = document.body.clientHeight;
 
     canvas.style.display = 'block';
 
     const ctx = canvas.getContext('2d');
     const pieces = [];
-    const numberOfPieces = 2500;
+    const numberOfPieces = canvas.height;
     let lastUpdateTime = Date.now();
     const x_const = 0.25;
     const max_times = 250;
@@ -137,10 +136,10 @@ function addConfetti() {
         lastUpdateTime = now;
 
         times_ran ++;
-
-        if (times_ran >= max_times * 10) {
+        
+        if (pieces.length <= 0) {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
-            canvas.style.display = '';
+            canvas.style.display = 'none';
             canvas.width = 0;
             canvas.height = 0;
         }

--- a/site/public/js/confetti.js
+++ b/site/public/js/confetti.js
@@ -31,8 +31,6 @@ function addConfetti() {
     });
 
     canvas.width  = window.innerWidth;
-    const body = document.body;
-    const html = document.documentElement;
     canvas.height = document.body.clientHeight;
 
     canvas.style.display = 'block';
@@ -136,7 +134,7 @@ function addConfetti() {
         lastUpdateTime = now;
 
         times_ran ++;
-        
+
         if (pieces.length <= 0) {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             canvas.style.display = 'none';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Confetti animation will stop based on cumulative animation time, which, however, is cumulated based on the screen's resolution. In that case, checking the time to determine whether to stop is inaccurate. 

More than that, the canvas's height currently will be initialized as a whole web page's size instead of the visible part's size. 

### What is the new behavior?

Change the canvas's height to the visible area's height.

Stop animation based on the piece list. When a piece is out of the visible area, it will be removed from the list. In that case, when every piece is out of the screen and no more visible piece, stop the animation. 

Modified the number of pieces based on the screen size so that it will not be too crowded
