### PR TITLE
[Refactor:System] forum refactoring @routes

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -81,9 +81,7 @@ class ForumController extends AbstractController {
         return [-1, $url];
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads/status", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/threads/status", methods: ["POST"])]
     public function changeThreadStatus($status, $thread_id = null) {
         if (is_null($thread_id)) {
             $thread_id = $_POST['thread_id'];
@@ -166,9 +164,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/categories/new", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/categories/new", methods: ["POST"])]
     public function addNewCategory($category = []) {
         $result = [];
         if (!empty($_POST["newCategory"])) {
@@ -208,9 +206,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/categories/delete", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/categories/delete", methods: ["POST"])]
     public function deleteCategory() {
         if (!empty($_POST["deleteCategory"])) {
             $category = (int) $_POST["deleteCategory"];
@@ -235,9 +233,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/categories/edit", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/categories/edit", methods: ["POST"])]
     public function editCategory() {
         $category_id = $_POST["category_id"];
         $category_desc = null;
@@ -277,9 +275,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/categories/reorder", methods={"POST"})
      * @AccessControl(permission="forum.modify_category")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/categories/reorder", methods: ["POST"])]
     public function reorderCategories() {
         $rows = $this->core->getQueries()->getCategories();
 
@@ -304,9 +302,9 @@ class ForumController extends AbstractController {
     //CODE WILL BE CONSOLIDATED IN FUTURE
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads/new", methods={"POST"})
      * @AccessControl(permission="forum.publish")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/threads/new", methods: ["POST"])]
     public function publishThread() {
         $markdown = !empty($_POST['markdown_status']);
         $current_user_id = $this->core->getUser()->getId();
@@ -420,9 +418,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/make_announcement", methods={"POST"})
      * @AccessControl(permission="forum.modify_announcement")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/make_announcement", methods: ["POST"])]
     public function makeAnnouncement(): JsonResponse {
         if (!isset($_POST['id'])) {
             $this->core->addErrorMessage("thread_id not provided");
@@ -458,18 +456,16 @@ class ForumController extends AbstractController {
         return JsonResponse::getSuccessResponse("Announcement successfully queued for sending");
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/search", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/search", methods: ["POST"])]
     public function search() {
         $results = $this->core->getQueries()->searchThreads($_POST['search_content']);
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'searchResult', $results);
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/posts/new", methods={"POST"})
      * @AccessControl(permission="forum.publish")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/new", methods: ["POST"])]
     public function publishPost() {
         $current_user_id = $this->core->getUser()->getId();
         $result = [];
@@ -570,9 +566,7 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderJsonSuccess($result);
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/posts/single", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/single", methods: ["POST"])]
     public function getSinglePost() {
         $post_id = $_POST['post_id'];
         $reply_level = $_POST['reply_level'];
@@ -611,9 +605,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/announcements", methods={"POST"})
      * @AccessControl(permission="forum.modify_announcement")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/announcements", methods: ["POST"])]
     public function alterAnnouncement(bool $type) {
         $thread_id = $_POST["thread_id"];
         $this->core->getQueries()->setAnnouncement($thread_id, $type);
@@ -621,9 +615,8 @@ class ForumController extends AbstractController {
         //TODO: notify on edited announcement
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads/bookmark", methods={"POST"})
-     */
+
+    #[Route("/courses/{_semester}/{_course}/forum/threads/bookmark", methods: ["POST"])]
     public function bookmarkThread(bool $type) {
         $thread_id = $_POST["thread_id"];
         $current_user = $this->core->getUser()->getId();
@@ -638,9 +631,8 @@ class ForumController extends AbstractController {
      * If applied on the first post of a thread, same action will be reflected on the corresponding thread
      *
      * @param int $modify_type (0/1/2) 0 => delete, 1 => edit content, 2 => undelete
-     *
-     * @Route("/courses/{_semester}/{_course}/forum/posts/modify", methods={"POST"})
      */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/modify", methods: ["POST"])]
     public function alterPost($modify_type) {
         $full_course_name = $this->core->getFullCourseName();
         $post_id = $_POST["post_id"] ?? $_POST["edit_post_id"];
@@ -779,10 +771,10 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads/merge", methods={"POST"})
      * @AccessControl(permission="forum.merge_thread")
      */
-    public function mergeThread() {
+    #[Route("/courses/{_semester}/{_course}/forum/threads/merge", methods: ["POST"])]
+        public function mergeThread() {
         $current_user_id = $this->core->getUser()->getId();
         $parent_thread_id = $_POST["merge_thread_parent"];
         $child_thread_id = $_POST["merge_thread_child"];
@@ -826,9 +818,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/posts/split", methods={"POST"})
      * @AccessControl(permission="forum.merge_thread")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/split", methods: ["POST"])]
     public function splitThread() {
         $title = $_POST["split_post_input"];
         $post_id = $_POST["split_post_id"];
@@ -1017,9 +1009,7 @@ class ForumController extends AbstractController {
         return $ordered_threads;
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/threads", methods: ["POST"])]
     public function getThreads($page_number = null) {
         $pageNumber = !empty($page_number) && is_numeric($page_number) ? (int) $page_number : 1;
         $show_deleted = $this->showDeleted();
@@ -1046,9 +1036,7 @@ class ForumController extends AbstractController {
             ]);
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads/single", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/threads/single", methods: ["POST"])]
     public function getSingleThread() {
         $thread_id = $_POST['thread_id'];
         // Checks if thread id is empty. If so, render "fail" json response case informing that thread id is empty.
@@ -1074,9 +1062,7 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderJsonSuccess($result);
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum", methods={"GET"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum", methods: ["POST"])]
     public function showFullThreads() {
         // preparing the params for threads
         $currentCourse = $this->core->getConfig()->getCourse();
@@ -1097,10 +1083,8 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderOutput('forum\ForumThread', 'showFullThreadsPage', $threads, $category_ids, $show_deleted, $show_merged_thread, $pageNumber);
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads", methods={"GET"})
-     * @Route("/courses/{_semester}/{_course}/forum/threads/{thread_id}", methods={"GET", "POST"}, requirements={"thread_id": "\d+"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/threads", methods: ["GET"])]
+    #[Route("/courses/{_semester}/{_course}/forum/threads/{thread_id}", methods: ["GET","POST"], requirements: ["thread_id"=>"\d+"])]
     public function showThreads($thread_id = null, $option = 'tree') {
         $user = $this->core->getUser()->getId();
         $currentCourse = $this->core->getConfig()->getCourse();
@@ -1201,9 +1185,7 @@ class ForumController extends AbstractController {
         return $colors;
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/threads/new", methods={"GET"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/threads/new", methods: ["GET"])]
     public function showCreateThread() {
         if (empty($this->core->getQueries()->getCategories())) {
             $this->core->redirect($this->core->buildCourseUrl(['forum', 'threads']));
@@ -1213,17 +1195,17 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/categories", methods={"GET"})
      * @AccessControl(permission="forum.view_modify_category")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/categories", methods: ["GET"])]
     public function showCategories() {
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'showCategories', $this->getAllowedCategoryColor());
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/posts/splitinfo",methods={"POST"})
      * @AccessControl(permission="forum.merge_thread")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/splitinfo", methods: ["POST"])]
     public function getSplitPostInfo() {
         $post_id = $_POST["post_id"];
         $result = $this->core->getQueries()->getPostOldThread($post_id);
@@ -1240,9 +1222,9 @@ class ForumController extends AbstractController {
     }
 
     /**
-     * @Route("/courses/{_semester}/{_course}/forum/posts/history", methods={"POST"})
      * @AccessControl(role="LIMITED_ACCESS_GRADER")
      */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/history", methods: ["POST"])]
     public function getHistory() {
         $post_id = $_POST["post_id"];
         $output = [];
@@ -1303,9 +1285,7 @@ class ForumController extends AbstractController {
         return $this->core->getUser()->accessFullGrading() || $this->core->getUser()->getId() === $author;
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/posts/get", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/posts/get", methods: ["POST"])]
     public function getEditPostContent() {
         $post_id = $_POST["post_id"];
         if (!empty($post_id)) {
@@ -1352,9 +1332,7 @@ class ForumController extends AbstractController {
         $output['expiration'] = $result["pinned_expiration"];
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/forum/stats")
-     */
+    #[Route("/courses/{_semester}/{_course}/forum/stats")]
     public function showStats() {
         $posts = $this->core->getQueries()->getPosts();
         $num_posts = count($posts);
@@ -1386,9 +1364,7 @@ class ForumController extends AbstractController {
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'statPage', $users);
     }
 
-    /**
-     * @Route("/courses/{_semester}/{_course}/post/likes", methods={"POST"})
-     */
+    #[Route("/courses/{_semester}/{_course}/posts/likes", methods: ["POST"])]
     public function toggleLike(): JsonResponse {
         $requiredKeys = ['post_id', 'current_user'];
         foreach ($requiredKeys as $key) {

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -774,7 +774,7 @@ class ForumController extends AbstractController {
      * @AccessControl(permission="forum.merge_thread")
      */
     #[Route("/courses/{_semester}/{_course}/forum/threads/merge", methods: ["POST"])]
-        public function mergeThread() {
+    public function mergeThread() {
         $current_user_id = $this->core->getUser()->getId();
         $parent_thread_id = $_POST["merge_thread_parent"];
         $child_thread_id = $_POST["merge_thread_child"];
@@ -1062,7 +1062,7 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderJsonSuccess($result);
     }
 
-    #[Route("/courses/{_semester}/{_course}/forum", methods: ["POST"])]
+    #[Route("/courses/{_semester}/{_course}/forum", methods: ["GET"])]
     public function showFullThreads() {
         // preparing the params for threads
         $currentCourse = $this->core->getConfig()->getCourse();

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1084,7 +1084,7 @@ class ForumController extends AbstractController {
     }
 
     #[Route("/courses/{_semester}/{_course}/forum/threads", methods: ["GET"])]
-    #[Route("/courses/{_semester}/{_course}/forum/threads/{thread_id}", methods: ["GET","POST"], requirements: ["thread_id"=>"\d+"])]
+    #[Route("/courses/{_semester}/{_course}/forum/threads/{thread_id}", methods: ["GET","POST"], requirements: ["thread_id" => "\d+"])]
     public function showThreads($thread_id = null, $option = 'tree') {
         $user = $this->core->getUser()->getId();
         $currentCourse = $this->core->getConfig()->getCourse();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Changing
BEFORE

![image](https://github.com/Submitty/Submitty/assets/72827303/2e6eea6b-f953-4661-a0a6-60efc6817e8d)

these implementations to have new PHP 8 syntax
ex)

AFTER

![image](https://github.com/Submitty/Submitty/assets/72827303/6580fd5d-c36c-4c2d-9bef-bd5e7ae32235)

Refactors all of the @routes to the new PHP8 Syntax of #[Route()] for all route calls in forum controller file.

### What is the new behavior?

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
