### PR TITLE
[Bugfix:Developer] Fix auto-tag action not running on all

### DIFF
--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -12,6 +12,13 @@ inactive_comment = "This PR has been inactive (no commits and no review comments
     " this PR will be labeled as Abandoned PR - Needs New Owner and"\
     " either another developer will finish the PR or it will be closed."
 
+today = datetime.datetime.now()
+two_weeks = timedelta(weeks=2)
+twelve_days = timedelta(days=12)
+two_days = timedelta(days=2)
+eastern = datetime.timezone(datetime.timedelta(hours=-5))
+et_today = today.astimezone(eastern)
+
 for json_data in json_output:
     already_warned = False
     string = json_data['updatedAt']
@@ -20,14 +27,8 @@ for json_data in json_output:
             already_warned = True
 
     json_time = datetime.datetime.fromisoformat(string.replace('Z', '+00:00'))
-    eastern = datetime.timezone(datetime.timedelta(hours=-5))
     et_time_update = json_time.astimezone(eastern)
 
-    today = datetime.datetime.now()
-    two_weeks = timedelta(weeks=2)
-    twelve_days = timedelta(days=12)
-    two_days = timedelta(days=2)
-    et_today = today.astimezone(eastern)
     tdiff = et_today - et_time_update
 
     num = str(json_data['number'])

--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -3,7 +3,7 @@ import subprocess
 import datetime
 from datetime import timedelta
 
-pr_json = "gh pr list --json updatedAt,labels,number,comments,reviews"
+pr_json = "gh pr list -L 1000 --json updatedAt,labels,number,comments,reviews"
 terminal_output = subprocess.check_output(pr_json, shell=True, text=True)
 json_output = json.loads(terminal_output)
 
@@ -46,5 +46,5 @@ for json_data in json_output:
         subprocess.run(['gh', 'pr', 'comment', num, '--body', inactive_comment])
     if ((tdiff > two_weeks and not already_abandoned) or (tdiff > two_days and already_warned)) and not approved:
         subprocess.run(['gh', 'pr', 'edit', num, '--add-label', 'Abandoned PR - Needs New Owner'])
-    if approved:
+    if approved and not already_abandoned:
         subprocess.run(['gh', 'pr', 'edit', num, '--remove-label', 'Abandoned PR - Needs New Owner'])

--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -36,15 +36,14 @@ for json_data in json_output:
         if labels['name'] == 'Abandoned PR - Needs New Owner':
             already_abandoned = True
 
+    approved = False
     for review in json_data['reviews']:
         if review["state"] == "APPROVED":
             approved = True
-        if review["state"] == "CHANGES_REQUESTED":
-            approved = False
 
     if tdiff > twelve_days and not already_abandoned and not already_warned and not approved:
         subprocess.run(['gh', 'pr', 'comment', num, '--body', inactive_comment])
     if ((tdiff > two_weeks and not already_abandoned) or (tdiff > two_days and already_warned)) and not approved:
         subprocess.run(['gh', 'pr', 'edit', num, '--add-label', 'Abandoned PR - Needs New Owner'])
-    if approved and not already_abandoned:
+    if approved and already_abandoned:
         subprocess.run(['gh', 'pr', 'edit', num, '--remove-label', 'Abandoned PR - Needs New Owner'])

--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -21,12 +21,12 @@ et_today = today.astimezone(eastern)
 
 for json_data in json_output:
     already_warned = False
-    string = json_data['updatedAt']
     for comment in json_data['comments']:
         if comment['body'] == inactive_comment:
             already_warned = True
 
-    json_time = datetime.datetime.fromisoformat(string.replace('Z', '+00:00'))
+    time_string = json_data['updatedAt']
+    json_time = datetime.datetime.fromisoformat(time_string.replace('Z', '+00:00'))
     et_time_update = json_time.astimezone(eastern)
 
     tdiff = et_today - et_time_update


### PR DESCRIPTION
### What is the current behavior?
Fixes #10449. The Github action that auto-tags abandoned PRs is bugged because it does not run on all PRs at once. This is because the script uses the command https://github.com/Submitty/Submitty/blob/54cc10dc7bcb385eabc95294382c65af9f9e8709/.github/bin/label_abandoned_prs.py#L6 By default, the Github CLI will return only 30 PRs (see the [documentation](https://cli.github.com/manual/gh_pr_list)), and obviously we have more than 30 open PRs. The CLI also returns the 30 *most recent* open PRs, so if a PR is old enough then it can just never get tagged, e.g. #8251.

### What is the new behavior?
The fix is to just change the limit with the `-L` flag,
https://github.com/Submitty/Submitty/blob/96a176aec2aeaa7b0dd4b5134048f76deb99218a/.github/bin/label_abandoned_prs.py#L6 which will make the script work as intended for up to 1000 open PRs. Of course it will be broken if we have more than that many, but we will probably have more important problems to deal with if Submitty ever has 1000 open PRs at the same time.

### Other information?
This PR also fixes two other issues with this script. Firstly, the script spams the Github API trying to remove the Abandoned tag from all approved PRs, even if it doesn't actually have the Abandoned tag. The solution here is just to check if it's tagged as Abandoned before attempting to remove the tag. Secondly, the script crashes if an abandoned PR has never had changes requested due to an undefined variable; this has been addressed as well.

I tested this by replacing the Github CLI calls with print statements to see what PRs were detected as abandoned, and checking that they all fit the criteria as expected.