### PR TITLE
[Bugfix:Notifications] fix display special message

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -92,17 +92,25 @@ class NavigationView extends AbstractView {
             //If statement seems redundant, but will help in case we ever decouple the is_file check from $display_custom_message
             if ($display_custom_message && is_file($message_file_path)) {
                 $message_json = json_decode(file_get_contents($message_file_path));
-                if (property_exists($message_json, 'special_message')) {
-                    $message_file_details = $message_json->special_message;
+                if ($message_json == null) {
+                    $display_custom_message = false;
+                }
+                else {
+                    if (property_exists($message_json, 'special_message')) {
+                        $message_file_details = $message_json->special_message;
 
-                    //If any fields are missing, treat this as though we just didn't have a message for this user.
-                    if (!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename')) {
-                        $display_custom_message = false;
-                        $messsage_file_details = null;
+                        //If any fields are missing, treat this as though we just didn't have a message for this user.
+                        if (!property_exists($message_file_details, 'title') || !property_exists($message_file_details, 'description') || !property_exists($message_file_details, 'filename')) {
+                            $display_custom_message = false;
+                            $messsage_file_details = null;
+                        }
                     }
                 }
             }
         }
+
+
+
 
 
         // ======================================================================================


### PR DESCRIPTION
### What is the current behavior?

![Screen Shot 2023-08-10 at 4 08 51 PM](https://github.com/Submitty/Submitty/assets/123261952/8bdca869-ab42-4526-9e75-ede03793a668)

### What is the new behavior?

Works with handling case for Null. 

https://stackoverflow.com/questions/70584290/php-8-0-method-exists-on-non-object-causes-fatal-typeerror

Moving up to PHP 8 caused this to happen. 
PHP 8 is going stricter with property_exists() function to raise a TypeError on invalid argument, in order to match the behavior of property_exists and method_exists function. 

fixes #9636 