### PR TITLE
[Bugfix:InstructorUI] Fix bulk upload not showing options

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -96,7 +96,11 @@
 		            <input type="text" id= "user_id" value ="" placeholder="{{ user_id }}"/>
                 </div>
             </div>
-            <div class="sub hide" id="pdf-submit-button">
+            <div class="sub hide" id="pdf-submit-button"
+            {% if is_bulk_upload %}
+                style="display: revert;"
+            {% endif %}
+            >
                 <div class="sub">
 
                     <div id="toggle-qr-split">
@@ -111,7 +115,7 @@
                         {% endif %}
                     </div>
 
-                    <div id="qr-split-opts">
+                    <div id="qr-split-opts" style="display: none;">
                         <br>
 
                         <span id="prefix-prompt">QR code prefix/suffix:
@@ -127,7 +131,11 @@
                         </div>
                     </div>
 
-                    <div id="numeric-split-opts">
+                    <div id="numeric-split-opts"
+                    {% if is_bulk_upload %}
+                        style="display: revert;"
+                    {% endif %}
+                    >
                         <label id="pages-prompt" for="num_pages">Split by Page Count:</label>
                         <input type="number" id= "num_pages" placeholder="required"/>
                     </div>
@@ -306,7 +314,10 @@
 
                         //TODO: move logic for loading submission mode from session storage into module file
                         const getSubmissionType = document.querySelector('input[name="submission-type"]:checked');
-                        const selected_radio_id = getSubmissionType === null ? null : getSubmissionType.id;
+                        const selected_radio_id = getSubmissionType === null
+                            ? {% if is_bulk_upload %} 'radio-bulk' {% else %} null {% endif %}
+                            : getSubmissionType.id;
+
                         if(selected_radio_id !== null && selected_radio_id !== 'radio-normal'){
                             for(let idx = 1; idx <= window.num_submission_boxes; idx++){
                                 window.deleteFiles(idx);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10106. The bulk upload UI does not show the options "Split by QR code" and "Split by Page Count," nor the "Warning: Submitting files for bulk upload!" banner, unless the user clicks the already-selected Bulk Upload radio button.

<img width="509" alt="Screenshot 2024-01-15 at 5 20 20 PM" src="https://github.com/Submitty/Submitty/assets/5871417/dddc7483-d220-468d-8c51-854e52c5bd36">

### What is the new behavior?

Clicking the radio button is no longer necessary. This is accomplished by setting the display styling in Twig using `{% if ... %}` with the `is_bulk_upload` flag.

![image](https://github.com/Submitty/Submitty/assets/116031952/ffe479ea-bbec-49be-b8e2-0da4a910a593)

### Other information?

Tested using the sample course in the Vagrant VM, by creating a few dummy bulk upload gradeables and checking the UI. I also checked that other gradeable types were unchanged.
