### PR TITLE
[Bugfix:Forum] Fix forum post preview rendering problem

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -589,6 +589,7 @@
 .thread-content {
     display: block;
     margin-bottom: 0.25em;
+    word-break: break-all;
 }
 
 .attachment-btn {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

Fixes #10722 

In the case post content is around a line long, the rendering for preview is broken.
### What is the current behavior?
<img width="238" alt="image" src="https://github.com/user-attachments/assets/1459cb02-3519-44a9-aff4-cddf28502025">

### What is the new behavior?
Added work break css.
<img width="245" alt="image" src="https://github.com/user-attachments/assets/39e9163f-e7e6-428f-8a8d-c48e5b379f61">
