### PR TITLE
Changed the calendar.css

### DIFF
--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -230,7 +230,7 @@ a.cal-gradeable-status-ann {
 a.cal-gradeable-status-ann:hover {
     padding: 0;
     font-style: italic;
-    cursor: default;
+    cursor: initial;
     border-style: solid;
     border-width: 3px!important;
 }


### PR DESCRIPTION
To achieve the expected behavior where the cursor never changes when hovering over the border of an announcement, we should set the cursor property to initial instead of default.
Change in calendar.css
a.cal-gradeable-status-ann:hover {
    padding: 0;
    font-style: italic;
    cursor: initial;
    border-style: solid;
    border-width: 3px!important;
}
