### PR TITLE
[UI/UX:Submission] Correct Collapse Gradeable's 950px

### DIFF
--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -96,7 +96,7 @@
     }
 }
 
-@media (max-width: 950px) {
+@media (max-width: 949px) {
     .course-section-heading {
         margin: 10px 0;
         font-weight: 400;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
fix #10816 

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
at 950px, the logic is break

### What is the new behavior?
I make the laptop view extend to 949 so 950 should still viewing what laptop size, and 949 will still behave as mobile UI 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
<img width="945" alt="testing" src="https://github.com/user-attachments/assets/b394f6ce-c8ff-4c9f-8e9e-e469be3c6138">
