### PR TITLE
[Feature:InstructorUI] Add course_ID to Manage section page

### DIFF
--- a/site/app/templates/admin/users/RotatingSectionsForm.twig
+++ b/site/app/templates/admin/users/RotatingSectionsForm.twig
@@ -49,6 +49,7 @@
                     <thead>
                         <tr>
                             <th>Section</th>
+                            <th>Course ID</th>
                             <th>Count</th>
                         </tr>
                     </thead>
@@ -58,12 +59,14 @@
                             {% if section['sections_registration_id'] in reg_sections_count|keys and
                                 reg_sections_count[section['sections_registration_id']] %}
                             <tr>
-                                <td>Section {{ section['sections_registration_id'] }} ({{ section['course_section_id'] }})</td>
+                                <td>Section {{ section['sections_registration_id'] }} </td>
+                                <td> {{ section['course_section_id'] }} </td>
                                 <td>{{ reg_sections_count[section['sections_registration_id']] }}</td>
                             </tr>
                             {% else %}
                             <tr>
-                                <td>Section {{ section['sections_registration_id'] }} ({{ section['course_section_id'] }})</td>
+                                <td>Section {{ section['sections_registration_id'] }}</td>
+                                <td> {{ section['course_section_id'] }} </td>
                                 <td>0</td>
                             </tr>
                             {% endif %}
@@ -72,11 +75,13 @@
                         {% if reg_sections_count['NULL'] %}
                         <tr>
                             <td>Section NULL</td>
+                            <td>NULL</td>
                             <td>{{ reg_sections_count['NULL'] }}</td>
                         </tr>
                         {% else %}
                         <tr>
                             <td>Section NULL</td>
+                            <td>0</td>
                             <td>0</td>
                         </tr>
                         {% endif %}

--- a/site/app/templates/admin/users/RotatingSectionsForm.twig
+++ b/site/app/templates/admin/users/RotatingSectionsForm.twig
@@ -58,12 +58,12 @@
                             {% if section['sections_registration_id'] in reg_sections_count|keys and
                                 reg_sections_count[section['sections_registration_id']] %}
                             <tr>
-                                <td>Section {{ section['sections_registration_id'] }}</td>
+                                <td>Section {{ section['sections_registration_id'] }} ({{ section['course_section_id'] }})</td>
                                 <td>{{ reg_sections_count[section['sections_registration_id']] }}</td>
                             </tr>
                             {% else %}
                             <tr>
-                                <td>Section {{ section['sections_registration_id'] }}</td>
+                                <td>Section {{ section['sections_registration_id'] }} ({{ section['course_section_id'] }})</td>
                                 <td>0</td>
                             </tr>
                             {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
Fixes part 3 of #8770 

### What is the current behavior?
Currently Manage Sections Page have table of sections w/o course section id
![Screen Shot 2023-06-16 at 12 33 11 PM](https://github.com/Submitty/Submitty/assets/123261952/a69b0c93-356f-4c88-80cf-765c9742a86c)

### What is the new behavior?
Updated Page includes course section id enclosed with parenthesis
![Screen Shot 2023-06-16 at 11 52 45 AM](https://github.com/Submitty/Submitty/assets/123261952/4d3d7212-8766-481d-9abf-5c97f80f5d1f)
 
