### PR TITLE
[Bugfix:System] Files in iframe Grading Interface

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -110,7 +110,7 @@ header('X-Frame-Options: SAMEORIGIN');
 header('X-Content-Type-Options: nosniff');
 
 // Prevents pages from being embedded in an iframe
-header("Content-Security-Policy: frame-ancestors 'self';");
+header('Content-Security-Policy: frame-ancestors \'self\'');
 
 // Prevent intermediaries from caching the resource
 header('Cache-Control: private');

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -110,7 +110,7 @@ header('X-Frame-Options: SAMEORIGIN');
 header('X-Content-Type-Options: nosniff');
 
 // Prevents pages from being embedded in an iframe
-header('Content-Security-Policy: frame-ancestors \'none\'');
+header("Content-Security-Policy: frame-ancestors 'self';");
 
 // Prevent intermediaries from caching the resource
 header('Cache-Control: private');


### PR DESCRIPTION
### What is the current behavior?
Using the 'none' option in the frame-ancestors directive prevents any content from being displayed in iframes, including content from the same origin. However, this poses a problem for displaying submission files in iframes within the Grading Interface.
![image](https://github.com/Submitty/Submitty/assets/96174078/531088e0-3e3f-44b9-a781-2d37cad9736c)


### What is the new behavior?
Now only pages from the same origin (same domain and protocol) are allowed to frame the content.