### PR TITLE
[Bugfix:System] Fix error in down migration

### DIFF
--- a/migration/migrator/migrations/course/20230425130619_user_last_initial_format.py
+++ b/migration/migrator/migrations/course/20230425130619_user_last_initial_format.py
@@ -37,6 +37,6 @@ def down(config, database, semester, course):
     """
 
     database.execute("""
-ALTED TABLE users DROP CONSTRAINT IF EXISTS users_user_last_initial_format_check;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_user_last_initial_format_check;
 ALTER TABLE users DROP COLUMN IF EXISTS user_last_initial_format;
     """)


### PR DESCRIPTION
Syntax error in the down for the course migration `20230425130619_user_last_initial_format.py` has been fixed.