### PR TITLE
[SECURITY][Bugfix:System] Prevent caching the resource

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -106,6 +106,9 @@ date_default_timezone_set($core->getConfig()->getTimezone()->getName());
 // Stops clickjacking on all pages
 header('X-Frame-Options: SAMEORIGIN');
 
+// Prevent intermediaries from caching the resource
+header('Cache-Control: private');
+
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', '1');
 if ($core->getConfig()->isDebug()) {


### PR DESCRIPTION
### What is the current behavior?
Before adding the Cache-Control: private header, the current behavior involves the potential caching of the resource by both intermediaries, such as proxy servers, and the client's browser. Intermediary servers might cache the resource, which could lead to outdated content being served to subsequent users. Additionally, the client's browser might cache the resource to expedite subsequent visits.

### What is the new behavior?
However, after incorporating the Cache-Control: private header, the new behavior emerges. In this updated scenario, intermediaries are explicitly prevented from caching the resource, ensuring that subsequent users receive the most current content. Although the resource can still be cached by the client's browser for quicker loading during subsequent visits, the risk of serving outdated content due to intermediary caching is mitigated by this header change.