### PR TITLE
[Feature ] Edit post with release date and category

### DIFF
--- a/site/app/templates/forum/EditPostForm.twig
+++ b/site/app/templates/forum/EditPostForm.twig
@@ -1,13 +1,11 @@
 {% extends 'generic/Popup.twig' %}
 
 {% block popup_id %}edit-user-post{% endblock %}
-
 {% block title_tag %}<h1 id="edit_user_prompt">Editing a post</h1>{% endblock %}
 
 {% block body %}
     <input type="hidden" id="edit_thread_id" name="edit_thread_id" value="" data-ays-ignore="true"/>
     <input type="hidden" id="edit_post_id" name="edit_post_id" value="" data-ays-ignore="true"/>
-    <input type="hidden" name="current_time" value="{{ current_time|date('Y-m-d H:i:s') }}">
 
     {% include 'forum/ThreadPostForm.twig' with {
         "show_title": true,
@@ -22,9 +20,9 @@
         "show_lock_date": true,
         "show_expiration" : true,
         "submit_label": "Update Post",
-        "categories" : categories|filter(category => not category.release_date or category.release_date <= current_time),
+        "categories" : categories,
         "attachment_script" : attachment_script,
-        "data_testid" : "forum-update-post",
+        "data_testid" : "forum-update-post"
     } %}
 
     <script>
@@ -35,16 +33,6 @@
             }
         });
         document.querySelector('.popup-box').onclick = null;
-
-        // Additional JavaScript to handle date-released categories
-        $(document).ready(function() {
-            $('.category-selection').each(function() {
-                var releaseDate = $(this).data('release-date');
-                if (releaseDate && new Date(releaseDate) > new Date('{{ current_time|date('Y-m-d H:i:s') }}')) {
-                    $(this).prop('disabled', true).addClass('disabled');
-                }
-            });
-        });
     </script>
 {% endblock %}
 
@@ -59,6 +47,4 @@
     <input class="btn btn-primary" type="submit" value="Submit" />
 {% endblock %}
 
-{% block buttons_panel %}
-    {# TODO: Make the post form not have its own buttons so we can use the normal buttons for the popup #}
-{% endblock %}
+{% block buttons_panel %}{% endblock %}

--- a/site/app/templates/forum/EditPostForm.twig
+++ b/site/app/templates/forum/EditPostForm.twig
@@ -1,9 +1,13 @@
 {% extends 'generic/Popup.twig' %}
+
 {% block popup_id %}edit-user-post{% endblock %}
+
 {% block title_tag %}<h1 id="edit_user_prompt">Editing a post</h1>{% endblock %}
+
 {% block body %}
     <input type="hidden" id="edit_thread_id" name="edit_thread_id" value="" data-ays-ignore="true"/>
     <input type="hidden" id="edit_post_id" name="edit_post_id" value="" data-ays-ignore="true"/>
+    <input type="hidden" name="current_time" value="{{ current_time|date('Y-m-d H:i:s') }}">
 
     {% include 'forum/ThreadPostForm.twig' with {
         "show_title": true,
@@ -18,10 +22,11 @@
         "show_lock_date": true,
         "show_expiration" : true,
         "submit_label": "Update Post",
-        "categories" : categories,
+        "categories" : categories|filter(category => not category.release_date or category.release_date <= current_time),
         "attachment_script" : attachment_script,
         "data_testid" : "forum-update-post",
     } %}
+
     <script>
         $("#thread_form").submit(function() {
             if((!$(this).prop("ignore-cat")) && $(this).find('.btn-selected').length == 0) {
@@ -30,20 +35,30 @@
             }
         });
         document.querySelector('.popup-box').onclick = null;
+
+        // Additional JavaScript to handle date-released categories
+        $(document).ready(function() {
+            $('.category-selection').each(function() {
+                var releaseDate = $(this).data('release-date');
+                if (releaseDate && new Date(releaseDate) > new Date('{{ current_time|date('Y-m-d H:i:s') }}')) {
+                    $(this).prop('disabled', true).addClass('disabled');
+                }
+            });
+        });
     </script>
 {% endblock %}
+
 {% block form %}
     <form id="thread_form" method="post" action="{{ edit_url }}">
         {{ parent() }}
     </form>
 {% endblock %}
+
 {% block buttons %}
     {{ block('close_button') }}
     <input class="btn btn-primary" type="submit" value="Submit" />
 {% endblock %}
+
 {% block buttons_panel %}
-    {#
-        TODO: Make the post form not have its own buttons so we can use the normal
-        buttons for the popup
-    #}
+    {# TODO: Make the post form not have its own buttons so we can use the normal buttons for the popup #}
 {% endblock %}


### PR DESCRIPTION
Fixes #10989 

### What is the current behavior?
issue #10989 
The edit post functionality doesn't correctly handle forum categories that are date-released. This causes issues when trying to edit posts in categories where the release date has passed.

### What is the new behavior?
The edit post form now correctly handles date-released categories:

Categories with release dates in the past are available for selection.
Categories with future release dates are not selectable.
The form submission process respects the category release dates

### Other information?
This change improves the user experience for instructors editing posts in the forum, ensuring that date-released categories are properly respected.

No, this is not a breaking change. It enhances existing functionality without altering the core behavior of the forum.
