### PR TITLE
[Refactor:Developer] Change Zulip good first issue notifs

### DIFF
--- a/.github/workflows/notify_issues.yml
+++ b/.github/workflows/notify_issues.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Send notification to Zulip
         if: github.event.label.name == 'good first issue'
         run: |
-          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=RPI Developers' \
+          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
           --data-urlencode 'topic=Available Good First Issue' --data-urlencode \
           'content=A good first issue has been posted. View here: [${{ github.event.issue.title }}](https://github.com/Submitty/Submitty/issues/${{ github.event.issue.number }}).
           View a list of all good first issues here: [Good First Issues](https://github.com/Submitty/Submitty/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)'


### PR DESCRIPTION
### What is the current behavior?
Zulip puts good first issues in the RPI devs channel

### What is the new behavior?
Zulip goes to Submitty Developer Studio (I think that was the agreed channel on during yesterdays meeting)
