### PR TITLE
[Bugfix:Calendar] Fixed Calendar for 0-1 Courses

### DIFF
--- a/site/app/controllers/calendar/CalendarController.php
+++ b/site/app/controllers/calendar/CalendarController.php
@@ -35,43 +35,46 @@ class CalendarController extends AbstractController {
         $calendar_messages = [];
 
         $courses = $this->core->getQueries()->getCourseForUserId($user->getId());
-
-        //Check if should see all courses
-        $show_all_courses = '1';
-        if (isset($_COOKIE['calendar_show_all'])) { //Check if show_all cookie exists
-            $show_all_courses = $_COOKIE['calendar_show_all'];
-        }
-        else { //No cookie, create cookie
-            setcookie('calendar_show_all', '1', time() + (10 * 365 * 24 * 60 * 60));
-            $show_all_courses = '1';
-        }
-
         $filtered_courses = [];
-        if ($show_all_courses === '1') {
-            $filtered_courses = $courses;
-        }
-        else {
-            //If can't see all courses, see specific course
-            if (isset($_COOKIE['calendar_course'])) { //if cookie exists, find matching course
-                $found_course = false;
-                foreach ($courses as $course) {
-                    $course_string = sprintf("%s %s", $course->getTitle(), $course->getTerm());
-                    if ($course_string === $_COOKIE['calendar_course']) {
-                        $found_course = true;
-                        array_push($filtered_courses, $course);
-                        break;
+        
+        //If there arent any courses, don't filter
+        if (count($courses) != 0) {
+            //Check if should see all courses
+            $show_all_courses = '1';
+            if (isset($_COOKIE['calendar_show_all'])) { //Check if show_all cookie exists
+                $show_all_courses = $_COOKIE['calendar_show_all'];
+            }
+            else { //No cookie, create cookie
+                setcookie('calendar_show_all', '1', time() + (10 * 365 * 24 * 60 * 60));
+                $show_all_courses = '1';
+            }
+
+            if ($show_all_courses === '1') {
+                $filtered_courses = $courses;
+            }
+            else {
+                //If can't see all courses, see specific course
+                if (isset($_COOKIE['calendar_course'])) { //if cookie exists, find matching course
+                    $found_course = false;
+                    foreach ($courses as $course) {
+                        $course_string = sprintf("%s %s", $course->getTitle(), $course->getTerm());
+                        if ($course_string === $_COOKIE['calendar_course']) {
+                            $found_course = true;
+                            array_push($filtered_courses, $course);
+                            break;
+                        }
+                    }
+                    if (!$found_course) { //If can't find course, default to first course
+                        $course_cookie_value = sprintf("%s %s", $courses[0]->getTitle(), $courses[0]->getTerm());
+                        setcookie('calendar_course', $course_cookie_value, time() + (10 * 365 * 24 * 60 * 60));
+                        array_push($filtered_courses, $courses[0]);
                     }
                 }
-                if (!$found_course) { //If can't find course, default to first course
-                    $course_cookie_value = sprintf("%s %s", $courses[1]->getTitle(), $courses[1]->getTerm());
+                else { //if cookie doesn't exist, choose first course
+                    $course_cookie_value = sprintf("%s %s", $courses[0]->getTitle(), $courses[0]->getTerm());
                     setcookie('calendar_course', $course_cookie_value, time() + (10 * 365 * 24 * 60 * 60));
-                    array_push($filtered_courses, $courses[1]);
+                    array_push($filtered_courses, $courses[0]);
                 }
-            }
-            else { //if cookie doesn't exist, choose first course
-                $course_cookie_value = sprintf("%s %s", $courses[1]->getTitle(), $courses[1]->getTerm());
-                setcookie('calendar_course', $course_cookie_value, time() + (10 * 365 * 24 * 60 * 60));
-                array_push($filtered_courses, $courses[1]);
             }
         }
 

--- a/site/app/controllers/calendar/CalendarController.php
+++ b/site/app/controllers/calendar/CalendarController.php
@@ -36,7 +36,7 @@ class CalendarController extends AbstractController {
 
         $courses = $this->core->getQueries()->getCourseForUserId($user->getId());
         $filtered_courses = [];
-        
+
         //If there arent any courses, don't filter
         if (count($courses) != 0) {
             //Check if should see all courses


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
![image](https://github.com/Submitty/Submitty/assets/47994802/7935a089-d1a7-41bc-98a3-4f0344c850b8)
This bug occurs when a user has 0 courses (i.e. superuser), has the `calendar_show_all` cookie set to 0, and doesn't have a `calendar_course` cookie set. The code does two things wrong:
1. It will by default choose a course from your courses, and use its data for the `calendar_course` cookie. This will give an error if you don't have any courses.
2. It uses the index of 1 rather than 0 to find a course, so if you have only 1 course it will also give an issue as you will access a course that doesn't exist.

### What is the new behavior?
Now that bug should be patched!

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
