### PR TITLE
[Feature:Developer] Add README Dark Mode Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img src="http://submitty.org/images/submitty_logo.png" alt="Submitty Logo" width="500px"/>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/Submitty/Submitty/blob/main/site/public/img/submitty_logo_white.png?raw=true">
+    <img src="https://github.com/Submitty/Submitty/blob/main/site/public/img/submitty_logo.png?raw=true" alt="Submitty Logo" width="500px"/>
+  </picture>
 </p>
 
 [![Submitty CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When looking at the dark mode GitHub main repo page for Submitty, the logo is extremely difficult to see.
<img width="1025" alt="image" src="https://github.com/Submitty/Submitty/assets/55092742/44a4f069-4eb0-4a42-9be9-069913b68d1f">


### What is the new behavior?
When using dark mode, the README will render the dark mode version instead.
<img width="1021" alt="image" src="https://github.com/Submitty/Submitty/assets/55092742/d8943eb4-5a34-4b4e-829f-30c783819a29">


### Other information?
This uses the picture tag to conditionally render the specific image. Nothing will change for light mode users.
