### PR TITLE
[Feature:RainbowGrades] Add gradeable alternates customization

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -160,6 +160,9 @@ class RainbowCustomization extends AbstractModel {
                         $c_gradeable['override_percent'] = true;
                         $c_gradeable['percent'] = ($json_bucket->ids[$j_index]->percent) * 100;
                     }
+                    if (isset($json_bucket->ids[$j_index]) && property_exists($json_bucket->ids[$j_index], 'alternate')) {
+                        $c_gradeable['alternate'] = $json_bucket->ids[$j_index]->alternate;
+                    }
                     $j_index++;
                 }
             }

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -179,7 +179,7 @@
 
                         <input id="enable-alternates" type="checkbox" name="enable-alternates">
                         <label for="enable-alternates">Enable Alternates:</label>
-                        <i>For each bucket, you may set gradeables as alternates of other gradeables.</i><br>
+                        <i>For each bucket, you may set gradeables as alternates of other gradeables. This function is experimental, and is designed for the Programming Languages course.</i><br>
                     </div>
                     <div id="config-wrapper">
                         {% for bucket, gradeables in customization_data %}

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -176,6 +176,10 @@
                         <input id="enable-per-gradeable-percents" type="checkbox" name="enable-per-gradeable-percents">
                         <label for="enable-per-gradeable-percents">Enable/Edit Per Gradeable Percents:</label>
                         <i>For each bucket, you may grade by percent instead of by points.</i><br>
+
+                        <input id="enable-alternates" type="checkbox" name="enable-alternates">
+                        <label for="enable-alternates">Enable Alternates:</label>
+                        <i>For each bucket, you may set gradeables as alternates of other gradeables.</i><br>
                     </div>
                     <div id="config-wrapper">
                         {% for bucket, gradeables in customization_data %}
@@ -292,6 +296,13 @@ to 50%, you would enter 10 in the A- box.
 To remove a curve simply blank all boxes."></i>
                                                     </div>
                                                 </div>
+                                                <label class="gradeable-li-info" id="alternate-checkbox-label-{{ gradeable['id'] }}">
+                                                    Alternate?
+                                                    <input id="alternate-checkbox-{{ gradeable['id'] }}" type="checkbox" name="alternate-checkbox-{{ gradeable['id'] }}">
+                                                </label>
+                                                <select class="gradeable-li-info" name="alternate-dropdown-{{ gradeable['id'] }}" id="alternate-dropdown-{{ gradeable['id'] }}" onfocus="GetPotentialAlternates(this, {{ gradeables|json_encode() }});" aria-label="Assign Alternate Gradeable">
+                                                    <option disabled selected value> -- select a gradeable -- </option>
+                                                </select>
                                             </li>
                                         {% endfor %}
                                     </ol>

--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -300,7 +300,7 @@ To remove a curve simply blank all boxes."></i>
                                                     Alternate?
                                                     <input id="alternate-checkbox-{{ gradeable['id'] }}" type="checkbox" name="alternate-checkbox-{{ gradeable['id'] }}">
                                                 </label>
-                                                <select class="gradeable-li-info" name="alternate-dropdown-{{ gradeable['id'] }}" id="alternate-dropdown-{{ gradeable['id'] }}" onfocus="GetPotentialAlternates(this, {{ gradeables|json_encode() }});" aria-label="Assign Alternate Gradeable">
+                                                <select class="gradeable-li-info" name="alternate-dropdown-{{ gradeable['id'] }}" id="alternate-dropdown-{{ gradeable['id'] }}" onfocus="GetPotentialAlternates(this, {{ gradeables|json_encode() }});" data-gradeables="{{ gradeables|json_encode() }}" data-gradeable="{{ gradeable|json_encode() }}" aria-label="Assign Alternate Gradeable">
                                                     <option disabled selected value> -- select a gradeable -- </option>
                                                 </select>
                                             </li>

--- a/site/public/css/rainbow-customization.css
+++ b/site/public/css/rainbow-customization.css
@@ -125,6 +125,7 @@
 .gradeable-li-right-of-input {
     display: flex;
     flex-direction: column;
+    margin-right: 32px;
 }
 
 i.fa-exclamation-triangle {

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -269,6 +269,7 @@ function getGradeableBuckets() {
                 const children = $(this).children();
                 // children[0] represents <div id="gradeable-pts-div-*">
                 // children[1] represents <div id="gradeable-percents-div-*">
+                // children[4] represents <select id="alternate-dropdown-*">
                 // replace divs with inputs
                 children[0] = children[0].children[0];
                 children[1] = children[1].children[0];
@@ -279,6 +280,12 @@ function getGradeableBuckets() {
                 // Get gradeable final grade percent, but only if Per Gradeable Percents was selected
                 if ($(children[1]).is(':visible')) {
                     gradeable.percent = parseFloat(children[1].value) / 100.0;
+                }
+
+                // Get alternate gradeable
+                const alternate_value = $(children[4]).find(':selected').val();
+                if ($(children[4]).is(':visible') && alternate_value !== '') {
+                    gradeable.alternate = alternate_value;
                 }
 
                 // Get gradeable release date
@@ -816,7 +823,7 @@ $(document).ready(() => {
         saveChanges();
     });
     // Attach a focusout event handler to all input and textarea elements within #gradeables after user finishes typing
-    $('#gradeables').find('input, textarea').on('focusout', () => {
+    $('#gradeables').find('input, textarea, select').on('focusout', () => {
         saveChanges();
     });
 

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -1,4 +1,4 @@
-/* exported addToTable, deleteRow manageWarningsGradeables ResetPerGradeablePercents GetPotentialAlternates */
+/* exported addToTable, deleteRow manageWarningsGradeables ResetPerGradeablePercents GetPotentialAlternates LoadAlternates */
 /* global buildCourseUrl csrfToken displayErrorMessage displaySuccessMessage */
 
 const benchmarks_with_input_fields = ['lowest_a-', 'lowest_b-', 'lowest_c-', 'lowest_d'];
@@ -122,6 +122,32 @@ function GetPotentialAlternates(el, gradeables) {
             el.appendChild(option);
         }
     });
+}
+
+// Load alternate gradeable when page is loaded
+function LoadAlternate(el, gradeables, dropdownGradeable) {
+    // If alternate is null, no alternate had been selected
+    if (typeof dropdownGradeable['alternate'] !== 'undefined') {
+        let title = '';
+        // Find the title of the alternate
+        gradeables.forEach((gradeable) => {
+            if (gradeable['id'] === dropdownGradeable['alternate']) {
+                title = gradeable['title'];
+            }
+        });
+
+        // Create option representing the alternate
+        const option = document.createElement('option');
+        option.value = dropdownGradeable['alternate'];
+        option.text = title;
+        el.appendChild(option);
+        // Select the option in the dropdown
+        $(el).val(dropdownGradeable['alternate']).change();
+
+        // Check the checkboxes to make the alternate dropdown visible
+        $('#enable-alternates').prop('checked', true);
+        $(`#alternate-checkbox-${dropdownGradeable['id']}`).prop('checked', true);
+    }
 }
 
 // Updates the sum of percentage points accounted for by the buckets being used
@@ -1195,6 +1221,13 @@ $(document).ready(() => {
         });
     });
 
+    // Load alternates from customization.json
+    const alternateDropdowns = $('select[id^="alternate-dropdown-"]');
+    alternateDropdowns.each((index, alternateDropdownDOMElement) => {
+        const alternateDropdown = $(alternateDropdownDOMElement);
+        LoadAlternate(alternateDropdownDOMElement, alternateDropdown.data('gradeables'), alternateDropdown.data('gradeable'));
+    });
+
     // Control visibility of gradeable alternate checkboxes
     const enableAlternatesCheckbox = $('#enable-alternates');
     const alternateCheckboxes = $('label[id^="alternate-checkbox-label-"]');
@@ -1210,7 +1243,6 @@ $(document).ready(() => {
     });
 
     // Control visibility of gradeable alternate dropdowns
-    const alternateDropdowns = $('select[id^="alternate-dropdown-"]');
     alternateDropdowns.each((index, alternateDropdown) => {
         const gradeableID = alternateDropdown.id.match(/^alternate-dropdown-(.+)$/)[1];
         const gradeableAlternate = $(`#alternate-checkbox-${gradeableID}`);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

# Do not merge until RainbowGrades backend is implemented

Steps to Test

1. Login to Instructor, then navigate to Grade Reports > Web-Based Rainbow Grades Customization.
2. Drag any item from Available Buckets to Assigned Buckets.
3. Click on the pencil icon next to **Category/Gradeable Configuration**, then check **Enable Alternates**.
4. Check any checkbox with label **Alternate?**, then select from the dropdown.

### What is the new behavior?
Adds the option to select alternates for a gradeable to the Web-Based Rainbow Grades Customization page. These alternates are for either/or gradeables, i.e. for when a student is meant to complete one gradeable from a selection.
![image](https://github.com/user-attachments/assets/dc4956f4-8ddb-4f6a-bb14-3821fe330625)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
