### PR TITLE
[Bugfix:SubminiPolls] Fixing PHP Unit Test

### DIFF
--- a/site/tests/app/entities/poll/PollTester.php
+++ b/site/tests/app/entities/poll/PollTester.php
@@ -295,7 +295,9 @@ class PollTester extends BaseUnitTest {
 
         $this->my_polls[1]->setEnded();
         // SetEnded sets EndTime to current time (no way to check exact millisecond)
-        $this->assertEquals($this->my_polls[2]->getEndTime()->format("Y-m-d"), date("Y-m-d"));
+        $endtime = $this->my_polls[1]->getEndTime()->format("Y-m-d");
+        $expectedDate = DateUtils::getDateTimeNow()->format("Y-m-d");
+        $this->assertEquals($endtime, $expectedDate);
 
         $this->my_polls[2]->setEndTime(new DateTime('2025-10-03 05:30:00'));
         $this->assertEquals($this->my_polls[2]->getEndTime()->format("Y-m-d H:i:s"), "2025-10-03 05:30:00");


### PR DESCRIPTION
Fixes PHP unit test to remove errors with timezones.