### PR TITLE
[Bugfix:Autograding] Fix get_vcs_info return value

### DIFF
--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -181,7 +181,8 @@ def prepare_autograding_and_submission_zip(
             )
             raise RuntimeError("ERROR: the submission directory does not exist", submission_path)
         print(which_machine, which_untrusted, "prepare zip", submission_path)
-        is_vcs, vcs_type, vcs_base_url, vcs_partial_path, using_subdirectory, vcs_subdirectory = get_vcs_info(
+        (is_vcs, vcs_type, vcs_base_url, vcs_partial_path,
+        using_subdirectory, vcs_subdirectory) = get_vcs_info(
             config,
             config.submitty['submitty_data_dir'],
             obj["semester"],

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -181,7 +181,7 @@ def prepare_autograding_and_submission_zip(
             )
             raise RuntimeError("ERROR: the submission directory does not exist", submission_path)
         print(which_machine, which_untrusted, "prepare zip", submission_path)
-        is_vcs, vcs_type, vcs_base_url, vcs_partial_path, vcs_subdirectory = get_vcs_info(
+        is_vcs, vcs_type, vcs_base_url, vcs_partial_path, using_subdirectory, vcs_subdirectory = get_vcs_info(
             config,
             config.submitty['submitty_data_dir'],
             obj["semester"],

--- a/autograder/autograder/packer_unpacker.py
+++ b/autograder/autograder/packer_unpacker.py
@@ -182,7 +182,7 @@ def prepare_autograding_and_submission_zip(
             raise RuntimeError("ERROR: the submission directory does not exist", submission_path)
         print(which_machine, which_untrusted, "prepare zip", submission_path)
         (is_vcs, vcs_type, vcs_base_url, vcs_partial_path,
-        using_subdirectory, vcs_subdirectory) = get_vcs_info(
+         using_subdirectory, vcs_subdirectory) = get_vcs_info(
             config,
             config.submitty['submitty_data_dir'],
             obj["semester"],


### PR DESCRIPTION
### What is the current behavior?
#9423 introduced a new variable, using_subdirectory that packer_unpacker.py get_vcs_info returns.
I missed an instance of that function, so there are errors in the autograding of zip submissions.
### What is the new behavior?
The return variable has been added, so the errors should be fixed. 