### PR TITLE
[Feature:Calendar] Background for Note text on the calendar

### DIFF
--- a/site/app/entities/calendar/CalendarItem.php
+++ b/site/app/entities/calendar/CalendarItem.php
@@ -81,7 +81,7 @@ class CalendarItem {
 
     public function setStringType(string $type): void {
         switch ($type) {
-            case 'text':
+            case 'note':
                 $this->type = self::TEXT;
                 break;
             case 'ann':
@@ -99,7 +99,7 @@ class CalendarItem {
     public function getTypeString(): string {
         switch ($this->type) {
             case self::TEXT:
-                return 'text';
+                return 'note';
             case self::ANNOUNCEMENT:
                 return 'ann';
         }

--- a/site/app/templates/calendar/EditCalendarItem.twig
+++ b/site/app/templates/calendar/EditCalendarItem.twig
@@ -10,7 +10,7 @@
     <input type="hidden" id="calendar-item-course-edit" name="course">
     <label for="calendar-item-type-edit">Message Type</label>
     <select id="calendar-item-type-edit" name="type">
-        <option value="text">Note</option>
+        <option value="note">Note</option>
         <option value="ann">Announcement</option>
     </select><br>
     <label for="calendar-item-text-edit">Message Text</label>

--- a/site/app/templates/calendar/NewCalendarItem.twig
+++ b/site/app/templates/calendar/NewCalendarItem.twig
@@ -13,7 +13,7 @@
     </select><br>
     <label for="calendar-item-type">Message Type</label>
     <select id="calendar-item-type" name="type">
-        <option value="text">Note</option>
+        <option value="note">Note</option>
         <option value="ann">Announcement</option>
     </select><br>
     <label for="calendar-item-text">Message Text</label>

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -140,6 +140,11 @@ function generateCalendarItem(item) {
     if (item['status'] === 'ann') {
         element.style.setProperty('border-color', item['color']);
     }
+    if (item['status'] === 'note') {
+        element.style.setProperty('border-color', 'green');
+        element.style.setProperty('border-style', 'dotted');
+        element.style.setProperty('border-width', '3px');
+    }
     if (exists) {
         element.style.setProperty('cursor','pointer');
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is no background for the announcement text, so it is not obvious where it is, or even that the user should pay attention to it.


closes issue #9250


### What is the new behavior?
Now the text has a dotted background.
![image](https://github.com/Submitty/Submitty/assets/96174078/055de0a7-bc7c-4731-87fb-6d252cff4d3e)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
