### PR TITLE
[Refactor:TAGrading] Use of data- selector instead of class's

### DIFF
--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -10,7 +10,7 @@
                         {% block title_tag %}
                             <h1>{% block title %}Untitled Form{% endblock %}</h1>
                             <button
-                                data-close="close-button"
+                                data-testid="close-button"
                                 onclick="{{ block('close_click_action') }}"
                                 class="btn btn-default close-button key_to_click"
                                 tabindex="-1" type="button"

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -10,6 +10,7 @@
                         {% block title_tag %}
                             <h1>{% block title %}Untitled Form{% endblock %}</h1>
                             <button
+                                data-close="close-button"
                                 onclick="{{ block('close_click_action') }}"
                                 class="btn btn-default close-button key_to_click"
                                 tabindex="-1" type="button"

--- a/site/cypress/e2e/Cypress-Gradeable/simple_grading.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/simple_grading.spec.js
@@ -34,13 +34,13 @@ describe('Test cases revolving around simple grading lab', () => {
             // Check Settings Tab
             cy.get('#settings-btn').click({ force: true });
             cy.get('#settings-popup').should('have.attr', 'style', '');
-            cy.get('#settings-popup').find('[data-close="close-button"]').click({ multiple: true });
+            cy.get('#settings-popup').find('[data-testid="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
 
             // Check Statistics Tab
             cy.get('#simple-stats-btn').click({ force: true });
             cy.get('#simple-stats-popup').should('have.attr', 'style', 'display: block;');
-            cy.get('#simple-stats-popup').find('[data-close="close-button"]').click({ multiple: true });
+            cy.get('#simple-stats-popup').find('[data-testid="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
 
         });
@@ -85,13 +85,13 @@ describe('Test cases revolving around simple grading test', () => {
             // Check Settings Tab
             cy.get('#settings-btn').click({ force: true });
             cy.get('#settings-popup').should('have.attr', 'style', '');
-            cy.get('#settings-popup').find('[data-close="close-button"]').click({ multiple: true });
+            cy.get('#settings-popup').find('[data-testid="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
 
             // Check Statistics Tab
             cy.get('#simple-stats-btn').click({ force: true });
             cy.get('#simple-stats-popup').should('have.attr', 'style', 'display: block;');
-            cy.get('#simple-stats-popup').find('[data-close="close-button"]').click({ multiple: true });
+            cy.get('#simple-stats-popup').find('[data-testid="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
         });
 

--- a/site/cypress/e2e/Cypress-Gradeable/simple_grading.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/simple_grading.spec.js
@@ -34,13 +34,13 @@ describe('Test cases revolving around simple grading lab', () => {
             // Check Settings Tab
             cy.get('#settings-btn').click({ force: true });
             cy.get('#settings-popup').should('have.attr', 'style', '');
-            cy.get('#settings-popup').find('.popup-box').find('div.popup-window').find('.form-title').find('button.btn.btn-default.close-button.key_to_click').click({ multiple: true });
+            cy.get('#settings-popup').find('[data-close="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
 
             // Check Statistics Tab
             cy.get('#simple-stats-btn').click({ force: true });
             cy.get('#simple-stats-popup').should('have.attr', 'style', 'display: block;');
-            cy.get('#simple-stats-popup').find('.popup-box').find('div.popup-window').find('.form-title').find('button.btn.btn-default.close-button.key_to_click').click({ multiple: true });
+            cy.get('#simple-stats-popup').find('[data-close="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
 
         });
@@ -85,13 +85,13 @@ describe('Test cases revolving around simple grading test', () => {
             // Check Settings Tab
             cy.get('#settings-btn').click({ force: true });
             cy.get('#settings-popup').should('have.attr', 'style', '');
-            cy.get('#settings-popup').find('.popup-box').find('div.popup-window').find('.form-title').find('button.btn.btn-default.close-button.key_to_click').click({ multiple: true });
+            cy.get('#settings-popup').find('[data-close="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
 
             // Check Statistics Tab
             cy.get('#simple-stats-btn').click({ force: true });
             cy.get('#simple-stats-popup').should('have.attr', 'style', 'display: block;');
-            cy.get('#simple-stats-popup').find('.popup-box').find('div.popup-window').find('.form-title').find('button.btn.btn-default.close-button.key_to_click').click({ multiple: true });
+            cy.get('#simple-stats-popup').find('[data-close="close-button"]').click({ multiple: true });
             cy.get('#settings-popup').should('have.attr', 'style', 'display: none;');
         });
 


### PR DESCRIPTION
Closes #10015 

### Please check if the PR fulfills these requirements:

* [✅] Screenshots are attached to Github PR

### What is the current behavior?
In the file `simple_grading.spec.js`, extremely long selectors are tied using multiple classes.

### What is the new behavior?
Usage of `data-` selector instead of class selectors.
This in turn improves testing stability.

Upon running `simple_grading.spec.js` in Cypress UI : 

![refactor-simple-grading](https://github.com/Submitty/Submitty/assets/81346327/afd74dea-d98a-4d82-b390-afffc29bd1ce)

