### PR TITLE
[Testing:Developer] Remove Unused Config Parameter

### DIFF
--- a/autograder/tests/data/submitty_config.json
+++ b/autograder/tests/data/submitty_config.json
@@ -12,7 +12,6 @@
         "cgi_url": "https://submitty.test.com/cgi-bin",
         "websocket_port": 8443,
         "institution_name": "Test University",
-        "username_change_text": "Submitty welcomes individuals of all ages, backgrounds, citizenships, disabilities, sex, education, ethnicities, family statuses, genders, gender identities, geographical locations, languages, military experience, political views, races, religions, sexual orientations, socioeconomic statuses, and work experiences. In an effort to create an inclusive environment, you may specify a preferred name to be used instead of what was provided on the registration roster.",
         "institution_homepage": "https://test.com",
         "timezone": "America/Los_Angeles",
         "duck_special_effects": false,


### PR DESCRIPTION
This changes one of the test configs brought in by #8803 to remove a parameter made obsolete by #8921 

@shailpatels wrote this as a comment for whichever was merged first, to change this afterwards. 
https://github.com/Submitty/Submitty/pull/8803/files/e67fdfc56e927f713f0993c206c37c2f4351c8fe#r1155356109

This change doesn't break anything, and the tests don't have to be edited because it is removing a parameter that wasn't being used in the tests anyway, but it will keep the test configs consistent with the actual configs used. 

I am also unsure if there is a better type/module for this PR's title. 