### PR TITLE
[Bugfix:Submission] Fixing Alert to Explain Locked Gradeable

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2572,7 +2572,7 @@ class Gradeable extends AbstractModel {
         if ($this->depends_on !== null && $this->depends_on_points !== null) {
             $dependent_gradeable = $this->core->getQueries()->getGradeableConfig($this->depends_on);
             $dependent_gradeable_points = strval($this->depends_on_points);
-            return ($dependent_gradeable->getTitle() . " first. A score of " . $dependent_gradeable_points . " is required.");
+            return ($dependent_gradeable->getTitle() . " first. " . $dependent_gradeable_points . " point(s) required.");
         }
         else {
             return '';

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2572,7 +2572,7 @@ class Gradeable extends AbstractModel {
         if ($this->depends_on !== null && $this->depends_on_points !== null) {
             $dependent_gradeable = $this->core->getQueries()->getGradeableConfig($this->depends_on);
             $dependent_gradeable_points = strval($this->depends_on_points);
-            return ($dependent_gradeable->getTitle() . " first. " . $dependent_gradeable_points . " point(s) required.");
+            return ($dependent_gradeable->getTitle() . " first with a score of " . $dependent_gradeable_points . " point(s)");
         }
         else {
             return '';

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2571,7 +2571,8 @@ class Gradeable extends AbstractModel {
     public function getPrerequisite(): string {
         if ($this->depends_on !== null && $this->depends_on_points !== null) {
             $dependent_gradeable = $this->core->getQueries()->getGradeableConfig($this->depends_on);
-            return $dependent_gradeable->getTitle();
+            $dependent_gradeable_points = strval($this->depends_on_points);
+            return ($dependent_gradeable->getTitle() . " first. A score of " . $dependent_gradeable_points . " is required.");
         }
         else {
             return '';

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -99,15 +99,8 @@
     {% else %}
         <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }} {% if button.hasOnclick() %} key_to_click {% endif %}{% if button.isDisabled() %} disabled{% endif %}" tabindex="0" style="pointer-events: auto;"
             {% if button.isDisabled() %}
-                {% if core.getUser().accessFullGrading() %}
-                    {% set str1 = 'Students are expected to satisfactorily complete ' %}
-                    {% set str2 = ' before they may access this gradeable. Click OK to bypass this requirement.'%}
-                    onclick="confirmBypass('{{ str1 ~ button.getPrerequisite() ~ str2 }}', '{{ button.getHref() }}' );"
-                    title='Please complete {{ button.getPrerequisite()}}.'
-                {% else %}
-                    onclick="alert('Please complete {{ button.getPrerequisite()}}.' )"
-                    title='Please complete {{ button.getPrerequisite()}}.' 
-                {% endif %}
+                onclick="alert('Please complete {{ button.getPrerequisite()}}.' )"
+                title='Please complete {{ button.getPrerequisite()}}.' 
             {% else %}
                 {# assigns the href unless button has onclick affect #}
                 {% if not button.hasOnclick() %}

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -101,12 +101,12 @@
             {% if button.isDisabled() %}
                 {% if core.getUser().accessFullGrading() %}
                     {% set str1 = 'Students are expected to satisfactorily complete ' %}
-                    {% set str2 = ' before they may access this gradeable.  Click OK to bypass this requirement.'%}
+                    {% set str2 = ' before they may access this gradeable. Click OK to bypass this requirement.'%}
                     onclick="confirmBypass('{{ str1 ~ button.getPrerequisite() ~ str2 }}', '{{ button.getHref() }}' );"
-                    title='Please complete {{ button.getPrerequisite()}}'
+                    title='Please complete {{ button.getPrerequisite()}}.'
                 {% else %}
-                    onclick="alert('Please complete {{ button.getPrerequisite()}}' )"
-                    title='Please complete {{ button.getPrerequisite()}}' 
+                    onclick="alert('Please complete {{ button.getPrerequisite()}}.' )"
+                    title='Please complete {{ button.getPrerequisite()}}.' 
                 {% endif %}
             {% else %}
                 {# assigns the href unless button has onclick affect #}

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -97,8 +97,9 @@
     {% if button is null %}
         <div class="button-placeholder"></div>
     {% else %}
-        <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }} {% if button.hasOnclick() %} key_to_click {% endif %}{% if button.isDisabled() %} disabled{% endif %}" tabindex="0" style="pointer-events: auto;"
+        <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }} {% if button.hasOnclick() %} key_to_click {% endif %}{% if button.isDisabled() %} disabled{% endif %}" tabindex="0"
             {% if button.isDisabled() %}
+                style="pointer-events: auto;"
                 onclick="alert('Please complete {{ button.getPrerequisite()}}.' )"
                 title='Please complete {{ button.getPrerequisite()}}.' 
             {% else %}

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -103,10 +103,10 @@
                     {% set str1 = 'Students are expected to satisfactorily complete ' %}
                     {% set str2 = ' before they may access this gradeable.  Click OK to bypass this requirement.'%}
                     onclick="confirmBypass('{{ str1 ~ button.getPrerequisite() ~ str2 }}', '{{ button.getHref() }}' );"
-                    title='Please complete {{ button.getPrerequisite()}} first'
+                    title='Please complete {{ button.getPrerequisite()}}'
                 {% else %}
-                    onclick="alert('Please complete {{ button.getPrerequisite()}} first' )"
-                    title='Please complete {{ button.getPrerequisite()}} first' 
+                    onclick="alert('Please complete {{ button.getPrerequisite()}}' )"
+                    title='Please complete {{ button.getPrerequisite()}}' 
                 {% endif %}
             {% else %}
                 {# assigns the href unless button has onclick affect #}

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -97,7 +97,7 @@
     {% if button is null %}
         <div class="button-placeholder"></div>
     {% else %}
-        <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }} {% if button.hasOnclick() %} key_to_click {% endif %}{% if button.isDisabled() %} disabled{% endif %}" tabindex="0"
+        <a class="{{ button.getClass() }}{{ (button.getTitle() == 'Edit' or button.getTitle() == 'Delete') and has_build_error ? 'edit-build-error' : '' }} {% if button.hasOnclick() %} key_to_click {% endif %}{% if button.isDisabled() %} disabled{% endif %}" tabindex="0" style="pointer-events: auto;"
             {% if button.isDisabled() %}
                 {% if core.getUser().accessFullGrading() %}
                     {% set str1 = 'Students are expected to satisfactorily complete ' %}

--- a/site/cypress/e2e/Cypress-Gradeable/edit_gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/edit_gradeable.spec.js
@@ -211,7 +211,7 @@ describe('Tests cases revolving around modifying gradeables', () => {
 
         ['instructor', 'ta', 'grader', 'student'].forEach((user) => {
             logoutLogin(user, ['sample']);
-            cy.get('[title="Please complete Autograde and TA Homework (C System Calls) first. 10 point(s) required."]').should('have.class', 'disabled');
+            cy.get('[title="Please complete Autograde and TA Homework (C System Calls) first with a score of 10 point(s)."]').should('have.class', 'disabled');
         });
 
         logoutLogin('instructor', ['sample', 'gradeable', 'open_peer_homework', 'update']);

--- a/site/cypress/e2e/Cypress-Gradeable/edit_gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/edit_gradeable.spec.js
@@ -211,7 +211,7 @@ describe('Tests cases revolving around modifying gradeables', () => {
 
         ['instructor', 'ta', 'grader', 'student'].forEach((user) => {
             logoutLogin(user, ['sample']);
-            cy.get('[title="Please complete Autograde and TA Homework (C System Calls) first"]').should('have.class', 'disabled');
+            cy.get('[title="Please complete Autograde and TA Homework (C System Calls) first. 10 point(s) required."]').should('have.class', 'disabled');
         });
 
         logoutLogin('instructor', ['sample', 'gradeable', 'open_peer_homework', 'update']);

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -69,7 +69,8 @@ fieldset[disabled] .btn {
 
 a.btn.disabled,
 fieldset[disabled] a.btn {
-    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.4;
 }
 
 .btn-default {

--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -69,8 +69,7 @@ fieldset[disabled] .btn {
 
 a.btn.disabled,
 fieldset[disabled] a.btn {
-    cursor: not-allowed;
-    opacity: 0.4;
+    pointer-events: none;
 }
 
 .btn-default {


### PR DESCRIPTION
Closes #10894 

### What is the current behavior?
When a gradeable is locked for a particular student, they do not know what prior gradeable they need to complete before being able to access the current one.

### What is the new behavior?
When a student hovers over the locked gradeable button, they see exactly what prior gradeable they need to complete and the score they need to receive on said gradeable.

![image](https://github.com/user-attachments/assets/e53699b6-0db2-4515-991e-7b2d138128d1)


### Other information?
To test, make a new gradeable with a prerequisite and required minimum score as an instructor. Then, as a student, hover over or click on that gradeable's "LOCKED" button.
