### PR TITLE
[Bugfix:InstructorUI] Email status page fix

### DIFF
--- a/site/app/entities/email/EmailEntity.php
+++ b/site/app/entities/email/EmailEntity.php
@@ -27,8 +27,8 @@ class EmailEntity {
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     protected DateTime $created;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    protected DateTime $sent;
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    protected ?DateTime $sent;
 
     #[ORM\Column(type: Types::STRING)]
     protected string $error;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When an email is sent, the database column `sent` will be null. With the recent Doctrine changes, it is expected that the value isn't null and flags an error. When trying to load the email status page with an unsent email, a frog robot error will occur.

### What is the new behavior?
I modified the attribute and PHP type to tell Doctrine it is nullable. The error no longer occurs.
