### PR TITLE
[Refactor:Developer] Remove key_to_click from buttons

### DIFF
--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -17,15 +17,15 @@
                 {# When adding a new notification setting make sure to add the notification-setting-input or the email-setting-input #}
                 <div class="button-group">
                     <div class="button-row">
-                        <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="checkAll(this)">Subscribe to all notifications</button>
-                        <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional notifications</button>
-                        <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".notification-setting-input" onclick="resetNotification(this)">Reset notification settings</button>
+                        <button type="button" class="notification-setting-button btn btn-default" tabindex="0" data-selector=".notification-setting-input" onclick="checkAll(this)">Subscribe to all notifications</button>
+                        <button type="button" class="notification-setting-button btn btn-default" tabindex="0" data-selector=".notification-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional notifications</button>
+                        <button type="button" class="notification-setting-button btn btn-default" tabindex="0" data-selector=".notification-setting-input" onclick="resetNotification(this)">Reset notification settings</button>
                     </div>
                     {% if email_enabled %}
                         <div class="button-row">
-                            <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="checkAll(this)">Subscribe to all emails</button>
-                            <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional emails</button>
-                            <button type="button" class="notification-setting-button btn btn-default key_to_click" tabindex="0" data-selector=".email-setting-input" onclick="resetNotification(this)">Reset email settings</button>
+                            <button type="button" class="notification-setting-button btn btn-default" tabindex="0" data-selector=".email-setting-input" onclick="checkAll(this)">Subscribe to all emails</button>
+                            <button type="button" class="notification-setting-button btn btn-default" tabindex="0" data-selector=".email-setting-input" onclick="unCheckAll(this)">Unsubscribe from all optional emails</button>
+                            <button type="button" class="notification-setting-button btn btn-default" tabindex="0" data-selector=".email-setting-input" onclick="resetNotification(this)">Reset email settings</button>
                         </div>
                     {% endif %}
                 </div>

--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -17,7 +17,7 @@
             <div class="card-btn-cont">
                 <button id="grade-summaries-button"
                         onclick="location.href='{{ summaries_url }}'"
-                        class="btn btn-primary key_to_click"
+                        class="btn btn-primary"
                         tabindex="0"
                 >
                     Generate Grade Summaries
@@ -34,7 +34,7 @@
             </div>
             <div class="card-btn-cont">
                 <button onclick="location.href='{{ csv_url }}'"
-                        class="btn btn-primary key_to_click"
+                        class="btn btn-primary"
                         tabindex="0"
                 >
                     Generate CSV Report
@@ -54,7 +54,7 @@
             </div>
             <div class="card-btn-cont">
                 <button onclick="location.href='{{ rainbow_grades_customization_url }}'"
-                        class="btn btn-primary key_to_click"
+                        class="btn btn-primary"
                         tabindex="0"
                 >
                     Web-Based Rainbow Grades Generation
@@ -74,7 +74,7 @@
                     
                             <button
                                 id="btn-upload-customization"
-                                class="btn btn-primary key_to_click"
+                                class="btn btn-primary"
                                 tabindex="0"
                                 type="button"
                             >

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableBase.twig
@@ -54,8 +54,8 @@
         </div>
         <br/>
         <div id="nav-controls">
-            <!--<button class="btn btn-primary key_to_click" tabindex="0" id="next_button" onClick="onChangeNavTab(adminGradeableNavTab+1);" style="margin-right:10px; float: right;">Next</button>
-            <button class="btn btn-primary key_to_click" tabindex="0" id="prev_button" onClick="onChangeNavTab(adminGradeableNavTab-1);" style="margin-right:10px; float: right;">Previous</button>-->
+            <!--<button class="btn btn-primary" tabindex="0" id="next_button" onClick="onChangeNavTab(adminGradeableNavTab+1);" style="margin-right:10px; float: right;">Next</button>
+            <button class="btn btn-primary" tabindex="0" id="prev_button" onClick="onChangeNavTab(adminGradeableNavTab-1);" style="margin-right:10px; float: right;">Previous</button>-->
             <!--<button class="btn btn-primary" type="submit" style="margin-right:10px; float: right;">Discard Changes</button>-->
         </div>
     </form>

--- a/site/app/templates/admin/late_day_cache/LateDayCacheBase.twig
+++ b/site/app/templates/admin/late_day_cache/LateDayCacheBase.twig
@@ -9,8 +9,8 @@
         </div>
 
         <div class="column-wrapper">
-            <button class="btn btn-default key_to_click" tabindex="0" id="calculate-btn" onclick="calculateLateDayCache()">Calculate Info</button>
-            <button class="btn btn-danger key_to_click" tabindex="0" id="flush-btn" onclick="flushLateDayCache()">Delete All</button>
+            <button class="btn btn-default" tabindex="0" id="calculate-btn" onclick="calculateLateDayCache()">Calculate Info</button>
+            <button class="btn btn-danger" tabindex="0" id="flush-btn" onclick="flushLateDayCache()">Delete All</button>
             </form>
         </div>
     </div>

--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -90,7 +90,7 @@ $( document ).ready(function() {
                                 <div class="no-border-box md-4">
                                     <div class="btn-annotation">
                                         <a class="btn btn-success key_to_click" style="margin-right:20px;" tabindex="0" onclick="openUrl('{{ student_pdf_view_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}&anon_path={{ file.anon_path|url_encode }}')">View Popup <i class="fas fa-window-restore"></i></a>
-                                        <button class = 'btn btn-default key_to_click' style="margin-right:20px;" onclick='downloadStudentAnnotations("{{ student_pdf_download_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}&anon_path={{ file.anon_path|url_encode }}&student_id={{ user_id }}", "{{file.path|url_encode}}", "annotated_pdfs")' aria-label="Download the file"> Download  
+                                        <button class = 'btn btn-default' style="margin-right:20px;" onclick='downloadStudentAnnotations("{{ student_pdf_download_url }}?filename={{ file.name }}&path={{ file.path|url_encode }}&anon_path={{ file.anon_path|url_encode }}&student_id={{ user_id }}", "{{file.path|url_encode}}", "annotated_pdfs")' aria-label="Download the file"> Download  
                                         <i class="fas fa-download" title="Download the file"></i></button>
                                     </div>
                                 </div>
@@ -110,7 +110,7 @@ $( document ).ready(function() {
     {% elseif grade_inquiry_available %}
         <i>Grade inquiries are due by</i> <b>{{ grade_inquiry_due_date|date(date_time_format)  }}</b>
         <div id="ShowGradeInquiryButton">
-            <button type="button" title="Open Grade Inquiry" onclick="$('#gradeInquiryBoxSection').show();$([document.documentElement, document.body]).animate({scrollTop: $('#gradeInquiryBoxSection').offset().top}, 1000);$(this).hide()" style="margin-right:10px;" class="btn btn-default key_to_click" tabindex="0">Open Grade Inquiry</button>
+            <button type="button" title="Open Grade Inquiry" onclick="$('#gradeInquiryBoxSection').show();$([document.documentElement, document.body]).animate({scrollTop: $('#gradeInquiryBoxSection').offset().top}, 1000);$(this).hide()" style="margin-right:10px;" class="btn btn-default" tabindex="0">Open Grade Inquiry</button>
         </div>
     {% elseif is_grade_inquiry_ended %}
         <i>Grade inquiries closed on</i> <b>{{ grade_inquiry_due_date|date(date_time_format)  }}</b>

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -75,7 +75,7 @@
     {% endif %}
 
     <span class="upduck-container">
-        <button data-testid="upduck-button" class="upduck-button text-decoration-none key_to_click" tabindex="0" onClick="toggleLike({{post.id}}, '{{current_user}}')" title="Like the post">
+        <button data-testid="upduck-button" class="upduck-button text-decoration-none" tabindex="0" onClick="toggleLike({{post.id}}, '{{current_user}}')" title="Like the post">
             <img id="likeIcon_{{post.id}}" src="{{ post_up_duck.upduck_user_liked ? '/img/on-duck-button.svg' : '/img/light-mode-off-duck.svg' }}" alt="Like" width="30" height="30">
         </button>
         <span data-testid="like-count" id="likeCounter_{{post.id}}" class="like-counter">{{ post_up_duck.upduck_count }}</span>

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -50,7 +50,7 @@
             
                 </script>
 
-                <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm key_to_click" tabindex="0">
+                <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm" tabindex="0">
                     <i class="fas fa-plus-circle fa-1x"></i> Add category
                 </button>
             </span>

--- a/site/app/templates/generic/Popup.twig
+++ b/site/app/templates/generic/Popup.twig
@@ -12,7 +12,7 @@
                             <button
                                 data-testid="close-button"
                                 onclick="{{ block('close_click_action') }}"
-                                class="btn btn-default close-button key_to_click"
+                                class="btn btn-default close-button"
                                 tabindex="-1" type="button"
                             >Close</button>
                         {% endblock %}

--- a/site/app/templates/grading/electronic/AutogradingPanel.twig
+++ b/site/app/templates/grading/electronic/AutogradingPanel.twig
@@ -3,7 +3,7 @@
     <div>
         <span class="grading_label">Autograding Testcases</span>
         <button id="autograding-results-open-all" class="btn btn-default" tabindex="0">Expand All</button>
-        <button id="autograding-results-close-all" class="btn btn-default " tabindex="0">Close All</button>
+        <button id="autograding-results-close-all" class="btn btn-default" tabindex="0">Close All</button>
         {% if can_regrade %}
             <div class="btn-group">
                 <button id="autograding-results-regrade-active" type="button" class="btn btn-primary">Regrade Active Version</button>

--- a/site/app/templates/grading/electronic/AutogradingPanel.twig
+++ b/site/app/templates/grading/electronic/AutogradingPanel.twig
@@ -2,8 +2,8 @@
 <div id="autograding_results" class="rubric_panel" data-highest-version="{{ highest_version }}" data-gradeable-id="{{ gradeable_id }}" data-user-id="{{ user_id }}" data-testid="autograding-results">
     <div>
         <span class="grading_label">Autograding Testcases</span>
-        <button id="autograding-results-open-all" class="btn btn-default key_to_click" tabindex="0">Expand All</button>
-        <button id="autograding-results-close-all" class="btn btn-default key_to_click" tabindex="0">Close All</button>
+        <button id="autograding-results-open-all" class="btn btn-default" tabindex="0">Expand All</button>
+        <button id="autograding-results-close-all" class="btn btn-default " tabindex="0">Close All</button>
         {% if can_regrade %}
             <div class="btn-group">
                 <button id="autograding-results-regrade-active" type="button" class="btn btn-primary">Regrade Active Version</button>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -90,7 +90,7 @@
             >Export Teams Members</a>
         {% endif %}
         {% if show_export_teams_button %}
-            <button class="btn btn-primary key_to_click"
+            <button class="btn btn-primary"
                     tabindex="0"
                     onclick="importTeamForm();"
             >
@@ -102,7 +102,7 @@
         {# Randomize team button #}
         {% if (not gradeable.isGradeByRegistration()) and (show_export_teams_button or show_import_teams_button) %}
             {% if past_grade_start_date %}
-                <button class="btn btn-default key_to_click"
+                <button class="btn btn-default"
                         tabindex="0"
                         data-testid="randomly-reassign-teams"
                         onclick="randomizeRotatingGroupsButton()"

--- a/site/app/templates/grading/electronic/GradingPanelHeader.twig
+++ b/site/app/templates/grading/electronic/GradingPanelHeader.twig
@@ -23,7 +23,7 @@
     <div class="panel-header-box">
         <span class="grade-panel" id="autograding_results_btn">
             <button title="Show/Hide Autograding Testcases (Press A)"
-                    class="invisible-btn key_to_click"
+                    class="invisible-btn"
                     tabindex="0"
                     data-testid="show-autograding"
             >
@@ -33,7 +33,7 @@
         </span>
         <span class="grade-panel" id="grading_rubric_btn" data-testid="grading-rubric-btn">
             <button title="Show/Hide Grading Rubric (Press G)"
-                    class="invisible-btn key_to_click"
+                    class="invisible-btn"
                     tabindex="0"
             >
                 <i class="fas fa-edit"></i><span>Rubric</span>
@@ -42,7 +42,7 @@
         </span>
         <span class="grade-panel" id="submission_browser_btn" data-testid="submission-browser-btn">
             <button title="Show/Hide Submission and Results Browser (Press O)"
-                    class="invisible-btn key_to_click"
+                    class="invisible-btn"
                     tabindex="0"
                     data-testid="show-submission"
             >
@@ -53,7 +53,7 @@
         {% if isStudentInfoPanel %}
             <span class="grade-panel" id="student_info_btn" data-testid="student-info-btn">
                 <button title="Show/Hide Student Information (Press S)"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                 >
                     <i class="fas fa-user"></i><span>Student Info</span>
@@ -63,7 +63,7 @@
         {% endif %}
         <span class="grade-panel" id="solution_ta_notes_btn" data-testid="solution-ta-notes-btn">
             <button title="Show Solution and TA notes"
-                    class="invisible-btn key_to_click"
+                    class="invisible-btn"
                     tabindex="0"
             >
                 <i class="fas fa-check"></i><span>Solutions/Notes</span>
@@ -73,7 +73,7 @@
         {% if isPeerPanel %}
             <span class="grade-panel" id="peer_info_btn" data-testid="peer-info-btn">
                 <button title="Show/Hide Peer Information (Press P)"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                 >
                     <i class="fas fa-users"></i><span>Peer</span>
@@ -84,7 +84,7 @@
         {% if isDiscussionPanel %}
             <span class="grade-panel" id="discussion_browser_btn" data-testid="discussion-browser-btn">
                 <button title="Show/Hide Discussion Posts"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                 >
                     <i class="fas fa-comment-alt"></i><span>Discussion</span>
@@ -95,7 +95,7 @@
         {% if isGradeInquiryPanel and not student_grader %}
             <span class="grade-panel" id="grade_inquiry_info_btn" data-testid="grade-inquiry-info-btn">
                 <button title="Show/Hide Grade Inquiry Information (Press X)"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                 >
                    <i class="fas {{ grade_inquiry_pending is defined ? 'fa-exclamation' : 'fa-hand-paper' }} grade_inquiry_icon"></i>

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -52,7 +52,7 @@
             </span>
             <span class="ta-navlink-cont" id="fullscreen-btn-cont">
                 <button title="Toggle the full screen mode"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="toggleFullScreenMode();"
                 >
@@ -62,7 +62,7 @@
             </span>
             <span class="ta-navlink-cont" id="two-panel-mode-btn">
                 <button title="Toggle the two panel mode"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="togglePanelSelectorModal(true);"
                 >
@@ -71,7 +71,7 @@
             </span>
             <span class="ta-navlink-cont" id="two-panel-exchange-btn">
                 <button title="Exchange the panel positions"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="exchangeTwoPanels();"
                 >
@@ -81,7 +81,7 @@
 
             <span class="ta-navlink-cont" id="grading-setting-btn"  data-testid="grading-setting-btn">
                 <button title="Show Grading Settings"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="showSettings();"
                 >

--- a/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
+++ b/site/app/templates/grading/electronic/PDFAnnotationEmbedded.twig
@@ -14,7 +14,7 @@
 <!-- Provide template of download / view all button to copy over to toolbar since this page is the only one that gets the necessary info -->
 <template id="permission-annotations-btn-template">
     {% if can_download is defined and can_download %}
-        <button id="download-annotations-btn" class='btn btn-default key_to_click' aria-label="Download the file" data-testid="download-annotations-btn">
+        <button id="download-annotations-btn" class='btn btn-default' aria-label="Download the file" data-testid="download-annotations-btn">
             Download <i class="fas fa-download" title="Download the file"></i>
         </button>
         <button id="toggle-annotations-btn" aria-label="Toggle Annotations" value="toggle-annotations" class="btn btn-default toolbar-action" data-testid="toggle-annotations-btn">Show All Annotations <i class="fas fa-eye"></i></button>

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -36,7 +36,7 @@
                         $('#' + currentCodeStyleRadio).prop('checked', true);
                     });
                 </script>
-                <button class="btn btn-default key_to_click" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
+                <button class="btn btn-default" tabindex="0" onclick="downloadSubmissionZip('{{  gradeable_id }}','{{ anon_submitter_id }}', {{ active_version }}, null, true)">Download Zip File</button>
 
                 <span style="padding-right: 10px; white-space: nowrap;"> <input aria-label="Auto open" type="checkbox" id="autoscroll_id" onclick="updateCookies();" class="key_to_click" tabindex="0"> <label for="autoscroll_id">Auto open</label> </span>
             </span>

--- a/site/app/templates/grading/popup_refactor/NavigationBar.twig
+++ b/site/app/templates/grading/popup_refactor/NavigationBar.twig
@@ -50,7 +50,7 @@
             </span>
             <span class="ta-navlink-cont" id="fullscreen-btn-cont">
                 <button title="Toggle the full screen mode"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="toggleFullScreenMode();"
                 >
@@ -60,7 +60,7 @@
             </span>
             <span class="ta-navlink-cont" id="two-panel-mode-btn">
                 <button title="Toggle the two panel mode"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="togglePanelSelectorModal(true);"
                 >
@@ -69,7 +69,7 @@
             </span>
             <span class="ta-navlink-cont" id="two-panel-exchange-btn">
                 <button title="Exchange the panel positions"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="exchangeTwoPanels();"
                 >
@@ -79,7 +79,7 @@
 
             <span class="ta-navlink-cont" id="grading-setting-btn">
                 <button title="Show Grading Settings"
-                        class="invisible-btn key_to_click"
+                        class="invisible-btn"
                         tabindex="0"
                         onclick="showSettings();"
                 >

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -19,8 +19,8 @@
         </div>
 
         <div>
-            <button class="btn btn-primary key_to_click" tabindex="0" id="settings-btn" onclick='showSettings()'>Settings/Hotkeys</button>
-            <button class="btn btn-primary key_to_click" tabindex="0" id="simple-stats-btn" onclick='showSimpleGraderStats("{{ action }}")'>View Statistics</button>
+            <button class="btn btn-primary" tabindex="0" id="settings-btn" onclick='showSettings()'>Settings/Hotkeys</button>
+            <button class="btn btn-primary" tabindex="0" id="simple-stats-btn" onclick='showSimpleGraderStats("{{ action }}")'>View Statistics</button>
         </div>
     </div>
 

--- a/site/app/templates/misc/MarkdownArea.twig
+++ b/site/app/templates/misc/MarkdownArea.twig
@@ -54,8 +54,8 @@
 <div class="markdown-area fill-available {{ root_class|default('') ? root_class : '' }}">
     <div {{ markdown_header_id is defined ? 'id=' ~ markdown_header_id: ''}}  class="markdown-area-header" style="display: {{ render_header|default(false) ? "flex" : "none" }}" data-mode="edit">
         <div class="markdown-mode-buttons">
-            <button title="Edit Markdown" type="button" onclick="previewMarkdown.call(this, 'edit')" class="markdown-mode-tab markdown-write-mode active key_to_click" data-testid="markdown-mode-tab-write">Write</button>
-            <button title="Preview Markdown" type="button" onclick="previewMarkdown.call(this, 'preview')" class="markdown-mode-tab markdown-preview-mode key_to_click" tabindex="0" data-initialize-preview="{{initialize_preview|default(false)}}" data-testid="markdown-mode-tab-preview">
+            <button title="Edit Markdown" type="button" onclick="previewMarkdown.call(this, 'edit')" class="markdown-mode-tab markdown-write-mode active" data-testid="markdown-mode-tab-write">Write</button>
+            <button title="Preview Markdown" type="button" onclick="previewMarkdown.call(this, 'preview')" class="markdown-mode-tab markdown-preview-mode" tabindex="0" data-initialize-preview="{{initialize_preview|default(false)}}" data-testid="markdown-mode-tab-preview">
                 Preview
             </button>
         </div>
@@ -63,11 +63,11 @@
             <a target="_blank" href="https://submitty.org/student/communication/markdown">
                 <i style="font-style:normal;" class="fa-question-circle"></i>
             </a>
-            <button type="button" title="Insert a link" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'link')" class="btn btn-default btn-markdown btn-markdown-link key_to_click"  tabindex="0">Link <i class="fas fa-link fa-1x"></i></button>
-            <button title="Insert a code segment" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'code')" class="btn btn-default btn-markdown btn-markdown-code key_to_click"  tabindex="0">Code <i class="fas fa-code fa-1x"></i></button>
-            <button title="Insert bold text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'bold')" class="btn btn-default btn-markdown btn-markdown-bold key_to_click"  tabindex="0">Bold <i class="fas fa-bold fa-1x"></i></button>
-            <button title="Insert italic text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'italic')" class="btn btn-default btn-markdown btn-markdown-italic key_to_click"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
-            <button title="Insert blockquote text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'blockquote')" class="btn btn-default btn-markdown btn-markdown-blockquote key_to_click" tabindex="0">Blockquote <i class="fas fa-quote-left fa-1x"></i></button>
+            <button type="button" title="Insert a link" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'link')" class="btn btn-default btn-markdown btn-markdown-link"  tabindex="0">Link <i class="fas fa-link fa-1x"></i></button>
+            <button title="Insert a code segment" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'code')" class="btn btn-default btn-markdown btn-markdown-code"  tabindex="0">Code <i class="fas fa-code fa-1x"></i></button>
+            <button title="Insert bold text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'bold')" class="btn btn-default btn-markdown btn-markdown-bold"  tabindex="0">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button title="Insert italic text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'italic')" class="btn btn-default btn-markdown btn-markdown-italic"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
+            <button title="Insert blockquote text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'blockquote')" class="btn btn-default btn-markdown btn-markdown-blockquote" tabindex="0">Blockquote <i class="fas fa-quote-left fa-1x"></i></button>
         </div>
     </div>
     <div class="markdown-area-body">

--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -89,7 +89,7 @@
             <input type="submit" value = "Invite" class="btn btn-primary" />
         </form>
         <br />
-        <button class="btn btn-danger key_to_click" tabindex="0" onclick="location.href='{{ leave_team_url }}'">Leave Team</button>
+        <button class="btn btn-danger" tabindex="0" onclick="location.href='{{ leave_team_url }}'">Leave Team</button>
     </div>
 {% elseif team == null %}
     <div class="content">
@@ -110,13 +110,13 @@
 
         {# Create new team button #}
         <br />
-        <button class="btn btn-primary key_to_click" id="create_new_team" tabindex="0" onclick="location.href='{{ create_team_url }}'">Create New Team </button>
+        <button class="btn btn-primary" id="create_new_team" tabindex="0" onclick="location.href='{{ create_team_url }}'">Create New Team </button>
 
         {% if lock == false %}
             {% if seeking_partner %}
-                &nbsp;or&nbsp;<button class="btn btn-danger key_to_click" tabindex="0" onclick="location.href='{{ stop_seek_url }}'">Stop Seeking Team/Partner </button>
+                &nbsp;or&nbsp;<button class="btn btn-danger" tabindex="0" onclick="location.href='{{ stop_seek_url }}'">Stop Seeking Team/Partner </button>
             {% else %}
-                &nbsp;or&nbsp;<button class="btn btn-primary key_to_click" tabindex="0" onclick="location.href='{{ seek_url }}'">Seek Team/Partner </button>
+                &nbsp;or&nbsp;<button class="btn btn-primary" tabindex="0" onclick="location.href='{{ seek_url }}'">Seek Team/Partner </button>
                 <br>
             {% endif %}
         {% endif %}

--- a/site/app/templates/submission/grade_inquiry/Discussion.twig
+++ b/site/app/templates/submission/grade_inquiry/Discussion.twig
@@ -76,43 +76,43 @@
                         <div id="grade-inquiry-actions" class="row" style="justify-content: flex-end" data-testid="grade-inquiry-actions">
                             {% if grade_inquiries[component.id] is not defined%}
                                 {# No request yet #}
-                                <button disabled type="button" formaction="{{ grade_inquiry_url }}" class="gi-submit btn btn-primary key_to_click" data-testid="submit-inquiry" tabindex="0" style="float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ grade_inquiry_url }}" class="gi-submit btn btn-primary" data-testid="submit-inquiry" tabindex="0" style="float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Submit Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status is defined and grade_inquiries[component.id].status == -1 and is_grading %}
                                 {# Grader view,request is open #}
-                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Post Additional Information
                                 </button>
-                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit gi-show-not-empty btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit gi-show-not-empty btn btn-primary" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Respond and Close Grade Inquiry
                                 </button>
-                                <button type="button" id="grading-close" formaction="{{ change_request_status_url }}" class="gi-submit-empty gi-show-empty btn btn-default key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button type="button" id="grading-close" formaction="{{ change_request_status_url }}" class="gi-submit-empty gi-show-empty btn btn-default" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Close Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status is defined and grade_inquiries[component.id].status == -1 %}
                                 {# Request pending, we can submit new posts #}
-                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Post Additional Information
                                 </button>
-                                <button type="button" formaction="{{ change_request_status_url }}" class="gi-submit-empty btn btn-default key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button type="button" formaction="{{ change_request_status_url }}" class="gi-submit-empty btn btn-default" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Close Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status is defined and grade_inquiries[component.id].status == 0 and is_grading %}
                                 {# Grader view, Request closed #}
                                 {# Letting Instructor reply(comment) to the inquiry without reopening the grade_inquiry #}
-                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ make_request_post_url }}" class="gi-submit btn btn-primary" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Add Comment
                                 </button>
-                                <button type="button" formaction="{{ change_request_status_url }}" class="gi-show-not-empty btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button type="button" formaction="{{ change_request_status_url }}" class="gi-show-not-empty btn btn-primary" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Respond and Reopen Grade Inquiry
                                 </button>
-                                <button type="button" formaction="{{ change_request_status_url }}" class="gi-show-empty btn btn-primary key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button type="button" formaction="{{ change_request_status_url }}" class="gi-show-empty btn btn-primary" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Reopen Grade Inquiry
                                 </button>
                             {% elseif grade_inquiries[component.id].status is defined and grade_inquiries[component.id].status == 0 %}
                                 {# Request closed #}
-                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default key_to_click" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
+                                <button disabled type="button" formaction="{{ change_request_status_url }}" class="gi-submit btn btn-default" tabindex="0" style="margin:15px 0 0 5px; float: right" onclick="onGradeInquirySubmitClicked(this)">
                                     Reopen Grade Inquiry
                                 </button>
                             {% endif %}

--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -6,8 +6,8 @@
     {% endif %}
 
     <div style="text-align:center;margin:10px;padding:5px;">
-        <button type="button" id="bulk_submit_all" class="btn btn-primary key_to_click" tabindex="0" onclick="submitAll(1)">Submit All Uploaded PDFS</button>
-        <button type="button" id="bulk_delete_all" class="btn btn-default key_to_click" tabindex="0" onclick="confirmDeleteAll()">Delete All Uploaded PDFS</button>
+        <button type="button" id="bulk_submit_all" class="btn btn-primary" tabindex="0" onclick="submitAll(1)">Submit All Uploaded PDFS</button>
+        <button type="button" id="bulk_delete_all" class="btn btn-default" tabindex="0" onclick="confirmDeleteAll()">Delete All Uploaded PDFS</button>
     </div>
 
     <table class="table table-striped table-bordered persist-area">
@@ -95,11 +95,11 @@
                             {{ file["page_count"] }}
                         </td>
                         <td>
-                            <button type="button" id="bulk_submit_{{ loop.index }}" class="btn btn-primary key_to_click" tabindex="0"
+                            <button type="button" id="bulk_submit_{{ loop.index }}" class="btn btn-primary" tabindex="0"
                             onclick="uploadSplit( {{ loop.index }} )">Submit</button>
                         </td>
                         <td>
-                            <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default key_to_click" tabindex="0" onclick="deleteSplit({{ loop.index }})">Delete</button>
+                            <button type="button" id="bulk_delete_{{ loop.index }}" class="btn btn-default" tabindex="0" onclick="deleteSplit({{ loop.index }})">Delete</button>
                         </td>
                     </tr>
                 {% endif %}

--- a/site/app/templates/submission/homework/BulkUploadProgressBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadProgressBox.twig
@@ -1,6 +1,6 @@
 <div class="content" id="bulk_progress_box">
 	<h2>Bulk upload processing progress
-		<button onClick="window.location.reload()" id="refresh_btn" style="margin:15px;" class="btn btn-default key_to_click" tabindex="0" disabled>Refresh</button>
+		<button onClick="window.location.reload()" id="refresh_btn" style="margin:15px;" class="btn btn-default" tabindex="0" disabled>Refresh</button>
 	</h2>
 	<div>
 		<h3 style="float:left;">Processing</h3>

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -21,10 +21,10 @@
                             <div>
                                 {% set extension = file.relative_name|split('.')|last|lower %}
                                 {% if extension in ['pdf', 'jpg', 'jpeg', 'c', 'cpp', 's', 'twig', 'py', 'java', 'png', 'txt', 'h', 'html', 'php', 'js', 'sql', 'sh', 'md', 'csv', 'salsa', 'erl', 'oz', 'pl', 'hs', 'gif', 'ipynb'] %}
-                                    <button class = 'btn btn-default key_to_click' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window"> View
+                                    <button class = 'btn btn-default' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window"> View
                                         <i class="fas fa-window-restore" title="Pop up the file in a new window"></i></button>
                                 {% endif %}
-                                <button class = 'btn btn-primary key_to_click' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
+                                <button class = 'btn btn-primary' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
                                     <i class="fas fa-download" title="Download the file"></i></button>
                             </div>
                         {% endif %}
@@ -35,9 +35,8 @@
                 <br />
                 <div class="flex-row">
                     <span>Download all files:</span>
-                     <button class = 'btn btn-primary key_to_click' 
+                     <button class = 'btn btn-primary' 
                         onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ submitter_id }}", "{{ display_version }}", "submission")'
-                        class="key_to_click"
                         tabindex="0"
                         aria-label="Download"
                         > Download all files

--- a/site/app/templates/submission/homework/leaderboard/Leaderboard.twig
+++ b/site/app/templates/submission/homework/leaderboard/Leaderboard.twig
@@ -13,7 +13,7 @@
     <div class="leaderboard-tab-bar-wrapper">
         <div class="btn-group" role="group" aria-label="Switch leaderboards">
             {% for leaderboard in leaderboards %}
-                <button type="button" class="leaderboard-nav key_to_click btn btn-secondary" id="{{leaderboard.getTag}}_nav" onclick="onChangeLeaderboard('{{leaderboard.getTag}}');">{{leaderboard.getTitle}}</button>
+                <button type="button" class="leaderboard-nav btn btn-secondary" id="{{leaderboard.getTag}}_nav" onclick="onChangeLeaderboard('{{leaderboard.getTag}}');">{{leaderboard.getTitle}}</button>
             {% endfor %}
         </div>
     </div>

--- a/site/public/templates/grading/settings/HotkeyList.twig
+++ b/site/public/templates/grading/settings/HotkeyList.twig
@@ -12,11 +12,11 @@
                     <button id="remap-{{ loop.index0 }}" data-testid="remap-{{ loop.index0 }}" class="btn btn-default remap-button" disabled="disabled">{{ hotkey.code }}</button>
                 {% else %}
                     {% set class = (hotkey.code == hotkey.originalCode) ? "btn-default" : "btn-primary" %}
-                    <button id="remap-{{ loop.index0 }}" data-testid="remap-{{ loop.index0 }}" class="btn {{ class }} remap-button remap-disable key_to_click" tabindex="0" onclick="remapHotkey({{ loop.index0 }});">{{ hotkey.code }}</button>
+                    <button id="remap-{{ loop.index0 }}" data-testid="remap-{{ loop.index0 }}" class="btn {{ class }} remap-button remap-disable" tabindex="0" onclick="remapHotkey({{ loop.index0 }});">{{ hotkey.code }}</button>
                 {% endif %}
             </td>
             <td class="button-cell" style="display: flex; justify-content: center; align-items: center;">
-                <button id="remap-unset-{{ loop.index0 }}" data-testid="remap-unset-{{ loop.index0 }}" class="btn btn-danger remap-disable key_to_click" tabindex="0" onclick="remapUnset({{ loop.index0 }});">&times;</button>
+                <button id="remap-unset-{{ loop.index0 }}" data-testid="remap-unset-{{ loop.index0 }}" class="btn btn-danger remap-disable" tabindex="0" onclick="remapUnset({{ loop.index0 }});">&times;</button>
             </td>
         </tr>
     {% endfor %}

--- a/site/public/templates/misc/MarkdownArea.twig
+++ b/site/public/templates/misc/MarkdownArea.twig
@@ -54,17 +54,17 @@
 <div class="markdown-area fill-available {{ root_class|default('') ? root_class : '' }}">
     <div {{ markdown_header_id is defined ? 'id=' ~ markdown_header_id: ''}}  class="markdown-area-header" style="display: {{ render_header|default(false) ? "flex" : "none" }}" data-mode="edit">
         <div class="markdown-mode-buttons">
-            <button title="Edit Markdown" type="button" onclick="previewMarkdown.call(this, 'edit')" class="markdown-mode-tab markdown-write-mode active key_to_click">Write</button>
-            <button title="Preview Markdown" type="button" onclick="previewMarkdown.call(this, 'preview')" class="markdown-mode-tab markdown-preview-mode key_to_click" tabindex="0" data-initialize-preview="{{initialize_preview|default(false)}}">Preview</button>
+            <button title="Edit Markdown" type="button" onclick="previewMarkdown.call(this, 'edit')" class="markdown-mode-tab markdown-write-mode active">Write</button>
+            <button title="Preview Markdown" type="button" onclick="previewMarkdown.call(this, 'preview')" class="markdown-mode-tab markdown-preview-mode" tabindex="0" data-initialize-preview="{{initialize_preview|default(false)}}">Preview</button>
         </div>
         <div class="markdown-area-toolbar">
             <a target="_blank" href="https://submitty.org/student/communication/markdown">
                 <i style="font-style:normal;" class="fa-question-circle"></i>
             </a>
-            <button type="button" title="Insert a link" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'link')" class="btn btn-default btn-markdown btn-markdown-link key_to_click"  tabindex="0">Link <i class="fas fa-link fa-1x"></i></button>
-            <button title="Insert a code segment" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'code')" class="btn btn-default btn-markdown btn-markdown-code key_to_click"  tabindex="0">Code <i class="fas fa-code fa-1x"></i></button>
-            <button title="Insert bold text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'bold')" class="btn btn-default btn-markdown btn-markdown-bold key_to_click"  tabindex="0">Bold <i class="fas fa-bold fa-1x"></i></button>
-            <button title="Insert italic text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'italic')" class="btn btn-default btn-markdown btn-markdown-italic key_to_click"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
+            <button type="button" title="Insert a link" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'link')" class="btn btn-default btn-markdown btn-markdown-link"  tabindex="0">Link <i class="fas fa-link fa-1x"></i></button>
+            <button title="Insert a code segment" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'code')" class="btn btn-default btn-markdown btn-markdown-code"  tabindex="0">Code <i class="fas fa-code fa-1x"></i></button>
+            <button title="Insert bold text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'bold')" class="btn btn-default btn-markdown btn-markdown-bold"  tabindex="0">Bold <i class="fas fa-bold fa-1x"></i></button>
+            <button title="Insert italic text" type="button" onclick="addMarkdownCode.call($('#{{ markdown_area_id }}'), 'italic')" class="btn btn-default btn-markdown btn-markdown-italic"  tabindex="0">Italics <i class="fas fa-italic fa-1x"></i></button>
         </div>
     </div>
     <div class="markdown-area-body">


### PR DESCRIPTION
Per Shail from #7819, remove all uses of `key_to_click` on buttons, where this class is redundant and serves no purpose since the functionality that `key_to_click` implements is the default for buttons.