### PR TITLE
[Feature:RainbowGrades] Remove benchmark_percent from display

### DIFF
--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -33,13 +33,12 @@ class RainbowCustomizationJSON extends AbstractModel {
     private array $plagiarism = [];
 
     // The order of allowed_display and allowed_display_description has to match
-    const allowed_display = ['grade_summary', 'grade_details', 'benchmark_percent',
-        'exam_seating', 'section', 'messages', 'warning', 'final_grade', 'manual_grade', 'final_cutoff', 'instructor_notes'];
+    const allowed_display = ['grade_summary', 'grade_details', 'exam_seating', 'section',
+        'messages', 'warning', 'final_grade', 'manual_grade', 'final_cutoff', 'instructor_notes'];
 
     const allowed_display_description = [
         "Display a column(row) for each gradeable bucket on the syllabus.", //grade_summary
         "Display a column(row) for each gradeable within each gradeable bucket on the syllabus.", //grade_details
-        "not used", //benchmark_percent
         "Used for assigned seating for exams, see also:  <a href='https://submitty.org/instructor/course_settings/rainbow_grades/exam_seating'>Exam Seating</a> ", //exam_seating
         "Display the students registration section.", //section
         "Display the optional text message at the top of the page.", //messages


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Login to Instructor, then navigate to Grade Reports > Web-Based Rainbow Grades Customization.

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is an unused checkbox for benchmark_percent under Display. Benchmark percents are toggled using Display Benchmarks.

### What is the new behavior?
Removed benchmark_percent checkbox.

### Additional Information
Merge https://github.com/Submitty/RainbowGrades/pull/76 simultaneously so that behavior of Submitty and RainbowGrades repositories match.
