### PR TITLE
[Refactor:Autograding] rm unnecessary import

### DIFF
--- a/more_autograding_examples/notebook_time_limit/config/custom_validation_code/timelimit.py
+++ b/more_autograding_examples/notebook_time_limit/config/custom_validation_code/timelimit.py
@@ -8,9 +8,6 @@
 import os
 import sys
 import json
-import traceback
-import re
-import tzlocal
 import math
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
#5286 introduced a `timelimit.py` script. However, it is not using some of the modules, `traceback`, `re`, `tzlocal`

Discovered during tzlocal reviewing process, and think we should clean up un-used imports for better searching results too. 

To test this PR, go to the file, and inspect if modules are used or not. 