### PR TITLE
[Bugfix:TAGrading] Show Peer Grading Status on TA interface

### DIFF
--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -116,7 +116,7 @@ class GradedComponentContainer extends AbstractModel {
         if ($this->component->isPeerComponent()) {
             // Try to find existing graded component for this component and user...
             foreach ($this->graded_components as $graded_component) {
-                if ($graded_component->getGrader()->getId() === $grader->getId()) {
+                if ($grader->accessGrading() || $graded_component->getGrader()->getId() === $grader->getId() ) {
                     // ... Found one
                     return $graded_component;
                 }

--- a/site/app/models/gradeable/GradedComponentContainer.php
+++ b/site/app/models/gradeable/GradedComponentContainer.php
@@ -116,7 +116,7 @@ class GradedComponentContainer extends AbstractModel {
         if ($this->component->isPeerComponent()) {
             // Try to find existing graded component for this component and user...
             foreach ($this->graded_components as $graded_component) {
-                if ($grader->accessGrading() || $graded_component->getGrader()->getId() === $grader->getId() ) {
+                if ($grader->accessGrading() || $graded_component->getGrader()->getId() === $grader->getId()) {
                     // ... Found one
                     return $graded_component;
                 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Fixes #10166 Currently, the peer grading completion status is only visible to the instructor. The status indicator does not change on the TA interface, regardless of whether a student has finished grading the component or not.

### What is the new behavior?
The status indicator is highlighted in purple on the TA interface if the student has graded their assigned peer component.

### Other information?
before change:
<img width="929" alt="d7b9f91408db1bf31d72d400db0a2c8" src="https://github.com/Submitty/Submitty/assets/75406429/17b3705d-6fd7-420e-b604-b3223b13d895">

after change:
<img width="960" alt="637709d334dcd03541c006c4a2a1d48" src="https://github.com/Submitty/Submitty/assets/75406429/860a1497-3bf2-4de8-ba48-0b2c9f127ee4">

