### PR TITLE
Grading Stats

### DIFF
--- a/site/app/templates/grading/electronic/ta_status/StatusData.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusData.twig
@@ -121,13 +121,15 @@
                 <br/>
                 <p><b>Number of unresolved grade inquiries:</b> {{ grade_inquiries }}</p>
                 <br/>
-                <p><b>Number of unresolved grade inquiries per grader</b></p>
-                <div style="margin-left: 20px">
-                {% for key, value in graders_of_inquiries %}
-                    <p>{{ key }}: {{ value }} </p>
-                {% endfor %}
-                </div>
-                <br/>
+                {% if  grade_inquiries > 0 %}
+                    <p><b>Number of unresolved grade inquiries per grader:</b></p>
+                    <div style="margin-left: 20px">
+                    {% for key, value in graders_of_inquiries %}
+                        <p>{{ key }}: {{ value }} </p>
+                    {% endfor %}
+                    </div>
+                {% endif %}
+                    <br/>
                 {% if grade_inquiry_per_component_allowed %}
                     {% for component in component_averages %}
                         <p><b>Number of unresolved grade inquiries for {{ component.getTitle() }}:</b> {{ component.getActiveGradeInquiryCount() }} </p>


### PR DESCRIPTION
### What is the current behavior?
"Number of unresolved grade inquiries per grader" should be displayed only when there are grade inquiries greater than 0
![image](https://github.com/Submitty/Submitty/assets/96174078/c0340135-496c-4d42-a63a-12c452d92966)

