### PR TITLE
[Bugfix:TAGrading] Download Files For Hidden Test Cases

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -301,7 +301,7 @@ class MiscController extends AbstractController {
         $autograde = $graded_gradeable->getAutoGradedGradeable()->getAutoGradedVersionInstance($version);
         $file_path = null;
         $testcase = $autograde->getTestcases()[$test_case - 1];
-        if (!$testcase->getTestcase()->isHidden() && $testcase->hasAutochecks()) {
+        if ($testcase->hasAutochecks()) {
             foreach ($testcase->getAutochecks() as $autocheck) {
                 $path = explode('/', $autocheck->getDiffViewer()->getActualFilename());
                 $actual_file_name = array_pop($path);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, if a test case is hidden, you are unable to download the student submission file
### What is the new behavior?
This fix allows the grader to download the student submission file, even if the test case is hidden
### Other information?
Closes #9668 
<!-- Is this a breaking change? -->
<!-- How did you test -->
