### PR TITLE
[Bugfix:InstructorUI] Fix displaying title

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -43,7 +43,7 @@
     </div>
 
     <div class="option-input col-md-6">
-        <input type='text' name='title' id='g_title' class="required auto_save new-gradeable" style="overflow:hidden" placeholder="(Required)" required value="{{ action != 'new' ? gradeable.getInstructionsUrl() : '' }}" />
+        <input type='text' name='title' id='g_title' class="required auto_save new-gradeable" style="overflow:hidden" placeholder="(Required)" required value="{{ action != 'new' ? gradeable.getTitle() : '' }}" />
     </div>
 </div>
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
This issue was introduced in https://github.com/Submitty/Submitty/pull/10339, it changed the default value to the Instructions URL instead of the title.
### What is the new behavior?
The default value has been reverted back to the title. 
![image](https://github.com/Submitty/Submitty/assets/46759635/bb2303e3-498d-4365-b2cb-5e5f635415f9)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
