### PR TITLE
[Bugfix:System] Fix xdebug.ini file during install

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -495,7 +495,7 @@ EOF
             cat << EOF >> /etc/php/${PHP_VERSION}/mods-available/xdebug.ini
 xdebug.output_dir=${SUBMITTY_REPOSITORY}/.vagrant/Ubuntu/profiler
 EOF
-            sed -i -e "s/debug/debug,profile/g" /etc/php/${PHP_VERSION}/mods-available/xdebug.ini
+            sed -i -e "s/xdebug.mode=debug/xdebug.mode=debug,profile/g" /etc/php/${PHP_VERSION}/mods-available/xdebug.ini
         fi
     fi
 


### PR DESCRIPTION
### What is the current behavior?
When installing the site, the following error will get printed out for any development machine now on Ubuntu 22. Xdebug will not work with this as is.

### What is the new behavior?
The error won't get printed out anymore and xdebug will work.
