### PR TITLE
[Bugfix:InstructorUI] Doc link, display errors on upload

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableUploadForm.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableUploadForm.twig
@@ -7,7 +7,7 @@
     </p>
     <p>
         For more formatting information, see
-        <a target="_blank" href="https://submitty.org/instructor/assignment-preparation/upload_gradeable">
+        <a target="_blank" href="https://submitty.org/instructor/assignment_preparation/upload_gradeable">
             Create Gradeable by Uploading JSON <i style="font-style:normal;" class="fa-question-circle"></i>
         </a>
     </p>

--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -358,7 +358,6 @@ function ajaxUploadGradeable() {
                     window.location = buildCourseUrl(['gradeable', data['data'], 'update']);
                 }
                 else {
-                    window.location = buildCourseUrl(['gradeable']);
                     alert(data['message']);
                     return false;
                 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant
* [X] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
If an upload gradeable via JSON configuration fails, the page redirects which prevents the user from seeing any error messages. The documentation link for the upload gradable model is broken

### What is the new behavior?
Page no longer redirects on error, allowing the alert to be shown. In the future this alert can be replaced with the usual red error message or with a modal that can display the errors better if the validation message is more complex

### Other information?
<!-- Is this a breaking change? -->
No
<!-- How did you test -->
Easiest way to test the error message is to upload a gradable config for one that exists already 
