### PR TITLE
[Bugfix:System] Add more error handling to SAML

### DIFF
--- a/site/app/authentication/SamlAuthentication.php
+++ b/site/app/authentication/SamlAuthentication.php
@@ -110,7 +110,8 @@ class SamlAuthentication extends AbstractAuthentication {
         unset($_SESSION['AuthnRequestID']);
         try {
             $this->auth->processResponse($request_id);
-        } catch (Error|ValidationError) {
+        }
+        catch (Error | ValidationError) {
             $this->core->addErrorMessage("Invalid request. Please try again.");
             return false;
         }

--- a/site/app/authentication/SamlAuthentication.php
+++ b/site/app/authentication/SamlAuthentication.php
@@ -7,6 +7,8 @@ use app\libraries\Core;
 use app\libraries\FileUtils;
 use app\libraries\SamlSettings;
 use OneLogin\Saml2\Auth;
+use OneLogin\Saml2\Error;
+use OneLogin\Saml2\ValidationError;
 
 class SamlAuthentication extends AbstractAuthentication {
     private $auth;
@@ -106,7 +108,12 @@ class SamlAuthentication extends AbstractAuthentication {
         }
         $request_id = $_SESSION['AuthnRequestID'];
         unset($_SESSION['AuthnRequestID']);
-        $this->auth->processResponse($request_id);
+        try {
+            $this->auth->processResponse($request_id);
+        } catch (Error|ValidationError) {
+            $this->core->addErrorMessage("Invalid request. Please try again.");
+            return false;
+        }
 
         if ($this->auth->isAuthenticated() && empty($this->auth->getErrors())) {
             $attribute_name = $this->core->getConfig()->getSamlOptions()['username_attribute'];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
If a malformed SAML packet is passed in during login, a server error is created.

### What is the new behavior?
A try catch was added to handle the malformed packet errors and instruct the user to login again.

### Other information?
Unfortunately, this is quite difficult to test but it simply just adds a try catch and handle the error.
