### PR TITLE
[Bugfix:Autograding] Remove duplicate Autograding Page

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -284,11 +284,6 @@ class GlobalController extends AbstractController {
                 "title" => "Gradebook",
                 "icon" => "fa-book-reader"
             ]);
-            $sidebar_buttons[] = new NavButton($this->core, [
-                "href" => $this->core->buildCourseUrl(['autograding_status']),
-                "title" => "Autograding Status",
-                "icon" => "fa-server"
-            ]);
         }
 
         // --------------------------------------------------------------------------


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, there are two pages of Auto grading status: one that only gets displayed after displaying rainbow grades, which is a faulty and duplicate one, while the other correct page is always shown even outside of a course. 
### What is the new behavior?
Remove duplicate Autograding Page. 
Closes #9672
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
