### PR TITLE
[Bugfix:Developer] Fix auto-tagger not running on all PRs

### DIFF
--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -3,7 +3,7 @@ import subprocess
 import datetime
 from datetime import timedelta
 
-pr_json = "gh pr list --json updatedAt,labels,number,comments,reviews"
+pr_json = "gh pr list -L 1000 --json updatedAt,labels,number,comments,reviews"
 terminal_output = subprocess.check_output(pr_json, shell=True, text=True)
 json_output = json.loads(terminal_output)
 


### PR DESCRIPTION
### What is the current behavior?
Fixes #10449. The Github action that auto-tags abandoned PRs is bugged because it does not run on all PRs at once. This is because the script uses the command https://github.com/Submitty/Submitty/blob/54cc10dc7bcb385eabc95294382c65af9f9e8709/.github/bin/label_abandoned_prs.py#L6 By default, the Github CLI will return only 30 PRs (see the [documentation](https://cli.github.com/manual/gh_pr_list)), and obviously we have more than 30 open PRs. The CLI also returns the 30 *most recent* open PRs, so if a PR is old enough then it can just never get tagged, e.g. #8251.

The reason why this was causing #10449 is because if there were more than 30 open PRs, and the 31st most recent PR was abandoned, the action would not "see" this PR and not tag it as such until one of the 30 most recent was merged or closed. This can sometimes take a long time, for example it took 22 days for #10350 to be tagged as abandoned, much longer than intended.

### What is the new behavior?
The fix is to just change the limit with the `-L` flag,
https://github.com/Submitty/Submitty/blob/96a176aec2aeaa7b0dd4b5134048f76deb99218a/.github/bin/label_abandoned_prs.py#L6 which will make the script work as intended for up to 1000 open PRs. Of course it will be broken if we have more than that many, but we will probably have more important problems to deal with if Submitty ever has 1000 open PRs at the same time.

### Other information?
I tested this by replacing the Github CLI calls with print statements to see what PRs were detected as abandoned, and checking that they all fit the criteria as expected.