### PR TITLE
[Bugfix:TAGrading] Checkpoint Grading Empty Section

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2169,7 +2169,7 @@ class Gradeable extends AbstractModel {
 
         $sections = [];
         foreach ($section_names as $section_name) {
-            $sections[] = new GradingSection($this->core, $this->isGradeByRegistration(), $section_name, $graders[$section_name] ?? [], $users[$section_name] ?? null, $teams[$section_name] ?? null);
+            $sections[] = new GradingSection($this->core, $this->isGradeByRegistration(), $section_name, $graders[$section_name] ?? [], $users[$section_name] ?? [], $teams[$section_name] ?? []);
         }
 
         return $sections;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
If you try to load the checkpoint grading page with an empty section, a frog robot error will occur. This is due to the null coalesce being null rather than an empty array.

### What is the new behavior?
The page loads normally as expected. The null coalesce is now just an empty array as it should be.

### Other information?
Tested locally and it does fix the issue.
