### PR TITLE
[Bugfix:Submission] Fix error message on do not grade

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1046,18 +1046,22 @@ class HomeworkView extends AbstractView {
         }
 
         $failed_file = '';
+        $file_count = 0;
         // See if the grade has succeeded or failed
-        if (count($param['files']) === 1) {
-            foreach ($param['files'] as $file) {
-                if (str_contains($file['relative_name'], 'failed')) {
-                    $failed_file = file_get_contents($file['path']);
-                // Exclude the Exception error message
-                    $failed_file = substr(strstr($failed_file, "\n"), 3);
+        if (in_array('files', $param)) {
+            $file_count = count($param['files']);
+            if ($file_count === 1) {
+                foreach ($param['files'] as $file) {
+                    if (str_contains($file['relative_name'], 'failed')) {
+                        $failed_file = file_get_contents($file['path']);
+                    // Exclude the Exception error message
+                        $failed_file = substr(strstr($failed_file, "\n"), 3);
+                    }
                 }
+                // Arbitrary size, currently bigger than all of the failed files, but
+                // could be increased if the failed files need more tips/messages
+                $failed_file = (strlen($failed_file) > 1000) ? substr($failed_file, 0, 1000) : $failed_file;
             }
-            // Arbitrary size, currently bigger than all of the failed files, but
-            // could be increased if the failed files need more tips/messages
-            $failed_file = (strlen($failed_file) > 1000) ? substr($failed_file, 0, 1000) : $failed_file;
         }
 
         // If its not git checkout
@@ -1076,7 +1080,7 @@ class HomeworkView extends AbstractView {
 
         $param = array_merge($param, [
             'failed_file' => $failed_file,
-            'file_length' => count($param['files']),
+            'file_length' => $file_count,
             'gradeable_id' => $gradeable->getId(),
             'student_download' => $gradeable->canStudentDownload(),
             'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails(),


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
#9399 was merged, and if the user selects 'do not grade this assignment', a site error would show with 'count must be used on an array'
![image](https://github.com/Submitty/Submitty/assets/46759635/dc75e9c9-e5ce-4884-a797-7ef78f634525)


### What is the new behavior?
This is now fixed
