### PR TITLE
[Bugfix:Autograding] system calls for c_failure_messages/M2

### DIFF
--- a/grading/system_call_categories.cpp
+++ b/grading/system_call_categories.cpp
@@ -176,6 +176,8 @@ void allow_system_calls(scmp_filter_ctx sc, const std::set<std::string> &categor
 
   // SAFELIST : FILE_MANAGEMENT
   ALLOW_SYSCALL(access);
+  ALLOW_SYSCALL(faccessat);
+  ALLOW_SYSCALL(faccessat2);
   ALLOW_SYSCALL(_llseek);
   ALLOW_SYSCALL(close);
   ALLOW_SYSCALL(creat);
@@ -473,8 +475,6 @@ void allow_system_calls(scmp_filter_ctx sc, const std::set<std::string> &categor
     ALLOW_SYSCALL(afs_syscall);
     ALLOW_SYSCALL(bdflush);
     ALLOW_SYSCALL(break);
-    ALLOW_SYSCALL(faccessat);
-    ALLOW_SYSCALL(faccessat2);
     ALLOW_SYSCALL(fallocate);
     ALLOW_SYSCALL(fanotify_init);
     ALLOW_SYSCALL(fanotify_mark);

--- a/grading/system_call_check.cpp
+++ b/grading/system_call_check.cpp
@@ -151,7 +151,7 @@ void parse_system_calls(std::ifstream& system_call_categories_file,
 
   // verify that we have all of the linux system calls (32 & 64 bit)
   std::cout << "all_system_calls.size() " <<  all_system_calls.size() << std::endl;
-  assert (all_system_calls.size() == 397);
+  assert (all_system_calls.size() == 398);
 }
 
 

--- a/more_autograding_examples/c_failure_messages/config/config.json
+++ b/more_autograding_examples/c_failure_messages/config/config.json
@@ -7,7 +7,10 @@
 
     "allow_system_calls" : [
         "PROCESS_CONTROL_NEW_PROCESS_THREAD",
-        "PROCESS_CONTROL_SCHEDULING"
+        "PROCESS_CONTROL_SCHEDULING",
+        "COMMUNICATIONS_AND_NETWORKING_SIGNALS",
+        "FILE_MANAGEMENT_RARE",
+        "PROCESS_CONTROL_ADVANCED"
     ],
 
     "assignment_message" :


### PR DESCRIPTION
### What is the current behavior?
The c_failure_messages example from more_autograding_examples does not work on M2.
It gets a zero grade due to a system call failure when running sort.

### What is the new behavior?
With these changes, now the submission runs and receives full credit.

Also the system_call_check utility had the wrong system call count.