### PR TITLE
[Refactor:InstructorUI] Revert back to standard media queries

### DIFF
--- a/site/.stylelintrc.json
+++ b/site/.stylelintrc.json
@@ -4,7 +4,8 @@
     "indentation": 4,
     "color-hex-length": "long",
     "selector-id-pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
-    "selector-class-pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$"
+    "selector-class-pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+    "media-feature-range-notation": null
   },
   "ignoreFiles": [
     "vendor/**",

--- a/site/public/css/authentication.css
+++ b/site/public/css/authentication.css
@@ -34,7 +34,7 @@
     padding: 0.5em 1em;
 }
 
-@media (width >= 768px) {
+@media (min-width: 768px) {
     #login-box {
         margin: 30px auto;
         min-width: 450px;

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -279,7 +279,7 @@ div.calendar-submit {
 div.calendar-submit label { text-align: "right"; }
 div.calendar-submit label::after { content: ":"; }
 
-@media (width <= 800px) {
+@media (max-width: 800px) {
     #calendar-list {
         margin: 0;
     }

--- a/site/public/css/configuration.css
+++ b/site/public/css/configuration.css
@@ -57,7 +57,7 @@
     margin: 0;
 }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     #room-seating-gradeable-id {
         flex: none;
     }

--- a/site/public/css/details.css
+++ b/site/public/css/details.css
@@ -115,7 +115,7 @@
     display: none;
 }
 
-@media (width <= 950px) {
+@media (max-width: 950px) {
     table.table,
     .table thead,
     .table tbody,
@@ -225,7 +225,7 @@
     }
 }
 
-@media (width >= 401px) {
+@media (min-width: 401px) {
     .content {
         padding: 30px;
     }
@@ -250,7 +250,7 @@
     }
 }
 
-@media (width >= 660px) {
+@media (min-width: 660px) {
     .markers-container {
         width: unset;
     }
@@ -275,7 +275,7 @@
     }
 }
 
-@media (width >= 780px) {
+@media (min-width: 780px) {
     #details-table tbody.details-info-header .info td {
         padding: 0;
     }
@@ -289,7 +289,7 @@
     }
 }
 
-@media (width >= 951px) {
+@media (min-width: 951px) {
     .details-action-box > * {
         margin-right: 5px;
     }

--- a/site/public/css/directory.css
+++ b/site/public/css/directory.css
@@ -42,7 +42,7 @@
     margin-top: 1vh;
 }
 
-@media (width >= 831px) {
+@media (min-width: 831px) {
     .directory-table tbody {
         counter-reset: student;
     }

--- a/site/public/css/docker_interface.css
+++ b/site/public/css/docker_interface.css
@@ -48,7 +48,7 @@
 }
 
 /* desktop view */
-@media (width >= 550px) {
+@media (min-width: 550px) {
     .docker-images-container {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -1524,7 +1524,7 @@ input[type="radio"][disabled=""]:checked::before {
 }
 
 /* Media queries */
-@media (width <= 540px) {
+@media (max-width: 540px) {
     #electronic-gradeable-container {
         margin: 0;
     }

--- a/site/public/css/exceptionforms.css
+++ b/site/public/css/exceptionforms.css
@@ -28,7 +28,7 @@ fieldset {
 #extensions-table td:nth-of-type(4)::before { content: "Number of Days of Extension"; }
 #extensions-table td:nth-of-type(5)::before { content: "Delete"; }
 
-@media (width >= 768px) {
+@media (min-width: 768px) {
     #extensions-table {
         text-align: left;
     }

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -59,7 +59,7 @@ nav a > i.f {
     padding-right: 70px;
 }
 
-@media (width <= 541px) {
+@media (max-width: 541px) {
     #breadcrumbs {
         padding-left: 0;
         padding-right: 0;
@@ -139,7 +139,7 @@ footer .footer-separator {
     display: block;
 }
 
-@media (width <= 541px) {
+@media (max-width: 541px) {
     #moorthy-duck {
         display: none;
     }
@@ -149,7 +149,7 @@ footer .footer-separator {
     }
 }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     #home-button,
     #logout-button {
         display: none;

--- a/site/public/css/grade-report.css
+++ b/site/public/css/grade-report.css
@@ -35,7 +35,7 @@
     width: 90%;
 }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     #grade-report-cont.content {
         padding: 30px;
         margin: 30px;
@@ -46,7 +46,7 @@
     }
 }
 
-@media (width >= 780px) {
+@media (min-width: 780px) {
     .card {
         padding: 24px 0;
         text-align: left;

--- a/site/public/css/gradeOverride.css
+++ b/site/public/css/gradeOverride.css
@@ -44,13 +44,13 @@ textarea,
 #grade-override-table td:nth-of-type(5)::before { content: "Comments"; }
 #grade-override-table td:nth-of-type(6)::before { content: "Delete"; }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     h1 {
         font-weight: bold;
     }
 }
 
-@media (width >= 768px) {
+@media (min-width: 768px) {
     .single-student label {
         flex: 0 0 0;
         width: 420px;
@@ -75,7 +75,7 @@ textarea,
     /* stylelint-enable selector-id-pattern, no-descending-specificity */
 }
 
-@media (width >= 830px) {
+@media (min-width: 830px) {
     #grade-override-table {
         text-align: left;
     }

--- a/site/public/css/latedaystableplugin.css
+++ b/site/public/css/latedaystableplugin.css
@@ -10,7 +10,7 @@
 
 #late-day-table td::before { content: attr(data-before-content); }
 
-@media (width >= 831px) {
+@media (min-width: 831px) {
     #late-day-table {
         margin: 1em 0 0;
     }

--- a/site/public/css/menu.css
+++ b/site/public/css/menu.css
@@ -107,7 +107,7 @@
     align-items: center;
 }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     #menu-button,
     #mobile-menu,
     #menu-overlay {

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -84,7 +84,7 @@
     background: var(--standard-focus-cornflowe-blue);
 }
 
-@media (width <= 401px) {
+@media (max-width: 401px) {
     .course-section-heading,
     .course-main .course-title {
         font-size: 16px;
@@ -96,7 +96,7 @@
     }
 }
 
-@media (width <= 950px) {
+@media (max-width: 950px) {
     .course-section-heading {
         margin: 10px 0;
         font-weight: 400;
@@ -136,7 +136,7 @@
     }
 }
 
-@media (width >= 950px) {
+@media (min-width: 950px) {
     #gradeables {
         display: table;
         width: 100%;

--- a/site/public/css/notifications.css
+++ b/site/public/css/notifications.css
@@ -76,7 +76,7 @@
     margin: 5px;
 }
 
-@media (width >= 768px) {
+@media (min-width: 768px) {
     #notification-header {
         display: table-row;
     }

--- a/site/public/css/officeHoursQueue.css
+++ b/site/public/css/officeHoursQueue.css
@@ -76,7 +76,7 @@ th {
   This will hide elements on phones. This is useful for extra content that
   is not normally needed such as a user id
 */
-@media only screen and (width <= 479px) {
+@media only screen and (max-width: 479px) {
     /* Put this on elements you dont need on mobile */
     .mobile-hide {
         display: none !important;
@@ -99,7 +99,7 @@ th {
 }
 
 /* Put this on elements you dont need on desktop */
-@media only screen and (width >= 480px) {
+@media only screen and (min-width: 480px) {
     .desktop-hide {
         display: none !important;
     }

--- a/site/public/css/plagiarism.css
+++ b/site/public/css/plagiarism.css
@@ -320,7 +320,7 @@ main#main.full-screen-mode .plagiarism-result-cont {
     text-shadow: 0 0 3px transparent;
 }
 
-@media (width <= 660px) {
+@media (max-width: 660px) {
     .nav-buttons a {
         width: 100%;
     }
@@ -333,7 +333,7 @@ main#main.full-screen-mode .plagiarism-result-cont {
     }
 }
 
-@media (width >= 660px) {
+@media (min-width: 660px) {
     #save-configuration-form {
         width: 80%;
     }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1876,7 +1876,7 @@ header > * {
     color: var(--standard-light-medium-gray);
 }
 
-@media (width <= 541px) {
+@media (max-width: 541px) {
     .content {
         padding: 30px 15px;
     }
@@ -1890,7 +1890,7 @@ header > * {
     }
 }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     .content {
         margin: 30px;
         max-height: none;
@@ -1901,7 +1901,7 @@ header > * {
     }
 }
 
-@media (width >= 768px) {
+@media (min-width: 768px) {
     .btn-wrapper {
         width: max-content;
     }

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -2,7 +2,7 @@ aside {
     display: none;
 }
 
-@media (width >= 541px) {
+@media (min-width: 541px) {
     aside {
         display: block;
         margin: 0 -30px 0 0;

--- a/site/public/css/submitbox.css
+++ b/site/public/css/submitbox.css
@@ -105,7 +105,7 @@
     right: 2rem;
 }
 
-@media (width <= 401px) {
+@media (max-width: 401px) {
     .grade-results {
         display: flex;
         flex-direction: column;
@@ -125,7 +125,7 @@
     }
 }
 
-@media (width <= 541px) {
+@media (max-width: 541px) {
     #gradeable-info h1 {
         font-size: 1.3rem;
         font-weight: initial;
@@ -178,7 +178,7 @@
     }
 }
 
-@media (width <= 950px) {
+@media (max-width: 950px) {
     #submission-version-select {
         width: 100%;
     }

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -32,7 +32,7 @@
     padding: 0.5em;
 }
 
-@media (width <= 830px) {
+@media (max-width: 830px) {
     table.mobile-table,
     .mobile-table thead,
     .mobile-table tbody,
@@ -82,7 +82,7 @@
     }
 }
 
-@media (width >= 831px) {
+@media (min-width: 831px) {
     .mobile-table {
         border: 1px solid var(--standard-hover-light-gray);
     }

--- a/site/public/css/user-profile.css
+++ b/site/public/css/user-profile.css
@@ -125,7 +125,7 @@
     color: var(--external-link-blue);
 }
 
-@media (width <= 401px) {
+@media (max-width: 401px) {
     .content {
         margin: 10px 0 0;
     }
@@ -138,7 +138,7 @@
     /* stylelint-enable selector-id-pattern */
 }
 
-@media (width <= 541px) {
+@media (max-width: 541px) {
     .flex-row-col {
         flex-direction: column;
     }

--- a/site/public/css/user-select.css
+++ b/site/public/css/user-select.css
@@ -1,4 +1,4 @@
-@media (width >= 768px) {
+@media (min-width: 768px) {
     #user-select {
         margin: 30px auto;
         min-width: 450px;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Stylelint v33 has enforced the use of the new range syntax for media queries. This syntax is relatively new and support is inadequate, which causes bugs on some browsers. Furthermore, the new syntax has no functional differences from the previous standard.

### What is the new behavior?
The media queries have been reverted back to the standard syntax, and stylelint has been configured to allow this.

