### PR TITLE
[Bugfix:InstructorUI] Fix Grade Report Summaries

### DIFF
--- a/migration/migrator/migrations/course/20231213021032_clear_late_day_cache.py
+++ b/migration/migrator/migrations/course/20231213021032_clear_late_day_cache.py
@@ -1,0 +1,33 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("DELETE FROM late_day_cache;")
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -290,11 +290,13 @@ class LateDays extends AbstractModel {
             $auto_graded_gradeable = $graded_gradeable->getAutoGradedGradeable();
             $submission_days_late = $auto_graded_gradeable->hasActiveVersion() ? $auto_graded_gradeable->getActiveVersionInstance()->getDaysLate() : 0;
             $exceptions = $graded_gradeable->getLateDayException($this->user);
+            $reason = $graded_gradeable->getReasonForException($this->user);
 
             $event_info['graded_gradeable'] = $graded_gradeable;
             $event_info['late_days_allowed'] = $late_days_allowed;
             $event_info['submission_days_late'] = $submission_days_late;
             $event_info['late_day_exceptions'] = $exceptions;
+            $event_info['reason_for_exception'] = $reason;
         }
 
         return $event_info;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
If instructors try to generate grade report summaries for their class and they also have excused absences, it is likely that it will fail/error.

### What is the new behavior?
This will no longer error. The cache had some bad values that would cause issues so it has now been cleared. This PR also adds a missed case of event info that doesn't have the reason.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
