### PR TITLE
[Bugfix:Developer] Fix Package VM Zulip Message

### DIFF
--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -48,9 +48,9 @@ jobs:
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
       - name: Send zulip message on failure
         if: failure()
-        run: >-
-          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }}
-            --data-urlencode 'type=stream'
-            --data-urlencode 'to=Submitty Developer Studio'
-            --data-urlencode 'topic=Vagrant Up Failures'
+        run: |
+          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} \
+            --data-urlencode 'type=stream' \
+            --data-urlencode 'to=Submitty Developer Studio' \
+            --data-urlencode 'topic=Vagrant Up Failures' \
             --data-urlencode 'content=The Package Vagrant VM Github Action has failed, this means the VM is not saved, and requires attention. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'

--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -15,39 +15,39 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install virtualbox and vagrant
-        run: brew install virtualbox vagrant
-      - name: Get latest version
-        id: get-version
-        run: |
-          TAG=$(git describe --tags --abbrev=0)
-          if ! [[ $TAG =~ ^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}$ ]]; then
-            echo "Invalid tag name: '$TAG'"
-            exit 1
-          fi
-          echo "version=${TAG:1}" >> $GITHUB_OUTPUT
-      - name: Vagrant Up
-        run: CI=1 vagrant up
-      - name: Validate image
-        run: curl --show-error --fail --include http://localhost:1511
-      - name: Save image
-        run: vagrant package --output submitty.box
-      - name: Publish image
-        run: |
-          vagrant cloud auth login --token ${{ secrets.VAGRANT_CLOUD_TOKEN }}
-          vagrant cloud publish SubmittyBot/ubuntu22-dev ${{ steps.get-version.outputs.version }}.$(date +"%y%m%d%H%M") virtualbox submitty.box --release --force
-          vagrant cloud auth logout
-      - name: Acquire Job ID
-        if: failure()
-        id: get-job-id
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
-          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
-          echo "job_id=$job_id" >> $GITHUB_OUTPUT
+      # - name: Install virtualbox and vagrant
+      #   run: brew install virtualbox vagrant
+      # - name: Get latest version
+      #   id: get-version
+      #   run: |
+      #     TAG=$(git describe --tags --abbrev=0)
+      #     if ! [[ $TAG =~ ^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}$ ]]; then
+      #       echo "Invalid tag name: '$TAG'"
+      #       exit 1
+      #     fi
+      #     echo "version=${TAG:1}" >> $GITHUB_OUTPUT
+      # - name: Vagrant Up
+      #   run: CI=1 vagrant up
+      # - name: Validate image
+      #   run: curl --show-error --fail --include http://localhost:1511
+      # - name: Save image
+      #   run: vagrant package --output submitty.box
+      # - name: Publish image
+      #   run: |
+      #     vagrant cloud auth login --token ${{ secrets.VAGRANT_CLOUD_TOKEN }}
+      #     vagrant cloud publish SubmittyBot/ubuntu22-dev ${{ steps.get-version.outputs.version }}.$(date +"%y%m%d%H%M") virtualbox submitty.box --release --force
+      #     vagrant cloud auth logout
+      # - name: Acquire Job ID
+      #   if: failure()
+      #   id: get-job-id
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+      #     job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+      #     echo "job_id=$job_id" >> $GITHUB_OUTPUT
       - name: Send zulip message on failure
-        if: failure()
+        # if: failure()
         run: |
           curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} \
             --data-urlencode 'type=stream' \

--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -15,39 +15,39 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # - name: Install virtualbox and vagrant
-      #   run: brew install virtualbox vagrant
-      # - name: Get latest version
-      #   id: get-version
-      #   run: |
-      #     TAG=$(git describe --tags --abbrev=0)
-      #     if ! [[ $TAG =~ ^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}$ ]]; then
-      #       echo "Invalid tag name: '$TAG'"
-      #       exit 1
-      #     fi
-      #     echo "version=${TAG:1}" >> $GITHUB_OUTPUT
-      # - name: Vagrant Up
-      #   run: CI=1 vagrant up
-      # - name: Validate image
-      #   run: curl --show-error --fail --include http://localhost:1511
-      # - name: Save image
-      #   run: vagrant package --output submitty.box
-      # - name: Publish image
-      #   run: |
-      #     vagrant cloud auth login --token ${{ secrets.VAGRANT_CLOUD_TOKEN }}
-      #     vagrant cloud publish SubmittyBot/ubuntu22-dev ${{ steps.get-version.outputs.version }}.$(date +"%y%m%d%H%M") virtualbox submitty.box --release --force
-      #     vagrant cloud auth logout
-      # - name: Acquire Job ID
-      #   if: failure()
-      #   id: get-job-id
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
-      #     job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
-      #     echo "job_id=$job_id" >> $GITHUB_OUTPUT
+      - name: Install virtualbox and vagrant
+        run: brew install virtualbox vagrant
+      - name: Get latest version
+        id: get-version
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          if ! [[ $TAG =~ ^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}$ ]]; then
+            echo "Invalid tag name: '$TAG'"
+            exit 1
+          fi
+          echo "version=${TAG:1}" >> $GITHUB_OUTPUT
+      - name: Vagrant Up
+        run: CI=1 vagrant up
+      - name: Validate image
+        run: curl --show-error --fail --include http://localhost:1511
+      - name: Save image
+        run: vagrant package --output submitty.box
+      - name: Publish image
+        run: |
+          vagrant cloud auth login --token ${{ secrets.VAGRANT_CLOUD_TOKEN }}
+          vagrant cloud publish SubmittyBot/ubuntu22-dev ${{ steps.get-version.outputs.version }}.$(date +"%y%m%d%H%M") virtualbox submitty.box --release --force
+          vagrant cloud auth logout
+      - name: Acquire Job ID
+        if: failure()
+        id: get-job-id
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+          echo "job_id=$job_id" >> $GITHUB_OUTPUT
       - name: Send zulip message on failure
-        # if: failure()
+        if: failure()
         run: |
           curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} \
             --data-urlencode 'type=stream' \


### PR DESCRIPTION
### What is the current behavior?
Github's documentation showed a given way to send a single multi-line command, however it wasn't working, and the zulip message was failing to send.
### What is the new behavior?
The Zulip message for the Package Vagrant VM job now correctly sends the message
https://submitty.zulipchat.com/#narrow/stream/409362-Submitty-Developer-Studio/topic/Vagrant.20Up.20Failures/near/444330979
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
