### PR TITLE
[Bugfix:RainbowGrades] Fix error when adding gradeable

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -156,7 +156,7 @@ class RainbowCustomization extends AbstractModel {
                         $c_gradeable['override'] = true;
                         $c_gradeable['override_max'] = $json_bucket->ids[$j_index]->max;
                     }
-                    if (property_exists($json_bucket->ids[$j_index], 'percent')) {
+                    if (isset($json_bucket->ids[$j_index]) && property_exists($json_bucket->ids[$j_index], 'percent')) {
                         $c_gradeable['override_percent'] = true;
                         $c_gradeable['percent'] = ($json_bucket->ids[$j_index]->percent) * 100;
                     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
After adding a gradeable to a bucket used in `customization.json`, the following error will appear after navigating to the Grade Reports > Web-Based GUI Customization.
![error after adding gradeable](https://github.com/user-attachments/assets/743721c6-6db3-47c4-adcd-a406d587b814)

Steps to Reproduce

1. Login to Instructor, then navigate to Grade Reports > Web-Based Rainbow Grades Customization.
2. Drag any item from **Available Buckets** to **Assigned Buckets**. 
3. Navigate to New Gradeable, and create a gradeable in the same bucket as used in the previous step.
4. Return to Web-Based Rainbow Grades Customization, and view error.

### What is the new behavior?
The new gradeable will no longer crash the customization page. If Per Gradeable Percents is enabled, the Per Gradeable Percent of the new gradeable will be the inverse of the number of gradeables in the bucket.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This error was introduced in PR #10763 (Add Gradeable Percents to GUI)
