### PR TITLE
[Bugfix:InstructorUI] Numeric Gradeable total update on delete

### DIFF
--- a/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
@@ -103,6 +103,7 @@
                 $('#mult-field-' + numNumeric, '.numerics-table').remove();
             }
             --numNumeric;
+            calculateTotalScore();
         }
 
         function addText(label) {


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The current behavior is that the textbox that contains the total score doesn't update on delete.
Fix #10938 

### What is the new behavior?
Update the total score on delete

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
