### PR TITLE
[Refactor:RainbowGrades] Refactor benchmark null operator

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -348,25 +348,16 @@ class RainbowCustomization extends AbstractModel {
      *
      * @return array multidimensional array of display benchmark data
      */
-    public function getDisplayBenchmarks() {
-        // Get allowed benchmarks
-        $displayBenchmarks = RainbowCustomizationJSON::allowed_display_benchmarks;
-        $retArray = [];
-
-        // If json file available then collect used benchmarks from that, else get empty array
-        !is_null($this->RCJSON) ?
-            $usedDisplayBenchmarks = $this->RCJSON->getDisplayBenchmarks() :
-            $usedDisplayBenchmarks = [];
-
-        // Add data into retArray
-        foreach ($displayBenchmarks as $displayBenchmark) {
-            in_array($displayBenchmark, $usedDisplayBenchmarks) ? $isUsed = true : $isUsed = false;
-
-            // Add benchmark to return array
-            $retArray[] = ['id' => $displayBenchmark, 'isUsed' => $isUsed];
+    public function getDisplayBenchmarks(): array {
+        $allowedBenchmarks = RainbowCustomizationJSON::allowed_display_benchmarks;
+        // null safe operator
+        $usedBenchmarks = $this->RCJSON?->getDisplayBenchmarks() ?? [];
+        $benchmarksData = [];
+        foreach ($allowedBenchmarks as $benchmark) {
+            $benchmarkUsed = in_array($benchmark, $usedBenchmarks);
+            $benchmarksData[] = ['id' => $benchmark, 'isUsed' => $benchmarkUsed];
         }
-
-        return $retArray;
+        return $benchmarksData;
     }
 
     /**


### PR DESCRIPTION
In order to improve readability and simplify logic below changes has been made. 

Ternary operation has been simplified for both  $usedDisplayBenchmarks and $isUsed.

Type hinting - following php8 standard.