### PR TITLE
[Feature:TAGrading] Latest TA Feedback on Version Conflict

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -36,7 +36,7 @@
          >
 
             <div class="box-title-total">
-                {{ Badge.render(nonhidden_earned, nonhidden_max, false) }}
+                {{ Badge.render(nonhidden_earned, nonhidden_max, false, true) }}
                 <h4>Autograding Total {% if show_hidden_breakdown %} <i>(Without Hidden Points)</i>{% endif %}</h4>
             </div>
         </div>
@@ -48,7 +48,7 @@
                 {% endif %}
             >
                 <div class="box-title-total">
-                    {{ Badge.render(hidden_earned, hidden_max, false) }}
+                    {{ Badge.render(hidden_earned, hidden_max, false, true) }}
                     <h4>Autograding Total <i>(With Hidden Points)</i></h4>
                 </div>
             </div>
@@ -144,7 +144,7 @@
                             {# Badge #}
                             {% if testcase.has_points %}
                                 {% if not testcase.hidden or show_hidden %}
-                                    {{ Badge.render(testcase.points, testcase.points_total, testcase.extra_credit) }}
+                                    {{ Badge.render(testcase.points, testcase.points_total, testcase.extra_credit, true) }}
                                 {% else %}
                                     <div class="badge">
                                         Hidden

--- a/site/app/templates/autograding/PeerResults.twig
+++ b/site/app/templates/autograding/PeerResults.twig
@@ -3,6 +3,9 @@
 {% import _self as self %}
 
 <script>
+{% if not active_same_as_graded %}
+    $('.peer-results-box').css('background-color', 'var(--standard-light-red)')
+{% endif %}
 {# When the user clicks on a peer tab in peer feedback mode, hide all other peer feedback panels, set all other tabs to unselected, set the clicked peer tab to selected and show the corresponding peer feedback panel #}
 
 function open_peer_feedback_tab(user, ordered_graders) {
@@ -53,14 +56,14 @@ function switch_feedback_modes() {
 </script>
 
 {% if not been_ta_graded %}
-    <br>
     <h3>This assignment has not been graded yet</h3>
+    <br>
 {% elseif not active_same_as_graded %}
-    <br>
     <h3>The version you have selected to be graded above does not match the version graded by your TA/instructor, please contact TA/instructor if necessary to resolve the problem.</h3>
-{% elseif not grading_complete %}
     <br>
+{% elseif not grading_complete %}
     <h3>Grading not complete, please contact an instructor/grader</h3>
+    <br>
 {% else %}
     <div class="sub">
 
@@ -78,7 +81,7 @@ function switch_feedback_modes() {
                     {% if peer_score >= peer_max %}
                         onclick="addConfetti();" style="cursor:pointer;"
                     {% endif %}>
-                    {{ Badge.render(peer_score, peer_max, false) }}
+                    {{ Badge.render(peer_score, peer_max, false, active_same_as_graded) }}
                     <h4>Peer Grading Total</h4>
                 </div>
             </div>
@@ -87,9 +90,9 @@ function switch_feedback_modes() {
             <div id="normal_peer_wrapper">
                 {% for component in peer_components %}
                     {% if component.peer_ids | length <= 5 %}
-                        {{ self.renderFewPeerResults(component, peer_aliases, ordered_graders)  }}
+                        {{ self.renderFewPeerResults(component, peer_aliases, ordered_graders, num_decimals, active_same_as_graded)  }}
                     {% else %}
-                        {{ self.renderManyPeerResults(component) }}
+                        {{ self.renderManyPeerResults(component, num_decimals, active_same_as_graded) }}
                     {% endif %}
                 {% endfor %}
             </div>
@@ -117,10 +120,10 @@ function switch_feedback_modes() {
 {% endif %}
 
 
-{%- macro renderManyPeerResults(component, num_decimals) -%}
+{%- macro renderManyPeerResults(component, num_decimals, active_same_as_graded) -%}
     <div class="box grade-results">
         <div class="no-border-box-badge">
-            {{ Badge.render(component.total_score, component.points_possible, component.extra_credit) }}
+            {{ Badge.render(component.total_score, component.points_possible, component.extra_credit, active_same_as_graded) }}
         </div>
         <div class="no-border-box-info" style="width:100%">
             <h4>
@@ -148,7 +151,7 @@ function switch_feedback_modes() {
                                     {{ mark.num_earned }}
                                 </td>
                                 <td class="peer-table-data">
-                                    {{ mark.points|number_format(num_decimals) }}
+                                    {{ mark.points|round(num_decimals) }}
                                 </td>
                                 <td class="peer-table-title-data">
                                     {{ mark.title|nl2br }}
@@ -164,10 +167,10 @@ function switch_feedback_modes() {
 {%- endmacro -%}
 
 
-{%- macro renderFewPeerResults(component, peer_aliases, ordered_graders, num_decimals) -%}
+{%- macro renderFewPeerResults(component, peer_aliases, ordered_graders, num_decimals, active_same_as_graded) -%}
     <div class="box grade-results">
         <div class="no-border-box-badge">
-            {{ Badge.render(component.total_score, component.points_possible, component.extra_credit) }}
+            {{ Badge.render(component.total_score, component.points_possible, component.extra_credit, active_same_as_graded) }}
         </div>
         <div class="no-border-box-info" style="width:100%">
             <h4>
@@ -207,7 +210,7 @@ function switch_feedback_modes() {
                                     </td>
                                 {% endfor %}
                                 <td class="peer-table-data">
-                                    {{ mark.points|number_format(num_decimals) }}
+                                    {{ mark.points|round(num_decimals) }}
                                 </td>
                                 <td class="peer-table-title-data">
                                     {{ mark.title|nl2br }}
@@ -245,7 +248,7 @@ function switch_feedback_modes() {
                                             {% else %}
                                                 <i class="far fa-square fa-1g"></i>
                                             {% endif %}
-                                            {{ mark.points|number_format(num_decimals) }}
+                                            {{ mark.points|round(num_decimals) }}
                                             {{ mark.title|nl2br }}
                                             </br>
                                         {% endfor %}

--- a/site/app/templates/autograding/TAResults.twig
+++ b/site/app/templates/autograding/TAResults.twig
@@ -9,26 +9,30 @@ $( document ).ready(function() {
         $("#gradeInquiryBoxSection").show();
         $("#ShowGradeInquiryButton").hide();
     }
+    {% if not active_same_as_graded %}
+        $(".ta-results-box").css('background-color', 'var(--standard-light-red)')
+    {% endif %}
 });
 </script>
 
 {% if not been_ta_graded %}
+    <h3>This assignment has not been graded yet, please contact an instructor/grader.</h3>
     <br>
-    <h3>This assignment has not been graded yet</h3>
-{% elseif not active_same_as_graded %}
-    <br>
-    <h3>The version you have selected to be graded above does not match the version graded by your TA/instructor, please contact TA/instructor if necessary to resolve the problem.</h3>
 {% elseif not grading_complete %}
+    <h3>Grading not complete, please contact an instructor/grader.</h3>
     <br>
-    <h3>Grading not complete, please contact an instructor/grader</h3>
 {% else %}
     <div class="sub">
+        {% if not active_same_as_graded %}
+            <h3>The version you have selected to be graded above does not match the version graded by your TA/instructor, please contact TA/instructor if necessary to resolve the problem.</h3>
+            <br>
+        {% endif %}
         {% if ta_components | length > 0 %}
             {# TA/Instructor Manual total #}
             <div class="box submission-page-total-header">
                 <div class="box-title-total key_to_click" tabindex="0">
 
-                    {{ Badge.render(ta_score, ta_max, false) }}
+                    {{ Badge.render(ta_score, ta_max, false, active_same_as_graded) }}
                     <h4>TA / Instructor Grading Total</h4>
                 </div>
             </div>
@@ -36,7 +40,7 @@ $( document ).ready(function() {
 
             {# TA Component boxes #}
             {% for component in ta_components %}
-                {{ TAResultsFunctions.renderComponent(component, false, num_decimals) }}
+                {{ TAResultsFunctions.renderComponent(component, false, num_decimals, active_same_as_graded) }}
             {% endfor %}
         {% endif %}
 

--- a/site/app/templates/functions/Badge.twig
+++ b/site/app/templates/functions/Badge.twig
@@ -2,12 +2,13 @@
 {# @var int  earned       Points earned #}
 {# @var int  max          Maximum points possible #}
 {# @var bool extra_credit If this is an extra credit component #}
-{% macro render(earned, max, extra_credit) %}
+{# @var bool active_same_as_graded If the active version is the same as the graded version, used to display version conflicts #}
+{% macro render(earned, max, extra_credit, active_same_as_graded) %}
     {% import _self as self %}
 
     {% set show = self.should_show(earned, max, extra_credit) == "true" %}
     {% if show %}
-        {% set background = self.get_style(earned, max, extra_credit) %}
+        {% set background = self.get_style(earned, max, extra_credit, active_same_as_graded) %}
         {% set text = self.format_value(earned, max, extra_credit) %}
 
         <span class="badge {{ background }}">{{ text }}</span>
@@ -20,14 +21,17 @@
 {# @var int  earned       Points earned #}
 {# @var int  max          Maximum points possible #}
 {# @var bool extra_credit If this is an extra credit component #}
-{%- macro get_style(earned, max, extra_credit) -%}
+{# @var bool active_same_as_graded If the active version is the same as the graded version, used to display version conflicts #}
+{%- macro get_style(earned, max, extra_credit, active_same_as_graded) -%}
     {%- apply spaceless -%}
         {# Color rules: #}
         {# Green is 100% or higher (for EC) #}
         {# Yellow is 51-99% #}
         {# Red is 0-50% or lower (for penalty) #}
         {# EC is gray if you didn't get any points #}
-        {% if extra_credit %}
+        {% if not active_same_as_graded %}
+            gray-background
+        {% elseif extra_credit %}
             {% if earned == 0 %}
                 gray-background
             {% else %}

--- a/site/app/templates/functions/TAResultsFunctions.twig
+++ b/site/app/templates/functions/TAResultsFunctions.twig
@@ -2,16 +2,20 @@
 {# @var obj component     A component object #}
 {# @var bool anonymous    Whether the component should be rendered without grader info #}
 {# @var int num_decimals  The number of decimals places the score should contain #}
-{% macro renderComponent(component, anonymous, num_decimals) %}
+{# @var bool active_same_as_graded If the active version is the same as the graded version, used to display version conflicts #}
+{% macro renderComponent(component, anonymous, num_decimals, active_same_as_graded) %}
     {% import 'functions/Badge.twig' as Badge %}
     <div class="box grade-results">
         <div class="box-badge">
-            {{ Badge.render(component.total_score, component.points_possible, component.extra_credit) }}
+            {{ Badge.render(component.total_score, component.points_possible, component.extra_credit, active_same_as_graded) }}
         </div>
         <div class="box-info">
             <h4>{{ component.title|escape }}
                 {% if component.graders|length != 0 and not anonymous %}
                     <i>(Graded by: {{ component.graders|join(' / ') }})</i>
+                {% endif %}
+                {% if component.version_graded > 0 and not active_same_as_graded %}
+                    For Version #{{ component.version_graded }}
                 {% endif %}
             </h4>
             <div style="float:left;">

--- a/site/app/templates/grading/electronic/EditPeerComponentsForm.twig
+++ b/site/app/templates/grading/electronic/EditPeerComponentsForm.twig
@@ -27,7 +27,7 @@
 	    	{% for component in components %}
 				{% if component_scores[component.id] is defined and component_scores[component.id][peer] is defined %}
 	    		<div class="box-badge">
-	        		{{ Badge.render(component_scores[component.id][peer], component.max, false) }}
+	        		{{ Badge.render(component_scores[component.id][peer], component.max, false, true) }}
 	        	</div>
 				{% endif %}
 	        	<span class="component-title col-no-gutters">

--- a/site/app/templates/submission/homework/PeerResultsBox.twig
+++ b/site/app/templates/submission/homework/PeerResultsBox.twig
@@ -1,5 +1,5 @@
 {# If the student does not submit anything, the only message will be "No submissions for this assignment." #}
-<div class="content">
+<div class="content peer-results-box">
     {% if been_peer_graded %}
         {{ rendered_peer_results|raw }}
     {% else %}

--- a/site/app/templates/submission/homework/TotalScoreBox.twig
+++ b/site/app/templates/submission/homework/TotalScoreBox.twig
@@ -10,7 +10,7 @@
                     style="cursor:pointer;"
                 {% endif %}
             >
-                {{ Badge.render(total_score, total_max, false) }}
+                {{ Badge.render(total_score, total_max, false, true) }}
                 <h4>Total</h4>
             </div>
         </div>

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -393,6 +393,7 @@ class AutoGradingView extends AbstractView {
                 'points_possible' => $component->getMaxValue(),
                 'student_comment' => $component->getStudentComment(),
 
+                'version_graded' => $container->getGradedVersion(),
                 'total_score' => $container->getTotalScore(),
                 'custom_mark_score' => $container->getScore(),
                 'comment' => $container->getComment(),
@@ -597,6 +598,7 @@ class AutoGradingView extends AbstractView {
                 'points_possible' => $component->getMaxValue(),
                 'student_comment' => $component->getStudentComment(),
 
+                'version_graded' => $container->getGradedVersion(),
                 'total_score' => $container->getTotalScore(),
                 'custom_mark_score' => $container->getScore(),
                 'comment' => $container->getComment(),


### PR DESCRIPTION
What is the current behavior?
Closes https://github.com/Submitty/Submitty/issues/10569
When a version conflict happens, the student loses the ability to see the previous feedback given by the TA/Instructor. This feature would be good for a writing class where feedback and resubmission is advised

What is the new behavior?
On version conflict, display the TA grading for the previous submission. Additionally, display the current version the student is on vs the version that is already graded

Other information?
Work-in-Progress