### PR TITLE
[UI/UX:RainbowGrades] Reorder RainbowCustomization items

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -44,117 +44,11 @@
                     {% endfor %}
                 </fieldset>
             </div>
-            <div id="display_benchmarks" class="customization_item">
-                <fieldset>
-                    <legend><h2>Display Benchmarks</h2></legend>
-                    {% for benchmark in display_benchmarks %}
-                        <p>
-                            <input type="checkbox" id="display_benchmarks_{{ benchmark.id }}" name="display_benchmarks" value="{{ benchmark.id }}" data-testid="display-benchmarks-{{ benchmark.id }}"
-                                   {% if benchmark.isUsed == true %}checked{% endif %}
-                            >
-                            <label for="display_benchmarks_{{ benchmark.id }}">{{ benchmark.id }}</label>
-                        </p>
-                    {% endfor %}
-                </fieldset>
-            </div>
-            <div id="benchmark_percents" class="customization_item">
-                <h2>Benchmark Percents</h2>
-                <p class="rg_info_message">You may adjust the minimum percent required to receive certain letter grades.  Enter this percentage as a decimal number.<br />As an example 90% would be entered as .9</p>
-                <div class="input-boxes">
-                    {% for benchmark in benchmarks_with_input_fields %}
-                        {% if benchmark_percents[benchmark] is defined %}
-                            {% set percent = benchmark_percents[benchmark] %}
-                        {% else %}
-                            {% set percent = '' %}
-                        {% endif %}
-
-                        <label for="benchmark_{{ benchmark }}" class="{{ benchmark }} input-label">{{ benchmark }}</label>
-                        <input type="text" id="benchmark_{{ benchmark }}" class="benchmark_percent_input {{ benchmark }}" data-benchmark="{{ benchmark }}" value="{{ percent }}">
-                    {% endfor %}
-                </div>
-            </div>
-            <div id="final_grade_cutoffs" class="customization_item">
-                <h2>Final Grade Cutoffs</h2>
-                <p class="rg_info_message">You may adjust the minimum percent required to receive certain final letter grades.  Enter this percentage as a decimal number out of 100.<br />As an example 90% would be entered as 90.0</p>
-                <div class="input-boxes">
-                    {% for cutoff_input in final_cutoff_input_fields %}
-                        {% if final_cutoff[cutoff_input] is defined %}
-                            {% set percent = final_cutoff[cutoff_input] %}
-                        {% else %}
-                            {% set percent = '' %}
-                        {% endif %}
-
-                        <label for="cutoff_{{ cutoff_input }}" class="{{ cutoff_input }} input-label">{{ cutoff_input }}</label>
-                        <input type="text" id="cutoff_{{ cutoff_input }}" class="final_cutoff_input {{ cutoff_input }}" name="final_grade_cutoffs" data-benchmark="{{ cutoff_input }}" value="{{ percent }}">
-                    {% endfor %}
-                </div>
-            </div>
             <div id="cust_messages" class="customization_item">
                 <h2>Messages</h2>
                 <label for="cust_messages_textarea" class="rg_info_message">You may enter a message that will appear above the student's rainbow grades.</label>
                 <textarea id="cust_messages_textarea">{% if 0 in messages|keys %}{{ messages[0] }}{% endif %}</textarea>
             </div>
-            <div id="section_labels" class="customization_item">
-                <h2>Section Labels</h2>
-                <p class="rg_info_message">You may use this area to assign a label to each section number, for example the name of the TA or TAs
-                    handling the section.  You may also leave it as the default, but it may not be blank.</p>
-                <div class="input-boxes">
-                    {% for section, label in sections_and_labels %}
-                        <label for="section_and_labels_{{ section }}" class="input-label">{{ section }}</label>
-                        <input type="text" data-section="{{ section }}" class="sections_and_labels" id="section_and_labels_{{ section }}" name="section_and_labels_{{ section }}" value="{{ label }}">
-                    {% endfor %}
-                </div>
-            </div>
-            <div id="plagiarism" class="customization_item">
-                <h2>Penalties for Academic Dishonesty and Plagiarism</h2>
-                <p class="rg_info_message">All students will receive a zero for the specified gradeable.  Additionally if a non-zero penalty value is indicated they will receive an additional reduction on the semester grade.  Penalty = 1 is a full letter grade.  Penalty = 0.5 is a half letter grade.  Penalty = 0.33 is a one third letter grade.</p>
-                <input type="hidden" name="csrf_token" value="{{ csrfToken }}" />
-                <input type="hidden" name="option" value="-1" />
-                <div class="option">
-                    <label for="user_id">
-                        <span>USER ID:</span>
-                        <input class="option-input" type="text" name="user_id" id="user_id">
-                    </label>
-                    <label for="g_id" class="option">Gradeable:</label>
-                    <select name="g_id" id="g_id">
-                        <option disabled selected value> -- select an option -- </option>
-                        {% for index, value in gradeables %}
-                            <option value="{{value['g_id']}}" >{{ value['g_title'] }}</option>
-                        {% endfor %}
-                    </select>
-                    <label for="marks">
-                        <span>Penalty:</span>
-                        <input class="option-input" type="text" name="marks" id="marks">
-                    </label>
-                    <button type="submit" class="btn btn-primary" onclick="addToTable()" aria-label="submit">
-                        <i class="fas fa-plus"></i>
-                    </button>
-                    {# This is a data table #}
-                    <table id="plagiarism-table" class="table table-striped table-bordered persist-area mobile-table">
-                        <caption id="title"></caption>
-                        <thead>
-                        <tr style="text-align:left">
-                            <th>USER ID</th>
-                            <th>Gradeable</th>
-                            <th>Penalty</th>
-                            <th>Delete</th>
-                        </tr>
-                        </thead>
-                        <tbody id="table-body" style="text-align:left">
-                        {% for entry in plagiarism %}
-                            <tr>
-                                <td>{{ entry.user }}</td>
-                                <td>{{ entry.gradeable }}</td>
-                                <td>{{ entry.penalty }}</td>
-                                <td><a onclick="deleteRow(this)"><i class="fas fa-trash"></i></a></td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-
             <div id="gradeables" class="customization_item">
                 <h2>Gradeables</h2>
                 <div style="width:45%;float:left;" id="buckets_used">
@@ -243,7 +137,7 @@
                                                        onblur="ClampPoints(this);"
                                                        onkeyup="DetectMaxOverride(this);">
                                                 <div class="gradeable-li-right-of-input">
-                                                        <div class="gradeable-li-info">
+                                                    <div class="gradeable-li-info">
                                                         <i class="fas fa-exclamation-triangle fa-rb tooltip">
                                                             <span class="tooltiptext tooltipbottom">
                                                                 WARNING: Max Score has been overridden in Rainbow Grades
@@ -292,6 +186,110 @@ To remove a curve simply blank all boxes."></i>
                             </div>
                         {% endfor %}
                     </div>
+                </div>
+            </div>
+            <div id="display_benchmarks" class="customization_item">
+                <fieldset>
+                    <legend><h2>Display Benchmarks</h2></legend>
+                    {% for benchmark in display_benchmarks %}
+                        <p>
+                            <input type="checkbox" id="display_benchmarks_{{ benchmark.id }}" name="display_benchmarks" value="{{ benchmark.id }}" data-testid="display-benchmarks-{{ benchmark.id }}"
+                                   {% if benchmark.isUsed == true %}checked{% endif %}
+                            >
+                            <label for="display_benchmarks_{{ benchmark.id }}">{{ benchmark.id }}</label>
+                        </p>
+                    {% endfor %}
+                </fieldset>
+            </div>
+            <div id="benchmark_percents" class="customization_item">
+                <h2>Benchmark Percents</h2>
+                <p class="rg_info_message">You may adjust the minimum percent required to receive certain letter grades.  Enter this percentage as a decimal number.<br />As an example 90% would be entered as .9</p>
+                <div class="input-boxes">
+                    {% for benchmark in benchmarks_with_input_fields %}
+                        {% if benchmark_percents[benchmark] is defined %}
+                            {% set percent = benchmark_percents[benchmark] %}
+                        {% else %}
+                            {% set percent = '' %}
+                        {% endif %}
+
+                        <label for="benchmark_{{ benchmark }}" class="{{ benchmark }} input-label">{{ benchmark }}</label>
+                        <input type="text" id="benchmark_{{ benchmark }}" class="benchmark_percent_input {{ benchmark }}" data-benchmark="{{ benchmark }}" value="{{ percent }}">
+                    {% endfor %}
+                </div>
+            </div>
+            <div id="section_labels" class="customization_item">
+                <h2>Section Labels</h2>
+                <p class="rg_info_message">You may use this area to assign a label to each section number, for example the name of the TA or TAs
+                    handling the section.  You may also leave it as the default, but it may not be blank.</p>
+                <div class="input-boxes">
+                    {% for section, label in sections_and_labels %}
+                        <label for="section_and_labels_{{ section }}" class="input-label">{{ section }}</label>
+                        <input type="text" data-section="{{ section }}" class="sections_and_labels" id="section_and_labels_{{ section }}" name="section_and_labels_{{ section }}" value="{{ label }}">
+                    {% endfor %}
+                </div>
+            </div>
+            <div id="final_grade_cutoffs" class="customization_item">
+                <h2>Final Grade Cutoffs</h2>
+                <p class="rg_info_message">You may adjust the minimum percent required to receive certain final letter grades.  Enter this percentage as a decimal number out of 100.<br />As an example 90% would be entered as 90.0</p>
+                <div class="input-boxes">
+                    {% for cutoff_input in final_cutoff_input_fields %}
+                        {% if final_cutoff[cutoff_input] is defined %}
+                            {% set percent = final_cutoff[cutoff_input] %}
+                        {% else %}
+                            {% set percent = '' %}
+                        {% endif %}
+
+                        <label for="cutoff_{{ cutoff_input }}" class="{{ cutoff_input }} input-label">{{ cutoff_input }}</label>
+                        <input type="text" id="cutoff_{{ cutoff_input }}" class="final_cutoff_input {{ cutoff_input }}" name="final_grade_cutoffs" data-benchmark="{{ cutoff_input }}" value="{{ percent }}">
+                    {% endfor %}
+                </div>
+            </div>
+            <div id="plagiarism" class="customization_item">
+                <h2>Penalties for Academic Dishonesty and Plagiarism</h2>
+                <p class="rg_info_message">All students will receive a zero for the specified gradeable.  Additionally if a non-zero penalty value is indicated they will receive an additional reduction on the semester grade.  Penalty = 1 is a full letter grade.  Penalty = 0.5 is a half letter grade.  Penalty = 0.33 is a one third letter grade.</p>
+                <input type="hidden" name="csrf_token" value="{{ csrfToken }}" />
+                <input type="hidden" name="option" value="-1" />
+                <div class="option">
+                    <label for="user_id">
+                        <span>USER ID:</span>
+                        <input class="option-input" type="text" name="user_id" id="user_id">
+                    </label>
+                    <label for="g_id" class="option">Gradeable:</label>
+                    <select name="g_id" id="g_id">
+                        <option disabled selected value> -- select an option -- </option>
+                        {% for index, value in gradeables %}
+                            <option value="{{value['g_id']}}" >{{ value['g_title'] }}</option>
+                        {% endfor %}
+                    </select>
+                    <label for="marks">
+                        <span>Penalty:</span>
+                        <input class="option-input" type="text" name="marks" id="marks">
+                    </label>
+                    <button type="submit" class="btn btn-primary" onclick="addToTable()" aria-label="submit">
+                        <i class="fas fa-plus"></i>
+                    </button>
+                    {# This is a data table #}
+                    <table id="plagiarism-table" class="table table-striped table-bordered persist-area mobile-table">
+                        <caption id="title"></caption>
+                        <thead>
+                        <tr style="text-align:left">
+                            <th>USER ID</th>
+                            <th>Gradeable</th>
+                            <th>Penalty</th>
+                            <th>Delete</th>
+                        </tr>
+                        </thead>
+                        <tbody id="table-body" style="text-align:left">
+                        {% for entry in plagiarism %}
+                            <tr>
+                                <td>{{ entry.user }}</td>
+                                <td>{{ entry.gradeable }}</td>
+                                <td>{{ entry.penalty }}</td>
+                                <td><a onclick="deleteRow(this)"><i class="fas fa-trash"></i></a></td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Login to Instructor, then navigate to Grade Reports > Web-Based Rainbow Grades Customization.

### What is the new behavior?
Initial reordering of items in Rainbow Web-Customization to the following scheme. Some of the following items have not yet been added.

1. display
2. messages
3. gradeables
4. benchmarks checkboxes
5. display %
6. section
7. final cutoffs
8. manual grades
9. notes
10. warning
11. plagiarism

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
