### PR TITLE
[Bugfix:HelpQueue] Empty Codes for office hours queue

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -8076,7 +8076,7 @@ AND gc_id IN (
         //first check if the queue has an access code
         $this->course_db->query("SELECT * FROM queue_settings WHERE UPPER(TRIM(code)) = UPPER(TRIM(?)) AND open = true", [$queue_code]);
         if ($this->course_db->getRowCount() > 0 && $this->course_db->rows()[0]['token'] == null) {
-            return $this->course_db->rows()[0]['code'];
+            return $this->course_db->row()['code'];
         }
         elseif ($token === null) {
             return false;

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -8075,8 +8075,8 @@ AND gc_id IN (
     public function getValidatedCode(string $queue_code, string $token = null) {
         //first check if the queue has an access code
         $this->course_db->query("SELECT * FROM queue_settings WHERE UPPER(TRIM(code)) = UPPER(TRIM(?)) AND open = true", [$queue_code]);
-        if ($this->course_db->getRowCount() > 0 && $this->course_db->row()['token'] == null) {
-            return $this->course_db->row()['code'];
+        if ($this->course_db->getRowCount() > 0 && $this->course_db->rows()[0]['token'] == null) {
+            return $this->course_db->rows()[0]['code'];
         }
         elseif ($token === null) {
             return false;

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -8075,8 +8075,9 @@ AND gc_id IN (
     public function getValidatedCode(string $queue_code, string $token = null) {
         //first check if the queue has an access code
         $this->course_db->query("SELECT * FROM queue_settings WHERE UPPER(TRIM(code)) = UPPER(TRIM(?)) AND open = true", [$queue_code]);
-        if ($this->course_db->getRowCount() > 0 && $this->course_db->rows()[0]['token'] == null) {
-            return $this->course_db->row()['code'];
+        $row = $this->course_db->row();
+        if ($this->course_db->getRowCount() > 0 && $row['token'] == null) {
+            return $row['code'];
         }
         elseif ($token === null) {
             return false;


### PR DESCRIPTION
### What is the current behavior?
PR #10394 changed all rows[0] into row(), which might change the functionality of the code and therefore broke the office hour queue.
progress on #10895 but still needs cypress tests

### What is the new behavior?
Revert the changes so now it behaves as expected

### Other information?
Cypress tests might be needed in the future so that this doesn't break again (please I've been doing cypress too much lately can someone else do it 😭 )