### PR TITLE
[Refactor:TAGrading] Late day cache improvement

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1677,19 +1677,34 @@ WHERE term=? AND course=? AND user_id=?",
      * ]
      */
     public function getLateDayCacheForUserGradeable(string $user_id, string $g_id): ?array {
-        $params = [$user_id, $g_id];
-        $query = "SELECT * FROM late_day_cache
-                    WHERE user_id=?
-                    AND g_id=?";
-        $this->course_db->query($query, $params);
+//        $params = [$user_id, $g_id];
+//        $query = "SELECT * FROM late_day_cache
+//                    WHERE user_id=?
+//                    AND g_id=?";
+//        $this->course_db->query($query, $params);
 
-        $row = $this->course_db->row();
+        static $cache = null;
+        if ($cache === null) {
+            $cache = [];
+            $full_query = "
+                SELECT * FROM late_day_cache WHERE g_id=?
+            ";
+            $this->course_db->query($full_query, [$g_id]);
+            $res = $this->course_db->rows();
+            foreach ($res as $row) {
+                $cache[$row["user_id"]] = $row;
+            }
+        }
+
+
+
+        $row = $cache[$user_id];
 
         // If cache doesn't exist, generate it and query again
         if (empty($row)) {
-            $this->generateLateDayCacheForUser($user_id);
-            $this->course_db->query($query, $params);
-            $row = $this->course_db->row();
+//            $this->generateLateDayCacheForUser($user_id);
+//            $this->course_db->query($query, $params);
+//            $row = $this->course_db->row();
         }
 
         // If cache still doesn't exist, the gradeable is not associated with

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1677,12 +1677,6 @@ WHERE term=? AND course=? AND user_id=?",
      * ]
      */
     public function getLateDayCacheForUserGradeable(string $user_id, string $g_id): ?array {
-//        $params = [$user_id, $g_id];
-//        $query = "SELECT * FROM late_day_cache
-//                    WHERE user_id=?
-//                    AND g_id=?";
-//        $this->course_db->query($query, $params);
-
         static $cache = null;
         if ($cache === null) {
             $cache = [];
@@ -1696,15 +1690,18 @@ WHERE term=? AND course=? AND user_id=?",
             }
         }
 
-
-
         $row = $cache[$user_id];
 
         // If cache doesn't exist, generate it and query again
         if (empty($row)) {
-//            $this->generateLateDayCacheForUser($user_id);
-//            $this->course_db->query($query, $params);
-//            $row = $this->course_db->row();
+            $params = [$user_id, $g_id];
+            $query = "SELECT * FROM late_day_cache
+                    WHERE user_id=?
+                    AND g_id=?";
+            $this->generateLateDayCacheForUser($user_id);
+            $this->course_db->query($query, $params);
+            $row = $this->course_db->row();
+            $cache[$user_id] = $row;
         }
 
         // If cache still doesn't exist, the gradeable is not associated with


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When the late day cache is fetched, it fetches the cache for each user on its own query. This becomes quite expensive as the class size grows.

### What is the new behavior?
Up front, a cache gets created with all user's late day info. Then per call it will fetch from that cache instead.

### Other information?
Went from 154 queries down to 16 queries on one of the TA grading pages.
