### PR TITLE
[UI/UX:Submission] change download all button CSS

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -25,13 +25,12 @@
                 <br />
                 <div class="flex-row">
                     <span>Download all files:</span>
-                    <a aria-label="Download zip of all files"
+                    <button class = 'btn btn-primary key_to_click' aria-label="Download zip of all files"
                        onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ user_id }}", "{{ display_version }}", "submission")'
-                       class="key_to_click"
                        tabindex="0"
-                    >
+                    > Download
                         <i class="fas fa-download" title="Download zip of all files"></i>
-                    </a>
+                    </button>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
According to issue[#9145](https://github.com/Submitty/Submitty/issues/9145): 

The download all button is small and hard to see and also inconsistent with the other download buttons

### What is the new behavior?
Change the UI for the download all button to be more consistent with the other buttons in gradeables.
![image](https://user-images.githubusercontent.com/99207376/234984845-e04a87ec-02f5-4253-980a-253ad9effe17.png)

