### PR TITLE
[Bugfix:System] Build submitty utils not in shared mount

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -164,7 +164,9 @@ fi
 
 echo -e "Install python_submitty_utils"
 
-pushd "${SUBMITTY_REPOSITORY}/python_submitty_utils"
+cp -r "${SUBMITTY_REPOSITORY}/python_submitty_utils" "${SUBMITTY_INSTALL_DIR}"
+pushd "${SUBMITTY_INSTALL_DIR}/python_submitty_utils"
+
 pip3 install .
 # Setting the permissions are necessary as pip uses the umask of the user/system, which
 # affects the other permissions (which ideally should be o+rx, but Submitty sets it to o-rwx).

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -164,7 +164,7 @@ fi
 
 echo -e "Install python_submitty_utils"
 
-cp -r "${SUBMITTY_REPOSITORY}/python_submitty_utils" "${SUBMITTY_INSTALL_DIR}"
+rsync -rtz "${SUBMITTY_REPOSITORY}/python_submitty_utils" "${SUBMITTY_INSTALL_DIR}"
 pushd "${SUBMITTY_INSTALL_DIR}/python_submitty_utils"
 
 pip3 install .


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Installation errors on some machines/configurations due to filesystem errors from running setuptools build script within shared directory on developer virtual machine.

### What is the new behavior?
Build has been moved outside of the mounted directory.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
