### PR TITLE
[Bugfix:System] Preserve submitty config keys

### DIFF
--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -494,6 +494,17 @@ if not args.worker:
 
 IGNORED_FILES_AND_DIRS = ['saml', 'login.md']
 
+system_message = None
+# this prevents clobbered system_message
+try:
+    with open(SUBMITTY_JSON,"r") as submitty_config:
+        load_submitty_json = json.load(submitty_config)
+        if "system_message" in load_submitty_json:
+            system_message = load_submitty_json["system_message"]
+except IOError:
+    pass
+
+
 if os.path.isdir(CONFIG_INSTALL_DIR):
     for file in os.scandir(CONFIG_INSTALL_DIR):
         if file.name not in IGNORED_FILES_AND_DIRS:
@@ -633,15 +644,7 @@ if not args.worker:
 
 config['worker'] = True if args.worker == 1 else False
 
-# this prevents clobbered system_message
-try:
-    with open(SUBMITTY_JSON,"r") as submitty_config:
-        load_submitty_json = json.load(submitty_config)
-        if "system_message" in load_submitty_json:
-                config["system_message"] = load_submitty_json["system_message"]
-except IOError:
-	pass
-
+#clobber 
 with open(SUBMITTY_JSON, 'w') as json_file:
     json.dump(config, json_file, indent=2)
 os.chmod(SUBMITTY_JSON, 0o444)

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -640,6 +640,7 @@ try:
         if "system_message" in load_submitty_json:
                 config["system_message"] = load_submitty_json["system_message"]
 except IOError:
+	pass
 
 with open(SUBMITTY_JSON, 'w') as json_file:
     json.dump(config, json_file, indent=2)

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -497,10 +497,10 @@ IGNORED_FILES_AND_DIRS = ['saml', 'login.md']
 system_message = None
 # this prevents clobbered system_message
 try:
-    with open(SUBMITTY_JSON,"r") as submitty_config:
+    with open(SUBMITTY_JSON,'r') as submitty_config:
         load_submitty_json = json.load(submitty_config)
-        if "system_message" in load_submitty_json:
-            system_message = load_submitty_json["system_message"]
+        if 'system_message' in load_submitty_json:
+            system_message = load_submitty_json['system_message']
 except IOError:
     pass
 

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -633,6 +633,14 @@ if not args.worker:
 
 config['worker'] = True if args.worker == 1 else False
 
+# this prevents clobbered system_message
+try:
+    with open(SUBMITTY_JSON,"r") as submitty_config:
+        load_submitty_json = json.load(submitty_config)
+        if "system_message" in load_submitty_json:
+                config["system_message"] = load_submitty_json["system_message"]
+except IOError:
+
 with open(SUBMITTY_JSON, 'w') as json_file:
     json.dump(config, json_file, indent=2)
 os.chmod(SUBMITTY_JSON, 0o444)

--- a/.setup/CONFIGURE_SUBMITTY.py
+++ b/.setup/CONFIGURE_SUBMITTY.py
@@ -644,7 +644,10 @@ if not args.worker:
 
 config['worker'] = True if args.worker == 1 else False
 
-#clobber 
+# this prevents a clobbered system message
+if system_message != None:
+    config['system_message'] = system_message
+
 with open(SUBMITTY_JSON, 'w') as json_file:
     json.dump(config, json_file, indent=2)
 os.chmod(SUBMITTY_JSON, 0o444)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:


### What is the current behavior?
Currently, when the CONFIGURE_SUBMITTY.py script is run, the system_message field located in /usr/local/submitty/config/submitty.json is not preserved. This can be annoying for sysadmins who don't want to have to rewrite their system_message everytime after they run CONFIGURE_SUBMITTY.py.
Closes #8151 
### What is the new behavior?
If the submitty.json file has defined a system_message, field, it is saved into the config of the new file.

### Other information?
You can test this by running the CONFIGURE_SUBMITTY.py script located in /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/CONFIGURE_SUBMITTY.py

Please try all sorts of edge cases. 
Examples:
Delete the submitty.json file and run
Change the field and run and make sure that it is preserved
leave the field empty
NOTE: we are assuming that the file is valid json, that is the user's responsibility
