### PR TITLE
[Bugfix:Forum] Fix Forum Post Spacing

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -34,7 +34,7 @@
 
     {% endif %}
 
-    <div class='pre-forum'><span class="post_content">{% include "forum/RenderPost.twig" with { "post_content": post_content, "render_markdown": render_markdown } only %}</span></div>
+    <div class='pre-forum'><div class='post_content'>{% include "forum/RenderPost.twig" with { "post_content": post_content, "render_markdown": render_markdown } only %}</div></div>
 
     <hr style="margin-bottom: 3px;">
 

--- a/site/app/templates/forum/RenderPost.twig
+++ b/site/app/templates/forum/RenderPost.twig
@@ -1,7 +1,7 @@
 {% if render_markdown %}
     {% include "misc/Markdown.twig" with { content: post_content } only %}
 {% else %}
-    <p>{{ post_content }}</p>
+    {{- post_content -}}
 {% endif %}
 {% if post_attachment is defined and post_attachment.exist == true %}
     <table>

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -641,12 +641,12 @@
     max-width: 100%;
 }
 
-/* stylelint-disable selector-class-pattern */
+/* stylelint-disable-next-line selector-class-pattern */
 .post_content p:first-child {
     margin-top: 0;
 }
 
-/* stylelint-disable selector-class-pattern */
+/* stylelint-disable-next-line selector-class-pattern */
 .post_content p:last-child {
     margin-bottom: 0;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -641,6 +641,14 @@
     max-width: 100%;
 }
 
+.post_content p:first-child {
+    margin-top: 0;
+}
+
+.post_content p:last-child {
+    margin-bottom: 0;
+}
+
 .markdown-inactive {
     color: var(--standard-light-gray);
 }
@@ -769,12 +777,4 @@
     margin-right: 10px;
     padding: unset;
     cursor: pointer;
-}
-
-.post_content .markdown p:first-child {
-    margin-top: 0;
-}
-
-.post_content .markdown p:last-child {
-    margin-bottom: 0;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -641,10 +641,12 @@
     max-width: 100%;
 }
 
+/* stylelint-disable selector-class-pattern */
 .post_content p:first-child {
     margin-top: 0;
 }
 
+/* stylelint-disable selector-class-pattern */
 .post_content p:last-child {
     margin-bottom: 0;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -48,7 +48,9 @@
 
 /* stylelint-disable-next-line selector-class-pattern, no-descending-specificity */
 .post_content {
+    display: flex;
     margin-right: 5px;
+    margin-top: 5px;
     white-space: pre-wrap;
 }
 
@@ -767,4 +769,12 @@
     margin-right: 10px;
     padding: unset;
     cursor: pointer;
+}
+
+.post_content .markdown p:first-child {
+    margin-top: 0;
+}
+
+.post_content .markdown p:last-child {
+    margin-bottom: 0;
 }


### PR DESCRIPTION
closes #10070 

### Please check if the PR fulfills these requirements:

* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

#10118 fixes the first part of #10070 by containing the post text in a block, but this way it adds extra spacing on top and bottom of a post to match that of a markdown enabled post, causing there to be more wasted space.

### What is the new behavior?

This PR adds whitespace control to the non-markdown enabled text and removes the extra spacing for the posts w/ markdown.
A 5px top-margin is added to improve the look and feel.

Before:
![image](https://github.com/Submitty/Submitty/assets/123511202/4f2f2559-5efd-46fb-97c7-2894bc80839a)


Now:
![image](https://github.com/Submitty/Submitty/assets/123511202/734c4a10-1367-4ec6-9a85-db8a6f4f7531)

