### PR TITLE
[Bugfix:TAGrading] Fix self_grading always false

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -312,17 +312,17 @@
     * @param {boolean} grader_removed true if existing grader was removed
     * @param {String} button_id the ID of the submit button to be enabled / disabled
     * @param {String} error_div_id the ID of the error message to be displayed if submit is disabled
-    * @param {boolean} self_grading true if the student and grader is different
+    * @param {boolean} self_grading true if the student and grader is same
     */
     function updateSubmitButton(valid_grader, valid_students, new_grader, grader_removed, button_id, error_div_id, self_grading) {
-        if (grader_removed || (valid_grader && !valid_students.includes(false) && (!new_grader || valid_students.includes(true)))) {
+        if (grader_removed || (valid_grader && !valid_students.includes(false) && (!new_grader || valid_students.includes(true))) && !self_grading) {
             $(error_div_id).hide();
             $(button_id).prop('disabled', false);
         } else {
             $(error_div_id).empty();
             if (!valid_grader) {
                 $(error_div_id).text("Please enter a valid new grader that is in the course and not already in the matrix.");
-            } else if (self_grading) {
+            } else if (self_grading || (valid_students.includes(false) && !self_grading)) {
                 $(error_div_id).text("Please note that student is not able to grade themselves.");
             } else if (valid_students.includes(false)) {
                 $(error_div_id).text("Please enter valid new students that are in the course and not already assigned to the grader.");
@@ -395,7 +395,9 @@
             valid_students = [];
         });
         $('#admin-gradeable-add-peers-form').on('blur', ':text#new_peer_grader', function() {
+            const grader_id = $(":text#new_peer_grader").val();
             valid_grader = checkNewGraderValid($(this));
+            self_grading = grader_id === $(this).val();
             updateSubmitButton(valid_grader, valid_students, true, false, "#admin-gradeable-add-peers-submit", "#submit-error2", self_grading);
         });
         $('#admin-gradeable-add-peers-form').on('blur', ':text.add_user_ids', function() {

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -315,7 +315,6 @@
     * @param {boolean} self_grading true if the student and grader is same
     */
     function updateSubmitButton(valid_grader, valid_students, new_grader, grader_removed, button_id, error_div_id, self_grading) {
-        console.log(self_grading);
         if (grader_removed || (valid_grader && !valid_students.includes(false) && (!new_grader || valid_students.includes(true))) && !self_grading) {
             $(error_div_id).hide();
             $(button_id).prop('disabled', false);

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -383,6 +383,7 @@
         $('#admin-gradeable-edit-peers-form').on('blur', ":text.add_user_ids", function() {
             const grader_id = $("#admin-gradeable-edit-peers-title").text().substr(18);
             checkNewStudentsValid(grader_id, $(this), valid_students, false);
+            self_grading = grader_id === $(this).val();
             updateSubmitButton(valid_grader, valid_students, false, false, "#admin-gradeable-edit-peers-submit", "#submit-error", self_grading);
         });
         $('#admin-gradeable-edit-peers-form').on('focus blur', '#remove_grader', function() {
@@ -400,6 +401,7 @@
         $('#admin-gradeable-add-peers-form').on('blur', ':text.add_user_ids', function() {
             const grader_id = $(":text#new_peer_grader").val();
             checkNewStudentsValid(grader_id, $(this), valid_students, true);
+            self_grading = grader_id === $(this).val();
             updateSubmitButton(valid_grader, valid_students, true, false, "#admin-gradeable-add-peers-submit", "#submit-error2", self_grading);
         });
     });

--- a/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeablePeers.twig
@@ -315,6 +315,7 @@
     * @param {boolean} self_grading true if the student and grader is same
     */
     function updateSubmitButton(valid_grader, valid_students, new_grader, grader_removed, button_id, error_div_id, self_grading) {
+        console.log(self_grading);
         if (grader_removed || (valid_grader && !valid_students.includes(false) && (!new_grader || valid_students.includes(true))) && !self_grading) {
             $(error_div_id).hide();
             $(button_id).prop('disabled', false);
@@ -397,7 +398,7 @@
         $('#admin-gradeable-add-peers-form').on('blur', ':text#new_peer_grader', function() {
             const grader_id = $(":text#new_peer_grader").val();
             valid_grader = checkNewGraderValid($(this));
-            self_grading = grader_id === $(this).val();
+            self_grading = grader_id === $(":text.add_user_ids").val();
             updateSubmitButton(valid_grader, valid_students, true, false, "#admin-gradeable-add-peers-submit", "#submit-error2", self_grading);
         });
         $('#admin-gradeable-add-peers-form').on('blur', ':text.add_user_ids', function() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
PR https://github.com/Submitty/Submitty/pull/10557 (define self_grading) missed a relevant change.
The expected error message when a student is added as their own grader is "**Please note that student is not able to grade themselves**", but the following error is returned instead. This is because the value of self_grading is not updated properly.
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
![Screenshot (4)](https://github.com/Submitty/Submitty/assets/119070053/f0415218-e39b-441e-8ed2-1932c7e70526)

After Zach request i tried all possible way to put valid student and grader i findthis issue (see the video)

https://github.com/user-attachments/assets/51372222-01a7-4626-a0c5-acfb989f5caf


### What is the new behavior?
The expected error message returned.
![Screenshot (3)](https://github.com/Submitty/Submitty/assets/119070053/4f9cf4c8-82fa-4c1f-9bd9-b66e6d3f7df9)

https://github.com/user-attachments/assets/8d47ec13-52e6-4d44-9990-bfdfb5da0ebf



### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
