### PR TITLE
[Bugfix:TAGrading] Fix Grade Inquiry Components

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1229,7 +1229,7 @@ class HomeworkView extends AbstractView {
                 $author_user_ids = array_map(function ($post) {
                     return $post["user_id"];
                 }, $grade_inquiry_posts_for_id);
-                $author_user_groups = $queries->getAuthorUserGroups($author_user_ids);
+                $author_user_groups = $queries->getAuthorUserGroups(array_values($author_user_ids));
 
                 $instructor_full_access = [];
                 $limited_access_grader = [];


### PR DESCRIPTION
### What is the current behavior?
If a student makes multiple grade inquiries by component, the grading and submission page will crash.
Fixes #9467

### What is the new behavior?
Both pages now load fine.

### Other information?
The issue was caused by `[1=>'USER_ID']` being passed into a query when it expected some element at index 0. To fix this a simple `array_values` was used to reset the keys.
