### PR TITLE
[Bugfix:Submission] Notebook upload file fix

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -443,6 +443,9 @@
             {% if not viewing_inactive_version %}
                 initMaxNoFiles({{max_file_uploads}});
                 initializeDropZone("upload{{ index }}");
+                var part = "{{ index }}";
+                initializeDragAndDrop();
+                createArray(part);
             {% endif %}
         });
     </script>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
fixes #10543

**Screenshots**
![explorer_wo1EuxpZKj](https://github.com/Submitty/Submitty/assets/7108039/d0417eb3-84c4-4b35-b22f-8906a431b31a)

This screenshot was supplied by @KCony 

The upload feature does not work for notebook gradeable.

### What is the new behavior?

The upload feature works as expected for notebook gradeable. 
![스크린샷 2024-06-13 오후 12 30 13](https://github.com/Submitty/Submitty/assets/123261952/57a6bd50-326e-4b43-94be-2581494c866b)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->


Please test this in many methods. 
Few I can think of is creating your own notebook gradeable, and use given [config.json](https://github.com/user-attachments/files/15809028/config.json) and attempt to upload file. 

Another way is to go to sample course -> gradeable -> notebook_filesubmission
and test the upload functionality. (Please refer to my screenshot above)


The problem was addFile & fileExists function in drag-and-drop.js has array that needs to be initialized but was missing it. 
The fix is minimal.