### PR TITLE
[Feature:HelpQueue] Fix queue notification trigger

### DIFF
--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -173,13 +173,13 @@
       alert("This browser does not support desktop notification");
     }
     else if (Notification.permission === "granted") {
-      new Notification("Notifications have been enabled. You will be notified when a student joins a previously inactive queue.");
+      new Notification("Notifications have been enabled. You will be notified when a student joins a queue.");
       setNotificationState(true);
     }
     else if (Notification.permission !== "denied") {
       Notification.requestPermission().then(function (permission) {
         if (permission === "granted") {
-          new Notification("Notifications have been enabled. You will be notified when a student joins a previously inactive queue.");
+          new Notification("Notifications have been enabled. You will be notified when a student joins a queue.");
           setNotificationState(true);
         }else{
           setNotificationState(false);
@@ -251,29 +251,24 @@
       }
   }
 
-  let wasQueueEmpty = true;
 
   function updateCurrentQueue() {
-      const queue_empty_before = $('.help_btn:visible[data-ready="true"]').length === 0;
-      const helping_student = $('.finish_helping_btn.btn-success:visible').length > 0;
+    const helping_student = $('.finish_helping_btn.btn-success:visible').length > 0;
 
-      $.get("{{base_url}}/current_queue", function(newQueue) {
-          $("#current_queue").replaceWith(newQueue);
-          filterQueues();
+    $.get("{{base_url}}/current_queue", function(newQueue) {
+        $("#current_queue").replaceWith(newQueue);
+        filterQueues();
 
-          const queue_empty_after = $('.help_btn:visible[data-ready="true"]').length === 0;
-
-          if (queue_empty_before && !queue_empty_after && !helping_student) {
-              if (push_notifications_enabled) {
-                  new Notification("A student is now waiting for help.");
-              }
-              if (window.audible_notifications_enabled) {
-                  window.notificationSound.play();
-              }
-          }
-          wasQueueEmpty = queue_empty_after;
-      });
-  }
+        if (!helping_student) {
+            if (push_notifications_enabled) {
+                new Notification("A student has joined the queue.");
+            }
+            if (window.audible_notifications_enabled) {
+                window.notificationSound.play();
+            }
+        }
+    });
+}
 
   function updateQueueStatus() {
       $.get("{{base_url}}/new_status", function(newStatus) {

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -252,7 +252,7 @@
   }
 
 
-  let wasQueueEmpty = 0;
+  let previousQueueLength = $('.help_btn:visible[data-ready="true"]').length;
 
   function updateCurrentQueue() {
     const helping_student = $('.finish_helping_btn.btn-success:visible').length > 0;
@@ -261,9 +261,9 @@
         $("#current_queue").replaceWith(newQueue);
         filterQueues();
 
-        const currentQueueCount = $('.help_btn:visible[data-ready="true"]').length;
+        const currentQueueLength = $('.help_btn:visible[data-ready="true"]').length;
 
-        if (currentQueueCount > wasQueueEmpty && !helping_student) {
+        if (currentQueueLength > previousQueueLength && !helping_student) {
             if (push_notifications_enabled) {
                 new Notification("A student has joined the queue.");
             }
@@ -271,7 +271,7 @@
                 window.notificationSound.play();
             }
         }
-        wasQueueEmpty = currentQueueCount;
+        previousQueueLength = currentQueueLength;
     });
 }
 

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -251,24 +251,28 @@
       }
   }
 
+  let wasQueueEmpty = true;
+
   function updateCurrentQueue() {
-      var queue_empty_before = $( '.help_btn:visible[data-ready="true"]' ).length === 0;
+      const queue_empty_before = $('.help_btn:visible[data-ready="true"]').length === 0;
+      const helping_student = $('.finish_helping_btn.btn-success:visible').length > 0;
 
       $.get("{{base_url}}/current_queue", function(newQueue) {
           $("#current_queue").replaceWith(newQueue);
           filterQueues();
 
-          var queue_empty_after = $( '.help_btn:visible[data-ready="true"]' ).length === 0;
-          var helping_student = $( '.finish_helping_btn.btn-success:visible').length > 0;
+          const queue_empty_after = $('.help_btn:visible[data-ready="true"]').length === 0;
 
-          if(push_notifications_enabled && queue_empty_before && !queue_empty_after && !helping_student) {
-              new Notification("A student is now waiting for help.");
+          if (queue_empty_before && !queue_empty_after && !helping_student) {
+              if (push_notifications_enabled) {
+                  new Notification("A student is now waiting for help.");
+              }
+              if (window.audible_notifications_enabled) {
+                  window.notificationSound.play();
+              }
           }
+          wasQueueEmpty = queue_empty_after;
       });
-
-      if (window.audible_notifications_enabled) {
-          window.notificationSound.play();
-      }
   }
 
   function updateQueueStatus() {

--- a/site/app/templates/officeHoursQueue/QueueFooter.twig
+++ b/site/app/templates/officeHoursQueue/QueueFooter.twig
@@ -252,6 +252,8 @@
   }
 
 
+  let wasQueueEmpty = 0;
+
   function updateCurrentQueue() {
     const helping_student = $('.finish_helping_btn.btn-success:visible').length > 0;
 
@@ -259,7 +261,9 @@
         $("#current_queue").replaceWith(newQueue);
         filterQueues();
 
-        if (!helping_student) {
+        const currentQueueCount = $('.help_btn:visible[data-ready="true"]').length;
+
+        if (currentQueueCount > wasQueueEmpty && !helping_student) {
             if (push_notifications_enabled) {
                 new Notification("A student has joined the queue.");
             }
@@ -267,6 +271,7 @@
                 window.notificationSound.play();
             }
         }
+        wasQueueEmpty = currentQueueCount;
     });
 }
 


### PR DESCRIPTION
Fix #10729 

### What is the current behavior?
In office hour queue, when notification is turned on, it only triggers when student joins an empty queue.
In addition, the sound triggers when student leaves the queue which is pretty unnecessasry.

 <img width="328" alt="image" src="https://github.com/user-attachments/assets/2f987453-aac8-4dc5-84a7-08481340f7ba">

### What is the new behavior?
Now notification triggers whenever student joins a queue and not when they leave.
