### PR TITLE
[Feature:Submission] View submitted file button

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -74,7 +74,7 @@
                     {% set displayName = course_material.getTitle|default(name) %}
                     <i class="fas fa-file" style="vertical-align: text-bottom;"></i>
                     {% set extension = name|split('.')|last|lower %}
-                    {% if '.' ~ extension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
+                    {% if extension in ['pdf', 'jpg', 'jpeg', 'c', 'cpp', 's', 'twig', 'py', 'java', 'png', 'txt', 'h', 'html', 'php', 'js', 'sql', 'sh', 'md', 'csv', 'salsa', 'erl', 'oz', 'pl', 'hs', 'gif'] %}
                         <a class="popout-item" target="_blank" href="{{ links[course_material.getId] }}" aria-label="Pop up {{ displayName }} in a new window" tabindex="0" style="text-decoration: none;">{{ name }} <i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
                     {% else %}
                         {{ displayName }}

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -16,11 +16,18 @@
                         <span>
                             {{ file.relative_name }} ({{ (file.size / 1024) | number_format(2) | default(-1) }}kb)
                         </span>
-                    {# download icon if student can download files #}
-                    {% if student_download %}
-                        <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
-                            <i class="fas fa-download" title="Download the file"></i></button>
-                    {% endif %}
+                        {# view and download icons if student is permitted to access files #}
+                        {% if student_download %}
+                            <div>
+                                {% set extension = file.relative_name|split('.')|last|lower %}
+                                {% if '.' ~ extension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
+                                    <button class = 'btn btn-default key_to_click' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="View {{file.relative_name}}"> View
+                                        <i class="fas fa-window-restore" title="View the file"></i></button>
+                                {% endif %}
+                                <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
+                                    <i class="fas fa-download" title="Download the file"></i></button>
+                            </div>
+                        {% endif %}
                     </div>
                 {% endif %}
             {% endfor %}

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -21,8 +21,8 @@
                             <div>
                                 {% set extension = file.relative_name|split('.')|last|lower %}
                                 {% if '.' ~ extension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
-                                    <button class = 'btn btn-default key_to_click' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="View {{file.relative_name}}"> View
-                                        <i class="fas fa-window-restore" title="View the file"></i></button>
+                                    <button class = 'btn btn-default key_to_click' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window"> View
+                                        <i class="fas fa-window-restore" title="Pop up the file in a new window"></i></button>
                                 {% endif %}
                                 <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
                                     <i class="fas fa-download" title="Download the file"></i></button>

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -20,7 +20,7 @@
                         {% if student_download %}
                             <div>
                                 {% set extension = file.relative_name|split('.')|last|lower %}
-                                {% if '.' ~ extension in ['.pdf', '.jpg', '.jpeg', '.c', '.cpp', '.s', '.twig', '.py', '.java', '.png', '.txt', '.h', '.html', '.php', '.js', '.sql', '.sh', '.md', '.csv', '.salsa', '.erl', '.oz', '.pl', '.hs', '.gif'] %}
+                                {% if extension in ['pdf', 'jpg', 'jpeg', 'c', 'cpp', 's', 'twig', 'py', 'java', 'png', 'txt', 'h', 'html', 'php', 'js', 'sql', 'sh', 'md', 'csv', 'salsa', 'erl', 'oz', 'pl', 'hs', 'gif'] %}
                                     <button class = 'btn btn-default key_to_click' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window"> View
                                         <i class="fas fa-window-restore" title="Pop up the file in a new window"></i></button>
                                 {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, students can access course materials in two ways: download or view in browser.
However, for files submitted to a gradeable, students can only download the file if they want to read it.
This can make it annoying for students trying to verify that the file they submitted is the correct one,
or verifying that their answer to a problem was correct.
Also, downloading the file across different versions clutters the user's downloads folder with multiple
different versions of the same file.

### What is the new behavior?
A "view" button has been added to the gradeable submission view, allowing students to view a pop up window displaying a submitted file in their browser, parallel to the current grader view functionality.

![image](https://github.com/Submitty/Submitty/assets/89281036/7e68602b-14bb-4112-9f89-284fa5e4998a)