### PR TITLE
[Feature:Developer] Add colors.css check

### DIFF
--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -296,6 +296,28 @@ jobs:
         run: python3 run_shellcheck.py  # Uses the default Python installed with Ubuntu
 
 
+  colors-css:
+    name: colors.css check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fetch main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: MAIN
+      - name: Fetch PR branch
+        uses: actions/checkout@v4
+        with:
+          path: PR
+      - name: Check file size change
+        run: |
+          FILEPATH="site/public/css/colors.css"
+          LINES_DIFF="$(($(wc -l < PR/$FILEPATH) - $(wc -l < MAIN/$FILEPATH)))"
+          if test $LINES_DIFF -gt 0; then
+            exit $LINES_DIFF
+          fi
+
+
   Cypress-System:
     runs-on: ubuntu-22.04
     services:

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -331,10 +331,11 @@ jobs:
           LINES_DIFF=$(($(wc -l < "$PR_FILE") - $(wc -l < "$MAIN_FILE")))
 
           if [ $LINES_DIFF -gt 0 ]; then
-            echo "Line difference: $LINES_DIFF"
+            echo "::error::colors.css has increased in size by $LINES_DIFF lines in this PR."
+            echo "::error::Please use existing colors in colors.css instead of adding new ones, to keep the size of the file manageable."
             exit $LINES_DIFF
           else
-            echo "No lines added."
+            echo "No lines added. OK."
           fi
 
 

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -297,24 +297,44 @@ jobs:
 
 
   colors-css:
-    name: colors.css check
+    name: colors.css Check
     runs-on: ubuntu-22.04
+
     steps:
-      - name: Fetch main branch
+      - name: Checkout main branch
         uses: actions/checkout@v4
         with:
           ref: main
           path: MAIN
-      - name: Fetch PR branch
+
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           path: PR
-      - name: Check file size change
+
+      - name: Compare file size
         run: |
           FILEPATH="site/public/css/colors.css"
-          LINES_DIFF="$(($(wc -l < PR/$FILEPATH) - $(wc -l < MAIN/$FILEPATH)))"
-          if test $LINES_DIFF -gt 0; then
+          MAIN_FILE="MAIN/$FILEPATH"
+          PR_FILE="PR/$FILEPATH"
+
+          if [ ! -f "$MAIN_FILE" ]; then
+            echo "Main file $MAIN_FILE does not exist."
+            exit 1
+          fi
+
+          if [ ! -f "$PR_FILE" ]; then
+            echo "PR file $PR_FILE does not exist."
+            exit 1
+          fi
+
+          LINES_DIFF=$(($(wc -l < "$PR_FILE") - $(wc -l < "$MAIN_FILE")))
+
+          if [ $LINES_DIFF -gt 0 ]; then
+            echo "Line difference: $LINES_DIFF"
             exit $LINES_DIFF
+          else
+            echo "No lines added."
           fi
 
 

--- a/.github/workflows/submitty_ci.yml
+++ b/.github/workflows/submitty_ci.yml
@@ -333,6 +333,7 @@ jobs:
           if [ $LINES_DIFF -gt 0 ]; then
             echo "::error::colors.css has increased in size by $LINES_DIFF lines in this PR."
             echo "::error::Please use existing colors in colors.css instead of adding new ones, to keep the size of the file manageable."
+            echo "::error::If adding to colors.css really is necessary for your PR, this requirement may be waived on maintainer review."
             exit $LINES_DIFF
           else
             echo "No lines added. OK."

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -242,6 +242,9 @@
     --code-box-background-light-gray: #fafafa;
     --code-box-font-color-dark-gray: #343a42;
     --invisible: #00000000;
+
+    /* color for barb */
+    --color-for-barb: #33661177;
 }
 
 [data-black_mode="black"][data-theme="dark"] {

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -361,6 +361,10 @@
     /* poll histogram colors */
     --histogram-default: var(--standard-light-blue);
     --histogram-correct: var(--standard-medium-dark-lime-green);
+
+    --sloc-for-barb: #220000;
+    --update-fileutils-php: #002211;
+    --tzlocal: #990011;
 }
 
 /* Dark Theme Versions of Colors */

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -242,9 +242,6 @@
     --code-box-background-light-gray: #fafafa;
     --code-box-font-color-dark-gray: #343a42;
     --invisible: #00000000;
-
-    /* color for barb */
-    --color-for-barb: #33661177;
 }
 
 [data-black_mode="black"][data-theme="dark"] {

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -361,10 +361,6 @@
     /* poll histogram colors */
     --histogram-default: var(--standard-light-blue);
     --histogram-correct: var(--standard-medium-dark-lime-green);
-
-    --sloc-for-barb: #220000;
-    --update-fileutils-php: #002211;
-    --tzlocal: #990011;
 }
 
 /* Dark Theme Versions of Colors */


### PR DESCRIPTION
### What is the current behavior?
The `colors.css` file is prone to becoming bloated over time; there are many duplicate and unnecessary colors and the file has grown to be pointlessly large.

### What is the new behavior?
This PR adds a CI check to make sure that new PRs do not increase the size of `colors.css`.

### Other information?
In commit 570f9a1, the check fails because I added a couple lines to `colors.css`.
![image](https://github.com/user-attachments/assets/b1a1eba9-3ec4-4b3c-8073-8c09d9c50254)
After reverting changes to `colors.css` in 4263c64, the check passes.
