### PR TITLE
[Bugfix:System] git clone in create sample courses

### DIFF
--- a/.setup/bin/sample_courses/utils/__init__.py
+++ b/.setup/bin/sample_courses/utils/__init__.py
@@ -84,13 +84,12 @@ def get_current_semester():
 
 
 def mimic_checkout(repo_path, checkout_path, vcs_subdirectory):
-    os.system(f'git clone {SUBMITTY_DATA_DIR}/vcs/git/{repo_path} {checkout_path}/tmp -b main')
+    os.system(f"su -c 'git clone {SUBMITTY_DATA_DIR}/vcs/git/{repo_path} {checkout_path}/tmp -b main' submitty_daemon")
     if vcs_subdirectory != '':
         if vcs_subdirectory[0] == '/':
             vcs_subdirectory = vcs_subdirectory[1:]
         file_path = os.path.join(f'{checkout_path}/tmp', vcs_subdirectory)
     else:
         file_path = os.path.join(f'{checkout_path}/tmp')
-
     shutil.copytree(file_path, f'{checkout_path}', dirs_exist_ok=True)
     shutil.rmtree(f'{checkout_path}/tmp')

--- a/.setup/bin/sample_courses/utils/__init__.py
+++ b/.setup/bin/sample_courses/utils/__init__.py
@@ -91,5 +91,6 @@ def mimic_checkout(repo_path, checkout_path, vcs_subdirectory):
         file_path = os.path.join(f'{checkout_path}/tmp', vcs_subdirectory)
     else:
         file_path = os.path.join(f'{checkout_path}/tmp')
+
     shutil.copytree(file_path, f'{checkout_path}', dirs_exist_ok=True)
     shutil.rmtree(f'{checkout_path}/tmp')

--- a/.setup/bin/sample_courses/utils/dependent.py
+++ b/.setup/bin/sample_courses/utils/dependent.py
@@ -32,20 +32,22 @@ def commit_submission_to_repo(user_id, src_file, repo_path, vcs_subdirectory) ->
     my_cwd = os.getcwd()
     with TemporaryDirectory() as temp_dir:
         os.chdir(temp_dir)
-        os.system(f'git clone {SUBMITTY_DATA_DIR}/vcs/git/{repo_path}')
+        os.system("chown -R submitty_daemon "+temp_dir)
+        os.system(f"su -c 'git clone {SUBMITTY_DATA_DIR}/vcs/git/{repo_path}' submitty_daemon")
         os.chdir(os.path.join(temp_dir, user_id))
-        os.system('git checkout main')
-        os.system('git pull')
+        os.system("su -c 'git checkout main' submitty_daemon")
+        os.system("su -c 'git pull' submitty_daemon")
         # use the above function to copy the files into the git repo for us
         dst: str = os.getcwd()
         if vcs_subdirectory != '':
             dst = os.path.join(dst, vcs_subdirectory)
-
         create_gradeable_submission(src_file, dst)
-        os.system('git add --all')
-        os.system(f"git config user.email '{user_id}@example.com'")
-        os.system(f"git config user.name '{user_id}'")
-        os.system("git commit -a --allow-empty -m 'adding submission files"
-                  f"' --author='{user_id} <{user_id}@example.com>'")
-        os.system('git push')
+        os.system("chown -R submitty_daemon "+temp_dir)
+        os.system("su -c 'git add --all' submitty_daemon")
+        os.system(f"su -c 'git config user.email \'user@example.com\'' submitty_daemon")
+        os.system(f"su -c 'git config user.name \'username\'' submitty_daemon")
+        my_command = ("git commit -a --allow-empty -m \"adding submission files\" "
+                      "--author=\"username <user@example.com>\"")
+        os.system("su -c '"+my_command+"' submitty_daemon")
+        os.system("su -c 'git push' submitty_daemon")
     os.chdir(my_cwd)

--- a/.setup/bin/sample_courses/utils/dependent.py
+++ b/.setup/bin/sample_courses/utils/dependent.py
@@ -41,11 +41,12 @@ def commit_submission_to_repo(user_id, src_file, repo_path, vcs_subdirectory) ->
         dst: str = os.getcwd()
         if vcs_subdirectory != '':
             dst = os.path.join(dst, vcs_subdirectory)
+
         create_gradeable_submission(src_file, dst)
         os.system("chown -R submitty_daemon "+temp_dir)
         os.system("su -c 'git add --all' submitty_daemon")
-        os.system(f"su -c 'git config user.email \'user@example.com\'' submitty_daemon")
-        os.system(f"su -c 'git config user.name \'username\'' submitty_daemon")
+        os.system("su -c 'git config user.email \'user@example.com\'' submitty_daemon")
+        os.system("su -c 'git config user.name \'username\'' submitty_daemon")
         my_command = ("git commit -a --allow-empty -m \"adding submission files\" "
                       "--author=\"username <user@example.com>\"")
         os.system("su -c '"+my_command+"' submitty_daemon")


### PR DESCRIPTION
### What is the current behavior?

A recent update to git now requires non-owners of shared repository directory to specify each directory as "safe".  This change broke our "vagrant up" scripts because 'git clone' and other git commands were run by the root user in the create sample courses script.   These directories are owned by the submitty_cgi user.

### What is the new behavior?

Now the git commands in create sample course script are run by the submitty_daemon user, which does have a global safe directory set.
