### PR TITLE
[Bugfix:System] Only notify from main repository

### DIFF
--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -8,10 +8,11 @@ on:
       - 'main'
 jobs:
   Notify-Failure:
+    if: github.repository == 'Submitty/Submitty'
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Zulip on failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }} 
         run: |
             curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
             --data-urlencode 'topic=Main CI Failures' --data-urlencode \

--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Zulip on failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }} 
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         run: |
             curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
             --data-urlencode 'topic=Main CI Failures' --data-urlencode \


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When I added the workflow to notify Zulip if the main branch ever had a CI error, I didn't think about working for any branch named 'main' on any fork.

### What is the new behavior?
Now the CI failure notifcation only runs on the main Submitty repository
