### PR TITLE
[Bugfix:Developer] Add python_submitty_utils to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,9 @@ updates:
       prefix: "[Dependency] "
       prefix-development: "[DevDependency] "
   - package-ecosystem: pip
-    directory: "/.setup/pip/"
+    directories:
+      - "/.setup/pip/"
+      - "/python_submitty_utils/"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
### What is the current behavior?
Dependabot does not check for updates in `/python_submitty_utils/requirements.txt`.

### What is the new behavior?
Dependabot does now checks for updates in `/python_submitty_utils/requirements.txt`.