### PR TITLE
[Bugfix:Developer] Fix image name for vagrant CI workflow

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -18,6 +18,6 @@ jobs:
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.
       # - run: vagrant plugin install vagrant-vbguest
-      - run: NO_SUBMISSIONS=1 vagrant up ubuntu-20.04
+      - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The vagrant CI workflow references the `ubuntu-20.04` image to validate that it builds successfully. It's been failing for about 3 weeks since #9334 was merged.

### What is the new behavior?

It will use the `ubuntu-22.04` image which is specified in the Vagrantfile and I will stop getting emails every day about this workflow failing.
