### PR TITLE
[Feature:System] Add vagrant provision warning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,6 +108,14 @@ Vagrant.configure(2) do |config|
     config.env.enable
   end
 
+  # Warn the user if they attempt to re-provision
+  if ARGV[0] == 'provision' and not Dir.glob(".vagrant/machines/*/*/action_provision").empty?
+    print "\e[31mWarning: Re-provisioning will destroy the existing virtual machine state.\nAre you sure you would like to proceed?\e[0m [y/N] "
+    if STDIN.gets.chomp.downcase != 'y'
+      exit
+    end
+  end
+
   if ON_CI
     config.ssh.insert_key = false
   else 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -110,7 +110,7 @@ Vagrant.configure(2) do |config|
 
   # Warn the user if they attempt to re-provision
   if ARGV[0] == 'provision' and not Dir.glob(".vagrant/machines/*/*/action_provision").empty?
-    print "\e[31mWarning: Re-provisioning will destroy the existing virtual machine state.\nAre you sure you would like to proceed?\e[0m [y/N] "
+    print "\e[31mWarning: A virtual machine has already been provisioned. Re-provisioning may destroy this existing virtual machine state.\nAre you sure you would like to proceed?\e[0m [y/N] "
     if STDIN.gets.chomp.downcase != 'y'
       exit
     end


### PR DESCRIPTION
The `vagrant provision` command will now display a warning to the user if the system has already been provisioned.
Resolves #10286 