### PR TITLE
[UI/UX:Calendar] Fix calendar Note cursor

### DIFF
--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -202,12 +202,14 @@ a.cal-gradeable-status-text {
     padding: 0;
     border: none;
     box-shadow: none;
+    cursor: default;
 }
 
 a.cal-gradeable-status-text:hover {
     color: var(--text-black);
     padding: 0;
     border: none;
+    cursor: default;
 }
 
 a.cal-gradeable-status-text:focus {

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -225,12 +225,13 @@ a.cal-gradeable-status-ann {
     border-style: solid;
     border-width: 3px;
     box-shadow: none;
+    cursor: default;
 }
 
 a.cal-gradeable-status-ann:hover {
+    cursor: default;
     padding: 0;
     font-style: italic;
-    cursor: default;
     border-style: solid;
     border-width: 3px!important;
 }

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -202,14 +202,12 @@ a.cal-gradeable-status-text {
     padding: 0;
     border: none;
     box-shadow: none;
-    cursor: default;
 }
 
 a.cal-gradeable-status-text:hover {
     color: var(--text-black);
     padding: 0;
     border: none;
-    cursor: default;
 }
 
 a.cal-gradeable-status-text:focus {
@@ -229,11 +227,11 @@ a.cal-gradeable-status-ann {
 }
 
 a.cal-gradeable-status-ann:hover {
+    cursor: default;
     padding: 0;
     font-style: italic;
     border-style: solid;
     border-width: 3px!important;
-    cursor: default;
 }
 
 a.cal-gradeable-status-ann:focus {

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -208,7 +208,6 @@ a.cal-gradeable-status-text {
 a.cal-gradeable-status-text:hover {
     color: var(--text-black);
     padding: 0;
-    cursor: default;
     border: none;
     cursor: default;
 }

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -202,6 +202,7 @@ a.cal-gradeable-status-text {
     padding: 0;
     border: none;
     box-shadow: none;
+    cursor: default;
 }
 
 a.cal-gradeable-status-text:hover {
@@ -209,6 +210,7 @@ a.cal-gradeable-status-text:hover {
     padding: 0;
     cursor: default;
     border: none;
+    cursor: default;
 }
 
 a.cal-gradeable-status-text:focus {
@@ -228,11 +230,11 @@ a.cal-gradeable-status-ann {
 }
 
 a.cal-gradeable-status-ann:hover {
-    cursor: default;
     padding: 0;
     font-style: italic;
     border-style: solid;
     border-width: 3px!important;
+    cursor: default;
 }
 
 a.cal-gradeable-status-ann:focus {

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -208,8 +208,8 @@ a.cal-gradeable-status-text {
 a.cal-gradeable-status-text:hover {
     color: var(--text-black);
     padding: 0;
-    border: none;
     cursor: default;
+    border: none;
 }
 
 a.cal-gradeable-status-text:focus {

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -225,13 +225,12 @@ a.cal-gradeable-status-ann {
     border-style: solid;
     border-width: 3px;
     box-shadow: none;
-    cursor: default;
 }
 
 a.cal-gradeable-status-ann:hover {
-    cursor: default;
     padding: 0;
     font-style: italic;
+    cursor: default;
     border-style: solid;
     border-width: 3px!important;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Fixes issue [#10171](https://github.com/Submitty/Submitty/issues/10171) 
This PR fixes an almost identical bug as was fixed in PR [#10125](https://github.com/Submitty/Submitty/pull/10125), except this fixes it for notes, instead of announcements in the calendar.

### What is the current behavior?
As the cursor is moved over the edge of a Note entry in the calendar view, the cursor changes to a pointer for a split second, before switching back to the default arrow cursor.

### What is the new behavior?
The cursor stays as an arrow, and doesn't change when dragged over the edge of Notes.

### Other information?
This is not a breaking change.
Tested from student, grader, and ta logins.