### PR TITLE
[Bugfix:Submission] Allow students to download submission zip of team assignment

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -348,11 +348,7 @@ class MiscController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl());
         }
 
-        $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $user_id, $gradeable->isTeamAssignment());
-
-        if ($gradeable->isTeamAssignment()) {
-            $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, null, $user_id);
-        }
+        $graded_gradeable = $this->core->getQueries()->getGradedGradeable($gradeable, $user_id, $user_id);
 
         if ($graded_gradeable === null) {
             $message = "You do not have access to that page.";

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -202,6 +202,7 @@ a.cal-gradeable-status-text {
     padding: 0;
     border: none;
     box-shadow: none;
+    cursor: default;
 }
 
 a.cal-gradeable-status-text:hover {

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -202,7 +202,6 @@ a.cal-gradeable-status-text {
     padding: 0;
     border: none;
     box-shadow: none;
-    cursor: default;
 }
 
 a.cal-gradeable-status-text:hover {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Fixes issue #10001 
For gradeables with team submissions enabled, when students click the "Download all files" button, they are redirected back to the course gradeables page and a pop-up appears saying "You do not have access to that page."
![image](https://github.com/Submitty/Submitty/assets/156256297/315709c3-dae8-4f37-97fa-a32757475199)

### What is the new behavior?
The "Download all files" button works as expected, prompting the download of the submission zip file.

### Other information?
My fix modifies the function which handles all submission zip downloads, including those from the student submission page as well as those from the grader "submissions and results browser" aka grading portal. Knowing this, I verified functionality from ta and instructor logins in the grading portal, as well as the submission page from a student login.