### PR TITLE
[Bugfix:Forum] Fix AJAX call for post likes

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1298,7 +1298,7 @@ function modifyThreadList(currentThreadId, currentCategoriesId, course, loadFirs
 function toggleLike(post_id, current_user) {
 
     // eslint-disable-next-line no-undef
-    const url = buildCourseUrl(['post', 'likes']);
+    const url = buildCourseUrl(['posts', 'likes']);
     $.ajax({
         url: url,
         type: 'POST',


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Resolves #10466 
Liking a forum post fails due to incorrect AJAX call.

### What is the new behavior?
The path has been updated to reflect the change in #10373.


