### PR TITLE
[Bugfix:Developer] Fix vagrant up slack message

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511
       - name: Acquire Job ID
+        if: failure()
         id: get-job-id
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What is the current behavior?
After I was testing the slack message on failure, I accidentally deleted the line to get the JOB ID on failure. This causes the vagrant up notification to not have the JOB ID, so the link is bad.

### What is the new behavior?
The line to run this on failure has been re-added, this will make the link accurate. 
