### PR TITLE
[Bugfix:Developer] Fix auto-tagger spamming GH API

### DIFF
--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -46,5 +46,5 @@ for json_data in json_output:
         subprocess.run(['gh', 'pr', 'comment', num, '--body', inactive_comment])
     if ((tdiff > two_weeks and not already_abandoned) or (tdiff > two_days and already_warned)) and not approved:
         subprocess.run(['gh', 'pr', 'edit', num, '--add-label', 'Abandoned PR - Needs New Owner'])
-    if approved:
+    if approved and already_abandoned:
         subprocess.run(['gh', 'pr', 'edit', num, '--remove-label', 'Abandoned PR - Needs New Owner'])


### PR DESCRIPTION
### What is the current behavior?
Currently, the auto-tag action attempts to remove the abandoned tag from all approved PRs, including those that don't actually have the abandoned tag. This is undesirable. 

### What is the new behavior?
The action now only removes the abandoned tag from *abandoned* PRs that have been approved.
