### PR TITLE
[Documentation:Developer] Fix formatting of first message reply

### DIFF
--- a/.github/FIRST_ISSUE_REPLY.md
+++ b/.github/FIRST_ISSUE_REPLY.md
@@ -1,18 +1,7 @@
 Thank you for your interest in the Submitty open source project!
 
-We encourage you to join our
-[Zulip](https://submitty.org/index/contact) server
-to discuss new features requests, bug reports, and technical implementation questions.
+We encourage you to join our [Zulip](https://submitty.org/index/contact) server to discuss new features requests, bug reports, and technical implementation questions.
 
-We welcome contributions from new developers!
-Please read our documentation on
-[how to get started with Submitty](https://submitty.org/developer/getting_started/index),
-specifically our pages on
-[setting up your development environment](https://submitty.org/developer/getting_started/vm_install_using_vagrant)
-and
-[making a pull request](https://submitty.org/developer/getting_started/make_a_pull_request).
+We welcome contributions from new developers!  Please read our documentation on [how to get started with Submitty](https://submitty.org/developer/getting_started/index), specifically our pages on [setting up your development environment](https://submitty.org/developer/getting_started/vm_install_using_vagrant) and [making a pull request](https://submitty.org/developer/getting_started/make_a_pull_request).
 
-NOTE: We do not use the Github issue 'assign' feature for first time
-prospective contributors.  You do not need to be assigned to an issue
-to create a pull request that will be reviewed by our team and then
-merged if it appropriately resolves the issue.
+NOTE: We do not use the Github issue 'assign' feature for first time prospective contributors.  You do not need to be assigned to an issue to create a pull request that will be reviewed by our team and then merged if it appropriately resolves the issue.


### PR DESCRIPTION
### What is the current behavior?
The messages we post in response to comments from new contributors are currently ill-formatted, with excess newlines.  For example:

![image](https://github.com/Submitty/Submitty/assets/16820599/acfc10da-2689-479f-8d4e-2c9115d6c27c)


### What is the new behavior?
This PR removes the newlines to fix the formatting:
![image](https://github.com/Submitty/Submitty/assets/16820599/a83d7b9f-7c99-4a76-a21c-4d0c8a8632c7)

