### PR TITLE
[Bugfix:Submission] LATE DAY ERROR

### DIFF
--- a/site/app/templates/submission/homework/LateDayMessage.twig
+++ b/site/app/templates/submission/homework/LateDayMessage.twig
@@ -40,7 +40,7 @@
                 {% if message.info.remaining == 0 %}
                     You have no late days remaining for future assignments.
                 {% else %}
-                    You have {{ message.info.remaining }} remaining late {{ self.day_or_days(message.info.remaining) }} for this assignment.
+                    You have {{ message.info.remaining }} remaining late {{ self.day_or_days(message.info.remaining) }} for future assignments.
                 {% endif %}
             {% elseif message.type == 'getting_zero' %}
                 {{ self.line_breaks(loop.index0 > 0 ? 1 : 0) }}


### PR DESCRIPTION
ISSUE ID : #10963
<h1>What is the current behavior?</h1>
In "Late Day Message" the text message says:
"You have 1 remaining late day for this assignment"

<h1>What is the new behavior</h1>
Now text message says:
"You have 1 remaining late day for future assignments"
