### PR TITLE
[Bugfix:RainbowGrades] Remove invalid display options

### DIFF
--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -28,20 +28,14 @@ class RainbowCustomizationJSON extends AbstractModel {
     private $gradeables = [];
 
     // The order of allowed_display and allowed_display_description has to match
-    const allowed_display = ['grade_summary', 'grade_details', 'benchmark_percent',
-        'exam_seating', 'section', 'messages', 'warning', 'final_grade', 'manual_grade', 'final_cutoff', 'instructor_notes'];
+    const allowed_display = ['grade_summary', 'grade_details',
+        'exam_seating', 'final_grade', 'instructor_notes'];
 
     const allowed_display_description = [
         "Display a column(row) for each gradeable bucket on the syllabus.", //grade_summary
         "Display a column(row) for each gradeable within each gradeable bucket on the syllabus.", //grade_details
-        "not used", //benchmark_percent
         "Used for assigned seating for exams, see also:  <a href='https://submitty.org/instructor/course_settings/rainbow_grades/exam_seating'>Exam Seating</a> ", //exam_seating
-        "Display the students registration section.", //section
-        "Display the optional text message at the top of the page.", //messages
-        "not used", //warning
         "Display the student's final term letter grade.", //final_grade
-        "not used", //manual_grade
-        "Display the histogram of average overall grade and count of students with each final term letter grade.", //final_cutoff
         "Optional message for specific students that are only visible on the instructor gradebook, these messages are never displayed to students." //instructor_notes
     ];
 

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -28,8 +28,13 @@ class RainbowCustomizationJSON extends AbstractModel {
     private $gradeables = [];
 
     // The order of allowed_display and allowed_display_description has to match
-    const allowed_display = ['grade_summary', 'grade_details',
-        'exam_seating', 'final_grade', 'instructor_notes'];
+    const allowed_display = [
+        'grade_summary',
+        'grade_details',
+        'exam_seating',
+        'final_grade',
+        'instructor_notes',
+    ];
 
     const allowed_display_description = [
         "Display a column(row) for each gradeable bucket on the syllabus.", //grade_summary


### PR DESCRIPTION
Currently there are invalid checkboxes in web based customization page, which creates errors (OOPS).
Indeed, this is a bad implement that leads a lot of confusion, because we are currently misusing/handling "display options" and "token" 

Display options includes following
` ["instructor_notes", "exam_seating", "academic_sanction_details" ("moss_details"),   "final_grade", "grade_summary", "grade_details", "display_rank_to_individual"(no longer used)]`

Tokens, includes following
`[messages, bonus_latedays, gradeables, final_cutoff, manual_grade, independentstudy, audit, earned_late_days]` etc

I have no idea why I tried to handle two separate entities at the same time. 

I think the correct way to handle this is

Create entry section for all tokens (just like we did for plagiarism)
Optionally we can keep the idea of checkbox to hide/appear those entry sections.

Anyhow, since we have instructors facing trouble, this would be initial fix


