### PR TITLE
[Feature:Submission] Render Jupyter output images

### DIFF
--- a/site/app/libraries/NotebookUtils.php
+++ b/site/app/libraries/NotebookUtils.php
@@ -45,6 +45,39 @@ class NotebookUtils {
                                 'type' => 'output',
                                 'output_text' => implode($output['text'] ?? []),
                             ];
+                        } elseif (($output['output_type'] ?? '') === 'display_data' && isset($output['data'])) {
+                            // Note: SVG files are not supported due to XSS risks
+                            $mime_types = [
+                                'image/png',
+                                'image/jpeg',
+                                'image/gif',
+                                'image/bmp',
+                                'text/plain', // Fall back to text/plain if it is available.
+                            ];
+
+                            $output_type = null;
+                            foreach ($mime_types as $mime_type) {
+                                if (isset($output['data'][$mime_type])) {
+                                    $output_type = $mime_type;
+                                    break;
+                                }
+                            }
+
+                            if ($output_type === 'text/plain') {
+                                // Display output text if we don't know how to render the content otherwise
+                                $cells[] = [
+                                    'type' => 'output',
+                                    'output_text' => $output['data']['text/plain'],
+                                ];
+                            } elseif ($output_type !== null) {
+                                $cells[] = [
+                                    'type' => 'image',
+                                    'image' => 'data:' . $output_type . ';base64, ' . $output['data'][$output_type],
+                                    'width' => 0,
+                                    'height' => 0,
+                                    'alt_text' => $output['data']['text/plain'] ?? '',
+                                ];
+                            }
                         }
                     }
 

--- a/site/app/libraries/NotebookUtils.php
+++ b/site/app/libraries/NotebookUtils.php
@@ -45,7 +45,8 @@ class NotebookUtils {
                                 'type' => 'output',
                                 'output_text' => implode($output['text'] ?? []),
                             ];
-                        } elseif (($output['output_type'] ?? '') === 'display_data' && isset($output['data'])) {
+                        }
+                        elseif (($output['output_type'] ?? '') === 'display_data' && isset($output['data'])) {
                             // Note: SVG files are not supported due to XSS risks
                             $mime_types = [
                                 'image/png',
@@ -69,7 +70,8 @@ class NotebookUtils {
                                     'type' => 'output',
                                     'output_text' => $output['data']['text/plain'],
                                 ];
-                            } elseif ($output_type !== null) {
+                            }
+                            elseif ($output_type !== null) {
                                 $cells[] = [
                                     'type' => 'image',
                                     'image' => 'data:' . $output_type . ';base64, ' . $output['data'][$output_type],

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -36,7 +36,7 @@
             {# Handle if cell is image #}
             {% elseif cell.type == "image" %}
 
-                <img src="{{ attribute(image_data, cell.image) }}"
+                <img src="{{ image_data is defined ? attribute(image_data, cell.image) : cell.image }}"
 
                 {% if cell.width > 0 %}
                     width="{{ cell.width }}"


### PR DESCRIPTION
### What is the current behavior?
#10648 added bare-bones support for viewing Jupyter notebooks in Submitty natively.  As of that PR, only text output is supported. 

### What is the new behavior?
This PR adds image output rendering to our Jupyter notebook support.  As per the [docs](https://jupyterlab.readthedocs.io/en/1.2.x/user/file_formats.html), we still need to implement several other types of output to be able to fully support Jupyter notebooks.  For now, the most common use cases have been covered.

![image](https://github.com/user-attachments/assets/eedc03a6-65b9-42da-a6e4-7890f788617b)

