### PR TITLE
[Feature:TAGrading] new 'grade inquiry only' button in grading index page

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -70,8 +70,9 @@
             </div>
         </div>
     {% endif %}
-    <button type="button" class="btn btn-primary" onclick="expandAllSections()">Expand All Sections</button>
     <button type="button" class="btn btn-primary" onclick="collapseAllSections()">Collapse All Sections</button>
+    <button type="button" class="btn btn-primary" onclick="grade_inquiry_only()">Grade Inquiry Only</button>
+    <button type="button" class="btn btn-primary" onclick="expandAllSections()">Expand All Sections</button>
     {% if message is not empty %}
     <div class="details-warning-box{% if message_warning %} details-warning-highlight{% else %} details-warning-neutral{% endif %}">
         {{ message }}
@@ -451,7 +452,7 @@
     {% elseif graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance() is not null and graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance().getDaysLate() > graded_gradeable.getGradeable().getLateDays() %}
         {% set contents = "Too Many Days Late" %}
         {% set btn_class = "btn-danger" %}
-    
+
     {% elseif graded_gradeable.getGradeable().isTaGrading() %}
         {# or info.late_day_info.isOnTimeSubmission() #}
             {% set contents = "Grade" %}
@@ -484,7 +485,7 @@
         {% set badge_count = graded_gradeable.getActiveGradeInquiryCount()  %}
     {%  endif %}
     <td style="text-align: center;">
-        <a data-testid="grade-button" class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ anon_ids[graded_gradeable.getSubmitter().getId()] }}&sort={{ context.sort }}&direction={{ context.direction }}">
+        <a data-testid="grade-button" {% if graded_gradeable.hasActiveGradeInquiry() %}data-grade-inquiry="true"{% endif %} class="btn {{ btn_class }}" href="{{ context.grade_url }}?who_id={{ anon_ids[graded_gradeable.getSubmitter().getId()] }}&sort={{ context.sort }}&direction={{ context.direction }}">
             {{ contents }}
             {% if badge_count > 0 and graded_gradeable.getGradeable().isGradeInquiryPerComponentAllowed()%}
                 <span class="notification-badge">{{ badge_count }}</span>
@@ -613,7 +614,7 @@
 
 {# Total Point Summary #}
 {% macro render_column_total(context, section, graded_gradeable, index, info, column) %}
-   
+
     {% set box_background = (graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance() is not null and graded_gradeable.getAutoGradedGradeable().getActiveVersionInstance().getDaysLate() > graded_gradeable.getGradeable().getLateDays()) ? "late-box" : "" %}
 
     {# todo: this is a lot of math for the view, we should move this into the Gradeable model #}

--- a/site/public/js/details.js
+++ b/site/public/js/details.js
@@ -96,6 +96,9 @@ function expandAllSections() {
         $(this).addClass('panel-head-active');
         $(this).next().show();
     });
+    $('[data-testid=grade-button]').each(function() {
+        $(this).closest('[data-testid="grade-table"]').show();  // show gradeable items with active inquiries
+    });
     collapseItems.clear();
     updateCollapsedSections();
 }
@@ -108,4 +111,16 @@ function collapseAllSections() {
         collapseItems.add($(this).attr('data-section-id'));
     });
     updateCollapsedSections();
+}
+
+function grade_inquiry_only() {
+    $('[data-testid=grade-button]').each(function() {
+        var hasGradeInquiry = typeof $(this).attr('data-grade-inquiry') !== 'undefined';
+        if (!hasGradeInquiry) {
+            $(this).closest('[data-testid="grade-table"]').hide();  // hide gradeable items without active inquiries
+        }
+        else {
+            $(this).closest('[data-testid="grade-table"]').show();  // show gradeable items with active inquiries
+        }
+    });
 }


### PR DESCRIPTION
### What is the current behavior?
Given a large course, grading index page may have many grade inquiries, and it is burdensome to scroll and check each individual grade inquiries (although they are displayed with red box).

### What is the new behavior?
new 'grade inquiry only' button allow graders only view homework with grade inquiry
![image](https://github.com/Submitty/Submitty/assets/114595115/69018b5c-958b-4bb9-9b5d-be67b3c5cacc)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
