### PR TITLE
[Feature:Submission] Hide Accessibility Text for Disabled

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -111,12 +111,13 @@
                     {% endif %}
 
                     if ({{ cell.rows }} > 0) {
-                        var editor_{{ num_codeboxes }} = getLargeCodeMirror(document.getElementById("codebox_{{ num_codeboxes }}"), config_{{ num_codeboxes }});
+                        var show_accessbility_message = {{ is_grader_view ? "false" : "true" }}
+                        var editor_{{ num_codeboxes }} = getLargeCodeMirror(document.getElementById("codebox_{{ num_codeboxes }}"), config_{{ num_codeboxes }}, show_accessbility_message);
                         editor_{{ num_codeboxes }}.setSize(null, rowsToPixels({{ cell.rows }}));
                         $('#codebox_{{ num_codeboxes }}').addClass("large-mirror");
                     }
                     else {
-                        var editor_{{ num_codeboxes }} = getSmallCodeMirror(document.getElementById("codebox_{{ num_codeboxes }}"), config_{{ num_codeboxes }});
+                        var editor_{{ num_codeboxes }} = getSmallCodeMirror(document.getElementById("codebox_{{ num_codeboxes }}"), config_{{ num_codeboxes }}, show_accessbility_message);
                         $('#codebox_{{ num_codeboxes }}').addClass("small-mirror");
                     }
 

--- a/site/public/js/code-mirror-utils.js
+++ b/site/public/js/code-mirror-utils.js
@@ -12,7 +12,7 @@
  * @returns {CodeMirror}
  */
 function getLargeCodeMirror(attachment_elem, codemirror_config, show_accessibility_msg = true) {
-    if(show_accessibility_msg){
+    if (show_accessibility_msg) {
         const accessibility_msg = document.createElement('i');
         accessibility_msg.innerText = 'Press TAB to indent. Press ESC to advance from answer area.';
         accessibility_msg.style.fontSize = '75%';

--- a/site/public/js/code-mirror-utils.js
+++ b/site/public/js/code-mirror-utils.js
@@ -8,14 +8,16 @@
  * @param {HTMLElement} attachment_elem The instructional message and codemirror will be appended to this element.
  * @param {Object} codemirror_config A javascript object which defines the configuration the codemirror should be
  *                                   instantiated with.
+ * @param {boolean} show_accessibility_msg Indicates whether to display an accessibility message above the codemirror.
  * @returns {CodeMirror}
  */
-function getLargeCodeMirror(attachment_elem, codemirror_config) {
-    const accessibility_msg = document.createElement('i');
-    accessibility_msg.innerText = 'Press TAB to indent. Press ESC to advance from answer area.';
-    accessibility_msg.style.fontSize = '75%';
-    attachment_elem.appendChild(accessibility_msg);
-
+function getLargeCodeMirror(attachment_elem, codemirror_config, show_accessibility_msg = true) {
+    if(show_accessibility_msg){
+        const accessibility_msg = document.createElement('i');
+        accessibility_msg.innerText = 'Press TAB to indent. Press ESC to advance from answer area.';
+        accessibility_msg.style.fontSize = '75%';
+        attachment_elem.appendChild(accessibility_msg);
+    }
     // If no mode is set must explicitly set it to null otherwise codemirror will attempt to guess the language and
     // highlight.  This is not desirable when collecting plain text.
     if (!codemirror_config.mode) {


### PR DESCRIPTION
Fix #10643

### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant
* [X] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
CodeMirror currently displays accessibility help text above all code boxes. This text is confusing in places where the code box is disabled and it is impossible to navigate to it.


### What is the new behavior?
This commit updates the `getLargeCodeMirror` function to conditionally display the accessibility help text only when the CodeMirror instance is enabled. This prevents confusion in scenarios where the code box is disabled and navigation is not possible.

![image](https://github.com/Submitty/Submitty/assets/34382211/dbf21029-63d0-4075-8bea-1d0391a4749b)
