### PR TITLE
[Feature:Submission] View Submitted File Option

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -214,7 +214,7 @@ class SubmissionController extends AbstractController {
      * View a file submitted to a gradeable.
      */
     #[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/submitted_files/{gradeable_version}/{path}", requirements: ["gradeable_version" => "\d+", "path" => ".+"])]
-    public function viewSubmittedFile($gradeable_id, $gradeable_version, $path) {
+    public function viewSubmittedFile(string $gradeable_id, string $gradeable_version, string $path): array {
         $gradeable = $this->tryGetElectronicGradeable($gradeable_id);
         if ($gradeable === null) {
             $this->core->addErrorMessage('Could not find gradeable');
@@ -271,8 +271,6 @@ class SubmissionController extends AbstractController {
                 $contents
             );
         }
-
-        return ['error' => true, 'message' => "Something went wrong"];
     }
 
     /**

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -16,11 +16,18 @@
                         <span>
                             {{ file.relative_name }} ({{ (file.size / 1024) | number_format(2) | default(-1) }}kb)
                         </span>
-                    {# download icon if student can download files #}
-                    {% if student_download %}
-                        <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
-                            <i class="fas fa-download" title="Download the file"></i></button>
-                    {% endif %}
+                        {# view and download icons if student is permitted to access files #}
+                        <div>
+                            {% set extension = file.relative_name|split('.')|last|lower %}
+                            {% if student_download %}
+                                {% if '.' ~ extension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
+                                    <button class = 'btn btn-default key_to_click' onclick='location += "/submitted_files/{{ display_version }}/{{ file.relative_name|url_encode }}"' aria-label="View {{file.relative_name}}"> View
+                                        <i class="fas fa-window-restore" title="View the file"></i></button>
+                                {% endif %}
+                                <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
+                                    <i class="fas fa-download" title="Download the file"></i></button>
+                            {% endif %}
+                        </div>
                     </div>
                 {% endif %}
             {% endfor %}

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -21,7 +21,7 @@
                             {% set extension = file.relative_name|split('.')|last|lower %}
                             {% if student_download %}
                                 {% if '.' ~ extension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
-                                    <button class = 'btn btn-default key_to_click' onclick='location += "/submitted_files/{{ display_version }}/{{ file.relative_name|url_encode }}"' aria-label="View {{file.relative_name}}"> View
+                                    <button class = 'btn btn-default key_to_click' onclick='open("submitted_files/{{ display_version }}/{{ file.relative_name|url_encode }}", "_blank")' aria-label="View {{file.relative_name}}"> View
                                         <i class="fas fa-window-restore" title="View the file"></i></button>
                                 {% endif %}
                                 <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, students can access course materials in two ways: download or view in browser.
However, for files submitted to a gradeable, students can only download the file if they want to read it.
This can make it annoying for students trying to verify that the file they submitted is the correct one,
or verifying that their answer to a problem was correct.
Also, downloading the file across different versions clutters the user's downloads folder with multiple
different versions of the same file.

### What is the new behavior?
A "view" button has been added to the gradeable submission view, allowing students to view a submitted file in their browser, parallel to the current functionality for course materials.

![Screenshot 2024-05-25 at 11 50 03 AM](https://github.com/Submitty/Submitty/assets/89281036/6d1e61c8-750d-4853-877b-56b040fef0bb)

### Other information?
When testing this feature, please take great care to verify the security of the implementation.
We want to make sure there is no case in which a student is not permitted to access a certain file and the interface allows them to view it.
