### PR TITLE
[Bugfix:System]  sloc drop constraint fix

### DIFF
--- a/migration/migrator/migrations/course/20240707024127_sloc_for_barb.py
+++ b/migration/migrator/migrations/course/20240707024127_sloc_for_barb.py
@@ -18,6 +18,8 @@ def up(config, database, semester, course):
         ALTER TABLE autograding_metrics
         ADD COLUMN IF NOT EXISTS source_lines_of_code integer;
         ALTER TABLE autograding_metrics
+        DROP CONSTRAINT IF EXISTS sloc_non_negative;
+        ALTER TABLE autograding_metrics
         ADD CONSTRAINT sloc_non_negative CHECK (source_lines_of_code >= 0);
     """)
 


### PR DESCRIPTION
Current migration #10678 has some issue, it does not check if the constraint already exists.
This is a problem if system goes over some migration up & rollback, and fails with error "sloc_non_negative" constraint already exist. To prevent this happening we need to check if the constraint exists. 
Hoewever, PostgreSQL does not support ADD CONSTRAINT IF NOT EXISTS 
So one of the many option is to have DROP IF EXISTS before ADD regardless.
Yes it is expensive operation but we are OK with it.
You can find some reference in other migrations that we did (ex: user_last_initial_format.py)
