### PR TITLE
[Testing:RainbowGrades] Rainbow customization accessibility

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -120,7 +120,7 @@
                         <span>Penalty:</span>
                         <input class="option-input" type="text" name="marks" id="marks">
                     </label>
-                    <button type="submit" class="btn btn-primary" onclick="addToTable()">
+                    <button type="submit" class="btn btn-primary" onclick="addToTable()" aria-label="submit">
                         <i class="fas fa-plus"></i>
                     </button>
                     {# This is a data table #}

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -124,27 +124,17 @@
                         <i class="fas fa-plus"></i>
                     </button>
                     {# This is a data table #}
-                    <style>
-                        #plagiarism-table th:first-child,
-                        #plagiarism-table td:first-child {
-                            text-align: left;
-                        }
-                        #plagiarism-table th:nth-child(2),
-                        #plagiarism-table td:nth-child(2) {
-                            text-align: left;
-                        }
-                    </style>
                     <table id="plagiarism-table" class="table table-striped table-bordered persist-area mobile-table">
                         <caption id="title"></caption>
                         <thead>
-                        <tr>
+                        <tr style="text-align:left">
                             <th>USER ID</th>
                             <th>Gradeable</th>
                             <th>Penalty</th>
                             <th>Delete</th>
                         </tr>
                         </thead>
-                        <tbody id="table-body">
+                        <tbody id="table-body" style="text-align:left">
                         {% for entry in plagiarism %}
                             <tr>
                                 <td>{{ entry.user }}</td>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -116,9 +116,9 @@
                             <option value="{{value['g_id']}}" >{{ value['g_title'] }}</option>
                         {% endfor %}
                     </select>
-                    <label for="penalty">
+                    <label for="marks">
                         <span>Penalty:</span>
-                        <input class="option-input" type="text" name="penalty" id="penalty">
+                        <input class="option-input" type="text" name="marks" id="marks">
                     </label>
                     <button type="submit" class="btn btn-primary" onclick="addToTable()">
                         <i class="fas fa-plus"></i>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -118,7 +118,7 @@
                     </select>
                     <label for="penalty">
                         <span>Penalty:</span>
-                        <input class="option-input" type="text" name="marks" id="marks">
+                        <input class="option-input" type="text" name="penalty" id="penalty">
                     </label>
                     <button type="submit" class="btn btn-primary" onclick="addToTable()">
                         <i class="fas fa-plus"></i>

--- a/site/cypress/e2e/Cypress-System/accessibility.spec.js
+++ b/site/cypress/e2e/Cypress-System/accessibility.spec.js
@@ -45,6 +45,7 @@ const urls = [
     '/courses/{}/{}/plagiarism',
     '/courses/{}/{}/plagiarism/configuration/new',
     '/courses/{}/{}/reports',
+    '/courses/{}/{}/reports/rainbow_grades_customization',
     '/courses/{}/{}/late_table',
     '/courses/{}/{}/grades',
     '/courses/{}/{}/polls',

--- a/site/cypress/fixtures/accessibility_baseline.json
+++ b/site/cypress/fixtures/accessibility_baseline.json
@@ -87,6 +87,9 @@
         "Attribute “name” not allowed on element “span” at this point."
     ],
     "/courses/{}/{}/reports": [],
+    "/courses/{}/{}/reports/rainbow_grades_customization": [
+        "Attribute “unselectable” not allowed on element “ul” at this point."
+    ],
     "/courses/{}/{}/late_table": [],
     "/courses/{}/{}/grades": []
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

To view changes, login to Instructor, navigate to Grade Reports > Web-Based Rainbow Grades Generation

### What is the current behavior?
Resolves #10505
HTML validator does not catch issues with Rainbow Grades Customization.
![image](https://github.com/Submitty/Submitty/assets/56311867/44d40eed-6404-4fb0-a4a5-7b247b7d2037)


### What is the new behavior?
HTML validator catches issues with Rainbow Grades Customization, with no visual UI changes (only those that affect accessibility).
![image](https://github.com/Submitty/Submitty/assets/56311867/af017918-f4eb-48b0-a310-2d13882ee565)
(the alert stems from the navigation menu, not Rainbow Customization)

### Other information?
<!-- How did you test -->
Cypress Accessibility tests pass for Rainbow Grades Customization, and the site is visually unchanged.
Site accessibility was tested with WAVE.