### PR TITLE
[Bugfix:InstructorUI] Different repo_name in generate_repos.py

### DIFF
--- a/bin/generate_repos.py
+++ b/bin/generate_repos.py
@@ -178,7 +178,7 @@ is_team = False
 course_conn_string = db_utils.generate_connect_string(
     DATABASE_HOST,
     DATABASE_PORT,
-    f"submitty_{args.semester}_{args.course}", # database name
+    f"submitty_{args.semester}_{args.course}",
     DATABASE_USER,
     DATABASE_PASS,
 )
@@ -208,7 +208,7 @@ elif not args.non_interactive:
     for gradeable in gradeables:
         # the eg_vcs_partial_path has pattern like `gradeable_id/user_id`, so we need to use regex to match the gradeable_id
         if gradeable.eg_vcs_host_type == 1 and re.match(f'^{args.repo_name}/', gradeable.eg_vcs_partial_path):
-            print("Find matching gradeable_id '{}' in the course.".format(gradeable.g_id))
+            print("Found matching gradeable_id '{}' in the course that uses the requested repo name.".format(gradeable.g_id))
             is_repo_name_in_gradeables = True
             response = input ("Should we continue and make individual repositories named '"+args.repo_name+"' for each student/team? (y/n) ")
             if not response.lower() == 'y':
@@ -216,7 +216,7 @@ elif not args.non_interactive:
                 sys.exit()
 
     if is_repo_name_in_gradeables == False:
-        print ("Warning: Please make the gradeable before attempting to run this script!")
+        print ("ERROR: Please make the gradeable before attempting to run this script!")
         print ("exiting")
         sys.exit()
 


### PR DESCRIPTION
Fixes #10137 

### What is the new behavior?
First create 2 different gradeable to test the following three conditions.

Gradeable 1: Not a VCS gradeable
Gradeable 2: A VCS gradeable with vcs_type = " choose repository name (can be used for multiple gradeables)"
<img width="1121" alt="截圖 2024-02-21 下午11 55 16" src="https://github.com/Submitty/Submitty/assets/60954116/ede866cf-98c8-4782-ba39-55024eb4bd20">

## Test result
Case 1: It will exit directly and show warning messages. (use Gradeable 1)
<img width="826" alt="case1_result" src="https://github.com/Submitty/Submitty/assets/60954116/735ba2e6-6273-4f9a-8269-ae4464e20d91">
Case 2: It will show different warning message, asking the user to create a gradeable in advance. (Random string to mock "gradeable id")
<img width="831" alt="case2_result" src="https://github.com/Submitty/Submitty/assets/60954116/8faf0ce8-c696-4d2e-8d1e-5d3f36ba7b3a">
Case 3: It will show that the "repo_name" was found in at least one gradeable, and then ask the user whether to continue creating/update. (use Gradeable 2)
<img width="814" alt="vcs-multiople-result" src="https://github.com/Submitty/Submitty/assets/60954116/d00fb732-bf37-42f4-8395-ee120fed597d">

### Notes
I am not sure whether this work flow is acceptable by users, please give me some suggestions! Thank you!




