### PR TITLE
[Feature:Autograding] Add copy_file_range syscall

### DIFF
--- a/grading/system_call_categories.cpp
+++ b/grading/system_call_categories.cpp
@@ -529,6 +529,7 @@ void allow_system_calls(scmp_filter_ctx sc, const std::set<std::string> &categor
     ALLOW_SYSCALL(vm86old);
     ALLOW_SYSCALL(vmsplice);
     ALLOW_SYSCALL(vserver);
+    ALLOW_SYSCALL(copy_file_range);
   }
 
   // RESTRICTED : UNKNOWN_MODULE


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
We don't have the `copy_file_range` syscall on our allowed list. The go compiler uses this syscall so this is needed.

### What is the new behavior?
The syscall is now added in the unknown category for configuration that may need it.


