### PR TITLE
[Refactor:System] Update minimum CMake to 3.20

### DIFF
--- a/grading/CMakeLists.txt
+++ b/grading/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.20)
 project (sample_assignment)
 
 ###################################################################################


### PR DESCRIPTION
### What is the current behavior?
The Submitty installation script currently prints a CMake deprecation error:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

### What is the new behavior?
This PR increases the minimum required CMake version to 3.20.  The current version of CMake installed in the VM is 3.22.
