### PR TITLE
[UI/UX:TAGrading] Update sort_type for "Total" field

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -493,7 +493,7 @@ HTML;
                 $columns[]     = ["width" => "10%", "title" => "Grading",          "function" => "grading_blind"];
             }
             if ($peer === false) {
-                $columns[]     = ["width" => "15%", "title" => "Total",            "function" => "total"];
+                $columns[]     = ["width" => "15%", "title" => "Total",            "function" => "total",  "sort_type" => "first"];
             }
             $columns[]         = ["width" => "15%", "title" => "Active Version",   "function" => "active_version"];
         }
@@ -534,7 +534,7 @@ HTML;
             else {
                 $columns[]     = ["width" => "8%",  "title" => "Grading",       "function" => "grading"];
             }
-            $columns[]         = ["width" => "7%",  "title" => "Total",            "function" => "total"];
+            $columns[]         = ["width" => "7%",  "title" => "Total",            "function" => "total",  "sort_type" => "first"];
             $columns[]         = ["width" => "10%", "title" => "Active Version",   "function" => "active_version"];
             if ($gradeable->isTaGradeReleased()) {
                 $columns[]     = ["width" => "8%",  "title" => "Viewed Grade",     "function" => "viewed_grade"];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
What problem are you trying to solve with Submitty
Currently in the grading details page you can sort by user id, first name, or last name. However, when grading certain things it would be useful to grade by how many point the person got on the assignment. Currently to do this you have to go through the list and look for the scores manually.

### What is the new behavior?
Now the sorting can be done based on how many points the person got on the assignment.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
