### PR TITLE
[Bugfix:TAGrading] Wait for promise before navigating

### DIFF
--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -12,16 +12,19 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
         cy.get('[data-testid="component-64"]').click();
+        cy.get('[data-testid="component-64"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
         cy.get('[data-testid="component-64"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Minor errors in Read Me')
             .and('contain', 'Major errors in Read Me or Read Me missing');
         cy.get('body').type('{0}');
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
-        cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
         cy.get('[data-testid="component-65"]').click();
+        cy.get('[data-testid="component-65"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
         cy.get('[data-testid="component-65"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Code is unreadable')
@@ -29,10 +32,11 @@ describe('Test cases for TA grading page', () => {
             .and('contain', 'Code is difficult to understand');
         cy.get('body').type('{3}');
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');
-        cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
         cy.get('[data-testid="component-66"]').click();
+        cy.get('[data-testid="component-66"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
         cy.get('[data-testid="component-66"]')
             .should('contain', 'Full Credit')
             .and('contain', 'No documentation')
@@ -40,17 +44,17 @@ describe('Test cases for TA grading page', () => {
             .and('contain', 'Way too much documentation and/or documentation makes no sense');
         cy.get('body').type('{2}');
         cy.get('[data-testid="grading-total"]').eq(2).should('contain', '2 / 5');
-        cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
         cy.get('[data-testid="component-67"]').click();
+        cy.get('[data-testid="component-67"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
         cy.get('[data-testid="component-67"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Extra credit done poorly')
             .and('contain', 'Extra credit is acceptable');
         cy.get('body').type('{0}');
         cy.get('[data-testid="grading-total"]').eq(3).should('contain', '0 / 0');
-        cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');

--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -3209,14 +3209,14 @@ function saveComponent(component_id) {
         // We're in grade mode, so save the graded component
         // The grader didn't change the grade at all, so don't save (don't put our name on a grade we didn't contribute to)
         if (!gradedComponentsEqual(gradedComponent, OLD_GRADED_COMPONENT_LIST[component_id])) {
-            saveGradedComponent(component_id);
             if (!isSilentEditModeEnabled()) {
                 GRADED_COMPONENTS_LIST[component_id].grader_id = getGraderId();
             }
             GRADED_COMPONENTS_LIST[component_id].verifier_id = '';
+            return saveGradedComponent(component_id);
         }
         else if (gradedComponent.graded_version !== getDisplayVersion()) {
-            ajaxChangeGradedVersion(getGradeableId(), getAnonId(), getDisplayVersion(), [component_id]).then(async () => {
+            return ajaxChangeGradedVersion(getGradeableId(), getAnonId(), getDisplayVersion(), [component_id]).then(async () => {
                 await reloadGradingComponent(component_id, false, false);
             });
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
More partial (?) work for #10973
The promise chain would not be properly returned and therefore `closeAllComponents().then()` would not fire after components were saved. (This is potentially not as much of a problem as it seems since there is a check every 100ms to see if there are requests in progress and navigation would hold off for there to be 0)
### What is the new behavior?
All requests must finish before the navigation is started.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Had to change tests to wait for new component to open since it now properly waits for requests to be made