### PR TITLE
[Bugfix:Submission] Redirect out of submission if no team

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -90,8 +90,9 @@ class SubmissionController extends AbstractController {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
             return ['error' => true, 'message' => 'No gradeable with that id.'];
         }
-        elseif ($gradeable->isTeamAssignment() && $graded_gradeable === null && !$this->core->getUser()->accessAdmin()) {
-            $this->core->addErrorMessage('Must be on a team to access submission');
+        // Irrespective of the access level, user should be redirected out of page if not present in a team
+        elseif ($gradeable->isTeamAssignment() && $graded_gradeable === null) {
+            $this->core->addErrorMessage('Must be on a team to access submission.');
             $this->core->redirect($this->core->buildCourseUrl());
             return ['error' => true, 'message' => 'Must be on a team to access submission.'];
         }

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -90,8 +90,8 @@ class SubmissionController extends AbstractController {
             $this->core->getOutput()->renderOutput('Error', 'noGradeable', $gradeable_id);
             return ['error' => true, 'message' => 'No gradeable with that id.'];
         }
-        // Irrespective of the access level, user should be redirected out of page if not present in a team
         elseif ($gradeable->isTeamAssignment() && $graded_gradeable === null) {
+            // Irrespective of the access level, user should be redirected out of page if not present in a team
             $this->core->addErrorMessage('Must be on a team to access submission.');
             $this->core->redirect($this->core->buildCourseUrl());
             return ['error' => true, 'message' => 'Must be on a team to access submission.'];


### PR DESCRIPTION
Closes #9566 

### Please check if the PR fulfills these requirements:

* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Instructor still has access to submission page for a team-gradeable even after team has been abandoned

### What is the new behavior?
Instructor or any other user gets booted out of submission page on reload, if not present in a team

### Other information?
### To Test : 

- Open two browsers, login as same instructor in both
- In first browser, create a team and access a team-gradeable's submission page
- In second, go to manage teams and leave the team
- Come back to first and reload the page
- You can observe that the user gets redirected out of submission page with an alert saying "Must be on a team to access submission."
