### PR TITLE
[UI/UX:RainbowGrades] Align customization fields

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -76,7 +76,7 @@
             <div id="final_grade_cutoffs" class="customization_item">
                 <h2>Final Grade Cutoffs</h2>
                 <p class="rg_info_message">You may adjust the minimum percent required to receive certain final letter grades.  Enter this percentage as a decimal number out of 100.<br />As an example 90% would be entered as 90.0</p>
-                <div class="input-percents">
+                <div class="input-boxes">
                     {% for cutoff_input in final_cutoff_input_fields %}
                         {% if final_cutoff[cutoff_input] is defined %}
                             {% set percent = final_cutoff[cutoff_input] %}
@@ -84,7 +84,7 @@
                             {% set percent = '' %}
                         {% endif %}
 
-                        <label for="cutoff_{{ cutoff_input }}" class="{{ cutoff_input }} cutoff-label">{{ cutoff_input }}</label>
+                        <label for="cutoff_{{ cutoff_input }}" class="{{ cutoff_input }} input-label">{{ cutoff_input }}</label>
                         <input type="text" id="cutoff_{{ cutoff_input }}" class="final_cutoff_input {{ cutoff_input }}" name="final_grade_cutoffs" data-benchmark="{{ cutoff_input }}" value="{{ percent }}">
                     {% endfor %}
                 </div>
@@ -98,9 +98,9 @@
                 <h2>Section Labels</h2>
                 <p class="rg_info_message">You may use this area to assign a label to each section number, for example the name of the TA or TAs
                     handling the section.  You may also leave it as the default, but it may not be blank.</p>
-                <div class="input-percents">
+                <div class="input-boxes">
                     {% for section, label in sections_and_labels %}
-                        <label for="section_and_labels_{{ section }}" class="cutoff-label">{{ section }}</label>
+                        <label for="section_and_labels_{{ section }}" class="input-label">{{ section }}</label>
                         <input type="text" data-section="{{ section }}" class="sections_and_labels" id="section_and_labels_{{ section }}" name="section_and_labels_{{ section }}" value="{{ label }}">
                     {% endfor %}
                 </div>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -60,18 +60,18 @@
             <div id="benchmark_percents" class="customization_item">
                 <h2>Benchmark Percents</h2>
                 <p class="rg_info_message">You may adjust the minimum percent required to receive certain letter grades.  Enter this percentage as a decimal number.<br />As an example 90% would be entered as .9</p>
-                {% for benchmark in benchmarks_with_input_fields %}
-                    {% if benchmark_percents[benchmark] is defined %}
-                        {% set percent = benchmark_percents[benchmark] %}
-                    {% else %}
-                        {% set percent = '' %}
-                    {% endif %}
+                <div class="input-boxes">
+                    {% for benchmark in benchmarks_with_input_fields %}
+                        {% if benchmark_percents[benchmark] is defined %}
+                            {% set percent = benchmark_percents[benchmark] %}
+                        {% else %}
+                            {% set percent = '' %}
+                        {% endif %}
 
-                    <p>
-                        <label for="benchmark_{{ benchmark }}" class="{{ benchmark }}">{{ benchmark }}</label>
+                        <label for="benchmark_{{ benchmark }}" class="{{ benchmark }} input-label">{{ benchmark }}</label>
                         <input type="text" id="benchmark_{{ benchmark }}" class="benchmark_percent_input {{ benchmark }}" data-benchmark="{{ benchmark }}" value="{{ percent }}">
-                    </p>
-                {% endfor %}
+                    {% endfor %}
+                </div>
             </div>
             <div id="final_grade_cutoffs" class="customization_item">
                 <h2>Final Grade Cutoffs</h2>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -98,12 +98,12 @@
                 <h2>Section Labels</h2>
                 <p class="rg_info_message">You may use this area to assign a label to each section number, for example the name of the TA or TAs
                     handling the section.  You may also leave it as the default, but it may not be blank.</p>
-                {% for section, label in sections_and_labels %}
-                    <p>
-                        <label for="section_and_labels_{{ section }}">{{ section }}</label>
+                <div class="input-percents">
+                    {% for section, label in sections_and_labels %}
+                        <label for="section_and_labels_{{ section }}" class="cutoff-label">{{ section }}</label>
                         <input type="text" data-section="{{ section }}" class="sections_and_labels" id="section_and_labels_{{ section }}" name="section_and_labels_{{ section }}" value="{{ label }}">
-                    </p>
-                {% endfor %}
+                    {% endfor %}
+                </div>
             </div>
             <div id="plagiarism" class="customization_item">
                 <h2>Penalties for Academic Dishonesty and Plagiarism</h2>

--- a/site/public/css/rainbow-customization.css
+++ b/site/public/css/rainbow-customization.css
@@ -213,13 +213,13 @@ hr {
     align-items: center;
 }
 
-.input-percents {
+.input-boxes {
     display: inline-grid;
     grid-template-columns: auto auto; /* two columns */
     grid-gap: 0 0.2em;
 }
 
-.cutoff-label {
+.input-label {
     padding: 4px 6px;
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

To test functionality, login as Instructor, then navigate to Grade Reports -> Web-Based Rainbow Grades Generation.

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Several input fields on the Web-Based Rainbow Grades Generation page are unaligned.
![image](https://github.com/Submitty/Submitty/assets/56311867/ebbc727b-3834-403b-950c-440f77400606)
![image](https://github.com/Submitty/Submitty/assets/56311867/757c1819-3652-4e3f-9cf7-728cdfd0e4aa)

### What is the new behavior?
Consistently aligns input fields.
![image](https://github.com/Submitty/Submitty/assets/56311867/d4044a9f-6e61-4ba4-98ce-e359d271a23d)
![image](https://github.com/Submitty/Submitty/assets/56311867/025a5b0b-4908-40b3-b61d-3c9a8e0d9c81)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
