### PR TITLE
[Bugfix:TAGrading] Fix Incorrect Stats for Grader Scores

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -682,7 +682,7 @@ class ElectronicGraderController extends AbstractController {
             $graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
             $late_components = $this->core->getQueries()->getBadGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
             $ta_graded_components = $this->core->getQueries()->getGradedComponentsCountByGradingSections($gradeable_id, $sections, $section_key, $gradeable->isTeamAssignment());
-            $component_averages = $this->core->getQueries()->getAverageComponentScores($gradeable_id, $section_key, $gradeable->isTeamAssignment(), $override_cookie, $bad_submissions_cookie, $null_section_cookie);
+            $component_averages = $this->core->getQueries()->getAverageComponentScores($gradeable_id, $section_key, $gradeable->isTeamAssignment(), $bad_submissions_cookie, $null_section_cookie);
             $autograded_average = $this->core->getQueries()->getAverageAutogradedScores($gradeable_id, $section_key, $gradeable->isTeamAssignment(), $bad_submissions_cookie, $null_section_cookie);
             $overall_average = $this->core->getQueries()->getAverageForGradeable($gradeable_id, $section_key, $gradeable->isTeamAssignment(), $override_cookie, $bad_submissions_cookie, $null_section_cookie);
             $order = new GradingOrder($this->core, $gradeable, $this->core->getUser(), true);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2186,7 +2186,7 @@ ORDER BY {$u_or_t}.{$section_key}",
         }
 
         // Check if we want to include null sections within the average
-        if ($null_section != 'include') {
+        if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
             $this->course_db->query(
@@ -2206,7 +2206,7 @@ ORDER BY {$u_or_t}.{$section_key}",
             $bad_submission_count = $this->course_db->row()['cnt'];
 
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions != 'include' && $bad_submission_count > 0) {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2281,7 +2281,7 @@ ORDER BY gc_order
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
         }
-        if ($null_section != 'include') {
+        if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
             $this->course_db->query(
@@ -2301,7 +2301,7 @@ ORDER BY gc_order
             $bad_submission_count = $this->course_db->row()['cnt'];
 
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions != 'include' && $bad_submission_count > 0) {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2372,7 +2372,7 @@ ORDER BY gc_order
             $users_or_teams = "gradeable_teams";
             $user_or_team_id = "team_id";
         }
-        if ($null_section != 'include') {
+        if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
 
@@ -2392,7 +2392,7 @@ ORDER BY gc_order
             );
             $bad_submission_count = $this->course_db->row()['cnt'];
 
-        if ($bad_submissions != 'include' && $bad_submission_count > 0) {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "AND NOT EXISTS (
                 SELECT 1
                 FROM late_day_cache AS ldc
@@ -2501,14 +2501,14 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         $params = [$g_id, $count];
 
         // Check if we want to exclude grade overridden gradeables
-        if (!$is_team && $override == 'include') {
+        if (!$is_team && $override === 'include') {
             $exclude = "AND NOT EXISTS (SELECT * FROM grade_override
                         WHERE u.user_id = grade_override.user_id
                         AND grade_override.g_id=gc.g_id)";
         }
 
         // Check if we want to include null sections within the average
-        if ($null_section != 'include') {
+        if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
 
@@ -2529,7 +2529,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
             $bad_submission_count = $this->course_db->row()['cnt'];
 
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions != 'include' && $bad_submission_count > 0) {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2539,7 +2539,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         }
 
         // Check if we want to combine grade overridden marks within averages
-        if (!$is_team && $override == 'include') {
+        if (!$is_team && $override === 'include') {
             $include = " UNION SELECT gd.gd_id, marks::numeric AS g_score, marks::numeric AS max, COUNT(*) as count, 0 as autograding
                 FROM grade_override
                 INNER JOIN users as u ON u.user_id = grade_override.user_id
@@ -2606,7 +2606,7 @@ SELECT round((AVG(g_score) + AVG(autograding)),2) AS avg_score, round(stddev_pop
             $sections_query = "{$grade_type}_section IN " . $this->createParameterList(count($sections));
             $params = array_merge($sections, $params);
         }
-        if ($null_section == 'include') {
+        if ($null_section === 'include') {
             $null_section_condition = " IS NOT FALSE";
         }
 

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -54,6 +54,8 @@ class SimpleStat extends AbstractModel {
     public function __construct(Core $core, $details = []) {
         parent::__construct($core);
         if (isset($details['gc_id'])) {
+            $bad_submissions_cookie = array_key_exists('include_bad_submissions', $_COOKIE) ? $_COOKIE['include_bad_submissions'] : 'omit';
+            $null_section_cookie = array_key_exists('include_null_section', $_COOKIE) ? $_COOKIE['include_null_section'] : 'omit';
             $this->component = true;
             $this->title = $details['gc_title'];
             $this->max_value = $details['gc_max_value'];
@@ -63,7 +65,7 @@ class SimpleStat extends AbstractModel {
             $this->is_peer_component = $details['gc_is_peer'];
             $this->count = $details['count'];
             $this->active_grade_inquiry_count = $details['active_grade_inquiry_count'];
-            $this->grader_info = $this->core->getQueries()->getAverageGraderScores($details['g_id'], $details['gc_id'], $details['section_key'], $details['team']);
+            $this->grader_info = $this->core->getQueries()->getAverageGraderScores($details['g_id'], $details['gc_id'], $details['section_key'], $details['team'], $bad_submissions_cookie, $null_section_cookie);
         }
         else {
             $this->component = false;

--- a/site/app/models/SimpleStat.php
+++ b/site/app/models/SimpleStat.php
@@ -54,8 +54,8 @@ class SimpleStat extends AbstractModel {
     public function __construct(Core $core, $details = []) {
         parent::__construct($core);
         if (isset($details['gc_id'])) {
-            $bad_submissions_cookie = array_key_exists('include_bad_submissions', $_COOKIE) ? $_COOKIE['include_bad_submissions'] : 'omit';
-            $null_section_cookie = array_key_exists('include_null_section', $_COOKIE) ? $_COOKIE['include_null_section'] : 'omit';
+            $bad_submissions_cookie = $_COOKIE['include_bad_submissions'] ?? 'omit';
+            $null_section_cookie = $_COOKIE['include_null_section'] ?? 'omit';
             $this->component = true;
             $this->title = $details['gc_title'];
             $this->max_value = $details['gc_max_value'];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, in the grading stats page. the statistics available for each grader (count,average,stddev) are not correctly calculated:
 
![image](https://github.com/Submitty/Submitty/assets/131885371/200de6f4-24c3-4d82-886e-f2b43707df17)
Notice how the stats for the grader for a specific component differ from the overall stats per components.
Additionally, the stats for the grader per component don't interact with the newly added filters.

### What is the new behavior?
![image](https://github.com/Submitty/Submitty/assets/131885371/dec2e5f9-5954-455d-8091-efa34986dcee)
The stats for the grader per component are correctly calculated and interact with the filters 
### Other information?
Additionally, this PR reformats some queries related to the statistics for better code practise. 