### PR TITLE
[Bugfix:Forum] Markdown Code stays highlighted

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -345,6 +345,7 @@ function socketNewOrEditPostHandler(post_id, reply_level, post_box_id=null, edit
                 // eslint-disable-next-line no-undef
                 file_array[post_box_id] = [];
                 uploadImageAttachments(`#${post_id}-reply .upload_attachment_box`);
+                hljs.highlightAll();
 
             }
             catch (error) {
@@ -2016,6 +2017,8 @@ function loadThreadHandler() {
                 saveScrollLocationOnRefresh('posts_list');
 
                 $('.post_reply_form').submit(publishPost);
+
+                hljs.highlightAll();
             },
             error: function() {
                 window.alert('Something went wrong while trying to display thread details. Please try again.');

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1,4 +1,4 @@
-/* global displaySuccessMessage */
+/* global displaySuccessMessage, hljs */
 
 // eslint-disable-next-line no-unused-vars
 function categoriesFormEvents() {
@@ -345,7 +345,6 @@ function socketNewOrEditPostHandler(post_id, reply_level, post_box_id=null, edit
                 // eslint-disable-next-line no-undef
                 file_array[post_box_id] = [];
                 uploadImageAttachments(`#${post_id}-reply .upload_attachment_box`);
-                // eslint-disable-next-line no-undef
                 hljs.highlightAll();
 
             }
@@ -2018,7 +2017,6 @@ function loadThreadHandler() {
                 saveScrollLocationOnRefresh('posts_list');
 
                 $('.post_reply_form').submit(publishPost);
-                // eslint-disable-next-line no-undef
                 hljs.highlightAll();
             },
             error: function() {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2017,7 +2017,6 @@ function loadThreadHandler() {
                 saveScrollLocationOnRefresh('posts_list');
 
                 $('.post_reply_form').submit(publishPost);
-
                 hljs.highlightAll();
             },
             error: function() {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -345,6 +345,7 @@ function socketNewOrEditPostHandler(post_id, reply_level, post_box_id=null, edit
                 // eslint-disable-next-line no-undef
                 file_array[post_box_id] = [];
                 uploadImageAttachments(`#${post_id}-reply .upload_attachment_box`);
+                // eslint-disable-next-line no-undef
                 hljs.highlightAll();
 
             }
@@ -2017,6 +2018,7 @@ function loadThreadHandler() {
                 saveScrollLocationOnRefresh('posts_list');
 
                 $('.post_reply_form').submit(publishPost);
+                // eslint-disable-next-line no-undef
                 hljs.highlightAll();
             },
             error: function() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When changing between threads, markdown code would lose the highlights made by hljs.

### What is the new behavior?
The markdown code stays highlighted when flipping through threads and for new posts coming in from other users.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
