### PR TITLE
[Feature:API] Add testcases to student api

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1052,6 +1052,30 @@ class SubmissionController extends AbstractController {
 
         $graded_gradeable = $graded_gradeable->getAutoGradedGradeable();
 
+        $testcase_array = [];
+        if ($graded_gradeable->hasActiveVersion()) {
+            $gradeable_version = $graded_gradeable->getAutoGradedVersions()[$graded_gradeable->getActiveVersion()] ?? null;
+            if ($gradeable_version !== null) {
+                // Gets arrays, and cleans empty arrays
+                $testcase_array = array_filter(array_map(function (AutoGradedTestcase $testcase) {
+                    $testcase_config = $testcase->getTestcase();
+                    if ($testcase->canView()) {
+                        return [
+                            'name' => $testcase_config->getName(),
+                            'details' => $testcase_config->getDetails(),
+                            'is_extra_credit' => $testcase_config->isExtraCredit(),
+                            'points_available' => $testcase_config->getPoints(),
+                            'has_extra_results' => $testcase->hasAutochecks(),
+                            'points_received' => $testcase->getPoints(),
+                            'testcase_message' => $testcase_config->canViewTestcaseMessage() ? $testcase->getMessage() : ''
+                        ];
+                    } else {
+                        return [];
+                    }
+                }, $gradeable_version->getTestcases()));
+            }
+        }
+
         return JsonResponse::getSuccessResponse([
             'is_queued' => $graded_gradeable->isQueued(),
             'queue_position' => $graded_gradeable->getQueuePosition(),
@@ -1061,7 +1085,8 @@ class SubmissionController extends AbstractController {
             'has_active_version' => $graded_gradeable->hasActiveVersion(),
             'highest_version' => $graded_gradeable->getHighestVersion(),
             'total_points' => ($graded_gradeable->hasActiveVersion() ? $graded_gradeable->getTotalPoints() : null),
-            'total_percent' => ($graded_gradeable->hasActiveVersion() ? $graded_gradeable->getTotalPercent() : null)
+            'total_percent' => ($graded_gradeable->hasActiveVersion() ? $graded_gradeable->getTotalPercent() : null),
+            'test_cases' => $testcase_array
         ]);
     }
 

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -23,6 +23,7 @@ use app\models\GradingOrder;
 use Symfony\Component\Routing\Annotation\Route;
 use app\models\notebook\SubmissionCodeBox;
 use app\models\notebook\SubmissionMultipleChoice;
+use app\models\gradeable\AutoGradedTestcase;
 
 class SubmissionController extends AbstractController {
     private $upload_details = [

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1069,7 +1069,8 @@ class SubmissionController extends AbstractController {
                             'points_received' => $testcase->getPoints(),
                             'testcase_message' => $testcase_config->canViewTestcaseMessage() ? $testcase->getMessage() : ''
                         ];
-                    } else {
+                    }
+                    else {
                         return [];
                     }
                 }, $gradeable_version->getTestcases()));

--- a/site/cypress/e2e/Cypress-Feature/student_api.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/student_api.spec.js
@@ -71,32 +71,32 @@ describe('Tests cases for the Student API', () => {
                         'is_extra_credit': false,
                         'points_available': 2,
                         'points_received': 2,
-                        'testcase_message': ''
-                    }
+                        'testcase_message': '',
+                    };
                     const coding_style = {
                         'name': 'Coding Style',
                         'details': '',
                         'is_extra_credit': false,
                         'points_available': 0,
                         'points_received': 0,
-                        'testcase_message': ''
-                    }
+                        'testcase_message': '',
+                    };
                     const documentation = {
                         'name': 'Documentation',
                         'details': '',
                         'is_extra_credit': false,
                         'points_available': 0,
                         'points_received': 0,
-                        'testcase_message': ''
-                    }
+                        'testcase_message': '',
+                    };
                     const extra_credit = {
                         'name': 'Extra Credit',
                         'details': '',
                         'is_extra_credit': true,
                         'points_available': 5,
                         'points_received': 5,
-                        'testcase_message': ''
-                    }
+                        'testcase_message': '',
+                    };
                     expect(data.testcases).to.contain(read_me);
                     expect(data.testcases).to.contain(coding_style);
                     expect(data.testcases).to.contain(documentation);

--- a/site/cypress/e2e/Cypress-Feature/student_api.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/student_api.spec.js
@@ -52,55 +52,48 @@ describe('Tests cases for the Student API', () => {
             }).then((response) => {
                 expect(response.body.status).to.equal('success');
                 // Can't test exact values due to randomness of CI speed
-                const data = JSON.stringify(response.body.data);
-                expect(data).to.contain('is_queued');
-                expect(data).to.contain('queue_position'),
-                expect(data).to.contain('is_grading'),
-                expect(data).to.contain('has_submission'),
-                expect(data).to.contain('autograding_complete'),
-                expect(data).to.contain('has_active_version'),
-                expect(data).to.contain('highest_version'),
-                expect(data).to.contain('total_points'),
-                expect(data).to.contain('total_percent');
-                expect(data).to.contain('testcases');
+                const data = response.body.data;
+                const data_string = JSON.stringify(response.body.data);
+                expect(data_string).to.contain('is_queued');
+                expect(data_string).to.contain('queue_position'),
+                expect(data_string).to.contain('is_grading'),
+                expect(data_string).to.contain('has_submission'),
+                expect(data_string).to.contain('autograding_complete'),
+                expect(data_string).to.contain('has_active_version'),
+                expect(data_string).to.contain('highest_version'),
+                expect(data_string).to.contain('total_points'),
+                expect(data_string).to.contain('total_percent');
+                expect(data_string).to.contain('test_cases');
                 // CI doesn't have grades
+                // Requires VCS Subdirectory gradeable to be graded
                 if (Cypress.env('run_area') !== 'CI') {
-                    const read_me = {
-                        'name': 'Read Me',
-                        'details': '',
+                    const python_test = {
+                        'name': 'Python test',
+                        'details': 'python3 *.py',
                         'is_extra_credit': false,
-                        'points_available': 2,
-                        'points_received': 2,
-                        'testcase_message': '',
-                    };
-                    const coding_style = {
-                        'name': 'Coding Style',
-                        'details': '',
-                        'is_extra_credit': false,
-                        'points_available': 0,
-                        'points_received': 0,
-                        'testcase_message': '',
-                    };
-                    const documentation = {
-                        'name': 'Documentation',
-                        'details': '',
-                        'is_extra_credit': false,
-                        'points_available': 0,
-                        'points_received': 0,
-                        'testcase_message': '',
-                    };
-                    const extra_credit = {
-                        'name': 'Extra Credit',
-                        'details': '',
-                        'is_extra_credit': true,
                         'points_available': 5,
                         'points_received': 5,
                         'testcase_message': '',
                     };
-                    expect(data.testcases).to.contain(read_me);
-                    expect(data.testcases).to.contain(coding_style);
-                    expect(data.testcases).to.contain(documentation);
-                    expect(data.testcases).to.contain(extra_credit);
+                    const submitted_pdf = {
+                        'name': 'Submitted a .pdf file',
+                        'details': '',
+                        'is_extra_credit': false,
+                        'points_available': 1,
+                        'points_received': 1,
+                        'testcase_message': '',
+                    };
+                    const words = {
+                        'name': 'Required 500-1000 Words',
+                        'details': '',
+                        'is_extra_credit': false,
+                        'points_available': 1,
+                        'points_received': 0,
+                        'testcase_message': '',
+                    };
+                    expect(data.test_cases[0]).to.contain(python_test);
+                    expect(data.test_cases[1]).to.contain(submitted_pdf);
+                    expect(data.test_cases[2]).to.contain(words);
                 }
             });
 

--- a/site/cypress/e2e/Cypress-Feature/student_api.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/student_api.spec.js
@@ -1,5 +1,5 @@
-import {getApiKey} from '../../support/utils';
-import {getCurrentSemester} from '../../support/utils';
+import { getApiKey } from '../../support/utils';
+import { getCurrentSemester } from '../../support/utils';
 
 describe('Tests cases for the Student API', () => {
     it('Should get correct responses', () => {
@@ -62,6 +62,46 @@ describe('Tests cases for the Student API', () => {
                 expect(data).to.contain('highest_version'),
                 expect(data).to.contain('total_points'),
                 expect(data).to.contain('total_percent');
+                expect(data).to.contain('testcases');
+                // CI doesn't have grades
+                if (Cypress.env('run_area') !== 'CI') {
+                    const read_me = {
+                        'name': 'Read Me',
+                        'details': '',
+                        'is_extra_credit': false,
+                        'points_available': 2,
+                        'points_received': 2,
+                        'testcase_message': ''
+                    }
+                    const coding_style = {
+                        'name': 'Coding Style',
+                        'details': '',
+                        'is_extra_credit': false,
+                        'points_available': 0,
+                        'points_received': 0,
+                        'testcase_message': ''
+                    }
+                    const documentation = {
+                        'name': 'Documentation',
+                        'details': '',
+                        'is_extra_credit': false,
+                        'points_available': 0,
+                        'points_received': 0,
+                        'testcase_message': ''
+                    }
+                    const extra_credit = {
+                        'name': 'Extra Credit',
+                        'details': '',
+                        'is_extra_credit': true,
+                        'points_available': 5,
+                        'points_received': 5,
+                        'testcase_message': ''
+                    }
+                    expect(data.testcases).to.contain(read_me);
+                    expect(data.testcases).to.contain(coding_style);
+                    expect(data.testcases).to.contain(documentation);
+                    expect(data.testcases).to.contain(extra_credit);
+                }
             });
 
             // Success, successfully sent to be graded


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently, the student api only returns the total grade points, and doesn't include which of the tests the points came from. 

### What is the new behavior?
This adds the testcases the user can view to the return values, giving more information on what failed, and why. 
API tests will be converted to Jest in a future PR. 

