### PR TITLE
[Bugfix:TAGrading] Anonymous Mode now shows too late

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -516,6 +516,9 @@
     {% elseif graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0 %}
         {% set contents = "Cancelled Submission" %}
         {% set btn_class = "btn-default" %}
+    {% elseif info.on_time_submission == false %}
+        {% set contents = "Too Many Days Late" %}
+        {% set btn_class = "btn-danger" %}
     {% elseif graded_gradeable.getGradeable().isTaGrading() %}
         {% set contents = "Grade" %}
         {% set btn_class = "btn-primary" %}


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Closes #10120 
Too Many late days are not in the anonymous view of the TA Grading Interface

### What is the new behavior?
Add in "Too many late days" to the anonymous view of the TA Grading Interface.

### Other information?
https://www.diffchecker.com/oRToVozk/
Should we do anything about these two functions? They are practically the same.
In addition, the peer view of grading anonymous should never run.
<img width="906" alt="image" src="https://github.com/user-attachments/assets/8eaea6db-cc75-4d2e-bf3e-2b3bb48a318c">
