### PR TITLE
[Bugfix:Gradeable] Fixed incorrectly displayed text in editing gradeable

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -89,7 +89,7 @@
             <div class="option-alt"><a target=_blank href="http://submitty.org/instructor/create_edit_gradeable#types-of-gradeables">What is the type of the gradeable <i style="font-style:normal;" class="fa-question-circle"></i></a></div>
             <span class="required_type" >(Required)</span>
         {% else %}
-            <fieldset><legend><b style='font-size:18px'>Gradeable type</b>: <span id="gradeable-type-string" data-hw="{{ gradeable_type_strings['electronic_hw'] | e('html_attr') }}" data-bulk="{{ gradeable_type_strings['electronic_bulk'] | e('html_attr') }}">{{ type_string }}</span></legend>
+            <fieldset><legend><b style='font-size:18px'>Gradeable type</b>: <span id="gradeable-type-string" data-hw="{{ gradeable_type_strings['electronic_bulk'] | e('html_attr') }}" data-bulk="{{ gradeable_type_strings['electronic_bulk'] | e('html_attr') }}">{{ type_string }}</span></legend>
             <br />
         {% endif %}
         <div id="gradeable_type_container" {{ action == 'edit' ? 'hidden' : '' }}>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Previous displayed:
![image](https://github.com/Submitty/Submitty/assets/73798707/52a8aadc-40c6-46eb-9bc7-96735c522405)

"Gradeable Type: Students will submit one or more files by direct upload to the Submitty website"

### What is the new behavior?

<img width="917" alt="image" src="https://github.com/Submitty/Submitty/assets/73798707/344c3bbc-8487-4299-ac0a-0d119ccb5daa">

Now displays:
"Gradeable Type: TA/Instructor will (bulk) upload scanned .pdf for online manual grading"


closes #9485

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
