### PR TITLE
[Bugfix:Forum] Add check for empty thread list

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -928,9 +928,12 @@ SQL;
 
     /**
      * @param int[] $thread_ids
-     * @return array<int, mixed[]>
+     * @return null|array<int, mixed[]> array of posts, indexed by thread id.
      */
-    public function getFirstPostForThreads(array $thread_ids): array {
+    public function getFirstPostForThreads(array $thread_ids): null|array {
+        if (count($thread_ids) == 0) {
+            return null;
+        }
         $placeholders = $this->createParameterList(count($thread_ids));
         $this->course_db->query("SELECT * FROM posts WHERE parent_id = -1 AND thread_id IN {$placeholders}", $thread_ids);
         $return = [];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Right now a query function getFirstPostForThreads gets called to display the forum, and it requires a list of thread ids to serve as keys for the query. If the list is empty, sql throws an error.

### What is the new behavior?
If the array passed has no elements, the getFirstPostForThreads will return null. The function is called at ForumThreadView.php line 760. It then handles null/missing array indices at lines 767-772.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
