### PR TITLE
[Bugfix:Forum] Disable Unresolve Button

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -182,8 +182,10 @@ function testAndGetAttachments(post_box_id, dynamic_check) {
         return false;
     }
     else {
-        const submitButton = document.querySelector(`[data-post_box_id="${post_box_id}"] input[type="submit"]`);
-        submitButton.disabled = false;
+        const submitButtons = document.querySelectorAll(`[data-post_box_id="${post_box_id}"] input[type="submit"]`);
+        submitButtons.forEach((button) => {
+            button.disabled = false;
+        });
         return files;
     }
 }
@@ -2507,7 +2509,7 @@ function setupDisableReplyThreadForm() {
         //For all thread forms either reply's or posts, ensure that when text area is empty, the submit button appears to be disabled
         const textArea = form.querySelector('textarea');
 
-        const submitButton = form.querySelector('input[type="submit"]');
+        const submitButtons = form.querySelectorAll('input[type="submit"]');
 
         if (textArea.id === 'reply_box_1' || textArea.id === 'reply_box_2') {
             // Should not apply for first two reply_box's as they imply the post itself which should be handled by another controller due to extensive inputs
@@ -2517,12 +2519,9 @@ function setupDisableReplyThreadForm() {
         const inputTest = () => {
             const imageAttachments = form.querySelectorAll('.file-upload-table .file-label');
 
-            if (textArea.value.trim() === '' && imageAttachments.length === 0) {
-                submitButton.disabled = true;
-            }
-            else {
-                submitButton.disabled = false;
-            }
+            submitButtons.forEach((button) => {
+                button.disabled = textArea.value.trim() === '' && imageAttachments.length === 0;
+            });
         };
 
         textArea.addEventListener('input', () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, the reply buttons on the forum are disabled when no text or files have been added for a valid response to a post, but the respond and unresolve button is not accounted for.

### What is the new behavior?
The respond and unresolve button is now accounted for when viewing as a student or instructor after a given post has been marked as resolved. 

### Other information?
This is a small change that builds on the implementation in [#10129](https://github.com/Submitty/Submitty/pull/10129)