### PR TITLE
[UI/UX:InstructorUI] Show Future Gradeable in Calendar

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4862,7 +4862,7 @@ SQL;
      * @param string $user_id
      * @return array
      */
-    public function getGraderLevelAccessCourse($user_id): array {
+    public function getGraderLevelAccessCourse(string $user_id): array {
         $this->submitty_db->query("SELECT term, course FROM courses_users WHERE user_id=? AND user_group<4", [$user_id]);
         return $this->submitty_db->rows();
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -4858,6 +4858,16 @@ SQL;
     }
 
     /**
+     * Get all courses where the user with the specified user_id is assigned as a grader
+     * @param string $user_id
+     * @return array
+     */
+    public function getGraderLevelAccessCourse($user_id): array {
+        $this->submitty_db->query("SELECT term, course FROM courses_users WHERE user_id=? AND user_group<4", [$user_id]);
+        return $this->submitty_db->rows();
+    }
+
+    /**
      * Get all unarchived courses where the user with the specified user_id is assigned as an instructor
      */
     public function getInstructorLevelUnarchivedCourses(string $user_id): array {
@@ -5783,22 +5793,6 @@ AND gc_id IN (
         );
         return count($this->submitty_db->rows()) >= 1 &&
             $this->submitty_db->row()['is_instructor'];
-    }
-
-    public function checkIsGraderInCourse($user_id, $course, $semester) {
-        // find user_group < 4
-        $this->submitty_db->query(
-            "
-            SELECT
-                CASE WHEN user_group < 4 THEN TRUE
-                ELSE FALSE
-                END
-            AS is_grader
-            FROM courses_users WHERE user_id=? AND course=? AND term=?",
-            [$user_id, $course, $semester]
-        );
-        return count($this->submitty_db->rows()) >= 1 &&
-            $this->submitty_db->row()['is_grader'];
     }
 
     public function getGradeInquiryStatus($user_id, $gradeable_id) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5785,6 +5785,22 @@ AND gc_id IN (
             $this->submitty_db->row()['is_instructor'];
     }
 
+    public function checkIsGraderInCourse($user_id, $course, $semester) {
+        // find user_group < 4
+        $this->submitty_db->query(
+            "
+            SELECT
+                CASE WHEN user_group < 4 THEN TRUE
+                ELSE FALSE
+                END
+            AS is_grader
+            FROM courses_users WHERE user_id=? AND course=? AND term=?",
+            [$user_id, $course, $semester]
+        );
+        return count($this->submitty_db->rows()) >= 1 &&
+            $this->submitty_db->row()['is_grader'];
+    }
+
     public function getGradeInquiryStatus($user_id, $gradeable_id) {
         $this->course_db->query("SELECT * FROM grade_inquiries WHERE user_id = ? AND g_id = ? ", [$user_id, $gradeable_id]);
         return ($this->course_db->getRowCount() > 0) ? $this->course_db->row()['status'] : 0;

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -70,16 +70,28 @@ class CalendarInfo extends AbstractModel {
         $info = new CalendarInfo($core);
         $date_format = $core->getConfig()->getDateTimeFormat()->getFormat('gradeable');
 
-        // unserialize the gradeables_of_user 
         $unserialized_gradeables = [];
+        // Get courses that the access level is grader so that the calendar can show the Beta and Future section gradeables
+        $grader_level_courses = $core->getQueries()->getGraderLevelAccessCourse($core->getUser()->getId());
         
         foreach ($gradeables_of_user["gradeables"] as $id => $gradeable) {
             [$semester, $course_title, $_] = unserialize($id);
-            $unserialized_gradeables[$id] = [
-                'semester' => $semester,
-                'course' => $course_title,
-                'gradeable' => $gradeable
+            $term_course_object = [
+                'term' => $semester,
+                'course' => $course_title
             ];
+            if (in_array($term_course_object, $grader_level_courses)) {
+                $unserialized_gradeables[$id] = [
+                    'user_group' => "Grader",
+                    'gradeable' => $gradeable
+                ];
+            }
+            else {
+                $unserialized_gradeables[$id] = [
+                    'user_group' => "Student",
+                    'gradeable' => $gradeable
+                ];
+            }
         }
 
         $gradeable_list = new GradeableList($core, $core->getUser(), $unserialized_gradeables);

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -90,6 +90,7 @@ class CalendarInfo extends AbstractModel {
 
         // Get the gradeables from the GradeableList and group them by section
         $gradeable_list_sections = [
+            GradeableList::FUTURE => $gradeable_list->getFutureGradeables(),
             GradeableList::OPEN => $gradeable_list->getOpenGradeables(),
             GradeableList::GRADING => $gradeable_list->getGradingGradeables(),
             GradeableList::CLOSED => $gradeable_list->getClosedGradeables(),

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -73,7 +73,6 @@ class CalendarInfo extends AbstractModel {
         $unserialized_gradeables = [];
         // Get courses that the access level is grader so that the calendar can show the Beta and Future section gradeables
         $grader_level_courses = $core->getQueries()->getGraderLevelAccessCourse($core->getUser()->getId());
-        
         foreach ($gradeables_of_user["gradeables"] as $id => $gradeable) {
             [$semester, $course_title, $_] = unserialize($id);
             $term_course_object = [

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -70,7 +70,19 @@ class CalendarInfo extends AbstractModel {
         $info = new CalendarInfo($core);
         $date_format = $core->getConfig()->getDateTimeFormat()->getFormat('gradeable');
 
-        $gradeable_list = new GradeableList($core, $core->getUser(), $gradeables_of_user["gradeables"]);
+        // unserialize the gradeables_of_user 
+        $unserialized_gradeables = [];
+        
+        foreach ($gradeables_of_user["gradeables"] as $id => $gradeable) {
+            [$semester, $course_title, $_] = unserialize($id);
+            $unserialized_gradeables[$id] = [
+                'semester' => $semester,
+                'course' => $course_title,
+                'gradeable' => $gradeable
+            ];
+        }
+
+        $gradeable_list = new GradeableList($core, $core->getUser(), $unserialized_gradeables);
 
         $i = 1;
         /** @var Course $course */

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -91,6 +91,7 @@ class CalendarInfo extends AbstractModel {
         // Get the gradeables from the GradeableList and group them by section
         $gradeable_list_sections = [
             GradeableList::FUTURE => $gradeable_list->getFutureGradeables(),
+            GradeableList::BETA => $gradeable_list->getBetaGradeables(),
             GradeableList::OPEN => $gradeable_list->getOpenGradeables(),
             GradeableList::GRADING => $gradeable_list->getGradingGradeables(),
             GradeableList::CLOSED => $gradeable_list->getClosedGradeables(),

--- a/site/app/models/CalendarInfo.php
+++ b/site/app/models/CalendarInfo.php
@@ -70,7 +70,7 @@ class CalendarInfo extends AbstractModel {
         $info = new CalendarInfo($core);
         $date_format = $core->getConfig()->getDateTimeFormat()->getFormat('gradeable');
 
-        $unserialized_gradeables = [];
+        $unserialized_gradeables = array();
         // Get courses that the access level is grader so that the calendar can show the Beta and Future section gradeables
         $grader_level_courses = $core->getQueries()->getGraderLevelAccessCourse($core->getUser()->getId());
         foreach ($gradeables_of_user["gradeables"] as $id => $gradeable) {

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -98,7 +98,8 @@ class GradeableList extends AbstractModel {
             if (is_array($gradeable) && array_key_exists("user_group", $gradeable) && array_key_exists("gradeable", $gradeable)) {
                 $user_group = $gradeable["user_group"];
                 $gradeable = $gradeable["gradeable"];
-            }else {
+            }
+            else {
                 $user_group = null;
             }
             switch (self::getGradeableSection($this->core, $gradeable, $user_group)) {

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -318,10 +318,10 @@ class GradeableList extends AbstractModel {
         }
         elseif (($core->getUser()->accessGrading() || $user_group === "Grader") && $gradeable->getTaViewStartDate() <= $now) {
             // TA access from course pages
-            return self::BETA; 
+            return self::BETA;
         }
-        // Instructor access from either crouse pages and home pages(i.e. from Calendar page)
         elseif ($core->getUser()->accessAdmin() || $core->getUser()->accessFaculty()) {
+            // Instructor access from either crouse pages and home pages(i.e. from Calendar page)
             return self::FUTURE;
         }
         return -1;

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -95,8 +95,13 @@ class GradeableList extends AbstractModel {
         $this->now = $this->core->getDateTimeNow();
 
         foreach ($this->gradeables as $id => $gradeable) {
-            [$semester, $course_title, $_] = @unserialize($id);
-            if ($semester === false || $course_title === false) {
+            // Only gradeables from CalendarInfo be an array of 3 elements
+            if ( is_array($gradeable) && array_keys($gradeable) === ['semester', 'course', 'gradeable']) {
+                $semester = $gradeable['semester'];
+                $course_title = $gradeable['course'];
+                $gradeable = $gradeable['gradeable'];
+            }
+            else {
                 $semester = $course_title = null;
             }
             switch (self::getGradeableSection($this->core, $gradeable, $course_title, $semester)) {
@@ -260,7 +265,7 @@ class GradeableList extends AbstractModel {
      * @param Gradeable $gradeable
      * @return int the section number; or -1 if not categorized
      */
-    public static function getGradeableSection(Core $core, Gradeable $gradeable, String $course_title = null, $semester = null): int {
+    public static function getGradeableSection(Core $core, Gradeable $gradeable, string $course_title = null, $semester = null): int {
         $now = DateUtils::getDateTimeNow();
         if ($gradeable->hasReleaseDate() && $gradeable->getGradeReleasedDate() <= $now) {
             return self::GRADED;

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -98,6 +98,8 @@ class GradeableList extends AbstractModel {
             if (is_array($gradeable) && array_key_exists("user_group", $gradeable) && array_key_exists("gradeable", $gradeable)) {
                 $user_group = $gradeable["user_group"];
                 $gradeable = $gradeable["gradeable"];
+            }else {
+                $user_group = null;
             }
             switch (self::getGradeableSection($this->core, $gradeable, $user_group)) {
                 case self::FUTURE:

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -261,10 +261,6 @@ class GradeableList extends AbstractModel {
      * @return int the section number; or -1 if not categorized
      */
     public static function getGradeableSection(Core $core, Gradeable $gradeable, String $course_title = null, $semester = null): int {
-        // echo "<script>console.log('semester: " . $semester . "');</script>";
-        // echo "<script>console.log('course_title: " . $course_title . "');</script>";
-        // echo "<script>console.log('gradeable id: " . $gradeable->getId() . "');</script>";
-        
         $now = DateUtils::getDateTimeNow();
         if ($gradeable->hasReleaseDate() && $gradeable->getGradeReleasedDate() <= $now) {
             return self::GRADED;

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -312,10 +312,10 @@ class GradeableList extends AbstractModel {
         ) {
             return self::OPEN;
         }
-        elseif ($core->getUser()->accessGrading() && $gradeable->getTaViewStartDate() <= $now) {
+        elseif ($core->getUser()->getAccessLevel() < 4 && $gradeable->getTaViewStartDate() <= $now) {
             return self::BETA;
         }
-        elseif ($core->getUser()->accessAdmin()) {
+        elseif ($core->getUser()->getAccessLevel() < 3) {
             return self::FUTURE;
         }
         return -1;

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
         - app
         - public/index.php
         - socket/index.php
+    treatPhpDocTypesAsCertain: false
     ignoreErrors:
         - '#Access to an undefined property Ratchet\\ConnectionInterface::\$resourceId\.#'
         - '#Access to an undefined property Ratchet\\ConnectionInterface::\$httpRequest\.#'


### PR DESCRIPTION
fixes #10234 

### What is the current behavior?
Both the Beta & Future section gradeable are invisible from the calendar. 
Future section: gradeable has not been shown to anyone except for the instructor/system admin.
Beta section: gradeable has been opened to TAs

### What is the new behavior?
Both due dates of Future & Beta section gradeable are visible from the calendar. 

The following are the date set for a Future Gradeable named `Test Future`:

<img width="926" alt="截圖 2024-03-12 下午12 58 58" src="https://github.com/Submitty/Submitty/assets/60954116/b442c167-199a-405a-aec1-081af7e0afff">

The due date is shown on 3/20:

<img width="1494" alt="截圖 2024-03-12 下午12 57 26" src="https://github.com/Submitty/Submitty/assets/60954116/85e39ac0-1abc-4bcb-90d8-3d0e45be977a">


### Other information?
To detect BETA section:
I added a new function `getGraderLevelAccessCourse` in `DatabaseQueries.php` to help `CalendarInfo.php` to get the courses which the current user has the grader access level. It will be passed to the `GradeableList.php` to verify for BETA section.

To detect FUTURE section:
I used `accessFaculty()` to detect whether the user is an instructor or not. Since most of the faculty should also be the instructor of the course, I just use `accessFaculty()` to fulfill this needs. However, if there are any concerns, please let me know!