### PR TITLE
[Bugfix:System] Temporary restrict Virtualbox to 7.0

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -14,11 +14,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: brew install virtualbox@beta vagrant
+      - run: brew install vagrant
       # Installing this is skipped in CI as using it was causing some corruption in
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.
       # - run: vagrant plugin install vagrant-vbguest
+      - name: install virtual box 7.0.20
+        run: |
+          curl -LO https://download.virtualbox.org/virtualbox/7.0.20/VirtualBox-7.0.20-163906-OSX.dmg
+          hdiutil mount VirtualBox-7.0.20-163906-OSX.dmg
+          sudo installer -pkg /Volumes/VirtualBox/VirtualBox.pkg -target /
+          hdiutil unmount /Volumes/VirtualBox
+          
       - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -15,17 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: brew install vagrant
-      # Installing this is skipped in CI as using it was causing some corruption in
-      # attempting to mount the shared folder. The guest and host guest additions
-      # versions are close enough that we are fine without it.
-      # - run: vagrant plugin install vagrant-vbguest
       - name: install virtual box 7.0.20
         run: |
           curl -LO https://download.virtualbox.org/virtualbox/7.0.20/VirtualBox-7.0.20-163906-OSX.dmg
           hdiutil mount VirtualBox-7.0.20-163906-OSX.dmg
           sudo installer -pkg /Volumes/VirtualBox/VirtualBox.pkg -target /
           hdiutil unmount /Volumes/VirtualBox
-          
+      # Installing this is skipped in CI as using it was causing some corruption in
+      # attempting to mount the shared folder. The guest and host guest additions
+      # versions are close enough that we are fine without it.
+      # - run: vagrant plugin install vagrant-vbguest
       - run: NO_SUBMISSIONS=1 vagrant up ubuntu-22.04
       - name: Validate image
         run: curl --show-error --fail --include http://localhost:1511

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: brew install virtualbox vagrant
+      - run: brew install virtualbox@beta vagrant
       # Installing this is skipped in CI as using it was causing some corruption in
       # attempting to mount the shared folder. The guest and host guest additions
       # versions are close enough that we are fine without it.


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The Vagrant up github action is currently not working with the new VirtualBox 7.1 update. 
https://formulae.brew.sh/cask/virtualbox
https://forums.virtualbox.org/viewtopic.php?t=112320&sid=7ac5fd1e5fa51bd37e24ceede0fa6a1d&start=15

### What is the new behavior?
Restricts the version to 7.0.20
currently working on my [forked repo](https://github.com/williamschen23/Submitty/actions/workflows/vagrant_up.yaml)
