### PR TITLE
[Bugfix:TAGrading] Check for bad submissions in statistics

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2259,13 +2259,13 @@ ORDER BY {$u_or_t}.{$section_key}",
     /**
      * Gets the number of bad (late) graded submissions associated with this gradeable.
      *
-     * @param  int $g_id gradeable id we are looking up
+     * @param  string $g_id gradeable id we are looking up
      * @param  string $section_key key we are basing grading sections off of
      * @param  boolean $is_team true if the gradeable is a team assignment
      * @param  string $null_section to check if we look in the null section or not
      * @return int the number of bad submissions
      */
-    private function getBadSubmissionsCount(int $g_id, string $section_key, bool $is_team, string $null_section): int {
+    private function getBadSubmissionsCount(string $g_id, string $section_key, bool $is_team, string $null_section): int {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2296,7 +2296,7 @@ ORDER BY {$u_or_t}.{$section_key}",
         return $this->course_db->row()['cnt'];
     }
 
-    public function getAverageComponentScores(int $g_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageComponentScores(string $g_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2392,7 +2392,7 @@ ORDER BY gc_order
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount(intval($g_id), $section_key, $is_team, $null_section) > 0) {
+        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team, $null_section) > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2449,7 +2449,7 @@ ORDER BY gc_order
         return $return;
     }
 
-    public function getAverageAutogradedScores(int $g_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageAutogradedScores(string $g_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
 
         $u_or_t = "u";
         $users_or_teams = "users";
@@ -2548,7 +2548,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
 
-    public function getAverageForGradeable(int $g_id, string $section_key, bool $is_team, string $override, string $bad_submissions, string $null_section) {
+    public function getAverageForGradeable(string $g_id, string $section_key, bool $is_team, string $override, string $bad_submissions, string $null_section) {
 
         $u_or_t = "u";
         $users_or_teams = "users";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2385,7 +2385,7 @@ ORDER BY gc_order
         );
         $bad_submission_count = $this->course_db->row()['cnt'];
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include' && $bad_submission_count>0) {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2474,7 +2474,7 @@ ORDER BY gc_order
             [$g_id]
         );
         $bad_submission_count = $this->course_db->row()['cnt'];
-        if ($bad_submissions !== 'include' && $bad_submission_count>0) {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2265,7 +2265,7 @@ ORDER BY {$u_or_t}.{$section_key}",
      * @param  string $null_section to check if we look in the null section or not
      * @return int the number of bad submissions
      */
-    private function getBadSubmissionsCount(int $g_id, string $section_key, bool $is_team, string $null_section) {
+    private function getBadSubmissionsCount(int $g_id, string $section_key, bool $is_team, string $null_section): int {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2392,7 +2392,7 @@ ORDER BY gc_order
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team, $null_section) > 0) {
+        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount(intval($g_id), $section_key, $is_team, $null_section) > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2263,6 +2263,7 @@ ORDER BY {$u_or_t}.{$section_key}",
         $user_or_team_id = "user_id";
         $null_section_condition = "";
         $bad_submissions_condition = "";
+        $bad_submission_count = 0;
         $params = [$g_id, $g_id, $g_id, $g_id];
         if ($is_team) {
             $u_or_t = "t";
@@ -2274,8 +2275,23 @@ ORDER BY {$u_or_t}.{$section_key}",
         if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
+        $this->course_db->query(
+            "SELECT COUNT(*) as cnt
+            FROM gradeable_component AS gc, {$users_or_teams} AS {$u_or_t}
+            WHERE gc.g_id=? {$null_section_condition}
+            AND EXISTS (
+                SELECT 1
+                FROM late_day_cache AS ldc
+                WHERE ldc.{$user_or_team_id} = {$u_or_t}.{$user_or_team_id}
+                AND ldc.g_id=gc.g_id
+                AND ldc.submission_days_late > ldc.late_day_exceptions
+                AND ldc.late_days_change = 0
+            )",
+            [$g_id]
+        );
+        $bad_submission_count = $this->course_db->row()['cnt'];
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include') {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2343,6 +2359,7 @@ ORDER BY gc_order
         $user_or_team_id = "user_id";
         $null_section_condition = "";
         $bad_submissions_condition = "";
+        $bad_submission_count = 0;
         $params = [$gc_id, $g_id, $g_id, $g_id];
         if ($is_team) {
             $u_or_t = "t";
@@ -2352,8 +2369,23 @@ ORDER BY gc_order
         if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
+        $this->course_db->query(
+            "SELECT COUNT(*) as cnt
+            FROM gradeable_component AS gc, {$users_or_teams} AS {$u_or_t}
+            WHERE gc.g_id=? {$null_section_condition}
+            AND EXISTS (
+                SELECT 1
+                FROM late_day_cache AS ldc
+                WHERE ldc.{$user_or_team_id} = {$u_or_t}.{$user_or_team_id}
+                AND ldc.g_id=gc.g_id
+                AND ldc.submission_days_late > ldc.late_day_exceptions
+                AND ldc.late_days_change = 0
+            )",
+            [$g_id]
+        );
+        $bad_submission_count = $this->course_db->row()['cnt'];
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include') {
+        if ($bad_submissions !== 'include' && $bad_submission_count>0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2417,6 +2449,7 @@ ORDER BY gc_order
         $user_or_team_id = "user_id";
         $bad_submissions_condition = '';
         $null_section_condition = '';
+        $bad_submission_count = 0;
         $params = [$g_id];
         if ($is_team) {
             $u_or_t = "t";
@@ -2426,8 +2459,22 @@ ORDER BY gc_order
         if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
-
-        if ($bad_submissions !== 'include') {
+        $this->course_db->query(
+            "SELECT COUNT(*) as cnt
+            FROM gradeable_component AS gc, {$users_or_teams} AS {$u_or_t}
+            WHERE gc.g_id=? {$null_section_condition}
+            AND EXISTS (
+                SELECT 1
+                FROM late_day_cache AS ldc
+                WHERE ldc.{$user_or_team_id} = {$u_or_t}.{$user_or_team_id}
+                AND ldc.g_id=gc.g_id
+                AND ldc.submission_days_late > ldc.late_day_exceptions
+                AND ldc.late_days_change = 0
+            )",
+            [$g_id]
+        );
+        $bad_submission_count = $this->course_db->row()['cnt'];
+        if ($bad_submissions !== 'include' && $bad_submission_count>0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2519,7 +2566,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         $include = '';
         $null_section_condition = '';
         $bad_submissions_condition = '';
-
+        $bad_submission_count = 0;
         if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
@@ -2545,8 +2592,23 @@ SELECT COUNT(*) from gradeable_component where g_id=?
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
 
+        $this->course_db->query(
+            "SELECT COUNT(*) as cnt
+            FROM gradeable_component AS gc, {$users_or_teams} AS {$u_or_t}
+            WHERE gc.g_id=? {$null_section_condition}
+            AND EXISTS (
+                SELECT 1
+                FROM late_day_cache AS ldc
+                WHERE ldc.{$user_or_team_id} = {$u_or_t}.{$user_or_team_id}
+                AND ldc.g_id=gc.g_id
+                AND ldc.submission_days_late > ldc.late_day_exceptions
+                AND ldc.late_days_change = 0
+            )",
+            [$g_id]
+        );
+        $bad_submission_count = $this->course_db->row()['cnt'];
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include') {
+        if ($bad_submissions !== 'include' && $bad_submission_count > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2265,7 +2265,7 @@ ORDER BY {$u_or_t}.{$section_key}",
      * @param  string $null_section to check if we look in the null section or not
      * @return int the number of bad submissions
      */
-    private function getBadSubmissionsCount(int $g_id, string $section_key, boolean $is_team, string $null_section) {
+    private function getBadSubmissionsCount(int $g_id, string $section_key, bool $is_team, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2296,7 +2296,7 @@ ORDER BY {$u_or_t}.{$section_key}",
         return $this->course_db->row()['cnt'];
     }
 
-    public function getAverageComponentScores(int $g_id, string $section_key, boolean $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageComponentScores(int $g_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2376,7 +2376,7 @@ ORDER BY gc_order
         return $return;
     }
 
-    public function getAverageGraderScores(int $g_id, int $gc_id, string $section_key, boolean $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageGraderScores(int $g_id, int $gc_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2449,7 +2449,7 @@ ORDER BY gc_order
         return $return;
     }
 
-    public function getAverageAutogradedScores(int $g_id, string $section_key, boolean $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageAutogradedScores(int $g_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
 
         $u_or_t = "u";
         $users_or_teams = "users";
@@ -2548,7 +2548,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
 
-    public function getAverageForGradeable(int $g_id, string $section_key, boolean $is_team, string $override, string $bad_submissions, string $null_section) {
+    public function getAverageForGradeable(int $g_id, string $section_key, bool $is_team, string $override, string $bad_submissions, string $null_section) {
 
         $u_or_t = "u";
         $users_or_teams = "users";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2265,7 +2265,7 @@ ORDER BY {$u_or_t}.{$section_key}",
      * @param  string $null_section to check if we look in the null section or not
      * @return int the number of bad submissions
      */
-    private function getBadSubmissionsCount($g_id, $section_key, $is_team, string $null_section) {
+    private function getBadSubmissionsCount(int $g_id, string $section_key, boolean $is_team, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2296,7 +2296,7 @@ ORDER BY {$u_or_t}.{$section_key}",
         return $this->course_db->row()['cnt'];
     }
 
-    public function getAverageComponentScores($g_id, $section_key, $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageComponentScores(int $g_id, string $section_key, boolean $is_team, string $bad_submissions, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2376,7 +2376,7 @@ ORDER BY gc_order
         return $return;
     }
 
-    public function getAverageGraderScores($g_id, $gc_id, $section_key, $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageGraderScores(int $g_id, int $gc_id, string $section_key, boolean $is_team, string $bad_submissions, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
@@ -2449,7 +2449,7 @@ ORDER BY gc_order
         return $return;
     }
 
-    public function getAverageAutogradedScores($g_id, $section_key, $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageAutogradedScores(int $g_id, string $section_key, boolean $is_team, string $bad_submissions, string $null_section) {
 
         $u_or_t = "u";
         $users_or_teams = "users";
@@ -2548,7 +2548,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         return new SimpleStat($this->core, $this->course_db->rows()[0]);
     }
 
-    public function getAverageForGradeable($g_id, $section_key, $is_team, string $override, string $bad_submissions, string $null_section) {
+    public function getAverageForGradeable(int $g_id, string $section_key, boolean $is_team, string $override, string $bad_submissions, string $null_section) {
 
         $u_or_t = "u";
         $users_or_teams = "users";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2376,7 +2376,7 @@ ORDER BY gc_order
         return $return;
     }
 
-    public function getAverageGraderScores(int $g_id, int $gc_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
+    public function getAverageGraderScores(string $g_id, int $gc_id, string $section_key, bool $is_team, string $bad_submissions, string $null_section) {
         $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -2270,7 +2270,6 @@ ORDER BY {$u_or_t}.{$section_key}",
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
         $null_section_condition = "";
-        $bad_submission_count = 0;
         if ($is_team) {
             $u_or_t = "t";
             $users_or_teams = "gradeable_teams";
@@ -2294,8 +2293,7 @@ ORDER BY {$u_or_t}.{$section_key}",
             )",
             [$g_id]
         );
-        $bad_submission_count = $this->course_db->row()['cnt'];
-        return $bad_submission_count;
+        return $this->course_db->row()['cnt'];
     }
 
     public function getAverageComponentScores($g_id, $section_key, $is_team, string $bad_submissions, string $null_section) {
@@ -2316,7 +2314,7 @@ ORDER BY {$u_or_t}.{$section_key}",
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team,$null_section) > 0) {
+        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team, $null_section) > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2394,7 +2392,7 @@ ORDER BY gc_order
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team,$null_section) > 0) {
+        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team, $null_section) > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2467,7 +2465,7 @@ ORDER BY gc_order
         if ($null_section !== 'include') {
             $null_section_condition = "AND {$u_or_t}.{$section_key} IS NOT NULL";
         }
-        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team,$null_section) > 0) {
+        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team, $null_section) > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc
@@ -2585,7 +2583,7 @@ SELECT COUNT(*) from gradeable_component where g_id=?
         }
 
         // Check if we want to include late (bad) submissions into the average
-        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team,$null_section) > 0) {
+        if ($bad_submissions !== 'include' && $this->getBadSubmissionsCount($g_id, $section_key, $is_team, $null_section) > 0) {
             $bad_submissions_condition = "INNER JOIN(
                 SELECT DISTINCT ldc.{$user_or_team_id}
                 FROM late_day_cache AS ldc

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -5261,37 +5261,7 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has parameter \\$g_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has parameter \\$is_team with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageAutogradedScores\\(\\) has parameter \\$section_key with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has parameter \\$g_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has parameter \\$is_team with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageComponentScores\\(\\) has parameter \\$section_key with no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 
@@ -5301,42 +5271,7 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$g_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$is_team with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageForGradeable\\(\\) has parameter \\$section_key with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$g_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$gc_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$is_team with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getAverageGraderScores\\(\\) has parameter \\$section_key with no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Bulk upload gradeables can't have submissions past their due date. Therefore there aren't any rows of these gradeables in the late day cache. When omitting the bad submissions from the statistic page (which is the default setting), the code adds a query to get the necessary data from the late day cache. However, if there are no entries in the table, it will mess up all statistics.
### What is the new behavior?
Check if there are any bad submissions before omitting them from the statistics.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
