### PR TITLE
[Refactor:Developer] Update vagrant_up action

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -10,14 +10,7 @@ permissions:
 
 jobs:
   vagrant-up:
-    runs-on: macos-10.15
-
-    strategy:
-      matrix:
-        include:
-          - image: ubuntu-20.04
-            port: 1511
-      fail-fast: false
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -25,6 +18,6 @@ jobs:
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.
       # - run: vagrant plugin install vagrant-vbguest
-      - run: NO_SUBMISSIONS=1 vagrant up ${{ matrix.image }}
+      - run: NO_SUBMISSIONS=1 vagrant up ubuntu-20.04
       - name: Validate image
-        run: curl --show-error --fail --include http://localhost:${{ matrix.port }}
+        run: curl --show-error --fail --include http://localhost:1511


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] ~~Tests for the changes have been added/updated (if possible)~~
* [ ] ~~Documentation has been updated/added if relevant~~

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Current `Vagrant Up` CI operation runs on deprecated `macos-10.15`, see: https://github.com/actions/runner-images/issues/5583 .
This may explain why recent vagrant up actions are failing.

### What is the new behavior?
This pr replaces GitHub runner base image from `macos-10.15` to `macos-latest`.
This pr also clean up the file, since the matrix is no longer needed as we are no longer testing vagrant up against Ubuntu 18.04, which was updated on  #7925.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
