### PR TITLE
[Bugfix:Autograding] backwards compatible vcs subdirectory

### DIFF
--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -65,7 +65,7 @@ def get_vcs_info(config, top_dir, semester, course, gradeable, userid,  teamid):
     if is_vcs:
         if 'vcs_partial_path' in form_json:
             vcs_partial_path = form_json['vcs_partial_path']
-            vcs_subdirectory = form_json["subdirectory"] if is_vcs else ''
+            vcs_subdirectory = form_json["subdirectory"]
         else:
             # for backwards compatibility - if gradeable was built before
             # version v23.06.00 was installed

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -59,6 +59,18 @@ def get_vcs_info(config, top_dir, semester, course, gradeable, userid,  teamid):
     )
     vcs_base_url = vcs_base_url.replace('{$vcs_type}', vcs_type)
     vcs_base_url = vcs_base_url.replace('{$user_id}', userid)
+
+    vcs_partial_path = ''
+    vcs_subdirectory = ''
+    if is_vcs:
+        if 'vcs_partial_path' in form_json:
+            vcs_partial_path = form_json['vcs_partial_path']
+            vcs_subdirectory = form_json["subdirectory"] if is_vcs else ''
+        else:
+            # for backwards compatibility - if gradeable was built before
+            # version v23.06.00 was installed
+            vcs_partial_path = form_json['subdirectory']
+
     vcs_partial_path = form_json['vcs_partial_path'] if is_vcs else ''
     vcs_partial_path = vcs_partial_path.replace("{$vcs_type}", userid)
     vcs_partial_path = vcs_partial_path.replace("{$gradeable_id}", gradeable)

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -71,12 +71,10 @@ def get_vcs_info(config, top_dir, semester, course, gradeable, userid,  teamid):
             # version v23.06.00 was installed
             vcs_partial_path = form_json['subdirectory']
 
-    vcs_partial_path = form_json['vcs_partial_path'] if is_vcs else ''
     vcs_partial_path = vcs_partial_path.replace("{$vcs_type}", userid)
     vcs_partial_path = vcs_partial_path.replace("{$gradeable_id}", gradeable)
     vcs_partial_path = vcs_partial_path.replace("{$team_id}", teamid)
     vcs_partial_path = vcs_partial_path.replace("{$user_id}", userid)
-    vcs_subdirectory = form_json["subdirectory"] if is_vcs else ''
     vcs_subdirectory = vcs_subdirectory.replace("{$vcs_type}", vcs_type)
     vcs_subdirectory = vcs_subdirectory.replace("{$gradeable_id}", gradeable)
     vcs_subdirectory = vcs_subdirectory.replace("{$user_id}", userid)


### PR DESCRIPTION
### What is the current behavior?
A VCS gradeable created and built before installing v23.06.00 will not have the partial_path field in the form.json file.  This will cause an error upon upgrading unless the gradeable is rebuilt.

### What is the new behavior?
Backwards compatible logic allows grading of gradeables built before v23.06.00.
New gradeables, and old gradeables built after installation work as well.