### PR TITLE
[Bugfix:TAGrading] Rendering Team IDs for Graders

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -513,6 +513,7 @@ HTML;
                 }
                 else {
                     $columns[] = ["width" => "10%", "title" => "Team ID",          "function" => "team_id", "sort_type" => "id"];
+                    $columns[] = ["width" => "6%",  "title" => "Team Name",        "function" => "team_name"];
                     $columns[] = ["width" => "32%", "title" => "Team Members",     "function" => "team_members"];
                 }
             }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -503,7 +503,7 @@ HTML;
 
         if ($peer || $anon_mode || $team_and_anon) {
             if ($gradeable->isTeamAssignment()) {
-                if ($gradeable->getPeerBlind() === Gradeable::DOUBLE_BLIND_GRADING || $anon_mode) {
+                if ($gradeable->getPeerBlind() === Gradeable::DOUBLE_BLIND_GRADING || $anon_mode || $team_and_anon) {
                     $columns[] = ["width" => "10%", "title" => "Team ID",     "function" => "team_id_anon"];
                 }
                 $peer_and_anon = ($this->core->getUser()->getGroup() === User::GROUP_STUDENT &&
@@ -512,6 +512,7 @@ HTML;
                     $columns[] = ["width" => "30%", "title" => "Team Members",     "function" => "team_members_anon"];
                 }
                 else {
+                    $columns[] = ["width" => "10%", "title" => "Team ID",          "function" => "team_id", "sort_type" => "id"];
                     $columns[] = ["width" => "32%", "title" => "Team Members",     "function" => "team_members"];
                 }
             }
@@ -556,7 +557,8 @@ HTML;
                     $columns[] = ["width" => "26%", "title" => "Team Members",     "function" => "team_members"];
                 }
                 else {
-                    $columns[] = ["width" => "10%",  "title" => "Team Name",        "function" => "team_name"];
+                    $columns[] = ["width" => "10%", "title" => "Team ID",          "function" => "team_id", "sort_type" => "id"];
+                    $columns[] = ["width" => "10%",  "title" => "Team Name",       "function" => "team_name"];
                     $columns[] = ["width" => "40%", "title" => "Team Members",     "function" => "team_members"];
                 }
             }

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -504,7 +504,7 @@ HTML;
         if ($peer || $anon_mode || $team_and_anon) {
             if ($gradeable->isTeamAssignment()) {
                 if ($gradeable->getPeerBlind() === Gradeable::DOUBLE_BLIND_GRADING || $anon_mode || $team_and_anon) {
-                    $columns[] = ["width" => "10%", "title" => "Team ID",     "function" => "team_id_anon"];
+                    $columns[] = ["width" => "10%", "title" => "Team ID",          "function" => "team_id_anon"];
                 }
                 $peer_and_anon = ($this->core->getUser()->getGroup() === User::GROUP_STUDENT &&
                     $gradeable->getPeerBlind() === Gradeable::DOUBLE_BLIND_GRADING);
@@ -559,7 +559,7 @@ HTML;
                 }
                 else {
                     $columns[] = ["width" => "10%", "title" => "Team ID",          "function" => "team_id", "sort_type" => "id"];
-                    $columns[] = ["width" => "10%",  "title" => "Team Name",       "function" => "team_name"];
+                    $columns[] = ["width" => "10%", "title" => "Team Name",        "function" => "team_name"];
                     $columns[] = ["width" => "40%", "title" => "Team Members",     "function" => "team_members"];
                 }
             }
@@ -582,10 +582,10 @@ HTML;
                 $columns[]     = ["width" => "8%",  "title" => "Graded Questions", "function" => "graded_questions"];
             }
             if ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === Gradeable::SINGLE_BLIND_GRADING) {
-                $columns[]     = ["width" => "8%",  "title" => "Grading",       "function" => "grading_blind"];
+                $columns[]     = ["width" => "8%",  "title" => "Grading",          "function" => "grading_blind"];
             }
             else {
-                $columns[]     = ["width" => "8%",  "title" => "Grading",       "function" => "grading"];
+                $columns[]     = ["width" => "8%",  "title" => "Grading",          "function" => "grading"];
             }
             $columns[]         = ["width" => "7%",  "title" => "Total",            "function" => "total"];
             $columns[]         = ["width" => "10%", "title" => "Active Version",   "function" => "active_version"];


### PR DESCRIPTION
Closes #9682  

### Please check if the PR fulfills these requirements:

* [✅] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Limited access graders are not able to view Team IDs if they are not anonymized by instructors
This is also applicable for peer graders.

### What is the new behavior?
Limited access and peer graders are now able to view Team IDs when they are not anonymized by instructors
and they are able to view Anonymized Team IDs when they are anonymized by instructors.

**Limited Access grader (Not anonymized)**
![limited-grader-team](https://github.com/Submitty/Submitty/assets/81346327/651c083b-b185-4a25-a5cf-7546451dbfdf)

**Limited Access grader (Anonymized)**
![limited-grader-team-anon](https://github.com/Submitty/Submitty/assets/81346327/75dcc2ea-9a10-4761-ae11-50c984f65a3c)

**Peer grader  (Not anonymized)**
![peer-team](https://github.com/Submitty/Submitty/assets/81346327/4f4e2999-c485-4e86-8112-53e1bdb9acac)


**Peer grader  (Anonymized)**
![peer-team-anon](https://github.com/Submitty/Submitty/assets/81346327/6d435b9c-f8ab-49d2-8d0b-528deda3816b)



