### PR TITLE
[Bugfix:Developer] Increase max allowable Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     commit-message:
       prefix: "[Dependency] "
       prefix-development: "[DevDependency] "
+    open-pull-requests-limit: 100
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:
@@ -19,6 +20,7 @@ updates:
     commit-message:
       prefix: "[Dependency] "
       prefix-development: "[DevDependency] "
+    open-pull-requests-limit: 100
   - package-ecosystem: pip
     directories:
       - "/.setup/pip/"
@@ -29,6 +31,7 @@ updates:
       - dependencies
     commit-message:
       prefix: "[Dependency] "
+    open-pull-requests-limit: 100
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -39,3 +42,4 @@ updates:
       - dependencies
     commit-message:
       prefix: "[DevDependency] "
+    open-pull-requests-limit: 100


### PR DESCRIPTION
### What is the current behavior?
Dependabot only opens five PRs per environment [by default](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit).  We have far more than 5 dependencies which need to be updated every month.

### What is the new behavior?
This PR increases the limit to allow all of our dependencies to be updated every month if updates are available.