### PR TITLE
[Dependency] Revert "Bump xlsx2csv from 0.8.1 to 0.8.2 (#10155)"

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -22,6 +22,7 @@ sqlalchemy==1.4.29
 psutil==5.9.6
 python-dateutil==2.8.2
 watchdog==3.0.0
+# Held back from 0.8.2 as no whl is available which breaks installing on Ubuntu 22.04
 xlsx2csv==0.8.1
 pause==0.3
 paramiko==3.3.1

--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -22,7 +22,7 @@ sqlalchemy==1.4.29
 psutil==5.9.6
 python-dateutil==2.8.2
 watchdog==3.0.0
-xlsx2csv==0.8.2
+xlsx2csv==0.8.1
 pause==0.3
 paramiko==3.3.1
 tzlocal==2.1


### PR DESCRIPTION
This reverts commit c81f5e2eae22e2ff30d04664ce1a8e6746c2afbe.

### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `xlsx2csv@0.8.2` only provides a source distribution which fails to install on Ubuntu 22.04 with the version of pip that comes from `python3-pip`:

```
    ubuntu-22.04: Collecting xlsx2csv==0.8.2
    ubuntu-22.04:   Downloading xlsx2csv-0.8.2.tar.gz (227 kB)
    ubuntu-22.04:      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 227.1/227.1 KB 18.4 MB/s eta 0:00:00
    ubuntu-22.04:   Installing build dependencies: started
    ubuntu-22.04:   Installing build dependencies: finished with status 'done'
    ubuntu-22.04:   Getting requirements to build wheel: started
    ubuntu-22.04:   Getting requirements to build wheel: finished with status 'done'
    ubuntu-22.04:   Preparing metadata (pyproject.toml): started
    ubuntu-22.04:   Preparing metadata (pyproject.toml): finished with status 'done'
    ubuntu-22.04:   WARNING: Generating metadata for package xlsx2csv produced metadata for project name unknown. Fix your #egg=xlsx2csv fragments.
    ubuntu-22.04: Discarding https://files.pythonhosted.org/packages/c9/d1/70613896bd07a49cfb19312838b8ffb29232e6be5c8e381b953473468e5b/xlsx2csv-0.8.2.tar.gz#sha256=cdd272c82f8b32f1cee76aeaef87b2ee3549661fddf90f7ecf2310967a16fc84 (from https://pypi.org/simple/xlsx2csv/): Requested unknown from https://files.pythonhosted.org/packages/c9/d1/70613896bd07a49cfb19312838b8ffb29232e6be5c8e381b953473468e5b/xlsx2csv-0.8.2.tar.gz#sha256=cdd272c82f8b32f1cee76aeaef87b2ee3549661fddf90f7ecf2310967a16fc84 (from -r /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/pip/system_requirements.txt (line 25)) has inconsistent name: filename has 'xlsx2csv', but metadata has 'unknown'
    ubuntu-22.04: ERROR: Could not find a version that satisfies the requirement xlsx2csv==0.8.2 (from versions: 0.6, 0.6.1, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.7.7, 0.7.8, 0.8.0, 0.8.1, 0.8.2)
    ubuntu-22.04: ERROR: No matching distribution found for xlsx2csv==0.8.2
```

`xlsx2csv@0.8.2` is the first version in the last bunch that does not provide a `.whl` build, and so requires a newer version of pip to be installed for now, though ideally upstream could provide a whl and that'd allow us to upgrade (https://github.com/dilshod/xlsx2csv/issues/276).

### What is the new behavior?

Reverted to `xlsx2csv@0.8.1`. Our usage of this module is pretty basic, and the bugfixes included in the latest version don't really affect us, so there's no need to force our upgrade to `0.8.2` at the moment.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Vagrant up should succeed: https://github.com/Submitty/Submitty/actions/runs/7800496541
