### PR TITLE
[Bugfix:Forum] Remove threadlist resolve button

### DIFF
--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -46,14 +46,6 @@
                 </span>
             </div>
             {% if is_full_page is defined and is_full_page %}
-                <span>
-                    {% if (user_group <= 3 or thread.author_info.user_id == current_user) and thread.thread_resolve_state == -1 %}
-                        <span class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click"
-                           onClick="return false; changeThreadStatus({{ thread.thread_id }});"
-                           title="Mark thread as resolved"
-                        >Mark as resolved</span>
-                    {% endif %}
-                </span>
                 <div class="post-action-container">
                     <span>
                         {% if user_group <= 2 and thread.author_info.user_id != current_user %}


### PR DESCRIPTION
### What is the current behavior?
A broken `Mark as resolved` button appears on unresolved threads in the discussion forum's main page (Thread list).

### What is the new behavior?
The broken button is gone, rather than fixed as decided by myself and @bmcutler.

See issue #9426.

