### PR TITLE
[Refactor: SQLTables] Renaming "late_day_exceptions" table and column

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -840,6 +840,17 @@ CREATE TABLE public.electronic_gradeable_version (
 
 
 --
+-- Name: excused_absence_extensions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.excused_absence_extensions (
+    user_id character varying(255) NOT NULL,
+    g_id character varying(255) NOT NULL,
+    excused_absence_extensions integer NOT NULL
+);
+
+
+--
 -- Name: forum_posts_history; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1217,17 +1228,6 @@ CREATE TABLE public.grading_rotating (
     sections_rotating_id integer NOT NULL,
     user_id character varying NOT NULL,
     g_id character varying NOT NULL
-);
-
-
---
--- Name: late_day_exceptions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.late_day_exceptions (
-    user_id character varying(255) NOT NULL,
-    g_id character varying(255) NOT NULL,
-    late_day_exceptions integer NOT NULL
 );
 
 
@@ -2214,10 +2214,10 @@ ALTER TABLE ONLY public.grading_rotating
 
 
 --
--- Name: late_day_exceptions late_day_exceptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: excused_absence_extensions late_day_exceptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.late_day_exceptions
+ALTER TABLE ONLY public.excused_absence_extensions
     ADD CONSTRAINT late_day_exceptions_pkey PRIMARY KEY (g_id, user_id);
 
 
@@ -2564,10 +2564,10 @@ CREATE TRIGGER gradeable_version_change AFTER INSERT OR DELETE OR UPDATE ON publ
 
 
 --
--- Name: late_day_exceptions late_day_extension_change; Type: TRIGGER; Schema: public; Owner: -
+-- Name: excused_absence_extensions late_day_extension_change; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER late_day_extension_change AFTER INSERT OR DELETE OR UPDATE ON public.late_day_exceptions FOR EACH ROW EXECUTE PROCEDURE public.late_day_extension_change();
+CREATE TRIGGER late_day_extension_change AFTER INSERT OR DELETE OR UPDATE ON public.excused_absence_extensions FOR EACH ROW EXECUTE PROCEDURE public.late_day_extension_change();
 
 
 --
@@ -3050,18 +3050,18 @@ ALTER TABLE ONLY public.late_day_cache
 
 
 --
--- Name: late_day_exceptions late_day_exceptions_g_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: excused_absence_extensions late_day_exceptions_g_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.late_day_exceptions
+ALTER TABLE ONLY public.excused_absence_extensions
     ADD CONSTRAINT late_day_exceptions_g_id_fkey FOREIGN KEY (g_id) REFERENCES public.gradeable(g_id) ON DELETE CASCADE;
 
 
 --
--- Name: late_day_exceptions late_day_exceptions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: excused_absence_extensions late_day_exceptions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.late_day_exceptions
+ALTER TABLE ONLY public.excused_absence_extensions
     ADD CONSTRAINT late_day_exceptions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON UPDATE CASCADE;
 
 

--- a/migration/migrator/migrations/course/20231022152303_renaming_late_day_exceptions.py
+++ b/migration/migrator/migrations/course/20231022152303_renaming_late_day_exceptions.py
@@ -1,0 +1,43 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+
+    sql = """ALTER TABLE late_day_exceptions RENAME TO excused_absence_extensions;
+            ALTER TABLE excused_absence_extensions RENAME COLUMN late_day_exceptions TO excused_absence_extensions;"""
+    database.execute(sql)
+
+    pass
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+
+    sql = """ALTER TABLE excused_absence_extensions RENAME TO late_day_exceptions;
+            ALTER TABLE late_day_exceptions RENAME COLUMN excused_absence_extensions TO late_day_exceptions;"""
+    database.execute(sql)
+
+    pass

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4284,13 +4284,13 @@ ORDER BY gt.{$section_key}",
         $this->course_db->query(
             "
         SELECT u.user_id, user_givenname,
-          user_preferred_givenname, user_familyname, late_day_exceptions
+          user_preferred_givenname, user_familyname, excused_absence_extensions
         FROM users as u
-        FULL OUTER JOIN late_day_exceptions as l
+        FULL OUTER JOIN excused_absence_extensions as l
           ON u.user_id=l.user_id
         WHERE g_id=?
-          AND late_day_exceptions IS NOT NULL
-          AND late_day_exceptions>0
+          AND excused_absence_extensions IS NOT NULL
+          AND excused_absence_extensions>0
         ORDER BY user_email ASC;",
             [$gradeable_id]
         );
@@ -7964,11 +7964,11 @@ WHERE current_state IN
               /* Join team late day exceptions */
               LEFT JOIN (
                 SELECT
-                  json_agg(e.late_day_exceptions) AS array_late_day_exceptions,
+                  json_agg(e.excused_absence_extensions) AS array_late_day_exceptions,
                   json_agg(e.user_id) AS array_late_day_user_ids,
                   t.team_id,
                   g_id
-                FROM late_day_exceptions e
+                FROM excused_absence_extensions e
                 LEFT JOIN teams t ON e.user_id=t.user_id AND t.state=1
                 GROUP BY team_id, g_id
               ) AS ldet ON g.g_id=ldet.g_id AND ldet.team_id=team.team_id';
@@ -7995,7 +7995,7 @@ WHERE current_state IN
               u.course_section_id,
               u.rotating_section,
               u.registration_type,
-              ldeu.late_day_exceptions,
+              ldeu.excused_absence_extensions,
               u.registration_subsection';
             $submitter_inject = '
             JOIN (
@@ -8019,7 +8019,7 @@ WHERE current_state IN
             ) AS u ON (eg IS NULL OR NOT eg.team_assignment) AND u. g_id=g.g_id
 
             /* Join user late day exceptions */
-            LEFT JOIN late_day_exceptions ldeu ON g.g_id=ldeu.g_id AND u.user_id=ldeu.user_id';
+            LEFT JOIN excused_absence_extensions ldeu ON g.g_id=ldeu.g_id AND u.user_id=ldeu.user_id';
         }
         if ($team && count($teams) > 0) {
             $team_placeholders = implode(',', array_fill(0, count($teams), '?'));


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
There is a database table named "late_day_exceptions" and a column in that same table also named "late_day_exceptions".

A common confusion is between "late days" (student controlled homework deadline flexibility on any assignment)
and "excused absence extensions" (instructor entered deadline extensions for a specific assignment)
![image](https://github.com/Submitty/Submitty/assets/143554135/afb679fc-2beb-45ce-a2cf-d3d1cf5c0cdf)


### What is the new behavior?
Only the "late_day_exceptions" table and "late_day_exceptions" column inside of the table names have been changed to "excused_absence_extensions". These changes have also been made in DatabaseQueries.php, but no "late_day_exceptions" variable names have been changed.

<img width="304" alt="image" src="https://github.com/Submitty/Submitty/assets/143554135/5ec6f0b7-e4aa-4de1-9729-1cc00f7f2974">



