### PR TITLE
[Bugfix:InstructorUI] Remove lowest null handling

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -122,10 +122,9 @@ class RainbowCustomization extends AbstractModel {
                     $this->bucket_counts[$bucket] = $json_bucket->count;
                 }
 
-                if (!empty($json_bucket->remove_lowest)) {
+                if (property_exists($json_bucket, 'remove_lowest')) {
                     $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest;
-                }
-                else {
+                } else {
                     $this->bucket_remove_lowest[$bucket] = 0;
                 }
             }

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -124,7 +124,8 @@ class RainbowCustomization extends AbstractModel {
 
                 if (!empty($json_bucket->remove_lowest)) {
                     $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest;
-                } else {
+                }
+                else {
                     $this->bucket_remove_lowest[$bucket] = 0;
                 }
             }

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -122,12 +122,7 @@ class RainbowCustomization extends AbstractModel {
                     $this->bucket_counts[$bucket] = $json_bucket->count;
                 }
 
-                if (property_exists($json_bucket, 'remove_lowest')) {
-                    $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest;
-                }
-                else {
-                    $this->bucket_remove_lowest[$bucket] = 0;
-                }
+                $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest ?? 0;
             }
         }
 

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -122,7 +122,11 @@ class RainbowCustomization extends AbstractModel {
                     $this->bucket_counts[$bucket] = $json_bucket->count;
                 }
 
-                $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest;
+                if (!empty($json_bucket->remove_lowest)) {
+                    $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest;
+                } else {
+                    $this->bucket_remove_lowest[$bucket] = 0;
+                }
             }
         }
 

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -124,7 +124,8 @@ class RainbowCustomization extends AbstractModel {
 
                 if (property_exists($json_bucket, 'remove_lowest')) {
                     $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest;
-                } else {
+                }
+                else {
                     $this->bucket_remove_lowest[$bucket] = 0;
                 }
             }


### PR DESCRIPTION
Currently, when web-based GUI customization page is rendered, users may get below screenshot image warning (screenshot credit to @zacharymnp) 
![스크린샷 2024-07-09 오전 11 07 16](https://github.com/Submitty/Submitty/assets/123261952/dbd09bca-c620-435f-b557-72ecf01caa38)


This is occurring because when we are loading json, it is looking for remove_lowest even when there is none.

In order to reproduce/test this issue, go to reports page -> customization page -> drag few gradeable to assigned bucket. Hit save changes. Refresh page, and will see the screenshot warning. 

With this change, it checks whether remove_lowest is specified or not, and if it is not, it would set it to zero, and only parse when it is specified. 
