### PR TITLE
[Feature:RainbowGrades] base_url for rainbowgrades

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -80,6 +80,18 @@ class ReportController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl(['reports']));
         }
 
+        $url_base_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'reports', 'base_url.json');
+        $base_url = $this->core->getConfig()->getBaseUrl();
+
+        // Encode $base_url as a json string
+        $json_data = json_encode(['base_url' => $base_url]);
+
+        // Write the json string to the file
+        if (!file_put_contents($url_base_path, $json_data)) {
+            $this->core->addErrorMessage('Unable to write to base_url.json');
+            $this->core->redirect($this->core->buildCourseUrl(['reports']));
+        }
+
         $g_sort_keys = [
             'type',
             'CASE WHEN submission_due_date IS NOT NULL THEN submission_due_date ELSE g.g_grade_released_date END',


### PR DESCRIPTION
#10433  is related issue. 
In order to add link to submission in Rainbowgrades, we need to know the base_url of the server.
However, generate grade summaries(ggs) does not load url info. 

### What is the new behavior?
With this change, ggs will create/store `base_url.json` in the reports directory. `({$SUBMITTY_DATA_DIR}/courses/{$SEMESTER}/{$COURSE}/reports)`

### To test: 
go to http://localhost:1511/courses/f24/sample/reports
click Generate Grade Summaries -> go to terminal and `cd /var/local/submitty/courses/f24/sample/reports`
see base_url.json -> see the content by `emacs base_url.json`
check base_url is `http://localhost:1511/`

<img width="864" alt="스크린샷 2024-07-23 오후 12 54 04" src="https://github.com/user-attachments/assets/a5ba7f5a-4ca4-42bc-b4fa-1473c5773ec7">

<img width="690" alt="스크린샷 2024-07-23 오후 12 53 50" src="https://github.com/user-attachments/assets/0639c19c-bec0-47a7-9eb7-c997db702751">
