### PR TITLE
[Bugfix:Notifications] Fix flattened email count

### DIFF
--- a/site/app/libraries/NotificationFactory.php
+++ b/site/app/libraries/NotificationFactory.php
@@ -269,8 +269,8 @@ class NotificationFactory {
             }
         }
         if (!empty($flattened_emails)) {
-            $this->core->getQueries()->insertEmails($flattened_emails, count($flattened_emails) / 6);
+            $this->core->getQueries()->insertEmails($flattened_emails, count($flattened_emails) / 7);
         }
-        return count($flattened_emails) / 6;
+        return count($flattened_emails) / 7;
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
If you make an announcement, a site error will occur due to the flattened email count being divided by the wrong number.

### What is the new behavior?
Making an announcement no longer creates an error and that count is now divided by the right number.

### Other information?
Tested locally and works as expected now.
