### PR TITLE
[Bugfix:Forum] Fix syntax error for error handling

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1766,8 +1766,8 @@ function deletePostToggle(isDeletion, thread_id, post_id, author, time, csrf_tok
                 }
                 catch (err) {
                     // eslint-disable-next-line no-undef
-                    displayErrorMessage('Error parsing data. Please try again').
-                        return;
+                    displayErrorMessage('Error parsing data. Please try again');
+                    return;
                 }
                 if (json['status'] === 'fail') {
                     // eslint-disable-next-line no-undef

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1709,8 +1709,8 @@ function reorderCategories(csrf_token) {
             }
             catch (err) {
                 // eslint-disable-next-line no-undef
-                displayErrorMessage('Error parsing data. Please try again').
-                    return;
+                displayErrorMessage('Error parsing data. Please try again');
+                return;
             }
             if (json['status'] === 'fail') {
                 // eslint-disable-next-line no-undef
@@ -1972,8 +1972,8 @@ function loadThreadHandler() {
                 }
                 catch (err) {
                     // eslint-disable-next-line no-undef
-                    displayErrorMessage('Error parsing data. Please try again').
-                        return;
+                    displayErrorMessage('Error parsing data. Please try again');
+                    return;
                 }
                 if (json['status'] === 'fail') {
                     // eslint-disable-next-line no-undef


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant
* [] Screenshots are attached to Github PR if visual/UI changes were made (N/A)

### What is the current behavior?
If the forum backend sends an invalid JSON response the client-side code to handle it throws an exception due to invalid syntax this prevents the cypress test for forum pronoun changes to fail since it will abort on an exception thrown from our software

### What is the new behavior?
Removes the error allowing cypress to pass that part of the test and prevents the forum from silently putting exceptions in the console if this happens to a real user. 


