### PR TITLE
[Dependency] Pin requests version to 2.31.0

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -14,7 +14,8 @@ opencv-python-headless==4.9.0.80
 # jsonschema & jsonref & pytz & tzlocal
 pytz==2023.3.post1 # Submitty-util specific.
 
-
+# Docker gets broken with 2.32.0 current release (before a hotfix is applied)
+requests==2.31.0
 python-pam==2.0.2
 ruamel.yaml==0.18.5
 psycopg2-binary==2.9.9


### PR DESCRIPTION
### What is the current behavior?
Docker-py breaks with the current version of requests (2.32.0)

### What is the new behavior?
This PR pins requests version to 2.31.0, which will fix Docker until a hotfix is applied to docker-py. 