### PR TITLE
[Bugfix:Forum] Fixing Fixed Markdown Area Texbox

### DIFF
--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -173,9 +173,9 @@
 }
 
 .markdown-area textarea {
-    resize: vertical;
+    resize: none;
+    overflow-y: hidden;
     min-height: 100px;
-    max-height: 300px;
     tab-size: 4;
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
The text box for markdown regions on the forum can be expanded, but the box returns to its original size when you enter more text into it. I tested some other text boxes and most had the same issue.

https://github.com/Submitty/Submitty/assets/143554135/549b8b0b-4a45-491b-9587-d7cd57c0e183

### What is the new behavior?
Talked to Cutler and we agreed to remove the user resizing all together and make it so that it auto resizes without needing a scroll bar. This works for every text box that had the same problem (i.e. creating submini poll, course setting).

https://github.com/Submitty/Submitty/assets/143554135/6fce6389-e803-449a-8dde-8145651b6d38