### PR TITLE
[Bugfix:TAGrading] progress bar

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1856,7 +1856,7 @@ class Gradeable extends AbstractModel {
         $graded_components = [];
         if ($this->isGradeByRegistration()) {
             $sections = $grader->getGradingRegistrationSections();
-            if ($this->core->getAccess()->canI("grading.electronic.grade.if_no_sections_exist") && !isset($sections)) {
+            if ($this->core->getAccess()->canI("grading.electronic.grade.if_no_sections_exist") && $sections === []) {
                 $sections = $this->core->getQueries()->getRegistrationSections();
                 foreach ($sections as $i => $section) {
                     $sections[$i] = $section['sections_registration_id'];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When graders are assigned to grade by registration section and instruction did not assign any section, progress bar under the grade button is missing

### What is the new behavior?
show the progress bar

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
