### PR TITLE
[Bugfix:InstructorUI] Fix error: 0 items for Numeric gradeable

### DIFF
--- a/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
@@ -127,7 +127,7 @@
             }
             if(requestedText == 0 && $('#numeric_num-items').val() == 0){
                 alert('You must have at least one item');
-                $('#save_status').html('<span style="color: red">Some Changes Failed!</span>');
+                $('#save_status').text('Some Changes Failed!').css('color', 'red');
             } else {
                 while (numText < requestedText) {
                     addText('');
@@ -149,7 +149,7 @@
 
             if(requestedNumeric == 0 && $('#numeric_num_text_items').val() == 0){
                 alert('You must have at least one item');
-                $('#save_status').html('<span style="color: red">Some Changes Failed!</span>');
+                $('#save_status').text('Some Changes Failed!').css('color', 'red');
             } else {
                 while (numNumeric < requestedNumeric) {
                     addNumeric(numNumeric + 1, 0, false);

--- a/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/NumericRubric.twig
@@ -125,15 +125,20 @@
             if (isNaN(requestedText) || requestedText < 0) {
                 requestedText = 0;
             }
-            while (numText < requestedText) {
-                addText('');
-            }
-            while (numText > requestedText) {
-                removeText();
+            if(requestedText == 0 && $('#numeric_num-items').val() == 0){
+                alert('You must have at least one item');
+                $('#save_status').html('<span style="color: red">Some Changes Failed!</span>');
+            } else {
+                while (numText < requestedText) {
+                    addText('');
+                }
+                while (numText > requestedText) {
+                    removeText();
+                }
+                // When changing to a valid text item count, save the rubric
+                saveRubric(false);
             }
 
-            // When changing text item count, save the rubric
-            saveRubric(false);
         });
 
         $('#numeric_num-items').on('change', function (e) {
@@ -141,15 +146,20 @@
             if (isNaN(requestedNumeric) || requestedNumeric < 0) {
                 requestedNumeric = 0;
             }
-            while (numNumeric < requestedNumeric) {
-                addNumeric(numNumeric + 1, 0, false);
-            }
-            while (numNumeric > requestedNumeric) {
-                removeNumeric();
-            }
 
-            // When numeric item count, save the rubric
-            saveRubric(false);
+            if(requestedNumeric == 0 && $('#numeric_num_text_items').val() == 0){
+                alert('You must have at least one item');
+                $('#save_status').html('<span style="color: red">Some Changes Failed!</span>');
+            } else {
+                while (numNumeric < requestedNumeric) {
+                    addNumeric(numNumeric + 1, 0, false);
+                }
+                while (numNumeric > requestedNumeric) {
+                    removeNumeric();
+                }
+                // When numeric item count, save the rubric
+                saveRubric(false);
+            }
         });
 
         let components = {{ gradeable_components_enc|raw }};


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently if a numeric gradeable has 0 items, it throws a lot of json_decode() errors.
Fix #10947 

### What is the new behavior?
We can use js to restrict the rubric to not have 0 items

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
