### PR TITLE
[Bugfix:System] Fixes CSV Upload Error

### DIFF
--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -342,7 +342,10 @@ class LateController extends AbstractController {
             ];
         }
 
-        $rows = file($csv_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $file_content = file_get_contents($csv_file);
+        $file_content = preg_replace("/\r\n|\r/", "\n", $file_content);
+        $rows = explode("\n", $file_content);
+        $rows = array_filter($rows, 'strlen');
         if ($rows === false) {
             $data = null;
             return [

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -343,16 +343,16 @@ class LateController extends AbstractController {
         }
 
         $file_content = file_get_contents($csv_file);
-        $file_content = preg_replace("/\r\n|\r/", "\n", $file_content);
-        $rows = explode("\n", $file_content);
-        $rows = array_filter($rows, 'strlen');
-        if ($rows === false) {
+        if ($file_content === false) {
             $data = null;
             return [
                 "success" => false,
                 "error" => "Could not open CSV file for reading",
             ];
         }
+        $file_content = preg_replace("/\r\n|\r/", "\n", $file_content);
+        $rows = explode("\n", $file_content);
+        $rows = array_filter($rows, 'strlen');
         foreach ($rows as $idx => $row) {
             $row_number = $idx + 1;
             $fields = explode(',', $row);

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -341,9 +341,8 @@ class LateController extends AbstractController {
                 "error" => "Invalid mimetype, must start with 'text/', got '{$mime_type}'"
             ];
         }
-        $context = stream_context_create(['file' => ['eol' => "\n"]]);
 
-        $rows = file($csv_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES, $context);
+        $rows = file($csv_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if ($rows === false) {
             $data = null;
             return [

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -341,9 +341,9 @@ class LateController extends AbstractController {
                 "error" => "Invalid mimetype, must start with 'text/', got '{$mime_type}'"
             ];
         }
-        ini_set("auto_detect_line_endings", true);
+        $context = stream_context_create(['file' => ['eol' => "\n"]]);
 
-        $rows = file($csv_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $rows = file($csv_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES, $context);
         if ($rows === false) {
             $data = null;
             return [


### PR DESCRIPTION
Closes #9871
### What is the current behavior?
Currently, when uploading a CSV file on the excused absence extension page, an error is given due to invalid json being parsed.
This is due to a deprecated code warning in lateController.php for ini_set("auto_detect_line_endings", true);.
![image](https://github.com/Submitty/Submitty/assets/143554378/60667c38-1b1a-4e44-ae2d-b2aa130a2d33)


### What is the new behavior?
Deprecated code is replaced by manual newline parsing, removing the error.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
