### PR TITLE
[Refactor:Developer] Remove ubuntu:custom, fix broken config

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -860,7 +860,6 @@ ${proxy}
 fi
 
 su -c 'docker pull submitty/autograding-default:latest' ${DAEMON_USER}
-su -c 'docker tag submitty/autograding-default:latest ubuntu:custom' ${DAEMON_USER}
 
 #################################################################
 # RESTART SERVICES

--- a/more_autograding_examples/notebook_expected_string/config/config.json
+++ b/more_autograding_examples/notebook_expected_string/config/config.json
@@ -1,7 +1,6 @@
 {
     "required_capabilities": "notebook",
 
-    "hide_submitted_files" : true,
 //    "hide_version_and_test_details" : true,
 
     "assignment_message" : "# Welcome To My Favorite Notebook Gradeable\n  \

--- a/more_autograding_examples/python_custom_docker_rlimits/config/config.json
+++ b/more_autograding_examples/python_custom_docker_rlimits/config/config.json
@@ -16,7 +16,7 @@
             "containers" : [
                 {
                     "container_name" : "container0",
-                    "container_image": "ubuntu:custom",
+                    "container_image": "submitty/autograding-default:latest",
                     "commands" : ["python3 *.py"]
                 }
             ],


### PR DESCRIPTION
Two quick fixes to the autograding examples.
1. Removes ubuntu:custom which is a confusing alias that shouldn't be used.
2. Removes an invalid field from a config.