### PR TITLE
[Bugfix:Developer] Fix CI Flag and Ignore Flag File

### DIFF
--- a/.github_actions_ci_flag
+++ b/.github_actions_ci_flag
@@ -1,1 +1,0 @@
-This file is used to check if Submitty is being run in the Github Actions CI.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Pipfile.lock
 .phpunit.result.cache
 
 .env
+.github_actions_ci_flag

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -38,7 +38,7 @@ if [ -d "${THIS_DIR}/../.utm" ]; then
 fi
 
 CI=0
-if [ -d "${THIS_DIR}/../.github_actions_ci_flag" ]; then
+if [ -f "${THIS_DIR}/../.github_actions_ci_flag" ]; then
     CI=1
 fi
 
@@ -89,7 +89,8 @@ fi
 # FORCE CORRECT TIME SKEW
 # This may happen on a development virtual machine
 # SEE GITHUB ISSUE #7885 - https://github.com/Submitty/Submitty/issues/7885
-if [[[ "${VAGRANT}" == 1 ] || [ "${UTM}" == 1 ]] && [ "${CI}" == 0 ]]; then
+
+if [[( "${VAGRANT}" == 1  ||  "${UTM}" == 1 ) &&  "${CI}" == 0 ]]; then
     sudo service ntp stop
     sudo ntpd -gq
     sudo service ntp start


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
The CI flag works on CI, but not locally because of a formatting issue. 

### What is the new behavior?
The CI flag is now fixed, and accurately skipping the NTPD setup on CI, but allowing it to run on local machines. 
Also, the flag file was added, so all users who didn't delete the file were running it as if they were in the CI, so this file has been added to the .gitignore file, so if someone is testing the feature, it won't be committed and sent to all users who pull. 