### PR TITLE
[Bugfix:Developer] Fix Main CI success message

### DIFF
--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Echo success message
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         run: |
-            echo('All Tests have passed')
+            echo "All Tests have passed" 

--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Echo success message
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         run: |
-            echo "All Tests have passed" 
+            echo "All Tests have passed"


### PR DESCRIPTION
### What is the current behavior?
Currently the Notify Main on CI Failure workflow fails if the CI doesn't because of a syntax error in the echo statement.

### What is the new behavior?
This syntax error is no longer present. 