### PR TITLE
[Bugfix:TAGrading] Keep Silent Regrade Box Checked

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -567,7 +567,7 @@ function onAjaxInit() {}
 
 function readCookies() {
 
-    const silent_edit_enabled = Cookies.get('silent_edit_enabled') || '';
+    const silent_edit_enabled = Cookies.get('silent_edit_enabled') === 'true' || '';
 
     const autoscroll = Cookies.get('autoscroll') || '';
     const opened_mark = Cookies.get('opened_mark') || '';


### PR DESCRIPTION
Fixes #10379 

### What is the new behavior?
The silent regrade box is checked corresponded to the "silent_edit_enabled" cookies. Always keep updated.

### Other information?
I found the problem is due to the wrong type of variable "silent_edit_enabled" read from the cookies. Previously, it was read as a string, however it should be casted to boolean.


https://github.com/Submitty/Submitty/assets/60954116/2f0f9fca-0c14-48eb-b050-72ef19eaa0e3



