### PR TITLE
[Bugfix:InstructorUI] error checking logic for exam seating

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -149,7 +149,7 @@ class NavigationView extends AbstractView {
                 }
 
                 // if the user seating details have both a building and a room property
-                if (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
+                else if (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
                     $seating_config_path = FileUtils::joinPaths(
                         $this->core->getConfig()->getCoursePath(),
                         'uploads',

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -149,7 +149,7 @@ class NavigationView extends AbstractView {
                 }
 
                 // if the user seating details have both a building and a room property
-                else if (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
+                elseif (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
                     $seating_config_path = FileUtils::joinPaths(
                         $this->core->getConfig()->getCoursePath(),
                         'uploads',

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -146,9 +146,10 @@ class NavigationView extends AbstractView {
                 if ($user_seating_details === null || filesize($seating_user_path) == 0) {
                     //print error message without breaking (ex ERR: Please contact instructor)
                     $seating_config = 'empty-case-handling';
-                } elseif (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
-                  // if the user seating details have both a building and a room property
-                  $seating_config_path = FileUtils::joinPaths(
+                }
+                elseif (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
+                    // if the user seating details have both a building and a room property
+                    $seating_config_path = FileUtils::joinPaths(
                         $this->core->getConfig()->getCoursePath(),
                         'uploads',
                         'seating',

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -146,11 +146,9 @@ class NavigationView extends AbstractView {
                 if ($user_seating_details === null || filesize($seating_user_path) == 0) {
                     //print error message without breaking (ex ERR: Please contact instructor)
                     $seating_config = 'empty-case-handling';
-                }
-
-                // if the user seating details have both a building and a room property
-                elseif (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
-                    $seating_config_path = FileUtils::joinPaths(
+                } elseif (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {
+                  // if the user seating details have both a building and a room property
+                  $seating_config_path = FileUtils::joinPaths(
                         $this->core->getConfig()->getCoursePath(),
                         'uploads',
                         'seating',


### PR DESCRIPTION
When Exam Seating is misconfigured (files missing, named incorrectly, values incorrect) we get crashes (Frog Robot) instead of more helpful error messages.  

Here's one specific error that will be fixed with this PR change

```
TypeError (Code: 0) thrown in /usr/local/submitty/site/app/views/NavigationView.php (Line 152) by:
                if (property_exists($user_seating_details, 'building') && property_exists($user_seating_details, 'room')) {

Message:
property_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
```