### PR TITLE
[Bugfix:Developer] Initialize "os" key in Docker UI

### DIFF
--- a/site/app/views/admin/DockerView.php
+++ b/site/app/views/admin/DockerView.php
@@ -135,7 +135,7 @@ class DockerView extends AbstractView {
                 // Parse the OS description
                 $is_match = preg_match("/Description:\t(.+)/", $buffer, $matches);
                 if ($is_match) {
-                    $machine_system_details[$current_machine]["os"] = $matches[1];
+                    $machine_system_details[$current_machine]["os"] = $matches[1] ?? null;
                 }
 
                 // Parse the docker version
@@ -231,6 +231,7 @@ class DockerView extends AbstractView {
                     $machine_system_details[$current_machine]["daemon"] = null;
                     $machine_system_details[$current_machine]["disk"] = null;
                     $machine_system_details[$current_machine]["load"] = null;
+                    $machine_system_details[$current_machine]["os"] ??= null;
                 }
 
                 $is_match = preg_match("/Worker Service: (.+)/", $buffer, $matches);


### PR DESCRIPTION
### What is the current behavior?
https://github.com/Submitty/Submitty/pull/10271 missed the "os" key, which is believed to be the cause of [this](https://github.com/Submitty/Submitty/actions/runs/8515492568/job/23323056920) CI failure.

### What is the new behavior?
The "os" key is initialized to null.

The original source of the Docker UI test flakiness is PR https://github.com/Submitty/Submitty/pull/7932.  Notably, the last comment on that PR discusses the flakiness of the tests, and the subsequent [commit](https://github.com/Submitty/Submitty/pull/7932/commits/5acb72fb030ac02cbd54195e786a62dbea96f386) comments out a test in an attempt to fix the flakiness.  In the future, it would be worthwhile to investigate the commented-out test to see if it is now reliable.