### PR TITLE
[Bugfix:InstructorUI] Force Late Days to be a positive number

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -852,7 +852,8 @@ CREATE TABLE public.electronic_gradeable (
     CONSTRAINT eg_grade_inquiry_start_date_max CHECK ((eg_grade_inquiry_start_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
     CONSTRAINT eg_submission_date CHECK ((eg_submission_open_date <= eg_submission_due_date)),
     CONSTRAINT eg_submission_due_date_max CHECK ((eg_submission_due_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
-    CONSTRAINT eg_team_lock_date_max CHECK ((eg_team_lock_date <= '9999-03-01 00:00:00-05'::timestamp with time zone))
+    CONSTRAINT eg_team_lock_date_max CHECK ((eg_team_lock_date <= '9999-03-01 00:00:00-05'::timestamp with time zone)),
+    CONSTRAINT late_days_positive CHECK ((eg_late_days >= 0))
 );
 
 

--- a/migration/migrator/migrations/course/20240816095713_late_days_constraint.py
+++ b/migration/migrator/migrations/course/20240816095713_late_days_constraint.py
@@ -1,0 +1,43 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute("""
+        UPDATE electronic_gradeable
+        SET eg_late_days = 0
+        WHERE eg_late_days < 0;
+    """)
+
+    database.execute("""
+        ALTER TABLE electronic_gradeable
+        ADD CONSTRAINT late_days_positive CHECK (eg_late_days >= 0)
+    """)
+    pass
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1386,7 +1386,15 @@ class AdminGradeableController extends AbstractController {
             if (isset($details[$date_property])) {
                 $dates[$date_property] = $details[$date_property];
 
-                if ($dates[$date_property] > DateUtils::MAX_TIME) {
+                if ($date_property === 'late_days') {
+                    if (!is_numeric($dates[$date_property])) {
+                        $errors[$date_property] = 'Late days must be a number';
+                    }
+                    elseif (intval($dates[$date_property]) < 0) {
+                        $errors[$date_property] = 'Late days must be a positive number';
+                    }
+                }
+                elseif ($dates[$date_property] > DateUtils::MAX_TIME) {
                     $errors[$date_property] = Gradeable::date_display_names[$date_property] . ' Date is higher than the max allowed date! (' . DateUtils::MAX_TIME . ')';
                 }
 


### PR DESCRIPTION
### What is the current behavior?
You can enter a negative late days value, and although I don't think this impacts submission, it would not throw an error on the gradeable update screen.

### What is the new behavior?
You now cannot enter a negative value for values.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
