### PR TITLE
[Feature:SubminiPolls] Adding Poll Calendar Selector Shortcut

### DIFF
--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -206,8 +206,8 @@
     let MAX_SIZE = {{ max_size }};
     let size_is_valid = true;
     let poll_type = "{{ poll is not null ? poll.getQuestionType() : 'poll-type-single-response-survey' }}";
-
-    flatpickr(".date_picker", {
+    
+    flatpickr("#poll-date", {
             plugins: [ShortcutButtonsPlugin(
                     {
                         button: [
@@ -240,7 +240,6 @@
                 fp.calendarContainer.firstChild.childNodes[1].firstChild.firstChild.setAttribute('aria-label', 'Month');
             }
         });
-
     function changePollType() {
         let count = $(".option_id").length;
         for (let i = 0; i < count; i++) {

--- a/site/app/templates/polls/PollForm.twig
+++ b/site/app/templates/polls/PollForm.twig
@@ -207,13 +207,39 @@
     let size_is_valid = true;
     let poll_type = "{{ poll is not null ? poll.getQuestionType() : 'poll-type-single-response-survey' }}";
 
-    flatpickr('.poll-date', {
-        allowInput: true,
-        dateFormat: "Y-m-d",
-        onReady: (a, b, fp) => {
-            fp.calendarContainer.firstChild.childNodes[1].firstChild.firstChild.setAttribute('aria-label', 'Month');
-        }
-    });
+    flatpickr(".date_picker", {
+            plugins: [ShortcutButtonsPlugin(
+                    {
+                        button: [
+                            {
+                                label: "Today"
+                            },
+                            {
+                                label: "Tomorrow"
+                            }
+                        ],
+                        label: "or",
+                        onClick: (index, fp) => {
+                            let date;
+                            switch (index) {
+                                case 0:
+                                    date = new Date();
+                                    break;
+                                case 1:
+                                    date = new Date();
+                                    date.setDate(date.getDate() + 1);
+                                    break;
+                            }
+                            fp.setDate(date, true);
+                        }
+                    }
+                )],
+            allowInput: true,
+            dateFormat: "Y-m-d",
+            onReady: (a, b, fp) => {
+                fp.calendarContainer.firstChild.childNodes[1].firstChild.firstChild.setAttribute('aria-label', 'Month');
+            }
+        });
 
     function changePollType() {
         let count = $(".option_id").length;

--- a/site/app/views/PollView.php
+++ b/site/app/views/PollView.php
@@ -100,7 +100,6 @@ class PollView extends AbstractView {
             'poll' => $poll,
             'max_size' => Utils::returnBytes(ini_get('upload_max_filesize')),
             'is_survey' => $is_survey,
-
-        ]);
+          ]);
     }
 }

--- a/site/app/views/PollView.php
+++ b/site/app/views/PollView.php
@@ -100,6 +100,7 @@ class PollView extends AbstractView {
             'poll' => $poll,
             'max_size' => Utils::returnBytes(ini_get('upload_max_filesize')),
             'is_survey' => $is_survey,
+
         ]);
     }
 }

--- a/site/app/views/PollView.php
+++ b/site/app/views/PollView.php
@@ -100,7 +100,6 @@ class PollView extends AbstractView {
             'poll' => $poll,
             'max_size' => Utils::returnBytes(ini_get('upload_max_filesize')),
             'is_survey' => $is_survey,
-            'today' => $this->core->getDateTimeNow(),
-          ]);
+        ]);
     }
 }

--- a/site/app/views/PollView.php
+++ b/site/app/views/PollView.php
@@ -100,6 +100,7 @@ class PollView extends AbstractView {
             'poll' => $poll,
             'max_size' => Utils::returnBytes(ini_get('upload_max_filesize')),
             'is_survey' => $is_survey,
+            'today' => $this->core->getDateTimeNow(),
           ]);
     }
 }


### PR DESCRIPTION
Fixes #10942 
Before:
![{A404F605-F422-401C-8908-862D0BEC948A}](https://github.com/user-attachments/assets/a0e1ec74-8399-46e1-aaa6-9f74f52ddd18)

After:
![{B137253E-BB6A-42F3-A32D-08249C6D67AC}](https://github.com/user-attachments/assets/d7fced0d-8742-4f13-88ca-8c3344e57b84)

### What is the current behavior?
No shortcut button that would help quickly assign the date as today or tomorrow.

### What is the new behavior?
I added a today and tomorrow button to assign the poll release date to today or tomorrow quickly.