### PR TITLE
[Testing:Developer] Make forum tests not run in CI

### DIFF
--- a/tests/e2e/test_forum.py
+++ b/tests/e2e/test_forum.py
@@ -228,6 +228,7 @@ class TestForum(BaseTestCase):
                 self.check_socket_message('merge_thread')
             assert self.driver.find_element(By.ID, "merge-threads").value_of_css_property("display") == "none"
 
+    @unittest.skipUnless(os.environ.get('CI') is None, "CI test is flaky")
     def test_basic_operations_thread(self):
         title = "E2E Sample Title E2E"
         content = "E2E Sample Content E2E"
@@ -255,7 +256,7 @@ class TestForum(BaseTestCase):
         except Exception as e:
             print(self.driver.page_source)
             raise e
-
+    @unittest.skipUnless(os.environ.get('CI') is None, "CI test is flaky")
     def test_forum_merge_thread(self):
         self.init_and_enable_discussion()
         title1 = "E2E Test 1 E2E"
@@ -300,7 +301,8 @@ class TestForum(BaseTestCase):
         # Cleanup
         self.delete_thread(title3)
         self.delete_thread(title1)
-
+        
+    @unittest.skipUnless(os.environ.get('CI') is None, "CI test is flaky")
     def test_categories(self):
         title1 = "E2E Sample Title 1 E2E"
         content1 = "E2E Sample Content 1 E2E"


### PR DESCRIPTION
### What is the current behavior?
The forum tests are flaky, some of them are consistantly erroring with 'cannot find element 'logout''
### What is the new behavior?
#9393 is refactoring the selenium tests to be cypress tests, so this PR is to make the selenium forum tests to not run in the CI. 