### PR TITLE
[Dependency] update DrMemory 2.6.0

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -559,6 +559,39 @@ else
 fi
 
 
+#################################################################
+# DRMEMORY SETUP
+#################
+
+# Dr Memory is a tool for detecting memory errors in C++ programs (similar to Valgrind)
+
+# FIXME: Use of this tool should eventually be moved to containerized
+# autograding and not installed on the native primary and worker
+# machines by default
+
+# FIXME: DrMemory is initially installed in install_system.sh
+# It is re-installed here (on every Submitty software update) in case of version updates.
+
+pushd /tmp > /dev/null
+
+echo "Updating DrMemory..."
+
+rm -rf /tmp/DrMemory*
+wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEMORY_TAG}/DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz -o /dev/null > /dev/null 2>&1
+tar -xpzf DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz
+rsync --delete -a /tmp/DrMemory-Linux-${DRMEMORY_VERSION}/ ${SUBMITTY_INSTALL_DIR}/drmemory
+rm -rf /tmp/DrMemory*
+
+chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/drmemory
+chmod -R 755 ${SUBMITTY_INSTALL_DIR}/drmemory
+
+
+
+echo "...DrMemory ${DRMEMORY_TAG} update complete."
+
+popd > /dev/null
+
+
 ########################################################################################################################
 ########################################################################################################################
 # COPY VARIOUS SCRIPTS USED BY INSTRUCTORS AND SYS ADMINS FOR COURSE ADMINISTRATION

--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -19,5 +19,5 @@ export HAMCREST_VERSION=1.3
 export JACOCO_VERSION=0.8.0
 
 # DR. MEMORY
-export DRMEMORY_TAG=release_2.3.0
-export DRMEMORY_VERSION=2.3.0-1
+export DRMEMORY_TAG=release_2.6.0
+export DRMEMORY_VERSION=2.6.0

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -388,10 +388,17 @@ fi
 
 # Dr Memory is a tool for detecting memory errors in C++ programs (similar to Valgrind)
 
+# FIXME: Use of this tool should eventually be moved to containerized
+# autograding and not installed on the native primary and worker
+# machines by default
+
+# FIXME: DrMemory is also re-installed in INSTALL_SUBMITTY_HELPER.sh
+
 pushd /tmp > /dev/null
 
 echo "Getting DrMemory..."
 
+rm -rf /tmp/DrMemory*
 wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEMORY_TAG}/DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz -o /dev/null > /dev/null 2>&1
 tar -xpzf DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz
 rsync --delete -a /tmp/DrMemory-Linux-${DRMEMORY_VERSION}/ ${SUBMITTY_INSTALL_DIR}/drmemory

--- a/grading/TestCase.cpp
+++ b/grading/TestCase.cpp
@@ -449,7 +449,7 @@ const nlohmann::json TestCase::get_test_case_limits() const {
     adjust_test_case_limits(_test_case_limits,RLIMIT_RSS,1000*1000*1000);  // 1 GB
 
     adjust_test_case_limits(_test_case_limits,RLIMIT_STACK,290*1000*1000);  // 290 MB
-    adjust_test_case_limits(_test_case_limits,RLIMIT_DATA,3000*1000*1000);  // 3 GB
+    adjust_test_case_limits(_test_case_limits,RLIMIT_DATA,2147*1000*1000);  // 2.1 GB (nearly max integer)
   }
 
   if (isSubmittyCount()) {

--- a/grading/system_call_categories.cpp
+++ b/grading/system_call_categories.cpp
@@ -42,6 +42,7 @@ void allow_system_calls(scmp_filter_ctx sc, const std::set<std::string> &categor
   ALLOW_SYSCALL(memfd_create);
 #endif
   ALLOW_SYSCALL(futex);
+  ALLOW_SYSCALL(mincore);
 
   // RESTRICTED : PROCESS_CONTROL_MEMORY_ADVANCED
   if (categories.find("PROCESS_CONTROL_MEMORY_ADVANCED") != categories.end()) {
@@ -492,7 +493,6 @@ void allow_system_calls(scmp_filter_ctx sc, const std::set<std::string> &categor
 #endif
     ALLOW_SYSCALL(keyctl);
     ALLOW_SYSCALL(lookup_dcookie);
-    ALLOW_SYSCALL(mincore);
     ALLOW_SYSCALL(mlock);
 #ifdef __NR_mlock2
     ALLOW_SYSCALL(mlock2);

--- a/grading/system_call_check.cpp
+++ b/grading/system_call_check.cpp
@@ -150,8 +150,8 @@ void parse_system_calls(std::ifstream& system_call_categories_file,
   }
 
   // verify that we have all of the linux system calls (32 & 64 bit)
-  //std::cout << "all_system_calls.size() " <<  all_system_calls.size() << std::endl;
-  assert (all_system_calls.size() == 394);
+  std::cout << "all_system_calls.size() " <<  all_system_calls.size() << std::endl;
+  assert (all_system_calls.size() == 397);
 }
 
 


### PR DESCRIPTION
https://drmemory.org/page_download.html
This update is necessary to use Ubuntu22 / g++11