### PR TITLE
[Bugfix:Forum] Fix forum socket update

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -584,6 +584,8 @@ class ForumController extends AbstractController {
         }
         $thread_id = $post['thread_id'];
         $thread = $this->core->getQueries()->getThread($thread_id);
+        $first_post = $this->core->getQueries()->getFirstPostForThread($thread_id);
+        $first_post_author_id = $first_post['author_user_id'];
         $GLOBALS['totalAttachments'] = 0;
         $GLOBALS['post_box_id'] = $_POST['post_box_id'];
         $unviewed_posts = [$post_id];
@@ -594,6 +596,7 @@ class ForumController extends AbstractController {
         $result = $this->core->getOutput()->renderTemplate(
             'forum\ForumThread',
             'createPost',
+            $first_post_author_id,
             $thread,
             $post,
             $unviewed_posts,

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -12,6 +12,7 @@ use app\libraries\DateUtils;
 use app\libraries\routers\AccessControl;
 use app\libraries\routers\Enabled;
 use app\libraries\response\JsonResponse;
+use app\views\forum\ForumThreadView;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -586,6 +587,11 @@ class ForumController extends AbstractController {
         $thread = $this->core->getQueries()->getThread($thread_id);
         $first_post = $this->core->getQueries()->getFirstPostForThread($thread_id);
         $first_post_author_id = $first_post['author_user_id'];
+        $upduck_count = $this->core->getQueries()->getUpduckInfoForPosts([$post_id])[$post_id];
+        $upduck_liked_by_user = array_key_exists($post_id, $this->core->getQueries()->getUserLikesForPosts(
+            [$post_id],
+            $this->core->getUser()->getId()
+        ));
         $GLOBALS['totalAttachments'] = 0;
         $GLOBALS['post_box_id'] = $_POST['post_box_id'];
         $unviewed_posts = [$post_id];
@@ -603,6 +609,8 @@ class ForumController extends AbstractController {
             $first,
             $reply_level,
             'tree',
+            $upduck_count,
+            $upduck_liked_by_user,
             true,
             $author_info[$post["author_user_id"]],
             $post_attachments[$post["id"]][0],

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -12,7 +12,6 @@ use app\libraries\DateUtils;
 use app\libraries\routers\AccessControl;
 use app\libraries\routers\Enabled;
 use app\libraries\response\JsonResponse;
-use app\views\forum\ForumThreadView;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
If you are on the forum page and a new post is added through the websocket, an error will come up that it cannot parse new post. It will also frog robot on the backend.

### What is the new behavior?
New posts will dynamically load in without an issue. This was due to missing arguments in the createPost function when called by renderTemplate.

### Other information?
Tested locally and new forum posts load fine
