### PR TITLE
[Testing:Submission] Fix development pdf exam settings #9485

### DIFF
--- a/.setup/bin/sample_courses/models/course/course_create_gradeables.py
+++ b/.setup/bin/sample_courses/models/course/course_create_gradeables.py
@@ -91,6 +91,7 @@ class Course_create_gradeables:
             gradeable_annotation_path = os.path.join(self.course_path, "annotations", gradeable.id)
 
             submission_count = 0
+            gradeable_type = gradeable.gradeable_type
             max_submissions = gradeable.max_random_submissions
             max_individual_submissions = gradeable.max_individual_submissions
             # makes a section be ungraded if the gradeable is not electronic

--- a/.setup/bin/sample_courses/models/gradeable.py
+++ b/.setup/bin/sample_courses/models/gradeable.py
@@ -67,7 +67,7 @@ class Gradeable(object):
         self.annotated_pdf = False
         self.annotation_path = None
         self.annotations = []
-        self.gradeable_type = "Students will submit one or more files by direct upload to the Submitty website"
+        self.gradeable_type = ""
 
         if "gradeable_config" in gradeable:
             self.gradeable_config = gradeable["gradeable_config"]

--- a/.setup/bin/sample_courses/models/gradeable.py
+++ b/.setup/bin/sample_courses/models/gradeable.py
@@ -67,6 +67,7 @@ class Gradeable(object):
         self.annotated_pdf = False
         self.annotation_path = None
         self.annotations = []
+        self.gradeable_type = Students will submit one or more files by direct upload to the Submitty website
 
         if "gradeable_config" in gradeable:
             self.gradeable_config = gradeable["gradeable_config"]
@@ -81,6 +82,10 @@ class Gradeable(object):
                 self.max_random_submissions = int(
                     gradeable["eg_max_random_submissions"]
                 )
+
+            if "eg_gradeable_type" in gradeable:
+                self.gradeable_type = 
+                    gradeable["eg_gradeable_type"]
 
             if "eg_max_individual_submissions" in gradeable:
                 self.max_individual_submissions = int(

--- a/.setup/bin/sample_courses/models/gradeable.py
+++ b/.setup/bin/sample_courses/models/gradeable.py
@@ -67,7 +67,7 @@ class Gradeable(object):
         self.annotated_pdf = False
         self.annotation_path = None
         self.annotations = []
-        self.gradeable_type = ""
+        self.gradeable_type = "electronic_hw"
 
         if "gradeable_config" in gradeable:
             self.gradeable_config = gradeable["gradeable_config"]

--- a/.setup/bin/sample_courses/models/gradeable.py
+++ b/.setup/bin/sample_courses/models/gradeable.py
@@ -67,7 +67,7 @@ class Gradeable(object):
         self.annotated_pdf = False
         self.annotation_path = None
         self.annotations = []
-        self.gradeable_type = Students will submit one or more files by direct upload to the Submitty website
+        self.gradeable_type = "Students will submit one or more files by direct upload to the Submitty website"
 
         if "gradeable_config" in gradeable:
             self.gradeable_config = gradeable["gradeable_config"]

--- a/.setup/data/courses/development.yml
+++ b/.setup/data/courses/development.yml
@@ -528,7 +528,7 @@ gradeables:
     eg_has_due_date: true
     eg_has_release_date: true
     eg_max_random_submissions: 0
-    eg_gradeable_type: TA/Instructor will (bulk) upload scanned .pdf for online manual grading
+    eg_gradeable_type: electronic_bulk
 
   - gradeable_config: pdf_word_count
     components:

--- a/.setup/data/courses/development.yml
+++ b/.setup/data/courses/development.yml
@@ -528,7 +528,7 @@ gradeables:
     eg_has_due_date: true
     eg_has_release_date: true
     eg_max_random_submissions: 0
-    eg_bulk_test: true
+    eg_gradeable_type: TA/Instructor will (bulk) upload scanned .pdf for online manual grading
 
   - gradeable_config: pdf_word_count
     components:

--- a/.setup/data/courses/development.yml
+++ b/.setup/data/courses/development.yml
@@ -528,6 +528,7 @@ gradeables:
     eg_has_due_date: true
     eg_has_release_date: true
     eg_max_random_submissions: 0
+    eg_bulk_test: true
 
   - gradeable_config: pdf_word_count
     components:


### PR DESCRIPTION
IN PROGRESS PR!!! Current Error:
 File "/usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/sample_courses/models/course/__init__.py", line 8, in <module>
    from sample_courses.models.gradeable import Gradeable
  File "/usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/sample_courses/models/gradeable.py", line 87
    self.gradeable_type =
                          ^
Syntax Error: invalid syntax
===========================================================================
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #9485
In the development course, there is a pdf exam gradeable set to the wrong type.

### What is the new behavior?
It is the correct gradeable type.

### Other information?
<!-- Is this a breaking change? -->
No, it will make the sample courses and gradeables in sync with each other making it easier when testing.

<!-- How did you test -->
Open the branch.
In vagrant ssh run this command:
 sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/recreate_sample_courses.sh
Go to the development course in instructor. Then look for the pdf exam gradeable and see that it now says "TA/Instructor will (bulk) upload scanned .pdf for online manual grading" instead of "Students will submit one or more files by direct upload to the Submitty website"