### PR TITLE
[Bugfix:Developer] Fix Cypress Accessibility on Windows

### DIFF
--- a/site/cypress/e2e/cypress-feature/accessibility.spec.js
+++ b/site/cypress/e2e/cypress-feature/accessibility.spec.js
@@ -1,9 +1,15 @@
+// Note: This test requires you have Java and JDK installed and added to your path.
+
 import { getCurrentSemester } from '../../support/utils.js';
 
 import vnu from 'vnu-jar';
+const path = require('path');
 
 const semester = getCurrentSemester();
 const course = 'sample';
+
+// Remove command is different on Windows.
+const rm_command = Cypress.platform === 'win32' ? 'rd /s /q cypress\\tmp' : 'rm -r cypress/tmp';
 
 const urls = [
     '/home',
@@ -57,7 +63,7 @@ describe('Test cases for the site\'s adherence to accessibility guidelines', () 
             baseline = new Map(Object.entries(data));
         });
 
-        cy.exec('rm -r cypress/tmp', { failOnNonZeroExit: false });
+        cy.exec(rm_command, { failOnNonZeroExit: false });
     });
 
     beforeEach(() => {
@@ -66,7 +72,7 @@ describe('Test cases for the site\'s adherence to accessibility guidelines', () 
     });
 
     afterEach(() => {
-        cy.exec('rm -r cypress/tmp');
+        cy.exec(rm_command);
     });
 
     for (const url of urls) {
@@ -75,6 +81,7 @@ describe('Test cases for the site\'s adherence to accessibility guidelines', () 
             cy.get('html:root').eq(0).invoke('prop', 'outerHTML').then(content => {
                 cy.writeFile('cypress/tmp/doc.html', `<!DOCTYPE html>\n${content}`, 'utf8').then(() => {
                     cy.exec(`java -jar "${vnu}" --format json cypress/tmp/doc.html`, { failOnNonZeroExit: false }).then(result => {
+                        console.log(result.stderr)
                         const output = JSON.parse(result.stderr);
 
                         const foundErrorMessages = [];


### PR DESCRIPTION
### What is the current behavior?
Currently on Windows, Cypress's `accessibility.spec.js` test fails on `main` because it uses `rm -r`, a Linux and Mac-only command.

### What is the new behavior?
The test no longer fails on Windows machines on `main`.