### PR TITLE
[Bugfix:Submission] Fix Empty Repo Warning

### DIFF
--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1074,7 +1074,7 @@ class HomeworkView extends AbstractView {
         $failed_file = '';
         $file_count = 0;
         // See if the grade has succeeded or failed
-        if (in_array('files', $param)) {
+        if (array_key_exists('files', $param)) {
             $file_count = count($param['files']);
             if ($file_count === 1) {
                 foreach ($param['files'] as $file) {

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -14080,11 +14080,6 @@ parameters:
 			path: app/views/grading/SimpleGraderView.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/views/submission/HomeworkView.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/views/submission/HomeworkView.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When submitting an assignment to a VCS gradeable, it will always give out a warning that the repo is empty even if it's not.

### What is the new behavior?
If the repo isn't empty, the warning does not show anymore as expected. `in_array` was used when `array_key_exists` should have been used.

### Other information?
Tested locally and warning message gone.
