### PR TITLE
[Bugfix:Forum] Warning for Discard Changes in Post Edit

### DIFF
--- a/site/app/templates/forum/EditPostForm.twig
+++ b/site/app/templates/forum/EditPostForm.twig
@@ -27,7 +27,7 @@
                 return false;
             }
         });
-
+        document.querySelector('.popup-box').onclick = null;
     </script>
 {% endblock %}
 {% block form %}

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -949,6 +949,9 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
 
 // eslint-disable-next-line no-unused-vars
 function cancelEditPostForum() {
+    if (!checkAreYouSureForm()) {
+        return;
+    }
     const markdown_header = $('#markdown_header_0');
     const edit_button = markdown_header.find('.markdown-write-mode');
     if (markdown_header.attr('data-mode') === 'preview') {
@@ -957,7 +960,6 @@ function cancelEditPostForum() {
     $('#edit-user-post').css('display', 'none');
     $(this).closest('.thread-post-form').find('[name=thread_post_content]').val('');
     $('#title').val('');
-    $(this).closest('form').trigger('reinitialize.areYouSure');
 }
 
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
### What is the current behavior?
Fixes #4164
Also read comments in the original issue.

### What is the new behavior?
confirm() is added to the edit post pop-up form when an user is discarding their unsaved changes. 
Note: Close-when-clicked-outside feature is disabled for the same pop-up.


### Screen shots
![image](https://github.com/Submitty/Submitty/assets/123511202/e4e3a49d-2d1e-4c41-a9cc-b3218f875980)