### PR TITLE
[Bugfix:RainbowGrades] Remove display benchmark

### DIFF
--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -28,13 +28,12 @@ class RainbowCustomizationJSON extends AbstractModel {
     private $gradeables = [];
 
     // The order of allowed_display and allowed_display_description has to match
-    const allowed_display = ['grade_summary', 'grade_details', 'display_benchmark', 'benchmark_percent',
+    const allowed_display = ['grade_summary', 'grade_details', 'benchmark_percent',
         'exam_seating', 'section', 'messages', 'warning', 'final_grade', 'manual_grade', 'final_cutoff', 'instructor_notes'];
 
     const allowed_display_description = [
         "Display a column(row) for each gradeable bucket on the syllabus.", //grade_summary
         "Display a column(row) for each gradeable within each gradeable bucket on the syllabus.", //grade_details
-        "Display a row(column) for each benchmark/comparison selected below.", //display_benchmark
         "not used", //benchmark_percent
         "Used for assigned seating for exams, see also:  <a href='https://submitty.org/instructor/course_settings/rainbow_grades/exam_seating'>Exam Seating</a> ", //exam_seating
         "Display the students registration section.", //section


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
fixes #9933 
There is problem with display benchmark button, removing the option so that GUI do not insert invalid argument to json file.
### What is the new behavior?
![Screen Shot 2023-10-26 at 1 22 02 AM](https://github.com/Submitty/Submitty/assets/123261952/8c065e36-690c-4d76-8206-0c2b68e7461b)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
