### PR TITLE
[Bugfix:Developer] Remove chrome driver setup

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -195,12 +195,3 @@ runs:
         sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework
         bash tests/git_test.sh
       shell: bash
-
-    - uses: nanasess/setup-chromedriver@master
-    - name: Setup chromedriver
-      run: |
-        sudo systemctl restart submitty_autograding_worker
-        sudo systemctl restart submitty_autograding_shipper
-        export DISPLAY=:99
-        chromedriver --url-base=/wd/hub &
-      shell: bash


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
The Cypress and Integration tests occasionally fail on the setup phase of the github action, with the error 
![image](https://github.com/Submitty/Submitty/assets/46759635/1cf693cf-6977-4bed-919d-754625a69be8)

### What is the new behavior?
Since we are no longer using Selenium for CI, and Cypress and Integration tests do not use the chrome driver, the setup has been removed, which should also remove the occasional errors in the setup phase. 