### PR TITLE
[Bugfix:Forum] fix attachment upload in forum

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -162,9 +162,11 @@
                     var part = "{{ post_box_id }}";
                     initializeDragAndDrop();
                     createArray(part);
-                    $(".upload_attachment_box").each(function() {
-                        this.addEventListener("click", clicked_on_box, false);
+                    
+                    $(".parent-container").on("click", ".upload_attachment_box", function() {
+                        clicked_on_box.apply(this, arguments);
                     });
+
                 });
             </script>
         {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #9794 [](https://github.com/Submitty/Submitty/issues/9794)
To reproduce the issue:
go to forum and click on reply thread or create new thread.
click upload attachment.
now the user need to select the item twice in the doc page, to upload the items. 
### What is the new behavior?
The doc page will no longer pop up twice since the user upload the attachment.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
