### PR TITLE
[Bugfix:TAGrading] Modify TA/Admin's rows in lab grading

### DIFF
--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -221,7 +221,7 @@
 {% macro render_row(action, gradeable, section_id, grade, index, components_numeric, anon_ids) %}
     <tr id="row-{{ section_id }}-{{ index }}" data-gradeable="{{ gradeable.getId() }}" data-user="{{ grade.getSubmitter().getId() }}" data-anon="{{ anon_ids[grade.getSubmitter().getId()] }}" data-row="{{ index }}"
         {% if not grade.getSubmitter().isTeam() and grade.getSubmitter().getUser().accessGrading() %}
-            style='background: #7bd0f7;'
+            class="highlighted-row"
         {% endif %}
     >
         <td class="">{{ index + 1 }}</td>

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -53,12 +53,8 @@ tr:nth-child(even) td:nth-child(n+1):nth-child(-n+5) {
     background: var(--standard-light-gray);
 }
 
-.highlighted-row td:nth-child(n+1):nth-child(-n+5) {
+.highlighted-row td:nth-child(n+1):nth-child(-n+5){
     background: var(--standard-focus-cornflower-blue) !important ;
-}
-
-tr:nth-child(odd) td:nth-child(n+1):nth-child(-n+5) {
-    background: var(--default-white);
 }
 
 #data-table td:focus,

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -53,6 +53,10 @@ tr:nth-child(even) td:nth-child(n+1):nth-child(-n+5) {
     background: var(--standard-light-gray);
 }
 
+.highlighted-row td:nth-child(n+1):nth-child(-n+5){
+    background: var(--standard-focus-cornflower-blue) !important ;
+}
+
 #data-table td:focus,
 #data-table textarea:focus,
 #data-table input:focus {

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -45,16 +45,16 @@ tr > td:nth-child(5) {
     border-right: 1px solid var(--standard-medium-gray);
 }
 
+.highlighted-row td:nth-child(n+1):nth-child(-n+5){
+    background: var(--standard-focus-cornflower-blue) !important ;
+}
+
 tr:nth-child(odd) td:nth-child(n+1):nth-child(-n+5) {
     background: var(--default-white);
 }
 
 tr:nth-child(even) td:nth-child(n+1):nth-child(-n+5) {
     background: var(--standard-light-gray);
-}
-
-.highlighted-row td:nth-child(n+1):nth-child(-n+5){
-    background: var(--standard-focus-cornflower-blue) !important ;
 }
 
 #data-table td:focus,

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -53,8 +53,12 @@ tr:nth-child(even) td:nth-child(n+1):nth-child(-n+5) {
     background: var(--standard-light-gray);
 }
 
-.highlighted-row td:nth-child(n+1):nth-child(-n+5){
+.highlighted-row td:nth-child(n+1):nth-child(-n+5) {
     background: var(--standard-focus-cornflower-blue) !important ;
+}
+
+tr:nth-child(odd) td:nth-child(n+1):nth-child(-n+5) {
+    background: var(--default-white);
 }
 
 #data-table td:focus,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<img width="1019" alt="image" src="https://github.com/Submitty/Submitty/assets/122962727/868bb582-669e-40a2-a2b9-0021abeb0fb1">
TA/admin color in lab's grading is exactly like other students in /courses/f23/sample/gradeable/grading_lab/grading?view=all
The blue checks were also not able to be removed for TA which is originally supposed be used to highlight TA. Possibly caused by duplicated blue.

### What is the new behavior?
TA/Admin's color now highlighted and matches the color shown in manage student. 
<img width="1019" alt="image" src="https://github.com/Submitty/Submitty/assets/122962727/d9ba8e0a-4ee4-47d9-9092-279d5e4f6ae8">
Here is TA/admin colors as reference
<img width="1016" alt="image" src="https://github.com/Submitty/Submitty/assets/122962727/3e57ad3d-2cac-474e-ac5b-78a057208323">

### Other information?
<!-- How did you test -->
Tested in dark mode to verify if its color is still the same comparing to manage student.