### PR TITLE
[Bugfix:InstructorUI] Fix link to Rainbow Grades documentation

### DIFF
--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -46,7 +46,7 @@
             <div class="title-cont">
                 Web interface for creation and customization of Rainbow Grades for this course.
                 <a target=_blank
-                   href="https://submitty.org/instructor/rainbow_grades/"
+                   href="https://submitty.org/instructor/course_settings/rainbow_grades/"
                 >
                     Rainbow Grades Documentation
                     <i style="font-style:normal;" class="fa-question-circle"></i>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, there is a superlink on the Grade Reports page, Rainbow Grades Section, suppose direct to the documentation page on submitty.org that helps instructor learn it works. But seems like it's not catch up some refactor of the submitty.org.
The superlink is now not direct to the right place. See screenshots attached.
<img width="593" alt="截屏2024-01-26 17 01 47" src="https://github.com/Submitty/Submitty/assets/92846547/c151714d-4d15-4db2-991d-efd9c8efe646">
<img width="1241" alt="截屏2024-01-26 17 03 21" src="https://github.com/Submitty/Submitty/assets/92846547/45f53ed8-2178-425e-8b51-4e3ba7f23b5d">

### What is the new behavior?
The link is now works well.

### Other information?
This is a tiny change with just letters changed.
