### PR TITLE
[Bugfix:Forum] Indentation w/ Markdown Disabled

### DIFF
--- a/site/app/templates/forum/RenderPost.twig
+++ b/site/app/templates/forum/RenderPost.twig
@@ -1,7 +1,7 @@
 {% if render_markdown %}
     {% include "misc/Markdown.twig" with { content: post_content } only %}
 {% else %}
-    {{ post_content }}
+    <p>{{ post_content }}</p>>
 {% endif %}
 {% if post_attachment is defined and post_attachment.exist == true %}
     <table>

--- a/site/app/templates/forum/RenderPost.twig
+++ b/site/app/templates/forum/RenderPost.twig
@@ -1,7 +1,7 @@
 {% if render_markdown %}
     {% include "misc/Markdown.twig" with { content: post_content } only %}
 {% else %}
-    <p>{{ post_content }}</p>>
+    <p>{{ post_content }}</p>
 {% endif %}
 {% if post_attachment is defined and post_attachment.exist == true %}
     <table>


### PR DESCRIPTION
First part of #10070 

### Please check if the PR fulfills these requirements:

* [x] Screenshots are attached to Github PR if visual/UI changes were made

Before:
![image](https://github.com/Submitty/Submitty/assets/123511202/4d83c958-51a2-46d2-8c7a-053db51600dd)
After:
![image](https://github.com/Submitty/Submitty/assets/123511202/07ab2d21-1504-441b-bb89-0fc9165897b9)

### What is the current behavior?

Barb on Zulip:
"...the indentation on the forum is looking a little squirrelly to me on some threads/some posts within the thread. See how each post in this screenshot has a little extra space at the start of the first line? But It doesn't happen on every post in every thread." 

When a forum post is created (including replies) without markdown option toggled, the text is indented automatically. The text with markdown appears to be normal. 

### What is the new behavior?

Forum post text is indented correctly regardless.

