### PR TITLE
[Bugfix:TAGrading] unable to view earlier pdf submission

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -65,7 +65,7 @@ class MiscController extends AbstractController {
         elseif (strpos($file_path, 'checkout') !== false) {
             $directory = 'checkout';
         }
-        $check_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $directory, $gradeable_id, $id, $active_version);
+        $check_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $directory, $gradeable_id, $id);
 
         if ($gradeable->isGradeByRegistration()) {
             $section = $submitter->getRegistrationSection();


### PR DESCRIPTION
Fix #9984

### What is the current behavior?
Instructor is unable to view previous pdf submission.
Viewing earlier pdf submission will result in error caused by the line below in function `encodePDF`
`$check_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $directory, $gradeable_id, $id, $active_version);`

### What is the new behavior?

https://github.com/Submitty/Submitty/assets/122962727/9c1ff290-b0f2-4a03-b2fb-292f4120cec2


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
