### PR TITLE
[Refactor:Developer] Remove unused `clang` Python bindings

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -34,9 +34,6 @@ jsonref==1.1.0
 docker==6.1.2
 urllib3==2.0.4
 
-# Python3 implementation of python-clang bindings (may not work < 6.0)
-clang==14.0
-
 # Python libraries for QR bulk upload
 pyzbar==0.1.9
 pdf2image==1.16.3


### PR DESCRIPTION
### What is the current behavior?
The `clang` dependency is currently unused.  Before Lichen started managing an independent list of dependencies, this was used to tokenize C/C++ files for Lichen.

### What is the new behavior?
The Python bindings for `clang` have been removed.
