### PR TITLE
[Bugfix:System] Adduser group optional

### DIFF
--- a/sbin/adduser_course.py
+++ b/sbin/adduser_course.py
@@ -31,7 +31,7 @@ def parse_args():
     parser.add_argument('course', help='title of the course')
     parser.add_argument('registration_section', nargs='?', default=None,
                         help='registration section that the user is added into')
-    parser.add_argument('user_group', default=1,
+    parser.add_argument('--user_group', default=1,
                         help='group the user belongs to 1:Instructor 2:Full Access Grader 3:Limited Access Grader 4:Student')
 
     return parser.parse_args()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
In https://github.com/Submitty/Submitty/pull/10133, a new group argument was added to the adduser script. However, it is not an optional argument since it is missing `--`. The create course script will error as is and not add the instructor to the course.

### What is the new behavior?
`--` has been added in front of the argument so this is now an optional argument. The create course script does not fail anymore.

### Other information?
Tested locally and it fixed it.
