### PR TITLE
[Refactor:System] Switch PDO to DBAL

### DIFF
--- a/site/.performance_warning_ignore.json
+++ b/site/.performance_warning_ignore.json
@@ -44,5 +44,6 @@
   "/courses/<term>/<course>/polls/newPoll",
   "/courses/<term>/<course>/polls/editPoll/submitEdits",
   "/courses/<term>/<course>/polls/deletePoll",
-  "/courses/<term>/<course>/upload"
+  "/courses/<term>/<course>/upload",
+  "/courses/<term>/<course>/email_status_page"
 ]

--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -82,10 +82,8 @@ class UserProfileController extends AbstractController {
     public function setPrefLocale() {
         if (isset($_POST['locale'])) {
             $user = $this->core->getUser();
-            $success = $user->setPreferredLocale(empty($_POST['locale']) ? null : $_POST['locale']);
-            if ($success) {
-                return JsonResponse::getSuccessResponse([ 'locale' => $user->getPreferredLocale() ]);
-            }
+            $user->setPreferredLocale(empty($_POST['locale']) ? null : $_POST['locale']);
+            return JsonResponse::getSuccessResponse([ 'locale' => $user->getPreferredLocale() ]);
         }
 
         return JsonResponse::getFailResponse('Failed to update user locale.');

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -257,9 +257,7 @@ class ElectronicGraderController extends AbstractController {
                 foreach ($students as $student) {
                     array_push($student_list, ['user_id' => $student->getId()]);
                     if ($submit_before_grading) {
-                        if ($this->core->getQueries()->getUserHasSubmission($gradeable, $student->getId()) == $student->getId()) {
-                        }
-                        else {
+                        if ($this->core->getQueries()->getUserHasSubmission($gradeable, $student->getId())) {
                             array_push($student_array, $student->getId());
                         }
                     }
@@ -300,9 +298,7 @@ class ElectronicGraderController extends AbstractController {
              $sorted_students[$reg_sec][] = $student;
              array_push($student_list, ['user_id' => $student->getId()]);
             if ($submit_before_grading) {
-                if ($this->core->getQueries()->getUserHasSubmission($gradeable, $student->getId()) == $student->getId()) {
-                }
-                else {
+                if ($this->core->getQueries()->getUserHasSubmission($gradeable, $student->getId())) {
                     array_push($student_array, $student->getId());
                 }
             }

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -202,7 +202,7 @@ class Core {
         $this->database_factory = new DatabaseFactory($this->config->getDatabaseDriver());
 
         $this->submitty_db = $this->database_factory->getDatabase($this->config->getSubmittyDatabaseParams());
-        $this->submitty_db->connect();
+        $this->submitty_db->connect($this->config->isDebug());
 
         $this->setQueries($this->database_factory->getQueries($this));
         $this->submitty_entity_manager = $this->createEntityManager($this->submitty_db);
@@ -228,7 +228,7 @@ class Core {
             return;
         }
         $this->course_db = $this->database_factory->getDatabase($this->config->getCourseDatabaseParams());
-        $this->course_db->connect();
+        $this->course_db->connect($this->config->isDebug());
 
         $this->setQueries($this->database_factory->getQueries($this));
         $this->course_entity_manager = $this->createEntityManager($this->course_db);

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -127,13 +127,13 @@ abstract class AbstractDatabase {
 
     /**
      * Run a query against the connected DBAL DB.
+     * This function will throw an exception if it fails.
+     * Otherwise, it can be assumed it succeeded.
      *
      * @param string $query
      * @param array $parameters
-     *
-     * @return boolean true if query succeeded, else false.
      */
-    public function query($query, $parameters = []) {
+    public function query($query, $parameters = []): void {
         try {
             foreach ($parameters as &$parameter) {
                 if (gettype($parameter) === "boolean") {
@@ -163,8 +163,6 @@ abstract class AbstractDatabase {
         catch (DBALException $dbalException) {
             throw new DatabaseException($dbalException->getMessage(), $query, $parameters);
         }
-
-        return true;
     }
 
     /**
@@ -184,7 +182,8 @@ abstract class AbstractDatabase {
     public function queryIterator(string $query, array $parameters = [], $callback = null) {
         $lower = trim(strtolower($query));
         if (!str_starts_with($lower, "select")) {
-            return $this->query($query, $parameters);
+            $this->query($query, $parameters);
+            return true;
         }
         try {
             $statement = $this->conn->prepare($query);

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -3,12 +3,20 @@
 namespace app\libraries\database;
 
 use app\exceptions\DatabaseException;
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Logging\Middleware;
 
+/**
+ * @psalm-import-type Params from DriverManager
+ */
 abstract class AbstractDatabase {
     /**
-     * @var \PDO|null
+     * @var Connection|null
      */
-    protected $link = null;
+    protected $conn = null;
 
     /**
      * @var array
@@ -17,15 +25,7 @@ abstract class AbstractDatabase {
 
     protected $row_count = 0;
 
-    /**
-     * @var int
-     */
-    protected $query_count = 0;
-
-    /**
-     * @var array
-     */
-    protected $all_queries = [];
+    protected QueryLogger $query_logger;
 
     /**
      * @var bool
@@ -34,15 +34,6 @@ abstract class AbstractDatabase {
 
     protected $username = null;
     protected $password = null;
-
-    /**
-     * Should we emulate prepares within PDO. Generally we want to leave this to false, but for some
-     * drivers (such as PDO_MySQL, it may be beneficial for performance to turn this to true
-     * @var bool
-     */
-    protected $emulate_prepares = false;
-
-    protected $columns = [];
 
     /**
      * Database constructor. This function (overridden in all children) sets our
@@ -62,13 +53,16 @@ abstract class AbstractDatabase {
         }
     }
 
-    abstract public function getDSN();
+    /**
+     * @psalm-return Params
+     */
+    abstract public function getConnectionDetails(): array;
 
-    public function getConnection(): \PDO {
-        if ($this->link === null) {
+    public function getConnection(): Connection {
+        if ($this->conn === null) {
             throw new DatabaseException("Database not yet connected");
         }
-        return $this->link;
+        return $this->conn;
     }
 
     /**
@@ -87,7 +81,7 @@ abstract class AbstractDatabase {
 
     /**
      * Connects to a database through the PDO extension (@link http://php.net/manual/en/book.pdo.php).
-     * We wrap the potential exception that would get thrown by the PDO constructor so that we can
+     * We wrap the potential exception that would get thrown by the DBAL constructor so that we can
      * bubble up the message, without exposing any of the parameters used by the connect function
      * as we don't wany anyone to get the DB details.
      *
@@ -95,50 +89,43 @@ abstract class AbstractDatabase {
      */
     public function connect() {
         // Only start a new connection if we're not already connected to a DB
-        if ($this->link === null) {
-            $this->query_count = 0;
-            $this->all_queries = [];
+        if ($this->conn === null) {
             try {
-                if (isset($this->username) && isset($this->password)) {
-                    $this->link = new \PDO($this->getDSN(), $this->username, $this->password);
-                }
-                elseif (isset($this->username)) {
-                    $this->link = new \PDO($this->getDSN(), $this->username);
-                }
-                else {
-                    $this->link = new \PDO($this->getDSN());
-                }
+                $this->query_logger = new QueryLogger();
+                $logger_middleware = new Middleware($this->query_logger);
+                $config = new Configuration();
+                $config->setMiddlewares([$logger_middleware]);
 
-                $this->link->setAttribute(\PDO::ATTR_EMULATE_PREPARES, $this->emulate_prepares);
-                $this->link->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+                $details = $this->getConnectionDetails();
+                $this->conn = DriverManager::getConnection($details, $config);
             }
-            catch (\PDOException $pdoException) {
-                throw new DatabaseException($pdoException->getMessage());
+            catch (DBALException $dbalException) {
+                throw new DatabaseException($dbalException->getMessage());
             }
         }
     }
 
     /**
-     * "Disconnect" from current PDO connection by just setting the link to null, and PDO will take care of actually
-     * recycling the connection upon the GC destruction of the PDO object. This will additionally commit any open
-     * transactions before disconnecting.
+     * "Disconnect" from the underlying connection and set it to null for any further new connections.
+     * This will additionally commit any open transactions before disconnecting.
      */
     public function disconnect() {
         if ($this->transaction) {
             $this->rollback();
         }
-        $this->link = null;
+        $this->conn->close();
+        $this->conn = null;
     }
 
     /**
      * @return bool Returns true if we're connected to a database, else return false
      */
     public function isConnected() {
-        return $this->link !== null;
+        return $this->conn !== null;
     }
 
     /**
-     * Run a query against the connected PDO DB.
+     * Run a query against the connected DBAL DB.
      *
      * @param string $query
      * @param array $parameters
@@ -147,7 +134,6 @@ abstract class AbstractDatabase {
      */
     public function query($query, $parameters = []) {
         try {
-            $this->query_count++;
             foreach ($parameters as &$parameter) {
                 if (gettype($parameter) === "boolean") {
                     $parameter = $this->convertBoolean($parameter);
@@ -158,31 +144,26 @@ abstract class AbstractDatabase {
                     }
                 }
             }
-            $this->all_queries[] = [$query, $parameters];
-            $statement = $this->link->prepare($query);
-            $result = $statement->execute($parameters);
+            $statement = $this->conn->prepare($query);
+            $result = $statement->executeQuery($parameters);
 
             $this->row_count = null;
             $identity = QueryIdentifier::identify($query);
             if (
                 in_array($identity, [QueryIdentifier::UPDATE, QueryIdentifier::DELETE, QueryIdentifier::INSERT])
             ) {
-                $this->row_count = $statement->rowCount();
+                $this->row_count = $result->rowCount();
             }
             elseif ($identity === QueryIdentifier::SELECT) {
-                $columns = $this->getColumnData($statement);
-                $this->results = $statement->fetchAll(\PDO::FETCH_ASSOC);
-                foreach ($this->results as $idx => $result) {
-                    $this->results[$idx] = $this->transformResult($result, $columns);
-                }
+                $this->results = $result->fetchAllAssociative();
                 $this->row_count = count($this->results);
             }
         }
-        catch (\PDOException $pdoException) {
-            throw new DatabaseException($pdoException->getMessage(), $query, $parameters);
+        catch (DBALException $dbalException) {
+            throw new DatabaseException($dbalException->getMessage(), $query, $parameters);
         }
 
-        return $result;
+        return true;
     }
 
     /**
@@ -205,54 +186,14 @@ abstract class AbstractDatabase {
             return $this->query($query, $parameters);
         }
         try {
-            $this->query_count++;
-            $this->all_queries[] = [$query, $parameters];
-            $statement = $this->link->prepare($query);
-            $statement->execute($parameters);
+            $statement = $this->conn->prepare($query);
+            $result = $statement->executeQuery($parameters);
             $this->row_count = null;
-            return new DatabaseRowIterator($statement, $this, $callback);
+            return new DatabaseRowIterator($result, $callback);
         }
-        catch (\PDOException $exception) {
+        catch (DBALException $exception) {
             throw new DatabaseException($exception->getMessage(), $query, $parameters);
         }
-    }
-
-    /**
-     * @param \PDOStatement $statement
-     *
-     * @return array
-     */
-    public function getColumnData($statement) {
-        $columns = [];
-        for ($i = 0; $i < $statement->columnCount(); $i++) {
-            $col = $statement->getColumnMeta($i);
-            if ($col !== false) {
-                $columns[$col['name']] = $col;
-            }
-        }
-        return $columns;
-    }
-
-    /**
-     * @param array $result
-     * @param array $columns
-     *
-     * @return mixed
-     */
-    public function transformResult(array $result, array $columns) {
-        foreach ($result as $col => $value) {
-            if (isset($columns[$col])) {
-                $column = $columns[$col];
-                if ($column['native_type'] === 'integer' && $column['pdo_type'] !== \PDO::PARAM_INT) {
-                    $value = (int) $value;
-                }
-                elseif ($column['native_type'] === 'boolean' && $column['pdo_type'] !== \PDO::PARAM_BOOL) {
-                    $value = (bool) $value;
-                }
-                $result[$col] = $value;
-            }
-        }
-        return $result;
     }
 
     /**
@@ -261,7 +202,7 @@ abstract class AbstractDatabase {
      */
     public function beginTransaction(): void {
         if (!$this->transaction) {
-            $this->transaction = $this->link->beginTransaction();
+            $this->transaction = $this->conn->beginTransaction();
         }
     }
 
@@ -270,14 +211,14 @@ abstract class AbstractDatabase {
      */
     public function commit(): void {
         if ($this->transaction) {
-            $this->link->commit();
+            $this->conn->commit();
             $this->transaction = false;
         }
     }
 
     public function rollback(): void {
         if ($this->transaction) {
-            $this->link->rollBack();
+            $this->conn->rollBack();
             $this->transaction = false;
         }
     }
@@ -314,7 +255,7 @@ abstract class AbstractDatabase {
 
     /**
      * If the last query was a SELECT, returns the number of rows returned else if
-     * it's a UPDATE, DELETE, or INSERT, we use PDOStatement::rowCount to get the
+     * it's a UPDATE, DELETE, or INSERT, we use Result::rowCount to get the
      * number of affected rows.
      *
      * @link http://php.net/manual/en/pdostatement.rowcount.php
@@ -326,24 +267,24 @@ abstract class AbstractDatabase {
     }
 
     /**
-     * Return count of total queries run against current PDO connection
+     * Return count of total queries run against current DBAL connection
      */
     public function getQueryCount(): int {
-        return count($this->all_queries);
+        return count($this->query_logger->getQueries());
     }
 
     public function getQueries(): array {
-        return $this->all_queries;
+        return $this->query_logger->getQueries();
     }
 
     /**
-     * Get all queries run against the current PDO connection, with placeholders replaced by their values
+     * Get all queries run against the current DBAL connection, with placeholders replaced by their values
      *
      * @return string[]
      */
     public function getPrintQueries(): array {
         $print = [];
-        foreach ($this->all_queries as $query) {
+        foreach ($this->query_logger->getQueries() as $query) {
             $print[] = DatabaseUtils::formatQuery($query[0], $query[1]);
         }
         return $print;
@@ -351,7 +292,7 @@ abstract class AbstractDatabase {
 
     public function hasDuplicateQueries(): bool {
         $queries = [];
-        foreach ($this->all_queries as $query) {
+        foreach ($this->query_logger->getQueries() as $query) {
             $queries[] = $query[0];
         }
         return count($queries) !== count(array_unique($queries));
@@ -374,7 +315,7 @@ abstract class AbstractDatabase {
      * @return mixed ID of the last inserted row
      */
     public function getLastInsertId($name = null) {
-        return $this->link->lastInsertId($name);
+        return $this->conn->lastInsertId($name);
     }
 
     /**

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -108,7 +108,7 @@ abstract class AbstractDatabase {
 
     /**
      * "Disconnect" from the underlying connection and set it to null for any further new connections.
-     * This will additionally commit any open transactions before disconnecting.
+     * This will additionally rollback any open transactions before disconnecting.
      */
     public function disconnect() {
         if ($this->transaction) {

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -80,7 +80,7 @@ abstract class AbstractDatabase {
     abstract public function fromPHPToDatabaseArray($array);
 
     /**
-     * Connects to a database through the PDO extension (@link http://php.net/manual/en/book.pdo.php).
+     * Connects to a database through the DBAL library.
      * We wrap the potential exception that would get thrown by the DBAL constructor so that we can
      * bubble up the message, without exposing any of the parameters used by the connect function
      * as we don't wany anyone to get the DB details.

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -141,11 +141,10 @@ class DatabaseQueries {
      * Update a user's preferred locale in the master database.
      *
      * @param User $user The user object to modify
-     * @param string $locale The locale string to set it to, must be one of Core::getSupportedLocales()
-     * @return bool Whether the operation was successful
+     * @param string|null $locale The locale string to set it to, must be one of Core::getSupportedLocales()
      */
-    public function updateSubmittyUserPreferredLocale(User $user, string|null $locale): bool {
-        return $this->submitty_db->query("UPDATE users SET user_preferred_locale=? WHERE user_id=?", [$locale, $user->getId()]);
+    public function updateSubmittyUserPreferredLocale(User $user, string|null $locale): void {
+        $this->submitty_db->query("UPDATE users SET user_preferred_locale=? WHERE user_id=?", [$locale, $user->getId()]);
     }
 
     /**
@@ -7386,12 +7385,12 @@ AND gc_id IN (
      * @param  String                     $userid
      * @return bool
      */
-    public function getUserHasSubmission(Gradeable $gradeable, string $userid) {
-
-        return $this->course_db->query(
+    public function getUserHasSubmission(Gradeable $gradeable, string $userid): bool {
+        $this->course_db->query(
             'SELECT user_id FROM electronic_gradeable_data WHERE g_id=? AND (user_id=?)',
             [$gradeable->getId(), $userid]
         );
+        return $this->course_db->getRowCount() > 0;
     }
 
     /**

--- a/site/app/libraries/database/DatabaseRowIterator.php
+++ b/site/app/libraries/database/DatabaseRowIterator.php
@@ -2,6 +2,8 @@
 
 namespace app\libraries\database;
 
+use Doctrine\DBAL\Result;
+
 /**
  * Class DatabaseRowIterator
  *
@@ -14,31 +16,26 @@ namespace app\libraries\database;
  * used within a foreach loop.
  */
 class DatabaseRowIterator implements \Iterator {
-    private $statement;
-    private $database;
+    private Result $overall_result;
     private $callback;
-    private $result;
+    private mixed $current_result;
     private $key = -1;
     private $valid = true;
-    private $columns = [];
 
     /**
      * DatabaseRowIterator constructor.
      *
-     * @param \PDOStatement    $statement
-     * @param AbstractDatabase $database
+     * @param Result           $result
      * @param null|callable    $callback
      */
-    public function __construct(\PDOStatement $statement, $database, $callback = null) {
-        $this->statement = $statement;
-        $this->database = $database;
-        $this->columns = $this->database->getColumnData($this->statement);
+    public function __construct(Result $result, $callback = null) {
+        $this->overall_result = $result;
         $this->callback = $callback;
         $this->next();
     }
 
     public function current(): mixed {
-        return $this->result;
+        return $this->current_result;
     }
 
     public function next(): void {
@@ -46,15 +43,13 @@ class DatabaseRowIterator implements \Iterator {
             return;
         }
         $this->key++;
-        $this->result = $this->statement->fetch(\PDO::FETCH_ASSOC);
-        if ($this->result === false) {
+        $this->current_result = $this->overall_result->fetchAssociative();
+        if ($this->current_result === false) {
             $this->valid = false;
             return;
         }
-        $this->result = $this->database->transformResult($this->result, $this->columns);
         if ($this->callback !== null) {
-            /** @var mixed $this->result */
-            $this->result = call_user_func($this->callback, $this->result);
+            $this->current_result = call_user_func($this->callback, $this->current_result);
         }
     }
 
@@ -70,8 +65,8 @@ class DatabaseRowIterator implements \Iterator {
     }
 
     public function close() {
-        $this->statement->closeCursor();
+        $this->overall_result->free();
         $this->valid = false;
-        $this->result = null;
+        $this->current_result = null;
     }
 }

--- a/site/app/libraries/database/PostgresqlDatabase.php
+++ b/site/app/libraries/database/PostgresqlDatabase.php
@@ -30,21 +30,32 @@ class PostgresqlDatabase extends AbstractDatabase {
         }
     }
 
-    public function getDSN() {
-        $params = [];
+    public function getConnectionDetails(): array {
+        $details = [
+            'driver' => 'pdo_pgsql'
+        ];
+
         if ($this->host !== null) {
-            $params[] = "host={$this->host}";
+            $details['host'] = $this->host;
         }
 
         if ($this->port !== null && ($this->host === null || $this->host[0] !== '/')) {
-            $params[] = "port={$this->port}";
+            $details['port'] = $this->port;
         }
 
         if (isset($this->dbname)) {
-            $params[] = "dbname={$this->dbname}";
+            $details['dbname'] = $this->dbname;
         }
 
-        return 'pgsql:' . implode(';', $params);
+        if ($this->username !== null) {
+            $details['user'] = $this->username;
+        }
+
+        if ($this->password !== null) {
+            $details['password'] = $this->password;
+        }
+
+        return $details;
     }
 
     /**

--- a/site/app/libraries/database/QueryLogger.php
+++ b/site/app/libraries/database/QueryLogger.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace app\libraries\database;
+
+use Psr\Log\AbstractLogger;
+
+class QueryLogger extends AbstractLogger {
+    /**
+     * @var mixed[][]
+     *
+     * This is a 2D array containing database queries that have been logged.
+     * Each element in a 2 element array containing the query and an array of parameters.
+     */
+    protected array $queries = [];
+
+    /**
+     * @param $level
+     * @param \Stringable|string $message
+     * @param array<mixed> $context
+     * @return void
+     */
+    public function log($level, \Stringable|string $message, array $context = []): void {
+        if ($level === "debug") { // SQL queries are in the debug level
+            if (!isset($context['sql'])) {
+                return; // Ignore if SQL is not set
+            }
+            $this->queries[] = [
+                $context['sql'],
+                $context['params']
+            ];
+        }
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function getQueries(): array {
+        return $this->queries;
+    }
+}

--- a/site/app/libraries/database/QueryLogger.php
+++ b/site/app/libraries/database/QueryLogger.php
@@ -20,10 +20,8 @@ class QueryLogger extends AbstractLogger {
      * @return void
      */
     public function log($level, \Stringable|string $message, array $context = []): void {
-        if ($level === "debug") { // SQL queries are in the debug level
-            if (!isset($context['sql'])) {
-                return; // Ignore if SQL is not set
-            }
+        // SQL queries are in the debug level, but we want to ignore any other debug log
+        if ($level === "debug" && isset($context['sql'])) {
             $this->queries[] = [
                 $context['sql'],
                 $context['params']

--- a/site/app/libraries/database/QueryLogger.php
+++ b/site/app/libraries/database/QueryLogger.php
@@ -24,7 +24,7 @@ class QueryLogger extends AbstractLogger {
         if ($level === "debug" && isset($context['sql'])) {
             $this->queries[] = [
                 $context['sql'],
-                $context['params']
+                $context['params'] ?? []
             ];
         }
     }

--- a/site/app/libraries/database/QueryLogger.php
+++ b/site/app/libraries/database/QueryLogger.php
@@ -3,6 +3,7 @@
 namespace app\libraries\database;
 
 use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
 
 class QueryLogger extends AbstractLogger {
     /**
@@ -21,7 +22,7 @@ class QueryLogger extends AbstractLogger {
      */
     public function log($level, \Stringable|string $message, array $context = []): void {
         // SQL queries are in the debug level, but we want to ignore any other debug log
-        if ($level === "debug" && isset($context['sql'])) {
+        if ($level === LogLevel::DEBUG && isset($context['sql'])) {
             $this->queries[] = [
                 $context['sql'],
                 $context['params'] ?? []

--- a/site/app/libraries/database/SqliteDatabase.php
+++ b/site/app/libraries/database/SqliteDatabase.php
@@ -12,21 +12,22 @@ class SqliteDatabase extends AbstractDatabase {
         parent::__construct($connection_params);
         if (isset($connection_params['path'])) {
             $this->path = $connection_params['path'];
+            $this->memory = false;
         }
         else {
             $this->memory = isset($connection_params['memory']) && $connection_params['memory'] === true;
         }
     }
 
-    public function getDSN() {
-        $param = '';
+    public function getConnectionDetails(): array {
+        $details = [
+            'driver' => 'pdo_sqlite',
+            'memory' => $this->memory
+        ];
         if (isset($this->path)) {
-            $param = $this->path;
+            $details['path'] = $this->path;
         }
-        elseif ($this->memory === true) {
-            $param = ':memory:';
-        }
-        return "sqlite:{$param}";
+        return $details;
     }
 
     public function fromDatabaseToPHPArray($text, $parse_bools = false, $start = 0, &$end = null) {

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -390,18 +390,13 @@ class User extends AbstractModel {
     /**
      * Update the user's preferred locale.
      *
-     * @param string $locale The desired new locale, must be one of Core::getSupportedLocales()
-     * @return bool Whether or not the operation was successful
+     * @param string|null $locale The desired new locale, must be one of Core::getSupportedLocales()
      */
-    public function setPreferredLocale(string|null $locale): bool {
+    public function setPreferredLocale(string|null $locale): void {
         if (is_null($locale) || in_array($locale, $this->core->getSupportedLocales())) {
-            $success = $this->core->getQueries()->updateSubmittyUserPreferredLocale($this, $locale);
-            if ($success) {
-                $this->preferred_locale = $locale;
-                return true;
-            }
+            $this->core->getQueries()->updateSubmittyUserPreferredLocale($this, $locale);
+            $this->preferred_locale = $locale;
         }
-        return false;
     }
 
 

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -9,7 +9,6 @@ class EmailRepository extends EntityRepository {
     const MAX_SUBJECTS_PER_PAGE = 10;
 
     public function getEmailsByPage(int $page, $semester = null, $course = null): array {
-        $this->_em->getConnection()->getConfiguration()->setSQLLogger(null);
         $subjects = $this->getPageSubjects($page, $semester, $course);
         $result = [];
 

--- a/site/composer.json
+++ b/site/composer.json
@@ -24,7 +24,7 @@
     "browscap/browscap-php": "7.2.0",
     "cboden/ratchet": "0.4.4",
     "doctrine/annotations": "1.14.3",
-    "doctrine/dbal": "2.13.9",
+    "doctrine/dbal": "3.8.2",
     "doctrine/orm": "2.18.2",
     "egulias/email-validator": "4.0.2",
     "lcobucci/jwt": "5.0.0",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b9c9cc0f7807693135d112a7deea835",
+    "content-hash": "11437b2e8198d750aff440114047ff1b",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -615,35 +615,40 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.9",
+            "version": "3.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "c480849ca3ad6706a39c970cdfe6888fa8a058b8"
+                "reference": "a19a1d05ca211f41089dffcc387733a6875196cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c480849ca3ad6706a39c970cdfe6888fa8a058b8",
-                "reference": "c480849ca3ad6706a39c970cdfe6888fa8a058b8",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/a19a1d05ca211f41089dffcc387733a6875196cb",
+                "reference": "a19a1d05ca211f41089dffcc387733a6875196cb",
                 "shasum": ""
             },
             "require": {
-                "doctrine/cache": "^1.0|^2.0",
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
                 "doctrine/deprecations": "^0.5.3|^1",
-                "doctrine/event-manager": "^1.0",
-                "ext-pdo": "*",
-                "php": "^7.1 || ^8"
+                "doctrine/event-manager": "^1|^2",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
             },
             "require-dev": {
-                "doctrine/coding-standard": "9.0.0",
-                "jetbrains/phpstorm-stubs": "2021.1",
-                "phpstan/phpstan": "1.4.6",
-                "phpunit/phpunit": "^7.5.20|^8.5|9.5.16",
-                "psalm/plugin-phpunit": "0.16.1",
-                "squizlabs/php_codesniffer": "3.6.2",
-                "symfony/cache": "^4.4",
-                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "4.22.0"
+                "doctrine/coding-standard": "12.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.1",
+                "phpstan/phpstan": "1.10.57",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpunit/phpunit": "9.6.16",
+                "psalm/plugin-phpunit": "0.18.4",
+                "slevomat/coding-standard": "8.13.1",
+                "squizlabs/php_codesniffer": "3.8.1",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0",
+                "vimeo/psalm": "4.30.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -654,7 +659,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                    "Doctrine\\DBAL\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -697,14 +702,13 @@
                 "queryobject",
                 "sasql",
                 "sql",
-                "sqlanywhere",
                 "sqlite",
                 "sqlserver",
                 "sqlsrv"
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.9"
+                "source": "https://github.com/doctrine/dbal/tree/3.8.2"
             },
             "funding": [
                 {
@@ -720,7 +724,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-02T20:28:55+00:00"
+            "time": "2024-02-12T18:36:36+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -7841,5 +7845,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -2278,7 +2278,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 21
+			count: 19
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-
@@ -5302,11 +5302,6 @@ parameters:
 
 		-
 			message: "#^Call to method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getRawUsersWithOverriddenGrades\\(\\) with incorrect case\\: getRawUsersWIthOverriddenGrades$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Comparison operation \"\\>\" between int\\<min, 0\\> and 0 is always false\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -3981,11 +3981,6 @@ parameters:
 			path: app/libraries/Core.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, Doctrine\\\\DBAL\\\\Logging\\\\DebugStack\\|null given\\.$#"
-			count: 1
-			path: app/libraries/Core.php
-
-		-
 			message: "#^PHPDoc tag @var with type app\\\\repositories\\\\SessionRepository is not subtype of type app\\\\repositories\\\\SessionRepository\\<app\\\\entities\\\\Session\\>\\.$#"
 			count: 1
 			path: app/libraries/Core.php
@@ -5196,11 +5191,6 @@ parameters:
 			path: app/libraries/database/AbstractDatabase.php
 
 		-
-			message: "#^Foreach overwrites \\$result with its value variable\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/libraries/database/AbstractDatabase.php
@@ -5236,16 +5226,6 @@ parameters:
 			path: app/libraries/database/AbstractDatabase.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getColumnData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getDSN\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getQueries\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/libraries/database/AbstractDatabase.php
@@ -5267,26 +5247,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:rows\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:transformResult\\(\\) has parameter \\$columns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:transformResult\\(\\) has parameter \\$result with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
-			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$all_queries type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
-			message: "#^Property app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:\\$columns has no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/AbstractDatabase.php
 
@@ -8176,37 +8136,12 @@ parameters:
 			path: app/libraries/database/DatabaseRowIterator.php
 
 		-
-			message: "#^PHPDoc tag @var with type mixed is not subtype of native type \\$this\\(app\\\\libraries\\\\database\\\\DatabaseRowIterator\\)\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseRowIterator.php
-
-		-
 			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$callback has no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseRowIterator.php
 
 		-
-			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$columns has no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseRowIterator.php
-
-		-
-			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$database has no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseRowIterator.php
-
-		-
 			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$key has no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseRowIterator.php
-
-		-
-			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$result has no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseRowIterator.php
-
-		-
-			message: "#^Property app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:\\$statement has no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseRowIterator.php
 
@@ -8262,11 +8197,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/database/PostgresqlDatabase.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\PostgresqlDatabase\\:\\:getDSN\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/PostgresqlDatabase.php
 
@@ -8327,11 +8257,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:fromPHPToDatabaseArray\\(\\) has parameter \\$array with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/SqliteDatabase.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\SqliteDatabase\\:\\:getDSN\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/SqliteDatabase.php
 

--- a/site/tests/app/controllers/AuthenticationControllerTester.php
+++ b/site/tests/app/controllers/AuthenticationControllerTester.php
@@ -13,6 +13,7 @@ use tests\BaseUnitTest;
 
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class AuthenticationControllerTester extends BaseUnitTest {
     public function setUp(): void {

--- a/site/tests/app/controllers/MiscControllerTester.php
+++ b/site/tests/app/controllers/MiscControllerTester.php
@@ -42,6 +42,7 @@ class MiscControllerTester extends \PHPUnit\Framework\TestCase {
     /**
      * @dataProvider userDataProvider
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testReadFileSite($user_details): void {
         $this->getFunctionMock('app\controllers', 'header')

--- a/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
+++ b/site/tests/app/controllers/course/CourseMaterialsControllerTester.php
@@ -252,6 +252,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testModifyCourseMaterials() {
         $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
@@ -323,6 +324,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testUpdateCourseMaterial() {
         $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')
@@ -398,6 +400,7 @@ class CourseMaterialsControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testDeleteCourseMaterial() {
         $this->getFunctionMock('app\controllers\course', 'is_uploaded_file')

--- a/site/tests/app/controllers/student/SubmissionControllerTester.php
+++ b/site/tests/app/controllers/student/SubmissionControllerTester.php
@@ -25,6 +25,7 @@ use tests\utils\NullOutput;
 
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class SubmissionControllerTester extends BaseUnitTest {
     use \phpmock\phpunit\PHPMock;
@@ -353,6 +354,7 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * Basic upload, only one part and one file, simple sanity check.
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testUploadOneBucket() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -406,6 +408,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      *
      * @numParts 2
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testUploadTwoBuckets() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -472,6 +475,7 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * Test what happens if we're uploading a zip that contains a directory.
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testZipWithDirectory() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -534,6 +538,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * Upload a second version of a gradeable with no previous files and different files per upload. Test
      * that both versions exist and neither bled over to the other.
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSecondVersionNoPrevious() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -606,6 +611,7 @@ class SubmissionControllerTester extends BaseUnitTest {
     /**
      * @numParts 2
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSecondVersionPreviousTwoParts() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -644,6 +650,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * Upload a second version of a gradeable that includes previous files, but there's no overlap in file names
      * so we should have one file in version 1 and two files in version 2
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSecondVersionPreviousNoOverlap() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -697,6 +704,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * This should only include the version that was uploaded (and not use the previous).
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSecondVersionPreviousOverlap() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -755,6 +763,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * that overlaps the file from the first version.
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSecondVersionPreviousOverlapZip() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -813,6 +822,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * be left alone.
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testZipInsideZip() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -857,6 +867,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * in the zip (the one not in a zip contains a single 'a' while the two files in the zip are blank).
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSameFilenameInZip() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -881,6 +892,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * This tests the same thing as testSameFilenameInZip(), however we submit "test.txt" before "zippedfiles.zip"
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSameFilenameInZipReversed() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -910,6 +922,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testFilenameWithSpaces() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -936,6 +949,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testZipContaingFilesWithSpaces() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1132,6 +1146,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorMissingPreviousFile() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1245,6 +1260,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorOnCopyingPrevious() {
         $this->addUploadFile('test1.txt');
@@ -1281,6 +1297,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorOnCopyingFile() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1301,6 +1318,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorCleanupTempFiles() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1383,6 +1401,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorBrokenHistoryFile() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1405,6 +1424,7 @@ class SubmissionControllerTester extends BaseUnitTest {
      * We're testing that rolling back the history works on failure to upload the second version of the file
      *
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorHistorySecondVersion() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1451,6 +1471,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorWriteSettingsFile() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')
@@ -1474,6 +1495,7 @@ class SubmissionControllerTester extends BaseUnitTest {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testErrorWriteTimestampFile() {
         $this->getFunctionMock('app\controllers\student', 'is_uploaded_file')

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -83,6 +83,7 @@ class FileUtilsTester extends \PHPUnit\Framework\TestCase {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRecursiveRmDirFileFail() {
         FileUtils::createDir($this->path);
@@ -97,6 +98,7 @@ class FileUtilsTester extends \PHPUnit\Framework\TestCase {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRecursiveRmDirRecurseFail() {
         FileUtils::createDir($this->path);
@@ -446,6 +448,7 @@ STRING;
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRecursiveChmodFail() {
         $this->getFunctionMock("app\\libraries", "chmod")

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -195,6 +195,7 @@ class UtilsTester extends \PHPUnit\Framework\TestCase {
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testCheckUploadedImageFileImageSizeFalse() {
         try {

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -41,7 +41,7 @@ class AbstractDatabaseTester extends \PHPUnit\Framework\TestCase {
         $database = new SqliteDatabase(['memory' => true]);
 
         $this->assertFalse($database->isConnected());
-        $database->connect();
+        $database->connect(true);
         $this->assertTrue($database->isConnected());
 
         $this->setupDatabase($database);

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -181,7 +181,7 @@ SELECT * FROM test");
 
     public function testPrintQueries() {
         $database = new SqliteDatabase(['memory' => true]);
-        $database->connect();
+        $database->connect(true);
         $database->query("CREATE TABLE test(pid integer PRIMARY KEY, tcol text NOT NULL)");
         $database->query("INSERT INTO test VALUES (?, ?)", [1, 'a']);
         $this->assertEquals([

--- a/site/tests/app/libraries/database/AbstractDatabaseTester.php
+++ b/site/tests/app/libraries/database/AbstractDatabaseTester.php
@@ -7,7 +7,7 @@ use app\libraries\database\AbstractDatabase;
 use app\libraries\database\PostgresqlDatabase;
 use app\libraries\database\SqliteDatabase;
 use app\libraries\FileUtils;
-use PDO;
+use Doctrine\DBAL\Connection;
 
 class AbstractDatabaseTester extends \PHPUnit\Framework\TestCase {
     private $queries = [
@@ -27,7 +27,7 @@ class AbstractDatabaseTester extends \PHPUnit\Framework\TestCase {
     public function testGetConnection() {
         $database = new SqliteDatabase(['memory' => true]);
         $database->connect();
-        $this->assertInstanceOf(PDO::class, $database->getConnection());
+        $this->assertInstanceOf(Connection::class, $database->getConnection());
     }
 
     public function testThrowsOnNoConnection() {
@@ -278,44 +278,11 @@ SELECT * FROM test ORDER BY pid");
         $this->assertNull($iterator->next());
     }
 
-    public function testTransform() {
-        $columns = [
-            'pid' => [
-                'native_type' => 'integer',
-                'table' => 'test',
-                'flags' => [],
-                'name' => 'pid',
-                'pdo_type' => \PDO::PARAM_STR
-            ],
-            'tcol' => [
-                'native_type' => 'string',
-                'table' => 'test',
-                'flags' => [],
-                'name' => 'tcol',
-                'pdo_type' => \PDO::PARAM_STR
-            ],
-            'bcol' => [
-                'native_type' => 'boolean',
-                'table' => 'test',
-                'flags' => [],
-                'name' => 'bcol',
-                'pdo_type' => \PDO::PARAM_STR
-            ]
-        ];
-        $result = [
-            'pid' => '1',
-            'tcol' => 'a',
-            'bcol' => 'true'
-        ];
-        $database = new SqliteDatabase();
-        $result = $database->transformResult($result, $columns);
-        $this->assertSame(['pid' => 1, 'tcol' => 'a', 'bcol' => true], $result);
-    }
-
     public function testInvalidDSN() {
         $database = new PostgresqlDatabase(['dbname' => 'invalid_db']);
         $this->expectException(\app\exceptions\DatabaseException::class);
         $database->connect();
+        $database->query("SELECT * FROM test");
     }
 
     public function testBadQuery() {

--- a/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
+++ b/site/tests/app/libraries/database/PostgresqlDatabaseTester.php
@@ -7,22 +7,46 @@ use app\libraries\database\PostgresqlDatabase;
 class PostgresqlDatabaseTester extends \PHPUnit\Framework\TestCase {
     public function testPostgresqlHost() {
         $database = new PostgresqlDatabase(['host' => 'localhost']);
-        $this->assertEquals("pgsql:host=localhost", $database->getDSN());
+        $this->assertEquals(
+            [
+                'driver' => 'pdo_pgsql',
+                'host' => 'localhost'
+            ],
+            $database->getConnectionDetails()
+        );
     }
 
     public function testPostgresqlPort() {
         $database = new PostgresqlDatabase(['port' => '15432']);
-        $this->assertEquals('pgsql:port=15432', $database->getDSN());
+        $this->assertEquals(
+            [
+                'driver' => 'pdo_pgsql',
+                'port' => '15432'
+            ],
+            $database->getConnectionDetails()
+        );
     }
 
     public function testPostgresqlDbname() {
         $database = new PostgresqlDatabase(['dbname' => 'submitty']);
-        $this->assertEquals('pgsql:dbname=submitty', $database->getDSN());
+        $this->assertEquals(
+            [
+                'driver' => 'pdo_pgsql',
+                'dbname' => 'submitty'
+            ],
+            $database->getConnectionDetails()
+        );
     }
 
     public function testPostgresqlUnixSocket() {
         $database = new PostgresqlDatabase(['host' => '/var/run/postgresql', 'port' => 5432]);
-        $this->assertEquals('pgsql:host=/var/run/postgresql', $database->getDSN());
+        $this->assertEquals(
+            [
+                'driver' => 'pdo_pgsql',
+                'host' => '/var/run/postgresql'
+            ],
+            $database->getConnectionDetails()
+        );
     }
 
     public function arrayData() {

--- a/site/tests/app/libraries/database/SqliteDatabaseTester.php
+++ b/site/tests/app/libraries/database/SqliteDatabaseTester.php
@@ -7,12 +7,18 @@ use app\libraries\database\SqliteDatabase;
 class SqliteDatabaseTester extends \PHPUnit\Framework\TestCase {
     public function testMemorySqliteDSN() {
         $database = new SqliteDatabase(['memory' => true]);
-        $this->assertEquals("sqlite::memory:", $database->getDSN());
+        $this->assertEquals(
+            ['memory' => true, 'driver' => 'pdo_sqlite'],
+            $database->getConnectionDetails()
+        );
     }
 
     public function testPathSqliteDSN() {
         $database = new SqliteDatabase(['path' => '/tmp/test.sq3']);
-        $this->assertEquals("sqlite:/tmp/test.sq3", $database->getDSN());
+        $this->assertEquals(
+            ['memory' => false, 'path' => '/tmp/test.sq3', 'driver' => 'pdo_sqlite'],
+            $database->getConnectionDetails()
+        );
     }
 
     public function testFromDatabaseToPHPArray() {

--- a/site/tests/app/libraries/response/MultiResponseTester.php
+++ b/site/tests/app/libraries/response/MultiResponseTester.php
@@ -79,6 +79,7 @@ EOD;
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRedirectOnlyResponse() {
         $redirect_response = new RedirectResponse('http://example.com');
@@ -92,6 +93,7 @@ EOD;
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testWebAndRedirectResponseUsesRedirect() {
         $web_response = new WebResponse("Error", "errorPage", "You don't have access to this page.");
@@ -111,6 +113,7 @@ EOD;
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRedirectAndJsonResponseUsesRedirect() {
         $redirect_response = new RedirectResponse('http://example.com');

--- a/site/tests/app/libraries/response/RedirectResponseTester.php
+++ b/site/tests/app/libraries/response/RedirectResponseTester.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 class RedirectResponseTester extends TestCase {
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRedirectResponse() {
         $core = new Core();

--- a/site/tests/app/libraries/routers/WebRouterTester.php
+++ b/site/tests/app/libraries/routers/WebRouterTester.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class WebRouterTester extends BaseUnitTest {
     public function testLogin() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
We currently wrap our AbstractDatabase around PDO for both Postgres and SQLite. We should also be upgrading DBAL to 3 (and eventually 4 since that was just released) which has been an open PR for a while. Doctrine ORM requires DBAL because that is what it uses as it's database layer. We pass in our existing PDO instance to ORM/DBAL to avoid creating a new database connection.

We are using DBAL 2.13.9.

### What is the new behavior?
This PR changes AbstractDatabase to now wrap DBAL instead of PDO. DBAL wraps PDO so we essentially just have an extra layer in between AbstractDatabase and PDO. If we were to keep AbstractDatabase using PDO, we would need to double our database connections to support DBAL 3 and higher. This is because DBAL removed the ability to pass in a user provided PDO instance. So we either would need to double the database connections or switch our connection. The idea is to maintain just 1 DBAL connection for each the master and course DBs and to just pass that into ORM now.

We are now using DBAL 3.8.2.

### Other information?
As little has been changed to replace PDO to DBAL in AbstractDatabase.
