### PR TITLE
[Feature:Calendar] Button to Set Calendar Date to Today

### DIFF
--- a/site/app/templates/calendar/Calendar.twig
+++ b/site/app/templates/calendar/Calendar.twig
@@ -51,13 +51,9 @@
     }
 </script>
 
-
 {# Begin Calendar #}
 <div class="content">
     <h1>Calendar</h1>
-    <button type="button" onclick="setDateToToday()" class="btn btn-primary">
-        <i class="fas fa-clock"></i> Today
-    </button>
     <div class="cal-content">
         <div class="cal-toolbar">
             {% if instructor_courses|length > 0 %}
@@ -65,7 +61,6 @@
                     <i class="fas fa-plus"></i> New Item
                 </button>
             {% endif %}
-
                 <button type="button" onclick="openOptionsModal()" class="btn btn-primary">
                     <i class="fas fa-sliders"></i> Options
                 </button>
@@ -74,6 +69,9 @@
                     <option value="two_week" {% if (view_cookie is defined)  and view_cookie == "two_week" %} selected {% endif %}>Two Week</option>
                     <option value="one_week" {% if (view_cookie is defined)  and view_cookie == "one_week" %} selected {% endif %}>One Week</option>
                 </select>
+                <button id="calendar-today-button" type="button" onclick="setDateToToday()" class="btn btn-primary">
+                    <i class="fas fa-clock"></i> Today
+                </button>
         </div>
 
         {# Legend #}

--- a/site/app/templates/calendar/Calendar.twig
+++ b/site/app/templates/calendar/Calendar.twig
@@ -55,6 +55,9 @@
 {# Begin Calendar #}
 <div class="content">
     <h1>Calendar</h1>
+    <button type="button" onclick="setDateToToday()" class="btn btn-primary">
+        <i class="fas fa-clock"></i> Today
+    </button>
     <div class="cal-content">
         <div class="cal-toolbar">
             {% if instructor_courses|length > 0 %}

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -60,6 +60,10 @@ a.cal-btn:focus {
     float: right;
 }
 
+#calendar-today-button{
+    float:right
+}
+
 .cal-month-title {
     font-size: 26px;
     text-transform: uppercase;

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -61,7 +61,8 @@ a.cal-btn:focus {
 }
 
 #calendar-today-button{
-    float:right
+    float:right;
+    margin-right: 10px;
 }
 
 .cal-month-title {

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -11,16 +11,16 @@ const monthNamesShort = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
  * @returns {void} : only changes cookies and calendar date
  */
 function setDateToToday(){
-    const type = $("#calendar-item-type-edit").val();
+    const type = $ ('#calendar-item-type-edit').val();
     const currentDay = new Date();
-    Cookies.set("calendar_year", currentDay.getFullYear());
-    Cookies.set("calendar_month", currentDay.getMonth()+1);
-    Cookies.set("calendar_day", currentDay.getDate());
+    Cookies.set('calendar_year', currentDay.getFullYear());
+    Cookies.set('calendar_month', currentDay.getMonth()+1);
+    Cookies.set('calendar_day', currentDay.getDate());
 
-    let cookie_year = currentDay.getFullYear();
-    let cookie_month = currentDay.getMonth()+1;
-    let cookie_day = currentDay.getDate();
-    
+    const cookie_year = currentDay.getFullYear();
+    const cookie_month = currentDay.getMonth()+1;
+    const cookie_day = currentDay.getDate();
+
     loadCalendar(cookie_month, cookie_year, cookie_day, type);
 }
 

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -1,4 +1,4 @@
-/* exported prevMonth, nextMonth, loadCalendar, loadFullCalendar, editCalendarItemForm, deleteCalendarItem, openNewItemModal, openOptionsModal, updateCalendarOptions, colorLegend */
+/* exported prevMonth, nextMonth, loadCalendar, loadFullCalendar, editCalendarItemForm, deleteCalendarItem, openNewItemModal, openOptionsModal, updateCalendarOptions, colorLegend, setDateToToday */
 /* global curr_day, curr_month, curr_year, gradeables_by_date, instructor_courses, buildUrl */
 /* global csrfToken */
 
@@ -10,7 +10,6 @@ const monthNamesShort = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
  * Sets the current date to today and then changes the calendar
  * @returns {void} : only changes cookies and calendar date
  */
-// eslint-disable-next-line no-unused-vars
 function setDateToToday() {
     const type = $('#calendar-item-type-edit').val();
     const currentDay = new Date();

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -7,6 +7,24 @@ const monthNames = ['December', 'January', 'February', 'March', 'April', 'May', 
 const monthNamesShort = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
 
 /**
+ * Sets the current date to today and then changes the calendar
+ * @returns {void} : only changes cookies and calendar date
+ */
+function setDateToToday(){
+    const type = $("#calendar-item-type-edit").val();
+    const currentDay = new Date();
+    Cookies.set("calendar_year", currentDay.getFullYear());
+    Cookies.set("calendar_month", currentDay.getMonth()+1);
+    Cookies.set("calendar_day", currentDay.getDate());
+
+    let cookie_year = currentDay.getFullYear();
+    let cookie_month = currentDay.getMonth()+1;
+    let cookie_day = currentDay.getDate();
+    
+    loadCalendar(cookie_month, cookie_year, cookie_day, type);
+}
+
+/**
  * Gets the previous month of a given month
  * @param month : int the current month (1 as January and 12 as December)
  * @param year : int the current year

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -10,8 +10,9 @@ const monthNamesShort = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
  * Sets the current date to today and then changes the calendar
  * @returns {void} : only changes cookies and calendar date
  */
-function setDateToToday(){
-    const type = $ ('#calendar-item-type-edit').val();
+// eslint-disable-next-line no-useless-concat
+function setDateToToday() {
+    const type = $('#calendar-item-type-edit').val();
     const currentDay = new Date();
     Cookies.set('calendar_year', currentDay.getFullYear());
     Cookies.set('calendar_month', currentDay.getMonth()+1);

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -10,7 +10,7 @@ const monthNamesShort = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
  * Sets the current date to today and then changes the calendar
  * @returns {void} : only changes cookies and calendar date
  */
-// eslint-disable-next-line no-useless-concat
+// eslint-disable-next-line no-undef
 function setDateToToday() {
     const type = $('#calendar-item-type-edit').val();
     const currentDay = new Date();

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -10,7 +10,7 @@ const monthNamesShort = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
  * Sets the current date to today and then changes the calendar
  * @returns {void} : only changes cookies and calendar date
  */
-// eslint-disable-next-line no-undef
+// eslint-disable-next-line no-unused-vars
 function setDateToToday() {
     const type = $('#calendar-item-type-edit').val();
     const currentDay = new Date();


### PR DESCRIPTION
![Screenshot from 2024-04-06 13-09-31](https://github.com/Submitty/Submitty/assets/122404476/adb80c74-aa75-4109-8b0d-25d36f471fe2)


The current behavior is that, to change the date to the current day, the user must press the arrow keys repeatedly.

The new behavior is that, there is now a blue button on the upper left-hand side of the calendar page that
sets the calendar date to the current day/month/year and also updates all cookies.

This should not be a breaking change and was tested on both student and instructor accounts. 

However, this pr could interfere with my other calendar pr #10249 which creates month/year dropdowns which may or may not update when the button is pressed.