### PR TITLE
[Dependency] Lock Doctrine DBAL

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -23,6 +23,7 @@
     "aptoma/twig-markdown": "3.4.1",
     "cboden/ratchet": "0.4.4",
     "doctrine/annotations": "1.14.3",
+    "doctrine/dbal": "2.13.9",
     "doctrine/orm": "2.12.3",
     "egulias/email-validator": "3.2.5",
     "lcobucci/jwt": "4.3.0",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf72ce508ec7471f47ba36ca7ce50ed3",
+    "content-hash": "0a070fb9ecfca1a91876b4fc3d34c3e3",
     "packages": [
         {
             "name": "aptoma/twig-markdown",


### PR DESCRIPTION
### What is the current behavior?
Currently we have Doctrine ORM installed which relies on Doctrine DBAL. Doctrine DBAL is then left to install whatever version deemed by Composer and the composer.json of ORM. It's highly recommended to lock DBAL according to the [Doctrine ORM docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.14/tutorials/getting-started.html#project-setup).

DBAL is getting bumped a major version in #9213 which is why it's failing. So now we'll have fine grained control on both.

### What is the new behavior?
DBAL is now locked in our composer.json. No lock file changes except a hash change.
