### PR TITLE
[Refactor:Developer] Combine GH Actions Dependabot entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,15 +28,9 @@ updates:
     commit-message:
       prefix: "[Dependency] "
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - dependencies
-    commit-message:
-      prefix: "[DevDependency] "
-  - package-ecosystem: "github-actions"
-    directory: "/actions/e2e-Setup-Composite"
+    directories:
+      - "/"
+      - "/actions/e2e-Setup-Composite"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
### What is the current behavior?
Right now, there are two `package-ecosystem: "github-actions"` blocks in the Dependabot config. This is because the config predates the `directories:` feature.

### What is the new behavior?
This PR merges the two `github-actions` blocks into one using [`directories:`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories) to replace `directory:`.