### PR TITLE
[Bugfix:Developer] Fix stale PR CI retagging after 2 days

### DIFF
--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -22,9 +22,8 @@ et_today = today.astimezone(eastern)
 for json_data in json_output:
     already_warned = False
     updated_at_string = json_data['updatedAt']
-    for comment in json_data['comments']:
-        if comment['body'] == inactive_comment:
-            already_warned = True
+    if json_data["comments"] and json_data["comments"][-1]["body"] == inactive_comment:
+        already_warned = True
 
     json_time = datetime.datetime.fromisoformat(updated_at_string.replace('Z', '+00:00'))
     et_time_update = json_time.astimezone(eastern)


### PR DESCRIPTION
### What is the current behavior?
If a PR is abandoned, then picked up by a new owner, and then left inactive for 2 days, then the PR is re-tagged as abandoned. This is because the warning has already been issued the first time and the script checks if it exists at all before tagging as abandoned. 

### What is the new behavior?
This PR makes the script only check the latest comment for the inactivity warning before tagging so that this doesn't happen.