### PR TITLE
[Bugfix:Developer] Use id for main notifications

### DIFF
--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
             curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
             --data-urlencode 'topic=Main CI Failures' --data-urlencode \
-            'content=The Github Actions CI has failed on the Main branch, View here: [Main CI](https://github.com/Submitty/Submitty/actions/runs/${{ github.event.workflow_run.run_id }})'
+            'content=The Github Actions CI has failed on the Main branch, View here: [Main CI](https://github.com/Submitty/Submitty/actions/runs/${{ github.event.workflow_run.id }})'
       - name: Echo success message
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         run: |


### PR DESCRIPTION
### What is the current behavior?
I tested this functionality on a fork, and forgot to bring a change that fixed this issue. The workflow_run event has an id, not a run_id. 

### What is the new behavior?
The URL used for the link now has the accurate information, so it will show the Main CI that failed. 