### PR TITLE
[Bugfix:Forum] Highlight new posts in Forum

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2607,7 +2607,6 @@ function newPostWhileUserOnline(){
         }
     });
     captureChange.observe(post_list, { childList: true});
-    alert('loaded');
 }
 setTimeout(function(){
     newPostWhileUserOnline();

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -339,6 +339,7 @@ function socketNewOrEditPostHandler(post_id, reply_level, post_box_id=null, edit
                     original_post.remove();
                 }
 
+                $(`#${post_id}`).addClass('new_post');
                 $(`#${post_id}-reply`).css('display', 'none');
                 $(`#${post_id}-reply`).submit(publishPost);
                 // eslint-disable-next-line no-undef
@@ -2591,23 +2592,3 @@ function pinAnnouncement(thread_id, type, csrf_token) {
         });
     }
 }
-
-function newPostWhileUserOnline(){
-    const post_list = document.getElementById('posts_list');
-
-    const captureChange = new MutationObserver((mutationList , observer)=>{
-        for (let mutation of mutationList){
-            if (mutation.type === 'childList'){
-                mutation.addedNodes.forEach(node => {
-                    if (node.nodeType === Node.ELEMENT_NODE) {
-                        node.classList.add('new_post')
-                    }
-                });
-            }
-        }
-    });
-    captureChange.observe(post_list, { childList: true});
-}
-setTimeout(function(){
-    newPostWhileUserOnline();
-}, 4000);

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2591,3 +2591,24 @@ function pinAnnouncement(thread_id, type, csrf_token) {
         });
     }
 }
+
+function newPostWhileUserOnline(){
+    const post_list = document.getElementById('posts_list');
+
+    const captureChange = new MutationObserver((mutationList , observer)=>{
+        for (let mutation of mutationList){
+            if (mutation.type === 'childList'){
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        node.classList.add('new_post')
+                    }
+                });
+            }
+        }
+    });
+    captureChange.observe(post_list, { childList: true});
+    alert('loaded');
+}
+setTimeout(function(){
+    newPostWhileUserOnline();
+}, 4000);


### PR DESCRIPTION
### What is the current behavior?
When a user got a new post while he is in the forum page, user's browser will render it as a read message. But, it should be rendered as an unread message.

### What is the new behavior?
Now, if a user got a post while user is in the forum page, browser will render it as an unread message.

### Other information?
(Changed according to the request from @DarthNyan.)
Changes : Added a code line to add 'new_post' class when displaying a new post.
I tested this on my VM.
It works on dark mode as well (a white color transparent overlay). 

However, I was unable to find the logical error why the system treat new messages like this. Let's try to find a more sustainable method soon. Working on it :)

closes #10319 

Thank you.
