### PR TITLE
[Refactor:CourseMaterials] Use one variable for beginning of time

### DIFF
--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -13,6 +13,9 @@ class DateUtils {
     /** @var string $MAX_TIME Max limit we allow for parsed DateTimes to avoid compatibility issues between PHP and DB */
     const MAX_TIME = '9999-02-01 00:00:00';
 
+    /** @var string $BEGINING_OF_TIME feature we use in Course Materials */
+    const BEGINING_OF_TIME = '1900-02-01 00:00:00';
+
     /** @var \DateTimeZone $timezone */
     private static $timezone;
 

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -136,7 +136,7 @@
                             let date;
                             switch (index) {
                                 case 0:
-                                    date = new Date("1900-01-01 00:00:00");
+                                    date = new Date('{{ begining_of_time_date }}');
                                     break;
                                 case 1:
                                     date = new Date();

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -133,7 +133,7 @@
                         let date;
                         switch (index) {
                             case 0:
-                                date = new Date("1900-01-01 00:00:00");
+                                date = new Date('{{ begining_of_time_date }}');
                                 break;
                             case 1:
                                 date = new Date();

--- a/site/app/templates/course/SetAllReleaseForm.twig
+++ b/site/app/templates/course/SetAllReleaseForm.twig
@@ -56,7 +56,7 @@
                             let date;
                             switch (index) {
                                 case 0:
-                                    date = new Date("1900-01-01 00:00:00");
+                                    date = new Date('{{ begining_of_time_date }}');
                                     break;
                                 case 1:
                                     date = new Date();

--- a/site/app/templates/course/SetFolderReleaseForm.twig
+++ b/site/app/templates/course/SetFolderReleaseForm.twig
@@ -89,7 +89,7 @@
                                 let date;
                                 switch (index) {
                                     case 0:
-                                        date = new Date("1900-01-01 00:00:00");
+                                        date = new Date('{{ begining_of_time_date }}');
                                         break;
                                     case 1:
                                         date = new Date();

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -179,7 +179,7 @@
                                 let date;
                                 switch (index) {
                                     case 0:
-                                        date = new Date("1900-01-01 00:00:00");
+                                        date = new Date('{{ begining_of_time_date }}');
                                         break;
                                     case 1:
                                         date = new Date();

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -5,6 +5,7 @@ namespace app\views\course;
 use app\entities\course\CourseMaterial;
 use app\libraries\FileUtils;
 use app\views\AbstractView;
+use app\libraries\DateUtils;
 
 class CourseMaterialsView extends AbstractView {
     public function listCourseMaterials(array $course_materials_db) {
@@ -26,7 +27,7 @@ class CourseMaterialsView extends AbstractView {
         $folder_ids = [];
         $links = [];
         $base_view_url = $this->core->buildCourseUrl(['course_material']);
-        $begining_of_time_date = "1900-01-01 00:00:00";
+        $begining_of_time_date = DateUtils::BEGINING_OF_TIME;
         /** @var CourseMaterial $course_material */
         foreach ($course_materials_db as $course_material) {
             $rel_path = substr($course_material->getPath(), strlen($base_course_material_path) + 1);

--- a/site/app/views/course/CourseMaterialsView.php
+++ b/site/app/views/course/CourseMaterialsView.php
@@ -26,7 +26,7 @@ class CourseMaterialsView extends AbstractView {
         $folder_ids = [];
         $links = [];
         $base_view_url = $this->core->buildCourseUrl(['course_material']);
-
+        $begining_of_time_date = "1900-01-01 00:00:00";
         /** @var CourseMaterial $course_material */
         foreach ($course_materials_db as $course_material) {
             $rel_path = substr($course_material->getPath(), strlen($base_course_material_path) + 1);
@@ -156,7 +156,8 @@ class CourseMaterialsView extends AbstractView {
             "course_materials" => $final_structure,
             "folder_ids" => $folder_ids,
             "links" => $links,
-            "folder_paths" => $folder_paths
+            "folder_paths" => $folder_paths,
+            "begining_of_time_date" => $begining_of_time_date
         ]);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
The beginning of time feature is used in all date time picker in course materials. We recently changed the date from 1000 to 1900. 
### What is the new behavior?
In case we decide to change it again later, this refactor would allow the developer to change one variable in one file, instead of 5 different ones in 5 different files.
### Other information?
Closes #9762
<!-- Is this a breaking change? -->
<!-- How did you test -->
