### PR TITLE
sql toolbox resize changes only vertial resize

### DIFF
--- a/site/public/css/sql-toolbox.css
+++ b/site/public/css/sql-toolbox.css
@@ -1,6 +1,10 @@
 #toolbox-textarea {
     width: 100%;
     height: 300px;
+    max-width: 100%;
+    min-width: 100%;
+    min-height: 300px;
+    box-sizing: border-box;
 }
 
 #query-results {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
#10016 
unexpected text area resizable 

### What is the new behavior?
The SQL toolbox text area does not expand beyond the parent div. as now text area is always on 100% width and minimum height is now 300px and can expand vertically only.


https://github.com/Submitty/Submitty/assets/85556603/2d4ddaa8-a324-46f6-ae3f-c37f9345d410


### Other information?
<!-- Is this a breaking change? -->
  minor CSS styling changes
<!-- How did you test -->
Checked on Different broswers and resizing tab window and textarea.
