### PR TITLE
[Testing:Developer] Add Dependabot for composite action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,14 @@ updates:
       - dependencies
     commit-message:
       prefix: "[DevDependency] "
+  - package-ecosystem: "github-actions"
+    directory: "/actions/e2e-Setup-Composite"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+    open-pull-requests-limit: 15
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "[DevDependency] "


### PR DESCRIPTION
### What is the current behavior?
#9105 created a "composite" action which is used as a base for several different CI pipelines.  Dependabot doesn't know about anything outside `.github/workflows` by default, so a separate configuration is required.

### What is the new behavior?
Adds a new entry to the Dependabot configuration file to support the new composite action.
