### PR TITLE
[Bugfix:Submission] Excessive Version Conflict on Navigation

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -585,7 +585,7 @@ class NavigationView extends AbstractView {
             }
             elseif (
                 $gradeable->isTaGrading()
-                    && $gradeable->isTaGradeReleased() || !$gradeable->hasReleaseDate()
+                    && ($gradeable->isTaGradeReleased() || !$gradeable->hasReleaseDate())
                     && $graded_gradeable->isTaGradingComplete()
                     && $ta_graded_gradeable->hasVersionConflict()
                     && $list_section == GradeableList::GRADED


### PR DESCRIPTION
### URGENT
### What is the current behavior?
Version Conflict shows up too much on navigation, instead of View Grade/View Submission, because of a missing parenthesis in the conditional.
<img width="336" alt="image" src="https://github.com/user-attachments/assets/e708cd68-6c55-4913-a3c7-833b7c934e75">


### What is the new behavior?
Fix the conditional