### PR TITLE
[Bugfix:Submission] Remove redundant late day cache call

### DIFF
--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -43,24 +43,10 @@ class LateDays extends AbstractModel {
         $graded_gradeables = array_filter($graded_gradeables, function (GradedGradeable $gg) {
             return $gg->getGradeable()->getType() === GradeableType::ELECTRONIC_FILE;
         });
-        $ggs = [];
-        foreach ($graded_gradeables as $gg) {
-            $ggs[$gg->getGradeableId()] = $gg;
-        }
+
         // Get the late day updates that the instructor will enter
         $this->late_days_updates = $late_day_updates ?? $this->core->getQueries()->getLateDayUpdates($user->getId());
-        $this->core->getQueries()->generateLateDayCacheForUser($user->getId());
         $late_day_cache = $this->core->getQueries()->getLateDayCacheForUser($user->getId());
-        // Construct late days info for each gradeable
-        foreach ($late_day_cache as $id => $ldc) {
-            $ldc['graded_gradeable'] = $ggs[$id] ?? null;
-            $info = new LateDayInfo(
-                $core,
-                $user,
-                $ldc
-            );
-            $this->late_day_info[$id] = $info;
-        }
         // Get all late day events (late day updates and graded gradeable submission dates)
         $late_day_events = $this->createLateDayEvents($graded_gradeables);
 

--- a/site/cypress/e2e/Cypress-Feature/late_days_cache.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/late_days_cache.spec.js
@@ -138,6 +138,7 @@ describe('Test cases involving late day cache updates', () => {
 
             // Check cache
             cy.visit(['sample', 'bulk_late_days']);
+            calculateCache();
             cy.get('[USER_ID=instructor] > [id="Late Allowed Homework"]')
                 .contains('0')
                 .should('exist');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
There is an unnecessary call to generate the late day cache in LateDays.php. This is causing duplicate keys in the late day cache.
### What is the new behavior?
Remove unnecessary and redundant call
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
