### PR TITLE
[SECURITY][Bugfix:System] Referrer Policy Update

### DIFF
--- a/site/public/index.php
+++ b/site/public/index.php
@@ -115,6 +115,9 @@ header('Content-Security-Policy: frame-ancestors \'self\'');
 // Prevent intermediaries from caching the resource
 header('Cache-Control: private');
 
+// Set the referrer policy to strict-origin-when-cross-origin to prevent the browser from sending the full URL
+header('Referrer-Policy: strict-origin-when-cross-origin');
+
 // We only want to show notices and warnings in debug mode, as otherwise errors are important
 ini_set('display_errors', '1');
 if ($core->getConfig()->isDebug()) {


### PR DESCRIPTION
### What is the current behavior?
Before this patch, no referrer policy is defined, and the browser's default behavior regarding the transmission of referrer information is in effect. This may lead to the browser potentially sending the complete URL as the referrer when navigating to different origins, which can have privacy and security implications.

### What is the new behavior?
After applying this patch, the HTTP response sets the referrer policy to "strict-origin-when-cross-origin." This ensures that the browser will send the full URL as the referrer only when navigating to a cross-origin resource, enhancing privacy and security by reducing unnecessary disclosure of information to external websites.

