### PR TITLE
[Testing:Submission] Re-add part of cypress autograding test

### DIFF
--- a/site/cypress/e2e/autograding_status_1.spec.js
+++ b/site/cypress/e2e/autograding_status_1.spec.js
@@ -44,23 +44,23 @@ skipOn(Cypress.env('run_area') === 'CI', () => {
             cy.get('.alert-success').invoke('text').should('contain', '101 submissions added to queue for regrading');
             cy.visit(autograding_status_path);
             cy.get('#toggle-btn').should('have.text', 'Pause Update').click().should('have.text', 'Resume Update');
-            cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
-            cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
-            cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
-            cy.get('#course-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
-            cy.get('#course-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
+            // cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
+            // cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
+            // cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
+            // cy.get('#course-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#course-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
 
-            cy.wait(500);
-            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
-            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '101'));
+            // cy.wait(500);
+            // cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
+            // cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '101'));
 
             // add a non regrade job and see that the site is updated
 
@@ -73,22 +73,22 @@ skipOn(Cypress.env('run_area') === 'CI', () => {
             cy.visit(autograding_status_path);
 
             cy.get('#toggle-btn').should('have.text', 'Pause Update').click().should('have.text', 'Resume Update');
-            cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
-            cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
-            cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
-            cy.get('#course-table tbody tr td').should('contain', 'future_no_tas_homework');
-            cy.get('#course-table tbody tr td').should('contain', '1');
+            // cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
+            // cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
+            // cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
+            // cy.get('#course-table tbody tr td').should('contain', 'future_no_tas_homework');
+            // cy.get('#course-table tbody tr td').should('contain', '1');
 
-            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', '1'));
-            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
-            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
-            cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '102'));
+            // cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', '1'));
+            // cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
+            // cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
+            // cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '102'));
 
         });
 

--- a/site/cypress/e2e/autograding_status_1.spec.js
+++ b/site/cypress/e2e/autograding_status_1.spec.js
@@ -1,5 +1,5 @@
-// import {getCurrentSemester} from '../support/utils.js';
-import {skipOn} from '@cypress/skip-test';
+import { getCurrentSemester } from '../support/utils.js';
+import { skipOn } from '@cypress/skip-test';
 
 const autograding_status_path = 'autograding_status';
 
@@ -10,7 +10,7 @@ skipOn(Cypress.env('run_area') === 'CI', () => {
             cy.visit('/');
             cy.login();
             cy.wait(500);
-            cy.viewport(1920,1200);
+            cy.viewport(1920, 1200);
             cy.visit(autograding_status_path);
         });
 

--- a/site/cypress/e2e/autograding_status_1.spec.js
+++ b/site/cypress/e2e/autograding_status_1.spec.js
@@ -31,66 +31,66 @@ skipOn(Cypress.env('run_area') === 'CI', () => {
 
         });
         // FIXME
-        // it('Should show newly added autograding jobs', () => {
-        //     cy.visit('/');
-        //     cy.login();
-        //     cy.wait(500);
+        it('Should show newly added autograding jobs', () => {
+            cy.visit('/');
+            cy.login();
+            cy.wait(500);
 
-        //     // trigger regrade for a gradeable
-        //     cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/closed_homework/grading/details`);
-        //     cy.wait(500);
-        //     cy.get('.regrade-btn').click();
-        //     cy.wait(200);
-        //     cy.get('.alert-success').invoke('text').should('contain', '101 submissions added to queue for regrading');
-        //     cy.visit(autograding_status_path);
-        //     cy.get('#toggle-btn').should('have.text', 'Pause Update').click().should('have.text', 'Resume Update');
-        //     cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
-        //     cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
-        //     cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
-        //     cy.get('#course-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#course-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
+            // trigger regrade for a gradeable
+            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/closed_homework/grading/details`);
+            cy.wait(500);
+            cy.get('.regrade-btn').click();
+            cy.wait(200);
+            cy.get('.alert-success').invoke('text').should('contain', '101 submissions added to queue for regrading');
+            cy.visit(autograding_status_path);
+            cy.get('#toggle-btn').should('have.text', 'Pause Update').click().should('have.text', 'Resume Update');
+            cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
+            cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
+            cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
+            cy.get('#course-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
+            cy.get('#course-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
 
-        //     cy.wait(500);
-        //     cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
-        //     cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '101'));
+            cy.wait(500);
+            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
+            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '101'));
 
-        //     // add a non regrade job and see that the site is updated
+            // add a non regrade job and see that the site is updated
 
-        //     cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/future_no_tas_homework`);
-        //     cy.wait(500);
-        //     cy.get('.upload-box').selectFile('cypress/fixtures/sample_upload.py', { action: 'drag-drop' });
-        //     cy.get('#submit').click();
-        //     cy.wait(500);
+            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/future_no_tas_homework`);
+            cy.wait(500);
+            cy.get('.upload-box').selectFile('cypress/fixtures/sample_upload.py', { action: 'drag-drop' });
+            cy.get('#submit').click();
+            cy.wait(500);
 
-        //     cy.visit(autograding_status_path);
+            cy.visit(autograding_status_path);
 
-        //     cy.get('#toggle-btn').should('have.text', 'Pause Update').click().should('have.text', 'Resume Update');
-        //     cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
-        //     cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
-        //     cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
-        //     cy.get('#course-table tbody tr td').should('contain', 'future_no_tas_homework');
-        //     cy.get('#course-table tbody tr td').should('contain', '1');
+            cy.get('#toggle-btn').should('have.text', 'Pause Update').click().should('have.text', 'Resume Update');
+            cy.get('#course-table tbody tr td').eq(0).then(element => cy.get(element).should('contain', getCurrentSemester()));
+            cy.get('#course-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', 'sample'));
+            cy.get('#course-table tbody tr td').should('contain', 'closed_homework');
+            cy.get('#course-table tbody tr td').should('contain', 'future_no_tas_homework');
+            cy.get('#course-table tbody tr td').should('contain', '1');
 
-        //     cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', '1'));
-        //     cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
-        //     cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
-        //     cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '102'));
+            cy.get('#autograding-status-table tbody tr td').eq(1).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(2).then(element => cy.get(element).should('contain', '1'));
+            cy.get('#autograding-status-table tbody tr td').eq(3).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(4).then(element => cy.get(element).should('contain', '101'));
+            cy.get('#autograding-status-table tbody tr td').eq(5).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(6).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(7).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(8).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(9).then(element => cy.get(element).should('contain', ''));
+            cy.get('#autograding-status-table tbody tr td').eq(10).then(element => cy.get(element).should('contain', '102'));
 
-        // });
+        });
 
         it('should only allow instructor level users', () => {
             // attempt to visit page as student


### PR DESCRIPTION
### What is the current behavior?
Part of the cypress autograding status tests were removed in #9462
### What is the new behavior?
This PR adds part of them back, in hopes that it will fix the ubuntu 22 cypress tests failing. 

Related to #9459 and #9334
