### PR TITLE
[Testing:Developer] Improve flakiness of vagrant up workflow

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - run: brew install virtualbox vagrant
       # Installing this is skipped in CI as using it was causing some corruption in
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   vagrant-up:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,8 @@ $stderr.sync = true
 
 require 'json'
 
+ON_CI = !ENV.fetch('CI', '').empty?
+
 def gen_script(machine_name, worker: false)
   no_submissions = !ENV.fetch('NO_SUBMISSIONS', '').empty?
   extra = ENV.fetch('EXTRA', '')
@@ -138,8 +140,11 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider 'virtualbox' do |vb, override|
-    vb.memory = 2048
-    vb.cpus = 2
+    # We limit resources when running on CI to avoid resource exhaustion and it isn't used for grading stuff or
+    # other things we do in dev.
+    vb.memory = ON_CI ? 1024 : 2048
+    vb.cpus = ON_CI ? 1 : 2
+
     # When you put your computer (while running the VM) to sleep, then resume work some time later the VM will be out
     # of sync timewise with the host for however long the host was asleep. Of course, the VM by default will
     # detect this and if the drift is great enough, it'll resync things such that the time matches, otherwise


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The vagrant up workflow often fails right now, where VirtualBox is stuck in a "gurumeditation" state. There is https://github.com/actions/runner-images/issues/8730 which indicates others are running into the same problem, and while GH has closed the issue with it's fixed and sometimes the workflow does succeed, it's still often failing. My only guess is that per https://github.com/actions/runner-images/issues/8730#issuecomment-1834391700, there are different machines that run macOS-12 builds and certain ones just always fail :shrug:.

### What is the new behavior?

PR updates the vagrant up workflow to use macOS 13 which while in beta seems to provide a much more stable interface for vagrant/virtualbox, and that I was able to run the workflow 4 times in a row (with one disconnect failure, which I think is due to machine running out of resources?), something we haven't seen in a long time (https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml).

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
