### PR TITLE
[Bugfix:Submission] Fix VCS Autograding Info

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -5,7 +5,7 @@
 {% endif %}
 
 {# Submitted files #}
-{% if student_download or core.getUser().accessGrading() %}
+{% if student_download or is_vcs or core.getUser().accessGrading() %}
     <h4>Submitted Files</h4>
     <div class="row">
         <div class="box col-md-6" id="submitted-files">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
On VCS gradeables, when a student submits their repository, the info about autograding and submitted files does not show. Instructors or any member of the grading team do not have this problem.

### What is the new behavior?
The autograding info and submitted files now displays for students.

### Other information?
Tested locally and now works as expected.

This issue originated from https://github.com/Submitty/Submitty/pull/9087.
