### PR TITLE
[UI/UX:System] Peer Grading Submission Browser 

### DIFF
--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -10,7 +10,9 @@
                     <button class="btn btn-default expand-button" data-linked-type="checkout" data-clicked-state="wasntClicked"  id="togglCheckoutButton">Open/Close Checkout</button>
                 {% endif %}
 
-                <button class="btn btn-default expand-button" data-linked-type="results" data-clicked-state="wasntClicked"  id="toggleResultButton">Open/Close Results</button>
+                {% if not student_grader %}
+                    <button class="btn btn-default expand-button" data-linked-type="results" data-clicked-state="wasntClicked"  id="toggleResultButton">Open/Close Results</button>
+                {% endif %}
 
                 <script>
                     $(document).ready(function(){

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -2,7 +2,14 @@
     <div >
         <div id="directory_view">
             <span style="line-height: 40px;">
+                {% if not student_grader %}
                 <span class="grading_label">Submissions and Results Browser</span>
+                {% endif %}
+                
+                {% if student_grader %}
+                <span class="grading_label">Submissions Browser</span>
+                {% endif %}
+
                 <button class="btn btn-default expand-button" data-linked-type="submissions" data-clicked-state="wasntClicked" id="toggleSubmissionButton">Open/Close Submissions</button>
 
                 {# check if there are vcs files, if yes display the toggle button, else don't display it #}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
The student grader cannot see the results folder so the button "Open/Close Results" shouldn't be there.
![image](https://github.com/Submitty/Submitty/assets/96174078/aa95bd4f-0c4b-46f9-94d0-da0f9cd50431)


### What is the new behavior?
Now the button is not visible to the student grader. Closes #9570 
![image](https://github.com/Submitty/Submitty/assets/96174078/7fe353fe-9694-4648-b50b-2d1cedeff771)
