### PR TITLE
[Bugfix:CourseMaterials] Change image when Open/Close all folders

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -803,13 +803,19 @@ function openAllDivForCourseMaterials() {
     if (elem.hasClass('open')) {
         elem.hide();
         elem.removeClass('open');
-        $($($(elem.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-folder-open').addClass('fa-folder');
+        for (let i = 0; i < elem.length; i++) {
+          const ele_each = elem[i];
+          $($($($(ele_each).parent().children()[0]).children()[0]).children()[0]).removeClass('fa-folder-open').addClass('fa-folder');
+        }
         return 'closed';
     }
     else {
         elem.show();
         elem.addClass('open');
-        $($($(elem.parent().children()[0]).children()[0]).children()[0]).removeClass('fa-folder').addClass('fa-folder-open');
+        for (let i = 0; i < elem.length; i++) {
+          const ele_each = elem[i];
+          $($($($(ele_each).parent().children()[0]).children()[0]).children()[0]).removeClass('fa-folder').addClass('fa-folder-open');
+        }
         return 'open';
     }
     return false;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
According to [#issue9207](https://github.com/Submitty/Submitty/issues/9207), if a folder is opened and the close all folders button is clicked then the folder is closed but the image still shows an open folder image. 

### What is the new behavior?
A wrong jQuery selector causes the bug. By adding a for loop, every folder image would change after the user click the Open/Close All Folders button.
