### PR TITLE
[Bugfix:InstructorUI] skip perms check for config_upload

### DIFF
--- a/.setup/pip/dev_requirements.txt
+++ b/.setup/pip/dev_requirements.txt
@@ -1,7 +1,7 @@
 # Development Requirements
 
 # Linters
-pylint==3.2.6
+pylint==3.2.7
 flake8-bugbear==24.4.26
 flake8==7.1.1
 

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1542,20 +1542,22 @@ class Gradeable extends AbstractModel {
             foreach ($cur_paths as $cur_path) {
                 $is_dir = is_dir($cur_path);
 
-                $config_upload_dir = $this->core->getConfig()->getCoursePath()."/config_upload/";
+                $config_upload_dir = $this->core->getConfig()->getCoursePath() . "/config_upload/";
 
                 $is_in_config_upload_dir =
                   (strlen($config_upload_dir) < strlen($cur_path)) &&
-                  (substr($cur_path,0,strlen($config_upload_dir)) == $config_upload_dir);
+                  (substr($cur_path, 0, strlen($config_upload_dir)) == $config_upload_dir);
 
-                if (!$is_config_upload_dir &&
-                    !$this->checkValidPerms($cur_path, $group_map, $user_map, $is_dir)) {
-                    return "Invalid permissions on a file or directory within specified path:".$cur_path;
+                if (
+                    !$is_config_upload_dir
+                    && !$this->checkValidPerms($cur_path, $group_map, $user_map, $is_dir)
+                    ) {
+                    return "Invalid permissions on a file or directory within specified path:" . $cur_path;
                 }
                 if ($is_dir) {
                     $next_paths_tmp = @scandir($cur_path);
                     if (!is_array($next_paths_tmp)) {
-                        return "Invalid directory array: ".$next_paths_tmp;
+                        return "Invalid directory array: " . $next_paths_tmp;
                     }
                     foreach ($next_paths_tmp as $next_path) {
                         if ($next_path === "." || $next_path === "..") {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1550,7 +1550,7 @@ class Gradeable extends AbstractModel {
                 $is_in_config_upload_dir = str_starts_with($cur_path, $config_upload_dir);
 
                 if (
-                    !$is_config_upload_dir
+                    !$is_in_config_upload_dir
                     && !$this->checkValidPerms($cur_path, $group_map, $user_map, $is_dir)
                 ) {
                     return "Invalid permissions on a file or directory within specified path:" . $cur_path;

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1541,13 +1541,21 @@ class Gradeable extends AbstractModel {
         while ($checked_paths <= 1000 && count($cur_paths) !== 0) {
             foreach ($cur_paths as $cur_path) {
                 $is_dir = is_dir($cur_path);
-                if (!$this->checkValidPerms($cur_path, $group_map, $user_map, $is_dir)) {
-                    return "Invalid permissions on a file or directory within specified path.";
+
+                $config_upload_dir = $this->core->getConfig()->getCoursePath()."/config_upload/";
+
+                $is_in_config_upload_dir =
+                  (strlen($config_upload_dir) < strlen($cur_path)) &&
+                  (substr($cur_path,0,strlen($config_upload_dir)) == $config_upload_dir);
+
+                if (!$is_config_upload_dir &&
+                    !$this->checkValidPerms($cur_path, $group_map, $user_map, $is_dir)) {
+                    return "Invalid permissions on a file or directory within specified path:".$cur_path;
                 }
                 if ($is_dir) {
                     $next_paths_tmp = @scandir($cur_path);
                     if (!is_array($next_paths_tmp)) {
-                        return "Invalid permissions on a file or directory within specified path.";
+                        return "Invalid directory array: ".$next_paths_tmp;
                     }
                     foreach ($next_paths_tmp as $next_path) {
                         if ($next_path === "." || $next_path === "..") {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1542,8 +1542,11 @@ class Gradeable extends AbstractModel {
             foreach ($cur_paths as $cur_path) {
                 $is_dir = is_dir($cur_path);
 
+                // We don't need to check the permissions for autograding configurations
+                // in this courses config_upload directory.
+                // Instructor users can upload configs to this directory through the web UI
+                // and they can select and use these configs to autograding their assignments.
                 $config_upload_dir = $this->core->getConfig()->getCoursePath() . "/config_upload/";
-
                 $is_in_config_upload_dir =
                   (strlen($config_upload_dir) < strlen($cur_path)) &&
                   (substr($cur_path, 0, strlen($config_upload_dir)) == $config_upload_dir);
@@ -1551,7 +1554,7 @@ class Gradeable extends AbstractModel {
                 if (
                     !$is_config_upload_dir
                     && !$this->checkValidPerms($cur_path, $group_map, $user_map, $is_dir)
-                    ) {
+                ) {
                     return "Invalid permissions on a file or directory within specified path:" . $cur_path;
                 }
                 if ($is_dir) {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1547,7 +1547,7 @@ class Gradeable extends AbstractModel {
                 // Instructor users can upload configs to this directory through the web UI
                 // and they can select and use these configs to autograding their assignments.
                 $config_upload_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "config_upload");
-                $is_in_config_upload_dir = str_starts_with($cur_path,$config_upload_dir);
+                $is_in_config_upload_dir = str_starts_with($cur_path, $config_upload_dir);
 
                 if (
                     !$is_config_upload_dir

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1547,9 +1547,7 @@ class Gradeable extends AbstractModel {
                 // Instructor users can upload configs to this directory through the web UI
                 // and they can select and use these configs to autograding their assignments.
                 $config_upload_dir = $this->core->getConfig()->getCoursePath() . "/config_upload/";
-                $is_in_config_upload_dir =
-                  (strlen($config_upload_dir) < strlen($cur_path)) &&
-                  (substr($cur_path, 0, strlen($config_upload_dir)) == $config_upload_dir);
+                $is_in_config_upload_dir = str_starts_with($cur_path,$config_upload_dir);
 
                 if (
                     !$is_config_upload_dir


### PR DESCRIPTION
### What is the current behavior?
If we have an instructor user who is NOT in the linux group for the course.
And that instructor user uploads a config using the 'Edit Gradeable' -> 'Submissions/Autograding' -> 'Upload a custom autograding configuration' 
They unfortunately CANNOT select that config from the dropdown menu.

They get this error:
<img width="429" alt="Screenshot 2024-09-04 at 9 03 11 PM" src="https://github.com/user-attachments/assets/bd2bdfe1-accc-49d7-96a4-c67a1b6ae81b">

### What is the new behavior?
The step that verifies the user has linux permission to the selected directory is skipped if the path is a subdirectory of the courses config_upload directory.