### PR TITLE
[Refactor:Developer] Remove key_to_click 2

### DIFF
--- a/site/app/templates/admin/Report.twig
+++ b/site/app/templates/admin/Report.twig
@@ -17,7 +17,7 @@
             <div class="card-btn-cont">
                 <button id="grade-summaries-button"
                         onclick="location.href='{{ summaries_url }}'"
-                        class="btn btn-primary key_to_click"
+                        class="btn btn-primary"
                         tabindex="0"
                 >
                     Generate Grade Summaries
@@ -34,7 +34,7 @@
             </div>
             <div class="card-btn-cont">
                 <button onclick="location.href='{{ csv_url }}'"
-                        class="btn btn-primary key_to_click"
+                        class="btn btn-primary"
                         tabindex="0"
                 >
                     Generate CSV Report
@@ -54,7 +54,7 @@
             </div>
             <div class="card-btn-cont">
                 <button onclick="location.href='{{ rainbow_grades_customization_url }}'"
-                        class="btn btn-primary key_to_click"
+                        class="btn btn-primary"
                         tabindex="0"
                 >
                     Web-Based Rainbow Grades Generation
@@ -74,7 +74,7 @@
                     
                             <button
                                 id="btn-upload-customization"
-                                class="btn btn-primary key_to_click"
+                                class="btn btn-primary"
                                 tabindex="0"
                                 type="button"
                             >


### PR DESCRIPTION
This is part 2 of removing key_to_click from button. 
#10740 was missing Reports.twig.
