### PR TITLE
[UI/UX:TAGrading] Disable notebook fields when grading

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -77,7 +77,7 @@
                     data-recent_submission="{{ cell.recent_submission }}"
                     data-version_submission="{{ cell.version_submission }}"
                     onkeyup="handle_input_keypress();"
-                    {% if viewing_inactive_version %}
+                    {% if viewing_inactive_version or is_grader_view %}
                         style="pointer-events:none;"
                     {% endif %}
                 >
@@ -126,7 +126,7 @@
                         document.getElementById("codebox_{{ num_codeboxes }}_recent_button").style.visibility = 'hidden';
                     {% else %}
                         setCodeBox("codebox_{{ num_codeboxes }}", "recent");
-                        document.getElementById("codebox_{{ num_codeboxes }}_clear_button").disabled = {{ viewing_inactive_version ? 'true' : 'false'}}
+                        document.getElementById("codebox_{{ num_codeboxes }}_clear_button").disabled = {{ viewing_inactive_version or is_grader_view ? 'true' : 'false'}}
                         document.getElementById("codebox_{{ num_codeboxes }}_recent_button").disabled = true;
                     {% endif %}
                 </script>
@@ -163,8 +163,8 @@
                                        name="multiple_choice_{{ num_multiple_choice }}"
                                        id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                        value="{{ cell.choices[idx].value }}"
-                                       onclick="handle_input_keypress({{ viewing_inactive_version }});"
-                                       {% if viewing_inactive_version %}
+                                       onclick="handle_input_keypress({{ viewing_inactive_version or is_grader_view }});"
+                                       {% if viewing_inactive_version or is_grader_view %}
                                            disabled = "disabled"
                                        {% endif %}
                                 />
@@ -190,7 +190,7 @@
                                        name="multiple_choice_{{ num_multiple_choice }}"
                                        id="multiple_choice_{{ num_multiple_choice }}_{{ loop.index0 }}"
                                        value="{{ cell.choices[idx].value }}"
-                                       onclick="handle_input_keypress({{ viewing_inactive_version }});"
+                                       onclick="handle_input_keypress({{ viewing_inactive_version or is_grader_view }});"
                                 />
                                 {% include "misc/Markdown.twig" with {
                                     "content" : cell.choices[idx].description
@@ -207,7 +207,7 @@
                     $("multiple_choice_{{ num_multiple_choice }}_1").attr("disabled", true);
                     {# Populate checkboxes initially #}
                     {% if cell.recent_submission is defined %}
-                        setMultipleChoices("mc_field_{{ num_multiple_choice }}", {{ viewing_inactive_version }});
+                        setMultipleChoices("mc_field_{{ num_multiple_choice }}", {{ viewing_inactive_version or is_grader_view }});
                     {% endif %}
 
                     {# Configure initial state for the button #}


### PR DESCRIPTION
### What is the current behavior?
The answer fields in the notebook panel of the TA grading interface are only disabled for submissions other than the active submission.  These fields should always be disabled in the TA grading interface.

### What is the new behavior?
All notebook fields are disabled in the TA grading interface.  In

### Other information?
In the future, it would be good to put together a set of comprehensive tests for the notebook panel of the TA grading interface.