### PR TITLE
[Bugfix:Autograding] update autograding compilation limits

### DIFF
--- a/grading/TestCase.cpp
+++ b/grading/TestCase.cpp
@@ -444,9 +444,12 @@ const nlohmann::json TestCase::get_test_case_limits() const {
     // 10 seconds was sufficient time to compile most Data Structures
     // homeworks, but some submissions required slightly more time
     adjust_test_case_limits(_test_case_limits,RLIMIT_CPU,60);              // 60 seconds
-    adjust_test_case_limits(_test_case_limits,RLIMIT_FSIZE,10*1000*1000);  // 10 MB executable
+    adjust_test_case_limits(_test_case_limits,RLIMIT_FSIZE,200*1000*1000);  // 200 MB executable
 
     adjust_test_case_limits(_test_case_limits,RLIMIT_RSS,1000*1000*1000);  // 1 GB
+
+    adjust_test_case_limits(_test_case_limits,RLIMIT_STACK,290*1000*1000);  // 290 MB
+    adjust_test_case_limits(_test_case_limits,RLIMIT_DATA,3000*1000*1000);  // 3 GB
   }
 
   if (isSubmittyCount()) {

--- a/grading/execute_limits.cpp
+++ b/grading/execute_limits.cpp
@@ -44,7 +44,7 @@ const std::vector<int> limit_names = {
 const std::map<int,rlim_t> system_limits = 
   { 
     { RLIMIT_CPU,        600              }, // 10 minutes per test
-    { RLIMIT_FSIZE,      100*1000*1000    }, // 100 MB created file size
+    { RLIMIT_FSIZE,      200*1000*1000    }, // 200 MB created file size
     { RLIMIT_DATA,       RLIM_INFINITY    }, // heap                // 1 GB
     { RLIMIT_STACK,      RLIM_INFINITY    }, // stack size          // 50 MB
     { RLIMIT_CORE,       RLIM_INFINITY    }, // allow core files?   // FIXME: 0


### PR DESCRIPTION
### What is the current behavior?
Autograding compilation was failing for some student CGAL programs (that used multiple modules of CGAL libaries).
Both the virtual memory and the file size limits were execeeded during compilation.

### What is the new behavior?
Compilation test cases will now have a default higher memory limit.  (This was aleady adjustable by the instructor.)
Compilation test cases will now have a larger limit on the created file size.  (This adjustment allowed by the instructor previously had a lower cap that was insufficient.)