### PR TITLE
[Feature:Calendar] Changed Calendar Cells Based on View

### DIFF
--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -154,6 +154,18 @@ h2.cal-month-title {
     height: 100px;
 }
 
+.cal-day-cell-twoweek{
+    min-height: 100px;
+    max-height: 390px;
+    height: 200px;
+}
+
+.cal-day-cell-week{
+    min-height: 100px;
+    max-height: 780px;
+    height: 400px;
+}
+
 .cal-cell-expand {
     height: 195px;
 }

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -264,11 +264,24 @@ function deleteCalendarItem() {
  * @param view_semester : boolean if the calendar is viewing the entire semester. If so, the day cell would show both the month and date
  * @returns {HTMLElement} the HTML Element containing the cell
  */
-function generateDayCell(year, month, day, curr_view_month, view_semester=false) {
+function generateDayCell(year, month, day, curr_view_month, view_mode, view_semester=false) {
     const cell_date_str = dateToStr(year, month, day);
 
     const content = document.createElement('td');
-    content.classList.add('cal-day-cell');
+    //change the css of the cell based on the view mode:
+    if(view_mode == 'month'){
+        content.classList.add('cal-day-cell');
+    }
+    else if(view_mode == 'twoweek'){
+        content.classList.add('cal-day-cell-twoweek');
+    }
+    else if(view_mode == 'week'){
+        content.classList.add('cal-day-cell-week');
+    }
+    else{
+        content.classList.add('cal-day-cell');
+    }
+
     content.id = `cell-${cell_date_str}`;
     if (view_semester) {
         content.classList.add('cal-cell-expand');
@@ -475,7 +488,7 @@ function generateCalendarOfMonth(view_year, view_month, view_day) {
         const lastMonthEnd = new Date(view_year, view_month - 1, 0).getDate();
         const lastMonthStart = lastMonthEnd + 1 - startWeekday;
         for (let day = lastMonthStart; day <= lastMonthEnd; day++) {
-            curRow.appendChild(generateDayCell(view_year, view_month - 1, day, view_month));
+            curRow.appendChild(generateDayCell(view_year, view_month - 1, day, view_month, 'month'));
         }
     }
 
@@ -483,7 +496,7 @@ function generateCalendarOfMonth(view_year, view_month, view_day) {
     const daysInMonth = new Date(view_year, view_month, 0).getDate();
     let weekday = startWeekday;
     for (let day = 1; day <= daysInMonth; day++) {
-        curRow.appendChild(generateDayCell(view_year, view_month, day, view_month));
+        curRow.appendChild(generateDayCell(view_year, view_month, day, view_month, 'month'));
         if (weekday === 6) {
             weekday = 0;
             // Next week should show on next line
@@ -499,7 +512,7 @@ function generateCalendarOfMonth(view_year, view_month, view_day) {
     if (weekday !== 0) {
         const remain = 7 - weekday;
         for (let day = 1; day <= remain; day++) {
-            curRow.appendChild(generateDayCell(view_year, view_month + 1, day, view_month));
+            curRow.appendChild(generateDayCell(view_year, view_month + 1, day, view_month, 'month'));
             if (weekday === 6) {
                 weekday = 0;
             }
@@ -541,7 +554,7 @@ function generateCalendarOfMonthWeek(view_year, view_month, view_day) {
     // Show days at the end of last month that belongs to the first week of current month
     if (view_day-currentDay <= 0) {
         for (let day = lastMonthStart; day <= lastMonthEnd; day++) {
-            curRow.appendChild(generateDayCell(view_year, view_month - 1, day, view_month));
+            curRow.appendChild(generateDayCell(view_year, view_month - 1, day, view_month, 'week'));
             print_day++;
         }
     }
@@ -549,20 +562,20 @@ function generateCalendarOfMonthWeek(view_year, view_month, view_day) {
     // Make the day cells before the "current" date
     if (print_day < currentDay) {
         for (let day = view_day - currentDay + print_day; print_day < currentDay; day++) {
-            curRow.appendChild(generateDayCell(view_year, view_month, day, view_month));
+            curRow.appendChild(generateDayCell(view_year, view_month, day, view_month, 'week'));
             print_day++;
         }
     }
 
     // Make the "current" day, and the days after in the month
     for (let day = view_day; print_day <= 6 && day <= daysInMonth; day++) {
-        curRow.appendChild(generateDayCell(view_year, view_month, day, view_month));
+        curRow.appendChild(generateDayCell(view_year, view_month, day, view_month, 'week'));
         print_day++;
     }
 
     // Makes any days that spill into the next month
     for (let day = 1; print_day <= 6; day++) {
-        curRow.appendChild(generateDayCell(view_year, view_month + 1, day, view_month));
+        curRow.appendChild(generateDayCell(view_year, view_month + 1, day, view_month, 'week'));
         print_day++;
     }
     tableBody.appendChild(curRow);
@@ -598,7 +611,7 @@ function generateCalendarOfMonthTwoWeek(view_year, view_month, view_day) {
     // Show days at the end of last month that belongs to the first week of current month
     if (view_day-currentDay <= 0) {
         for (let day = lastMonthStart; day <= lastMonthEnd; day++) {
-            curRow.appendChild(generateDayCell(view_year, view_month - 1, day, view_month));
+            curRow.appendChild(generateDayCell(view_year, view_month - 1, day, view_month, 'twoweek'));
             print_day++;
         }
     }
@@ -606,14 +619,14 @@ function generateCalendarOfMonthTwoWeek(view_year, view_month, view_day) {
     // Make the day cells before the "current" date
     if (print_day < currentDay) {
         for (let day = view_day - currentDay + print_day; print_day < currentDay; day++) {
-            curRow.appendChild(generateDayCell(view_year, view_month, day, view_month));
+            curRow.appendChild(generateDayCell(view_year, view_month, day, view_month, 'twoweek'));
             print_day++;
         }
     }
 
     // Make the "current" day, and the days after in the month
     for (let day = view_day; print_day <= 13 && day <= daysInMonth; day++) {
-        curRow.appendChild(generateDayCell(view_year, view_month, day, view_month));
+        curRow.appendChild(generateDayCell(view_year, view_month, day, view_month, 'twoweek'));
         print_day++;
         // If the day is the last day of the week, then make a new row
         if (print_day === 7) {
@@ -625,7 +638,7 @@ function generateCalendarOfMonthTwoWeek(view_year, view_month, view_day) {
 
     // Makes any days that spill into the next month
     for (let day = 1; print_day <= 13; day++) {
-        curRow.appendChild(generateDayCell(view_year, view_month + 1, day, view_month));
+        curRow.appendChild(generateDayCell(view_year, view_month + 1, day, view_month, 'twoweek'));
         print_day++;
         // If the day is the last day of the week, then make a new row
         if (print_day === 7) {

--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -269,16 +269,16 @@ function generateDayCell(year, month, day, curr_view_month, view_mode, view_seme
 
     const content = document.createElement('td');
     //change the css of the cell based on the view mode:
-    if(view_mode == 'month'){
+    if (view_mode === 'month') {
         content.classList.add('cal-day-cell');
     }
-    else if(view_mode == 'twoweek'){
+    else if (view_mode === 'twoweek') {
         content.classList.add('cal-day-cell-twoweek');
     }
-    else if(view_mode == 'week'){
+    else if (view_mode === 'week') {
         content.classList.add('cal-day-cell-week');
     }
-    else{
+    else {
         content.classList.add('cal-day-cell');
     }
 


### PR DESCRIPTION
Changed the calendar cells to be larger based on the viewing mode(month, two-week, week)

![Screenshot from 2024-03-25 15-29-22](https://github.com/Submitty/Submitty/assets/122404476/11e7597f-2ecf-4b10-9777-b66791b91591)

![Screenshot from 2024-03-25 15-29-09](https://github.com/Submitty/Submitty/assets/122404476/ba3ea95b-28e8-4981-8e32-1bf2c68e5240)

The current behavior is that if you change viewing modes from 'Month' to 'Two Week' or 'Week', it simply hides the extra weeks. The purpose of the other view modes is to make cells larger to fit more information and be less crammed for users who have many items on their calendar.

The new behavior is that the cells will expand based on the viewing mode as well as the number of items in each cell. 

This is not a breaking change and was tested on instructor and student accounts.
