### PR TITLE
[Bugfix:CourseMaterials] Course materials links open In new tab

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -61,7 +61,7 @@
             <div class="file-viewer">
                 {% if course_material.isLink %}
                     <i class="fas fa-link" style="vertical-align: text-bottom;"></i>
-                    <a href="{{ course_material.getUrl }}" onclick="markViewed([{{ course_material.getId }}])" onauxclick="markViewed([{{ course_material.getId }}])">{{ course_material.getUrlTitle }}</a>
+                        <a class="popout-item" target="_blank" href="{{ course_material.getUrl }}" onclick="markViewed([{{ course_material.getId }}])" onauxclick="markViewed([{{ course_material.getId }}])" aria-label="Pop up {{ course_material.getUrlTitle }} in a new window" tabindex="0" style="text-decoration: none;">{{ course_material.getUrlTitle }} <i class="fas fa-window-restore" title="Pop up the link in a new window"></i></a>
                 {% else %}
                     <i class="fas fa-file" style="vertical-align: text-bottom;"></i>
                     {% set extension = name|split('.')|last|lower %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
 Fixes #9175 

### What is the new behavior?
Links in Course Materials opens in a new tab now.
### Other information?

