### PR TITLE
[Bugfix:Developer] Fix auto move drafts to WIP

### DIFF
--- a/.github/workflows/sort_draft_prs.yml
+++ b/.github/workflows/sort_draft_prs.yml
@@ -40,7 +40,7 @@ jobs:
     name: Move drafts to Work-in-Progress and non-drafts to Seeking Reviewer
     needs: get-token-and-pr-id
     env:
-      GITHUB_TOKEN: ${{ needs.get-token-and-pr-id.outputs.token }}
+      GH_TOKEN: ${{ needs.get-token-and-pr-id.outputs.token }}
       PR_PROJECT_ID: ${{ needs.get-token-and-pr-id.outputs.pr-project-id }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What is the current behavior?
The auto draft mover fails.

### What is the new behavior?
Fixes a bug introduced in #10775. Variable `GITHUB_TOKEN` has been renamed to `GH_TOKEN` so that gh cli works correctly.