### PR TITLE
[Bugfix:InstructorUI] Fix HTML typo in StudentList

### DIFF
--- a/site/app/templates/admin/users/StudentList.twig
+++ b/site/app/templates/admin/users/StudentList.twig
@@ -90,7 +90,7 @@
             {% for registration, students in sections %}
                 <tbody id="section-{{ registration }}">
                     <tr class="info">
-                        <th class="section-break" colspan="{{ count }}">Students Enrolled in Registration Section {{ registration }}</td>
+                        <th class="section-break" colspan="{{ count }}">Students Enrolled in Registration Section {{ registration }}</th>
                     </tr>
                     {% for student in students %}
                         {% set class = "" %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
There is a typo'd closing tag in StudentList.twig, https://github.com/Submitty/Submitty/blob/ce5cfa3836e1719bf502476da254234f881108b9/site/app/templates/admin/users/StudentList.twig#L93
In view-source mode, Firefox complains about it.
![image](https://github.com/Submitty/Submitty/assets/116031952/0a92b924-845b-434d-80f4-5029d98bfb5f)


### What is the new behavior?
Changes `</td>` to `</th>`.