### PR TITLE
[Bugfix:Forum] Post not displaying when exceed width

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -52,6 +52,7 @@
     margin-right: 5px;
     margin-top: 5px;
     white-space: pre-wrap;
+    overflow-x: auto;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -53,6 +53,7 @@
     margin-top: 5px;
     white-space: pre-wrap;
     overflow-x: auto;
+    padding-bottom: 1em;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */


### PR DESCRIPTION
Fix #10485
### What is the current behavior?
Thread won't be able to view when exceed the width of post box, might stop student from viewing wider code blocks.

### What is the new behavior?
Added horizontal scroll as the issue mentioned
![image](https://github.com/Submitty/Submitty/assets/122962727/91d20c62-b9ca-4438-a0c2-9812db2ee213)

