### PR TITLE
[UI/UX:TAGrading] Change enable anon to anonymous

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -47,7 +47,7 @@
                 {% if toggle_anon_button %}
                 <button class="btn btn-default" id="toggle-anon-button"
                     onclick="changeAnon()">
-                    {{ anon_mode ? "Disable Anon Mode" : "Enable Anon Mode" }}
+                    {{ anon_mode ? "Disable Anonymous Mode" : "Enable Anonymous Mode" }}
                 </button>
                 {% endif %}
             </div>


### PR DESCRIPTION
### What is the current behavior?
On the gradeable details page, the button to enable anonymous mode says "Enable Anon Mode." While anon is the abbreviation for anonymous used throughout Submitty's source code, non-developers will not know this abbreviation.

### What is the new behavior?
Now the button reads, "Enable Anonymous Mode."