### PR TITLE
[Bugfix:Autograding] Docker Network Random ID

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -963,6 +963,13 @@ fi
 
 #############################################################################
 
+# Restart docker if not in CI
+if [[ "$CI" -ne "0" ]] ; then
+    echo -n "restarting docker..."
+    systemctl restart docker
+    echo "done"
+fi
+
 # Restart php-fpm and apache
 if [ "${WORKER}" == 0 ]; then
     if [[ "$#" == 0 || ("$#" == 1 && "$1" != "skip_web_restart") || ("$#" -ge 2  && ("$1" != "skip_web_restart" && "$2" != "skip_web_restart")) ]]; then

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -963,6 +963,11 @@ fi
 
 #############################################################################
 
+# Restart docker
+echo -n "restarting docker..."
+systemctl restart docker
+echo "done"
+
 # Restart php-fpm and apache
 if [ "${WORKER}" == 0 ]; then
     if [[ "$#" == 0 || ("$#" == 1 && "$1" != "skip_web_restart") || ("$#" -ge 2  && ("$1" != "skip_web_restart" && "$2" != "skip_web_restart")) ]]; then

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -963,11 +963,6 @@ fi
 
 #############################################################################
 
-# Restart docker
-echo -n "restarting docker..."
-systemctl restart docker
-echo "done"
-
 # Restart php-fpm and apache
 if [ "${WORKER}" == 0 ]; then
     if [[ "$#" == 0 || ("$#" == 1 && "$1" != "skip_web_restart") || ("$#" -ge 2  && ("$1" != "skip_web_restart" && "$2" != "skip_web_restart")) ]]; then

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -1,5 +1,7 @@
 import json
 import os
+import random
+import string
 import traceback
 import time
 from pwd import getpwnam
@@ -345,7 +347,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                         pass
                 raise
 
-    def network_containers(self, containers):
+    def network_containers(self, containers, random_str):
         """ Given a set of containers, network them per their specifications. """
         if len(containers) <= 1:
             return
@@ -358,18 +360,18 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             none_network.disconnect(container.container, force=True)
 
         if self.get_router(containers) is not None:
-            self.network_containers_with_router(containers)
+            self.network_containers_with_router(containers, random_str)
         else:
-            self.network_containers_routerless(containers)
+            self.network_containers_routerless(containers, random_str)
 
         # Provide an initialization file to each container.
         self.create_knownhosts_txt(containers)
-        self.create_knownhosts_json(containers)
+        self.create_knownhosts_json(containers, random_str)
 
-    def network_containers_routerless(self, containers):
+    def network_containers_routerless(self, containers, random_str):
         """ If there is no router, all containers are added to the same network. """
         client = docker.from_env(timeout=60)
-        network_name = f'{self.untrusted_user}_routerless_network'
+        network_name = f'{self.untrusted_user}_routerless_network_{random_str}'
 
         # Assumes untrustedXX naming scheme, where XX is a number
         untrusted_num = int(self.untrusted_user.replace('untrusted', '')) + 100
@@ -387,6 +389,12 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         )
         client.close()
 
+        self.log_container(
+            'NET_CREATED',
+            network_name,
+            network.short_id
+        )
+
         host = 2
         for container in containers:
             ip_address = f'{ip_address_start}.{host}'
@@ -399,7 +407,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             host += 1
         self.networks.append(network)
 
-    def network_containers_with_router(self, containers):
+    def network_containers_with_router(self, containers, random_str):
         """
         If there is a router, all containers are added to their own network, on which the only
         other endpoint is the router, which has been aliased to impersonate all other reachable
@@ -415,7 +423,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         container_to_subnet = {}
 
         for container in containers:
-            network_name = f"{container.full_name}_network"
+            network_name = f"{container.full_name}_network_{random_str}"
             if container.name == 'router':
                 continue
             # We are creating a new subnet with a new subnet number
@@ -432,6 +440,12 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                 ipam=ipam_config,
                 driver='bridge',
                 internal=True
+            )
+
+            self.log_container(
+                'NET_CREATED',
+                network_name,
+                network.short_id
             )
 
             # We connect the container with host=2. Later we'll connect the router with host=3
@@ -467,7 +481,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         # Connect the router to all networks.
         for startpoint, endpoints in router_connections.items():
             full_startpoint_name = f'{self.untrusted_user}_{startpoint}'
-            network_name = f"{full_startpoint_name}_network"
+            network_name = f"{full_startpoint_name}_network_{random_str}"
             # Store the ip address of the router on this network
             router_ip = f'{network_num}.{untrusted_num}.{container_to_subnet[startpoint]}.3'
             router.set_ip_address(network_name, router_ip)
@@ -486,6 +500,11 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         for network in self.networks:
             try:
                 network.remove()
+                self.log_container(
+                    'NET_DESTROYED',
+                    network.name,
+                    network.short_id
+                )
                 network.client.api.close()
                 network.client.close()
                 self.log_message(
@@ -499,7 +518,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                 )
         self.networks.clear()
 
-    def create_knownhosts_json(self, containers):
+    def create_knownhosts_json(self, containers, random_str):
         """
         Given a set of containers, add initialization files to each
         container's directory which specify how to connect to other endpoints
@@ -528,7 +547,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                     connected_container_name,
                     containers
                 )
-                network_name = f"{container.full_name}_network"
+                network_name = f"{container.full_name}_network_{random_str}"
                 # If there is a router, the router is impersonating all other
                 # containers, but has only one ip address.
                 if router is not None:
@@ -549,7 +568,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                         ip_address = connected_container.get_ip_address(network_name)
                 else:
                     ip_address = connected_container.get_ip_address(
-                        f'{self.untrusted_user}_routerless_network'
+                        f'{self.untrusted_user}_routerless_network_{random_str}'
                     )
 
                 container_knownhost['hosts'][connected_container.name] = {
@@ -803,9 +822,15 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                 # Linter hates this line (return in a finally), but the workaround just adds noise
                 return -1  # noqa: B012
 
+
+        random_str = ''
+        valid_chars = string.ascii_letters + string.digits
+        for _ in range(6):
+            random_str += valid_chars[random.randrange(0, len(valid_chars))]
+
         try:
             self.create_containers(containers, script, arguments)
-            self.network_containers(containers)
+            self.network_containers(containers, random_str)
         except Exception:
             self.log_message(
                 'ERROR: Could not create or network containers. '

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -822,7 +822,6 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                 # Linter hates this line (return in a finally), but the workaround just adds noise
                 return -1  # noqa: B012
 
-
         random_str = ''
         valid_chars = string.ascii_letters + string.digits
         for _ in range(6):

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -555,16 +555,16 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
                     if container.name == 'router' and connected_container_name == 'router':
                         continue
                     elif container.name == connected_container_name:
-                        network_name = f"{container.full_name}_network"
+                        network_name = f"{container.full_name}_network_{random_str}"
                         ip_address = container.get_ip_address(network_name)
                     # If this node is not the router, we must inject the router
                     elif container.name != 'router':
                         # Get the router's ip on the container's network
-                        network_name = f"{container.full_name}_network"
+                        network_name = f"{container.full_name}_network_{random_str}"
                         ip_address = router.get_ip_address(network_name)
                     else:
                         # If we are the router, get the connected container's ip on its own network
-                        network_name = f"{self.untrusted_user}_{connected_container_name}_network"
+                        network_name = f"{self.untrusted_user}_{connected_container_name}_network_{random_str}"
                         ip_address = connected_container.get_ip_address(network_name)
                 else:
                     ip_address = connected_container.get_ip_address(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
All of our docker network names consist of the untrusted user ID plus a static string.

### What is the new behavior?
These docker network names now have a random ID appended to them to lower than chance of a network name collision.

Additional logging is added for network creation and deletion.

Docker is also restarted on every install.

### Other information?
Network name collision should not happen on most machines but it is happening on one of our production machines.
