### PR TITLE
[Bugfix:System] Stricter Course Rejoin Requirements

### DIFF
--- a/site/app/controllers/SelfRejoinController.php
+++ b/site/app/controllers/SelfRejoinController.php
@@ -36,14 +36,35 @@ class SelfRejoinController extends AbstractController {
         $course = $this->core->getConfig()->getCourse();
         $term = $this->core->getConfig()->getTerm();
 
-        // If manually removed from course, this was probably intentional removal.
-        if (
-            $user->isManualRegistration()
-            || !$this->core->getQueries()->
-                wasStudentEverInCourse($user_id, $course, $term)
-        ) {
+
+        // --------------------------------
+        // Reasons why you can't rejoin:
+
+        // Can't rejoin courses you were never in.
+        if (!$this->core->getQueries()->wasStudentEverInCourse($user_id, $course, $term)) {
             return false;
         }
+
+        // Can't rejoin a course if you're still registered.
+        if ($user->getRegistrationSection() !== null) {
+            return false;
+        }
+
+        // Can't rejoin archived courses.
+        $course_status = $this->core->getQueries()->getCourseStatus($term, $course);
+        if ($course_status === 2) {
+            return false;
+        }
+
+        // If manually removed from course, this was probably intentional removal.
+        if ($user->isManualRegistration()) {
+            return false;
+        }
+        // --------------------------------
+
+
+        // --------------------------------
+        // Meeting the requirements to rejoin
 
         $acceses = $this->core->getQueries()->getAttendanceInfoOneStudent($user_id);
         foreach ($acceses as $access_place => $timestamp) {
@@ -60,7 +81,10 @@ class SelfRejoinController extends AbstractController {
         if (abs(DateUtils::calculateDayDiff($term_start_date)) <= 14) {
             return true;
         }
+        // --------------------------------
 
+
+        // If don't meet requirements to rejoin, then can't rejoin.
         return false;
     }
 


### PR DESCRIPTION
### What is the current behavior?
Students can "rejoin" courses they are already in if they specifically go to the null access page. They can also rejoin archived courses.

### What is the new behavior?
Students can only rejoin in the null section, and the course must be not archived.
