### PR TITLE
[Bugfix:System] update migration for legacy courses

### DIFF
--- a/migration/migrator/migrations/course/20230601123230_change_regrade_to_grade_inquiry.py
+++ b/migration/migrator/migrations/course/20230601123230_change_regrade_to_grade_inquiry.py
@@ -28,6 +28,18 @@ def up(config, database, semester, course):
     :param course: Code of course being migrated
     :type course: str
     """
+
+    # First we need to patch missing constraints from existing courses prior to Fall 2019
+    database.execute("""
+
+        alter table electronic_gradeable drop constraint if exists eg_regrade_allowed_true;
+
+        alter table electronic_gradeable add constraint eg_regrade_allowed_true CHECK
+            (((eg_regrade_allowed IS TRUE) OR (eg_regrade_allowed IS FALSE)));
+
+    """)
+
+
     database.execute("""
         ALTER TABLE regrade_discussion
             RENAME TO grade_inquiry_discussion;


### PR DESCRIPTION
### What is the current behavior?

Unfortunately the migration in PR #9398 assumed that a constraint exists, however, this constraint was added early in Fall 2019 without an appropriate migration, so courses created during and before Fall 2019 are missing this constraint.

### What is the new behavior?

The migration has been modified to add the constraint before running the rename operation.