### PR TITLE
[UI/UX:Submission] Add separators between notebook cells

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -18,7 +18,7 @@
         </div>
     {% endif %}
     {% for cell in notebook %}
-        <div id="content_{{ loop.index0 }}" class="{{ cell.type }}" {% if cell.item_ref is defined %}data-item-ref={{ cell.item_ref }}{% else %}data-non-item-ref={{data_non_item_ref}}{% set data_non_item_ref = data_non_item_ref + 1 %}{% endif %}>
+        <div id="content_{{ loop.index0 }}" class="{{ cell.type }} notebook-cell" {% if cell.item_ref is defined %}data-item-ref={{ cell.item_ref }}{% else %}data-non-item-ref={{data_non_item_ref}}{% set data_non_item_ref = data_non_item_ref + 1 %}{% endif %}>
 
             {# Handle if cell is markdown #}
             {% if cell.type == "markdown" %}
@@ -31,7 +31,7 @@
 
             {# Handle "output" cells #}
             {% elseif cell.type == "output" %}
-                <pre class="notebook-output-cell">{{ cell.output_text }}</pre>
+                <pre class="notebook-output-cell-content">{{ cell.output_text }}</pre>
 
             {# Handle if cell is image #}
             {% elseif cell.type == "image" %}
@@ -277,6 +277,7 @@
             {% endif %}
 
         </div>
+        <hr>
 
     {% endfor %}
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2396,11 +2396,14 @@ End of slider switch
 }
 /* stylelint-enable no-descending-specificity */
 
-.notebook-output-cell {
+.notebook-output-cell-content {
     background-color: var(--standard-light-gray);
     padding: 1em;
     margin-bottom: 1em;
-    border-radius: 0 0 0.5em 0.5em;
     overflow-wrap: anywhere;
     white-space: pre-wrap;
+}
+
+.notebook-cell {
+    padding: 0 0.5em;
 }


### PR DESCRIPTION
### What is the current behavior?
Notebooks are currently rendered with no space between cells. 

### What is the new behavior?
This PR adds subtle separators between cells in a notebook.  A side effect of this change is output cells becoming detached from the cell the output came from.  In a future PR, I plan to render output cells as children of a parent cell, rather than their own standalone cells.

![image](https://github.com/user-attachments/assets/b8b8b26e-113c-45d7-97a9-2599bc02b32b)

![image](https://github.com/user-attachments/assets/6c7daa4d-535d-405c-8fcf-955d656f60da)

![image](https://github.com/user-attachments/assets/f4c6638d-8179-4845-a110-7b34fc23b0d4)
