### PR TITLE
[Bugfix:RainbowGrades] Fix final cutoff customization

### DIFF
--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -423,7 +423,7 @@ function getFinalCutoffPercent() {
     const final_cutoff = {};
     const letter_grades = ['A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+', 'D'];
 
-    $('.final_cutoff_input').each(() => {
+    $('.final_cutoff_input').each(function () {
         // Get data
         const letter_grade = this.getAttribute('data-benchmark').toString();
         const percent = this.value;
@@ -454,6 +454,7 @@ function buildJSON() {
         display: getDisplay(),
         display_benchmark: getDisplayBenchmark(),
         benchmark_percent: getBenchmarkPercent(),
+        final_cutoff: getFinalCutoffPercent(),
         section: getSection(),
         gradeables: getGradeableBuckets(),
         messages: getMessages(),


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Login to Instructor, then navigate to Grade Reports > Web-Based Rainbow Grades Customization.

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The following error on the Rainbow Grades customization page was caused by a refactor in PR #10551 (Update ESLint style rules).
![error](https://github.com/Submitty/Submitty/assets/56311867/c3b80163-5075-4f3f-9c7b-a358ca477e75)

### What is the new behavior?
Final Cutoffs can once again be set using the Rainbow Grades customization page.
