### PR TITLE
[Feature:Developer] Add FROM_SCRATCH and PREBUILT_VERSION

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -130,9 +130,9 @@ Vagrant.configure(2) do |config|
   arch = `uname -m`.chomp
   arm = arch == 'arm64' || arch == 'aarch64'
   apple_silicon = Vagrant::Util::Platform.darwin? && (arm || (`sysctl -n machdep.cpu.brand_string`.chomp.start_with? 'Apple M'))
-  
+  use_prebuilt_version = !ENV.fetch('PREBUILT_VERSION', '').empty?
   custom_box = ENV.has_key?('VAGRANT_BOX') 
-  base_box = ENV.has_key?('BASE_BOX') || apple_silicon || arm
+  base_box = ENV.has_key?('BASE_BOX') || ENV.has_key?('FROM_SCRATCH') || apple_silicon || arm
   # The time in seconds that Vagrant will wait for the machine to boot and be accessible.
   config.vm.boot_timeout = 600
 
@@ -165,6 +165,9 @@ Vagrant.configure(2) do |config|
         override.vm.box = base_boxes[:base]
       else
         config.ssh.username = 'root'
+        if use_prebuilt_version
+          override.vm.box_version = ENV.fetch('PREBUILT_VERSION')
+        end
       end
     end
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
If you want to do a full vagrant up without using the prebuilt vagrant box, you use `BASE_BOX=1 vagrant up`

Also, there is no way to specify the version of the prebuilt box without editing the vagrant file. 
### What is the new behavior?
`BASE_BOX=1` variable name is somewhat confusing, so `FROM_SCRATCH=1` is the new method, and `BASE_BOX=1` will be deprecated, and removed sometime in the future. 

`PREBUILT_VERSION={version}` has been added as a supported ENV variable.
 **NOTE** 
Use JUST the numbers and the decimals, NOT the leading V. 
An example :
 `PREBUILT_VERSION=24.04.01.2405050238 vagrant up` for mac and linux or 
`SET PREBUILT_VERSION=24.04.01.2405050238`
`vagrant up` for windows
