### PR TITLE
[Bugfix:System] Check DB connected before closing

### DIFF
--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -336,10 +336,10 @@ class Core {
             $this->logPerformanceWarning();
         }
 
-        if ($this->course_db !== null && $this->course_db->isConnected()) {
+        if ($this->course_db !== null) {
             $this->course_db->disconnect();
         }
-        if ($this->submitty_db !== null && $this->submitty_db->isConnected()) {
+        if ($this->submitty_db !== null) {
             $this->submitty_db->disconnect();
         }
     }

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -335,11 +335,10 @@ class Core {
         if ($this->config !== null && $this->config->isDebug() && $this->hasDBPerformanceWarning()) {
             $this->logPerformanceWarning();
         }
-
-        if ($this->course_db !== null) {
+        if ($this->course_db !== null && $this->course_db->isConnected()) {
             $this->course_db->disconnect();
         }
-        if ($this->submitty_db !== null) {
+        if ($this->submitty_db !== null && $this->submitty_db->isConnected()) {
             $this->submitty_db->disconnect();
         }
     }

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -335,6 +335,7 @@ class Core {
         if ($this->config !== null && $this->config->isDebug() && $this->hasDBPerformanceWarning()) {
             $this->logPerformanceWarning();
         }
+
         if ($this->course_db !== null && $this->course_db->isConnected()) {
             $this->course_db->disconnect();
         }

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -114,7 +114,7 @@ abstract class AbstractDatabase {
         if ($this->transaction) {
             $this->rollback();
         }
-        if($this->conn) {
+        if ($this->conn) {
             $this->conn->close();
         }
         $this->conn = null;

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -114,7 +114,9 @@ abstract class AbstractDatabase {
         if ($this->transaction) {
             $this->rollback();
         }
-        $this->conn->close();
+        if($this->conn) {
+            $this->conn->close();
+        }
         $this->conn = null;
     }
 

--- a/site/app/libraries/database/AbstractDatabase.php
+++ b/site/app/libraries/database/AbstractDatabase.php
@@ -114,7 +114,7 @@ abstract class AbstractDatabase {
         if ($this->transaction) {
             $this->rollback();
         }
-        if ($this->conn) {
+        if ($this->conn !== null) {
             $this->conn->close();
         }
         $this->conn = null;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently in some cases, when deconstructing the database object, an error is thrown trying to disconnect from a null object, due to the database not being connected. 
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
![image](https://github.com/Submitty/Submitty/assets/46759635/f30c9931-493d-46df-9fbc-0828f72a3beb)

### What is the new behavior?
![image](https://github.com/Submitty/Submitty/assets/46759635/2fa47405-5b88-4c10-9354-45fc97a8cd85)
Now it checks if the database is connected before attempting to close the connection. 
See https://github.com/Submitty/Submitty/pull/10281 for discovery 
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
