### PR TITLE
[Refactor:Developer] Remove iClicker 

### DIFF
--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -27,7 +27,7 @@ class RainbowCustomizationJSON extends AbstractModel {
     private $benchmark_percent;         // Init in constructor
     private $gradeables = [];
 
-    const allowed_display = ['instructor_notes', 'grade_summary', 'grade_details', 'iclicker', 'final_grade',
+    const allowed_display = ['instructor_notes', 'grade_summary', 'grade_details', 'final_grade',
         'exam_seating', 'display_rank_to_individual', 'display_benchmark', 'benchmark_percent', 'section', 'messages',
         'final_cutoff', 'manual_grade', 'warning'];
 


### PR DESCRIPTION
Simple deletion of iClicker variable in Submitty Repo. fetching customization file will no longer consider iClicker as variable for display option. 

Related Submitty/RainbowGrades#55