### PR TITLE
[Feature:RainbowGrades] add version conflict

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -511,6 +511,7 @@ class ReportController extends AbstractController {
                     }
                     else {
                         $entry['note'] = 'Score is set to 0 because there are version conflicts.';
+                        $entry['version_conflict'] = 'true';
                     }
                 }
             }


### PR DESCRIPTION
This is related to /Submitty/Rainbowgrades/#69
This PR modifies the reportcontroller to add version_conflict boolean to json
Then it will be used in Rainbowgrades code to correctly generate border-outline of the gradeable. 

<img width="518" alt="Screen Shot 2023-12-13 at 3 07 49 AM" src="https://github.com/Submitty/Submitty/assets/123261952/4a7804a8-3654-4ee7-99c6-862cb33815e5">
