### PR TITLE
[UI/UX:InstructorUI] Rename Create and Edit Queue buttons

### DIFF
--- a/site/app/templates/officeHoursQueue/NewQueue.twig
+++ b/site/app/templates/officeHoursQueue/NewQueue.twig
@@ -1,6 +1,6 @@
 {% extends 'generic/Popup.twig' %}
 {% block popup_id %}new-queue{% endblock %}
-{% block title %}Open New Queue{% endblock %}
+{% block title %}Create Queue{% endblock %}
 
 {% block body %}
     <form method="post" id="open_new_queue" action="{{base_url}}" style="height:auto;">

--- a/site/app/templates/officeHoursQueue/NewQueue.twig
+++ b/site/app/templates/officeHoursQueue/NewQueue.twig
@@ -29,7 +29,7 @@
             <b>Zoom link:&nbsp;&nbsp;</b> .*zoom\.us.* <br><br>
         </div>
     </div>
-    <button id="open_new_queue_btn" type="submit" class="btn btn-primary" data-testid="open-new-queue-btn" >Open New Queue</button>
+    <button id="open_new_queue_btn" type="submit" class="btn btn-primary" data-testid="open-new-queue-btn" >Create Queue</button>
     </form>
     <script>
         let queueDraggable = $(".popup-window").draggable();

--- a/site/app/templates/officeHoursQueue/QueueButtonBar.twig
+++ b/site/app/templates/officeHoursQueue/QueueButtonBar.twig
@@ -5,10 +5,10 @@
 <br>
 <div>
 <button id="toggle_new_queue" class="btn btn-primary filter_btn" type="button" onclick="$('#new-queue').show()" data-testid="toggle-new-queue">
-    Open New Queue
+    Create Queue
 </button>
   <button id="toggle_filter_settings" class="btn btn-primary filter_btn" type="button" onclick="$('#filter-settings').show()" data-testid="toggle-filter-settings">
-    Edit Existing Queue
+    Edit Queue
   </button>
   <button id="toggle_announcement_settings" class="btn btn-primary filter_btn" type="button" onclick="$('#announcement-settings').show()" data-testid="toggle-announcement-settings">
     Edit Announcement

--- a/site/app/templates/officeHoursQueue/QueueFilter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFilter.twig
@@ -1,6 +1,6 @@
 {% extends 'generic/Popup.twig' %}
 {% block popup_id %}filter-settings{% endblock %}
-{% block title %}Edit Existing Queue{% endblock %}
+{% block title %}Edit Queue{% endblock %}
 
 {% block body %}
   <span class="option-title">Modify access code</span>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Open New Queue and Edit Existing Queue buttons on the instructor view on the Office Hours Queue page are misnamed.
![image](https://github.com/user-attachments/assets/609d9d6c-e0ac-4782-9299-19535433e5d4)
![image](https://github.com/user-attachments/assets/37c364d8-1457-456a-ad6d-5144f1c96c92)
![image](https://github.com/user-attachments/assets/12896c56-084f-437c-b353-502a8a3aa20e)

### What is the new behavior?
Buttons renamed to Create Queue and Edit Queue.
![image](https://github.com/user-attachments/assets/d5263605-f266-45a1-9bba-29296d9bc630)
![image](https://github.com/user-attachments/assets/16ae3c7b-f403-4651-a76e-c531c671bf64)
![image](https://github.com/user-attachments/assets/39cbe9d1-d52e-4e96-bd02-f3ee769c89e2)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
