### PR TITLE
[Bugfix:Developer] Fix flaky docker ui cypress test

### DIFF
--- a/site/app/views/admin/DockerView.php
+++ b/site/app/views/admin/DockerView.php
@@ -229,6 +229,8 @@ class DockerView extends AbstractView {
                     $machine_system_details[$current_machine]["worker"] = null;
                     $machine_system_details[$current_machine]["shipper"] = null;
                     $machine_system_details[$current_machine]["daemon"] = null;
+                    $machine_system_details[$current_machine]["disk"] = null;
+                    $machine_system_details[$current_machine]["load"] = null;
                 }
 
                 $is_match = preg_match("/Worker Service: (.+)/", $buffer, $matches);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently the docker UI cypress test fails sometimes, even when PRs don't affect the page. After tracing the error message through the code, this occurs when the PHP app is unable to fully parse a system info file located in /var/local/submitty/logs/sysinfo, leaving specific array keys unset which results in twig throwing an error. I believe this occurs in Github Actions when the relevant file fails to fully generate before it tries to render the site.

### What is the new behavior?
By initializing the relevant array keys to null before parsing the file, we allow the twig template to render and tests to continue.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
To reproduce: on main, comment out line 251 of DockerView.php `$machine_system_details[$current_machine]["disk"] = $matches[1];`, rebuild the site, and then reload the page. You should receive an error regarding an undefined key "disk", which is the same error Github Actions sometimes throws. Try commenting out that same line on this branch and the page should still render.