### PR TITLE
Warning messages for late submissions appearing without reloading

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -390,13 +390,15 @@
     function makeSubmission(user_id, highest_version, is_pdf, path, git_user_id, git_repo_id, merge_previous=false, clobber=false) {
         // submit the selected pdf
         path = decodeURIComponent(path);
+        var days_past_deadline = checkDeadline();
         if (is_pdf) {
             submitSplitItem("{{ csrf_token }}", "{{ gradeable_id }}", user_id, path, merge_previous, clobber);
         }
-
         // otherwise, this is a regular submission of the uploaded files
         else if (user_id == "") {
-            handleSubmission({{ late_days_use }},
+            handleSubmission(
+                days_past_deadline,
+                {{ late_days_use }},
                 {{ days_to_be_charged }},
                 {{ allowed_late_days }},
                 {{ min_team_would_be_late_days_remaining }},
@@ -417,7 +419,9 @@
             );
         }
         else {
-            handleSubmission({{ late_days_use }},
+            handleSubmission(
+                days_past_deadline,
+                {{ late_days_use }},
                 {{ days_to_be_charged }},
                 {{ allowed_late_days }},
                 {{ min_team_would_be_late_days_remaining }},

--- a/site/public/js/submission-page.js
+++ b/site/public/js/submission-page.js
@@ -97,6 +97,19 @@ function syncWithServer(criticalSync) {
         }
     }
 }
+function checkDeadline() {
+
+  curTime += (Date.now()-lastTime);
+  const time = Math.floor((deadline - curTime) / 1000);
+  const days = Math.floor(time / (3600 * 24));
+
+    if (document.getElementById('gradeable-time-remaining-text') !== null) {
+            if (curTime > deadline) {
+                return Math.max(days, 1);
+            }
+}
+  return 0;
+}
 
 function updateTime() {
     if (Math.abs(Date.now() - lastTime) > 5000) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
--> Warning messages for late submissions don't appear without reloading the website.
### What is the new behavior?
-->  closes issue #9465 
