### PR TITLE
[Bugfix:InstructorUI] Fix New/Edit Gradeable Header

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -124,7 +124,7 @@
     function onTitleChange() {
         let title = $('#g_title').val();
         let my_id = $('#g_id').val();
-        if (title !== '') {
+        if (title !== '' || my_id !== '') {
             title = ': [' + my_id + '] ' + title;
         }
         $('#modal_label_title').text(title);

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -127,7 +127,7 @@
         if (title !== '') {
             title = ': [' + my_id + '] ' + title;
         }
-        $('#modal_label_title').html(title);
+        $('#modal_label_title').text(title);
     }
 
     $(document).ready(function() {

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -13,6 +13,7 @@
         <div class="modal-header" style="overflow: auto;">
             <div>
                 <h1 id="myModalLabel">{{ action == 'edit' ? 'Edit Gradeable' : 'New Gradeable' }}
+                    <span id="modal_label_title"></span>
                     {% if action == 'new' %}
                     <button class="btn btn-primary" type="button" data-testid="upload-gradeable-btn" id="upload-gradeable-btn" style="float:right;" onclick="javascript:newGradeableJsonForm()" >Upload Gradeable JSON</button>
                     {% elseif action == 'edit' %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Part of the header for the New/Edit Gradeable page, which displayed the title and ID of the gradeable, was accidentally removed in PR #10100 (Ability to Upload JSON to make gradeable) by the commit titled 'better code, catch parse errors, change button location'.

### What is the new behavior?
The deleted element was reintroduced and the Javascript was improved slightly.
![image](https://github.com/Submitty/Submitty/assets/56311867/ad753905-77db-4829-81e0-15fb4ee8896c)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
