### PR TITLE
[Refactor:SubminiPolls] Modifying Poll Cypress Test to test Frontend more accurately

### DIFF
--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -285,6 +285,10 @@ describe('Test cases revolving around polls functionality', () => {
 
         cy.reload(); // Will not need this after websockets.
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().should('not.be.checked');
+        cy.contains('Poll Cypress Test').siblings(':nth-child(8)').click();
+        cy.get('[data-testid="timer"]').contains('Poll Ended');
+        cy.go('back');
+
         // Removing duration to continue testing
         // Editing the poll to remove timer
         cy.contains('Poll Cypress Test').siblings(':nth-child(1)').children().click();
@@ -422,6 +426,9 @@ describe('Test cases revolving around polls functionality', () => {
         cy.reload();
         // Validate that the poll is closed.
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().should('not.be.checked');
+        cy.contains('Poll Cypress Test').siblings(':nth-child(8)').click();
+        cy.get('[data-testid="timer"]').contains('Poll Ended');
+        cy.go('back');
 
         // log into student, now we can see the histogram on closed poll
         cy.logout();


### PR DESCRIPTION

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

Currently, the cypress test is testing the front end displaying "Poll Ended" more as status than understanding if the Poll Ends after a given time interval. The cypress test isn't accurately testing the 'time' functionality of the front end.

### What is the new behavior?

An additional front-end check was added after the wait statement to ensure that the front end was synchronized with the back end after the given interval.

