### PR TITLE
[Feature:SubminiPolls] Hide "Show Answer" if Poll is a Survey

### DIFF
--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -133,7 +133,7 @@
             <option value="always" {{ poll is not null and poll.getReleaseHistogram() == 'always' ? "selected" : "" }}>Always</option>
         </select>
         <br><br>
-        <div {{is_survey ? "style='display:none'" : "style='display:inline-block'"}}>
+        <div id="show-answer-release">
             <label for="student-answer-release-setting" class="option-title">
                 Show correct response to students:
             </label>
@@ -217,8 +217,25 @@
         }
     });
 
+    function initializePollType() {
+        if ($("#poll-type-single-response-survey").is(":checked")
+            || $("#poll-type-multiple-response-survey").is(":checked")) {
+            $("#show-answer-release").hide();
+        } else {
+            $("#show-answer-release").show();
+        }
+    }
+
     function changePollType() {
         let count = $(".option_id").length;
+        if ($("#poll-type-single-response-survey").is(":checked")
+                || $("#poll-type-multiple-response-survey").is(":checked")) {
+            $("#show-answer-release").hide();
+
+        } else {
+            $("#show-answer-release").show();
+
+        }
         for (let i = 0; i < count; i++) {
             if ($("#poll-type-single-response-survey").is(":checked")
                 || $("#poll-type-multiple-response-survey").is(":checked")) {
@@ -418,7 +435,7 @@
     $(document).ready(function() {
         setEventHandlers();
         $("#new-poll-form").on("change click", submitErrorChecks);
-
+        initializePollType();
         let submit_form = false;
         $("#new-poll-form").submit(function(event) {
             if (!submit_form && {{ poll is not null ? "true" : "false" }} && !$(`#poll-type-${ poll_type }`).is(':checked')) {

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -133,14 +133,16 @@
             <option value="always" {{ poll is not null and poll.getReleaseHistogram() == 'always' ? "selected" : "" }}>Always</option>
         </select>
         <br><br>
-        <label for="student-answer-release-setting" class="option-title">
-            Show correct response to students:
-        </label>
-        <select id="student-answer-release-setting" name="release_answer">
-            <option value="never" {{ poll is null or poll.getReleaseAnswer() == 'never' ? "selected" : "" }}>Never</option>
-            <option value="when_ended" {{ poll is not null and poll.getReleaseAnswer() == 'when_ended' ? "selected" : "" }}>After Poll Ended</option>
-            <option value="always" {{ poll is not null and poll.getReleaseAnswer() == 'always' ? "selected" : "" }}>Always</option>
-        </select>
+        <div {{is_survey ? "style='display:none'" : "style='display:inline-block'"}}
+            <label for="student-answer-release-setting" class="option-title">
+                Show correct response to students:
+            </label>
+            <select id="student-answer-release-setting" name="release_answer">
+                <option value="never" {{ poll is null or poll.getReleaseAnswer() == 'never' ? "selected" : "" }}>Never</option>
+                <option value="when_ended" {{ poll is not null and poll.getReleaseAnswer() == 'when_ended' ? "selected" : "" }}>After Poll Ended</option>
+                <option value="always" {{ poll is not null and poll.getReleaseAnswer() == 'always' ? "selected" : "" }}>Always</option>
+            </select>
+        </div>
         <div class="break-above">
             <label for="poll-custom-options" class="option-title credit-form-item">
                 Allow student-written responses?

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -426,6 +426,7 @@
     $(document).ready(function() {
         setEventHandlers();
         $("#new-poll-form").on("change click", submitErrorChecks);
+        
         let submit_form = false;
         $("#new-poll-form").submit(function(event) {
             if (!submit_form && {{ poll is not null ? "true" : "false" }} && !$(`#poll-type-${ poll_type }`).is(':checked')) {

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -426,7 +426,7 @@
     $(document).ready(function() {
         setEventHandlers();
         $("#new-poll-form").on("change click", submitErrorChecks);
-        
+
         let submit_form = false;
         $("#new-poll-form").submit(function(event) {
             if (!submit_form && {{ poll is not null ? "true" : "false" }} && !$(`#poll-type-${ poll_type }`).is(':checked')) {

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -36,37 +36,37 @@
         </span>
 
         <div class="poll-type-option">
-            <input type="radio" id="poll-type-single-response-single-correct" name="question_type" value="single-response-single-correct" onclick="changePollType()" {{ question_type == 'single-response-single-correct'? "checked" : "" }}></input>
+            <input type="radio" id="poll-type-single-response-single-correct" name="question_type" data-testid="single-response-one-answer" value="single-response-single-correct" onclick="changePollType()" {{ question_type == 'single-response-single-correct'? "checked" : "" }}></input>
             <label for="poll-type-single-response-single-correct">single response - single correct</label>
             <p class="poll-type-description"><i>Students can select only one response, and there is only one full credit answer.</i></p>
         </div>
 
         <div class="poll-type-option">
-            <input type="radio" id="poll-type-single-response-multiple-correct" name="question_type" value="single-response-multiple-correct" onclick="changePollType()" {{ question_type == 'single-response-multiple-correct'? "checked" : "" }}></input>
+            <input type="radio" id="poll-type-single-response-multiple-correct" name="question_type" data-testid="single-response-multiple-answer" value="single-response-multiple-correct" onclick="changePollType()" {{ question_type == 'single-response-multiple-correct'? "checked" : "" }}></input>
             <label for="poll-type-single-response-multiple-correct">single response - multiple correct</label>
             <p class="poll-type-description"><i>Students can select only one response, and there are one or more full credit answers.</i></p>
         </div>
 
         <div class="poll-type-option">
-            <input type="radio" id="poll-type-single-response-survey" name="question_type" value="single-response-survey" onclick="changePollType()" {{ question_type == 'single-response-survey'? "checked" : "" }}></input>
+            <input type="radio" id="poll-type-single-response-survey" name="question_type" data-testid="single-response-survey" value="single-response-survey" onclick="changePollType()" {{ question_type == 'single-response-survey'? "checked" : "" }}></input>
             <label for="poll-type-single-response-survey">single response - survey</label>
             <p class="poll-type-description"><i>Students can select only one response, and any selection is worth full credit.</i></p>
         </div>
 
         <div class="poll-type-option">
-            <input type="radio" id="poll-type-multiple-response-exact" name="question_type" value="multiple-response-exact" onclick="changePollType()" {{ question_type == 'multiple-response-exact'? "checked" : "" }}></input>
+            <input type="radio" id="poll-type-multiple-response-exact" name="question_type" data-testid="multiple-response" value="multiple-response-exact" onclick="changePollType()" {{ question_type == 'multiple-response-exact'? "checked" : "" }}></input>
             <label for="poll-type-multiple-response-exact">multiple response - exact</label>
             <p class="poll-type-description"><i>Students can select one or more responses, and they receive full credit only if their selection exactly matches the instructor's selection.</i></p>
         </div>
 
         <div class="poll-type-option">
-            <input type="radio" id="poll-type-multiple-response-flexible" name="question_type" value="multiple-response-flexible" onclick="changePollType()" {{ question_type == 'multiple-response-flexible'? "checked" : "" }}></input>
+            <input type="radio" id="poll-type-multiple-response-flexible" name="question_type" data-testid="multiple-response-flexible" value="multiple-response-flexible" onclick="changePollType()" {{ question_type == 'multiple-response-flexible'? "checked" : "" }}></input>
             <label for="poll-type-multiple-response-flexible">multiple response - flexible</label>
             <p class="poll-type-description"><i>Students can select one or more responses, and they receive full credit if they select at least one of the instructor's selected responses and do not select any of the instructor's unselected responses.</i></p>
         </div>
 
         <div class="poll-type-option">
-            <input type="radio" id="poll-type-multiple-response-survey" name="question_type" value="multiple-response-survey" onclick="changePollType()" {{ question_type == 'multiple-response-survey'? "checked" : "" }}></input>
+            <input type="radio" id="poll-type-multiple-response-survey" name="question_type" data-testid="multiple-response-survey" value="multiple-response-survey" onclick="changePollType()" {{ question_type == 'multiple-response-survey'? "checked" : "" }}></input>
             <label for="poll-type-multiple-response-survey">multiple response - survey</label>
             <p class="poll-type-description"><i>Students can select one or more responses, and any selection is worth full credit.</i></p>
         </div>
@@ -133,7 +133,7 @@
             <option value="always" {{ poll is not null and poll.getReleaseHistogram() == 'always' ? "selected" : "" }}>Always</option>
         </select>
         <br><br>
-        <div id="show-answer-release">
+        <div id="show-answer-release" data-testid="show-answer">
             <label for="student-answer-release-setting" class="option-title">
                 Show correct response to students:
             </label>

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -133,7 +133,7 @@
             <option value="always" {{ poll is not null and poll.getReleaseHistogram() == 'always' ? "selected" : "" }}>Always</option>
         </select>
         <br><br>
-        <div {{is_survey ? "style='display:none'" : "style='display:inline-block'"}}
+        <div {{is_survey ? "style='display:none'" : "style='display:inline-block'"}}>
             <label for="student-answer-release-setting" class="option-title">
                 Show correct response to students:
             </label>

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -133,7 +133,7 @@
             <option value="always" {{ poll is not null and poll.getReleaseHistogram() == 'always' ? "selected" : "" }}>Always</option>
         </select>
         <br><br>
-        <div id="show-answer-release" data-testid="show-answer">
+        <div id="show-answer-release" data-testid="show-answer" {{is_survey ? "style='display:none'" : "style='display:inline-block'"}}>
             <label for="student-answer-release-setting" class="option-title">
                 Show correct response to students:
             </label>
@@ -216,15 +216,6 @@
             fp.calendarContainer.firstChild.childNodes[1].firstChild.firstChild.setAttribute('aria-label', 'Month');
         }
     });
-
-    function initializePollType() {
-        if ($("#poll-type-single-response-survey").is(":checked")
-            || $("#poll-type-multiple-response-survey").is(":checked")) {
-            $("#show-answer-release").hide();
-        } else {
-            $("#show-answer-release").show();
-        }
-    }
 
     function changePollType() {
         let count = $(".option_id").length;
@@ -435,7 +426,6 @@
     $(document).ready(function() {
         setEventHandlers();
         $("#new-poll-form").on("change click", submitErrorChecks);
-        initializePollType();
         let submit_form = false;
         $("#new-poll-form").submit(function(event) {
             if (!submit_form && {{ poll is not null ? "true" : "false" }} && !$(`#poll-type-${ poll_type }`).is(':checked')) {

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -204,6 +204,11 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#enable-timer').check();
         cy.get('#timer-inputs').should('be.visible');
         cy.get('#enable-timer').should('be.checked');
+        // Testing 'Show Answers' disappearing after poll becomes survey
+        cy.get('#show-answer-release').should('be.visible');
+        cy.get('#poll-type-single-response-survey').check();
+        cy.get('#show-answer-release').should('not.be.visible');
+        cy.get('#poll-type-single-response-multiple-correct').check();
         // Add 5 seconds to timer
         cy.get('#timer-inputs').within(() => {
             cy.get('#poll-hours').clear();

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -205,10 +205,10 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#timer-inputs').should('be.visible');
         cy.get('#enable-timer').should('be.checked');
         // Testing 'Show Answers' disappearing after poll becomes survey
-        cy.get('#show-answer-release').should('be.visible');
-        cy.get('#poll-type-single-response-survey').check();
-        cy.get('#show-answer-release').should('not.be.visible');
-        cy.get('#poll-type-single-response-multiple-correct').check();
+        cy.get('[data-testid="show-answer"]').should('be.visible');
+        cy.get('[data-testid="single-response-survey"]').check();
+        cy.get('[data-testid="show-answer"]').should('not.be.visible');
+        cy.get('[data-testid="single-response-multiple-answer"]').check();
         // Add 5 seconds to timer
         cy.get('#timer-inputs').within(() => {
             cy.get('#poll-hours').clear();


### PR DESCRIPTION
Fixes #10941 

Not a Survey UI: 
![{BA524EB6-0FC7-4373-9E8E-C9623FF9D94E}](https://github.com/user-attachments/assets/6f82e379-fc57-494a-9b7b-00cb2738e918)
Survey:
![{3547D097-92F3-4E5B-9ED1-CA5E9484C69C}](https://github.com/user-attachments/assets/f0e713bd-1988-4bbb-a000-c9a49b73cd3c)

### What is the current behavior?
Even if the survey is a poll it displays an option where you can choose if students should be able to see the answer.

### What is the new behavior?
If it is a survey poll, it means there is no answer, therefore; that option should be omitted.
