### PR TITLE
[Bugfix:System] Fix VCS permission on install

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -206,6 +206,7 @@ else
     DAEMONPHP_GROUP="${DAEMON_GROUP}"
 fi
 DAEMONCGI_GROUP=$(jq -r '.daemoncgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
+DAEMONPHPCGI_GROUP=$(jq -r '.daemonphpcgi_group' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 SUPERVISOR_USER=$(jq -r '.supervisor_user' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json")
 
 ########################################################################################################################
@@ -331,9 +332,9 @@ if [ "${WORKER}" == 0 ]; then
     chmod  751                                        "${SUBMITTY_DATA_DIR}/courses"
     chown  "${PHP_USER}:${PHP_USER}"                  "${SUBMITTY_DATA_DIR}/user_data"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/user_data"
-    chown  "root:${DAEMONCGI_GROUP}"                  "${SUBMITTY_DATA_DIR}/vcs"
+    chown  "root:${DAEMONPHPCGI_GROUP}"               "${SUBMITTY_DATA_DIR}/vcs"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs"
-    chown  "root:${DAEMONCGI_GROUP}"                  "${SUBMITTY_DATA_DIR}/vcs/git"
+    chown  "root:${DAEMONPHPCGI_GROUP}"               "${SUBMITTY_DATA_DIR}/vcs/git"
     chmod  770                                        "${SUBMITTY_DATA_DIR}/vcs/git"
 fi
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -494,7 +494,7 @@ class HomeworkView extends AbstractView {
                 $this->core->getConfig()->getTerm(),
                 $this->core->getConfig()->getCourse(),
                 $gradeable->getId(),
-                $student_id
+                $graded_gradeable->getSubmitter()->getId()
             );
             $vcs_repo_exists = file_exists($path);
         }


### PR DESCRIPTION
### What is the current behavior?
PR https://github.com/Submitty/Submitty/pull/10164 added a migration which changed the permissions of the vcs directory and subdirectories. In one of the install scripts it changes the permission back to the old value which breaks the website submission. Also it only uses the student ID for checking the repo path.

### What is the new behavior?
The install script was edited to set permissions correctly. Now it will use student ID or team ID for the repo path to support team gradeables too.

### Other information?
Tested locally and submission pages works correctly after install
