### PR TITLE
[Bugfix:TAGrading] Wait for all Ajax calls to complete

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -777,6 +777,7 @@ function gotoNextStudent() {
             window_location += `&component_id=${getFirstOpenComponentId()}`;
             break;
     }
+    
     if (!navigate_assigned_students_only) {
         window_location += '&navigate_assigned_students_only=false';
     }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -777,7 +777,7 @@ function gotoNextStudent() {
             window_location += `&component_id=${getFirstOpenComponentId()}`;
             break;
     }
-    
+
     if (!navigate_assigned_students_only) {
         window_location += '&navigate_assigned_students_only=false';
     }

--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -647,10 +647,16 @@ function updateCookies() {
 // -----------------------------------------------------------------------------
 // Student navigation
 
-function waitForAllAjaxToComplete() {
-    if ($.active > 0) {
-        setTimeout(waitForAllAjaxToComplete, 100);
-    }
+function waitForAllAjaxToComplete(callback) {
+    const checkAjax = () => {
+        if ($.active > 0) {
+            setTimeout(checkAjax, 100);
+        }
+        else {
+            callback();
+        }
+    };
+    checkAjax();
 }
 
 function gotoMainPage() {
@@ -658,8 +664,9 @@ function gotoMainPage() {
 
     if (getGradeableId() !== '') {
         closeAllComponents(true).then(() => {
-            waitForAllAjaxToComplete();
-            window.location = window_location;
+            waitForAllAjaxToComplete(() => {
+                window.location = window_location;
+            });
         }).catch(() => {
             if (confirm('Could not save open component, go to main page anyway?')) {
                 window.location = window_location;
@@ -717,8 +724,9 @@ function gotoPrevStudent() {
 
     if (getGradeableId() !== '') {
         closeAllComponents(true).then(() => {
-            waitForAllAjaxToComplete();
-            window.location = window_location;
+            waitForAllAjaxToComplete(() => {
+                window.location = window_location;
+            });
         }).catch(() => {
             if (confirm('Could not save open component, change student anyway?')) {
                 window.location = window_location;
@@ -769,15 +777,15 @@ function gotoNextStudent() {
             window_location += `&component_id=${getFirstOpenComponentId()}`;
             break;
     }
-
     if (!navigate_assigned_students_only) {
         window_location += '&navigate_assigned_students_only=false';
     }
 
     if (getGradeableId() !== '') {
         closeAllComponents(true).then(() => {
-            waitForAllAjaxToComplete();
-            window.location = window_location;
+            waitForAllAjaxToComplete(() => {
+                window.location = window_location;
+            });
         }).catch(() => {
             if (confirm('Could not save open component, change student anyway?')) {
                 window.location = window_location;


### PR DESCRIPTION
### What is the current behavior?
Currently on different browsers, it either waits or doesn't wait for all the ajax calls to complete. This would result in a race condition where the code was getting components that weren't saved, and would not save it. From a graders standpoint, unless they had console open, they would not get an error.

Another aspect of this has to do with the different ways the browser deals with event loops, which chrome apparently just solves all async requests and then moves to the next page. However, Firefox and Safari casually just moves on while the async requests happen, which messes with the code as it is also looking for elements on the screen. At least this is my interpretation of the issue

partial(?) work for #10973 

### What is the new behavior?
Properly wait for all the ajax calls to complete. This is done through a callback that only executes after it is done, so the event loop does not matter anymore. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested on Firefox, Chrome, and Safari
