### PR TITLE
[Feature:Developer] Support ARM on vmware

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,7 @@ base_boxes = Hash[]
 
 # Should all be base Ubuntu boxes that use the same version
 base_boxes.default         = "bento/ubuntu-22.04"
-base_boxes[:arm_parallels] = "bento/ubuntu-22.04-arm64"
+base_boxes[:arm_bento] = "bento/ubuntu-22.04-arm64"
 base_boxes[:libvirt]       = "generic/ubuntu2204"
 base_boxes[:arm_mac_qemu]  = "perk/ubuntu-2204-arm64"
 
@@ -167,7 +167,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "parallels" do |prl, override|
     unless custom_box
       if (arm || apple_silicon)
-        override.vm.box = base_boxes[:arm_parallels]
+        override.vm.box = base_boxes[:arm_bento]
       end
     end
 
@@ -178,6 +178,11 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "vmware_desktop" do |vmware, override|
+    unless custom_box
+      if (arm || apple_silicon)
+        override.vm.box = base_boxes[:arm_bento]
+      end
+    end
     vmware.vmx["memsize"] = "2048"
     vmware.vmx["numvcpus"] = "2"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,7 @@ base_boxes = Hash[]
 
 # Should all be base Ubuntu boxes that use the same version
 base_boxes.default         = "bento/ubuntu-22.04"
-base_boxes[:arm_bento] = "bento/ubuntu-22.04-arm64"
+base_boxes[:arm_bento]     = "bento/ubuntu-22.04-arm64"
 base_boxes[:libvirt]       = "generic/ubuntu2204"
 base_boxes[:arm_mac_qemu]  = "perk/ubuntu-2204-arm64"
 


### PR DESCRIPTION
### What is the current behavior?
Trying to run vagrant using vmware on ARM does not work as it will always use the x86 image.

### What is the new behavior?
The ARM image gets specified when needed for the vmware provider. This will not effect any other provider and vmware would still work fine for anyone not on ARM.

### Other information?
I tested this since I needed this change to use the VM on my machine.
