### PR TITLE
[Bugfix:Forum] Fix ForumController's incorrect argument

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -584,7 +584,7 @@ class ForumController extends AbstractController {
             [$post_id],
             $this->core->getUser()->getId()
         ));
-        $staffLiked = $this->core->getQueries()->getInstructorUpduck($post_id);
+        $staffLiked = $this->core->getQueries()->getInstructorUpduck([$post_id]);
         $boolStaffLiked = in_array($post["id"], $staffLiked, true);
         $GLOBALS['totalAttachments'] = 0;
         $GLOBALS['post_box_id'] = $_POST['post_box_id'];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When attempting to fetch a single post, ForumController will send a frog robot due to an incorrect argument error.

### What is the new behavior?
ForumController works as intended.

