### PR TITLE
[Testing:Developer] Add slack message on vagrant up failure

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
       - name: Acquire Job ID
+        if: failure()
         id: get-job-id
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -34,4 +34,4 @@ jobs:
       - name: Send slack message on failure
         if: failure()
         run: |
-          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/jobs/${{ steps.get-job-id.outputs.job_id }}"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}
+          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -18,7 +18,8 @@ jobs:
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.
       # - run: vagrant plugin install vagrant-vbguest
-      - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
+      - run: |
+          exit 1
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
       - name: Acquire Job ID

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -18,12 +18,10 @@ jobs:
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.
       # - run: vagrant plugin install vagrant-vbguest
-      - run: |
-          exit 1
+      - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
       - name: Acquire Job ID
-        if: failure()
         id: get-job-id
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -32,4 +32,4 @@ jobs:
       - name: Send slack message on failure
         if: failure()
         run: |
-          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ GITHUB_RUN_ID }}/jobs/${{ steps.get-job-id.outputs.job_id }}"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}
+          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/jobs/${{ steps.get-job-id.outputs.job_id }}"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -21,3 +21,7 @@ jobs:
       - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
+      - name: Send slack message on failure
+        if: failure() 
+        run: | 
+          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -21,7 +21,15 @@ jobs:
       - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
+      - name: Acquire Job ID
+        id: get-job-id
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+          echo "job_id=$job_id" >> $GITHUB_OUTPUT
       - name: Send slack message on failure
         if: failure()
         run: |
-          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}
+          curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ GITHUB_RUN_ID }}/jobs/${{ steps.get-job-id.outputs.job_id }}"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -22,6 +22,6 @@ jobs:
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
       - name: Send slack message on failure
-        if: failure() 
-        run: | 
+        if: failure()
+        run: |
           curl -X POST -H "Content-type: application/json" --data '{"text":"The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml"}' ${{ secrets.VAGRANT_UP_WEBHOOK }}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently the vagrant up github action is a cron job, so it is run on a schedule. Due to this, it only sends notifications to the last person to edit the workflow file. If this person is away for any significant period, the failing job can go unnoticed by other developers. This is a problem, as new developers won't be able to reliably run 'vagrant up', which will slow development. 

### What is the new behavior?
This adds a notification VIA a slack app that notifies all who are in the slack channel of the vagrant up failure. 
![image](https://github.com/Submitty/Submitty/assets/46759635/21316cc6-9f04-4e77-b31d-4e4e7b232b88)

The first two messages were debugging, and the last one was a mock failure to show it works. 

Closes #9596 
