### PR TITLE
[Bugfix:System] Error in install script

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -495,7 +495,7 @@ EOF
             cat << EOF >> /etc/php/${PHP_VERSION}/mods-available/xdebug.ini
 xdebug.output_dir=${SUBMITTY_REPOSITORY}/.vagrant/Ubuntu/profiler
 EOF
-            sed -i -e "s/debug/debug,profile/g"
+            sed -i -e "s/debug/debug,profile/g" /etc/php/${PHP_VERSION}/mods-available/xdebug.ini
         fi
     fi
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
System installation fails due to missing argument to command in shell script.
Fixes #9529 

### What is the new behavior?
The error has been fixed.
