### PR TITLE
[Bugfix:RainbowGrades] Close span tag in RainbowCustomization

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -219,7 +219,7 @@
                                                                     <br><br>
                                                                     Actual Max Score: {{ gradeable["max_score"] }}
                                                                     <br>
-                                                                    Override Max Score: <span id="override-maxscore-{{ gradeable["id"] }}"><span>
+                                                                    Override Max Score: <span id="override-maxscore-{{ gradeable["id"] }}"></span>
                                                                 </span>
                                                             </i>
                                                             <i class="fas fa-chart-line fa-gradeable-curve fa-rb" id="gradeable-curve-button-{{ gradeable['id'] }}"></i>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the new behavior?
HTML no longer has a blank span tag, which does not visibly change the site.
![image](https://github.com/Submitty/Submitty/assets/56311867/d9837330-f746-49db-8e79-11e9f2b53551)

