### PR TITLE
[Bugfix:Calendar] Appearance of Calander in a Superuser account 

### DIFF
--- a/site/app/views/calendar/CalendarView.php
+++ b/site/app/views/calendar/CalendarView.php
@@ -102,7 +102,7 @@ class CalendarView extends AbstractView {
             "show_legend" => $show_legend,
             "color_options" => $course_colors,
             "show_all_cookie" => isset($_COOKIE['calendar_show_all']) ? $_COOKIE['calendar_show_all'] : 1,
-            "calendar_course_cookie" => isset($_COOKIE['calendar_course']) ? $_COOKIE['calendar_course'] : $formatted_courses[0],
+            "calendar_course_cookie" => isset($_COOKIE['calendar_course']) && !empty($formatted_courses) ? $_COOKIE['calendar_course'] : reset($formatted_courses),
         ]);
     }
 }


### PR DESCRIPTION
What is the current behaviour?
![image](https://github.com/Submitty/Submitty/assets/45318331/6d84d6df-5754-417a-8638-7140a7003f43)

calendar is not visible properly when accessed via superuser account..

What is the new behavior?
![image](https://github.com/Submitty/Submitty/assets/45318331/e6c96dac-b4d0-4304-bb7c-430ca41cdfba)

Calander now appears as expected