### PR TITLE
[UI/UX:RainbowGrades] Expand Customization dropdowns

### DIFF
--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -608,6 +608,7 @@ function setCustomizationItemVisibility(elem) {
     const checkbox_to_cust_item = new Map([
         ['final_grade', '#final_grade_cutoffs'],
         ['messages', '#cust_messages'],
+        ['section', '#section_labels'],
     ]);
     const checkbox_name = elem.value;
     const cust_item_id = checkbox_to_cust_item.get(checkbox_name);
@@ -669,9 +670,10 @@ $(document).ready(() => {
      * Configure visibility handler for all customization items other than benchmark percents
      * Visibility is controlled by whether the corresponding boxes are selected in the display area
      */
+    const dropdown_checkboxes = ['final_grade', 'messages', 'section'];
     $('#display input').each(function() {
 
-        if (this.value === 'final_grade' || this.value === 'messages') {
+        if (dropdown_checkboxes.includes(this.value)) {
             // Set the initial visibility on load
             setCustomizationItemVisibility(this);
 

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -605,13 +605,13 @@ function setInputsVisibility(elem) {
  * */
 function setCustomizationItemVisibility(elem) {
     //maps a checkbox name to the corresponding customization item id
-    const checkbox_to_cust_item = new Map([
-        ['final_grade', '#final_grade_cutoffs'],
-        ['messages', '#cust_messages'],
-        ['section', '#section_labels'],
-    ]);
+    const checkbox_to_cust_item = {
+        'final_grade': '#final_grade_cutoffs',
+        'messages': '#cust_messages',
+        'section': '#section_labels',
+    };
     const checkbox_name = elem.value;
-    const cust_item_id = checkbox_to_cust_item.get(checkbox_name);
+    const cust_item_id = checkbox_to_cust_item[checkbox_name];
     const is_checked = elem.checked;
 
     if (is_checked) {

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -600,16 +600,24 @@ function setInputsVisibility(elem) {
 }
 
 /**
- * Sets the visibility for 'final grade cutoffs' input boxes
- * based on the 'final_grade' boxes in 'display' being selected / un-selected
+ * Sets the visibility for input boxes other than benchmark percents
+ * based on the corresponding boxes in 'display' being selected / un-selected
  * */
-function setFinalGradeCutoffsVisibility() {
-    // Sets visibility of 'final grade cutoffs' based on 'display_final_grade'
-    if ($("input[value='final_grade']:checked").val()) {
-        $('#final_grade_cutoffs').show();
+function setCustomizationItemVisibility(elem) {
+    //maps a checkbox name to the corresponding customization item id
+    const checkbox_to_cust_item = new Map([
+        ['final_grade', '#final_grade_cutoffs'],
+        ['messages', '#cust_messages'],
+    ]);
+    const checkbox_name = elem.value;
+    const cust_item_id = checkbox_to_cust_item.get(checkbox_name);
+    const is_checked = elem.checked;
+
+    if (is_checked) {
+        $(cust_item_id).show();
     }
     else {
-        $('#final_grade_cutoffs').hide();
+        $(cust_item_id).hide();
     }
 }
 
@@ -658,18 +666,18 @@ $(document).ready(() => {
     });
 
     /**
-     * Configure visibility handler for final grade cutoff boxes
-     * Visibility is controlled by whether the final_grade box is selected in the display area
+     * Configure visibility handler for all customization items other than benchmark percents
+     * Visibility is controlled by whether the corresponding boxes are selected in the display area
      */
     $('#display input').each(function() {
 
-        if (this.value === 'final_grade') {
+        if (this.value === 'final_grade' || this.value === 'messages') {
             // Set the initial visibility on load
-            setFinalGradeCutoffsVisibility();
+            setCustomizationItemVisibility(this);
 
             // Register a click handler to adjust visibility when boxes are selected / un-selected
-            $(this).change(() => {
-                setFinalGradeCutoffsVisibility();
+            $(this).change(function() {
+                setCustomizationItemVisibility(this);
             });
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

To test functionality, login as Instructor, then navigate to Grade Reports -> Web-Based Rainbow Grades Generation.
Currently, 'section',  'messages, and 'final_grade' should have a corresponding dropdown item.

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The Web-Based Rainbow Grades Generation page is cluttered, and will become more so if new items are added to it in the future.

### What is the new behavior?
Simplifies the process of adding customization items as show/hide options via checkbox dropdowns. It also incorporates existing customization items into dropdowns.

https://github.com/Submitty/Submitty/assets/56311867/417766d1-61f5-4fae-91ee-d161d5a15e1e

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
