### PR TITLE
[Testing:Developer] Specific Errors for accessibility.spec.js

### DIFF
--- a/site/cypress/e2e/Cypress-System/accessibility.spec.js
+++ b/site/cypress/e2e/Cypress-System/accessibility.spec.js
@@ -107,7 +107,9 @@ describe('Test cases for the site\'s adherence to accessibility guidelines', () 
                             });
                         }
 
-                        expect(foundErrors).to.be.empty;
+                        if (foundErrors.length > 0) {
+                            throw new Error(`Accessibility errors at ${url}:\n${foundErrorMessages.join('\n')}`);
+                        }
                     });
                 });
             });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, when failing accessibility.spec.js, no specific error messages are given and an assertion error shows up. This makes the test very difficult to debug.
![image](https://github.com/Submitty/Submitty/assets/143554378/1fb5640d-54a1-4476-aff7-41744b9bd8da)


### What is the new behavior?
On this branch, the test now displays all found error messages when failing, making it easier to debug.
![image](https://github.com/Submitty/Submitty/assets/143554378/4ee22f04-6ddf-4d78-8dbd-5d6eb9d8d3ee)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
