### PR TITLE
[Bugfix:Forum] Fix toggle active on preview

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1863,6 +1863,8 @@ function previewMarkdown(mode) {
         markdown_preview.show();
         markdown_preview_load_spinner.show();
         markdown_toolbar.hide();
+        $('.markdown-write-mode').removeClass('active');
+        $('.markdown-preview-mode').addClass('active');
         $.ajax({
             url: buildUrl(['markdown']),
             type: 'POST',
@@ -1887,6 +1889,8 @@ function previewMarkdown(mode) {
         markdown_toolbar.show();
         markdown_header.attr('data-mode', 'edit');
         accessibility_message.show();
+        $('.markdown-write-mode').addClass('active');
+        $('.markdown-preview-mode').removeClass('active');
     }
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10541
Currently, the 'preview' button for a post on the discussion forum does not get marked as active (highlighted in white) when it is clicked.

This bug was caused by #10203

### What is the new behavior?
The 'preview' button activity will get toggled on click.
![preview](https://github.com/Submitty/Submitty/assets/56311867/0e85be28-8b68-4001-9d66-dc8803cadc0c)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
