### PR TITLE
[Bugfix:System] Fix main notifications

### DIFF
--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -8,7 +8,7 @@ on:
       - 'main'
 jobs:
   Notify-Failure:
-    if: github.repository == 'Submitty/Submitty'
+    if: ${{ github.repository == 'Submitty/Submitty' }}
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Zulip on failure

--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -8,7 +8,7 @@ on:
       - 'main'
 jobs:
   Notify-Failure:
-    if: ${{ github.repository == 'Submitty/Submitty' }}
+    if: ${{ github.event.workflow_run.head_repository.full_name == 'Submitty/Submitty' }}
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Zulip on failure


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Any branch named "main" will notify Zulip if the tests fail

### What is the new behavior?
It will only notify if the head_repository (the requesting repository, not the repository where the workflow file is located) is Submitty/Submitty