### PR TITLE
[Feature:System] Add Term to Rejoin Email

### DIFF
--- a/site/app/controllers/SelfRejoinController.php
+++ b/site/app/controllers/SelfRejoinController.php
@@ -111,11 +111,12 @@ class SelfRejoinController extends AbstractController {
         }
 
         $course = ucwords($this->core->getConfig()->getCourse());
+        $term = $this->core->getConfig()->getTerm();
 
-        $subject = "User Rejoin: $first_name $last_name ($user_id) of $course";
+        $subject = "User Rejoin: $first_name $last_name ($user_id) of $term $course";
         $body = <<<EMAIL
             The student $first_name $last_name ($user_id), who had been automatically removed
-            from the course $course, has readded themselves in section $joined_section.
+            from the course $course of term $term, has readded themselves in section $joined_section.
 
             Please move them to their appropiate section. If this rejoin was a mistake,
             you may move the student to the Null section.


### PR DESCRIPTION
### What is the current behavior?
When a student self readds themselves, the email does not say what term the course they rejoin is a part of.

### What is the new behavior?
The term is now specified.

# Images
Email subject:
![image](https://github.com/Submitty/Submitty/assets/51209504/da7e37a3-af3e-4a13-87ee-366387eadca4)
