### PR TITLE
[Bugfix:Submission] Moved the text outside the label tag.

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -202,7 +202,7 @@
             const warningIds = {"hide-materials-checkbox": "upload-form", "hide-materials-checkbox-edit": "edit-form", "hide-folder-materials-checkbox-edit": "edit-folder-form"};
             var callerId = clicked.target ? clicked.target.id : clicked; //can be an event or id itself
             var caller = $('#'+callerId);
-            var warningMessage = $('#'+callerId+' ~ #'+warningIds[callerId]+'-hide-warning');
+            var warningMessage = $('#'+warningIds[callerId]+'-hide-warning');
             if (caller.hasClass('partial-checkbox')) {
                 caller.removeClass('partial-checkbox');
                 caller.siblings()[0].remove();
@@ -212,10 +212,10 @@
                 caller.prop('checked', true);
             }
             if(caller.is(':checked') && warningMessage.length === 0) {
-                var callerParent = caller.parent().get(0);
-                callerParent.insertAdjacentHTML(
-                    'beforeend',
-                    '<span id="'+warningIds[callerId]+`-hide-warning" class="red-message full-width">\nWarning:
+                var callerParentNext = caller.parent().next().get(0);
+                callerParentNext.insertAdjacentHTML(
+                    'afterend',
+                    '<span id="'+warningIds[callerId]+`-hide-warning" class="red-message full-width mt-0">\nWarning:
                     Students can view the hidden course material by guessing the corresponding
                     course material ID (a simple number). It is recommended to instead use the release date feature
                     if it is necessary to prevent students from accessing course materials.\n</span>`

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -55,9 +55,12 @@
         <label>
             <input id="hide-folder-materials-checkbox-edit" type="checkbox" onchange="handleHideMaterialsChange()">
             Hide from Students<br>
+    
+        </label>
+        <p>
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
-        </label>
+        </p>
         <script>
             function handleHideMaterialsChange() {
                 enableFullUpdate();

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -52,11 +52,11 @@
             <strong>Note:</strong> <em>Everyone with grading access will be able to view all the materials irrespective of the release date/time.</em>
             </span>
         </label>
-        <label>
+        <label class="my-0">
             <input id="hide-folder-materials-checkbox-edit" type="checkbox" onchange="handleHideMaterialsChange()">
             Hide from Students
         </label>
-        <p class="mt-0">
+        <p class="my-0">
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -54,10 +54,9 @@
         </label>
         <label>
             <input id="hide-folder-materials-checkbox-edit" type="checkbox" onchange="handleHideMaterialsChange()">
-            Hide from Students<br>
-    
+            Hide from Students
         </label>
-        <p>
+        <p class="mt-0">
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -64,9 +64,11 @@
         <label>
             <input id="hide-materials-checkbox-edit" type="checkbox">
             Hide from Students<br>
+        </label>
+        <p>
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
-        </label>
+        </p>
         <label hidden id="edit-url-url-label">
             <span>
                 <strong>Edit link url:</strong>

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -61,11 +61,11 @@
             </span>
             <input id="edit-sort" value="Check" type="text" size="26"/>
         </label>
-        <label>
+        <label class="my-0">
             <input id="hide-materials-checkbox-edit" type="checkbox">
             Hide from Students
         </label>
-        <p class="mt-0">
+        <p class="my-0">
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -63,9 +63,9 @@
         </label>
         <label>
             <input id="hide-materials-checkbox-edit" type="checkbox">
-            Hide from Students<br>
+            Hide from Students
         </label>
-        <p>
+        <p class="mt-0">
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -63,9 +63,11 @@
         <label>
             <input id="hide-materials-checkbox" type="checkbox" value="off">
             Hide from Students<br>
+        </label>
+        <p>
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
-        </label>
+        </p>
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <fieldset>
             <legend class="black-message">

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -62,9 +62,9 @@
         </label>
         <label>
             <input id="hide-materials-checkbox" type="checkbox" value="off">
-            Hide from Students<br>
+            Hide from Students
         </label>
-        <p>
+         <p class="mt-0">
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -60,11 +60,11 @@
             </span>
             <input id="upload_sort" value="0.0" type="text" size="26"/>
         </label>
-        <label>
+        <label class="my-0">
             <input id="hide-materials-checkbox" type="checkbox" value="off">
             Hide from Students
         </label>
-         <p class="mt-0">
+         <p class="my-0">
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [X] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Fixes #10039 

On clicking anywhere on the paragraph of text beneath the checkbox and to the right of the "hide from students" text toggles this checkbox.

![image](https://github.com/Submitty/Submitty/assets/34382211/4d0c11a3-fc4e-4b23-bdbf-776032193c5d)


### What is the new behavior?
=> On clicking anywhere on the paragraph of text beneath the checkbox and to the right of the "hide from students" text will not toggle this checkbox.

![image](https://github.com/Submitty/Submitty/assets/34382211/234f086b-8648-4e5e-a649-44690441df33)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
None.