### PR TITLE
[Bugfix:Submission] Handle Jupyter string values properly

### DIFF
--- a/site/app/libraries/NotebookUtils.php
+++ b/site/app/libraries/NotebookUtils.php
@@ -23,7 +23,7 @@ class NotebookUtils {
                 case 'markdown':
                     $cells[] = [
                         'type' => 'markdown',
-                        'markdown_data' => implode($cell['source']),
+                        'markdown_data' => is_array($cell['source']) ? implode($cell['source']) : (string) $cell['source'],
                     ];
                     break;
                 case 'code':
@@ -31,7 +31,7 @@ class NotebookUtils {
                         'type' => 'short_answer',
                         'label' => '',
                         'programming_language' => $filedata['metadata']['language_info']['name'] ?? 'python',
-                        'initial_value' => implode($cell['source']),
+                        'initial_value' => is_array($cell['source']) ? implode($cell['source']) : (string) $cell['source'],
                         'rows' => count($cell['source']),
                         'filename' => $cell['id'] ?? 'notebook-cell-' . rand(),
                         'recent_submission' => '',
@@ -43,7 +43,7 @@ class NotebookUtils {
                         if (($output['output_type'] ?? '') === 'stream') {
                             $cells[] = [
                                 'type' => 'output',
-                                'output_text' => implode($output['text'] ?? []),
+                                'output_text' => is_array($output['text'] ?? '') ? implode($output['text']) : (string) ($output['text'] ?? ''),
                             ];
                         }
                         elseif (($output['output_type'] ?? '') === 'display_data' && isset($output['data'])) {


### PR DESCRIPTION
### What is the current behavior?
Jupyter notebook rendering errors have been reported on production due to Jupyter notebooks using string values instead of array values for some fields.  For example:
```
TypeError (Code: 0) thrown in /usr/local/submitty/site/app/libraries/NotebookUtils.php (Line 26) by:
                       'markdown_data' => implode($cell['source']),
Message:
implode(): Argument #1 ($pieces) must be of type array, string given
.
.
.
```

### What is the new behavior?
This PR fixes the issue by handling an array if an array value is submitted, and casting to a string otherwise.