### PR TITLE
[Bugfix:Submission] Remove error message from non VCS

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionBox.twig
+++ b/site/app/templates/submission/homework/CurrentVersionBox.twig
@@ -97,7 +97,7 @@
                 {% endif %}
             </div>
         {% endif %}
-        {% if (failed_file != '') or (file_length == 0 and not incomplete_autograding) %}
+        {% if (failed_file != '' or (file_count == 0 and not incomplete_autograding)) and is_vcs %}
         <div id="error-message" class="red-message">
             <b>Warning: The submitted repository is empty.</b><br/>
             {% if failed_file != '' %}

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1096,7 +1096,7 @@ class HomeworkView extends AbstractView {
 
         $param = array_merge($param, [
             'failed_file' => $failed_file,
-            'file_length' => $file_count,
+            'file_count' => $file_count,
             'gradeable_id' => $gradeable->getId(),
             'student_download' => !$gradeable->isVcs() && $gradeable->canStudentDownload(),
             'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails(),


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
![image](https://github.com/Submitty/Submitty/assets/46759635/98a44e53-c7e7-4a16-93d0-d3eee620e7d7)

In #9399 submission error messages were added, and intended for VCS gradeables. 

### What is the new behavior?
![image](https://github.com/Submitty/Submitty/assets/46759635/339f0106-666c-4b34-9d38-b891d1f73fdc)
Now the error messages only show up on VCS gradeables as intended

