### PR TITLE
Student name to full access grader

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1195,7 +1195,7 @@ HTML;
     public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
-        if ($gradeable->getLimitedAccessBlind() == 2) {
+        if ($gradeable->getLimitedAccessBlind() == 2 && $this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER) {
             $isBlind = true;
         }
         $home_url = $this->core->buildCourseUrl(['gradeable', $graded_gradeable->getGradeableId(), 'grading', 'details']) . '?' . http_build_query(['sort' => $sort, 'direction' => $direction]);


### PR DESCRIPTION
### What is the current behavior?
When the instructor checks Blinded Grading, the name of the student is also disappeared at the full access graders side.

### What is the new behavior?
The name of the student is displayed to the full access TA. Closes #9637 

![image](https://github.com/Submitty/Submitty/assets/96174078/42838985-309e-4158-a6ff-6581bb767d3f)


