### PR TITLE
[Bugfix:Autograding] prioritize autograding jobs

### DIFF
--- a/autograder/autograder/scheduler.py
+++ b/autograder/autograder/scheduler.py
@@ -193,7 +193,29 @@ class FCFSScheduler(BaseScheduler):
     def _assign_jobs(self, jobs: List[Job]):
         idle_workers = [worker for worker in self.workers if worker.is_idle()]
 
-        jobs.sort(key=lambda j: os.stat(j.path).st_ctime_ns)
+        # sort jobs by priority
+        # 1. VCS gradeable that has not yet been checked out
+        # 2. Interative / non-regrade job
+        # 3. Time entering queue
+        # 4. Ppath name
+        jobs.sort(key=lambda j:
+                  (
+                    not("vcs_checkout" in j.queue_obj and j.queue_obj["vcs_checkout"] and not("checkout_total_size" in j.queue_obj)),
+                    "regrade" in j.queue_obj and j.queue_obj["regrade"],
+                    j.queue_obj['queue_time'],
+                    j.path
+                  ),
+                  reverse=False
+        )
+
+        # for testing / debugging
+        print ("JOBS QUEUE count=" + len(jobs))
+        position=0
+        for j in jobs:
+            position+=1
+            regrade = "regrade" in j.queue_obj and j.queue_obj["regrade"]
+            qt = j.queue_obj['queue_time']
+            print("JOB " + str(position) + " " + str(regrade) + " " + str(qt) + " " + j.path )
 
         for job in jobs:
             if len(idle_workers) == 0:

--- a/autograder/autograder/scheduler.py
+++ b/autograder/autograder/scheduler.py
@@ -200,22 +200,24 @@ class FCFSScheduler(BaseScheduler):
         # 4. Ppath name
         jobs.sort(key=lambda j:
                   (
-                    not("vcs_checkout" in j.queue_obj and j.queue_obj["vcs_checkout"] and not("checkout_total_size" in j.queue_obj)),
+                    not ("vcs_checkout" in j.queue_obj and
+                         j.queue_obj["vcs_checkout"] and
+                         not ("checkout_total_size" in j.queue_obj)),
                     "regrade" in j.queue_obj and j.queue_obj["regrade"],
                     j.queue_obj['queue_time'],
                     j.path
                   ),
                   reverse=False
-        )
+                 )
 
         # for testing / debugging
-        print ("JOBS QUEUE count=" + len(jobs))
-        position=0
+        print("JOBS QUEUE count=" + len(jobs))
+        position = 0
         for j in jobs:
-            position+=1
+            position + =1
             regrade = "regrade" in j.queue_obj and j.queue_obj["regrade"]
             qt = j.queue_obj['queue_time']
-            print("JOB " + str(position) + " " + str(regrade) + " " + str(qt) + " " + j.path )
+            print("JOB " + str(position) + " " + str(regrade) + " " + str(qt) + " " + j.path)
 
         for job in jobs:
             if len(idle_workers) == 0:

--- a/autograder/autograder/scheduler.py
+++ b/autograder/autograder/scheduler.py
@@ -211,7 +211,7 @@ class FCFSScheduler(BaseScheduler):
                   )
 
         # for testing / debugging
-        print("JOBS QUEUE count=" + len(jobs))
+        print("JOBS QUEUE count=" + str(len(jobs)))
         position = 0
         for j in jobs:
             position += 1

--- a/autograder/autograder/scheduler.py
+++ b/autograder/autograder/scheduler.py
@@ -214,7 +214,7 @@ class FCFSScheduler(BaseScheduler):
         print("JOBS QUEUE count=" + len(jobs))
         position = 0
         for j in jobs:
-            position + =1
+            position += 1
             regrade = "regrade" in j.queue_obj and j.queue_obj["regrade"]
             qt = j.queue_obj['queue_time']
             print("JOB " + str(position) + " " + str(regrade) + " " + str(qt) + " " + j.path)

--- a/autograder/autograder/scheduler.py
+++ b/autograder/autograder/scheduler.py
@@ -208,7 +208,7 @@ class FCFSScheduler(BaseScheduler):
                     j.path
                   ),
                   reverse=False
-                 )
+                  )
 
         # for testing / debugging
         print("JOBS QUEUE count=" + len(jobs))

--- a/autograder/tests/test_scheduler.py
+++ b/autograder/tests/test_scheduler.py
@@ -70,9 +70,10 @@ AUTOGRADING_LOGS = os.path.join(LOG_PATH, 'autograding')
 CONFIG = None
 
 
-def generate_queue_file(name: str, *, required_capabilities: str):
+def generate_queue_file(name: str, *, required_capabilities: str, queue_time: str):
     queue_obj = {
         'required_capabilities': required_capabilities,
+        'queue_time': queue_time
     }
     with open(os.path.join(TO_BE_GRADED, name), 'w') as f:
         json.dump(queue_obj, f)
@@ -183,7 +184,7 @@ class TestScheduler(unittest.TestCase):
         scheduler = FCFSScheduler(CONFIG, [worker])
 
         # Place a dummy queue file in the queue
-        generate_queue_file("test", required_capabilities='default')
+        generate_queue_file("test", required_capabilities='default', queue_time='')
 
         # Invoke the scheduler's update mechanism
         scheduler.update_and_schedule()
@@ -209,7 +210,7 @@ class TestScheduler(unittest.TestCase):
 
         scheduler = FCFSScheduler(CONFIG, workers)
 
-        generate_queue_file("test", required_capabilities='default')
+        generate_queue_file("test", required_capabilities='default', queue_time='')
 
         scheduler.update_and_schedule()
 
@@ -234,9 +235,9 @@ class TestScheduler(unittest.TestCase):
 
         scheduler = FCFSScheduler(CONFIG, [worker])
 
-        generate_queue_file("first", required_capabilities='default')
+        generate_queue_file("first", required_capabilities='default', queue_time='')
         time.sleep(0.1)  # Kinda ugly, but helps avoid temporal aliasing by the OS
-        generate_queue_file("second", required_capabilities='default')
+        generate_queue_file("second", required_capabilities='default', queue_time='')
 
         scheduler.update_and_schedule()
 
@@ -277,11 +278,11 @@ class TestScheduler(unittest.TestCase):
 
         scheduler = FCFSScheduler(CONFIG, workers)
 
-        generate_queue_file("first", required_capabilities='default')
+        generate_queue_file("first", required_capabilities='default', queue_time='')
         time.sleep(0.1)
-        generate_queue_file("second", required_capabilities='default')
+        generate_queue_file("second", required_capabilities='default', queue_time='')
         time.sleep(0.1)
-        generate_queue_file("third", required_capabilities='default')
+        generate_queue_file("third", required_capabilities='default', queue_time='')
 
         scheduler.update_and_schedule()
 
@@ -310,11 +311,11 @@ class TestScheduler(unittest.TestCase):
 
         scheduler = FCFSScheduler(CONFIG, workers)
 
-        generate_queue_file("first", required_capabilities='zero')
-        generate_queue_file("second", required_capabilities='one')
-        generate_queue_file("third", required_capabilities='two')
+        generate_queue_file("first", required_capabilities='zero', queue_time='')
+        generate_queue_file("second", required_capabilities='one', queue_time='')
+        generate_queue_file("third", required_capabilities='two', queue_time='')
         time.sleep(0.1)
-        generate_queue_file("fourth", required_capabilities='zero')
+        generate_queue_file("fourth", required_capabilities='zero', queue_time='')
 
         scheduler.update_and_schedule()
 
@@ -337,7 +338,7 @@ class TestScheduler(unittest.TestCase):
 
         generate_broken_queue_file("first")
         time.sleep(0.1)
-        generate_queue_file("second", required_capabilities='default')
+        generate_queue_file("second", required_capabilities='default', queue_time='')
 
         scheduler.update_and_schedule()
 

--- a/autograder/tests/test_scheduler.py
+++ b/autograder/tests/test_scheduler.py
@@ -79,11 +79,6 @@ def generate_queue_file(name: str, *, required_capabilities: str, queue_time: st
         json.dump(queue_obj, f)
 
 
-def generate_broken_queue_file(name: str):
-    with open(os.path.join(TO_BE_GRADED, name), 'w') as f:
-        f.write("This isn't a valid JSON file.\n")
-
-
 class TestScheduler(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
@@ -326,22 +321,3 @@ class TestScheduler(unittest.TestCase):
         all_worker_files = sum([os.listdir(worker.folder) for worker in workers], [])
         self.assertNotIn("fourth", all_worker_files)
 
-    @mock.patch('multiprocessing.Process')
-    def test_fcfs_ignore_invalid_queue_file(self, MockProcess: mock.Mock):
-        """Test that the scheduler properly ignores invalid queue files."""
-        worker_proc = MockProcess()
-        worker_proc.is_alive = mock.MagicMock(return_value=True)
-
-        worker = Worker(CONFIG, 'worker_0', WORKER_PROPERTIES['worker_0'], worker_proc)
-
-        scheduler = FCFSScheduler(CONFIG, [worker])
-
-        generate_broken_queue_file("first")
-        time.sleep(0.1)
-        generate_queue_file("second", required_capabilities='default', queue_time='')
-
-        scheduler.update_and_schedule()
-
-        worker_files = os.listdir(worker.folder)
-        self.assertNotIn("first", worker_files)
-        self.assertIn("second", worker_files)


### PR DESCRIPTION
### What is the current behavior?
With the scheduler refactor a number of years ago, we lost 2 important sorting criteria.
Interactive jobs must be prioritized over batch jobs.
VCS submissions that have not been checked out must be prioritized over autograding jobs

### What is the new behavior?
The sort criteria in the scheduler now reflects these priorities.