### PR TITLE
[Refactor:Calendar] Luxon Date Objects

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -262,7 +262,6 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
 
     chown -R ${PHP_USER}:${PHP_USER} ${NODE_FOLDER}
 
-    #
     echo "Copy NPM packages into place"
     # clean out the old install so we don't leave anything behind
     rm -rf ${VENDOR_FOLDER}
@@ -325,7 +324,7 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
     cp -R ${NODE_FOLDER}/jquery-ui-dist/images ${VENDOR_FOLDER}/jquery-ui/
     #luxon
     mkdir ${VENDOR_FOLDER}/luxon
-    cp ${NODE_FOLDER}/luxon/build/global/luxon.js ${VENDOR_FOLDER}/luxon
+    cp ${NODE_FOLDER}/luxon/build/global/luxon.min.js ${VENDOR_FOLDER}/luxon
     # pdfjs
     mkdir ${VENDOR_FOLDER}/pdfjs
     cp ${NODE_FOLDER}/pdfjs-dist/build/pdf.min.js ${VENDOR_FOLDER}/pdfjs

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -289,9 +289,6 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
     mkdir ${VENDOR_FOLDER}/codemirror-spell-checker
     cp ${NODE_FOLDER}/codemirror-spell-checker/dist/spell-checker.min.js ${VENDOR_FOLDER}/codemirror-spell-checker
     cp ${NODE_FOLDER}/codemirror-spell-checker/dist/spell-checker.min.css ${VENDOR_FOLDER}/codemirror-spell-checker
-    #luxon
-    mkdir ${VENDOR_FOLDER}/luxon
-    cp ${NODE_FOLDER}/luxon/build/global/luxon.js ${VENDOR_FOLDER}/luxon
     #codemirror6
     mkdir ${VENDOR_FOLDER}/codemirror6
     mkdir ${VENDOR_FOLDER}/codemirror6/view
@@ -326,6 +323,9 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
     mkdir ${VENDOR_FOLDER}/jquery-ui
     cp ${NODE_FOLDER}/jquery-ui-dist/*.min.* ${VENDOR_FOLDER}/jquery-ui
     cp -R ${NODE_FOLDER}/jquery-ui-dist/images ${VENDOR_FOLDER}/jquery-ui/
+    #luxon
+    mkdir ${VENDOR_FOLDER}/luxon
+    cp ${NODE_FOLDER}/luxon/build/global/luxon.js ${VENDOR_FOLDER}/luxon
     # pdfjs
     mkdir ${VENDOR_FOLDER}/pdfjs
     cp ${NODE_FOLDER}/pdfjs-dist/build/pdf.min.js ${VENDOR_FOLDER}/pdfjs

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -262,6 +262,7 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
 
     chown -R ${PHP_USER}:${PHP_USER} ${NODE_FOLDER}
 
+    #
     echo "Copy NPM packages into place"
     # clean out the old install so we don't leave anything behind
     rm -rf ${VENDOR_FOLDER}
@@ -288,6 +289,9 @@ if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
     mkdir ${VENDOR_FOLDER}/codemirror-spell-checker
     cp ${NODE_FOLDER}/codemirror-spell-checker/dist/spell-checker.min.js ${VENDOR_FOLDER}/codemirror-spell-checker
     cp ${NODE_FOLDER}/codemirror-spell-checker/dist/spell-checker.min.css ${VENDOR_FOLDER}/codemirror-spell-checker
+    #luxon
+    mkdir ${VENDOR_FOLDER}/luxon
+    cp ${NODE_FOLDER}/luxon/build/global/luxon.js ${VENDOR_FOLDER}/luxon
     #codemirror6
     mkdir ${VENDOR_FOLDER}/codemirror6
     mkdir ${VENDOR_FOLDER}/codemirror6/view

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -193,11 +193,11 @@ HTML;
         $this->addVendorJs(FileUtils::joinPaths('jquery', 'jquery.min.js'));
         $this->addVendorJs(FileUtils::joinPaths('jquery-ui', 'jquery-ui.min.js'));
         $this->addVendorJs(FileUtils::joinPaths('js-cookie', 'js.cookie.min.js'));
+        $this->addVendorJs(FileUtils::joinPaths('luxon', 'luxon.min.js'));
         $this->addInternalJs('diff-viewer.js');
         $this->addInternalJs('server.js');
         $this->addInternalJs('menu.js');
         $this->addInternalJs('testcase-output.js');
-        $this->addVendorJs(FileUtils::joinPaths('luxon', 'luxon.min.js'));
     }
 
     /**

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -197,8 +197,7 @@ HTML;
         $this->addInternalJs('server.js');
         $this->addInternalJs('menu.js');
         $this->addInternalJs('testcase-output.js');
-
-        $this->addVendorJs(FileUtils::joinPaths('luxon', 'luxon.js'));
+        $this->addVendorJs(FileUtils::joinPaths('luxon', 'luxon.min.js'));
     }
 
     /**

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -197,6 +197,8 @@ HTML;
         $this->addInternalJs('server.js');
         $this->addInternalJs('menu.js');
         $this->addInternalJs('testcase-output.js');
+
+        $this->addVendorJs(FileUtils::joinPaths('luxon', 'luxon.js'));
     }
 
     /**

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -34,6 +34,7 @@
         "jquery.are-you-sure": "1.9.0",
         "js-cookie": "3.0.5",
         "jspdf": "^2.5.1",
+        "luxon": "^3.4.3",
         "mermaid": "10.4.0",
         "pdfjs-dist": "2.10.377",
         "plotly.js-dist": "2.25.2",
@@ -9332,6 +9333,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -19398,6 +19407,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -38,7 +38,7 @@
     "jquery.are-you-sure": "1.9.0",
     "js-cookie": "3.0.5",
     "jspdf": "^2.5.1",
-    "luxon": "^3.4.3",
+    "luxon": "3.4.3",
     "mermaid": "10.4.0",
     "pdfjs-dist": "2.10.377",
     "plotly.js-dist": "2.25.2",

--- a/site/package.json
+++ b/site/package.json
@@ -38,6 +38,7 @@
     "jquery.are-you-sure": "1.9.0",
     "js-cookie": "3.0.5",
     "jspdf": "^2.5.1",
+    "luxon": "^3.4.3",
     "mermaid": "10.4.0",
     "pdfjs-dist": "2.10.377",
     "plotly.js-dist": "2.25.2",

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -1,4 +1,4 @@
-const DateTime = require('luxon');
+var DateTime = luxon.DateTime;
 
 function calculateLateDays(inputDate) {
     const select_menu = document.getElementById('g_id');
@@ -11,7 +11,6 @@ function calculateLateDays(inputDate) {
     const new_due_date = DateTime.fromISO(inputDate);
     const old_due_date = DateTime.fromISO(due_date_value);
     const diff = Math.max(0, new_due_date.diff(old_due_date, 'days').days);
-    console.log("HERHEHEHRHEHR" + due_date_value, new_due_date, old_due_date, diff);
     document.getElementById('late_days').value = diff;
 }
 

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -1,4 +1,4 @@
-const { DateTime } = require("luxon");
+const DateTime = require('luxon');
 
 function calculateLateDays(inputDate) {
     const select_menu = document.getElementById('g_id');
@@ -6,10 +6,12 @@ function calculateLateDays(inputDate) {
         alert('Please select a gradeable first!');
         return;
     }
+    
     const due_date_value = select_menu.options[select_menu.selectedIndex].getAttribute('data-due-date');
     const new_due_date = DateTime.fromISO(inputDate);
     const old_due_date = DateTime.fromISO(due_date_value);
     const diff = Math.max(0, new_due_date.diff(old_due_date, 'days').days);
+    console.log("HERHEHEHRHEHR" + due_date_value, new_due_date, old_due_date, diff);
     document.getElementById('late_days').value = diff;
 }
 

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -1,3 +1,4 @@
+/* global luxon */
 const DateTime = luxon.DateTime;
 
 function calculateLateDays(inputDate) {

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -7,7 +7,7 @@ function calculateLateDays(inputDate) {
         alert('Please select a gradeable first!');
         return;
     }
-    
+
     const due_date_value = select_menu.options[select_menu.selectedIndex].getAttribute('data-due-date');
     const new_due_date = DateTime.fromISO(inputDate);
     const old_due_date = DateTime.fromISO(due_date_value);

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -11,7 +11,7 @@ function calculateLateDays(inputDate) {
     const due_date_value = select_menu.options[select_menu.selectedIndex].getAttribute('data-due-date');
     const new_due_date = DateTime.fromISO(inputDate);
     const old_due_date = DateTime.fromISO(due_date_value);
-    const diff = Math.max(0, new_due_date.diff(old_due_date, 'days').days);
+    const diff = Math.floor(Math.max(0, new_due_date.diff(old_due_date, 'days').days));
     document.getElementById('late_days').value = diff;
 }
 

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -1,4 +1,4 @@
-var DateTime = luxon.DateTime;
+const DateTime = luxon.DateTime;
 
 function calculateLateDays(inputDate) {
     const select_menu = document.getElementById('g_id');

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -1,3 +1,5 @@
+const { DateTime } = require("luxon");
+
 function calculateLateDays(inputDate) {
     const select_menu = document.getElementById('g_id');
     if (select_menu.selectedIndex === 0) {
@@ -5,13 +7,9 @@ function calculateLateDays(inputDate) {
         return;
     }
     const due_date_value = select_menu.options[select_menu.selectedIndex].getAttribute('data-due-date');
-    const new_due_date = new Date(inputDate);
-    const old_due_date = new Date(due_date_value);
-    let delta = (new_due_date.getTime() - old_due_date.getTime()) / (1000*60*60*24);
-    if (delta < 0) {
-        delta = 0;
-    }
-    const diff = Math.floor(delta);
+    const new_due_date = DateTime.fromISO(inputDate);
+    const old_due_date = DateTime.fromISO(due_date_value);
+    const diff = Math.max(0, new_due_date.diff(old_due_date, 'days').days);
     document.getElementById('late_days').value = diff;
 }
 
@@ -34,10 +32,10 @@ $(document).ready(() => {
                     let date;
                     switch (index) {
                         case 0:
-                            date = new Date();
+                            date = DateTime.now();
                             break;
                         case 1:
-                            date = new Date('9998-01-01');
+                            date = DateTime.fromISO('9998-01-01');
                             break;
                     }
                     fp.setDate(date, true);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
We use the builtin JS date library in a number of places. While this mostly works, we keep getting bit by browser implementation specific stuff and pitfalls because it's not a very developer friendly interface. This is especially a bit hairy as we then do bits of math with these dates, which is equally error prone. Many of the strings passed in do not follow the ISO8601 format and rely on non-standard browser behavior to parse the date.

### What is the new behavior?
Instead of using the builtin JS date library, we will be using Luxon. I have only made this change in latedays.js so the team can review and approve of integrating Luxon for the rest of Submitty.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
