### PR TITLE
[Bugfix:Developer] update vagrant worker ip address

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -532,7 +532,6 @@ if not args.worker:
         if args.worker_pair:
             worker_dict["submitty-worker"] = {
                 "capabilities": ['default'],
-                #"address": "172.18.2.8",
                 "address": "192.168.56.21",
                 "username": "submitty",
                 "num_autograding_workers": NUM_GRADING_SCHEDULER_WORKERS,

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -532,7 +532,8 @@ if not args.worker:
         if args.worker_pair:
             worker_dict["submitty-worker"] = {
                 "capabilities": ['default'],
-                "address": "172.18.2.8",
+                #"address": "172.18.2.8",
+                "address": "192.168.56.21",
                 "username": "submitty",
                 "num_autograding_workers": NUM_GRADING_SCHEDULER_WORKERS,
                 "enabled": True

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -320,7 +320,6 @@ if ! cut -d ':' -f 1 /etc/passwd | grep -q ${DAEMON_USER} ; then
         su submitty_daemon -c "cd ~/"
         su submitty_daemon -c "ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ''"
         su submitty_daemon -c "echo 'successfully created ssh key'"
-        #su submitty_daemon -c "sshpass -p 'submitty' ssh-copy-id -i ~/.ssh/id_rsa.pub -o StrictHostKeyChecking=no submitty@172.18.2.8"
         su submitty_daemon -c "sshpass -p 'submitty' ssh-copy-id -i ~/.ssh/id_rsa.pub -o StrictHostKeyChecking=no submitty@192.168.56.21"
     fi
 fi

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -320,7 +320,8 @@ if ! cut -d ':' -f 1 /etc/passwd | grep -q ${DAEMON_USER} ; then
         su submitty_daemon -c "cd ~/"
         su submitty_daemon -c "ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ''"
         su submitty_daemon -c "echo 'successfully created ssh key'"
-        su submitty_daemon -c "sshpass -p 'submitty' ssh-copy-id -i ~/.ssh/id_rsa.pub -o StrictHostKeyChecking=no submitty@172.18.2.8"
+        #su submitty_daemon -c "sshpass -p 'submitty' ssh-copy-id -i ~/.ssh/id_rsa.pub -o StrictHostKeyChecking=no submitty@172.18.2.8"
+        su submitty_daemon -c "sshpass -p 'submitty' ssh-copy-id -i ~/.ssh/id_rsa.pub -o StrictHostKeyChecking=no submitty@192.168.56.21"
     fi
 fi
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,7 +111,6 @@ Vagrant.configure(2) do |config|
   config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
     # If this IP address changes, it must be changed in install_system.sh and
     # CONFIGURE_SUBMITTY.py to allow the ssh connection
-    #ubuntu.vm.network "private_network", ip: "172.18.2.8"
     ubuntu.vm.network "private_network", ip: "192.168.56.21"
     ubuntu.vm.network 'forwarded_port', guest: 22, host: 2220, id: 'ssh'
     ubuntu.vm.provision 'shell', inline: $worker_script

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,7 +111,8 @@ Vagrant.configure(2) do |config|
   config.vm.define 'submitty-worker', autostart: autostart_worker do |ubuntu|
     # If this IP address changes, it must be changed in install_system.sh and
     # CONFIGURE_SUBMITTY.py to allow the ssh connection
-    ubuntu.vm.network "private_network", ip: "172.18.2.8"
+    #ubuntu.vm.network "private_network", ip: "172.18.2.8"
+    ubuntu.vm.network "private_network", ip: "192.168.56.21"
     ubuntu.vm.network 'forwarded_port', guest: 22, host: 2220, id: 'ssh'
     ubuntu.vm.provision 'shell', inline: $worker_script
   end


### PR DESCRIPTION
### What is the current behavior?
The instructions:
https://submitty.org/developer/getting_started/worker_vm

```
WORKER_PAIR=1 vagrant up
```

fail because the hardcoded ip address for the vagrant worker is out of allowed range (a restriction added sometime in the last year).

### What is the new behavior?

I've switched the hardcoded ip address from: "172.18.2.8" to "192.168.56.21"