### PR TITLE
Fix : #9875 Updated the RCOS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ System instructions located at [https://submitty.org/](https://submitty.org/)
 # Background
 
 [Submitty](https://submitty.org) is an open source course management, assignment submission, exam and grading system
-from the [Rensselaer Center for Open Source Software (RCOS)](https://rcos.io/),
+from the [Rensselaer Center for Open Source Software (RCOS)](https://new.rcos.io/),
 [Department of Computer Science](https://science.rpi.edu/computer-science) at
 [Rensselaer Polytechnic Institute](https://www.rpi.edu/).
 

--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -8,7 +8,7 @@
                     <a href="https://submitty.org" target="_blank" class="black-btn">Submitty</a>
                     <a href="https://github.com/Submitty/Submitty/releases/tag/{{ latest_tag }}" target="_blank" title = "{{ latest_tag }} {{ latest_commit }}" class="black-btn">{{ latest_tag }}</a>
                     <span class="footer-separator">|</span> <a href="https://github.com/Submitty/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub" class="black-btn"><i class="fab fa-github fa-lg"></i></a>
-                    <span class="footer-separator">|</span> <a href="https://rcos.io" target="_blank" class="black-btn">An RCOS project</a>
+                    <span class="footer-separator">|</span> <a href="https://new.rcos.io" target="_blank" class="black-btn">An RCOS project</a>
 
                     {% for link in footer_links %}
                         <span class="footer-separator">|</span>


### PR DESCRIPTION
Fixes #9875 RCOS link redirecting to the "new.rcos.io"

### What is the current behavior?
The RCOS link at the bottom of the page was redirecting to rcos.io link

### What is the new behavior?
The updated RCOS link redirects to "new.rcos.io" link
