### PR TITLE
[Bugfix:RainbowGrades] Fix plagiarism table refactor

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -328,7 +328,7 @@ To remove a curve simply blank all boxes."></i>
                             <th>Delete</th>
                         </tr>
                         </thead>
-                        <tbody id="table-body" style="text-align:left">
+                        <tbody id="plagiarism-table-body" style="text-align:left">
                         {% for entry in plagiarism %}
                             <tr>
                                 <td>{{ entry.user }}</td>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -314,7 +314,7 @@ To remove a curve simply blank all boxes."></i>
                         <span>Penalty:</span>
                         <input class="option-input" type="text" name="marks" id="marks">
                     </label>
-                    <button type="submit" class="btn btn-primary" onclick="addToTable()" aria-label="submit">
+                    <button type="submit" class="btn btn-primary" onclick="addToTable('plagiarism')" aria-label="submit">
                         <i class="fas fa-plus"></i>
                     </button>
                     {# This is a data table #}

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -299,9 +299,9 @@ To remove a curve simply blank all boxes."></i>
                 <input type="hidden" name="csrf_token" value="{{ csrfToken }}" />
                 <input type="hidden" name="option" value="-1" />
                 <div class="option">
-                    <label for="user_id">
+                    <label for="plagiarism-user-id">
                         <span>USER ID:</span>
-                        <input class="option-input" type="text" name="user_id" id="user_id">
+                        <input class="option-input" type="text" name="plagiarism-user-id" id="plagiarism-user-id">
                     </label>
                     <label for="g_id" class="option">Gradeable:</label>
                     <select name="g_id" id="g_id">
@@ -354,7 +354,7 @@ To remove a curve simply blank all boxes."></i>
             $(`#override-${gradeable_id}`).html(override.val());
         });
 
-        ["#plagiarism_user_id", "#manual-grading-user-id"].forEach(function(user_id) {
+        ["#plagiarism-user-id", "#manual-grading-user-id"].forEach(function(user_id) {
             $(user_id).autocomplete({
                 source: {{ student_full|raw }}
             });

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -327,7 +327,7 @@ function addToTable(table) {
     }
 
     const tableMap = {
-        plagiarism: ['plagiarism-table-body', 'plagiarism_user_id', 'g_id', 'marks'],
+        plagiarism: ['plagiarism-table-body', 'plagiarism-user-id', 'g_id', 'marks'],
         manualGrade: ['manual-grading-table-body', 'manual-grading-user-id', 'manual-grading-grade', 'manual-grading-note'],
     };
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The _Penalties for Academic Dishonesty and Plagiarism_ was partially refactored when the _Manual Grading_ table was added. There were a few portions that were missed leading to a loss of functionality of the _Penalties for Academic Dishonesty and Plagiarism_ table

### What is the new behavior?
_Penalties for Academic Dishonesty and Plagiarism_ table works.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
