### PR TITLE
[Bugfix:Forum] Post error WebSocket fix

### DIFF
--- a/site/public/js/websocket.js
+++ b/site/public/js/websocket.js
@@ -103,7 +103,9 @@ class WebSocketClient {
     }
 
     send(data) {
-        this.client.send(JSON.stringify(data));
+        if (this.client.readyState === WebSocket.OPEN) {
+            this.client.send(JSON.stringify(data));
+        }
     }
 
     removeClientListeners() {


### PR DESCRIPTION
### What is the current behavior?
Whenever adding a post to the forum, the reply wouldn't submit and the button would stay pressed despite the post actually going through.


### What is the new behavior?
The WebSocket will not send data unless there is a ready connection, and because of this change the reply will now send and reload the page. fixing the issue from issue 9788 (WebSocket error handling improvements).

### Other information?
I tested this by following the guide written under issue 9788, by stopping nginx and being off campus I was able to recreate the behavior and find a fix for it.
