### PR TITLE
[Bugfix:Submission] Added note to absence extension reason

### DIFF
--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -54,6 +54,7 @@
                     </select>
                 </span>
             </label>
+            <p><strong>Note:</strong> The optional reason for extension text will be displayed to the student on the Rainbow Grades page</p>
             <a class="btn btn-primary" href="javascript:updateHomeworkExtension()">Submit</a>
         </fieldset>
         <fieldset>

--- a/site/app/templates/course/EditCourseMaterialsFolderForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsFolderForm.twig
@@ -55,9 +55,12 @@
         <label>
             <input id="hide-folder-materials-checkbox-edit" type="checkbox" onchange="handleHideMaterialsChange()">
             Hide from Students<br>
+    
+        </label>
+        <p>
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
-        </label>
+        </p>
         <script>
             function handleHideMaterialsChange() {
                 enableFullUpdate();

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -64,9 +64,11 @@
         <label>
             <input id="hide-materials-checkbox-edit" type="checkbox">
             Hide from Students<br>
+        </label>
+        <p>
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
-        </label>
+        </p>
         <label hidden id="edit-url-url-label">
             <span>
                 <strong>Edit link url:</strong>

--- a/site/app/templates/course/UploadCourseMaterialsForm.twig
+++ b/site/app/templates/course/UploadCourseMaterialsForm.twig
@@ -63,9 +63,11 @@
         <label>
             <input id="hide-materials-checkbox" type="checkbox" value="off">
             Hide from Students<br>
+        </label>
+        <p>
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
-        </label>
+        </p>
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <fieldset>
             <legend class="black-message">


### PR DESCRIPTION
fixes #10041

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [X] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
![image](https://github.com/Submitty/Submitty/assets/34382211/e5be83cd-40d1-4d0c-bfb0-f262c2a679ad)

### What is the new behavior?
=> A new paragraph tag was added below the extension.
![image](https://github.com/Submitty/Submitty/assets/34382211/bded7f25-a631-4185-9c71-47d272821420)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
None.
