### PR TITLE
[Bugfix:CourseMaterials] Open course material links new tab

### DIFF
--- a/site/app/templates/UserProfile.twig
+++ b/site/app/templates/UserProfile.twig
@@ -3,6 +3,10 @@
         My Profile
     </h1>
     <div class="user-info-wrapper">
+        <!-- Display pronoun visibility note -->
+        <p class="std-margin">
+        Note: The pronouns you specify will be visible to all members of the teaching staff.
+        </p>
         <div id="user-card-img">
             <div class="user-img-cont">
                 {% set image = user.getDisplayImage() %}

--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -61,7 +61,7 @@
             <div class="file-viewer">
                 {% if course_material.isLink %}
                     <i class="fas fa-link" style="vertical-align: text-bottom;"></i>
-                    <a href="{{ course_material.getUrl }}" onclick="markViewed([{{ course_material.getId }}])" onauxclick="markViewed([{{ course_material.getId }}])">{{ course_material.getUrlTitle }}</a>
+                    <a target="_blank" href="{{ course_material.getUrl }}" onclick="markViewed([{{ course_material.getId }}])" onauxclick="markViewed([{{ course_material.getId }}])">{{ course_material.getUrlTitle }}</a>
                 {% else %}
                     <i class="fas fa-file" style="vertical-align: text-bottom;"></i>
                     {% set extension = name|split('.')|last|lower %}

--- a/site/app/templates/grading/Images.twig
+++ b/site/app/templates/grading/Images.twig
@@ -33,6 +33,7 @@
                             <div class="name">
                                 <br /><br />{{student.getDisplayedGivenName()}} {{student.getDisplayedFamilyName()}}
                                 <br />{{student.getId()}}
+                                <br />{{student.getPronouns()}}
                                 {% if has_full_access %}
                                     {% if student.getDisplayImageState() == 'preferred' %}
                                         <a href="javascript:flagUserImage('{{ student.getId() }}', true)">{{ constant('app\\views\\grading\\ImagesView::FLAG_ICON_HTML') | raw  }}</a>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #9175 

### What is the new behavior?
Added ( target="_blank" ) to open links of course material in new tab.

### Other information?

