### PR TITLE
[Bugfix:Forum] Fix alignment of help icon

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -70,13 +70,15 @@
     </div>
     <div class="form-group row">
         {% set min_height = (post_textarea_large is defined and post_textarea_large ? "40vmin":"100px") %}
-        <div role="button" id="markdown_toggle_{{ post_box_id }}"
+        <div class="button-row">
+            <div role="button" id="markdown_toggle_{{ post_box_id }}"
              class="markdown-toggle {{ render_markdown is defined and render_markdown ? "markdown-active":"markdown-inactive" }} key_to_click" tabindex="0"
              title="Render markdown" onclick="toggleMarkdown.call(this, {{ post_box_id }});"
-        >
-            <i class="fab fa-markdown fa-2x"></i>
+            >
+                <i class="fab fa-markdown fa-2x"></i>
+            </div>
+            <a target=_blank href="https://submitty.org/student/discussion_forum#formatting-a-post-using-markdown/" aria-label="Markdown Info"><i id="markdown-info-{{ post_box_id }}" style="font-style:normal;" class="far fa-question-circle disabled"></i></a>
         </div>
-        <a target=_blank href="https://submitty.org/student/discussion_forum#formatting-a-post-using-markdown/" aria-label="Markdown Info"><i id="markdown-info-{{ post_box_id }}" style="font-style:normal;" class="far fa-question-circle disabled"></i></a>
         {% if first_post_id is defined %}
             <a class="skip-btn skip-first-post" href="#{{ first_post_id }}">Skip to first post</a>
         {% endif %}

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -452,8 +452,8 @@
 }
 
 .history-buffer {
-    margin-bottom:3px;
-    margin-top:1.5em;
+    margin-bottom: 3px;
+    margin-top: 1.5em;
 }
 
 /* stylelint-disable-next-line selector-id-pattern */
@@ -779,4 +779,10 @@
     margin-right: 10px;
     padding: unset;
     cursor: pointer;
+}
+
+.button-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10250.

### What is the new behavior?
Help icon is now vertically aligned with the Markdown button.

![Screenshot 2024-03-19 163507](https://github.com/Submitty/Submitty/assets/32400122/325227fd-aa9e-4a86-b5b0-c973970d487f)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Please let me know if there are UI unit tests / snapshot tests that I missed. I did not find any.
