### PR TITLE
[Bugfix:Developer] Fix Github Actions Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/actions/e2e-Setup-Composite"
+      - "/.github/actions/e2e-Setup-Composite"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
### What is the current behavior?
Currently, Dependabot fails to update Github Actions, with the following log error. This appears to have been an issue since it was added in #9431.
```
  proxy | 2024/08/05 16:47:44 proxy starting, commit: f375444b32b70ee41e6084e7b6ffc09599dcc194
  proxy | 2024/08/05 16:47:44 Listening (:1080)
updater | 2024-08-05T16:47:44.463490099 [865327624:main:WARN:src/devices/src/legacy/serial.rs:222] Detached the serial input due to peer close/error.
updater | time="2024-08-05T16:47:46Z" level=info msg="guest starting" commit=10a56669fe8a0eaa1a40681e640fae7d411d58c1
updater | time="2024-08-05T16:47:46Z" level=info msg="starting job..." fetcher_timeout=10m0s job_id=865327624 updater_timeout=45m0s updater_version=5e17fc0ed2a028c94809836dd5e5b4495b1e3235-github-actions
updater | 2024/08/05 16:47:50 INFO <job_865327624> Starting job processing
updater | 2024/08/05 16:47:50 INFO <job_865327624> Job definition: {"job":{"allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"commit-message-options":{"include-scope":null,"prefix":"[DevDependency] ","prefix-development":null},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"debug":null,"dependencies":null,"dependency-group-to-refresh":null,"dependency-groups":[],"existing-group-pull-requests":[],"existing-pull-requests":[],"experiments":{"dependency-change-validation":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"max-updater-run-time":2700,"package-manager":"github_actions","proxy-log-response-body-on-auth-failure":true,"reject-external-code":false,"repo-private":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"api-endpoint":"https://api.github.com/","branch":null,"directories":["/.","/actions/e2e-Setup-Composite"],"directory":null,"hostname":"github.com","provider":"github","repo":"Submitty/Submitty"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false}}
updater | 
  proxy | 2024/08/05 16:47:50 [002] GET https://github.com:443/Submitty/Submitty/info/refs?service=git-upload-pack
  proxy | 2024/08/05 16:47:50 [002] * authenticating git server request (host: github.com)
  proxy | 2024/08/05 16:47:50 [002] 200 https://github.com:443/Submitty/Submitty/info/refs?service=git-upload-pack
  proxy | 2024/08/05 16:47:50 [004] POST https://github.com:443/Submitty/Submitty/git-upload-pack
  proxy | 2024/08/05 16:47:50 [004] * authenticating git server request (host: github.com)
  proxy | 2024/08/05 16:47:50 [004] 200 https://github.com:443/Submitty/Submitty/git-upload-pack
  proxy | 2024/08/05 16:47:50 [006] POST https://github.com:443/Submitty/Submitty/git-upload-pack
  proxy | 2024/08/05 16:47:50 [006] * authenticating git server request (host: github.com)
  proxy | 2024/08/05 16:47:51 [006] 200 https://github.com:443/Submitty/Submitty/git-upload-pack
updater | 2024/08/05 16:47:52 ERROR <job_865327624> Error during file fetching; aborting: /actions/e2e-Setup-Composite/<anything>.yml not found
updater | 2024/08/05 16:47:52 INFO <job_865327624> Finished job processing
updater | 2024/08/05 16:47:52 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +---------------------------+
updater | |          Errors           |
updater | +---------------------------+
updater | | dependency_file_not_found |
updater | +---------------------------+
updater | time="2024-08-05T16:47:53Z" level=info msg="task complete" container_id=job-865327624-file-fetcher exit_code=0 job_id=865327624 step=fetcher
updater | time="2024-08-05T16:47:53Z" level=warning msg="failed during fetch, skipping updater" job_id=865327624
```

### What is the new behavior?
This PR fixes the path to the `e2e-Setup-Composite` dir so Dependabot should work as intended.