### PR TITLE
[Bugfix:Forum] Hide future categories

### DIFF
--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -139,7 +139,9 @@
 			<label id="filter_unread_btn" class="btn btn-default btn-sm inline-block filter-inactive" for="unread">Unread Only</label> <input type="checkbox" id="unread" name="unread" data-ays-ignore="true"/>
 			<div id="thread_category" aria-label="Select thread category" class="inline-block" data-ays-ignore="true">
 				{% for category in categories %}
-					<button class="btn btn-sm filter-inactive" type="button" id="categoryid_{{ category.category_id }}" data-cat_id="{{ category.category_id }}" data-btn-selected="false">{{ category.category_desc }}</button>
+					{% if category.visible_date is null or category.diff > 0 %}
+						<button class="btn btn-sm filter-inactive" type="button" id="categoryid_{{ category.category_id }}" data-cat_id="{{ category.category_id }}" data-btn-selected="false">{{ category.category_desc }}</button>
+					{% endif %}
 				{% endfor %}
 			</div>
 			<div id="thread_status_select" aria-label="Select thread status" class="inline-block" data-ays-ignore="true">


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current  #behavior?
unreleased forum categories shown in filter Fixes #10903

### What is the new behavior?
Its not showing now. 
I checked `threadpostform.twig` file, where the behavior was right. It was simply checking if the visible date is null or less than current time.
Therefore I added the same logic in `ForumBar.twig` file, I checked it worked fine, 

### Other information?
I have attached the screenshot
Unreleased Future category
![Screenshot 2024-09-05 121233](https://github.com/user-attachments/assets/b58f401c-f870-46b4-a312-47e82191597b)

Now its not present in filters inside forum.
![Screenshot 2024-09-05 115243](https://github.com/user-attachments/assets/6d815caf-19b1-4f5a-b29b-921449e52cb0)
