### PR TITLE
[Bugfix:Submission] TypeError NUM_MARKDOWN variable

### DIFF
--- a/site/public/js/notebook_builder/widgets/markdown-widget.js
+++ b/site/public/js/notebook_builder/widgets/markdown-widget.js
@@ -1,6 +1,6 @@
 /* global Widget, NUM_MARKDOWN, buildUrl, csrfToken, displayErrorMessage */
 /* exported MarkdownWidget */
-
+let NUM_MARKDOWN = 0;
 class MarkdownWidget extends Widget {
     constructor() {
         super();

--- a/site/public/js/notebook_builder/widgets/markdown-widget.js
+++ b/site/public/js/notebook_builder/widgets/markdown-widget.js
@@ -1,6 +1,6 @@
 /* global Widget, NUM_MARKDOWN, buildUrl, csrfToken, displayErrorMessage */
 /* exported MarkdownWidget */
-let NUM_MARKDOWN = 0;
+
 class MarkdownWidget extends Widget {
     constructor() {
         super();

--- a/site/public/js/notebook_builder/widgets/widget.js
+++ b/site/public/js/notebook_builder/widgets/widget.js
@@ -1,5 +1,5 @@
 /* exported NUM_MARKDOWN, Widget */
-const NUM_MARKDOWN = 0;
+let NUM_MARKDOWN = 0;
 
 class Widget {
     /**

--- a/site/public/js/notebook_builder/widgets/widget.js
+++ b/site/public/js/notebook_builder/widgets/widget.js
@@ -1,5 +1,4 @@
-/* exported NUM_MARKDOWN, Widget */
-let NUM_MARKDOWN = 0;
+/* exported Widget */
 
 class Widget {
     /**

--- a/site/public/js/notebook_builder/widgets/widget.js
+++ b/site/public/js/notebook_builder/widgets/widget.js
@@ -1,5 +1,6 @@
-/* exported Widget */
-
+/* exported NUM_MARKDOWN, Widget */
+// eslint-disable-next-line prefer-const
+let NUM_MARKDOWN = 0;
 class Widget {
     /**
      * Get the html representation of the widget.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
This typeError is after the merged of this PR #10554
as **NUM_MARKDOWN** is assigned `const `but  we are changing this variable value in markdown-widget.js 
https://github.com/Submitty/Submitty/blob/9ca03854abffa3cebea8420b25d88f8c2a4f6010/site/public/js/notebook_builder/widgets/markdown-widget.js#L58
 

https://github.com/user-attachments/assets/05bf071d-383d-418a-bd4f-1c9f67f583dc



### What is the new behavior?
fixed the typeerror


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Head over to any notebook_builder (http://localhost:1511/courses/f24/sample/notebook_builder/open_homework/edit)
click on markdown button