### PR TITLE
[Bugfix:TAGrading] Fixed title and Shortcut for Notebook

### DIFF
--- a/site/app/templates/grading/electronic/NotebookPanel.twig
+++ b/site/app/templates/grading/electronic/NotebookPanel.twig
@@ -4,6 +4,7 @@
 
 
 <div id="notebook-view" class="draggable rubric_panel" style="display:none">
+    <span class="grading_label"> Notebook View </span>
 	{% include 'notebook/Notebook.twig' with {
         "notebook": notebook,
         "testcase_messages" : testcase_messages,

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -1,4 +1,5 @@
 <div class="notebook" id="notebook-main-view">
+    <span class="grading_label"> Notebook View </span>
     <script>
         const USER_ID = "{{student_id}}";
     </script>

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -1,5 +1,4 @@
 <div class="notebook" id="notebook-main-view">
-    <span class="grading_label"> Notebook View </span>
     <script>
         const USER_ID = "{{student_id}}";
     </script>

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1153,7 +1153,7 @@ registerKeyHandler({ name: 'Toggle Peer Panel', code: 'KeyP' }, () => {
 });
 
 registerKeyHandler({ name: 'Toggle Notebook Panel', code: 'KeyN' }, () => {
-    $('#grading_rubric_btn button').trigger('click');
+    $('#notebook-view-btn button').trigger('click');
     updateCookies();
 });
 registerKeyHandler({ name: 'Toggle Solution/TA-Notes Panel', code: 'KeyT' }, () => {


### PR DESCRIPTION
Closes #10510

### What is the current behavior?
**No title for Notebook** 
<img width="1295" alt="Screenshot 2024-06-05 at 1 38 56 PM" src="https://github.com/Submitty/Submitty/assets/119070053/4b25b1ec-b672-4d14-8b7a-3bb34202c072">

Keyboard shortcut bug (Reflecting to same panel for both Key G and N)

https://github.com/Submitty/Submitty/assets/119070053/96419705-d32b-42bd-8caf-cfd32d165a07


### What is the new behavior?
**Fixed the Title**
<img width="1295" alt="Screenshot 2024-06-05 at 1 40 14 PM" src="https://github.com/Submitty/Submitty/assets/119070053/ab2cec78-408f-43a9-979e-ab0a65bdcfbb">

**Fixed the Bug**

https://github.com/Submitty/Submitty/assets/119070053/b973e44c-8ac7-478c-90fb-f25dd6397b82


