### PR TITLE
[Bugfix:TAGrading] Fix deleting all comments

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -3530,7 +3530,7 @@ class ElectronicGraderController extends AbstractController {
             $ta_graded_gradeable->deleteGradedComponent($component, $this->core->getQueries()->getUserById($peer_id));
         }
         $ta_graded_gradeable->removeOverallComment($peer_id);
-        $this->core->getQueries()->deleteOverallComment($gradeable_id, $peer_id);
+        $this->core->getQueries()->deleteOverallComment($gradeable_id, $peer_id, $graded_gradeable->getSubmitter()->getId());
         $this->core->getQueries()->deleteTaGradedGradeableByIds($gradeable_id, $peer_id);
         $ta_graded_gradeable->resetUserViewedDate();
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7222,6 +7222,12 @@ AND gc_id IN (
         $this->course_db->query($query, $params);
     }
 
+    /**
+     * @param string $gradeable_id
+     * @param string $grader_id
+     * @param string $submitter_id
+     * @return void
+     */
     public function deleteOverallComment($gradeable_id, $grader_id, $submitter_id) {
         $this->course_db->query(
             "DELETE FROM gradeable_data_overall_comment WHERE g_id=? AND goc_grader_id=? AND (goc_user_id=? OR goc_team_id=?)",

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7190,7 +7190,7 @@ AND gc_id IN (
     private function updateOverallComment(TaGradedGradeable $ta_graded_gradeable, $comment, $grader_id) {
         $g_id = $ta_graded_gradeable->getGradedGradeable()->getGradeable()->getId();
         if ($comment === "") {
-            $this->deleteOverallComment($g_id, $grader_id);
+            $this->deleteOverallComment($g_id, $grader_id, $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->getId());
             $ta_graded_gradeable->removeOverallComment($grader_id);
             return;
         }
@@ -7222,8 +7222,11 @@ AND gc_id IN (
         $this->course_db->query($query, $params);
     }
 
-    public function deleteOverallComment($gradeable_id, $grader_id) {
-        $this->course_db->query("DELETE FROM gradeable_data_overall_comment WHERE g_id=? AND goc_grader_id=?", [$gradeable_id, $grader_id]);
+    public function deleteOverallComment($gradeable_id, $grader_id, $submitter_id) {
+        $this->course_db->query(
+            "DELETE FROM gradeable_data_overall_comment WHERE g_id=? AND goc_grader_id=? AND (goc_user_id=? OR goc_team_id=?)",
+            [$gradeable_id, $grader_id, $submitter_id, $submitter_id]
+        );
     }
 
     /**

--- a/site/cypress/e2e/Cypress-Gradeable/ta_grading.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/ta_grading.spec.js
@@ -1,0 +1,38 @@
+describe('Test cases for TA grading page', () => {
+    it('Grader should be able to add and remove overall comments', () => {
+        cy.login('instructor');
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=jKjodWaRdEV9pBb&sort=id&direction=ASC']);
+        cy.get('#grading_rubric_btn').click();
+        cy.get('#overall-comment-instructor').should('have.value', '');
+        cy.get('#overall-comment-instructor').type('Comment1');
+        cy.get('#overall-comment-instructor').blur();
+        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+
+        cy.reload();
+        cy.get('#overall-comment-instructor').should('have.value', 'Comment1');
+
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=aYl92mR3NvJYGrK&sort=id&direction=ASC']);
+        // cy.get('#grading_rubric_btn').click();
+        cy.get('#overall-comment-instructor').should('have.value', '');
+        cy.get('#overall-comment-instructor').type('Comment2');
+        cy.get('#overall-comment-instructor').blur();
+        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+
+        cy.reload();
+        cy.get('#overall-comment-instructor').should('have.value', 'Comment2');
+
+        cy.get('#overall-comment-instructor').clear();
+        cy.get('#overall-comment-instructor').blur();
+        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+
+        cy.reload();
+        cy.get('#overall-comment-instructor').should('have.value', '');
+
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=jKjodWaRdEV9pBb&sort=id&direction=ASC']);
+        // cy.get('#grading_rubric_btn').click();
+        cy.get('#overall-comment-instructor').should('have.value', 'Comment1');
+        cy.get('#overall-comment-instructor').clear();
+        cy.get('#overall-comment-instructor').blur();
+        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+    });
+});

--- a/site/cypress/e2e/Cypress-Gradeable/ta_grading.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/ta_grading.spec.js
@@ -12,7 +12,6 @@ describe('Test cases for TA grading page', () => {
         cy.get('#overall-comment-instructor').should('have.value', 'Comment1');
 
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=aYl92mR3NvJYGrK&sort=id&direction=ASC']);
-        // cy.get('#grading_rubric_btn').click();
         cy.get('#overall-comment-instructor').should('have.value', '');
         cy.get('#overall-comment-instructor').type('Comment2');
         cy.get('#overall-comment-instructor').blur();
@@ -29,7 +28,6 @@ describe('Test cases for TA grading page', () => {
         cy.get('#overall-comment-instructor').should('have.value', '');
 
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=jKjodWaRdEV9pBb&sort=id&direction=ASC']);
-        // cy.get('#grading_rubric_btn').click();
         cy.get('#overall-comment-instructor').should('have.value', 'Comment1');
         cy.get('#overall-comment-instructor').clear();
         cy.get('#overall-comment-instructor').blur();

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -5826,21 +5826,6 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverallComment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverallComment\\(\\) has parameter \\$gradeable_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverallComment\\(\\) has parameter \\$grader_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:deleteOverriddenGrades\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)

### What is the current behavior?
As a grader, if you clear an overall comment, it will clear for all other graded submissions.

### What is the new behavior?
If you clear an overall comment, it will only clear that submission's overall comment. A Cypress test was added to confirm this behavior.