### PR TITLE
[Bugfix:InstructorUI] Fix formatting in Rainbow Grade Page

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -121,7 +121,7 @@
                             <input type="checkbox" id="display_{{ display_option.id }}" name="display" value="{{ display_option.id }}" data-testid="display-{{ display_option.id|replace({'_': '-'}) }}"
                                    {% if display_option.isUsed == true %}checked{% endif %}
                             >
-                            <label style="display: table-cell; width: 150px;" for="display_{{ display_option.id }}">{{ display_option.id }}</label>
+                            <label style="display: table-cell; width: 200px;" for="display_{{ display_option.id }}">{{ display_option.id }}</label>
                             <span style=" display: table-cell;"><em>{{ description | raw }}</em></span>
                         </div>
                         {% set counter = counter + 1 %}


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10881. The description of the "display_rank_to_individual" option in the Rainbow Grades Customization page was not spaced away properly due to formatting.
### What is the new behavior?
Increased the pixel width between options and descriptions, making it so display_rank_to_individual's description is formatted uniformly with the rest of the descriptions.

Before:
![formattingBefore](https://github.com/user-attachments/assets/699ff46d-722f-41b1-800d-ed3fc30cb37b)

After:
![formattingAfter](https://github.com/user-attachments/assets/cfb0b503-f93b-401c-a9d5-d17eab41469c)

Tested different website themes and resizes the browser via google chrome developer tools, looks fine from what I've seen. 
