### PR TITLE
[UI/UX:RainbowGrades] Remove collapsibles from web config

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -30,74 +30,64 @@
             <div id="display" class="customization_item">
                 <fieldset>
                     <legend><h2>Display</h2></legend>
-                    <div id="display_collapse" class="collapsible_area">
-                        {% set counter = 0 %}
-                        {% for display_option in display %}
-                            {% set description = display_description[counter] %}
-                            <div style="display: table;">
-                                <input type="checkbox" id="display_{{ display_option.id }}" name="display" value="{{ display_option.id }}"
-                                       {% if display_option.isUsed == true %}checked{% endif %}
-                                >
-                                <label style="display: table-cell; width: 150px;" for="display_{{ display_option.id }}">{{ display_option.id }}</label>
-                                <span style=" display: table-cell;"><em>{{ description | raw }}</em></span>
-                            </div>
-                            {% set counter = counter + 1 %}
-                        {% endfor %}
-                    </div>
+                    {% set counter = 0 %}
+                    {% for display_option in display %}
+                        {% set description = display_description[counter] %}
+                        <div style="display: table;">
+                            <input type="checkbox" id="display_{{ display_option.id }}" name="display" value="{{ display_option.id }}"
+                                   {% if display_option.isUsed == true %}checked{% endif %}
+                            >
+                            <label style="display: table-cell; width: 150px;" for="display_{{ display_option.id }}">{{ display_option.id }}</label>
+                            <span style=" display: table-cell;"><em>{{ description | raw }}</em></span>
+                        </div>
+                        {% set counter = counter + 1 %}
+                    {% endfor %}
                 </fieldset>
             </div>
             <div id="display_benchmarks" class="customization_item">
                 <fieldset>
                     <legend><h2>Display Benchmarks</h2></legend>
-                    <div id="display_benchmarks_collapse" class="collapsible_area">
-                        {% for benchmark in display_benchmarks %}
-                            <p>
-                                <input type="checkbox" id="display_benchmarks_{{ benchmark.id }}" name="display_benchmarks" value="{{ benchmark.id }}"
-                                       {% if benchmark.isUsed == true %}checked{% endif %}
-                                >
-                                <label for="display_benchmarks_{{ benchmark.id }}">{{ benchmark.id }}</label>
-                            </p>
-                        {% endfor %}
-                    </div>
+                    {% for benchmark in display_benchmarks %}
+                        <p>
+                            <input type="checkbox" id="display_benchmarks_{{ benchmark.id }}" name="display_benchmarks" value="{{ benchmark.id }}"
+                                   {% if benchmark.isUsed == true %}checked{% endif %}
+                            >
+                            <label for="display_benchmarks_{{ benchmark.id }}">{{ benchmark.id }}</label>
+                        </p>
+                    {% endfor %}
                 </fieldset>
             </div>
             <div id="benchmark_percents" class="customization_item">
                 <h2>Benchmark Percents</h2>
-                <div id="benchmark_percents_collapse" class="collapsible_area">
-                    <p class="rg_info_message">You may adjust the minimum percent required to receive certain letter grades.  Enter this percentage as a decimal number.<br />As an example 90% would be entered as .9</p>
-                    {% for benchmark in benchmarks_with_input_fields %}
-                        {% if benchmark_percents[benchmark] is defined %}
-                            {% set percent = benchmark_percents[benchmark] %}
-                        {% else %}
-                            {% set percent = '' %}
-                        {% endif %}
+                <p class="rg_info_message">You may adjust the minimum percent required to receive certain letter grades.  Enter this percentage as a decimal number.<br />As an example 90% would be entered as .9</p>
+                {% for benchmark in benchmarks_with_input_fields %}
+                    {% if benchmark_percents[benchmark] is defined %}
+                        {% set percent = benchmark_percents[benchmark] %}
+                    {% else %}
+                        {% set percent = '' %}
+                    {% endif %}
 
-                        <p>
-                            <label for="benchmark_{{ benchmark }}" class="{{ benchmark }}">{{ benchmark }}</label>
-                            <input type="text" id="benchmark_{{ benchmark }}" class="benchmark_percent_input {{ benchmark }}" data-benchmark="{{ benchmark }}" value="{{ percent }}">
-                        </p>
-                    {% endfor %}
-                </div>
+                    <p>
+                        <label for="benchmark_{{ benchmark }}" class="{{ benchmark }}">{{ benchmark }}</label>
+                        <input type="text" id="benchmark_{{ benchmark }}" class="benchmark_percent_input {{ benchmark }}" data-benchmark="{{ benchmark }}" value="{{ percent }}">
+                    </p>
+                {% endfor %}
             </div>
             <div id="cust_messages" class="customization_item">
                 <h2>Messages</h2>
-                <div id="cust_messages_collapse" class="collapsible_area">
-                    <label for="cust_messages_textarea" class="rg_info_message">You may enter a message that will appear above the student's rainbow grades.</label>
-                    <textarea id="cust_messages_textarea">{% if 0 in messages|keys %}{{ messages[0] }}{% endif %}</textarea>
-                </div>
+                <label for="cust_messages_textarea" class="rg_info_message">You may enter a message that will appear above the student's rainbow grades.</label>
+                <textarea id="cust_messages_textarea">{% if 0 in messages|keys %}{{ messages[0] }}{% endif %}</textarea>
             </div>
             <div id="section_labels" class="customization_item">
                 <h2>Section Labels</h2>
-                <div id="section_labels_collapse" class="collapsible_area">
-                    <p class="rg_info_message">You may use this area to assign a label to each section number, for example the name of the TA or TAs
-                        handling the section.  You may also leave it as the default but it may not be blank.</p>
-                    {% for section, label in sections_and_labels %}
-                        <p>
-                            <label for="section_and_labels_{{ section }}">{{ section }}</label>
-                            <input type="text" data-section="{{ section }}" class="sections_and_labels" id="section_and_labels_{{ section }}" name="section_and_labels_{{ section }}" value="{{ label }}">
-                        </p>
-                    {% endfor %}
-                </div>
+                <p class="rg_info_message">You may use this area to assign a label to each section number, for example the name of the TA or TAs
+                    handling the section.  You may also leave it as the default, but it may not be blank.</p>
+                {% for section, label in sections_and_labels %}
+                    <p>
+                        <label for="section_and_labels_{{ section }}">{{ section }}</label>
+                        <input type="text" data-section="{{ section }}" class="sections_and_labels" id="section_and_labels_{{ section }}" name="section_and_labels_{{ section }}" value="{{ label }}">
+                    </p>
+                {% endfor %}
             </div>
             <div id="plagiarism" class="customization_item">
                 <h2>Penalties for Academic Dishonesty and Plagiarism</h2>

--- a/site/public/css/rainbow-customization.css
+++ b/site/public/css/rainbow-customization.css
@@ -20,11 +20,6 @@
     font-size: 1.1em;
 }
 
-/* stylelint-disable-next-line selector-class-pattern */
-.collapsible_area {
-    margin-bottom: 10px;
-}
-
 /* stylelint-disable-next-line selector-id-pattern */
 #cust_messages_textarea {
     width: 80%;

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -552,27 +552,6 @@ function setInputsVisibility(elem) {
 
 $(document).ready(() => {
 
-    // Setup click handlers to handle collapsing and expanding each item
-    $('#display_benchmarks h2').click(() => {
-        $('#display_benchmarks_collapse').toggle();
-    });
-
-    $('#benchmark_percents h2').click(() => {
-        $('#benchmark_percents_collapse').toggle();
-    });
-
-    $('#section_labels h2').click(() => {
-        $('#section_labels_collapse').toggle();
-    });
-
-    $('#gradeables h2').click(() => {
-        $('#gradeables_collapse').toggle();
-    });
-
-    $('#cust_messages h2').click(() => {
-        $('#cust_messages_collapse').toggle();
-    });
-
     // Make the per-gradeable curve inputs toggle when the icon is clicked
     // eslint-disable-next-line no-unused-vars
     $('.fa-gradeable-curve').click(function(event) {
@@ -604,7 +583,7 @@ $(document).ready(() => {
      * Curve input boxes include the benchmark percent input boxes and also the per-gradeable curve input boxes
      * Visibility is controlled by which boxes are selected in the display benchmarks area
      */
-    $('#display_benchmarks_collapse input').each(function() {
+    $('#display_benchmarks input').each(function() {
 
         // Set the initial visibility on load
         setInputsVisibility(this);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

Login to Instructor, then navigate to Grade Reports > Web-Based Rainbow Grades Customization.

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The Rainbow Grades web customization includes collapsible_area items which are meant to reduce clutter, but they mostly get in the way. The toggle occurs when the title of each section is clicked.
![expanded](https://github.com/Submitty/Submitty/assets/56311867/82a23272-15c4-459c-a254-80372ad4f7e2)
![collapsed](https://github.com/Submitty/Submitty/assets/56311867/525fc805-2e5d-4e5e-a502-1c05642184d9)

### What is the new behavior?
Removes each collapsible_area without otherwise affecting the UI.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
