### PR TITLE
[Refactor:Developer] Update SAML port to 7001

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -157,7 +157,7 @@ Vagrant.configure(2) do |config|
     ubuntu.vm.network 'forwarded_port', guest: 1511, host: ENV.fetch('VM_PORT_SITE', 1511)
     ubuntu.vm.network 'forwarded_port', guest: 8443, host: ENV.fetch('VM_PORT_WS',   8443)
     ubuntu.vm.network 'forwarded_port', guest: 5432, host: ENV.fetch('VM_PORT_DB',  16442)
-    ubuntu.vm.network 'forwarded_port', guest: 7000, host: ENV.fetch('VM_PORT_SAML', 7000)
+    ubuntu.vm.network 'forwarded_port', guest: 7000, host: ENV.fetch('VM_PORT_SAML', 7001)
     ubuntu.vm.network 'forwarded_port', guest:   22, host: ENV.fetch('VM_PORT_SSH',  2222), id: 'ssh'
     ubuntu.vm.provision 'shell', inline: gen_script(vm_name, base: base_box)
   end


### PR DESCRIPTION
Vagrant currently attempts to forward to host port 7000 for SAML, which conflicts with the AirPlay receiver on macOS, which runs all the time by default.
Since we don't want new developers to have to deal with port conflicts on their first vagrant up, this PR changes the default port to 7001.