### PR TITLE
[Bugfix:Submission] Fixing Buggy Late Day Message Text

### DIFF
--- a/site/app/templates/submission/homework/LateDayMessage.twig
+++ b/site/app/templates/submission/homework/LateDayMessage.twig
@@ -37,10 +37,10 @@
                 {{ self.line_breaks(loop.index0 > 0 ? 2 : 0) }}
                 Your active version was submitted {{ message.info.late }} {{ self.day_or_days(message.info.late) }} after the deadline,
                 and you have been charged {{ message.info.charged }} late {{ self.day_or_days(message.info.charged) }} for this assignment.
-                {% if message.info.remaining == 0 %}
-                    You have no late days remaining for future assignments.
+                {% if message.info.allowed_remaining == 0 %}
+                    You have no late days remaining for this assignment.
                 {% else %}
-                    You have {{ message.info.remaining }} remaining late {{ self.day_or_days(message.info.remaining) }} for future assignments.
+                    You have {{ message.info.allowed_remaining }} remaining late {{ self.day_or_days(message.info.allowed_remaining) }} for this assignment.
                 {% endif %}
             {% elseif message.type == 'getting_zero' %}
                 {{ self.line_breaks(loop.index0 > 0 ? 1 : 0) }}

--- a/site/app/templates/submission/homework/LateDayMessage.twig
+++ b/site/app/templates/submission/homework/LateDayMessage.twig
@@ -85,8 +85,9 @@
                 {% endif %}
             {% endif %}
         {% endfor %}
+
         <br>
-        For more information, see your complete "My Late Days/Extensions" page.
+        For more information, see your complete <a href="{{ late_days_url }}">"My Late Days/Extensions"</a> page.
     </h4>
 </div>
 {% endif %}

--- a/site/app/templates/submission/homework/LateDayMessage.twig
+++ b/site/app/templates/submission/homework/LateDayMessage.twig
@@ -40,7 +40,7 @@
                 {% if message.info.remaining == 0 %}
                     You have no late days remaining for future assignments.
                 {% else %}
-                    You have {{ message.info.remaining }} remaining late {{ self.day_or_days(message.info.remaining) }} for this assignment.
+                    You have {{ message.info.remaining }} remaining late {{ self.day_or_days(message.info.remaining) }} for future assignments.
                 {% endif %}
             {% elseif message.type == 'getting_zero' %}
                 {{ self.line_breaks(loop.index0 > 0 ? 1 : 0) }}
@@ -85,6 +85,8 @@
                 {% endif %}
             {% endif %}
         {% endfor %}
+        <br>
+        For more information, see your complete "My Late Days/Extensions" page.
     </h4>
 </div>
 {% endif %}

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -274,7 +274,8 @@ class HomeworkView extends AbstractView {
                 $messages[] = ['type' => 'late', 'info' => [
                     'late' => $active_days_late,
                     'charged' => $active_days_charged,
-                    'remaining' => $late_day_budget
+                    'remaining' => $late_day_budget,
+                    'allowed_remaining' => $late_days_allowed - $active_days_charged
                 ]];
             }
             if ($error) {

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -337,10 +337,13 @@ class HomeworkView extends AbstractView {
             ]];
         }
 
+        $late_days_url = $this->core->buildCourseUrl(['late_table']);
+
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/LateDayMessage.twig', [
             'messages' => $messages,
             'error' => $error,
-            'daylight' => $daylight_message_required
+            'daylight' => $daylight_message_required,
+            'late_days_url' => $late_days_url
         ]);
     }
 


### PR DESCRIPTION
### What is the current behavior?
Closes #10963 

The late day messages currently do not display a link to the "My Late Days / Extensions" page and says "You have 1 remaining late day for this assignment" instead of for future assignments.

### What is the new behavior?

The code fixes the above behavior:
![image](https://github.com/user-attachments/assets/07ddbb25-f836-461a-aa5c-30569c50975f)

In the image above, the instructor makes a gradeable that has a limit of 3 late days allowed. The student uses one late day, and the code now displays that the student has two more late days remaining for that same assignment. Also, it displays a link at the bottom to the 'My Late Days / Extensions' page.

### Other information?
To test, make or go to a late gradeable, and check if the above changes have been made correctly.