### PR TITLE
[SECURITY][Bugfix:System] CORS Security Headers

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -115,6 +115,12 @@ header('Content-Security-Policy: frame-ancestors \'self\'');
 // Prevent intermediaries from caching the resource
 header('Cache-Control: private');
 
+// Set the cross-origin embedder policy to prevent the browser from loading the page if it is not CORS safe
+header('Cross-Origin-Embedder-Policy: credentialless');
+
+// Set the cross-origin opener policy to prevent the browser from sharing state with the page if it is not CORS safe
++header('Cross-Origin-Opener-Policy: same-origin');
+
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', '1');
 if ($core->getConfig()->isDebug()) {

--- a/site/public/index.php
+++ b/site/public/index.php
@@ -119,7 +119,7 @@ header('Cache-Control: private');
 header('Cross-Origin-Embedder-Policy: credentialless');
 
 // Set the cross-origin opener policy to prevent the browser from sharing state with the page if it is not CORS safe
-+header('Cross-Origin-Opener-Policy: same-origin');
+header('Cross-Origin-Opener-Policy: same-origin');
 
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', '1');


### PR DESCRIPTION
### What is the current behavior?
Before applying the provided code, the HTTP response does not specify any Cross-Origin Embedder Policy (COEP) or Cross-Origin Opener Policy (COOP) headers. This lack of configuration means the page is not enforcing any restrictions on resource loading from other origins or state sharing with different origins, potentially exposing it to security risks related to cross-origin requests and interactions.

### What is the new behavior?
After applying the provided code, the HTTP response sets the Cross-Origin Embedder Policy (COEP) to "credentialless," ensuring that the page will only load resources from origins that do not require credentials, thus enhancing security. Additionally, the Cross-Origin Opener Policy (COOP) is set to "same-origin," limiting state sharing to pages from the same origin, further mitigating security risks associated with cross-origin interactions. These measures collectively bolster the security of the web page by enforcing stricter CORS policies.
