### PR TITLE
[Documentation:Developer] Add vagrant up status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 [![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)
+[![Vagrant Up](https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml/badge.svg)](https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml)
 
 # Usage
 


### PR DESCRIPTION
### What is the current behavior?
In order to see if the vagrant up action is passing/failing you need to go to the actions tab and filter by the vagrant up action.

### What is the new behavior?
Another status badge, just like the regular CI badge, has been added to the README for the vagrant up nightly job. This just makes it quicker/easier to see if it's currently failing.

Here's a screenshot of what it would look like:
![image](https://github.com/Submitty/Submitty/assets/55092742/75da2729-3757-44cf-9466-210bee205306)
