### PR TITLE
[Refactor:InstructorUI] Refactor queries to collect data earlier

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5606,7 +5606,8 @@ AND gc_id IN (
               eg.*,
               gamo.*,
               gc.*,
-              (SELECT COUNT(*) AS cnt FROM grade_inquiries WHERE g_id=g.g_id AND status = -1) AS active_grade_inquiries_count
+              (SELECT COUNT(*) AS cnt FROM grade_inquiries WHERE g_id=g.g_id AND status = -1) AS active_grade_inquiries_count,
+              (SELECT EXISTS (SELECT 1 FROM gradeable_data WHERE g_id=g.g_id)) AS any_manual_grades
             FROM gradeable g
               LEFT JOIN (
                 SELECT

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -78,6 +78,7 @@ use app\controllers\admin\AdminGradeableController;
  * @method void setDependsOn($depends_on)
  * @method int getDependsOnPoints()
  * @method void setDependsOnPoints($depends_on_points)
+ * @method void setAnyManualGrades($any_manual_grades)
  * @method bool isGradeInquiryAllowed()
  * @method bool isGradeInquiryPerComponentAllowed()
  * @method void setGradeInquiryPerComponentAllowed($is_grade_inquiry_per_component)
@@ -153,7 +154,7 @@ class Gradeable extends AbstractModel {
 
     /** @prop
      * @var bool If any manual grades have been entered for this gradeable */
-    private $any_manual_grades = null;
+    protected $any_manual_grades = null;
     /** @prop
      * @var bool If any submissions exist */
     private $any_submissions = null;
@@ -340,6 +341,7 @@ class Gradeable extends AbstractModel {
         $this->setMinGradingGroup($details['min_grading_group']);
         $this->setSyllabusBucket($details['syllabus_bucket']);
         $this->setTaInstructions($details['ta_instructions']);
+        $this->setAnyManualGrades($details['any_manual_grades']);
         if (array_key_exists('peer_graders_list', $details)) {
             $this->setPeerGradersList($details['peer_graders_list']);
         }
@@ -1671,6 +1673,9 @@ class Gradeable extends AbstractModel {
      * @return Team[]
      */
     public function getTeams() {
+        if ($this->team_assignment === false) {
+            return [];
+        }
         if ($this->teams === null) {
             $this->teams = $this->core->getQueries()->getTeamsByGradeableId($this->getId());
         }

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -193,7 +193,8 @@ class SubmissionControllerTester extends BaseUnitTest {
             'allowed_minutes' => null,
             'depends_on' => null,
             'depends_on_points' => null,
-            'allow_custom_marks' => true
+            'allow_custom_marks' => true,
+            'any_manual_grades' => false
         ];
         $gradeable = new Gradeable($this->core, $details);
         if ($has_autograding_config) {

--- a/site/tests/app/models/gradeable/GradeableListTester.php
+++ b/site/tests/app/models/gradeable/GradeableListTester.php
@@ -811,7 +811,8 @@ class GradeableListTester extends BaseUnitTest {
             'allowed_minutes' => null,
             'depends_on' => null,
             'depends_on_points' => null,
-            'allow_custom_marks' => true
+            'allow_custom_marks' => true,
+            'any_manual_grades' => false
         ];
 
         return new Gradeable($core, $details);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
The instructor gradeables page makes 108 queries each page load. A lot of these queries are repetitive and can be refactored to use significantly less queries.

### What is the new behavior?
The gradeables page now uses 82 queries per page load which is about a 20% improvement. The gradeable canDelete function can be pretty expensive so I made it collect some data earlier and only query team info if it is a team gradeable.

### Other information?
There is still more work to be done here. The most expensive thing on the page is loading all of the status bars for grading but it uses a lot of query and PHP logic.
