### PR TITLE
[Bugfix:Autograding] Output rows not matching

### DIFF
--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -9,6 +9,7 @@
 .diff-code {
     font-family: monospace;
     color: var(--btn-text-black);
+    line-height: 1.8;
 }
 
 .diff-code .row {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
Fixes #10760 

### What is the current behavior?
Rows in autograding result not matching due to paddings between rows in expected output and empty rows having a smaller height.
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/55728763-3919-4b2c-a9bb-1ce2a7e1daca">
<img width="641" alt="image" src="https://github.com/user-attachments/assets/562a19d0-0888-4bde-b66d-53b76423b55e">

### What is the new behavior?
Give a preset height for rows in autograding result that would fit paddings too.

<img width="475" alt="image" src="https://github.com/user-attachments/assets/f74573a2-1e53-45cf-9e01-18120a47ae77">
<img width="614" alt="image" src="https://github.com/user-attachments/assets/63777a57-43bd-4523-976a-e5ad0845faa9">
