### PR TITLE
[Refactor:TAGrading] speed up rubric grading page

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2319,7 +2319,7 @@ function reloadGradingRubric(gradeable_id, anon_id) {
         })
         .then((graded_gradeable) => {
             GRADED_GRADEABLE = graded_gradeable;
-            return loadComponentData(gradeable_tmp.components, gradeable_id, anon_id)
+            return loadComponentData(gradeable_tmp, graded_gradeable)
                 .then(() => {
                     return renderGradingGradeable(getGraderId(), gradeable_tmp, graded_gradeable,
                         isGradingDisabled(), canVerifyGraders(), getDisplayVersion());
@@ -2337,23 +2337,23 @@ function reloadGradingRubric(gradeable_id, anon_id) {
 }
 /** 
 * Call this to save components and graded components to global list
-* @param {list} components
-* @param {string} gradeable_id
-* @param {string} anon_id
+* @param {Promise} gradeable
+* @param {Promise} graded_gradeable
 * @return {Promise}
 */
-async function loadComponentData(components, gradeable_id, anon_id) {
-    const loadComponent = async (component) => {
-        try {
-            COMPONENT_RUBRIC_LIST[component.id] = await ajaxGetComponentRubric(gradeable_id, component.id);
-            GRADED_COMPONENTS_LIST[component.id] = await ajaxGetGradedComponent(gradeable_id, component.id, anon_id);
-        } catch (err) {
-            console.error(`Error loading data for component ${component.id}: ${err}`);
+async function loadComponentData(gradeable, graded_gradeable) {
+    for (const component of gradeable.components) {
+        COMPONENT_RUBRIC_LIST[component.id] = component
+    }
+    if (graded_gradeable.graded_components) {
+        const graded_array = Object.values(graded_gradeable.graded_components);
+        for (const component of graded_array) {
+            GRADED_COMPONENTS_LIST[component.component_id] = component
         }
-    };
-
-    for (const component of components) {
-        await loadComponent(component);
+    } else {
+        for (const component of gradeable.components) {
+            GRADED_COMPONENTS_LIST[component.id] = undefined;
+        }
     }
 }
 /**

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -20,7 +20,7 @@
 
 const GRADED_COMPONENTS_LIST = {};
 const COMPONENT_RUBRIC_LIST = {};
-let GRADED_GRADEABLE = Promise.resolve();
+let GRADED_GRADEABLE = null
 
 /**
  * An associative object of <component-id> : <mark[]>
@@ -2511,23 +2511,14 @@ function toggleComponent(component_id, saveChanges, edit_mode = false) {
     // Component is open, so close it
     if (isComponentOpen(component_id)) {
         action = action.then(() => {
-            console.time('closeComponent');
-            return closeComponent(component_id, saveChanges, edit_mode)
-                .then(() => {
-                    console.timeEnd('closeComponent');
-                });
+            return closeComponent(component_id, saveChanges, edit_mode);
         });
     }
     else {
         action = action.then(() => {
-            console.time('closeAllComponents');
             return closeAllComponents(saveChanges, edit_mode)
                 .then(() => {
-                    console.timeEnd('closeAllComponents');
-                    console.time('openComponent');
-                    return (openComponent(component_id)).then(() => {
-                        console.timeEnd('openComponent');
-                    });
+                    return (openComponent(component_id));
                 });
         });
     }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2514,7 +2514,9 @@ function toggleComponent(component_id, saveChanges, edit_mode = false) {
         action = action.then(() => {
             console.time('closeComponent');
             return closeComponent(component_id, saveChanges, edit_mode)
-                .then(function () { console.timeEnd('closeComponent') });
+                .then(() => {
+                    console.timeEnd('closeComponent');
+                });
         });
     }
     else {
@@ -2524,7 +2526,9 @@ function toggleComponent(component_id, saveChanges, edit_mode = false) {
                 .then(() => {
                     console.timeEnd('closeAllComponents');
                     console.time('openComponent');
-                    return (openComponent(component_id)).then(function () { console.timeEnd('openComponent') });
+                    return (openComponent(component_id)).then(() => {
+                        console.timeEnd('openComponent');
+                    });
                 });
         });
     }

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1389,22 +1389,6 @@ function getPeerGradingEarned() {
 
 
 /**
- * Gets if all components have a grade assigned
- * @return {boolean} If all components have at least one mark checked
- */
-function getTaGradingComplete() {
-    let anyIncomplete = false;
-    $('.graded-component-data').each(function () {
-        const pointsEarned = $(this).attr('data-total_score');
-        if (pointsEarned === '') {
-            anyIncomplete = true;
-        }
-    });
-    return !anyIncomplete;
-}
-
-
-/**
  * Gets the number of ta grading points that can be earned
  * @return {number}
  */
@@ -2323,7 +2307,7 @@ function reloadGradingRubric(gradeable_id, anon_id) {
                 .then(() => {
                     return renderGradingGradeable(getGraderId(), gradeable_tmp, graded_gradeable,
                         isGradingDisabled(), canVerifyGraders(), getDisplayVersion());
-                })
+                });
         })
         .then((elements) => {
             setRubricDOMElements(elements);
@@ -2335,7 +2319,7 @@ function reloadGradingRubric(gradeable_id, anon_id) {
         });
 
 }
-/** 
+/**
 * Call this to save components and graded components to global list
 * @param {Promise} gradeable
 * @param {Promise} graded_gradeable
@@ -2343,14 +2327,15 @@ function reloadGradingRubric(gradeable_id, anon_id) {
 */
 async function loadComponentData(gradeable, graded_gradeable) {
     for (const component of gradeable.components) {
-        COMPONENT_RUBRIC_LIST[component.id] = component
+        COMPONENT_RUBRIC_LIST[component.id] = component;
     }
     if (graded_gradeable.graded_components) {
         const graded_array = Object.values(graded_gradeable.graded_components);
         for (const component of graded_array) {
-            GRADED_COMPONENTS_LIST[component.component_id] = component
+            GRADED_COMPONENTS_LIST[component.component_id] = component;
         }
-    } else {
+    }
+    else {
         for (const component of gradeable.components) {
             GRADED_COMPONENTS_LIST[component.id] = undefined;
         }
@@ -2463,7 +2448,7 @@ function reloadGradingComponent(component_id, editable = false, showMarkList = f
         .then((component) => {
             // Set the global mark list data for this component for conflict resolution
             OLD_MARK_LIST[component_id] = component.marks;
-            COMPONENT_RUBRIC_LIST[component_id] = component
+            COMPONENT_RUBRIC_LIST[component_id] = component;
 
             component_tmp = component;
             return ajaxGetGradedComponent(gradeable_id, component_id, getAnonId());
@@ -2527,19 +2512,19 @@ function toggleComponent(component_id, saveChanges, edit_mode = false) {
     // Component is open, so close it
     if (isComponentOpen(component_id)) {
         action = action.then(() => {
-            console.time("closeComponent");
+            console.time('closeComponent');
             return closeComponent(component_id, saveChanges, edit_mode)
-                .then(function () { console.timeEnd("closeComponent") });
+                .then(function () { console.timeEnd('closeComponent') });
         });
     }
     else {
         action = action.then(() => {
-            console.time("closeAllComponents");
+            console.time('closeAllComponents');
             return closeAllComponents(saveChanges, edit_mode)
                 .then(() => {
-                    console.timeEnd("closeAllComponents");
-                    console.time("openComponent");
-                    return (openComponent(component_id)).then(function () { console.timeEnd("openComponent") });
+                    console.timeEnd('closeAllComponents');
+                    console.time('openComponent');
+                    return (openComponent(component_id)).then(function () { console.timeEnd('openComponent') });
                 });
         });
     }
@@ -2855,9 +2840,6 @@ function closeComponentInstructorEdit(component_id, saveChanges) {
  */
 function closeComponentGrading(component_id, saveChanges) {
     let sequence = Promise.resolve();
-    const gradeable_id = getGradeableId();
-    const anon_id = getAnonId();
-    let component_tmp = null;
 
     GRADED_COMPONENTS_LIST[component_id] = getGradedComponentFromDOM(component_id);
     COMPONENT_RUBRIC_LIST[component_id] = getComponentFromDOM(component_id);
@@ -2870,9 +2852,8 @@ function closeComponentGrading(component_id, saveChanges) {
     // Finally, render the graded component in non-edit mode with the mark list hidden
     return sequence
         .then(() => {
-            injectGradingComponent(COMPONENT_RUBRIC_LIST[component_id], GRADED_COMPONENTS_LIST[component_id], false, false)
-
-        })
+            injectGradingComponent(COMPONENT_RUBRIC_LIST[component_id], GRADED_COMPONENTS_LIST[component_id], false, false);
+        });
 }
 
 /**

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -20,7 +20,7 @@
 
 const GRADED_COMPONENTS_LIST = {};
 const COMPONENT_RUBRIC_LIST = {};
-let GRADED_GRADEABLE = null
+let GRADED_GRADEABLE = null;
 
 /**
  * An associative object of <component-id> : <mark[]>

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -1314,7 +1314,6 @@ function getScoresFromDOM() {
         peer_grade_earned: getPeerGradingEarned(),
         peer_total: getPeerGradingTotal(),
         auto_grading_complete: false,
-
     };
 
     // Then check if auto grading scorse exist before adding them

--- a/site/public/templates/grading/Functions.twig
+++ b/site/public/templates/grading/Functions.twig
@@ -1,7 +1,7 @@
 {#
 Function for getting the badge style for a given set of total and earned points
 #}
-{% macro getBadgeStyle(earned, total, complete) %}
+{% macro getBadgeStyle(earned, total) %}
     {% if earned is defined and total is defined %}
         {% set percent = earned / total %}
         {% if percent < 0.5 %}

--- a/site/public/templates/grading/Functions.twig
+++ b/site/public/templates/grading/Functions.twig
@@ -3,22 +3,17 @@ Function for getting the badge style for a given set of total and earned points
 #}
 {% macro getBadgeStyle(earned, total, complete) %}
     {% if earned is defined and total is defined %}
-        {% if complete is defined and not complete %}
+        {% set percent = earned / total %}
+        {% if percent < 0.5 %}
+            red-background
+        {% elseif percent < 1 %}
+            yellow-background
+        {# total = 0 means extra credit part and should be grey when earned =0 #}
+        {% elseif total == 0 and earned == 0%}
             {# Nothing #}
+        {# should be green if you get 100% for earned/total or even more with extra credit#}
         {% else %}
-            {% set percent = earned / total %}
-            {% if percent < 0.5 %}
-                red-background
-            {% elseif percent < 1 %}
-                yellow-background
-            {# total = 0 means extra credit part and should be grey when earned =0 #}
-            {% elseif total == 0 and earned == 0%}
-                {# Nothing #}
-            {# should be green if you get 100% for earned/total or even more with extra credit#}
-            {% else %}
-                green-background
-            }
-            {% endif %}
+            green-background
         {% endif %}
     {% endif %}
 {% endmacro %}

--- a/site/public/templates/grading/TotalPeerScoreBox.twig
+++ b/site/public/templates/grading/TotalPeerScoreBox.twig
@@ -8,7 +8,7 @@ Required Parameters:
 
 #}
 <div class="box-title badge-container">
-        <strong id="score_total" class="badge {{ functions.getBadgeStyle(combined_peer_score,  peer_total,  peer_total) }}">
+        <strong id="score_total" class="badge {{ functions.getBadgeStyle(combined_peer_score,  peer_total) }}">
             {{ combined_peer_score is defined ? (combined_peer_score)|round(decimal_precision) : '&minus;' }} / {{ peer_total|round(decimal_precision) }}
         </strong>
         <strong>Combined Peer Grading Total</strong>

--- a/site/public/templates/grading/TotalScoreBox.twig
+++ b/site/public/templates/grading/TotalScoreBox.twig
@@ -13,7 +13,7 @@ l
     {% set show_total = true %}
     {% if auto_grading_total is defined %}
         <div class="box-title badge-container">
-            <strong id="autograding_total" class="badge {{ functions.getBadgeStyle(auto_grading_earned, auto_grading_total, auto_grading_complete) }}">
+            <strong id="autograding_total" class="badge {{ functions.getBadgeStyle(auto_grading_earned, auto_grading_total) }}">
                 {{ auto_grading_earned is defined ? auto_grading_earned|round(decimal_precision) : '&minus;' }} / {{ auto_grading_total|round(decimal_precision) }}
             </strong>
             <strong>Autograding Total</strong>
@@ -21,7 +21,7 @@ l
     {% endif %}
     {% if ta_grading_earned is defined %}
         <div class="box-title badge-container">
-            <strong id="grading_total" class="badge {{ functions.getBadgeStyle(ta_grading_earned, ta_grading_total, ta_grading_complete) }}">
+            <strong id="grading_total" class="badge {{ functions.getBadgeStyle(ta_grading_earned, ta_grading_total) }}">
                 {{ ta_grading_earned is defined ? ta_grading_earned|round(decimal_precision) : '&minus;' }} / {{ ta_grading_total|round(decimal_precision) }}
             </strong>
             {% if peer_gradeable == true %}
@@ -33,13 +33,13 @@ l
     {% endif %}
     {% if peer_grade_earned is defined %}
         <div class="box-title badge-container">
-            <strong id="score_total" class="badge {{ functions.getBadgeStyle(peer_grade_earned, peer_total, peer_total) }}">
+            <strong id="score_total" class="badge {{ functions.getBadgeStyle(peer_grade_earned, peer_total) }}">
                 {{ peer_grade_earned is defined ? peer_grade_earned|round(decimal_precision) : '&minus;' }} / {{ peer_total|round(decimal_precision) }}
             </strong>
             <strong>Individual Peer Grading Total</strong>
         </div>
         <div class="box-title badge-container">
-            <strong id="score_total" class="badge {{ functions.getBadgeStyle(combined_peer_score, peer_total, peer_total) }}">
+            <strong id="score_total" class="badge {{ functions.getBadgeStyle(combined_peer_score, peer_total) }}">
                 {{ combined_peer_score is defined ? combined_peer_score|round(decimal_precision) : '&minus;' }} / {{ peer_total|round(decimal_precision) }}
             </strong>
             <strong>Combined Peer Grading Total</strong>
@@ -61,7 +61,7 @@ l
             {% endif %}
         {% endif %}
         <div class="box-title badge-container">
-            <strong id="score_total" class="badge {{ functions.getBadgeStyle(total_earned, max_total, max_total) }}">
+            <strong id="score_total" class="badge {{ functions.getBadgeStyle(total_earned, max_total) }}">
                 {{ total_earned is defined ? total_earned|round(decimal_precision) : '&minus;' }} / {{ (max_total)|round(decimal_precision) }}
             </strong>
             <strong>Total</strong>
@@ -71,7 +71,7 @@ l
 
 {% if user_group == 4 %}
     <div class="box-title badge-container">
-        <strong id="score_total" class="badge {{ functions.getBadgeStyle(peer_grade_earned, peer_total, peer_total) }}">
+        <strong id="score_total" class="badge {{ functions.getBadgeStyle(peer_grade_earned, peer_total) }}">
             {{ peer_grade_earned is defined ? peer_grade_earned|round(decimal_precision) : '&minus;' }} / {{ peer_total|round(decimal_precision) }}
         </strong>
         <strong>My Peer Grading Total</strong>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
On the TA grading rubric page, toggling components (switching to the next question for grading) takes a long time to load. This slowdown occurs because:
toggleComponent() consists of two steps: closeAllComponents() and openComponent()
- Closing all components: Attempts to call closeComponent() on all components. Each call to closeComponent() waits for the server to save and then calls updateTotals() to update the total score. updateTotals() rerenders the entire gradeable component, which is time-consuming.
- Opening a component: It waits for closeAllComponents() to finish, then waits again for the server to retrieve the component.

### What is the new behavior?
With the implemented changes:
- Component information is now stored in a global list, so open component can render using info from the list
- closeAllComponents() only calls closeComponent() on components that are actually open.
- Changes are saved in the background instead of waiting.
- updateTotals() has been replaced with refreshTotalScoreBox(), which only rerenders the total score box at the bottom.

### Other information?
Changes were made only to the normal grading and edit mode paths. I couldn't figure out what the instructor edit mode is so I rewrote the code in a way that the instructor edit path will still follow the old workflow. 

Potential Issue with the Change: If two people are grading the same student and both load the page simultaneously, there's a possibility of data being overwritten. For example, if Person 1 grades the first question and Person 2, without refreshing their page, grades the same question afterward, the later input will overwrite the earlier one. However, I don't consider this a significant downside because graders are usually assigned to different students or questions, making such overlaps unlikely. Additionally, similar overwrite issues could occur even before the change when two graders opened the same component simultaneously.

<!-- Is this a breaking change? -->
For me, it is a significant improvement. My computer is old and slow, so the response time has improved dramatically, from nearly 3 seconds to under 0.1 seconds.
before:
<img width="172" alt="8d3e0670ce8c373d3bcc04ccb66942c" src="https://github.com/Submitty/Submitty/assets/75406429/49dde1bd-938e-43bc-8386-2b69bb04da60">
after:
<img width="271" alt="7aa862038bb7961f899bddebc65927c" src="https://github.com/Submitty/Submitty/assets/75406429/bcec49d7-83a6-4028-b79c-0656ff056108">

<!-- How did you test -->
try to grade a student and see if anything breaks
