### PR TITLE
[Bugfix:InstructorUI] Fix HTML typo in GraderList

### DIFF
--- a/site/app/templates/admin/users/GraderList.twig
+++ b/site/app/templates/admin/users/GraderList.twig
@@ -44,7 +44,7 @@
                 <tbody id="section-{{ grading_group }}">
                     {% if graders[grading_group]|length > 0 %}
                         <tr class="info">
-                            <th class="section-break" colspan="8">{{groups[grading_group].name}}</td>
+                            <th class="section-break" colspan="8">{{groups[grading_group].name}}</th>
                         </tr>
                         {% for grader in graders[grading_group] %}
                             <tr id="user-{{ grader.getId() }}">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
There is a typo closing tag in GraderList.twig,
```html
<th class="section-break" colspan="8">{{groups[grading_group].name}}</td>
```
In view-source mode, my browser complains about it.
![image](https://github.com/Submitty/Submitty/assets/116031952/1a0f5122-0b7a-4e69-9810-644bc6088d96)


### What is the new behavior?
Changes `</td>` to `</th>`.
