### PR TITLE
[Bugfix:CourseMaterials] Fix Datepicker Scrolling

### DIFF
--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -46,7 +46,7 @@
             <span>
                 <strong>Choose a time to release the files being uploaded:</strong>
             </span>
-            <input id="edit-folder-picker" class="edit-folder-picker type="text" size="26" onchange="enableFullUpdate()" style="pointer-events:auto;" ><br>
+            <input id="edit-folder-picker" class="edit-folder-picker" type="text" size="26" onchange="enableFullUpdate()" style="pointer-events:auto;" ><br>
             <span><em>Note: Everyone with grading access will be able to view all the materials irrespective of the release date/time.</em></span>
         </label>
         <label>

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -42,11 +42,11 @@
         <p style="margin: 0px;">
             <em>Note: Gray colored sections (if any) represent that some (but not all) materials inside this folder are restricted to those sections.</em>
         </p>
-        <label>
+        <label style="pointer-events:none;">
             <span>
                 <strong>Choose a time to release the files being uploaded:</strong>
             </span>
-            <input id="edit-folder-picker" class="edit-folder-picker" type="text" size="26" onchange="enableFullUpdate()"><br>
+            <input id="edit-folder-picker" class="edit-folder-picker type="text" size="26" onchange="enableFullUpdate()" style="pointer-events:auto;" ><br>
             <span><em>Note: Everyone with grading access will be able to view all the materials irrespective of the release date/time.</em></span>
         </label>
         <label>
@@ -110,7 +110,7 @@
             submit.attr('disabled', true);
         }
 
-        flatpickr('.edit-folder-picker', {
+        let edit_folder_fp = flatpickr('.edit-folder-picker', {
             plugins: [ShortcutButtonsPlugin(
                     {
                         button: [
@@ -149,6 +149,8 @@
                         }
                     }
             )],
+            appendTo: document.getElementById('edit-course-materials-folder-form'),
+            position: "above right",
             allowInput: true,
             enableTime: true,
             enableSeconds: true,
@@ -159,6 +161,9 @@
                 fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');
             }
         });
+    $('.form-body').on('scroll', function() {
+        edit_folder_fp._positionCalendar();
+    });
     </script>
 {% endblock %}
 {% block buttons %}

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -30,11 +30,11 @@
                 }
             </script>
         </fieldset>
-        <label>
+        <label id="edit_dt" style="pointer-events:none;">
             <span>
                 <strong>Choose a time to release the files being uploaded:</strong>
             </span>
-            <input id="edit-picker" class="edit-picker" type="text" size="26"><br>
+            <input id="edit-picker" class="edit-picker" type="text" size="26" style="pointer-events:auto;"><br>
             <span><em>Note: Everyone with grading access will be able to view all the materials irrespective of the release date/time.</em></span>
         </label>
         <label>
@@ -93,7 +93,7 @@
                 handleEditCourseMaterials("{{ csrf_token }}", hideFromStudents, id, sectionsEdit, null, cmTime, sort, sections_lock, null, url_url_val, url_title_val);
         };
 
-        flatpickr('.edit-picker', {
+        let edit_fp = flatpickr('.edit-picker', {
             plugins: [ShortcutButtonsPlugin(
                 {
                     button: [
@@ -132,6 +132,7 @@
                     }
                 }
             )],
+            appendTo: document.getElementById('edit-course-materials-form'),
             allowInput: true,
             enableTime: true,
             enableSeconds: true,
@@ -142,6 +143,9 @@
               fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');
             }
         });
+    $('.form-body').on('scroll', function() {
+        edit_fp._positionCalendar();
+    });
     </script>
 {% endblock %}
 {% block buttons %}

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -93,7 +93,7 @@
                 handleEditCourseMaterials("{{ csrf_token }}", hideFromStudents, id, sectionsEdit, null, cmTime, sort, sections_lock, null, url_url_val, url_title_val);
         };
 
-        let edit_fp = flatpickr('.edit-picker', {
+        const edit_fp = flatpickr('.edit-picker', {
             plugins: [ShortcutButtonsPlugin(
                 {
                     button: [

--- a/site/app/templates/course/SetAllReleaseForm.twig
+++ b/site/app/templates/course/SetAllReleaseForm.twig
@@ -34,7 +34,7 @@
         }
 
 
-        let release_date_fp = flatpickr("#date_to_release_all", {
+        const release_date_fp = flatpickr("#date_to_release_all", {
             plugins: [ShortcutButtonsPlugin(
                     {
                         button: [

--- a/site/app/templates/course/SetAllReleaseForm.twig
+++ b/site/app/templates/course/SetAllReleaseForm.twig
@@ -34,7 +34,7 @@
         }
 
 
-        flatpickr("#date_to_release_all", {
+        let release_date_fp = flatpickr("#date_to_release_all", {
             plugins: [ShortcutButtonsPlugin(
                     {
                         button: [
@@ -72,6 +72,7 @@
                         }
                     }
             )],
+            appendTo: document.getElementById('set-all-release-form'),
             allowInput: true,
             enableTime: true,
             enableSeconds: true,
@@ -82,6 +83,9 @@
                 fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');
             }
         });
+    $('.form-body').on('scroll', function() {
+        release_date_fp._positionCalendar();
+    });
     </script>
 
 {% endblock %}

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -67,7 +67,7 @@
         }
 
 
-        flatpickr("#date_to_release", {
+        let release_date_folder_fp = flatpickr("#date_to_release", {
                     plugins: [ShortcutButtonsPlugin(
                         {
                             button: [
@@ -115,6 +115,9 @@
                       fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');
                     }
                     });
+    $('.form-body').on('scroll', function() {
+        release_date_folder_fp._positionCalendar();
+    });
     </script>
 
 {% endblock %}

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -67,7 +67,7 @@
         }
 
 
-        let release_date_folder_fp = flatpickr("#date_to_release", {
+        const release_date_folder_fp = flatpickr("#date_to_release", {
                     plugins: [ShortcutButtonsPlugin(
                         {
                             button: [

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -105,6 +105,7 @@
                             }
                         }
                     )],
+                    appendTo: document.getElementById('set-folder-release-form'),
                     allowInput: true,
                     enableTime: true,
                     enableSeconds: true,

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -42,11 +42,11 @@
             {% endfor %}
             </div>
         </fieldset>
-        <label id="upload_dt">
+        <label id="upload_dt" style="pointer-events:none;">
             <span>
                 <strong>Choose a time to release the files being uploaded:</strong>
             </span>
-            <input id="upload_picker" class="date_picker" type="text" size="26" value='9998-01-01 00:00:00'><br>
+            <input id="upload_picker" class="date_picker" type="text" size="26" value='9998-01-01 00:00:00' style="pointer-events:auto;"><br>
             <span><em>Note: Everyone with grading access will be able to view all the materials irrespective of the release date/time.</em></span>
         </label>
         <label>
@@ -150,7 +150,7 @@
                 e.stopPropagation();
             });
         });
-        flatpickr('#upload_picker', {
+        let upload_fp = flatpickr('#upload_picker', {
                     plugins: [ShortcutButtonsPlugin(
                         {
                             button: [
@@ -199,7 +199,9 @@
                       fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');
                     }
                     });
-    object.style.zIndex
+    $('.form-body').on('scroll', function() {
+        upload_fp._positionCalendar();
+    });
     </script>
     <script>
         createArray(1);

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -150,7 +150,7 @@
                 e.stopPropagation();
             });
         });
-        let upload_fp = flatpickr('#upload_picker', {
+        const upload_fp = flatpickr('#upload_picker', {
                     plugins: [ShortcutButtonsPlugin(
                         {
                             button: [

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -188,6 +188,7 @@
                             }
                         }
                     )],
+                    appendTo: document.getElementById('upload-course-materials-form'),
                     allowInput: true,
                     enableTime: true,
                     enableSeconds: true,
@@ -198,6 +199,7 @@
                       fp.calendarContainer.childNodes[2].childNodes[4].firstChild.setAttribute('aria-label', 'Seconds');
                     }
                     });
+    object.style.zIndex
     </script>
     <script>
         createArray(1);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Although the problem of flatpickr elements not being closed properly and some related issues are resolved internally by the newest release, they would still only be scrollable through scrolling on the page directly under the pop-ups they're called in.


### What is the new behavior?
Flatpickr instances opened in modals or popups in the Course Materials page on Instructor's UI now will append to the parent elements or html input windows calling them.

Closes #9106 and #4712

### Other information?
This fix utilizes a combination of flatpickr's own configuration and some JavaScript for a temporary solution. In the long run, a replacement of the date-picker dependency or improvement on the pop-up forms across Submitty are expected.

Because flatpickr instances close and save the input only when clicked outside, I limited the trigger for pointer event from the whole flex-column to only on the input windows that call them in the Upload and 2 Edit forms, so it is easier to use.
