### PR TITLE
[Bugfix:System] Improve libvirt support

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -118,6 +118,8 @@ if [ ${DEV_VM} == 1 ] && [ ${WORKER} == 0 ]; then
 
     sed -i -e "s/PermitRootLogin prohibit-password/PermitRootLogin yes/g" /etc/ssh/sshd_config
 
+    chmod 755 -R /usr/local/submitty/GIT_CHECKOUT
+
     # Set up some convinence stuff for the root user on ssh
 
     INSTALL_HELP=$(cat <<'EOF'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,22 +76,27 @@ base_boxes[:arm_bento]     = "bento/ubuntu-22.04-arm64"
 base_boxes[:libvirt]       = "generic/ubuntu2204"
 base_boxes[:arm_mac_qemu]  = "perk/ubuntu-2204-arm64"
 
-def mount_folders(config, mount_options)
-  # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
+
+def mount_folders_with_type(config, mount_options, type)
+ # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
   # till post-provision (and this is mounted before provisioning), we want the group to be 'vagrant'
   # which is guaranteed to exist and that during install_system.sh we add submitty_daemon/submitty_php/etc to the
   # vagrant group so that they can write to this shared folder, primarily just for the log files
   owner = 'root'
   group = 'vagrant'
-  config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT/Submitty', create: true, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp
+  config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT/Submitty', create: true, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp, type: type
 
   optional_repos = %w(AnalysisTools AnalysisToolsTS Lichen RainbowGrades Tutorial CrashCourseCPPSyntax LichenTestData)
   optional_repos.each {|repo|
     repo_path = File.expand_path("../" + repo)
     if File.directory?(repo_path)
-      config.vm.synced_folder repo_path, "/usr/local/submitty/GIT_CHECKOUT/" + repo, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp
+      config.vm.synced_folder repo_path, "/usr/local/submitty/GIT_CHECKOUT/" + repo, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp, type:type
     end
   }
+end
+
+def mount_folders(config, mount_options)
+ mount_folders_with_type(config, mount_options, nil)
 end
 
 def get_workers()

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ base_boxes[:libvirt]       = "generic/ubuntu2204"
 base_boxes[:arm_mac_qemu]  = "perk/ubuntu-2204-arm64"
 
 
-def mount_folders_with_type(config, mount_options, type)
+def mount_folders(config, mount_options, type = nil)
  # ideally we would use submitty_daemon or something as the owner/group, but since that user doesn't exist
   # till post-provision (and this is mounted before provisioning), we want the group to be 'vagrant'
   # which is guaranteed to exist and that during install_system.sh we add submitty_daemon/submitty_php/etc to the
@@ -93,10 +93,6 @@ def mount_folders_with_type(config, mount_options, type)
       config.vm.synced_folder repo_path, "/usr/local/submitty/GIT_CHECKOUT/" + repo, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp, type:type
     end
   }
-end
-
-def mount_folders(config, mount_options)
- mount_folders_with_type(config, mount_options, nil)
 end
 
 def get_workers()
@@ -242,7 +238,7 @@ Vagrant.configure(2) do |config|
 
     libvirt.forward_ssh_port = true
 
-    mount_folders_with_type(override, [], "rsync")
+    mount_folders(override, [], "rsync")
   end
 
   config.vm.provider "qemu" do |qe, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -240,7 +240,7 @@ Vagrant.configure(2) do |config|
 
     libvirt.forward_ssh_port = true
 
-    mount_folders(override, [])
+    mount_folders_with_type(override, [], "rsync")
   end
 
   config.vm.provider "qemu" do |qe, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -235,6 +235,8 @@ Vagrant.configure(2) do |config|
       override.vm.box = base_boxes[:libvirt]
     end
 
+    libvirt.qemu_use_session = true
+
     libvirt.memory = 2048
     libvirt.cpus = 2
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When using libvirt as the Vagrant backend, the GIT_CHECKOUT folder in the vm has the wrong permissions, and other small problems that prevent usage. 

### What is the new behavior? 
* Sets the permission of GIT_CHECKOUT to 0755 if the virtual machine is running in dev mode
* When running with libvirt, vagrant now uses libvirt's qemu/kvm user session instead of the system one 
* When running with libvirt, vagrant now explicitly uses rsync to keep the vm's files in sync with the host

### Other information?
* To sync files, the user must run `vagrant rsync-auto` on the host.

### Is this a breaking change?
No

### How did you test
`vagrant up --provider=libvirt`