### PR TITLE
feat: Manage Graders Toggleable Columns

### DIFF
--- a/site/app/templates/admin/users/GraderList.twig
+++ b/site/app/templates/admin/users/GraderList.twig
@@ -2,25 +2,43 @@
     <header>
         <h1>Manage Graders</h1>
         <div class="btn-wrapper">
+            <a href="javascript:toggleColumnsForm()" class="btn btn-primary">Toggle Columns</a>
             <a href="javascript:newDownloadForm()" class="btn btn-primary">Download Graders</a>
             <a href="javascript:newGraderListForm()" class="btn btn-primary">Upload Grader List</a>
             <a href="javascript:newGraderForm()" class="btn btn-primary">New Grader</a>
             <a href="javascript:editRegistrationSectionsForm()" class="btn btn-primary">Assign Registration Sections for Grading</a>
         </div>
     </header>
+
     {# This is a data table #}
     {% if graders[1]|length + graders[2]|length + graders[3]|length > 0 %}
         <table id="grader-table" class="table table-striped mobile-table directory-table">
             <caption>Course Graders</caption>
             <thead>
+               <tr>
                 <th>#</th>
-                <th>User ID</th>
-                <th>First Name</th>
-                <th>Last Name</th>
-                <th>User Group</th>
-                <th>Registration Sections</th>
-                <th>Edit Grader</th>
-                <th>Demote Grader</th>
+                {% if active_columns[0] %}
+                    <th "text-align:left;">User ID</th>
+                {% endif %}
+                {% if active_columns[1] %}
+                    <th "text-align:left;">First Name</th>
+                {% endif %}
+                {% if active_columns[2] %}
+                    <th "text-align:left;">Last Name</th>
+                {% endif %}
+                {% if active_columns[3] %}
+                    <th "text-align:left;">User Group</th>
+                {% endif %}
+                {% if active_columns[4] %}
+                    <th "text-align:left;">Registration Sections</th>
+                {% endif %}
+                {% if active_columns[5] %}
+                    <th "text-align:left;">Edit Grader</th>
+                {% endif %}
+                {% if active_columns[6] %}
+                    <th "text-align:left;">Demote Grader</th>
+                {% endif %}
+               </tr>
             </thead>
             {% for grading_group in 1..3 %}
                 <tbody id="section-{{ grading_group }}">
@@ -31,23 +49,37 @@
                         {% for grader in graders[grading_group] %}
                             <tr id="user-{{ grader.getId() }}">
                                 <td></td>
-                                <td class="align-left">{{ grader.getId() }}</td>
-                                <td class="align-left">{{ grader.getDisplayedGivenName() }}</td>
-                                <td class="align-left">{{ grader.getDisplayedFamilyName() }}</td>
-                                <td>{{ groups[grader.getGroup()].name }}</td>
-                                <td>{{ grader.getGradingRegistrationSections()|join(", ") ?: "None" }}</td>
-                                <td>
-                                    <a href="javascript:editUserForm('{{ grader.getId() }}');"
-                                       aria-label="edit grader {{grader.getDisplayedGivenName()}} {{grader.getDisplayedFamilyName()}}">
-                                        <i class="fas fa-pencil-alt" title="Edit Grader"></i>
-                                    </a>
-                                </td>
-                                <td>
-                                    <a href="javascript:demoteGraderForm('{{ grader.getId() }}', '{{ grader.getDisplayedGivenName() }}', '{{ grader.getDisplayedFamilyName() }}');"
-                                        aria-label="">
-                                        <i class="fas fa-user-xmark" title="Demote Grader"></i>
-                                    </a>
-                                </td>
+                                {% if active_columns[0] %}
+                                     <td class="align-left td-grader-id">{{ grader.getId() }}</td>
+                                {% endif %}
+                                {% if active_columns[1] %}
+                                     <td class="align-left td-given-name">{{ grader.getDisplayedGivenName() }}</td>
+                                {% endif %}
+                                {% if active_columns[2] %}
+                                     <td class="align-left td-family-name">{{ grader.getDisplayedFamilyName() }}</td>
+                                {% endif %}
+                                {% if active_columns[3] %}
+                                     <td class="align-left td-grader-group">{{ groups[grader.getGroup()].name }}</td>
+                                {% endif %}
+                                {% if active_columns[4] %}
+                                     <td class="align-left td-registration-section">{{ grader.getGradingRegistrationSections()|join(", ") ?: "None" }}</td>
+                                {% endif %}
+                                {% if active_columns[5] %}
+                                     <td class="align-left td-edit-grader">
+                                        <a href="javascript:editUserForm('{{ grader.getId() }}');"
+                                        aria-label="edit grader {{grader.getDisplayedGivenName()}} {{grader.getDisplayedFamilyName()}}">
+                                            <i class="fas fa-pencil-alt" title="Edit Grader"></i>
+                                        </a>
+                                     </td>
+                                {% endif %}
+                                {% if active_columns[6] %}
+                                     <td class="align-left td-demote-grader">
+                                        <a href="javascript:demoteGraderForm('{{ grader.getId() }}', '{{ grader.getDisplayedGivenName() }}', '{{ grader.getDisplayedFamilyName() }}');"
+                                            aria-label="">
+                                            <i class="fas fa-user-xmark" title="Demote Grader"></i>
+                                        </a>
+                                     </td>
+                                {% endif %}
                             </tr>
                         {% endfor %}
                     {% else %}
@@ -63,6 +95,7 @@
     {% endif %}
 </div>
 {% include('admin/users/UserForm.twig') %}
+{% include('admin/users/ToggleManageGradeListColumns.twig') %}
 {% include('admin/users/GraderListForm.twig') %}
 {% include('admin/users/RegistrationSectionsForm.twig') with { 'num_rotating_sections': rot_sections|length } %}
 {% include('admin/users/DownloadForm.twig') with { 'code': 'grader' } %}

--- a/site/app/templates/admin/users/ToggleManageGradeListColumns.twig
+++ b/site/app/templates/admin/users/ToggleManageGradeListColumns.twig
@@ -1,0 +1,49 @@
+{% extends 'generic/Popup.twig' %}
+{% block popup_id %}toggle-columns-form{% endblock %}
+{% block title %}Toggle Columns{% endblock %}
+{% block body %}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+    <p class="toggle-columns-instructions">
+        Select which columns you would like to display.
+    </p>
+    <div class="toggle-columns-menu">
+        <div class="toggle-checkbox-area">
+            <input type="checkbox" class="toggle-columns-box">
+            <label>User ID</label>
+        </div>
+        <div class="toggle-checkbox-area">
+            <input type="checkbox" class="toggle-columns-box">
+            <label>First Name</label>   
+        </div>
+        <div class="toggle-checkbox-area">
+            <input type="checkbox" class="toggle-columns-box">
+            <label>Last Name</label>
+        </div>
+        <div class="toggle-checkbox-area">
+            <input type="checkbox" class="toggle-columns-box">
+            <label>User Group</label> 
+        </div>
+        <div class="toggle-checkbox-area">   
+            <input type="checkbox" class="toggle-columns-box">
+            <label>Registration Sections</label>
+        </div>
+        <div class="toggle-checkbox-area">
+            <input type="checkbox" class="toggle-columns-box">
+            <label>Edit Grader</label>
+        </div>
+        <div class="toggle-checkbox-area">
+            <input type="checkbox" class="toggle-columns-box">
+            <label>Demote Grader</label>
+        </div>
+    </div>
+    <div class="toggle-all-buttons">
+        <a href="javascript:fillAllCheckboxes(true)" class="btn btn-primary">All On</a>
+        <a href="javascript:fillAllCheckboxes(false)" class="btn btn-primary">All Off</a>
+    </div>
+{% endblock %}
+
+{% block buttons %}
+    {{ block('close_button') }}
+    <input name="submit" class="btn btn-primary key_to_click" type="submit" value="Submit" onclick="updateManageGradesColumns()"/>
+
+{% endblock %}

--- a/site/app/views/admin/UsersView.php
+++ b/site/app/views/admin/UsersView.php
@@ -54,12 +54,13 @@ class UsersView extends AbstractView {
      * @param bool   $use_database
      * @return string
      */
-    public function listGraders($graders_sorted, $reg_sections, $rot_sections, $download_info, $use_database = false) {
+    public function listGraders($graders_sorted, $reg_sections, $rot_sections, $download_info, $use_database = false, $active_columns = '1-1-1-1-1-1-1') {
         $this->core->getOutput()->addBreadcrumb('Manage Graders');
         $this->core->getOutput()->addInternalCss('directory.css');
         $this->core->getOutput()->addInternalCss('table.css');
         $this->core->getOutput()->addInternalCss('userform.css');
         $this->core->getOutput()->addInternalJs('userform.js');
+        $this->core->getOutput()->addInternalJs('manage-grades.js');
         $this->core->getOutput()->addInternalJs('directory.js');
         $this->core->getOutput()->enableMobileViewport();
 
@@ -89,7 +90,8 @@ class UsersView extends AbstractView {
             "csrf_token" => $this->core->getCsrfToken(),
             "download_info_json" => json_encode($download_info),
             "course" => $this->core->getConfig()->getCourse(),
-            "semester" => $this->core->getConfig()->getSemester()
+            "semester" => $this->core->getConfig()->getSemester(),
+            "active_columns" => explode('-', $active_columns)
         ]);
     }
 

--- a/site/public/css/directory.css
+++ b/site/public/css/directory.css
@@ -18,12 +18,13 @@
 #student-table .td-delete-student::before { content: "Delete Student"; }
 
 #grader-table td:nth-of-type(1) { display: none; }
-#grader-table td:nth-of-type(2)::before { content: "User ID"; }
-#grader-table td:nth-of-type(3)::before { content: "First Name"; }
-#grader-table td:nth-of-type(4)::before { content: "Last Name"; }
-#grader-table td:nth-of-type(5)::before { content: "User Group"; }
-#grader-table td:nth-of-type(6)::before { content: "Registration Sections"; }
-#grader-table td:nth-of-type(7)::before { content: "Edit Student"; }
+#grader-table .td-grader-id::before { content: "User ID"; }
+#grader-table .td-given-name::before { content: "First Name"; }
+#grader-table .td-family-name::before{ content: "Last Name"; }
+#grader-table .td-grader-group::before { content: "User Group"; }
+#grader-table .td-registration-section::before { content: "Registration Sections"; }
+#grader-table .td-edit-grader::before { content: "Edit Grader"; }
+#grader-table .td-demote-grader::before { content: "Demote Grader"; }
 
 #toggle-columns-form .toggle-columns-menu{
     display: grid;

--- a/site/public/js/manage-grades.js
+++ b/site/public/js/manage-grades.js
@@ -1,0 +1,68 @@
+/* exported toggleColumnsForm, updateManageStudentsColumns, fillAllCheckboxes
+*/
+
+//Data structure for active columns
+const checkboxes = document.getElementsByClassName('toggle-columns-box');
+
+//opens modal with initial settings for new student
+function toggleColumnsForm() {
+    const form = $('#toggle-columns-form');
+    form.css('display', 'block');
+    checkProperTicks();
+}
+
+//checks proper tick marks in modal
+function checkProperTicks() {
+    const selectedColumns = loadColumns();
+    for (let i = 0; i<checkboxes.length; i++) {
+        if (selectedColumns[i] === 1) {
+            checkboxes[i].checked = true;
+        }
+        else {
+            checkboxes[i].checked = false;
+        }
+    }
+}
+
+function updateManageGradesColumns() {
+    getCheckboxValues();
+    location.reload();
+}
+
+//Gets the values of all the checkboxes
+function getCheckboxValues() {
+    const selectedColumns = new Array(7);
+    for (let i = 0; i<checkboxes.length; i++) {
+        if (checkboxes[i].checked === true) {
+            selectedColumns[i] = 1;
+        }
+        else {
+            selectedColumns[i] = 0;
+        }
+    }
+    saveColumns(selectedColumns);
+}
+
+function fillAllCheckboxes(val) {
+    for (let i = 0; i<checkboxes.length; i++) {
+        checkboxes[i].checked = val;
+    }
+}
+
+//Cookies (loading and storing)
+function saveColumns(selectedColumns) {
+    Cookies.set('active_columns', selectedColumns.join('-'));
+}
+
+function loadColumns() {
+    const cookie = Cookies.get('active_columns').split('-');
+    for (let i = 0; i< cookie.length; i++) {
+        if (cookie[i] === '1') {
+            cookie[i] = 1;
+        }
+        else {
+            cookie[i] = 0;
+        }
+    }
+    return cookie;
+}


### PR DESCRIPTION
Closes #9438 
**Issue Description**:
What problem are you trying to solve with Submitty
Just like how we have toggleable columns for manage students, it would be nice to have an analogous feature in manage graders

Describe the way you'd like to solve this problem
Implement it similarly to PR https://github.com/Submitty/Submitty/pull/9188. (The PR that added toggleable columns to manage students)
Make sure to use the js-cookie library (for an example see PR https://github.com/Submitty/Submitty/pull/9314)

Additional context
This is what the feature looked like for Manage Students, and it should look similar to this
