### PR TITLE
[Bugfix:TAGrading] Fix color key

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1403,6 +1403,7 @@ end of styles used in the admin gradeable page
     background: linear-gradient(to right, #ffcc33 50%, #33cc33 50%);
     background-clip: text;
     color: transparent;
+    border-radius: 50%;
 
     /* chrome & safari */
     -webkit-text-fill-color: transparent;


### PR DESCRIPTION
Fixes #9160 

The "limited access grader verified" item on the grading index page color key is round now.