### PR TITLE
[UI/UX:Calendar] Fixed Cursor changing when hovering

### DIFF
--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -230,7 +230,7 @@ a.cal-gradeable-status-ann {
 a.cal-gradeable-status-ann:hover {
     padding: 0;
     font-style: italic;
-    cursor: default;
+    cursor: initial;
     border-style: solid;
     border-width: 3px!important;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**
- [ ] Tests for the changes have been added/updated (if possible)
- [ ] Documentation has been updated/added if relevant
- [ ] Screenshots are attached to Github PR if visual/UI changes were made

**What is the current behavior?**
When I drag my cursor across the border of an announcement, the cursor changes for just a split of a second, as if the border is clickable. If we can figure out what causes it and remove it, that would be nice.

**What is the new behavior?**
Fixes #9248

change :
a.cal-gradeable-status-ann:hover {
    padding: 0;
    font-style: italic;
    cursor: initial; // changed the cursor from default to initial
    border-style: solid;
    border-width: 3px!important;
}

explanation : 
The cursor: default; property sets the default cursor for an element, which can vary depending on the user's operating system and browser. However, it appears that we want to prevent the cursor from changing when hovering over the border of the announcement.
To achieve the expected behavior where the cursor never changes when hovering over the border of an announcement, we should set the cursor property to initial instead of default.

**Additional Information:**

