### PR TITLE
[Refactor:System] Adding submitty_test to submitty_help

### DIFF
--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -16,7 +16,7 @@ run_php_cs() {
 }
 
 
-if [ "$1" == "help" ] || [ -z "$1" ]; then
+if [ -z "$1" ] || [ "$1" == "help" ]; then
     echo "
           phpstan : php static analysis [option: --memory-limit 4G, --generate-baseline ...]
           phpcs   : php CodeSniffer

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -5,32 +5,36 @@ pushd /usr/local/submitty/GIT_CHECKOUT/Submitty/site  > /dev/null || {
     exit 1
 }
 
-COMPOSER_ALLOW_SUPERUSER=1 composer install
-
 run_php_stan() {
+    COMPOSER_ALLOW_SUPERUSER=1 composer install
     COMPOSER_ALLOW_SUPERUSER=1 composer run-script static-analysis "${@:2}" 2>/dev/null
 }
 
 run_php_cs() {
+    COMPOSER_ALLOW_SUPERUSER=1 composer install
     COMPOSER_ALLOW_SUPERUSER=1 composer run-script lint 2>/dev/null
 }
 
 
-if [ "$1" == "phpstan" ]; then
+if [ "$1" == "help" ] || [ -z "$1" ]; then
+    echo "
+          phpstan : php static analysis [option: --memory-limit 4G, --generate-baseline ...]
+          phpcs   : php CodeSniffer
+          php-lint: phpcs & phpstan
+          "
+elif [ "$1" == "phpstan" ]; then
     run_php_stan "$@"
 elif [ "$1" == "phpcs" ]; then
     run_php_cs
 elif [ "$1" == "php-lint" ]; then
     run_php_cs
     run_php_stan "$@"
-elif [ "$1" == "help" ]; then
-    echo "phpstan: php static analysis [option: --memory-limit 4G, --generate-baseline ...]
-          phpcs  : php CodeSniffer
-          php-lint: phpcs & phpstan"
 else
-    echo "Unknown test type: $1
+    echo "
+        Unknown test type: $1
         use phpstan, phpcs, php-lint
-        or help for detail"
+        or help for detail
+        "
 fi
 
 popd > /dev/null || {

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -127,6 +127,7 @@ The vagrant box comes with some handy aliases:
     submitty_install_site        - runs .setup/INSTALL_SUBMITTY_HELPER_SITE.sh
     submitty_install_bin         - runs .setup/INSTALL_SUBMITTY_HELPER_BIN.sh
     submitty_code_watcher        - runs .setup/bin/code_watcher.py
+    submitty_test                - runs .setup/SUBMITTY_TEST.sh
     submitty_restart_autograding - restart systemctl for autograding
     submitty_restart_services    - restarts all Submitty related systemctl
     lichen_install               - runs Lichen/install_lichen.sh


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
1) The test shortcut for PHP linting, submitty_test, does not show up to submitty_help. 
2) Composer installs whenever the command is ran.

### What is the new behavior?
1) Added text to show that submitty_test exists.
2) Moved composer to only install when a PHP lint is called. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
