### PR TITLE
[Bugfix:InstructorUI] 'Add Student' Popup Stays Open

### DIFF
--- a/site/app/templates/admin/users/UserForm.twig
+++ b/site/app/templates/admin/users/UserForm.twig
@@ -20,7 +20,8 @@
 		</a>
 		<label for="user_id">
             User ID:
-            <input class="readonly" type="text" name="user_id" id="user_id" readonly="readonly" placeholder="(Required)" autocomplete="off"/>
+            <input class="readonly" type="text" name="user_id" id="user_id" readonly="readonly" placeholder="(Required)" autocomplete="off" list="possible_users"/>
+            <datalist id="possible_users"> </datalist>
         </label>
         <label for="user_numeric_id">
             User Numeric ID:

--- a/site/public/js/userform.js
+++ b/site/public/js/userform.js
@@ -9,11 +9,12 @@ $("#edit-user-form").ready(function() {
                 autoCompleteOnUserId(json);
             });
 
-            $('[name="user_id"]', form).autocomplete({
-                appendTo: form,
-                source: Object.keys(json),
-                change: () => $('[name="user_id"]').change()
-            });
+            const dataList = $('#possible_users');
+            dataList.innerHTML = '';
+            const user_ids = Object.keys(json);
+            user_ids.forEach((user_id) => {
+                dataList.append(`<option value='${user_id}'>`);
+            })
 
             $(":text",$("#edit-user-form")).change(checkValidEntries);
         },


### PR DESCRIPTION
### What is the current behavior?
Selecting a student from the list of options in the Add Student menu for a course would close the popup window. You had to either click another form option or press enter to stay in the window.

### What is the new behavior?
The window now does not close accidentally.
Closes #9681 
### Images
![image](https://github.com/Submitty/Submitty/assets/51209504/65665ad2-c518-4747-a975-925b5937dc7d)
