### PR TITLE
[Bugfix:Developer] Remove regrade enabled from e2e

### DIFF
--- a/tests/e2e/test_grade_inquiry.py
+++ b/tests/e2e/test_grade_inquiry.py
@@ -12,18 +12,6 @@ class TestGradeInquiry(BaseTestCase):
     def __init__(self, testname):
         super().__init__(testname, log_in=False)
 
-    def set_grade_inquiries_for_course(self, allowed):
-        # ensure that grade inquiries are enabled for the course
-        self.driver.find_element(By.ID, "nav-sidebar-course-settings").click()
-        regrade_enabled_checkbox = self.driver.find_element(By.ID, "regrade-enabled")
-
-        if not regrade_enabled_checkbox.is_selected() and allowed:
-            regrade_enabled_checkbox.click()
-        elif regrade_enabled_checkbox.is_selected() and not allowed:
-            regrade_enabled_checkbox.click()
-        # navigate back to gradeable page
-        self.driver.find_element(By.ID, 'nav-sidebar-submitty').click()
-
     def set_grade_inquiries_for_gradeable(self, gradeable_id, date=None, allowed=True):
         # ensure that grade inquiries are enabled for grades_released_homework gradeable
         self.driver.find_element(By.XPATH, "//div[@id='"+gradeable_id+"']//*[contains(@class, 'fa-pencil-alt')]").click()
@@ -61,7 +49,6 @@ class TestGradeInquiry(BaseTestCase):
         # login as instructor
         self.log_in(user_id='instructor')
         self.click_class('sample')
-        self.set_grade_inquiries_for_course(True)
         self.set_grade_inquiries_for_gradeable(gradeable_id, date=grade_inquiry_deadline_date, allowed=True)
 
         # navigate to TA grading interface of student with normal submission
@@ -84,7 +71,6 @@ class TestGradeInquiry(BaseTestCase):
         # login as instructor
         self.log_in(user_id='instructor')
         self.click_class('sample')
-        self.set_grade_inquiries_for_course(True)
         self.set_grade_inquiries_for_gradeable(gradeable_id,date=grade_inquiry_deadline_date,allowed=True)
 
         # navigate to TA grading interface of student with no submission
@@ -110,7 +96,6 @@ class TestGradeInquiry(BaseTestCase):
         # login as instructor
         self.log_in(user_id='instructor')
         self.click_class('sample')
-        self.set_grade_inquiries_for_course(True)
         self.set_grade_inquiries_for_gradeable(gradeable_id,date=grade_inquiry_deadline_date,allowed=True)
 
         # navigate to TA grading interface of student with no inquiry
@@ -135,7 +120,6 @@ class TestGradeInquiry(BaseTestCase):
 
         self.log_in(user_id='instructor')
         self.click_class('sample')
-        self.set_grade_inquiries_for_course(True)
         self.set_grade_inquiries_for_gradeable(gradeable_id,date=grade_inquiry_deadline_date,allowed=True)
 
         self.log_out()


### PR DESCRIPTION
### What is the current behavior?
In the PR [#9356](https://github.com/Submitty/Submitty/pull/9356), the course level grade inquiry setting was removed.
However, this setting was not removed from the testing in e2e.

### What is the new behavior?
Global course grade inquiry setting is no longer tested in e2e tests.