### PR TITLE
[Bugfix:Autograding] Update PDF Dev Gradable

### DIFF
--- a/.setup/data/courses/development.yml
+++ b/.setup/data/courses/development.yml
@@ -528,6 +528,7 @@ gradeables:
     eg_has_due_date: true
     eg_has_release_date: true
     eg_max_random_submissions: 0
+    eg_bulk_test: true
 
   - gradeable_config: pdf_word_count
     components:


### PR DESCRIPTION
Thank you to @RitaLei123 for starting on this in a PR (#10068), this reverts some of the extra changes in that PR which fell out of scope of the issue. 

Resolves #9485 by changing the PDF Exam gradable to actually being a PDF exam (bulk upload by graders) and not student-submitted as before.

Making an issue to follow up on the problems I think Rita noticed while working on this.

Screenshot showing the change: 
![image](https://github.com/Submitty/Submitty/assets/34077605/68d9e037-b767-4177-91e2-2e4eeeca1a3d)
