### PR TITLE
[Bugfix:CourseMaterials] Change the Beginning of Time

### DIFF
--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -136,7 +136,7 @@
                             let date;
                             switch (index) {
                                 case 0:
-                                    date = new Date("1001-01-01 00:00:00");
+                                    date = new Date("2000-01-01 00:00:00");
                                     break;
                                 case 1:
                                     date = new Date();

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -136,7 +136,7 @@
                             let date;
                             switch (index) {
                                 case 0:
-                                    date = new Date("2000-01-01 00:00:00");
+                                    date = new Date("1900-01-01 00:00:00");
                                     break;
                                 case 1:
                                     date = new Date();

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -133,7 +133,7 @@
                         let date;
                         switch (index) {
                             case 0:
-                                date = new Date("1001-01-01 00:00:00");
+                                date = new Date("2000-01-01 00:00:00");
                                 break;
                             case 1:
                                 date = new Date();

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -133,7 +133,7 @@
                         let date;
                         switch (index) {
                             case 0:
-                                date = new Date("2000-01-01 00:00:00");
+                                date = new Date("1900-01-01 00:00:00");
                                 break;
                             case 1:
                                 date = new Date();

--- a/site/app/templates/course/SetAllReleaseForm.twig
+++ b/site/app/templates/course/SetAllReleaseForm.twig
@@ -55,7 +55,7 @@
                             let date;
                             switch (index) {
                                 case 0:
-                                    date = new Date("2000-01-01 00:00:00");
+                                    date = new Date("1900-01-01 00:00:00");
                                     break;
                                 case 1:
                                     date = new Date();

--- a/site/app/templates/course/SetAllReleaseForm.twig
+++ b/site/app/templates/course/SetAllReleaseForm.twig
@@ -55,7 +55,7 @@
                             let date;
                             switch (index) {
                                 case 0:
-                                    date = new Date("1001-01-01 00:00:00");
+                                    date = new Date("2000-01-01 00:00:00");
                                     break;
                                 case 1:
                                     date = new Date();

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -88,7 +88,7 @@
                                 let date;
                                 switch (index) {
                                     case 0:
-                                        date = new Date("2000-01-01 00:00:00");
+                                        date = new Date("1900-01-01 00:00:00");
                                         break;
                                     case 1:
                                         date = new Date();

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -88,7 +88,7 @@
                                 let date;
                                 switch (index) {
                                     case 0:
-                                        date = new Date("1001-01-01 00:00:00");
+                                        date = new Date("2000-01-01 00:00:00");
                                         break;
                                     case 1:
                                         date = new Date();

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -179,7 +179,7 @@
                                 let date;
                                 switch (index) {
                                     case 0:
-                                        date = new Date("2000-01-01 00:00:00");
+                                        date = new Date("1900-01-01 00:00:00");
                                         break;
                                     case 1:
                                         date = new Date();

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -179,7 +179,7 @@
                                 let date;
                                 switch (index) {
                                     case 0:
-                                        date = new Date("1001-01-01 00:00:00");
+                                        date = new Date("2000-01-01 00:00:00");
                                         break;
                                     case 1:
                                         date = new Date();


### PR DESCRIPTION
### What is the current behavior?
There is currently a bug on Submitty regarding course materials set to the distance past (See issue #9730). While course materials set to the distant past still do not work, this PR changes the "Beginning of Time" upload option to the year 1900 to circumvent the issue for now.

### What is the new behavior?
The "Beginning of Time" upload option works!

This PR closes issue #9733, a checkmark of issue #9730.