### PR TITLE
[Bugfix:TAGrading] Fix spec using S24 courses

### DIFF
--- a/site/cypress/e2e/Cypress-TAGrading/test_rubric_access.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/test_rubric_access.spec.js
@@ -1,7 +1,7 @@
 describe('Rubric Access Test', () => {
     it('test sample file exists student', () => {
         cy.login('aphacker');
-        cy.visit('/courses/s24/sample/download');
+        cy.visit(['sample', 'download']);
         cy.get('.content').should('contain', "You don't have access to this page.");
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
         cy.get('#error-0').should('contain', 'You do not have permission to grade Grading Homework');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes the issue of CI failing on TAGrading because of a rubric spec using hard-coded spring24.

### What is the new behavior?

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
