### PR TITLE
[Bugfix:Developer] Fix draft arranger for old PRs

### DIFF
--- a/.github/workflows/sort_draft_prs.yml
+++ b/.github/workflows/sort_draft_prs.yml
@@ -30,8 +30,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          PR_PROJECT_ID="$(gh project item-list --owner Submitty 1 --format json --jq "[.items[] | {id, labels, status, title: .content.title, repo: .content.repository, number: .content.number}] | .[] | select(.number == "$PR_ID").id")"
-          echo "pr-project-id="$PR_PROJECT_ID"" >> "$GITHUB_OUTPUT"
+          PR_PROJECT_ID="$(gh project item-list -L 9999 --owner Submitty 1 --format json --jq "[.items[] | {id, labels, status, title: .content.title, repo: .content.repository, number: .content.number}] | .[] | select(.number == "$PR_ID").id")"
+          echo "pr-project-id="${PR_PROJECT_ID:?}"" >> "$GITHUB_OUTPUT"
 
       - name: Move draft to Work in Progress
         if: ${{ (github.event.action == 'converted_to_draft') || ((github.event.action == 'opened') && (github.event.pull_request.draft == true)) }}


### PR DESCRIPTION
### What is the current behavior?
The auto draft mover fails.

### What is the new behavior?
Fixes one more bug introduced in #10775. By default, the github CLI only returns the most recent 30 PRs in queries, so this action would fail for any PR older than that due to not being able to find the PR ID. This PR changes the query to search the most recent 9999 PRs instead, which should be sufficient.