### PR TITLE
[Bugfix:Developer] Increased column Indices for clicking

### DIFF
--- a/site/cypress/e2e/late_days_allowed.spec.js
+++ b/site/cypress/e2e/late_days_allowed.spec.js
@@ -74,7 +74,7 @@ describe('Test cases involving the late days allowed page', () => {
             cy.login('bitdiddle');
             cy.visit(['sample', 'late_table']);
             cy.get('#late-day-table > tbody > tr > :nth-child(2)').contains('01/01/2021');
-            cy.get('#late-day-table > tbody > tr > :nth-child(7)').contains('+3');
+            cy.get('#late-day-table > tbody > tr > :nth-child(8)').contains('+3');
             cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').contains('3');
 
             // logout and log back in as the instructor
@@ -103,7 +103,7 @@ describe('Test cases involving the late days allowed page', () => {
             cy.login('bitdiddle');
             cy.visit(['sample', 'late_table']);
             cy.get('#late-day-table > tbody > tr > :nth-child(2)').contains('01/01/2021');
-            cy.get('#late-day-table > tbody > tr > :nth-child(7)').contains('+5');
+            cy.get('#late-day-table > tbody > tr > :nth-child(8)').contains('+5');
             cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').contains('5');
 
             // logout and log back in as the instructor


### PR DESCRIPTION
### What is the current behavior?
Before PR #9356 , the Grade Inquiries column in the LateDays table was only present if grade inquiries were enabled. When
grade inquiries became always enabled, the column was present even in the LateDaysAllowed cypress test, resulting in the indices in the test being off.

### What is the new behavior?
The appropriate indices have been incremented, causing the test to pass.