### PR TITLE
[Bugfix:Forum] Fix edit post websocket update

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -602,10 +602,11 @@ class ForumController extends AbstractController {
             true,
             $author_info[$post["author_user_id"]],
             $post_attachments[$post["id"]][0],
-            !empty($post_history),
+            count($post_history) > 0,
             in_array($post["id"], $merged_threads, true),
             true,
-            $this->core->getQueries()->existsAnnouncementsId($thread_id));
+            $this->core->getQueries()->existsAnnouncementsId($thread_id)
+        );
         return $this->core->getOutput()->renderJsonSuccess($result);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
In my testing of PR #9906 I noticed that when I edited a post, other users viewing the post would see an error. This was due to some changes I had made in PR #9988.

### What is the new behavior?
This fixes the error and now posts dynamically update when somebody else edits them.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
