### PR TITLE
[Bugfix:System] Fix urllib3 version crashing vagrant up

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -14,6 +14,9 @@ opencv-python-headless==4.6.0.66
 # jsonschema & jsonref & pytz & tzlocal
 pytz==2022.7.1 # Submitty-util specific.
 
+# v2 crashes docker install
+urllib3==1.26.14
+
 python-pam==2.0.2
 ruamel.yaml==0.17.21
 psycopg2-binary==2.9.6
@@ -31,7 +34,6 @@ distro==1.8.0
 jsonschema==3.2.0
 jsonref==0.2
 docker==6.0.1
-urllib3==1.26.14
 
 # For Lichen / Plagiarism Detection
 parso==0.8.3

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -31,6 +31,7 @@ distro==1.8.0
 jsonschema==3.2.0
 jsonref==0.2
 docker==6.0.1
+urllib3==1.26.14
 
 # For Lichen / Plagiarism Detection
 parso==0.8.3


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Vagrant installation fails due to a broken version of urllib3 crashing python docker.

### What is the new behavior?
Python dependency urllib3 has been locked to version 1.26.14.

