### PR TITLE
[Refactor:TAGrading] Add test ids for elements used in tests

### DIFF
--- a/site/app/templates/grading/electronic/GradingPanelHeader.twig
+++ b/site/app/templates/grading/electronic/GradingPanelHeader.twig
@@ -31,7 +31,7 @@
             </button>
             {{ self.renderPanelPositionSelector('autograding_results') }}
         </span>
-        <span class="grade-panel" id="grading_rubric_btn">
+        <span class="grade-panel" id="grading_rubric_btn" data-testid="grading-rubric-btn">
             <button title="Show/Hide Grading Rubric (Press G)"
                     class="invisible-btn key_to_click"
                     tabindex="0"
@@ -40,7 +40,7 @@
             </button>
             {{ self.renderPanelPositionSelector('grading_rubric') }}
         </span>
-        <span class="grade-panel" id="submission_browser_btn">
+        <span class="grade-panel" id="submission_browser_btn" data-testid="submission-browser-btn">
             <button title="Show/Hide Submission and Results Browser (Press O)"
                     class="invisible-btn key_to_click"
                     tabindex="0"
@@ -61,7 +61,7 @@
             {{ self.renderPanelPositionSelector('student_info') }}
             </span>
         {% endif %}
-        <span class="grade-panel" id="solution_ta_notes_btn">
+        <span class="grade-panel" id="solution_ta_notes_btn" data-testid="solution_ta_notes_btn">
             <button title="Show Solution and TA notes"
                     class="invisible-btn key_to_click"
                     tabindex="0"
@@ -71,7 +71,7 @@
             {{ self.renderPanelPositionSelector('solution_ta_notes') }}
         </span>
         {% if isPeerPanel %}
-            <span class="grade-panel" id="peer_info_btn">
+            <span class="grade-panel" id="peer_info_btn" data-testid="peer_info_btn">
                 <button title="Show/Hide Peer Information (Press P)"
                         class="invisible-btn key_to_click"
                         tabindex="0"
@@ -105,7 +105,7 @@
             </span>
         {% endif %}
         {% if is_notebook %}
-            <span class="grade-panel" id="notebook-view-btn">
+            <span class="grade-panel" id="notebook-view-btn" data-testid="notebook-view-btn">
                 <button title="Open student's view of their notebook gradeable"
                         class="invisible-btn"
                         tabindex="0"

--- a/site/app/templates/grading/electronic/GradingPanelHeader.twig
+++ b/site/app/templates/grading/electronic/GradingPanelHeader.twig
@@ -61,7 +61,7 @@
             {{ self.renderPanelPositionSelector('student_info') }}
             </span>
         {% endif %}
-        <span class="grade-panel" id="solution_ta_notes_btn" data-testid="solution_ta_notes_btn">
+        <span class="grade-panel" id="solution_ta_notes_btn" data-testid="solution-ta-notes-btn">
             <button title="Show Solution and TA notes"
                     class="invisible-btn key_to_click"
                     tabindex="0"
@@ -71,7 +71,7 @@
             {{ self.renderPanelPositionSelector('solution_ta_notes') }}
         </span>
         {% if isPeerPanel %}
-            <span class="grade-panel" id="peer_info_btn" data-testid="peer_info_btn">
+            <span class="grade-panel" id="peer_info_btn" data-testid="peer-info-btn">
                 <button title="Show/Hide Peer Information (Press P)"
                         class="invisible-btn key_to_click"
                         tabindex="0"

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_comments.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_comments.spec.js
@@ -2,35 +2,35 @@ describe('Test cases for TA grading page', () => {
     it('Grader should be able to add and remove overall comments', () => {
         cy.login('instructor');
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=jKjodWaRdEV9pBb&sort=id&direction=ASC']);
-        cy.get('#grading_rubric_btn').click();
-        cy.get('#overall-comment-instructor').should('have.value', '');
-        cy.get('#overall-comment-instructor').type('Comment1');
-        cy.get('#overall-comment-instructor').blur();
-        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+        cy.get('[data-testid="grading_rubric_btn"]').click();
+        cy.get('[data-testid="overall-comment-instructor"]').should('have.value', '');
+        cy.get('[data-testid="overall-comment-instructor"]').type('Comment1');
+        cy.get('[data-testid="overall-comment-instructor"]').blur();
+        cy.get('[data-testid="overall-comment-status"]').should('contain', 'All Changes Saved');
 
         cy.reload();
-        cy.get('#overall-comment-instructor').should('have.value', 'Comment1');
+        cy.get('[data-testid="overall-comment-instructor"]').should('have.value', 'Comment1');
 
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=aYl92mR3NvJYGrK&sort=id&direction=ASC']);
-        cy.get('#overall-comment-instructor').should('have.value', '');
-        cy.get('#overall-comment-instructor').type('Comment2');
-        cy.get('#overall-comment-instructor').blur();
-        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+        cy.get('[data-testid="overall-comment-instructor"]').should('have.value', '');
+        cy.get('[data-testid="overall-comment-instructor"]').type('Comment2');
+        cy.get('[data-testid="overall-comment-instructor"]').blur();
+        cy.get('[data-testid="overall-comment-status"]').should('contain', 'All Changes Saved');
 
         cy.reload();
-        cy.get('#overall-comment-instructor').should('have.value', 'Comment2');
+        cy.get('[data-testid="overall-comment-instructor"]').should('have.value', 'Comment2');
 
-        cy.get('#overall-comment-instructor').clear();
-        cy.get('#overall-comment-instructor').blur();
-        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+        cy.get('[data-testid="overall-comment-instructor"]').clear();
+        cy.get('[data-testid="overall-comment-instructor"]').blur();
+        cy.get('[data-testid="overall-comment-status"]').should('contain', 'All Changes Saved');
 
         cy.reload();
-        cy.get('#overall-comment-instructor').should('have.value', '');
+        cy.get('[data-testid="overall-comment-instructor"]').should('have.value', '');
 
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=jKjodWaRdEV9pBb&sort=id&direction=ASC']);
-        cy.get('#overall-comment-instructor').should('have.value', 'Comment1');
-        cy.get('#overall-comment-instructor').clear();
-        cy.get('#overall-comment-instructor').blur();
-        cy.get('.overall-comment-status').should('contain', 'All Changes Saved');
+        cy.get('[data-testid="overall-comment-instructor"]').should('have.value', 'Comment1');
+        cy.get('[data-testid="overall-comment-instructor"]').clear();
+        cy.get('[data-testid="overall-comment-instructor"]').blur();
+        cy.get('[data-testid="overall-comment-status"]').should('contain', 'All Changes Saved');
     });
 });

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_comments.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_comments.spec.js
@@ -2,7 +2,7 @@ describe('Test cases for TA grading page', () => {
     it('Grader should be able to add and remove overall comments', () => {
         cy.login('instructor');
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=jKjodWaRdEV9pBb&sort=id&direction=ASC']);
-        cy.get('[data-testid="grading_rubric_btn"]').click();
+        cy.get('[data-testid="grading-rubric-btn"]').click();
         cy.get('[data-testid="overall-comment-instructor"]').should('have.value', '');
         cy.get('[data-testid="overall-comment-instructor"]').type('Comment1');
         cy.get('[data-testid="overall-comment-instructor"]').blur();

--- a/site/cypress/e2e/Cypress-TAGrading/test_rubric_access.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/test_rubric_access.spec.js
@@ -15,7 +15,7 @@ describe('Rubric Access Test', () => {
         cy.get('#agree-button').click();
         cy.get('[data-testid="view-sections"]').click();
         cy.get('[data-testid="grade-button"]').eq(12).click();
-        cy.get('#grading_rubric_btn').click();
+        cy.get('[data-testid="grading-rubric-btn"]').click();
         const filePath = '../more_autograding_examples/image_diff_mirror/submissions/student1.png';
         cy.get('#attachment-upload').selectFile(filePath);
         cy.get('.key_to_click').find('[title="Delete the file"]').click();

--- a/site/public/templates/grading/GradingComponentHeader.twig
+++ b/site/public/templates/grading/GradingComponentHeader.twig
@@ -39,7 +39,7 @@
     } only %}
 </span>
 {% if component_version_conflict is same as(true) and not grading_disabled %}
-    <span class="version-warning col-5">
+    <span class="version-warning col-5" data-testid="version-warning">
         Please edit or ensure that comments from version {{ graded_component.graded_version }} still apply.
     </span>
 {% else %}

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -16,7 +16,7 @@ Required Parameters:
         <div class="col-6">
             <b>Overall Comment</b>
         </div>
-        <div class="col-6 overall-comment-status" id="overall-comment-status">
+        <div class="col-6 overall-comment-status" id="overall-comment-status" data-testid="overall-comment-status">
           All Changes Saved
         </div>
     </div>

--- a/site/public/templates/grading/SavingTools.twig
+++ b/site/public/templates/grading/SavingTools.twig
@@ -11,7 +11,7 @@ Required Parameters:
         <span class="btn btn-default save-tools-cancel key_to_click" tabindex="0" onclick="{{ cancel_on_click }} ;event.stopPropagation()">
             Discard
         </span>
-        <span class="btn btn-primary save-tools-save">
+        <span class="btn btn-primary save-tools-save" data-testid="save-tools-save">
             Save
         </span>
     {% endif %}

--- a/site/public/templates/misc/MarkdownArea.twig
+++ b/site/public/templates/misc/MarkdownArea.twig
@@ -71,6 +71,7 @@
         <label for="{{ markdown_area_id }}" tabindex="-1" class="screen-reader">{{ markdown_area_id }}</label>
         {% include "./AccessibilityMessage.twig" %}
         <textarea
+            data-testid="{{ markdown_area_id }}"
             id="{{ markdown_area_id }}"
             class="markdown-textarea fill-available {{ class is defined ? class }}"
             name="{{ markdown_area_name is defined ? markdown_area_name : "markdown_area" }}"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Elements in the TA grading interface are not referenced by data-testid in cypress tests.

### What is the new behavior?
Adds and uses test ids to refer to those elements.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
