### PR TITLE
[Documentation:Developer] Wrap placeholder text in HTML comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -22,10 +22,10 @@ Steps to reproduce the behavior:
 
 **Configuration**
  - OS: [e.g. Windows, Linux, ...]
- - Browser [e.g. chrome, safari]
+ - Browser [e.g. Chrome, Safari]
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,13 @@ assignees: ''
 ---
 
 **What problem are you trying to solve with Submitty**
-A clear and concise description of what the problem is.
+<!-- A clear and concise description of what the problem is. -->
 
 **Describe the way you'd like to solve this problem**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe any potential alternatives you'd tried to solve the problem**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
### What is the current behavior?
Our issue templates currently include placeholder text.  If the placeholder text is not removed manually prior to opening an issue, the placeholder text will remain visible once the issue is opened.

### What is the new behavior?
To reduce the amount of spam in our new issues, I have wrapped the placeholder text in HTML comments.  The placeholder text will now be hidden if it is not removed prior to opening an issue.