### PR TITLE
[Bugfix:System] Remove manual npm install

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -214,15 +214,6 @@ source ${CURRENT_DIR}/distro_setup/setup_distro.sh
 
 bash "${SUBMITTY_REPOSITORY}/.setup/update_system.sh"
 
-
-#################################################################
-# Node Package Setup
-####################
-# NOTE: with umask 0027, the npm packages end up with the wrong permissions.
-# (this happens if we re-run install_system on an existing installation).
-# So let's manually set the umask just for this call.
-(umask 0022 && npm install -g npm)
-
 #################################################################
 # STACK SETUP
 #################


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
We currently install npm again to get the latest version after installing node. This has an issue because it may try to fetch a version of npm that is incompatible with the current node version.

### What is the new behavior?
We no longer manually install npm again and instead rely on the version tied to the node version.

### Other information?
This does not resolve the deprecation issue. That will be fixed in a later PR.
A manual vagrant job has been kicked off to test here: https://github.com/Submitty/Submitty/actions/runs/6092760330
