### PR TITLE
[Bugfix:Autograding] Copy all named executables to runner

### DIFF
--- a/grading/TestCase.cpp
+++ b/grading/TestCase.cpp
@@ -56,10 +56,16 @@ std::vector<std::string> stringOrArrayOfStrings(nlohmann::json j, const std::str
   if (itr->is_string()) {
     answer.push_back(*itr);
   } else {
-    assert (itr->is_array());
+    if (!itr->is_array()) {
+      std::cerr << "ERROR: " << what << " must be a string or array of strings." << std::endl;
+      exit(1);
+    }
     nlohmann::json::const_iterator itr2 = itr->begin();
     while (itr2 != itr->end()) {
-      assert (itr2->is_string());
+      if (!itr2->is_string()) {
+        std::cerr << "ERROR: " << what << " must only contain strings." << std::endl;
+        exit(1);
+      }
       answer.push_back(*itr2);
       itr2++;
     }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -96,9 +96,7 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
         if (exe_name->is_array()) {
           for (typename nlohmann::json::iterator itr = exe_name->begin(); itr != exe_name->end(); itr++) {
             if (itr->is_string()) {
-              std::string name = to_string(*itr);
-              // to_string function inserts "" characters around the executable name. Need to strip.
-              whole_config["autograding"]["compilation_to_runner"].push_back("**/" + name.substr(1, name.size() - 2));
+              whole_config["autograding"]["compilation_to_runner"].push_back("**/" + itr->template get<std::string>());
             }
             else {
               throw std::invalid_argument("Unable to parse provided executable_name");
@@ -106,9 +104,7 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
           }
         }
         else if (exe_name->is_string()) {
-          std::string name = to_string(*exe_name);
-          // to_string function inserts "" characters around the executable name. Need to strip.
-          whole_config["autograding"]["compilation_to_runner"].push_back("**/" + name.substr(1, name.size() - 2));
+          whole_config["autograding"]["compilation_to_runner"].push_back("**/" + exe_name->template get<std::string>());
         }
       }
     }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -89,6 +89,9 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
     for (typename nlohmann::json::iterator testcase = testcases->begin(); testcase != testcases->end(); testcase++) {
       if (testcase->value("type", "") == "Compilation") {
         nlohmann::json::iterator exe_name = testcase->find("executable_name");
+        if (exe_name == testcase->end()) {
+          continue;
+        }
         // Handle single file or array of files.
         if (exe_name->is_array()) {
           for (typename nlohmann::json::iterator itr = exe_name->begin(); itr != exe_name->end(); itr++) {

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -95,11 +95,20 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
         // Handle single file or array of files.
         if (exe_name->is_array()) {
           for (typename nlohmann::json::iterator itr = exe_name->begin(); itr != exe_name->end(); itr++) {
-            whole_config["autograding"]["compilation_to_runner"].push_back(*itr);
+            if (itr->is_string()) {
+              std::string name = to_string(*itr);
+              // to_string function inserts "" characters around the executable name. Need to strip.
+              whole_config["autograding"]["compilation_to_runner"].push_back("**/" + name.substr(1, name.size() - 2));
+            }
+            else {
+              throw std::invalid_argument("Unable to parse provided executable_name");
+            }
           }
         }
-        else {
-          whole_config["autograding"]["compilation_to_runner"].push_back(*exe_name);
+        else if (exe_name->is_string()) {
+          std::string name = to_string(*exe_name);
+          // to_string function inserts "" characters around the executable name. Need to strip.
+          whole_config["autograding"]["compilation_to_runner"].push_back("**/" + name.substr(1, name.size() - 2));
         }
       }
     }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -84,6 +84,23 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
   }
 
   if (whole_config["autograding"].find("compilation_to_runner") == whole_config["autograding"].end()) {
+    // copy all executable names from compilation testcases to runner
+    nlohmann::json::iterator testcases = whole_config.find("testcases");
+    for (typename nlohmann::json::iterator testcase = testcases->begin(); testcase != testcases->end(); testcase++) {
+      if (testcase->value("type", "") == "Compilation") {
+        nlohmann::json::iterator exe_name = testcase->find("executable_name");
+        // Handle single file or array of files.
+        if (exe_name->is_array()) {
+          for (typename nlohmann::json::iterator itr = exe_name->begin(); itr != exe_name->end(); itr++) {
+            whole_config["autograding"]["compilation_to_runner"].push_back(*itr);
+          }
+        }
+        else {
+          whole_config["autograding"]["compilation_to_runner"].push_back(*exe_name);
+        }
+      }
+    }
+    // add all .out and .class in case executable name wasn't specified.
     whole_config["autograding"]["compilation_to_runner"].push_back("**/*.out");
     whole_config["autograding"]["compilation_to_runner"].push_back("**/*.class");
   }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -88,26 +88,9 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
     nlohmann::json::iterator testcases = whole_config.find("testcases");
     for (typename nlohmann::json::iterator testcase = testcases->begin(); testcase != testcases->end(); testcase++) {
       if (testcase->value("type", "") == "Compilation") {
-        nlohmann::json::iterator exe_name = testcase->find("executable_name");
-        if (exe_name == testcase->end()) {
-          continue;
-        }
-        // Handle single file or array of files.
-        if (exe_name->is_array()) {
-          for (typename nlohmann::json::iterator itr = exe_name->begin(); itr != exe_name->end(); itr++) {
-            if (itr->is_string()) {
-              whole_config["autograding"]["compilation_to_runner"].push_back("**/" + itr->template get<std::string>());
-            }
-            else {
-              throw std::invalid_argument("executable_name array must only contain strings.");
-            }
-          }
-        }
-        else if (exe_name->is_string()) {
-          whole_config["autograding"]["compilation_to_runner"].push_back("**/" + exe_name->template get<std::string>());
-        }
-        else {
-          throw std::invalid_argument("executable_name must be an array or string.");
+        std::vector<std::string> exe_names = stringOrArrayOfStrings(*testcase, "executable_name");
+        for(int i = 0, n = exe_names.size(); i < n; i++) {
+          whole_config["autograding"]["compilation_to_runner"].push_back("**/" + exe_names[i]);
         }
       }
     }

--- a/grading/load_config_json.cpp
+++ b/grading/load_config_json.cpp
@@ -99,12 +99,15 @@ void AddAutogradingConfiguration(nlohmann::json &whole_config) {
               whole_config["autograding"]["compilation_to_runner"].push_back("**/" + itr->template get<std::string>());
             }
             else {
-              throw std::invalid_argument("Unable to parse provided executable_name");
+              throw std::invalid_argument("executable_name array must only contain strings.");
             }
           }
         }
         else if (exe_name->is_string()) {
           whole_config["autograding"]["compilation_to_runner"].push_back("**/" + exe_name->template get<std::string>());
+        }
+        else {
+          throw std::invalid_argument("executable_name must be an array or string.");
         }
       }
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10121 . Currently, the autograder only copies .out and .class files from the compiler to the runner. This means if the instructor creates a compilation testcase that compiles into anything other than .out or .class, the file will not be copied to the runner and other testcases will fail.

### What is the new behavior?
Now, in addition to copying all .out and .class files to the runner, any file that is listed in the "executable_name" field in the gradeable's config.json will also be copied to the runner. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This needs more testing. I've been able to verify that it works when a single executable is produced, but I haven't been able to test whether it correctly handles an array of executable names. I'm currently working on a java example for this, and I'll upload it as a separate PR when it's done.