### PR TITLE
[Bugfix:Submission] Bulk upload validation error

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -22,7 +22,6 @@ use app\models\GradingOrder;
 use Symfony\Component\Routing\Annotation\Route;
 use app\models\notebook\SubmissionCodeBox;
 use app\models\notebook\SubmissionMultipleChoice;
-
 // Adds Fpdi library for getting page count of pdfs
 use setasign\Fpdi\Fpdi;
 
@@ -433,7 +432,7 @@ class SubmissionController extends AbstractController {
         // Initialize new instance of FPDI and get page count
         $pdf = new Fpdi();
         $actual_page_count = $pdf->setSourceFile($dst);
-            
+
         // Check if the actual page count matches the expected count
         if ($actual_page_count % $num_pages !== 0) {
             $error_message = "The PDF page count ($actual_page_count) is not divisible by the expected count per exam ($num_pages).";

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -430,7 +430,7 @@ class SubmissionController extends AbstractController {
         }
 
         // Initialize new instance of FPDI and get page count
-        if (!empty($dst)) {
+        if (!is_null($dst)) {
             $pdf = new Fpdi();
             $actual_page_count = $pdf->setSourceFile($dst);
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -22,9 +22,9 @@ use app\models\GradingOrder;
 use Symfony\Component\Routing\Annotation\Route;
 use app\models\notebook\SubmissionCodeBox;
 use app\models\notebook\SubmissionMultipleChoice;
-use setasign\Fpdi\Fpdi;
 
-//require_once __DIR__ . "/../../../vendor/autoload.php";
+// Adds Fpdi library for getting page count of pdfs
+use setasign\Fpdi\Fpdi;
 
 class SubmissionController extends AbstractController {
     private $upload_details = [
@@ -430,6 +430,17 @@ class SubmissionController extends AbstractController {
             }
         }
 
+        // Initialize new instance of FPDI and get page count
+        $pdf = new Fpdi();
+        $actual_page_count = $pdf->setSourceFile($dst);
+            
+        // Check if the actual page count matches the expected count
+        if ($actual_page_count % $num_pages !== 0) {
+            $error_message = "The PDF page count ($actual_page_count) is not divisible by the expected count per exam ($num_pages).";
+            return $this->core->getOutput()->renderJsonFail($error_message);
+        }
+
+        // pdf_check.cgi DEPRECATED
         // use pdf_check.cgi to check that # of pages is valid and split
         // also get the cover image and name for each pdf appropriately
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -430,13 +430,15 @@ class SubmissionController extends AbstractController {
         }
 
         // Initialize new instance of FPDI and get page count
-        $pdf = new Fpdi();
-        $actual_page_count = $pdf->setSourceFile($dst);
+        if(!empty($dst)){
+            $pdf = new Fpdi();
+            $actual_page_count = $pdf->setSourceFile($dst);
 
-        // Check if the actual page count matches the expected count
-        if ($actual_page_count % $num_pages !== 0) {
-            $error_message = "The PDF page count ($actual_page_count) is not divisible by the expected count per exam ($num_pages).";
-            return $this->core->getOutput()->renderJsonFail($error_message);
+            // Check if the actual page count matches the expected count
+            if ($actual_page_count % $num_pages !== 0) {
+                $error_message = "The PDF page count ($actual_page_count) is not divisible by the expected count per exam ($num_pages).";
+                return $this->core->getOutput()->renderJsonFail($error_message);
+            }
         }
 
         // pdf_check.cgi DEPRECATED

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -430,7 +430,7 @@ class SubmissionController extends AbstractController {
         }
 
         // Initialize new instance of FPDI and get page count
-        if (!is_null($dst)) {
+        if (defined($dst)) {
             $pdf = new Fpdi();
             $actual_page_count = $pdf->setSourceFile($dst);
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -430,7 +430,7 @@ class SubmissionController extends AbstractController {
         }
 
         // Initialize new instance of FPDI and get page count
-        if (defined($dst)) {
+        if (isset($dst)) {
             $pdf = new Fpdi();
             $actual_page_count = $pdf->setSourceFile($dst);
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -22,6 +22,9 @@ use app\models\GradingOrder;
 use Symfony\Component\Routing\Annotation\Route;
 use app\models\notebook\SubmissionCodeBox;
 use app\models\notebook\SubmissionMultipleChoice;
+use setasign\Fpdi\Fpdi;
+
+//require_once __DIR__ . "/../../../vendor/autoload.php";
 
 class SubmissionController extends AbstractController {
     private $upload_details = [
@@ -343,6 +346,7 @@ class SubmissionController extends AbstractController {
      * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/bulk", methods={"POST"})
      */
     public function ajaxBulkUpload($gradeable_id) {
+
         $is_qr = isset($_POST['use_qr_codes']) && $_POST['use_qr_codes'] === "true";
 
         if (!isset($_POST['num_pages']) && !$is_qr) {
@@ -394,8 +398,6 @@ class SubmissionController extends AbstractController {
         if ($file_size > $max_size) {
             return $this->uploadResult("File(s) uploaded too large.  Maximum size is " . ($max_size / 1000) . " kb. Uploaded file(s) was " . ($file_size / 1000) . " kb.", false);
         }
-
-        // creating uploads/bulk_pdf/gradeable_id directory
 
         $pdf_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "bulk_pdf", $gradeable->getId());
         if (!FileUtils::createDir($pdf_path)) {

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -430,7 +430,7 @@ class SubmissionController extends AbstractController {
         }
 
         // Initialize new instance of FPDI and get page count
-        if(!empty($dst)){
+        if (!empty($dst)) {
             $pdf = new Fpdi();
             $actual_page_count = $pdf->setSourceFile($dst);
 

--- a/site/composer.json
+++ b/site/composer.json
@@ -33,6 +33,8 @@
     "onelogin/php-saml": "4.1.0",
     "php-ds/php-ds": "1.4.1",
     "ramsey/uuid": "4.7.4",
+    "setasign/fpdf": "^1.8",
+    "setasign/fpdi": "2.5.0",
     "symfony/cache": "6.3.6",
     "symfony/config": "6.3.2",
     "symfony/http-foundation": "6.3.2",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -3796,6 +3796,120 @@
             "time": "2020-09-05T13:00:25+00:00"
         },
         {
+            "name": "setasign/fpdf",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "d77904018090c17dc9f3ab6e944679a7a47e710a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/d77904018090c17dc9f3ab6e944679a7a47e710a",
+                "reference": "d77904018090c17dc9f3ab6e944679a7a47e710a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "support": {
+                "source": "https://github.com/Setasign/FPDF/tree/1.8.2"
+            },
+            "time": "2019-12-08T10:32:10+00:00"
+        },
+        {
+            "name": "setasign/fpdi",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "ecf0459643ec963febfb9a5d529dcd93656006a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/ecf0459643ec963febfb9a5d529dcd93656006a4",
+                "reference": "ecf0459643ec963febfb9a5d529dcd93656006a4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "setasign/tfpdf": "<1.31"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7",
+                "setasign/fpdf": "~1.8",
+                "setasign/tfpdf": "~1.31",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "~6.2"
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use TCPDF or tFPDF as an alternative. There's no fixed dependency configured."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "setasign\\Fpdi\\": "src/"
+                }
+            },  
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                },
+                {
+                    "name": "Maximilian Kresse",
+                    "email": "maximilian.kresse@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ], 
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/Setasign/FPDI/issues",
+                "source": "https://github.com/Setasign/FPDI/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/setasign/fpdi",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-09-28T10:46:27+00:00"
+        },
+        {
             "name": "symfony/cache",
             "version": "v6.3.6",
             "source": {


### PR DESCRIPTION
![image](https://github.com/Submitty/Submitty/assets/60510960/9bcf44ed-0c85-4c25-8cd9-91ddc05e22c9)

### What is the current behavior?
Fixes #9986 - When there is a bulk upload with an incorrect number of split pages, there is no error that appears on the front end other than what is in the daemon log.

### What is the new behavior?
The new behavior shows an alert that appears saying "The PDF page count (# split pages) is not divisible by the expected count per exam (# pages in pdf)" and once the user hits "ok" it returns back to the submission page for the user to reload. The daemon log as described in the issue, no longer appears because the check for divisibility occurs before the job starts. 

### Other information?
It was tested manually by uploading multiple-page PDFs and inputting different incorrect split page counts. 
This code involves a library called FPDI which is a free pdf document importer for PHP. 
This is the link to FPDI documentation: [](https://github.com/Setasign/FPDI)
