### PR TITLE
[Bugfix:Autograding] autograding status race condition

### DIFF
--- a/site/app/models/QueueItem.php
+++ b/site/app/models/QueueItem.php
@@ -41,7 +41,15 @@ class QueueItem extends AbstractModel {
         }
         $this->start_time = filectime($json_file);
         $this->elapsed_time = $epoch_time - $this->start_time;
-        $this->queue_obj = FileUtils::readJsonFile($json_file);
+
+        $json = FileUtils::readJsonFile($json_file);
+        // Queue or grading file does not exist or is not parseable
+        if ($json === false) {
+            $this->queue_obj = [];
+            return;
+        }
+
+        $this->queue_obj = $json;
         $this->regrade = array_key_exists("regrade", $this->queue_obj);
     }
 }

--- a/site/app/models/QueueItem.php
+++ b/site/app/models/QueueItem.php
@@ -48,6 +48,5 @@ class QueueItem extends AbstractModel {
             $this->queue_obj = $json;
             $this->regrade = array_key_exists("regrade", $this->queue_obj);
         }
-
     }
 }

--- a/site/app/models/QueueItem.php
+++ b/site/app/models/QueueItem.php
@@ -44,12 +44,10 @@ class QueueItem extends AbstractModel {
 
         $json = FileUtils::readJsonFile($json_file);
         // Queue or grading file does not exist or is not parseable
-        if ($json === false) {
-            $this->queue_obj = [];
-            return;
+        if ($json != false) {
+            $this->queue_obj = $json;
+            $this->regrade = array_key_exists("regrade", $this->queue_obj);
         }
 
-        $this->queue_obj = $json;
-        $this->regrade = array_key_exists("regrade", $this->queue_obj);
     }
 }

--- a/site/app/models/QueueItem.php
+++ b/site/app/models/QueueItem.php
@@ -44,7 +44,7 @@ class QueueItem extends AbstractModel {
 
         $json = FileUtils::readJsonFile($json_file);
         // Queue or grading file does not exist or is not parseable
-        if ($json != false) {
+        if ($json !== false) {
             $this->queue_obj = $json;
             $this->regrade = array_key_exists("regrade", $this->queue_obj);
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10952 
Currently there is a change when requesting https://submitty.cs.rpi.edu//autograding_status/get_update to trigger a fatal error when the list of Items in the queue to return has an item finish before the response is fully formulated.
### What is the new behavior?

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested by submitting 1.5k gradables before and seeing the error occur multiple times while viewing the auto updating page, and then submitting 2k afterwards and not seeing the issue again.
