### PR TITLE
[Bugfix:Submission] Add git safe dir * for daemon

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -348,7 +348,8 @@ echo -e "\n# set by the .setup/install_system.sh script\numask 027" >> /home/${D
 # Add RainbowGrades repo as safe directory for GIT
 gitconfig_path="/home/${DAEMON_USER}/.gitconfig"
 gitconfig_content="[safe]
-    directory = ${RAINBOWGRADES_REPOSITORY}"
+    directory = ${RAINBOWGRADES_REPOSITORY}
+    directory = *"
 echo "$gitconfig_content" > "$gitconfig_path"
 sudo chown "${DAEMON_USER}:${DAEMON_USER}" "$gitconfig_path"
 

--- a/migration/migrator/migrations/system/20240606141301_add_git_safe_dir_daemon.py
+++ b/migration/migrator/migrations/system/20240606141301_add_git_safe_dir_daemon.py
@@ -1,0 +1,35 @@
+"""Migration for the Submitty system."""
+import os
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    DAEMON_USER = config.submitty_users['daemon_user']
+    RAINBOWGRADES_REPOSITORY = os.path.join(config.submitty['submitty_install_dir'], 'GIT_CHECKOUT','RainbowGrades')
+    gitconfig_path = f"/home/{DAEMON_USER}/.gitconfig"
+    gitconfig_content = """[safe]
+        directory = {}
+        directory = *""".format(RAINBOWGRADES_REPOSITORY)
+
+    with open(gitconfig_path, 'w') as file:
+        file.write(gitconfig_content)
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    DAEMON_USER = config.submitty_users['daemon_user']
+    RAINBOWGRADES_REPOSITORY = os.path.join(config.submitty['submitty_install_dir'], 'GIT_CHECKOUT','RainbowGrades')
+    gitconfig_path = f"/home/{DAEMON_USER}/.gitconfig"
+    gitconfig_content = """[safe]
+        directory = {}""".format(RAINBOWGRADES_REPOSITORY)
+
+    with open(gitconfig_path, 'w') as file:
+        file.write(gitconfig_content)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When submitting a vcs gradeable, submitty_daemon cannot clone the local repository due to how git handles permissions.

### What is the new behavior?
git `safe.directory = *` has been added so that submitty_daemon can clone the local repository.

### Other information?
Tested locally that it fixes the problem
