### PR TITLE
[Bugfix:System] Fix session cookie not updating

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -892,7 +892,7 @@ class Core {
                 }
                 else {
                     // If more than a day has passed since we last updated the cookie, update it with the new timestamp
-                    if ($this->session_manager->shouldSessionBeUpdated()) {
+                    if ($this->session_manager->checkAndUpdateSession()) {
                         $new_token = TokenManager::generateSessionToken(
                             $session_id,
                             $token->claims()->get('sub')

--- a/site/app/libraries/SessionManager.php
+++ b/site/app/libraries/SessionManager.php
@@ -58,11 +58,18 @@ class SessionManager {
 
     /**
      * Sessions should only be updated once per day to reduce load on the server.
-     * Check whether a day has passed since we last updated this session
+     * Updates the session if needed and returns if the update was performed.
      */
-    public function shouldSessionBeUpdated(): bool {
+    public function checkAndUpdateSession(): bool {
         $day_before_expiration = (new DateTime())->add(DateInterval::createFromDateString(self::SESSION_EXPIRATION))->sub(DateInterval::createFromDateString('1 day'));
-        return $this->session->getSessionExpires() < $day_before_expiration;
+        $needs_update = $this->session->getSessionExpires() < $day_before_expiration;
+
+        if ($needs_update) {
+            $this->session->updateSessionExpiration($this->core->getDateTimeNow());
+            $this->core->getSubmittyEntityManager()->flush();
+        }
+
+        return $needs_update;
     }
 
     /**

--- a/site/app/libraries/SessionManager.php
+++ b/site/app/libraries/SessionManager.php
@@ -53,12 +53,6 @@ class SessionManager {
             return false;
         }
 
-        // Only refresh the session once per day
-        if ($this->shouldSessionBeUpdated()) {
-            $this->session->updateSessionExpiration($this->core->getDateTimeNow());
-            $em->flush();
-        }
-
         return $this->session->getUserId();
     }
 

--- a/site/tests/app/libraries/SessionManagerTester.php
+++ b/site/tests/app/libraries/SessionManagerTester.php
@@ -82,7 +82,7 @@ class SessionManagerTester extends BaseUnitTest {
             ->expects($this->once())
             ->method('remove');
         $core->getSubmittyEntityManager()
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('flush');
         $manager = new SessionManager($core);
         $this->assertEquals('test', $manager->getSession('id'));

--- a/site/tests/app/libraries/SessionManagerTester.php
+++ b/site/tests/app/libraries/SessionManagerTester.php
@@ -60,14 +60,6 @@ class SessionManagerTester extends BaseUnitTest {
             ->method('getActiveSessionById')
             ->with('id')
             ->willReturn($session);
-        $session->expects($this->once())
-            ->method('updateSessionExpiration')
-            ->with(
-                $this->callback(function (\DateTime $dt): bool {
-                    $this->assertInstanceOf(\DateTime::class, $dt);
-                    return true;
-                })
-            );
         $core->getSubmittyEntityManager()
             ->expects($this->exactly(0))
             ->method('persist');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When the session gets closer to expiration it will update on the database but not the cookie. Thus the cookie will still expire and log the user out after the session expiration time.  The issue was introduced in https://github.com/Submitty/Submitty/pull/8620.

### What is the new behavior?
The cookie will now update when the session updates. The user will only get logged out after 2 weeks of inactivity.
