### PR TITLE
[Feature:Developer] Share DockerImages repo with dev VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,7 @@ def mount_folders(config, mount_options, type = nil)
   group = 'vagrant'
   config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT/Submitty', create: true, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp, type: type
 
-  optional_repos = %w(AnalysisTools AnalysisToolsTS Lichen RainbowGrades Tutorial CrashCourseCPPSyntax LichenTestData)
+  optional_repos = %w(AnalysisTools AnalysisToolsTS Lichen RainbowGrades Tutorial CrashCourseCPPSyntax LichenTestData DockerImages DockerImagesRPI)
   optional_repos.each {|repo|
     repo_path = File.expand_path("../" + repo)
     if File.directory?(repo_path)


### PR DESCRIPTION
### What is the current behavior?
It is currently difficult to test changes to Submitty docker images because the `DockerImages` and `DockerImagesRPI` repositories are not shared with the development VM if they are cloned locally.

### What is the new behavior?
This PR shares the `DockerImages` and `DockerImagesRPI` repositories with the development VM to make it easier to test changes to new images.