### PR TITLE
[Refactor:System] Remove unused `parso` dependency

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -34,9 +34,6 @@ jsonref==0.2
 docker==6.1.2
 urllib3==2.0.2
 
-# For Lichen / Plagiarism Detection
-parso==0.8.3
-
 # Python3 implementation of python-clang bindings (may not work < 6.0)
 clang==14.0
 


### PR DESCRIPTION
### What is the current behavior?
`parso` is no longer used in Submitty.  Lichen uses it, but maintains a separate [dependency file](https://github.com/Submitty/Lichen/blob/595867e04de001f4a4ec575d6cdf1d5dcd04a5c6/requirements.txt#L5) and only uses it in a Docker container.

### What is the new behavior?
`parso` has been removed.
