### PR TITLE
[Testing:Developer] Bump PHPStan to level 6

### DIFF
--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1,6 +1,71 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method app\\\\authentication\\\\AbstractAuthentication\\:\\:getUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\AbstractAuthentication\\:\\:setPassword\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\AbstractAuthentication\\:\\:setPassword\\(\\) has parameter \\$password with no type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\AbstractAuthentication\\:\\:setUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\AbstractAuthentication\\:\\:setUserId\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Property app\\\\authentication\\\\AbstractAuthentication\\:\\:\\$core has no type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Property app\\\\authentication\\\\AbstractAuthentication\\:\\:\\$password has no type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Property app\\\\authentication\\\\AbstractAuthentication\\:\\:\\$user_id has no type specified\\.$#"
+			count: 1
+			path: app/authentication/AbstractAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\SamlAuthentication\\:\\:redirect\\(\\) has parameter \\$old with no type specified\\.$#"
+			count: 1
+			path: app/authentication/SamlAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\SamlAuthentication\\:\\:setValidUsernames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/authentication/SamlAuthentication.php
+
+		-
+			message: "#^Method app\\\\authentication\\\\SamlAuthentication\\:\\:setValidUsernames\\(\\) has parameter \\$usernames with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/authentication/SamlAuthentication.php
+
+		-
+			message: "#^Property app\\\\authentication\\\\SamlAuthentication\\:\\:\\$auth has no type specified\\.$#"
+			count: 1
+			path: app/authentication/SamlAuthentication.php
+
+		-
+			message: "#^Property app\\\\authentication\\\\SamlAuthentication\\:\\:\\$valid_usernames has no type specified\\.$#"
+			count: 1
+			path: app/authentication/SamlAuthentication.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\AutoGradedVersion and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/AbstractController.php
@@ -27,9 +92,24 @@ parameters:
 			path: app/controllers/AuthenticationController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\AuthenticationController\\:\\:checkLogin\\(\\) has parameter \\$old with no type specified\\.$#"
+			count: 1
+			path: app/controllers/AuthenticationController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\AuthenticationController\\:\\:loginForm\\(\\) has parameter \\$old with no type specified\\.$#"
+			count: 1
+			path: app/controllers/AuthenticationController.php
+
+		-
 			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
 			count: 2
 			path: app/controllers/AuthenticationController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\AutogradingStatusController\\:\\:getAutogradingInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/AutogradingStatusController.php
 
 		-
 			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
@@ -38,6 +118,61 @@ parameters:
 
 		-
 			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:footer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:header\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_course_sidebar\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_course_sidebar\\(\\) has parameter \\$sidebar_buttons with no type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_course_sidebar\\(\\) has parameter \\$unread_notifications_count with no type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_sidebar\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_sidebar\\(\\) has parameter \\$sidebar_buttons with no type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_sidebar\\(\\) has parameter \\$unread_notifications_count with no type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_user_sidebar\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:prep_user_sidebar\\(\\) has parameter \\$sidebar_buttons with no type specified\\.$#"
+			count: 1
+			path: app/controllers/GlobalController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\GlobalController\\:\\:routeEquals\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/controllers/GlobalController.php
 
@@ -63,6 +198,21 @@ parameters:
 			path: app/controllers/HomePageController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\HomePageController\\:\\:createCourse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/HomePageController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\HomePageController\\:\\:createCoursePage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/HomePageController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\HomePageController\\:\\:getGroupUsers\\(\\) has parameter \\$group_name with no type specified\\.$#"
+			count: 1
+			path: app/controllers/HomePageController.php
+
+		-
 			message: "#^Result of \\|\\| is always true\\.$#"
 			count: 1
 			path: app/controllers/HomePageController.php
@@ -76,9 +226,179 @@ parameters:
 			path: app/controllers/MiscController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:checkBulkProgress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:checkBulkProgress\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:decodeAnonPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:decodeAnonPath\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:decodeAnonPath\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has parameter \\$course_material_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has parameter \\$dir with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has parameter \\$ta_grading with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:displayFile\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadAssignedZips\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadAssignedZips\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadAssignedZips\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadCourseFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadCourseFile\\(\\) has parameter \\$course_material_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadCourseFile\\(\\) has parameter \\$dir with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadCourseFile\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadCourseFile\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadSubmissionZip\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadSubmissionZip\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadSubmissionZip\\(\\) has parameter \\$is_anon with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadSubmissionZip\\(\\) has parameter \\$origin with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadSubmissionZip\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadSubmissionZip\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:downloadTestCaseResult\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:encodePDF\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:readFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:readFile\\(\\) has parameter \\$csrf_token with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:readFile\\(\\) has parameter \\$dir with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:readFile\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: app/controllers/MiscController.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/MiscController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\NavigationController\\:\\:navigationPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/NavigationController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\NavigationController\\:\\:noAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/NavigationController.php
 
 		-
 			message: """
@@ -102,6 +422,21 @@ parameters:
 				should not be used, just return WebResponse directly$#
 			"""
 			count: 2
+			path: app/controllers/NotificationController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\NotificationController\\:\\:validateNotificationSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/NotificationController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\NotificationController\\:\\:validateNotificationSettings\\(\\) has parameter \\$columns with no type specified\\.$#"
+			count: 1
+			path: app/controllers/NotificationController.php
+
+		-
+			message: "#^Property app\\\\controllers\\\\NotificationController\\:\\:\\$selections has no type specified\\.$#"
+			count: 1
 			path: app/controllers/NotificationController.php
 
 		-
@@ -129,12 +464,447 @@ parameters:
 			path: app/controllers/OfficeHoursQueueController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:addPerson\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:changeContactInformation\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:changeRegex\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:changeToken\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:deleteQueue\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:emptyQueue\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:finishHelpPerson\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:getQueueMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:removePerson\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:restorePerson\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:sendSocketMessage\\(\\) has parameter \\$msg_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:showNewAnnouncement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:showQueue\\(\\) has parameter \\$full_history with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:showQueueHistory\\(\\) has parameter \\$full_history with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:showQueueStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:showQueueStudentStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:startHelpPerson\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:switchQueue\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\OfficeHoursQueueController\\:\\:toggleQueue\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/controllers/OfficeHoursQueueController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\PollController\\:\\:editPoll\\(\\) has parameter \\$poll_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/PollController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\PollController\\:\\:getPollExportData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/PollController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\PollController\\:\\:hasAnswers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/PollController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\PollController\\:\\:viewResults\\(\\) has parameter \\$poll_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/PollController.php
+
+		-
 			message: """
 				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
 				should not be used, just return RedirectResponse directly$#
 			"""
 			count: 1
 			path: app/controllers/UserProfileController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:createGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:createGradeable\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:createGradeable\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:createGradeableRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:deleteGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:deleteGradeable\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editGradeableRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editGradeableRequest\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editGradeableRequest\\(\\) has parameter \\$nav_tab with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editGraderPeerSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editPage\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editPage\\(\\) has parameter \\$nav_tab with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:editPage\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueBuild\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueBuildFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueBuildFile\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueGenerateRepos\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueGenerateRepos\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueGenerateRepos\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:enqueueGenerateRepos\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:exportComponentsRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:exportComponentsRequest\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:genBlankComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:getValidPathsToConfigDirectories\\(\\) has parameter \\$dir_queue with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:getValidPathsToConfigDirectories\\(\\) has parameter \\$error_messages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:getValidPathsToConfigDirectories\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:importComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:importComponents\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:maxPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:maxPoints\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:newComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:newGraderPeerSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:newMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:newPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:openquickLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:openquickLink\\(\\) has parameter \\$action with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:openquickLink\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:parseCheckpoint\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:parseCheckpoint\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:parseNumeric\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:parseNumeric\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:parseText\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:parseText\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:rebuildGradeableRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:rebuildGradeableRequest\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:redirectToEdit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:redirectToEdit\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:shiftDates\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:shiftDates\\(\\) has parameter \\$dates with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:shufflePeerGrading\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGradeable\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGradeableRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGradeableRequest\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGraders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGraders\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGradersRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateGradersRequest\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateRubric\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateRubric\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateRubricRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:updateRubricRequest\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\AdminGradeableController\\:\\:writeFormConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/AdminGradeableController.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
@@ -174,11 +944,66 @@ parameters:
 			path: app/controllers/admin/ConfigurationController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ConfigurationController\\:\\:getGradeableSeatingOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ConfigurationController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\EmailRoomSeatingController\\:\\:replacePlaceholders\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/EmailRoomSeatingController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:deleteOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:deleteOverriddenGrades\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:getOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:getOverriddenGrades\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:updateOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:updateOverriddenGrades\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\GradeOverrideController\\:\\:viewOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/GradeOverrideController.php
+
+		-
 			message: """
 				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
 				should not be used, just return JsonResponse directly$#
 			"""
 			count: 18
+			path: app/controllers/admin/LateController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\LateController\\:\\:parseAndValidateCsv\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/LateController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\LateController\\:\\:parseAndValidateCsv\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
 			path: app/controllers/admin/LateController.php
 
 		-
@@ -197,8 +1022,68 @@ parameters:
 			path: app/controllers/admin/LateController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\NotebookBuilderController\\:\\:builder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/NotebookBuilderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\NotebookBuilderController\\:\\:checkPermissions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/NotebookBuilderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\NotebookBuilderController\\:\\:getFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/NotebookBuilderController.php
+
+		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 2
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:downloadConfigFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getIgnoreSubmissionType\\(\\) has parameter \\$usernames with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getIgnoreSubmissionType\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getJsonForConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getOtherOtherGradeables\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getOtherSemesterCourses\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getOverallRankings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:getRankingsForUser\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/PlagiarismController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\PlagiarismController\\:\\:toggleNightlyRerun\\(\\) has no return type specified\\.$#"
+			count: 1
 			path: app/controllers/admin/PlagiarismController.php
 
 		-
@@ -215,6 +1100,106 @@ parameters:
 			path: app/controllers/admin/ReportController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:autoRainbowGradesStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:cacheTeamGradedGradeables\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:displayGradebook\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:genDummyGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:generateCSVReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:generateCSVRow\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:generateCustomization\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:generateGradeSummaries\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:generateGradeSummary\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:generateReportInternal\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:getGradeSummariesLastRun\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:getSplitGradeables\\(\\) has parameter \\$sort_keys with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:getSplitGradeables\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:mergeGradedGradeables\\(\\) has parameter \\$team_graded_gradeables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:saveUserToFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:showReportPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\ReportController\\:\\:uploadRainbowConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Property app\\\\controllers\\\\admin\\\\ReportController\\:\\:\\$all_overrides has no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/ReportController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\StudentActivityDashboardController\\:\\:downloadData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/StudentActivityDashboardController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\StudentActivityDashboardController\\:\\:getStudents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/StudentActivityDashboardController.php
+
+		-
 			message: """
 				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
 				should not be used, just return RedirectResponse directly$#
@@ -227,6 +1212,66 @@ parameters:
 				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
 				should not be used, just return WebResponse directly$#
 			"""
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:ajaxGetSubmittyUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:ajaxGetUserDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:ajaxGetUserDetails\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:getUserDataFromUpload\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:reassignRegistrationSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:sectionsForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:updateRegistrationSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:updateRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:updateUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:updateUser\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:uploadUserList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/admin/UsersController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:viewStudentGrades\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/controllers/admin/UsersController.php
 
@@ -262,9 +1307,414 @@ parameters:
 			path: app/controllers/admin/WrapperController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:addDirs\\(\\) has parameter \\$dirs_to_make with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:deleteCourseMaterial\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:deleteCourseMaterial\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:downloadCourseMaterialZip\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:downloadCourseMaterialZip\\(\\) has parameter \\$course_material_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:modifyCourseMaterialsFileTimeStamp\\(\\) has parameter \\$newdatatime with no type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:recursiveEditFolder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:recursiveEditFolder\\(\\) has parameter \\$course_materials with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:resolveClashingMaterials\\(\\) has parameter \\$file_names with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:setFileTimeStamp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:setFileTimeStamp\\(\\) has parameter \\$courseMaterials with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\course\\\\CourseMaterialsController\\:\\:viewCourseMaterial\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/course/CourseMaterialsController.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between array\\<int, app\\\\entities\\\\course\\\\CourseMaterial\\> and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/course/CourseMaterialsController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:addNewCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:addNewCategory\\(\\) has parameter \\$category with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:alterAnnouncement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:alterPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:bookmarkThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:changeThreadStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:changeThreadStatus\\(\\) has parameter \\$status with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:changeThreadStatus\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:checkGoodAttachment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:checkGoodAttachment\\(\\) has parameter \\$file_post with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:checkGoodAttachment\\(\\) has parameter \\$isThread with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:checkGoodAttachment\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:deleteCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:editCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:editPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:editThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getAllowedCategoryColor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getEditPostContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getHistory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSavedCategoryIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSavedCategoryIds\\(\\) has parameter \\$category_ids with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSavedCategoryIds\\(\\) has parameter \\$currentCourse with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSavedThreadStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSavedThreadStatus\\(\\) has parameter \\$thread_status with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSinglePost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSingleThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$blockNumber with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$max_thread with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$show_merged_thread with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$thread_status with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSortedThreads\\(\\) has parameter \\$unread_threads with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getSplitPostInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getThreadContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getThreadContent\\(\\) has parameter \\$output with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getThreadContent\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:getThreads\\(\\) has parameter \\$page_number with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:isCategoryDeletionGood\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:isCategoryDeletionGood\\(\\) has parameter \\$category_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:isValidCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:isValidCategories\\(\\) has parameter \\$inputCategoriesIds with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:isValidCategories\\(\\) has parameter \\$inputCategoriesName with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:mergeThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:modifyAnonymous\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:modifyAnonymous\\(\\) has parameter \\$author with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:publishPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:publishThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:reorderCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:returnUserContentToPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:returnUserContentToPage\\(\\) has parameter \\$error with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:returnUserContentToPage\\(\\) has parameter \\$isThread with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:returnUserContentToPage\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:search\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showCreateThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showDeleted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showFullThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showMergedThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showMergedThreads\\(\\) has parameter \\$currentCourse with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showThreads\\(\\) has parameter \\$option with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showThreads\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:showUnreadThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\forum\\\\ForumController\\:\\:splitThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/forum/ForumController.php
 
 		-
 			message: "#^Elseif condition is always true\\.$#"
@@ -273,6 +1723,596 @@ parameters:
 
 		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:RandomizePeers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:RandomizePeers\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:addNewMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:adminTeamSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:adminTeamSubmit\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxAddComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxAddComponent\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxAddNewMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxAddNewMark\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxClearPeerMarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxClearPeerMarks\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxDeleteComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxDeleteComponent\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxDeleteMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxDeleteMark\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetAttachments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetAttachments\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetComponent\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetComponent\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradeableRubric\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradeableRubric\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedComponent\\(\\) has parameter \\$anon_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedComponent\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedComponent\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedGradeable\\(\\) has parameter \\$all_peers with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedGradeable\\(\\) has parameter \\$anon_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetGradedGradeable\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetMarkStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetMarkStats\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetStudentOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetStudentOutput\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetStudentOutput\\(\\) has parameter \\$index with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetStudentOutput\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxGetStudentOutput\\(\\) has parameter \\$who_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$autocheck_cnt with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$index with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$option with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$which with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxRemoveEmpty\\(\\) has parameter \\$who_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveComponent\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveComponentOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveComponentOrder\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveComponentPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveComponentPages\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveGradedComponent\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveMark\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveMarkOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveMarkOrder\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSaveOverallComment\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSetPeerFeedback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxSetPeerFeedback\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:ajaxVerifyComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:amIBlindGrading\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:amIBlindGrading\\(\\) has parameter \\$gradeable with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:amIBlindGrading\\(\\) has parameter \\$peer with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:amIBlindGrading\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:deleteAttachment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:deleteAttachment\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:deleteMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:exportTeams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:exportTeams\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:generateHistogramData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getGradeableRubric\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getGradedGradeable\\(\\) has parameter \\$all_peers with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getItempoolMapForSubmitter\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getMarkStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getSolutionTaNotesForGradeable\\(\\) has parameter \\$submitter_itempool_map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getSolutionTaNotesForGradeable\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getStats\\(\\) has parameter \\$total_graded with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:getStats\\(\\) has parameter \\$total_total with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:importTeams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:importTeams\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:randomizeTeamRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:randomizeTeamRotatingSections\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:removeEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveComponentOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveComponentOrder\\(\\) has parameter \\$orders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveComponentPages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveComponentPages\\(\\) has parameter \\$pages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveComponentsPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveGradedComponent\\(\\) has parameter \\$mark_ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveMarkOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveMarkOrder\\(\\) has parameter \\$orders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:saveOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:setAllGradAllGrading\\(\\) has parameter \\$student_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:setAllGradAllGrading\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:setRandomizedGraders\\(\\) has parameter \\$student_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:setRandomizedGraders\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$anon_mode with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$direction with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$filter with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$gradeable_version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$navigate_assigned_students_only with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showGrading\\(\\) has parameter \\$sort with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:showStatus\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:updateSolutionTaNotes\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:uploadAttachment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ElectronicGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ElectronicGraderController\\:\\:uploadAttachment\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
 			count: 1
 			path: app/controllers/grading/ElectronicGraderController.php
 
@@ -292,9 +2332,24 @@ parameters:
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ImagesController\\:\\:ajaxUploadImagesFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ImagesController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\grading\\\\ImagesController\\:\\:viewImagesPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/grading/ImagesController.php
+
+		-
 			message: "#^Parameter \\#1 \\$score of method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setScore\\(\\) expects float, string given\\.$#"
 			count: 1
 			path: app/controllers/grading/SimpleGraderController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\pdf\\\\PDFController\\:\\:showGraderPDFEmbedded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/pdf/PDFController.php
 
 		-
 			message: """
@@ -313,6 +2368,31 @@ parameters:
 			path: app/controllers/student/GradeInquiryController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\student\\\\GradeInquiryController\\:\\:getSingleGradeInquiryPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/GradeInquiryController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\GradeInquiryController\\:\\:notifyGradeInquiryEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/GradeInquiryController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\GradeInquiryController\\:\\:requestGradeInquiry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/GradeInquiryController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\LateDaysTableController\\:\\:showLateTablePage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/LateDaysTableController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\RainbowGradesController\\:\\:run\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/RainbowGradesController.php
+
+		-
 			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: app/controllers/student/SubmissionController.php
@@ -328,7 +2408,187 @@ parameters:
 			path: app/controllers/student/SubmissionController.php
 
 		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxBulkUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxBulkUpload\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxDeleteSplitItem\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxRegrade\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxRegrade\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSplitItem\\(\\) has parameter \\$clobber with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSplitItem\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSplitItem\\(\\) has parameter \\$merge with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSubmission\\(\\) has parameter \\$clobber with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSubmission\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSubmission\\(\\) has parameter \\$merge with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxUploadSubmission\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxValidGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:ajaxValidGradeable\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:checkRefresh\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:checkRefresh\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:checkRefresh\\(\\) has parameter \\$gradeable_version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:getTimeRemainingData\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:loadGradeableMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:loadGradeableMessage\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:showBulkStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:showBulkStats\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:showHomeworkPage\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:showHomeworkPage\\(\\) has parameter \\$gradeable_version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:showHomeworkPage\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:updateSubmissionVersion\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:updateSubmissionVersion\\(\\) has parameter \\$new_version with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:updateSubmissionVersion\\(\\) has parameter \\$ta with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:updateSubmissionVersion\\(\\) has parameter \\$who with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:uploadResult\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:uploadResult\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:uploadResult\\(\\) has parameter \\$success with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:verifyHomeworkPagePermissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:verifyHomeworkPagePermissions\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\SubmissionController\\:\\:verifyHomeworkPagePermissions\\(\\) has parameter \\$graded_gradeable with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
 			message: "#^Parameter \\#2 \\$array of function implode expects array\\<string\\>, array\\<app\\\\models\\\\User\\> given\\.$#"
+			count: 1
+			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Property app\\\\controllers\\\\student\\\\SubmissionController\\:\\:\\$upload_details has no type specified\\.$#"
 			count: 1
 			path: app/controllers/student/SubmissionController.php
 
@@ -336,6 +2596,111 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/student/SubmissionController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:acceptInvitation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:acceptInvitation\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:cancelInvitation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:cancelInvitation\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:createNewTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:createNewTeam\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:editSeekMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:editSeekMessage\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:leaveTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:leaveTeam\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:removeSeekMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:removeSeekMessage\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:seekTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:seekTeam\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:sendInvitation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:sendInvitation\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:setTeamName\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:showPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:showPage\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:stopSeekTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\TeamController\\:\\:stopSeekTeam\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/controllers/student/TeamController.php
 
 		-
 			message: """
@@ -346,9 +2711,34 @@ parameters:
 			path: app/controllers/superuser/SuperuserEmailController.php
 
 		-
+			message: "#^Method app\\\\entities\\\\course\\\\CourseMaterial\\:\\:getSections\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/course/CourseMaterial.php
+
+		-
 			message: "#^Parameter \\#1 \\$p of method Doctrine\\\\Common\\\\Collections\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:filter\\(\\) expects Closure\\(mixed\\=\\)\\: bool, Closure\\(app\\\\entities\\\\course\\\\CourseMaterialAccess\\)\\: bool given\\.$#"
 			count: 1
 			path: app/entities/course/CourseMaterial.php
+
+		-
+			message: "#^Property app\\\\entities\\\\course\\\\CourseMaterial\\:\\:\\$accesses with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/course/CourseMaterial.php
+
+		-
+			message: "#^Property app\\\\entities\\\\course\\\\CourseMaterial\\:\\:\\$sections with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/course/CourseMaterial.php
+
+		-
+			message: "#^Method app\\\\entities\\\\db\\\\Table\\:\\:getColumns\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/db/Table.php
+
+		-
+			message: "#^Property app\\\\entities\\\\db\\\\Table\\:\\:\\$columns with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/db/Table.php
 
 		-
 			message: "#^Property app\\\\entities\\\\email\\\\EmailEntity\\:\\:\\$body is never written, only read\\.$#"
@@ -401,9 +2791,139 @@ parameters:
 			path: app/entities/email/EmailEntity.php
 
 		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Category\\:\\:\\$threads with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Category.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Post\\:\\:\\$children with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Post.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Post\\:\\:\\$history with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Post.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Post\\:\\:\\$merged_threads with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Post.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Thread\\:\\:\\$categories with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Thread.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Thread\\:\\:\\$merged_on_this with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Thread.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Thread\\:\\:\\$posts with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Thread.php
+
+		-
+			message: "#^Property app\\\\entities\\\\forum\\\\Thread\\:\\:\\$viewers with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/forum/Thread.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:__construct\\(\\) has parameter \\$ignored_submissions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:__construct\\(\\) has parameter \\$other_gradeable_paths with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:__construct\\(\\) has parameter \\$other_gradeables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:__construct\\(\\) has parameter \\$regex with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:getIgnoredSubmissions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:getOtherGradeablePaths\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:getOtherGradeables\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:getRegexArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:setIgnoredSubmissions\\(\\) has parameter \\$ignored_submissions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:setOtherGradeablePaths\\(\\) has parameter \\$paths with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:setOtherGradeables\\(\\) has parameter \\$other_gradeables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:setRegexArray\\(\\) has parameter \\$regex with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
 			message: "#^Parameter \\#1 \\$p of method Doctrine\\\\Common\\\\Collections\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:filter\\(\\) expects Closure\\(mixed\\=\\)\\: bool, Closure\\(app\\\\entities\\\\plagiarism\\\\PlagiarismRunAccess\\)\\: bool given\\.$#"
 			count: 1
 			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Property app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:\\$access_times with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Property app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:\\$ignore_submissions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Property app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:\\$other_gradeable_paths type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Property app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:\\$other_gradeables type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Property app\\\\entities\\\\plagiarism\\\\PlagiarismConfig\\:\\:\\$regex type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/plagiarism/PlagiarismConfig.php
+
+		-
+			message: "#^Method app\\\\entities\\\\poll\\\\Option\\:\\:getUserResponses\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/poll/Option.php
 
 		-
 			message: "#^Property app\\\\entities\\\\poll\\\\Option\\:\\:\\$id is never written, only read\\.$#"
@@ -411,7 +2931,82 @@ parameters:
 			path: app/entities/poll/Option.php
 
 		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Option\\:\\:\\$user_responses with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/poll/Option.php
+
+		-
+			message: "#^Method app\\\\entities\\\\poll\\\\Poll\\:\\:addResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Method app\\\\entities\\\\poll\\\\Poll\\:\\:getOptions\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Method app\\\\entities\\\\poll\\\\Poll\\:\\:getSelectedOptionIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Method app\\\\entities\\\\poll\\\\Poll\\:\\:getUserResponses\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
 			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$image_path has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$options with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$question has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$question_type has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$release_answer has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$release_histogram has no type specified\\.$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$responses with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: app/entities/poll/Poll.php
+
+		-
+			message: "#^Property app\\\\entities\\\\poll\\\\Poll\\:\\:\\$status has no type specified\\.$#"
 			count: 1
 			path: app/entities/poll/Poll.php
 
@@ -421,7 +3016,107 @@ parameters:
 			path: app/entities/poll/Response.php
 
 		-
+			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:displayMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:getDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:logException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:setDisplayMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:setDisplayMessage\\(\\) has parameter \\$bool with no type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Property app\\\\exceptions\\\\BaseException\\:\\:\\$details has no type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Property app\\\\exceptions\\\\BaseException\\:\\:\\$log_exception has no type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Property app\\\\exceptions\\\\BaseException\\:\\:\\$show_exception_message has no type specified\\.$#"
+			count: 1
+			path: app/exceptions/BaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\CurlException\\:\\:__construct\\(\\) has parameter \\$curl_handle with no type specified\\.$#"
+			count: 1
+			path: app/exceptions/CurlException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\CurlException\\:\\:__construct\\(\\) has parameter \\$curl_return with no type specified\\.$#"
+			count: 1
+			path: app/exceptions/CurlException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\DatabaseException\\:\\:__construct\\(\\) has parameter \\$parameters with no type specified\\.$#"
+			count: 1
+			path: app/exceptions/DatabaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\DatabaseException\\:\\:__construct\\(\\) has parameter \\$query with no type specified\\.$#"
+			count: 1
+			path: app/exceptions/DatabaseException.php
+
+		-
+			message: "#^Method app\\\\exceptions\\\\FileNotFoundException\\:\\:__construct\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: app/exceptions/FileNotFoundException.php
+
+		-
 			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: app/libraries/Access.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Access\\:\\:canI\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Access.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Access\\:\\:canUser\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Access.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Access\\:\\:canUserAccessPath\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Access.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Access\\:\\:loadDirectories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Access.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Access\\:\\:requireArg\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Access.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Access\\:\\:\\$directories type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/libraries/Access.php
 
@@ -429,6 +3124,136 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 2
 			path: app/libraries/Access.php
+
+		-
+			message: "#^Class app\\\\libraries\\\\CascadingIterator implements generic interface Iterator but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: app/libraries/CascadingIterator.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\CascadingIterator\\:\\:iteratorKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/CascadingIterator.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\CascadingIterator\\:\\:seek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/CascadingIterator.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\CodeMirrorUtils\\:\\:getLanguages\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/CodeMirrorUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:addErrorMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:addErrorMessage\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:addNoticeMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:addNoticeMessage\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:addSuccessMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:addSuccessMessage\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:buildCourseUrl\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:buildUrl\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:disableRedirects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:getControllerTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:getCourseQueries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:getFullSemester\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:getSubmittyQueries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:loadAuthentication\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:loadCourseConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:loadGradingQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:loadMasterConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:loadModel\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:loadUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:redirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:setNotificationFactory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Core\\:\\:setSessionManager\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Core.php
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
@@ -441,6 +3266,26 @@ parameters:
 			path: app/libraries/Core.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\CourseMaterialsUtils\\:\\:finalAccessCourseMaterialCheck\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/CourseMaterialsUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\CourseMaterialsUtils\\:\\:insertCourseMaterialAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/CourseMaterialsUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\CustomCodeBlockRenderer\\:\\:__construct\\(\\) has parameter \\$baseRenderer with no type specified\\.$#"
+			count: 1
+			path: app/libraries/CustomCodeBlockRenderer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\CustomCodeBlockRenderer\\:\\:addLineNumbers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/CustomCodeBlockRenderer.php
+
+		-
 			message: "#^Parameter \\#1 \\$block of method League\\\\CommonMark\\\\Block\\\\Renderer\\\\FencedCodeRenderer\\:\\:render\\(\\) expects League\\\\CommonMark\\\\Block\\\\Element\\\\FencedCode\\|League\\\\CommonMark\\\\Block\\\\Element\\\\IndentedCode, League\\\\CommonMark\\\\Block\\\\Element\\\\AbstractBlock given\\.$#"
 			count: 1
 			path: app/libraries/CustomCodeBlockRenderer.php
@@ -451,9 +3296,94 @@ parameters:
 			path: app/libraries/CustomCodeInlineRenderer.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\DateUtils\\:\\:getAvailableTimeZones\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DateUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DateUtils\\:\\:getOrderedTZWithUTCOffset\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DateUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DateUtils\\:\\:getServerTimeJson\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DateUtils.php
+
+		-
 			message: "#^Unsafe access to private property app\\\\libraries\\\\DateUtils\\:\\:\\$timezone through static\\:\\:\\.$#"
 			count: 3
 			path: app/libraries/DateUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:buildViewer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:compressRange\\(\\) has parameter \\$range with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:compressRange\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:correctMbDiff\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:correctMbDiff\\(\\) has parameter \\$diffs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:destroyViewer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:getDisplay\\(\\) has parameter \\$lines with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:getDisplay\\(\\) has parameter \\$option with no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:getWhiteSpaces\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:isValidSpecialCharsOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:isValidSpecialCharsOption\\(\\) has parameter \\$option with no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:isValidType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:isValidType\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\DiffViewer\\:\\:reset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, bool given\\.$#"
@@ -461,9 +3391,79 @@ parameters:
 			path: app/libraries/DiffViewer.php
 
 		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$actual type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$actual_file_image has no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$actual_file_name has no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$add type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$built has no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$diff type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$difference_file_image has no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$expected type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$expected_file_image has no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$has_difference has no type specified\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
 			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$has_difference is never read, only written\\.$#"
 			count: 1
 			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$link type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\DiffViewer\\:\\:\\$white_spaces type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/DiffViewer.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ExceptionHandler\\:\\:setDisplayExceptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/ExceptionHandler.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ExceptionHandler\\:\\:setLogExceptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/ExceptionHandler.php
 
 		-
 			message: "#^Unsafe access to private property app\\\\libraries\\\\ExceptionHandler\\:\\:\\$display_exceptions through static\\:\\:\\.$#"
@@ -481,9 +3481,279 @@ parameters:
 			path: app/libraries/ExceptionHandler.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:areWordsInFile\\(\\) has parameter \\$words with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:checkForPermissionErrors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:emptyDir\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:encodeJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:encodeJson\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:getAllDirs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:getAllFiles\\(\\) has parameter \\$skip_files with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:getAllFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:getAllFilesTrimSearchPath\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:getDirContents\\(\\) has parameter \\$results with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:getTopEmptyDir\\(\\) has parameter \\$results with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:readJsonFile\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:validateUploadedFiles\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\FileUtils\\:\\:validateUploadedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/FileUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:checkGoodAttachment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:checkGoodAttachment\\(\\) has parameter \\$file_post with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:checkGoodAttachment\\(\\) has parameter \\$isThread with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:checkGoodAttachment\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:getDisplayName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:getDisplayName\\(\\) has parameter \\$anonymous with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:getDisplayName\\(\\) has parameter \\$real_name with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:isValidCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:isValidCategories\\(\\) has parameter \\$inputCategoriesIds with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:isValidCategories\\(\\) has parameter \\$inputCategoriesName with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\ForumUtils\\:\\:isValidCategories\\(\\) has parameter \\$rows with no type specified\\.$#"
+			count: 1
+			path: app/libraries/ForumUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:__construct\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:__construct\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:__construct\\(\\) has parameter \\$submitty_path with no type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:ensureLoadedQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:getAutogradingInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:reloadQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:updateDetailedQueueCount\\(\\) has parameter \\$capability_queue_counts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:updateDetailedQueueCount\\(\\) has parameter \\$course_info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:updateDetailedQueueCount\\(\\) has parameter \\$detailed_queue_counts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:updateDetailedQueueCount\\(\\) has parameter \\$machine_grading_counts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:updateDetailedQueueCount\\(\\) has parameter \\$open_autograding_workers_json with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\GradingQueue\\:\\:updateDetailedQueueCount\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\GradingQueue\\:\\:\\$grading_path has no type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\GradingQueue\\:\\:\\$grading_remaining has no type specified\\.$#"
+			count: 1
+			path: app/libraries/GradingQueue.php
+
+		-
 			message: "#^Property app\\\\libraries\\\\GradingQueue\\:\\:\\$grading_remaining is never read, only written\\.$#"
 			count: 1
 			path: app/libraries/GradingQueue.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:debug\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:error\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:fatal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logMessage\\(\\) has parameter \\$folder with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logMessage\\(\\) has parameter \\$log_message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logQueueActivity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logTAGrading\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:logTAGrading\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:setLogPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Logger\\:\\:warn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Logger\\:\\:\\$log_path has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Logger.php
 
 		-
 			message: "#^Unsafe access to private property app\\\\libraries\\\\Logger\\:\\:\\$log_path through static\\:\\:\\.$#"
@@ -506,9 +3776,624 @@ parameters:
 			path: app/libraries/Logger.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:createEmailsArray\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:createEmailsArray\\(\\) has parameter \\$recipients with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:createEmailsArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:createNotificationsArray\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:createNotificationsArray\\(\\) has parameter \\$recipients with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:createNotificationsArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:onNewAnnouncement\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:onNewPost\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:onNewThread\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:onPostModified\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:onTeamEvent\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:onTeamEvent\\(\\) has parameter \\$recipients with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:sendEmails\\(\\) has parameter \\$emails with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NotificationFactory\\:\\:sendNotifications\\(\\) has parameter \\$notifications with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NotificationFactory.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\NumberUtils\\:\\:getRandomIndices\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/NumberUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addBreadcrumb\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addBreadcrumb\\(\\) has parameter \\$external_link with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addBreadcrumb\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addBreadcrumb\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addBreadcrumb\\(\\) has parameter \\$use_as_heading with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalCss\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalCss\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalCss\\(\\) has parameter \\$folder with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalJs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalJs\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalJs\\(\\) has parameter \\$folder with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalModuleJs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addInternalModuleTwigJs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addRoomTemplatesTwigPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addVendorCss\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addVendorCss\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addVendorJs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:addVendorJs\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:bufferOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:disableBuffer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:disableRender\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:displayOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:getBreadcrumbs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:getCss\\(\\) return type with generic class Ds\\\\Set does not specify its types\\: TValue$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:getJs\\(\\) return type with generic class Ds\\\\Set does not specify its types\\: TValue$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:getModuleJs\\(\\) return type with generic class Ds\\\\Set does not specify its types\\: TValue$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:getOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:getPageName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:loadTwig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:loadTwig\\(\\) has parameter \\$full_load with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderFile\\(\\) has parameter \\$contents with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderFile\\(\\) has parameter \\$filename with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderFile\\(\\) has parameter \\$filetype with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderFooter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderJsonError\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderJsonFail\\(\\) has parameter \\$extra with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderJsonFail\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderJsonSuccess\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderOutput\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderOutput\\(\\) has parameter \\$view with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderResultMessage\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderString\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderTemplate\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderTemplate\\(\\) has parameter \\$view with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderTwigOutput\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:renderTwigTemplate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:setInternalResources\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:setPageName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:setPageName\\(\\) has parameter \\$page_name with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:timestampResource\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:timestampResource\\(\\) has parameter \\$file with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Output\\:\\:timestampResource\\(\\) has parameter \\$folder with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$breadcrumbs has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$content_only has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$css with generic class Ds\\\\Set does not specify its types\\: TValue$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$js with generic class Ds\\\\Set does not specify its types\\: TValue$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$loaded_views has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$module_js with generic class Ds\\\\Set does not specify its types\\: TValue$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$output_buffer has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$page_name has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$start_time has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$twig_loader has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$use_footer has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$use_header has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\Output\\:\\:\\$use_mobile_viewport has no type specified\\.$#"
+			count: 1
+			path: app/libraries/Output.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\PollUtils\\:\\:getPollExportData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/PollUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\PollUtils\\:\\:getPollTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/PollUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\PollUtils\\:\\:getReleaseAnswerSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/PollUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\PollUtils\\:\\:getReleaseHistogramSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/PollUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\SamlSettings\\:\\:getSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/SamlSettings.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\SessionManager\\:\\:\\$session has no type specified\\.$#"
+			count: 1
+			path: app/libraries/SessionManager.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\TokenManager\\:\\:generateSessionToken\\(\\) has parameter \\$persistent with no type specified\\.$#"
+			count: 1
+			path: app/libraries/TokenManager.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:checkUploadedImageFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:checkUploadedImageFile\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:getAutoFillData\\(\\) has parameter \\$append_numeric_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:getAutoFillData\\(\\) has parameter \\$students with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:getAutoFillData\\(\\) has parameter \\$students_version with no type specified\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:getFirstArrayElement\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:getLastArrayElement\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\Utils\\:\\:setCookie\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/Utils.php
+
+		-
 			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and 0 is always true\\.$#"
 			count: 1
 			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:__construct\\(\\) has parameter \\$connection_params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:connect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:disconnect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:fromDatabaseToPHPArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has parameter \\$array with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getColumnData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getDSN\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getQueries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:query\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:queryIterator\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:row\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:rows\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:transformResult\\(\\) has parameter \\$columns with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:transformResult\\(\\) has parameter \\$result with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$all_queries type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$columns has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$password has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$results type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$row_count has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$username has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/AbstractDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseFactory\\:\\:getDatabase\\(\\) has parameter \\$connection_params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseFactory.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseFactory\\:\\:\\$driver has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseFactory.php
 
 		-
 			message: "#^Call to function is_null\\(\\) with DateTime will always evaluate to false\\.$#"
@@ -521,9 +4406,2969 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:acceptTeamInvitation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addBookmarkedThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addNewCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addNewCategory\\(\\) has parameter \\$category with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addNewCategory\\(\\) has parameter \\$rank with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addNewCategory\\(\\) has parameter \\$visibleDate with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addSolutionForComponentId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addSolutionForComponentId\\(\\) has parameter \\$author_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addSolutionForComponentId\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addSolutionForComponentId\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addSolutionForComponentId\\(\\) has parameter \\$itempool_item with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addSolutionForComponentId\\(\\) has parameter \\$solution_text with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addToQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addToQueue\\(\\) has parameter \\$contact_info with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addToQueue\\(\\) has parameter \\$time_in with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:addToSeekingTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:alreadyInAQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$current_user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_join with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_order with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_parameters with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_select with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_where with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$show_merged_thread with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$thread_status with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$unread_threads with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$want_categories with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$want_order with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:cancelTeamInvitation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueContactInformation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueRegex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueRegex\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueRegex\\(\\) has parameter \\$regex_pattern with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueToken\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:changeQueueToken\\(\\) has parameter \\$token with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:checkIsInstructorInCourse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:checkIsInstructorInCourse\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:checkIsInstructorInCourse\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:checkIsInstructorInCourse\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:checkNonMappedUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:clearPeerGradingAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:clearTeamViewedTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:componentItempoolInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:componentItempoolInfo\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:componentItempoolInfo\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:convertInquiryComponentId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:convertInquiryComponentId\\(\\) has parameter \\$gradeable with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:countActiveUsersByGroup\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createGradedComponentMarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createNewTerm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createParameterList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createParameterList\\(\\) has parameter \\$len with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$anonymous with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$first with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$hasAttachment with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$markdown with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$parent_post with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createPost\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createTaGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createTeam\\(\\) has parameter \\$team_name with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$announcement with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$anon with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$expiration with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$hasAttachment with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$lock_thread_date with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$markdown with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$prof_pinned with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$status with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:createThread\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:declineAllTeamInvitations\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteAllRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteCategory\\(\\) has parameter \\$category_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteComponents\\(\\) has parameter \\$components with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteGradeInquiry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteGradeable\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteGradedComponentMarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteLateDays\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteMarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverallComment\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverallComment\\(\\) has parameter \\$grader_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteRegistrationSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteRegistrationSection\\(\\) has parameter \\$section with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteSamlMapping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteTaGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteTaGradedGradeableByIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editCategory\\(\\) has parameter \\$category_color with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editCategory\\(\\) has parameter \\$category_desc with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editCategory\\(\\) has parameter \\$category_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editCategory\\(\\) has parameter \\$visible_date with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has parameter \\$anon with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has parameter \\$markdown with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has parameter \\$original_creator with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editPost\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has parameter \\$expiration with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has parameter \\$lock_thread_date with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has parameter \\$status with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:editThread\\(\\) has parameter \\$thread_title with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:emptyQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncements\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncements\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncementsId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncementsId\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsPost\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsPost\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:filterCategoryDesc\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:filterCategoryDesc\\(\\) has parameter \\$category_desc with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findChildren\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findChildren\\(\\) has parameter \\$children with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findChildren\\(\\) has parameter \\$get_deleted with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findChildren\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findChildren\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findParentPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findParentPost\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:findThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:finishHelpUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:flushAllLateDayCache\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:generateOrderByClause\\(\\) has parameter \\$key_map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getActiveUserIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllAnonIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllAnonIdsByGradeable\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllAnonIdsByGradeableWithUserIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllCoursesForUserId\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllElectronicGradeablesIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllGradeablesIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllGradeablesIdsAndTitles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllOpenQueues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllParentAuthors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllQueues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllQueuesEver\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllRotatingSections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllSectionsForGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllSectionsForGradeable\\(\\) has parameter \\$gradeable with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllSubmittersWhoGotMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllSubmittersWhoGotMark\\(\\) has parameter \\$anon with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllSubmittersWhoGotMark\\(\\) has parameter \\$mark with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllTeamAnonIdsByGradeable\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllTeamViewedTimesForGradeable\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllTerms\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllThreadAuthors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllUsersIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAllUsersWithPreference\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAnonId\\(\\) has parameter \\$user_ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAttendanceInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAuthorOfThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAuthorOfThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAuthorUserGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAuthorUserGroups\\(\\) has parameter \\$author_ids with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has parameter \\$is_team with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has parameter \\$is_team with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$is_team with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$override with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$gc_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$is_team with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCategoriesIdForThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCategoriesIdForThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCountNullUsersRotatingSections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCourseStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCourseStatus\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCourseStatus\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCurrentQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getCurrentQueueState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getDeletedPostsByUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getDeletedPostsByUser\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getDisplayUserInfoFromUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getDisplayUserInfoFromUserId\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getEmailListWithIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getFirstPostForThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getFirstPostForThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiriesUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryDiscussions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryDiscussions\\(\\) has parameter \\$grade_inquiries with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryPost\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryStatus\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeInquiryStatus\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableAccessTeam\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableAccessUser\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableIdsForFullAccessLimitedGraders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableVersionHasAutogradingResults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableVersionHasAutogradingResults\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableVersionHasAutogradingResults\\(\\) has parameter \\$team_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableVersionHasAutogradingResults\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeableVersionHasAutogradingResults\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeablesRotatingGraderHistory\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradeablesRotatingGraderHistory\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByGradingSections\\(\\) has parameter \\$is_team with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByTeamGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByTeamGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByTeamGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedComponentsCountByTeamGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedPeerComponentsByRegistrationSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedPeerComponentsByRegistrationSection\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedPeerComponentsByRegistrationSection\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedPeerComponentsByRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedPeerComponentsByRotatingSection\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradedPeerComponentsByRotatingSection\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradersByUserType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradersForRegistrationSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradersForRegistrationSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradersForRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradersForRotatingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradersForRotatingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradingSectionsByUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getGradingSectionsByUserId\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getInstructorLevelAccessCourse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getInstructorLevelUnarchivedCourses\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLastLateDayUpdatesForUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLastQueueDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLastTimeInQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayCache\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayCacheForUser\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayCacheForUserGradeable\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayInformation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayInformation\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayUpdateTimestamps\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayUpdates\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLateDayUpdates\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLeaderboard\\(\\) has parameter \\$valid_testcases with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getLeaderboard\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getListOfCourseUsers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getMaxRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getMetrics\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNewGraders\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNotificationInfoById\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNotificationInfoById\\(\\) has parameter \\$notification_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNotificationInfoById\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumGradedPeerComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumGradedPeerComponents\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumGradedPeerComponents\\(\\) has parameter \\$grader with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumPeerComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumPeerComponents\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumUsersGraded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumUsersGraded\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumUsersWhoViewedGradeBySections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumUsersWhoViewedGradeBySections\\(\\) has parameter \\$gradeable with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumUsersWhoViewedGradeBySections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumUsersWhoViewedTeamAssignmentBySection\\(\\) has parameter \\$sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberAheadInQueueThisWeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberAheadInQueueThisWeek\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberAheadInQueueThisWeek\\(\\) has parameter \\$time_in with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberAheadInQueueToday\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberAheadInQueueToday\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberAheadInQueueToday\\(\\) has parameter \\$time_in with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberGradeInquiries\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberGradeInquiries\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberGradeInquiries\\(\\) has parameter \\$is_grade_inquiry_per_component_allowed with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getNumberRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getOtherCoursesWithSameGroup\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getParentPostId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getParentPostId\\(\\) has parameter \\$child_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPastQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerAssignment\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerAssignment\\(\\) has parameter \\$grader with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackForUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackForUser\\(\\) has parameter \\$anon with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackForUser\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackInstance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackInstance\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackInstance\\(\\) has parameter \\$grader_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerFeedbackInstance\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerGradingAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerGradingAssignmentForSubmitter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerGradingAssignmentForSubmitter\\(\\) has parameter \\$submitter_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPeerGradingAssignmentsForGrader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPost\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostHistory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostHistory\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostOldThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostOldThread\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPosts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$current_user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$filterOnUser with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$option with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsInThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsInThreads\\(\\) has parameter \\$thread_ids with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getProxyMappedUsers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataByQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataByWeekDay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataByWeekDayThisWeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataByWeekNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataOverall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataStudent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueDataToday\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueFromEntryId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueHasContactInformation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueMessage\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueNumberAheadOfYou\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueNumberAheadOfYou\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getQueueRegex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRawUsersWithOverriddenGrades\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRegisteredUsersWithNoRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRegistrationSections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getResolveState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getResolveState\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRootPostOfNonMergedThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRootPostOfNonMergedThread\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRootPostOfNonMergedThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRootPostOfNonMergedThread\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRotatingSections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRotatingSectionsByGrader\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRotatingSectionsForGradeableAndUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRotatingSectionsForGradeableAndUser\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRotatingSectionsForGradeableAndUser\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRotatingSectionsGradeableIDS\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSAMLAuthorizedUserIDs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSamlMappedUsers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getScoresForGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getScoresForGradeable\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getScoresForGradeable\\(\\) has parameter \\$is_team with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getScoresForGradeable\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSeekMessageByUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSession\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSimilarNumericIdMatches\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForAllComponentIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForAllComponentIds\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentId\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentId\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentItempoolItem\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentItempoolItem\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentItempoolItem\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSolutionForComponentItempoolItem\\(\\) has parameter \\$itempool_item with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSubmittedTeamCountByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSubmittedTeamCountByGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSubmittedTeamCountByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSubmittedTeamCountByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getSubmitterIdFromAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamAnonId\\(\\) has parameter \\$team_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamIdFromAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamIdFromAnonId\\(\\) has parameter \\$anon_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamViewedTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamsByGradeableAndRegistrationSections\\(\\) has parameter \\$sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTeamsByGradeableAndRotatingSections\\(\\) has parameter \\$sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadsBefore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadsBefore\\(\\) has parameter \\$page with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadsBefore\\(\\) has parameter \\$timestamp with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTimeJoinedQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalComponentCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalComponentCount\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedTeamCountByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedTeamCountByGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedTeamCountByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedTeamCountByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedUserCountByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedUserCountByGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedUserCountByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalSubmittedUserCountByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalUserCountByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalUserCountByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTotalUserCountByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnreadNotificationsCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnreadNotificationsCount\\(\\) has parameter \\$component with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnreadNotificationsCount\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnregisteredStudentsWithRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnviewedPosts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnviewedPosts\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnviewedPosts\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUserFromAnon\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUserFromAnon\\(\\) has parameter \\$anon_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUserFromAnon\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUserGroups\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsers\\(\\) has parameter \\$user_id_list with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersByIds\\(\\) has parameter \\$user_id_list with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersByIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersByRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersByRotatingSections\\(\\) has parameter \\$orderBy with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersByRotatingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersCountByRotatingSections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersInNullSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersInNullSection\\(\\) has parameter \\$orderBy with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersNotFullyGraded\\(\\) has parameter \\$component_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersNotFullyGraded\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersNotificationSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersOnTeamsForGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersOrTeamsById\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersOrTeamsById\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersSeekingTeamByGradeableId\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithLateDays\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithTeamByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithTeamByGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithTeamByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithTeamByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithoutTeamByGradingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithoutTeamByGradingSections\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithoutTeamByGradingSections\\(\\) has parameter \\$section_key with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUsersWithoutTeamByGradingSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getValidatedCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertBulkPeerGradingAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertCourseUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertEmails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertEmails\\(\\) has parameter \\$flattened_params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertGradeableAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertGradeableAnonId\\(\\) has parameter \\$user_ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewGradeInquiry\\(\\) has parameter \\$gc_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewGradeInquiryPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewGradeInquiryPost\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewGradeInquiryPost\\(\\) has parameter \\$gc_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewGradeInquiryPost\\(\\) has parameter \\$grade_inquiry_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewGradeInquiryPost\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewRegistrationSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewRegistrationSection\\(\\) has parameter \\$section with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNewRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNotifications\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertNotifications\\(\\) has parameter \\$flattened_notifications with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertPeerGradingAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertPeerGradingFeedback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertSamlMapping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertSubmittyUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:insertVersionDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:isAnyQueueOpen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:isStaffPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:isStaffPost\\(\\) has parameter \\$author_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:leaveTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:loadBookmarkedThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:loadThreadBlock\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:markNotificationAsSeen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:markNotificationAsSeen\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:mergeThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:mergeThread\\(\\) has parameter \\$child_root_post with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:mergeThread\\(\\) has parameter \\$child_thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:mergeThread\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:mergeThread\\(\\) has parameter \\$parent_thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:newSession\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:openQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:openQueue\\(\\) has parameter \\$regex_pattern with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:openQueue\\(\\) has parameter \\$require_contact_info with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:openQueue\\(\\) has parameter \\$token with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:postHasHistory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:postHasHistory\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removeFromSeekingTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removeNotificationsPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removeNotificationsPost\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removePeerAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removePeerAssignment\\(\\) has parameter \\$student_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removePeerAssignmentsForGrader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removeSessionById\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:removeUserFromQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:reorderCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:reorderCategories\\(\\) has parameter \\$categories_in_order with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:restoreUserToQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:rowsToArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:rowsToArray\\(\\) has parameter \\$rows with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:saveComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:saveGradeInquiry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:saveTaGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:searchThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:searchThreads\\(\\) has parameter \\$searchQuery with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:sendTeamInvitation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setAllTeamsRotatingSectionNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setAllUsersRotatingSectionNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setAnnounced\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setAnnounced\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setAnnouncement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setNonRegisteredUsersRotatingSectionNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setQueueMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setQueueMessage\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setQueueMessage\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setQueuePauseState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setupRotatingSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setupRotatingSections\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:setupRotatingSections\\(\\) has parameter \\$graders with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:splitPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:splitPost\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:splitPost\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:splitPost\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:startHelpUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:threadExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:toggleQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateActiveVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateComponentMarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateExtensions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateGradeOverride\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateGradeableComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateGradedComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateGradingRegistration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateLateDays\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateNotificationSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateNotificationSettings\\(\\) has parameter \\$results with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateOverallComment\\(\\) has parameter \\$comment with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateOverallComment\\(\\) has parameter \\$grader_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateOverallComments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateResolveState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateResolveState\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateResolveState\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateSamlMapping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateSeekingTeamMessageById\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateSessionExpiration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTaGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTeamAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTeamName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTeamRegistrationSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTeamRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTeamViewedTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateTeamsRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:updateUsersRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:viewedThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:viewedThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:viewedThread\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:visitThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:visitThread\\(\\) has parameter \\$current_user with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:visitThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseQueries.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between array\\<int\\> and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
+
+		-
+			message: "#^Class app\\\\libraries\\\\database\\\\DatabaseRowIterator implements generic interface Iterator but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:close\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$callback has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$columns has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$database has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$key has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$result has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$statement has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$valid has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseRowIterator.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseUtils\\:\\:formatQuery\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/DatabaseUtils.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:__construct\\(\\) has parameter \\$connection_params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:fromDatabaseToPHPArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:getDSN\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:parsePGArrayValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:parsePGArrayValue\\(\\) has parameter \\$return with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:\\$dbname has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:\\$host has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:\\$port has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/PostgresqlDatabase.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"
@@ -536,14 +7381,114 @@ parameters:
 			path: app/libraries/database/QueryIdentifier.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:__construct\\(\\) has parameter \\$connection_params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:fromDatabaseToPHPArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has parameter \\$array with no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:getDSN\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:\\$memory has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:\\$path has no type specified\\.$#"
+			count: 1
+			path: app/libraries/database/SqliteDatabase.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\plagiarism\\\\Interval\\:\\:getMatchingPositions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/plagiarism/Interval.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\plagiarism\\\\Interval\\:\\:getOthers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/plagiarism/Interval.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\plagiarism\\\\Interval\\:\\:\\$others type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/plagiarism/Interval.php
+
+		-
 			message: "#^PHPDoc tag @var for constant app\\\\libraries\\\\plagiarism\\\\PlagiarismUtils\\:\\:SUPPORTED_LANGUAGES with type int is incompatible with value array\\{plaintext\\: array\\{hash_size\\: 14\\}, python\\: array\\{hash_size\\: 14\\}, java\\: array\\{hash_size\\: 14\\}, cpp\\: array\\{hash_size\\: 14\\}, mips\\: array\\{hash_size\\: 5\\}\\}\\.$#"
 			count: 1
 			path: app/libraries/plagiarism/PlagiarismUtils.php
 
 		-
+			message: "#^Property app\\\\libraries\\\\response\\\\JsonResponse\\:\\:\\$json type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/response/JsonResponse.php
+
+		-
 			message: "#^Parameter \\#3 \\$code of static method app\\\\libraries\\\\response\\\\JsonResponse\\:\\:getErrorResponse\\(\\) expects string\\|null, int given\\.$#"
 			count: 1
 			path: app/libraries/response/MultiResponse.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\response\\\\WebResponse\\:\\:__construct\\(\\) has parameter \\$view_class with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/response/WebResponse.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\response\\\\WebResponse\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/response/WebResponse.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\response\\\\WebResponse\\:\\:\\$view_class type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/response/WebResponse.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\AccessControl\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/routers/AccessControl.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\AnnotatedRouteLoader\\:\\:configureRoute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/routers/AnnotatedRouteLoader.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\AnnotatedRouteLoader\\:\\:configureRoute\\(\\) has parameter \\$annot with no type specified\\.$#"
+			count: 1
+			path: app/libraries/routers/AnnotatedRouteLoader.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\AnnotatedRouteLoader\\:\\:configureRoute\\(\\) has parameter \\$class with generic class ReflectionClass but does not specify its types\\: T$#"
+			count: 1
+			path: app/libraries/routers/AnnotatedRouteLoader.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\Enabled\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/routers/Enabled.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\FeatureFlag\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/routers/FeatureFlag.php
 
 		-
 			message: """
@@ -567,6 +7512,26 @@ parameters:
 			path: app/libraries/routers/WebRouter.php
 
 		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\WebRouter\\:\\:checkFeatureFlag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/routers/WebRouter.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\WebRouter\\:\\:getCompiledRoutes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/routers/WebRouter.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\WebRouter\\:\\:loadCourse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/routers/WebRouter.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\routers\\\\WebRouter\\:\\:run\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/routers/WebRouter.php
+
+		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
 			path: app/libraries/routers/WebRouter.php
@@ -577,12 +7542,587 @@ parameters:
 			path: app/libraries/routers/WebRouter.php
 
 		-
+			message: "#^Property app\\\\libraries\\\\routers\\\\WebRouter\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/routers/WebRouter.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\socket\\\\Server\\:\\:log\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/socket/Server.php
+
+		-
+			message: "#^Method app\\\\libraries\\\\socket\\\\Server\\:\\:logError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/libraries/socket/Server.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$clients type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/socket/Server.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$pages type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/socket/Server.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$sessions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/socket/Server.php
+
+		-
+			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$users type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/libraries/socket/Server.php
+
+		-
 			message: "#^Call to function is_subclass_of\\(\\) with object and 'app\\\\\\\\Models…' will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/AbstractModel.php
 
 		-
+			message: "#^Method app\\\\models\\\\AbstractModel\\:\\:convertName\\(\\) has parameter \\$prefix_length with no type specified\\.$#"
+			count: 1
+			path: app/models/AbstractModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\AbstractModel\\:\\:setupProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/AbstractModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\AbstractModel\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/AbstractModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\AbstractModel\\:\\:\\$cache has no type specified\\.$#"
+			count: 1
+			path: app/models/AbstractModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\AbstractModel\\:\\:\\$modified has no type specified\\.$#"
+			count: 1
+			path: app/models/AbstractModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\AbstractModel\\:\\:\\$properties has no type specified\\.$#"
+			count: 1
+			path: app/models/AbstractModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\Breadcrumb\\:\\:__construct\\(\\) has parameter \\$use_as_heading with no type specified\\.$#"
+			count: 1
+			path: app/models/Breadcrumb.php
+
+		-
+			message: "#^Method app\\\\models\\\\Breadcrumb\\:\\:useAsHeading\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Breadcrumb.php
+
+		-
+			message: "#^Property app\\\\models\\\\Breadcrumb\\:\\:\\$external_url has no type specified\\.$#"
+			count: 1
+			path: app/models/Breadcrumb.php
+
+		-
+			message: "#^Property app\\\\models\\\\Breadcrumb\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/Breadcrumb.php
+
+		-
+			message: "#^Property app\\\\models\\\\Breadcrumb\\:\\:\\$url has no type specified\\.$#"
+			count: 1
+			path: app/models/Breadcrumb.php
+
+		-
+			message: "#^Property app\\\\models\\\\Breadcrumb\\:\\:\\$use_as_heading has no type specified\\.$#"
+			count: 1
+			path: app/models/Breadcrumb.php
+
+		-
+			message: "#^Method app\\\\models\\\\Button\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$aria_label has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$badge has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$class has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$date has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$disabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$href has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$icon has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$onclick has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$prefix has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$prerequisite has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$progress has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$subtitle has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Property app\\\\models\\\\Button\\:\\:\\$title_on_hover has no type specified\\.$#"
+			count: 1
+			path: app/models/Button.php
+
+		-
+			message: "#^Method app\\\\models\\\\CalendarInfo\\:\\:getColors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\CalendarInfo\\:\\:getItemsByDate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\CalendarInfo\\:\\:getItemsBySections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\CalendarInfo\\:\\:loadGradeableCalendarInfo\\(\\) has parameter \\$calendar_items with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\CalendarInfo\\:\\:loadGradeableCalendarInfo\\(\\) has parameter \\$courses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\CalendarInfo\\:\\:loadGradeableCalendarInfo\\(\\) has parameter \\$gradeables_of_user with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\CalendarInfo\\:\\:\\$items_by_sections type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/CalendarInfo.php
+
+		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:getLogPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:getWrapperFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:isSubmittyAdminUserVerified\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:loadCourseJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:loadCourseJson\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:loadCourseJson\\(\\) has parameter \\$course_json_path with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:loadCourseJson\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:loadMasterConfigs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:loadMasterConfigs\\(\\) has parameter \\$config_path with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:saveCourseJson\\(\\) has parameter \\$save with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:setConfigValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:setConfigValues\\(\\) has parameter \\$config with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:setConfigValues\\(\\) has parameter \\$keys with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:setConfigValues\\(\\) has parameter \\$section with no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Method app\\\\models\\\\Config\\:\\:wrapperEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$authentication has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$auto_rainbow_grades has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$base_url has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$cgi_tmp_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$cgi_url has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$config_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_database_params has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_email has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_home_url has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_json has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_json_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_name has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$course_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$database_driver has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$date_time_format has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$default_hw_late_days has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$default_student_late_days has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$display_custom_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$display_rainbow_grades_summary has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$duck_banner_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$email_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$feature_flags has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$forum_create_thread_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$forum_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$grade_inquiry_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$hidden_details has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$latest_commit has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$latest_tag has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$ldap_options type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$log_exceptions has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$php_user has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$polls_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$private_repository has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$queue_announcement_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$queue_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$queue_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$room_seating_gradeable_id has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$saml_options has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$seating_only_for_instructor has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$secret_session has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$seek_message_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$seek_message_instructions has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$submitty_database_params has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$submitty_install_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$submitty_log_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$submitty_path has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$system_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$term has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$timezone has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$upload_message has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$vcs_base_url has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$vcs_type has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$vcs_url has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$verified_submitty_admin_user has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$websocket_port has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$wrapper_files has no type specified\\.$#"
+			count: 1
+			path: app/models/Config.php
+
+		-
+			message: "#^Property app\\\\models\\\\Config\\:\\:\\$zero_rubric_grades has no type specified\\.$#"
 			count: 1
 			path: app/models/Config.php
 
@@ -592,9 +8132,699 @@ parameters:
 			path: app/models/Config.php
 
 		-
+			message: "#^Method app\\\\models\\\\Course\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Method app\\\\models\\\\Course\\:\\:getCapitalizedTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Method app\\\\models\\\\Course\\:\\:getCourseInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Method app\\\\models\\\\Course\\:\\:getLongTerm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Method app\\\\models\\\\Course\\:\\:loadDisplayName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\Course\\:\\:\\$display_name has no type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\Course\\:\\:\\$registration_section has no type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\Course\\:\\:\\$term has no type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\Course\\:\\:\\$term_name has no type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\Course\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\Course\\:\\:\\$user_group has no type specified\\.$#"
+			count: 1
+			path: app/models/Course.php
+
+		-
+			message: "#^Property app\\\\models\\\\DisplayImage\\:\\:\\$mime_type has no type specified\\.$#"
+			count: 1
+			path: app/models/DisplayImage.php
+
+		-
+			message: "#^Property app\\\\models\\\\DisplayImage\\:\\:\\$path has no type specified\\.$#"
+			count: 1
+			path: app/models/DisplayImage.php
+
+		-
+			message: "#^Method app\\\\models\\\\Email\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Email.php
+
+		-
+			message: "#^Property app\\\\models\\\\Email\\:\\:\\$body has no type specified\\.$#"
+			count: 1
+			path: app/models/Email.php
+
+		-
+			message: "#^Property app\\\\models\\\\Email\\:\\:\\$subject has no type specified\\.$#"
+			count: 1
+			path: app/models/Email.php
+
+		-
+			message: "#^Property app\\\\models\\\\Email\\:\\:\\$user_id has no type specified\\.$#"
+			count: 1
+			path: app/models/Email.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradeableAutocheck\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/GradeableAutocheck.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradeableAutocheck\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: app/models/GradeableAutocheck.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradeableAutocheck\\:\\:\\$display_as_sequence_diagram has no type specified\\.$#"
+			count: 1
+			path: app/models/GradeableAutocheck.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradeableAutocheck\\:\\:\\$index has no type specified\\.$#"
+			count: 1
+			path: app/models/GradeableAutocheck.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradeableAutocheck\\:\\:\\$messages has no type specified\\.$#"
+			count: 1
+			path: app/models/GradeableAutocheck.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradeableAutocheck\\:\\:\\$public has no type specified\\.$#"
+			count: 1
+			path: app/models/GradeableAutocheck.php
+
+		-
 			message: "#^Call to function is_null\\(\\) with array\\<string\\> will always evaluate to false\\.$#"
 			count: 2
 			path: app/models/GradingOrder.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingOrder\\:\\:initUsersNotFullyGraded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/GradingOrder.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingOrder\\:\\:sort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/GradingOrder.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingOrder\\:\\:sort\\(\\) has parameter \\$direction with no type specified\\.$#"
+			count: 1
+			path: app/models/GradingOrder.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingOrder\\:\\:sort\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/models/GradingOrder.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingSection\\:\\:__construct\\(\\) has parameter \\$graders with no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingSection\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingSection\\:\\:__construct\\(\\) has parameter \\$teams with no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingSection\\:\\:__construct\\(\\) has parameter \\$users with no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingSection\\:\\:containsTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Method app\\\\models\\\\GradingSection\\:\\:containsUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradingSection\\:\\:\\$graders has no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradingSection\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradingSection\\:\\:\\$registration has no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradingSection\\:\\:\\$teams has no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Property app\\\\models\\\\GradingSection\\:\\:\\$users has no type specified\\.$#"
+			count: 1
+			path: app/models/GradingSection.php
+
+		-
+			message: "#^Method app\\\\models\\\\NavButton\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/NavButton.php
+
+		-
+			message: "#^Method app\\\\models\\\\Notification\\:\\:createNotification\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Method app\\\\models\\\\Notification\\:\\:createNotification\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Method app\\\\models\\\\Notification\\:\\:createViewOnlyNotification\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Method app\\\\models\\\\Notification\\:\\:createViewOnlyNotification\\(\\) has parameter \\$core with no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Method app\\\\models\\\\Notification\\:\\:createViewOnlyNotification\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$component has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$created_at has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$current_user has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$elapsed_time has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$notify_content has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$notify_metadata has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$notify_not_to_source has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$notify_source has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$notify_target has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$seen has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Property app\\\\models\\\\Notification\\:\\:\\$view_only has no type specified\\.$#"
+			count: 1
+			path: app/models/Notification.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:__construct\\(\\) has parameter \\$full_history with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:cleanForId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:cleanForId\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:dayNumToDay\\(\\) has parameter \\$daynum with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:firstTimeInQueueThisWeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:firstTimeInQueueThisWeek\\(\\) has parameter \\$time with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:firstTimeInQueueToday\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:firstTimeInQueueToday\\(\\) has parameter \\$time with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getAllOpenQueues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getAllQueues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getAllQueuesEver\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getColor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getColor\\(\\) has parameter \\$index with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getColorFromCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getColorFromCode\\(\\) has parameter \\$code with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getColors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getContactInfo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getCurrentQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getCurrentQueueCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getCurrentQueueLastHelped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getCurrentQueueStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getCurrentQueueTimeIn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getFullHistory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getHelperName\\(\\) has parameter \\$query_row with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getIndexFromCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getIndexFromCode\\(\\) has parameter \\$code with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getNumberAheadInQueueThisWeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getNumberAheadInQueueToday\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getPastQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueAnnouncementMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataByQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataByWeekDay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataByWeekDayThisWeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataByWeekNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataOverall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataStudent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueDataToday\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueNumberAheadOfYou\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueNumberAheadOfYou\\(\\) has parameter \\$queue_code with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueOccupancy\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueSocketMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getQueueSocketMessageSentTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getRemoverName\\(\\) has parameter \\$query_row with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeBeingHelped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeBeingHelped\\(\\) has parameter \\$time_helped with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeBeingHelped\\(\\) has parameter \\$time_out with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeWaitingInQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeWaitingInQueue\\(\\) has parameter \\$removal_type with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeWaitingInQueue\\(\\) has parameter \\$time_helped with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeWaitingInQueue\\(\\) has parameter \\$time_in with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getTimeWaitingInQueue\\(\\) has parameter \\$time_out with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:getUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:inQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:intToStringTimePaused\\(\\) has parameter \\$int with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:isAnyQueueOpen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:isCurrentlyPaused\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:isGrader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:statNiceName\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:timeToHM\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:timeToHM\\(\\) has parameter \\$time with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:timeToISO\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:timeToISO\\(\\) has parameter \\$time with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:weekNumToDate\\(\\) has parameter \\$weeknum with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Method app\\\\models\\\\OfficeHoursQueueModel\\:\\:weekNumToDate\\(\\) has parameter \\$yearnum with no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$all_queues has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$code_to_index has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$colors has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$current_queue has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$current_queue_state has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$days has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$full_history has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$last_queue_details has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$niceNames has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\OfficeHoursQueueModel\\:\\:\\$queue_occupancy has no type specified\\.$#"
+			count: 1
+			path: app/models/OfficeHoursQueueModel.php
+
+		-
+			message: "#^Property app\\\\models\\\\QueueItem\\:\\:\\$elapsed_time has no type specified\\.$#"
+			count: 1
+			path: app/models/QueueItem.php
+
+		-
+			message: "#^Property app\\\\models\\\\QueueItem\\:\\:\\$grading_queue_obj has no type specified\\.$#"
+			count: 1
+			path: app/models/QueueItem.php
+
+		-
+			message: "#^Property app\\\\models\\\\QueueItem\\:\\:\\$queue_obj has no type specified\\.$#"
+			count: 1
+			path: app/models/QueueItem.php
+
+		-
+			message: "#^Property app\\\\models\\\\QueueItem\\:\\:\\$regrade has no type specified\\.$#"
+			count: 1
+			path: app/models/QueueItem.php
+
+		-
+			message: "#^Property app\\\\models\\\\QueueItem\\:\\:\\$start_time has no type specified\\.$#"
+			count: 1
+			path: app/models/QueueItem.php
 
 		-
 			message: "#^Call to function is_null\\(\\) with array will always evaluate to false\\.$#"
@@ -602,9 +8832,759 @@ parameters:
 			path: app/models/RainbowCustomization.php
 
 		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:buildCustomization\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:error\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getAvailableBuckets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getBucketCounts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getBucketPercentages\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getCustomizationData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getDisplayBenchmarks\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getErrorMessages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getMessages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getPerGradeableCurves\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:getUsedBuckets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:processForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:reorderBucket\\(\\) has parameter \\$bucket_gradeables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:reorderBucket\\(\\) has parameter \\$json_bucket_ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomization\\:\\:reorderBucket\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$RCJSON has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$available_buckets has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$bucket_counts has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$customization_data has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$error_messages has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$has_error has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$sections has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
 			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$sections is never read, only written\\.$#"
 			count: 1
 			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomization\\:\\:\\$used_buckets has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomization.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:addBenchmarkPercent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:addDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:addDisplayBenchmarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:addGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:addMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:addSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:getDisplayBenchmarks\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:getGradeables\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:getMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:loadFromJsonFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\RainbowCustomizationJSON\\:\\:saveToJsonFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomizationJSON\\:\\:\\$benchmark_percent has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomizationJSON\\:\\:\\$display has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomizationJSON\\:\\:\\$display_benchmark has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomizationJSON\\:\\:\\$gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomizationJSON\\:\\:\\$messages has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Property app\\\\models\\\\RainbowCustomizationJSON\\:\\:\\$section has no type specified\\.$#"
+			count: 1
+			path: app/models/RainbowCustomizationJSON.php
+
+		-
+			message: "#^Method app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$comment has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$displayed_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$displayed_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$legal_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$legal_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$loaded has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$marks has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$preferred_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleGradeOverriddenUser\\:\\:\\$preferred_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleGradeOverriddenUser.php
+
+		-
+			message: "#^Method app\\\\models\\\\SimpleLateUser\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Method app\\\\models\\\\SimpleLateUser\\:\\:getSinceTimestamp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$allowed_late_days has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$displayed_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$displayed_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$late_day_exceptions has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$legal_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$legal_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$loaded has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$preferred_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$preferred_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleLateUser\\:\\:\\$since_timestamp has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleLateUser.php
+
+		-
+			message: "#^Method app\\\\models\\\\SimpleStat\\:\\:__construct\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$active_grade_inquiry_count has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$average_score has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$component has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$count has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$grader_info has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$is_peer_component has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$max_value has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$order has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$standard_deviation has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Property app\\\\models\\\\SimpleStat\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/SimpleStat.php
+
+		-
+			message: "#^Method app\\\\models\\\\SuperuserEmail\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/SuperuserEmail.php
+
+		-
+			message: "#^Method app\\\\models\\\\Team\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Method app\\\\models\\\\Team\\:\\:getAssignmentSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$assignment_settings type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$invited_user_ids has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$invited_users has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$member_list has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$member_user_ids has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$member_users has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$registration_section has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$rotating_section has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Property app\\\\models\\\\Team\\:\\:\\$team_name has no type specified\\.$#"
+			count: 1
+			path: app/models/Team.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:constructNotificationSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:constructNotificationSettings\\(\\) has parameter \\$details with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:getAnonId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:getDisplayFullName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:getNotificationSetting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:getNotificationSetting\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:getNotificationSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:isSuperUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setDisplayedFamilyName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setDisplayedGivenName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setGradingRegistrationSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setGradingRegistrationSections\\(\\) has parameter \\$sections with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setLastInitialFormat\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setLegalFamilyName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setLegalFamilyName\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setLegalGivenName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setLegalGivenName\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setPassword\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setPassword\\(\\) has parameter \\$password with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setPreferredFamilyName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setPreferredFamilyName\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setPreferredGivenName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setRegistrationSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setRegistrationSection\\(\\) has parameter \\$section with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setRotatingSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:setRotatingSection\\(\\) has parameter \\$section with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:updateUserNotificationSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:updateUserNotificationSettings\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\User\\:\\:updateUserNotificationSettings\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$access_level has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$anon_id_by_gradeable type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$course_section_id has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$display_image_state has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$displayed_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$displayed_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$email has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$email_both has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$grading_registration_sections has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$group has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$last_initial_format has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$legal_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$legal_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$loaded has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$notification_settings has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$numeric_id has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$preferred_family_name has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$preferred_given_name has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$pronouns has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$registration_section has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$registration_subsection has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$registration_type has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$rotating_section has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Property app\\\\models\\\\User\\:\\:\\$secondary_email has no type specified\\.$#"
+			count: 1
+			path: app/models/User.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:setActiveVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:setAutoGradedVersions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:\\$active_version has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:\\$auto_graded_versions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:\\$graded_gradeable has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedGradeable.php
 
 		-
 			message: "#^Result of \\|\\| is always true\\.$#"
@@ -622,7 +9602,67 @@ parameters:
 			path: app/models/gradeable/AutoGradedGradeable.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:__construct\\(\\) has parameter \\$results_path with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:__construct\\(\\) has parameter \\$results_public_path with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:setAutochecks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:setMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:setPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:setView\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
 			message: "#^Parameter \\#6 \\$idx of class app\\\\models\\\\GradeableAutocheck constructor expects int, string given\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:\\$autochecks has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:\\$message has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:\\$points has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:\\$testcase has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\:\\:\\$view has no type specified\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedTestcase.php
 
@@ -637,6 +9677,231 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersion.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:getFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:getMetaFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:getPartFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:getResultsFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:getResultsPublicFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:getTestcaseMessages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:loadQueueStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:loadSubmissionFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:loadTestcases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setAutogradingComplete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setAutogradingComplete\\(\\) has parameter \\$complete with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setAutogradingCompleteInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setHiddenExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setHiddenExtraCredit\\(\\) has parameter \\$points with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setHiddenNonExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setHiddenNonExtraCredit\\(\\) has parameter \\$points with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setNonHiddenExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setNonHiddenExtraCredit\\(\\) has parameter \\$points with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setNonHiddenNonExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setNonHiddenNonExtraCredit\\(\\) has parameter \\$points with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setPointsInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setPointsInternal\\(\\) has parameter \\$points with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setSubmissionTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setSubmissionTime\\(\\) has parameter \\$submission_time with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setSubmissionTimeInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:setVersionInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$autograder_machine has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$autograding_complete has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$early_incentive_points has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$files has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$graded_testcases has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$hidden_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$hidden_non_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$meta_files has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$non_hidden_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$non_hidden_non_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$queue_position has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$results_files has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$results_public_files has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$submission_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$version has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersion.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersion.php
@@ -647,7 +9912,22 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersion.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setBatchRegrade\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setBatchRegrade\\(\\) is unused\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setGradeTime\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
@@ -657,7 +9937,17 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setGradingBegan\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setGradingBegan\\(\\) is unused\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setGradingFinished\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
@@ -667,7 +9957,17 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setQueueTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setQueueTime\\(\\) is unused\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setVcsRevision\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
@@ -677,14 +9977,679 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setWaitTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:setWaitTime\\(\\) is unused\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersionHistory.php
 
 		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$access_duration has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$batch_regrade has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$first_access_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$grade_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$grading_began has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$grading_finished has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$queue_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$submission_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$vcs_revision has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersionHistory\\:\\:\\$wait_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutoGradedVersionHistory.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:anyVisibleTestcases\\(\\) has parameter \\$submitter with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:getPersonalizedTestcases\\(\\) has parameter \\$submitter_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:getTestcasesWithTag\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:hasLoadGradeableMessageEnabled\\(\\) has parameter \\$user_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:parseTestCases\\(\\) has parameter \\$testcases with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:parseTestCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setEarlySubmissionMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setEarlySubmissionMinimumDaysEarly\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setEarlySubmissionMinimumPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setEarlySubmissionTestCases\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setMaxPossibleGradingTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setMaxSubmissionSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setMaxSubmissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setPartNames\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setRequiredCapabilities\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setTestCasePoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setTotalHiddenExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setTotalHiddenNonExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setTotalNonHiddenExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:setTotalNonHiddenNonExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$base_testcases has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$display_testcase_runtime_memory has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$early_submission_incentive has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$early_submission_message has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$early_submission_minimum_days_early has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$early_submission_minimum_points has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$early_submission_test_cases has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$gradeable_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$gradeable_message has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$hide_test_details has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$leaderboards has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$load_gradeable_message has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$load_gradeable_message_enabled has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$load_gradeable_message_first_time_only has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$max_possible_grading_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$max_submission_size has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$max_submissions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$notebook_config has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$notebook_gradeable has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$one_part_only has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$part_names has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$required_capabilities has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$total_hidden_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$total_hidden_non_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$total_non_hidden_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingConfig\\:\\:\\$total_non_hidden_non_extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingConfig.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/AutogradingConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:__construct\\(\\) has parameter \\$testcase with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:getTestcaseLabel\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setHidden\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setIndex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:setViewTestcaseMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$details has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$dispatcher_actions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$extra_credit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$graphics_actions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$hidden has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$index has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$points has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$publish_actions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$release_hidden_details has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$testcase_label has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\AutogradingTestcase\\:\\:\\$view_testcase_message has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/AutogradingTestcase.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:assertPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:assertPoints\\(\\) has parameter \\$points with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:deleteMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:deleteMarkInner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:export\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:forceDeleteMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:getExtraCreditPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:getNumericScore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:getPenaltyPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:hasExtraCredit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:hasPenalty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:import\\(\\) has parameter \\$arr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:importMark\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:isCountUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:parsePoints\\(\\) has parameter \\$points with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:parsePoints\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setDefault\\(\\) has parameter \\$default with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setIdFromDatabase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setIdInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setLowerClamp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setLowerClamp\\(\\) has parameter \\$lower_clamp with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setMarks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setMarksFromDatabase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setMarksFromDatabase\\(\\) has parameter \\$marks with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setMaxValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setMaxValue\\(\\) has parameter \\$max_value with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setPoints\\(\\) has parameter \\$points with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setUpperClamp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Component\\:\\:setUpperClamp\\(\\) has parameter \\$upper_clamp with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$any_grades has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$db_marks has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$default has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$is_itempool_linked has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$itempool has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$lower_clamp has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$marks has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$max_value has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$order has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$page has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$peer_component has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$student_comment has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$ta_comment has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$text has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Component\\:\\:\\$upper_clamp has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Component.php
 
 		-
 			message: "#^Result of \\|\\| is always true\\.$#"
@@ -697,7 +10662,692 @@ parameters:
 			path: app/models/gradeable/Component.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeInquiry\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeInquiry.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeInquiry\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeInquiry.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeInquiry\\:\\:setStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeInquiry.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeInquiry\\:\\:\\$gc_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeInquiry.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeInquiry\\:\\:\\$status has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeInquiry.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeInquiry\\:\\:\\$timestamp has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeInquiry.php
+
+		-
 			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:assertDates\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:checkValidPerms\\(\\) has parameter \\$group_map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:checkValidPerms\\(\\) has parameter \\$user_map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:createTeam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:deleteComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:deleteComponentInner\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:exportComponents\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:forceDeleteComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getDefaultConfigPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getPeerFeedback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getPeerFeedback\\(\\) has parameter \\$anon_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getPeerFeedback\\(\\) has parameter \\$grader_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getRepositoryPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getRotatingGraderSections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getSplitPdfFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:getStringThreadIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:importComponent\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:parseDates\\(\\) has parameter \\$dates with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setActiveGradeInquiriesCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setAllowedMinutesOverrides\\(\\) has parameter \\$overrides with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setAutogradingConfigPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setAutogradingConfigPath\\(\\) has parameter \\$skip_path_check with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setComponentsFromDatabase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setDates\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setDates\\(\\) has parameter \\$dates with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeDueDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeDueDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeInquiryAllowed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeInquiryAllowedInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeReleasedDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeReleasedDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeStartDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setGradeStartDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setIdInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setMinGradingGroup\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerFeedback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerFeedback\\(\\) has parameter \\$feedback with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerFeedback\\(\\) has parameter \\$grader_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerFeedback\\(\\) has parameter \\$student_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerGradersList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerGradersList\\(\\) has parameter \\$input with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPeerGradingSet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setPrecision\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setRandomPeerGradersList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setRandomPeerGradersList\\(\\) has parameter \\$input with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setRotatingGraderSections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setRotatingGraderSections\\(\\) has parameter \\$rotating_grader_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setSubmissionDueDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setSubmissionDueDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setSubmissionOpenDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setSubmissionOpenDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTaGrading\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTaGradingInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTaViewStartDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTaViewStartDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTeamAssignment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTeamAssignment\\(\\) has parameter \\$use_teams with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTeamAssignmentInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTeamLockDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTeamLockDate\\(\\) has parameter \\$date with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTeamSizeMax\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setType\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:setTypeInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Gradeable\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$active_grade_inquiries_count has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$allow_custom_marks has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$allowed_minutes has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$allowed_minutes_overrides has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$any_build_errors has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$any_manual_grades has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$any_submissions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$autograding_config has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$autograding_config_path has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$components has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$db_components has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$depends_on has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$depends_on_points has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$discussion_based has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$discussion_thread_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_due_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_inquiry_allowed has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_inquiry_due_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_inquiry_per_component_allowed has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_inquiry_start_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_released_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grade_start_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$grader_assignment_method has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$has_due_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$has_release_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$hidden_files has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$instructions_url has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$instructor_blind has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$late_days has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$late_submission_allowed has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$limited_access_blind has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$min_grading_group has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$peer_blind has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$peer_grade_set has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$peer_grading_pairs has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$precision has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$rotating_grader_sections has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$rotating_grader_sections_modified has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$split_pdf_files has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$student_download has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$student_submit has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$student_view has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$student_view_after_grades has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$submission_due_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$submission_open_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$syllabus_bucket has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$ta_grading has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$ta_instructions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$ta_view_start_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$team_assignment has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$team_lock_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$team_size_max has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$teams has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$using_subdirectory has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$vcs has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$vcs_host_type has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$vcs_partial_path has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Gradeable\\:\\:\\$vcs_subdirectory has no type specified\\.$#"
 			count: 1
 			path: app/models/gradeable/Gradeable.php
 
@@ -705,6 +11355,186 @@ parameters:
 			message: "#^Result of && is always true\\.$#"
 			count: 1
 			path: app/models/gradeable/Gradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$beta_gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$closed_gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$future_gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$graded_gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$grading_gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$open_gradeables has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradeableList\\:\\:\\$user has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableList.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeableUtils\\:\\:getAllGradeableListFromUserId\\(\\) has parameter \\$calendar_messages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableUtils.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeableUtils\\:\\:getAllGradeableListFromUserId\\(\\) has parameter \\$courses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableUtils.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeableUtils\\:\\:getGradeablesFromCourse\\(\\) has parameter \\$calendar_messages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableUtils.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeableUtils\\:\\:getGradeablesFromUserAndCourse\\(\\) has parameter \\$calendar_messages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableUtils.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradeableUtils\\:\\:getGradeablesFromUserAndCourse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradeableUtils.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setComponentId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setDbMarkIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setGradeTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setGrader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setGraderId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setMarkIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setMarkIdsFromDb\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setScore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setVerifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:setVerifyTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$comment has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$component_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$db_mark_ids has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$grade_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$graded_version has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$grader_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$mark_ids has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$marks_modified has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$score has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$verifier_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponent\\:\\:\\$verify_time has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponent.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between DateTime\\|string and null will always evaluate to false\\.$#"
@@ -722,9 +11552,124 @@ parameters:
 			path: app/models/gradeable/GradedComponent.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponentContainer\\:\\:setGradedComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponentContainer.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedComponentContainer\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponentContainer.php
+
+		-
 			message: "#^Parameter \\#1 \\$dividend of static method app\\\\libraries\\\\Utils\\:\\:safeCalcPercent\\(\\) expects int, float given\\.$#"
 			count: 1
 			path: app/models/gradeable/GradedComponentContainer.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedComponentContainer\\:\\:\\$graded_components has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedComponentContainer.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:getGradeInquiryByGcId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:getOverriddenComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:hasOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:hasSubmission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setAutoGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setGradeInquiries\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setGradeInquiries\\(\\) has parameter \\$grade_inquiries with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setGradeableId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setGradeableId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setLateDayExceptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setSubmitter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:setTaGradedGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$auto_graded_gradeable has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$grade_inquiries has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$gradeable_id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$late_day_exceptions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$overridden_grades has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$submitter has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\GradedGradeable\\:\\:\\$ta_graded_gradeable has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/GradedGradeable.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
@@ -737,6 +11682,186 @@ parameters:
 			path: app/models/gradeable/GradedGradeable.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:__construct\\(\\) has parameter \\$event_info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:fromSubmitter\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:generateEventInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:getSimpleMessageFromSatus\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$has_late_day_info has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$has_submission has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$late_day_date has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$late_day_exceptions has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$late_days_allowed has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$late_days_change has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$late_days_remaining has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDayInfo\\:\\:\\$submission_days_late has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDayInfo.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDays\\:\\:__construct\\(\\) has parameter \\$late_day_updates with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDays.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LateDays\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDays.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDays\\:\\:\\$late_day_info has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDays.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LateDays\\:\\:\\$late_days_updates has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LateDays.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\LeaderboardConfig\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/LeaderboardConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LeaderboardConfig\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LeaderboardConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LeaderboardConfig\\:\\:\\$tag has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LeaderboardConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LeaderboardConfig\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LeaderboardConfig.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\LeaderboardConfig\\:\\:\\$top_visible_students has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/LeaderboardConfig.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:setComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:setIdFromDatabase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:setIdInternal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:setPoints\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Mark\\:\\:\\$any_receivers has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Mark\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Mark\\:\\:\\$order has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Mark\\:\\:\\$points has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Mark\\:\\:\\$publish has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\Mark\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Mark.php
+
+		-
 			message: "#^Result of \\|\\| is always true\\.$#"
 			count: 1
 			path: app/models/gradeable/Mark.php
@@ -745,6 +11870,16 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Component and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/Mark.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Submitter\\:\\:getAnonId\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/Submitter.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\Submitter\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/Submitter.php
 
 		-
 			message: "#^Result of \\|\\| is always true\\.$#"
@@ -757,12 +11892,147 @@ parameters:
 			path: app/models/gradeable/Submitter.php
 
 		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:clearDeletedGradedComponents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:deleteGradedComponent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:getAttachments\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:getOverallComments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:getTotalPeerScore\\(\\) has parameter \\$grader with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:getTotalScore\\(\\) has parameter \\$grader with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:getTotalScorePercent\\(\\) has parameter \\$grader with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:getTotalTaScore\\(\\) has parameter \\$grader with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:removeOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:resetUserViewedDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setGradedComponentContainers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setGradedComponentContainers\\(\\) has parameter \\$graded_component_containers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setGradedComponentContainersFromDatabase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setIdFromDatabase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setOverallComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:setUserViewedDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Method app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
 			message: "#^Parameter \\#1 \\$dividend of static method app\\\\libraries\\\\Utils\\:\\:safeCalcPercent\\(\\) expects int, float given\\.$#"
 			count: 2
 			path: app/models/gradeable/TaGradedGradeable.php
 
 		-
 			message: "#^Parameter \\#2 \\$divisor of static method app\\\\libraries\\\\Utils\\:\\:safeCalcPercent\\(\\) expects int, float given\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$attachments has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$deleted_graded_components has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$graded_component_containers has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$graded_gradeable has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$overall_comments has no type specified\\.$#"
+			count: 1
+			path: app/models/gradeable/TaGradedGradeable.php
+
+		-
+			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$user_viewed_date has no type specified\\.$#"
 			count: 1
 			path: app/models/gradeable/TaGradedGradeable.php
 
@@ -782,9 +12052,484 @@ parameters:
 			path: app/models/gradeable/TaGradedGradeable.php
 
 		-
+			message: "#^Method app\\\\models\\\\notebook\\\\AbstractNotebookInput\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/AbstractNotebookInput.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\AbstractNotebookInput\\:\\:\\$file_name has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/AbstractNotebookInput.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:getMarkdownData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:getMarkdownData\\(\\) has parameter \\$cell with no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:getMostRecentNotebookSubmissions\\(\\) has parameter \\$new_notebook with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:getMostRecentNotebookSubmissions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:getNotebookImagePaths\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:getTestCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\Notebook\\:\\:parseNotebook\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\Notebook\\:\\:\\$file_submissions has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\Notebook\\:\\:\\$gradeable_id has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\Notebook\\:\\:\\$image_paths has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\Notebook\\:\\:\\$inputs has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\Notebook\\:\\:\\$item_pool has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\Notebook\\:\\:\\$notebook has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/Notebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\SubmissionCodeBox\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionCodeBox.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\SubmissionCodeBox\\:\\:\\$codeMirrorMode has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionCodeBox.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\SubmissionCodeBox\\:\\:\\$language has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionCodeBox.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\SubmissionCodeBox\\:\\:\\$row_count has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionCodeBox.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\SubmissionMultipleChoice\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionMultipleChoice.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\SubmissionMultipleChoice\\:\\:\\$allow_multiple has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionMultipleChoice.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\SubmissionMultipleChoice\\:\\:\\$choices has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionMultipleChoice.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\SubmissionMultipleChoice\\:\\:\\$randomize_order has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/SubmissionMultipleChoice.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:getItemFromPool\\(\\) has parameter \\$item with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:getTestCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:replaceNotebookItemsWithQuestions\\(\\) has parameter \\$raw_notebook with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:replaceNotebookItemsWithQuestions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Method app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:searchForItemPool\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$hashes has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$item_pool has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$notebook_config has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$selected_questions has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$test_cases has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$user_id has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Property app\\\\models\\\\notebook\\\\UserSpecificNotebook\\:\\:\\$warning has no type specified\\.$#"
+			count: 1
+			path: app/models/notebook/UserSpecificNotebook.php
+
+		-
+			message: "#^Class app\\\\repositories\\\\VcsAuthTokenRepository extends generic class Doctrine\\\\ORM\\\\EntityRepository but does not specify its types\\: T$#"
+			count: 1
+			path: app/repositories/VcsAuthTokenRepository.php
+
+		-
+			message: "#^Class app\\\\repositories\\\\course\\\\CourseMaterialRepository extends generic class Doctrine\\\\ORM\\\\EntityRepository but does not specify its types\\: T$#"
+			count: 1
+			path: app/repositories/course/CourseMaterialRepository.php
+
+		-
+			message: "#^Class app\\\\repositories\\\\email\\\\EmailRepository extends generic class Doctrine\\\\ORM\\\\EntityRepository but does not specify its types\\: T$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageNum\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageNum\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) has parameter \\$course with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) has parameter \\$page with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) has parameter \\$semester with no type specified\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/repositories/email/EmailRepository.php
+
+		-
+			message: "#^Class app\\\\repositories\\\\poll\\\\OptionRepository extends generic class Doctrine\\\\ORM\\\\EntityRepository but does not specify its types\\: T$#"
+			count: 1
+			path: app/repositories/poll/OptionRepository.php
+
+		-
+			message: "#^Method app\\\\repositories\\\\poll\\\\OptionRepository\\:\\:findByPollWithResponseCounts\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/repositories/poll/OptionRepository.php
+
+		-
+			message: "#^Class app\\\\repositories\\\\poll\\\\PollRepository extends generic class Doctrine\\\\ORM\\\\EntityRepository but does not specify its types\\: T$#"
+			count: 1
+			path: app/repositories/poll/PollRepository.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthTokenView\\:\\:showAuthTokenPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/AuthTokenView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthTokenView\\:\\:showAuthTokenPage\\(\\) has parameter \\$new_api_token with no type specified\\.$#"
+			count: 1
+			path: app/views/AuthTokenView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthTokenView\\:\\:showAuthTokenPage\\(\\) has parameter \\$new_vcs_token with no type specified\\.$#"
+			count: 1
+			path: app/views/AuthTokenView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthTokenView\\:\\:showAuthTokenPage\\(\\) has parameter \\$new_vcs_token_val with no type specified\\.$#"
+			count: 1
+			path: app/views/AuthTokenView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthTokenView\\:\\:showAuthTokenPage\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/AuthTokenView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthenticationView\\:\\:loginForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/AuthenticationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthenticationView\\:\\:loginForm\\(\\) has parameter \\$isSaml with no type specified\\.$#"
+			count: 1
+			path: app/views/AuthenticationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthenticationView\\:\\:loginForm\\(\\) has parameter \\$old with no type specified\\.$#"
+			count: 1
+			path: app/views/AuthenticationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthenticationView\\:\\:userSelection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/AuthenticationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AuthenticationView\\:\\:userSelection\\(\\) has parameter \\$users with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/AuthenticationView.php
+
+		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 2
 			path: app/views/AutoGradingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AutoGradingView\\:\\:convertToAnonPath\\(\\) has parameter \\$g_id with no type specified\\.$#"
+			count: 1
+			path: app/views/AutoGradingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AutoGradingView\\:\\:showPeerResults\\(\\) has parameter \\$uploaded_files with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/AutoGradingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AutoGradingView\\:\\:showTAResults\\(\\) has parameter \\$uploaded_files with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/AutoGradingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AutogradingStatusView\\:\\:displayPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/AutogradingStatusView.php
+
+		-
+			message: "#^Method app\\\\views\\\\AutogradingStatusView\\:\\:displayPage\\(\\) has parameter \\$progress with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/AutogradingStatusView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:courseErrorPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:courseErrorPage\\(\\) has parameter \\$error_message with no type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:errorPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:errorPage\\(\\) has parameter \\$error_message with no type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:exceptionPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:exceptionPage\\(\\) has parameter \\$error_message with no type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:genericError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:genericError\\(\\) has parameter \\$error_messages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:noAccessCourse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:noGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:noGradeable\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:unbuiltGradeable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\ErrorView\\:\\:unbuiltGradeable\\(\\) has parameter \\$gradeable_title with no type specified\\.$#"
+			count: 1
+			path: app/views/ErrorView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:footer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:footer\\(\\) has parameter \\$content_only with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:footer\\(\\) has parameter \\$footer_links with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:footer\\(\\) has parameter \\$runtime with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:footer\\(\\) has parameter \\$wrapper_urls with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$breadcrumbs with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$content_only with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$duck_img with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$js with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$notifications_info with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$page_name with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$sidebar_buttons with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$wrapper_urls with no type specified\\.$#"
+			count: 1
+			path: app/views/GlobalView.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\User and null will always evaluate to false\\.$#"
@@ -795,6 +12540,151 @@ parameters:
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: app/views/GlobalView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showCourseCreationPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showCourseCreationPage\\(\\) has parameter \\$courses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showCourseCreationPage\\(\\) has parameter \\$faculty with no type specified\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showCourseCreationPage\\(\\) has parameter \\$head_instructor with no type specified\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showCourseCreationPage\\(\\) has parameter \\$semesters with no type specified\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showHomePage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showHomePage\\(\\) has parameter \\$archived_courses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showHomePage\\(\\) has parameter \\$unarchived_courses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/HomePageView.php
+
+		-
+			message: "#^Method app\\\\views\\\\LateDaysTableView\\:\\:showLateTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/LateDaysTableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\LateDaysTableView\\:\\:showLateTablePage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/LateDaysTableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\LeaderboardView\\:\\:showLeaderboardPage\\(\\) has parameter \\$leaderboards with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/LeaderboardView.php
+
+		-
+			message: "#^Method app\\\\views\\\\LeaderboardView\\:\\:showLeaderboardTable\\(\\) has parameter \\$leaderboard_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/LeaderboardView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MarkdownView\\:\\:renderMarkdown\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/MarkdownView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MarkdownView\\:\\:renderMarkdown\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: app/views/MarkdownView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MarkdownView\\:\\:renderMarkdownArea\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/MarkdownView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MarkdownView\\:\\:renderMarkdownArea\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: app/views/MarkdownView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayCode\\(\\) has parameter \\$file_contents with no type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayCode\\(\\) has parameter \\$file_type with no type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayCode\\(\\) has parameter \\$filename with no type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayCode\\(\\) has parameter \\$search_enabled with no type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:displayFile\\(\\) has parameter \\$file_contents with no type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\MiscView\\:\\:tooLarge\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/MiscView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:closeSubmissionsWarning\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:deleteGradeableForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:getAllDeleteButtons\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:getAllEditButtons\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:getButtons\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
 
 		-
 			message: "#^Method app\\\\views\\\\NavigationView\\:\\:getDeleteButton\\(\\) never returns null so it can be removed from the return type\\.$#"
@@ -812,6 +12702,31 @@ parameters:
 			path: app/views/NavigationView.php
 
 		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:showGradeables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:showGradeables\\(\\) has parameter \\$gradeable_ids_and_titles with no type specified\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:showGradeables\\(\\) has parameter \\$graded_gradeables with no type specified\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:showGradeables\\(\\) has parameter \\$sections_to_list with no type specified\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NavigationView\\:\\:showGradeables\\(\\) has parameter \\$submit_everyone with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/NavigationView.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between float and 0 will always evaluate to false\\.$#"
 			count: 1
 			path: app/views/NavigationView.php
@@ -822,9 +12737,509 @@ parameters:
 			path: app/views/NavigationView.php
 
 		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotificationSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotificationSettings\\(\\) has parameter \\$notification_saves with no type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotifications\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotifications\\(\\) has parameter \\$current_course with no type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotifications\\(\\) has parameter \\$notification_saves with no type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotifications\\(\\) has parameter \\$notifications with no type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\NotificationView\\:\\:showNotifications\\(\\) has parameter \\$show_all with no type specified\\.$#"
+			count: 1
+			path: app/views/NotificationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderCurrentQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderCurrentQueue\\(\\) has parameter \\$viewer with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderNewAnnouncement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderNewAnnouncement\\(\\) has parameter \\$viewer with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderNewStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderNewStatus\\(\\) has parameter \\$viewer with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderPart\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderPart\\(\\) has parameter \\$twig_location with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderPart\\(\\) has parameter \\$viewer with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderQueueHistory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:renderQueueHistory\\(\\) has parameter \\$viewer with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStats\\(\\) has parameter \\$overallData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStats\\(\\) has parameter \\$queueData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStats\\(\\) has parameter \\$todayData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStats\\(\\) has parameter \\$weekDayData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStats\\(\\) has parameter \\$weekDayThisWeekData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStats\\(\\) has parameter \\$weekNumberData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStudentStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showQueueStudentStats\\(\\) has parameter \\$studentData with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showTheQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\OfficeHoursQueueView\\:\\:showTheQueue\\(\\) has parameter \\$viewer with no type specified\\.$#"
+			count: 1
+			path: app/views/OfficeHoursQueueView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PDFView\\:\\:downloadPDFEmbedded\\(\\) has parameter \\$annotation_jsons with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/PDFView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PDFView\\:\\:showPDFEmbedded\\(\\) has parameter \\$annotation_jsons with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/PDFView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:pollForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:showPoll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:showPoll\\(\\) has parameter \\$response_counts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:showPollsInstructor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:showPollsInstructor\\(\\) has parameter \\$dropdown_states with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:showPollsInstructor\\(\\) has parameter \\$response_counts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\PollView\\:\\:showPollsStudent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/PollView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ConfigurationView\\:\\:viewConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/ConfigurationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ConfigurationView\\:\\:viewConfig\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/ConfigurationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ConfigurationView\\:\\:viewConfig\\(\\) has parameter \\$gradeable_seating_options with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/ConfigurationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ConfigurationView\\:\\:viewConfig\\(\\) has parameter \\$submitty_admin_user with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/ConfigurationView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\DockerView\\:\\:displayDockerPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/DockerView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\DockerView\\:\\:displayDockerPage\\(\\) has parameter \\$docker_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/DockerView.php
+
+		-
 			message: "#^Parameter \\#2 \\$bytes of static method app\\\\libraries\\\\Utils\\:\\:formatBytes\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: app/views/admin/DockerView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\EmailRoomSeatingView\\:\\:displayPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/EmailRoomSeatingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\EmailRoomSeatingView\\:\\:displayPage\\(\\) has parameter \\$defaultBody with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/EmailRoomSeatingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\EmailRoomSeatingView\\:\\:displayPage\\(\\) has parameter \\$defaultSubject with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/EmailRoomSeatingView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ExtensionsView\\:\\:displayExtensions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/ExtensionsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ExtensionsView\\:\\:displayExtensions\\(\\) has parameter \\$gradeables with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/ExtensionsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeOverrideView\\:\\:displayOverriddenGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeOverrideView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeOverrideView\\:\\:displayOverriddenGrades\\(\\) has parameter \\$gradeables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/GradeOverrideView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeOverrideView\\:\\:displayOverriddenGrades\\(\\) has parameter \\$students with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/GradeOverrideView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:AdminGradeableAddPeersForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:AdminGradeableAddPeersForm\\(\\) has parameter \\$gradeable with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:AdminGradeableEditPeersForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:AdminGradeableEditPeersForm\\(\\) has parameter \\$gradeable with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:uploadConfigForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:uploadConfigForm\\(\\) has parameter \\$all_files with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:uploadConfigForm\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:uploadConfigForm\\(\\) has parameter \\$inuse_config with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\GradeableView\\:\\:uploadConfigForm\\(\\) has parameter \\$target_dir with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/GradeableView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDayForesnics\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDayForesnics\\(\\) has parameter \\$initial_late_days with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDayForesnics\\(\\) has parameter \\$students with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDays\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDays\\(\\) has parameter \\$initial_late_days with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDays\\(\\) has parameter \\$students with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\LateDayView\\:\\:displayLateDays\\(\\) has parameter \\$users with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/LateDayView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\PlagiarismView\\:\\:configurePlagiarismForm\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/PlagiarismView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\PlagiarismView\\:\\:configurePlagiarismForm\\(\\) has parameter \\$gradeables_with_plag_configs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/PlagiarismView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\PlagiarismView\\:\\:plagiarismMainPage\\(\\) has parameter \\$plagiarism_result_info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/PlagiarismView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\PlagiarismView\\:\\:showPlagiarismResult\\(\\) has parameter \\$rankings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/PlagiarismView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ReportView\\:\\:showFullGradebook\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/ReportView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ReportView\\:\\:showFullGradebook\\(\\) has parameter \\$grade_file with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/ReportView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ReportView\\:\\:showReportUpdates\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/ReportView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ReportView\\:\\:showReportUpdates\\(\\) has parameter \\$grade_summaries_last_run with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/ReportView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\ReportView\\:\\:showReportUpdates\\(\\) has parameter \\$json with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/ReportView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\SqlToolboxView\\:\\:showToolbox\\(\\) has parameter \\$tables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/SqlToolboxView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\StudentActivityDashboardView\\:\\:createTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/StudentActivityDashboardView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\StudentActivityDashboardView\\:\\:createTable\\(\\) has parameter \\$data_dump with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/StudentActivityDashboardView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\StudentActivityDashboardView\\:\\:downloadFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/StudentActivityDashboardView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\StudentActivityDashboardView\\:\\:downloadFile\\(\\) has parameter \\$file_url with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/StudentActivityDashboardView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listGraders\\(\\) has parameter \\$download_info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listGraders\\(\\) has parameter \\$graders_sorted with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listGraders\\(\\) has parameter \\$reg_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listGraders\\(\\) has parameter \\$rot_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listStudents\\(\\) has parameter \\$download_info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listStudents\\(\\) has parameter \\$formatted_tzs with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listStudents\\(\\) has parameter \\$reg_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listStudents\\(\\) has parameter \\$rot_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:listStudents\\(\\) has parameter \\$sorted_students with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:sectionsForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:sectionsForm\\(\\) has parameter \\$max_section with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:sectionsForm\\(\\) has parameter \\$not_null_counts with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:sectionsForm\\(\\) has parameter \\$null_counts with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:sectionsForm\\(\\) has parameter \\$reg_sections with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:sectionsForm\\(\\) has parameter \\$students with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:userForm\\(\\) has parameter \\$reg_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\UsersView\\:\\:userForm\\(\\) has parameter \\$rot_sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/admin/UsersView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\WrapperView\\:\\:displayPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/admin/WrapperView.php
+
+		-
+			message: "#^Method app\\\\views\\\\admin\\\\WrapperView\\:\\:displayPage\\(\\) has parameter \\$wrapper_files with no type specified\\.$#"
+			count: 1
+			path: app/views/admin/WrapperView.php
 
 		-
 			message: "#^Call to function is_array\\(\\) with app\\\\entities\\\\course\\\\CourseMaterial will always evaluate to false\\.$#"
@@ -832,8 +13247,548 @@ parameters:
 			path: app/views/course/CourseMaterialsView.php
 
 		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:listCourseMaterials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:listCourseMaterials\\(\\) has parameter \\$course_materials_db with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:removeEmptyFolders\\(\\) has parameter \\$course_materials with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:setFolderVisibilities\\(\\) has parameter \\$course_materials with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:setFolderVisibilities\\(\\) has parameter \\$folder_visibilities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:setFolderVisibilitiesR\\(\\) has parameter \\$course_materials with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:setFolderVisibilitiesR\\(\\) has parameter \\$folder_visibilities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:setSeen\\(\\) has parameter \\$course_materials with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\course\\\\CourseMaterialsView\\:\\:setSeen\\(\\) has parameter \\$seen with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/course/CourseMaterialsView.php
+
+		-
+			message: "#^Method app\\\\views\\\\email\\\\EmailStatusView\\:\\:EmailToKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/email/EmailStatusView.php
+
+		-
+			message: "#^Method app\\\\views\\\\email\\\\EmailStatusView\\:\\:EmailToKey\\(\\) has parameter \\$row with no type specified\\.$#"
+			count: 1
+			path: app/views/email/EmailStatusView.php
+
+		-
+			message: "#^Method app\\\\views\\\\email\\\\EmailStatusView\\:\\:renderStatusPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/email/EmailStatusView.php
+
+		-
+			message: "#^Method app\\\\views\\\\email\\\\EmailStatusView\\:\\:renderStatusPage\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/email/EmailStatusView.php
+
+		-
+			message: "#^Method app\\\\views\\\\email\\\\EmailStatusView\\:\\:showEmailStatusPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/email/EmailStatusView.php
+
+		-
 			message: "#^Expression \"\\$category_colors\" on a separate line does not do anything\\.$#"
 			count: 2
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:contentMarkdownToPlain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:contentMarkdownToPlain\\(\\) has parameter \\$str with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$display_option with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$first with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$includeReply with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$post with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$render with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$reply_level with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$thread_announced with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createPost\\(\\) has parameter \\$unviewed_posts with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:createThread\\(\\) has parameter \\$category_colors with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$activeThread with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$activeThreadAnnouncement with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$activeThreadTitle with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$current_categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$filtering with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$is_full_page with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$render with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$thread_id_p with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:displayThreadList\\(\\) has parameter \\$threads with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:filter_post_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:filter_post_content\\(\\) has parameter \\$original_post_content with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$categories with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$cookieSelectedCategories with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$cookieSelectedThreadStatus with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$cookieSelectedUnread with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$currentCategoriesIds with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$currentCourse with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$currentThread with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$display_option with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$includeReply with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$isCurrentFavorite with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$posts with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$render with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$threadExists with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$thread_announced with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:generatePostList\\(\\) has parameter \\$unviewed_posts with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getAllForumButtons\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getAllForumButtons\\(\\) has parameter \\$display_option with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getAllForumButtons\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getAllForumButtons\\(\\) has parameter \\$show_merged_thread with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getAllForumButtons\\(\\) has parameter \\$thread_exists with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getAllForumButtons\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getSavedForumCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getSavedForumCategories\\(\\) has parameter \\$categories with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getSavedForumCategories\\(\\) has parameter \\$current_course with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getSavedThreadStatuses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:getUnreadThreadStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:searchResult\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:searchResult\\(\\) has parameter \\$threads with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showAlteredDisplayList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showAlteredDisplayList\\(\\) has parameter \\$ajax with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showAlteredDisplayList\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showAlteredDisplayList\\(\\) has parameter \\$filtering with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showAlteredDisplayList\\(\\) has parameter \\$thread_id with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showAlteredDisplayList\\(\\) has parameter \\$threads with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showCategories\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showCategories\\(\\) has parameter \\$category_colors with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$ajax with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$display_option with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$initialPageNumber with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$max_thread with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$post_content_limit with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$posts with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$show_merged_thread with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$thread_announced with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$thread_resolve_state with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$threadsHead with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$unviewed_posts with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showForumThreads\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showFullThreadsPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showFullThreadsPage\\(\\) has parameter \\$category_ids with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showFullThreadsPage\\(\\) has parameter \\$page_number with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showFullThreadsPage\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showFullThreadsPage\\(\\) has parameter \\$show_merged_threads with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:showFullThreadsPage\\(\\) has parameter \\$threads with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeContent\\(\\) has parameter \\$first_post_content with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeContent\\(\\) has parameter \\$length with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeContent\\(\\) has parameter \\$sizeOfContent with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeTitle\\(\\) has parameter \\$length with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeTitle\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeTitle\\(\\) has parameter \\$titleDisplay with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:sizeTitle\\(\\) has parameter \\$titleLength with no type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:statPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/forum/ForumThreadView.php
+
+		-
+			message: "#^Method app\\\\views\\\\forum\\\\ForumThreadView\\:\\:statPage\\(\\) has parameter \\$users with no type specified\\.$#"
+			count: 1
 			path: app/views/forum/ForumThreadView.php
 
 		-
@@ -842,7 +13797,262 @@ parameters:
 			path: app/views/forum/ForumThreadView.php
 
 		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:adminTeamForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:adminTeamForm\\(\\) has parameter \\$all_reg_sections with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:adminTeamForm\\(\\) has parameter \\$all_rot_sections with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:adminTeamForm\\(\\) has parameter \\$students with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$anon_ids with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$anon_mode with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$direction with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$graders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$overrides with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$past_grade_start_date with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$sort with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:detailsPage\\(\\) has parameter \\$view_all with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$anon_mode with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$blind_grading with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$direction with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$from with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$rollbackSubmission with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$solution_ta_notes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$sort with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:hwGradingPage\\(\\) has parameter \\$submitter_itempool_map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:importTeamForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:popupMarkConflicts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:popupSettings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:popupStudents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:randomizeButtonWarning\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderDiscussionForum\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderDiscussionForum\\(\\) has parameter \\$isTeam with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderDiscussionForum\\(\\) has parameter \\$submitter with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderDiscussionForum\\(\\) has parameter \\$threadIds with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNavigationBar\\(\\) has parameter \\$anon_mode with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNavigationBar\\(\\) has parameter \\$blind_grading with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNavigationBar\\(\\) has parameter \\$from with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNavigationBar\\(\\) has parameter \\$limited_access_blind with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNotebookPanel\\(\\) has parameter \\$image_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNotebookPanel\\(\\) has parameter \\$notebook with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNotebookPanel\\(\\) has parameter \\$old_files with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderNotebookPanel\\(\\) has parameter \\$testcase_messages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderSolutionTaNotesPanel\\(\\) has parameter \\$solution_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:renderSolutionTaNotesPanel\\(\\) has parameter \\$submitter_itempool_map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statPage\\(\\) has parameter \\$users with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has parameter \\$autograded_average with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has parameter \\$component_averages with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has parameter \\$histogram_data with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has parameter \\$overall_average with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has parameter \\$overall_scores with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:statusPage\\(\\) has parameter \\$sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method class@anonymous/app/views/grading/ElectronicGraderView\\.php\\:1687\\:\\:getRandomIndices\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
 			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$working_dir has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/views/grading/ElectronicGraderView.php
 
@@ -852,9 +14062,79 @@ parameters:
 			path: app/views/grading/ElectronicGraderView.php
 
 		-
+			message: "#^Property app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:\\$user_id_to_User_cache has no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ElectronicGraderView.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between int and null will always evaluate to false\\.$#"
 			count: 2
 			path: app/views/grading/ElectronicGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ImagesView\\:\\:listStudentImages\\(\\) has parameter \\$grader_sections with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ImagesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ImagesView\\:\\:listStudentImages\\(\\) has parameter \\$has_full_access with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ImagesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\ImagesView\\:\\:listStudentImages\\(\\) has parameter \\$view with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/ImagesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\SimpleGraderView\\:\\:simpleDisplay\\(\\) has parameter \\$anon_ids with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/SimpleGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\SimpleGraderView\\:\\:simpleDisplay\\(\\) has parameter \\$graders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/grading/SimpleGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\SimpleGraderView\\:\\:simpleDisplay\\(\\) has parameter \\$sort with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/SimpleGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\grading\\\\SimpleGraderView\\:\\:simpleDisplay\\(\\) has parameter \\$student_full with no type specified\\.$#"
+			count: 1
+			path: app/views/grading/SimpleGraderView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\HomeworkView\\:\\:removeLowConfidenceDigits\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/submission/HomeworkView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\HomeworkView\\:\\:removeLowConfidenceDigits\\(\\) has parameter \\$confidences with no type specified\\.$#"
+			count: 1
+			path: app/views/submission/HomeworkView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\HomeworkView\\:\\:removeLowConfidenceDigits\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: app/views/submission/HomeworkView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\HomeworkView\\:\\:renderSingleGradeInquiryPost\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/submission/HomeworkView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\HomeworkView\\:\\:renderSubmissionsClosedBox\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/submission/HomeworkView.php
+
+		-
+			message: "#^Method class@anonymous/app/views/submission/HomeworkView\\.php\\:522\\:\\:getRandomIndices\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/submission/HomeworkView.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to false\\.$#"
@@ -862,10 +14142,90 @@ parameters:
 			path: app/views/submission/HomeworkView.php
 
 		-
+			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showGrades\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/submission/RainbowGradesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showGrades\\(\\) has parameter \\$grade_file with no type specified\\.$#"
+			count: 1
+			path: app/views/submission/RainbowGradesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showStudentToInstructor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/submission/RainbowGradesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showStudentToInstructor\\(\\) has parameter \\$grade_file with no type specified\\.$#"
+			count: 1
+			path: app/views/submission/RainbowGradesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showStudentToInstructor\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: app/views/submission/RainbowGradesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\GradeablesView\\:\\:showGradeablesList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/superuser/GradeablesView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SamlManagerView\\:\\:renderPage\\(\\) has parameter \\$invalid_users with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/superuser/SamlManagerView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SamlManagerView\\:\\:renderPage\\(\\) has parameter \\$proxy_mapped_users with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/views/superuser/SamlManagerView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SuperuserEmailView\\:\\:showEmailPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/views/superuser/SuperuserEmailView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SuperuserEmailView\\:\\:showEmailPage\\(\\) has parameter \\$num_faculty with no type specified\\.$#"
+			count: 1
+			path: app/views/superuser/SuperuserEmailView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SuperuserEmailView\\:\\:showEmailPage\\(\\) has parameter \\$num_full_access with no type specified\\.$#"
+			count: 1
+			path: app/views/superuser/SuperuserEmailView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SuperuserEmailView\\:\\:showEmailPage\\(\\) has parameter \\$num_instructor with no type specified\\.$#"
+			count: 1
+			path: app/views/superuser/SuperuserEmailView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SuperuserEmailView\\:\\:showEmailPage\\(\\) has parameter \\$num_limited_access with no type specified\\.$#"
+			count: 1
+			path: app/views/superuser/SuperuserEmailView.php
+
+		-
+			message: "#^Method app\\\\views\\\\superuser\\\\SuperuserEmailView\\:\\:showEmailPage\\(\\) has parameter \\$num_student with no type specified\\.$#"
+			count: 1
+			path: app/views/superuser/SuperuserEmailView.php
+
+		-
 			message: """
 				#^Call to deprecated method registerLoader\\(\\) of class Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:
 				This method is deprecated and will be removed in
 				            doctrine/annotations 2\\.0\\. Annotations will be autoloaded in 2\\.0\\.$#
 			"""
+			count: 1
+			path: public/index.php
+
+		-
+			message: "#^Function error_handler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: public/index.php
+
+		-
+			message: "#^Function exception_handler\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: public/index.php

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
         - '#Access to an undefined property Ratchet\\ConnectionInterface::\$resourceId\.#'
         - '#Access to an undefined property Ratchet\\ConnectionInterface::\$httpRequest\.#'
     reportAlwaysTrueInLastCondition: true
-    level: 5
+    level: 6
 
 services:
     - class: tests\phpstan\ModelClassExtension


### PR DESCRIPTION
### What is the current behavior?
We currently rely upon manual code review to enforce our PHP type annotations guidelines.  PHPStan can do this automatically.

### What is the new behavior?
This PR bumps PHPStan to level 6, which adds a set of rules which require PHP type annotations.

### Other information?
Given that development is quite active at the moment, I have ignored all of the existing errors.  Many of these are easy to fix, but fixing them risks creating merge conflicts which make other PRs harder to merge.  I plan to make a set of future PRs to pare down the list of ignored errors during a time when development is less active.
