### PR TITLE
[Feature:System] Add screenshot button Git PR Page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 * [ ] Tests for the changes have been added/updated (if possible)
 * [ ] Documentation has been updated/added if relevant
-* [ ] Screenshots have been included if visual changes were made
+* [ ] Screenshots are attached to Github PR if visual/UI changes were made
 
 ### What is the current behavior?
 <!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 * [ ] Tests for the changes have been added/updated (if possible)
 * [ ] Documentation has been updated/added if relevant
+* [ ] Screenshots have been included if visual changes were made
 
 ### What is the current behavior?
 <!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The current Git PR page does not have a requirement button for including a screenshot when there are visual changes.

![Screen Shot 2023-07-26 at 3 17 02 PM](https://github.com/Submitty/Submitty/assets/123261952/9c368827-adcb-4967-ac28-a38260a32716)



### What is the new behavior?

New Git PR page have a requirement button for including a screenshot when there are visual changes. 

![Screen Shot 2023-07-26 at 3 16 47 PM](https://github.com/Submitty/Submitty/assets/123261952/00813e7c-3c5c-43ae-9236-b426c0aa8e74)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
