### PR TITLE
[Bugfix:RainbowGrades] Save final cutoffs

### DIFF
--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -720,6 +720,9 @@ $(document).ready(() => {
     $('.sections_and_labels').on('change keyup paste', () => {
         saveChanges();
     });
+    $('.final_cutoff_input').on('change keyup paste', () => {
+        saveChanges();
+    });
     // Attach a focusout event handler to all input and textarea elements within #gradeables after user finishes typing
     $('#gradeables').find('input, textarea').on('focusout', () => {
         saveChanges();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Final cutoffs do not save until another customization item is updated.

### What is the new behavior?
Final cutoffs update on key up.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
