### PR TITLE
Dump Error Message to Results if no worker can run job

### DIFF
--- a/autograder/autograder/scheduler.py
+++ b/autograder/autograder/scheduler.py
@@ -237,10 +237,12 @@ class FCFSScheduler(BaseScheduler):
                             f"ERROR: no worker compatible with job {job.path}: no worker has "
                             f"capability {job.queue_obj['required_capabilities']}. Removing."
                         )
+                          self._dump_error_to_results(job, error_message)
                     else:
                         self.config.logger.log_message(
                             f"ERROR: could not load queue object for job {job.path}. Removing."
                         )
+                  self._dump_error_to_results(job, error_message)
                     with contextlib.suppress(FileNotFoundError):
                         os.remove(job.path)
                 continue
@@ -248,3 +250,9 @@ class FCFSScheduler(BaseScheduler):
             dest = random.choice(matching_workers)
             shutil.move(job.path, dest.folder)
             idle_workers.remove(dest)
+
+            def _dump_error_to_results(self, job, error_message):
+    results_dir = os.path.join(self.config.submitty['submitty_data_dir'], 'results', job.job_id)
+    os.makedirs(results_dir, exist_ok=True)
+    with open(os.path.join(results_dir, 'error_message.txt'), 'w') as f:
+        f.write(error_message)


### PR DESCRIPTION
Fixes #10737 
### What is the new behavior?
 
These changes implement the TODO by adding a method to dump the error message to the results directory, which will be accessible through the UI. The error message is now written to a file named 'error_message.txt' in the job's results directory
