### PR TITLE
[UI/UX:TAGrading] Show Unchecked Blue Marks in Closed View

### DIFF
--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -11,7 +11,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(2).should('contain', 'Documentation');
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
-        cy.get('[data-testid="component-64"]').click(20,25);
+        cy.get('[data-testid="component-64"]').click(20, 25);
         cy.get('[data-testid="component-64"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-64"]')
@@ -22,7 +22,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
-        cy.get('[data-testid="component-65"]').click(20,25);
+        cy.get('[data-testid="component-65"]').click(20, 25);
         cy.get('[data-testid="component-65"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-65"]')
@@ -34,7 +34,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
-        cy.get('[data-testid="component-66"]').click(20,25);
+        cy.get('[data-testid="component-66"]').click(20, 25);
         cy.get('[data-testid="component-66"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-66"]')
@@ -46,7 +46,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(2).should('contain', '2 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
-        cy.get('[data-testid="component-67"]').click(20,25);
+        cy.get('[data-testid="component-67"]').click(20, 25);
         cy.get('[data-testid="component-67"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-67"]')

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -11,6 +11,10 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(2).should('contain', 'Documentation');
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
+        cy.get('[data-testid="component-64"]')
+            .should('contain', 'Full Credit')
+            .and('contain', 'Minor errors in Read Me')
+            .and('contain', 'Major errors in Read Me or Read Me missing');
         cy.get('[data-testid="component-64"]').click(20, 25);
         cy.get('[data-testid="component-64"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -22,6 +26,11 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
+        cy.get('[data-testid="component-65"]')
+            .should('contain', 'Full Credit')
+            .and('contain', 'Code is unreadable')
+            .and('contain', 'Code is very difficult to understand')
+            .and('contain', 'Code is difficult to understand');
         cy.get('[data-testid="component-65"]').click(20, 25);
         cy.get('[data-testid="component-65"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -34,6 +43,11 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
+        cy.get('[data-testid="component-66"]')
+            .should('contain', 'Full Credit')
+            .and('contain', 'No documentation')
+            .and('contain', 'Very little documentation or documentation makes no sense')
+            .and('contain', 'Way too much documentation and/or documentation makes no sense');
         cy.get('[data-testid="component-66"]').click(20, 25);
         cy.get('[data-testid="component-66"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -46,6 +60,10 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(2).should('contain', '2 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
+        cy.get('[data-testid="component-67"]')
+            .should('contain', 'Full Credit')
+            .and('contain', 'Extra credit done poorly')
+            .and('contain', 'Extra credit is acceptable');
         cy.get('[data-testid="component-67"]').click(20, 25);
         cy.get('[data-testid="component-67"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -61,14 +61,14 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
         cy.get('[data-testid="component-67"]')
-            .should('contain', 'Full Credit')
+            .should('contain', 'No Credit')
             .and('contain', 'Extra credit done poorly')
             .and('contain', 'Extra credit is acceptable');
         cy.get('[data-testid="component-67"]').click(20, 25);
         cy.get('[data-testid="component-67"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-67"]')
-            .should('contain', 'Full Credit')
+            .should('contain', 'No Credit')
             .and('contain', 'Extra credit done poorly')
             .and('contain', 'Extra credit is acceptable');
         cy.get('body').type('{0}');

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -11,7 +11,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(2).should('contain', 'Documentation');
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
-        cy.get('[data-testid="component-64"]').click();
+        cy.get('[data-testid="component-64"]').click(25,20);
         cy.get('[data-testid="component-64"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Minor errors in Read Me')
@@ -21,7 +21,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
-        cy.get('[data-testid="component-65"]').click();
+        cy.get('[data-testid="component-65"]').click(25,20);
         cy.get('[data-testid="component-65"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Code is unreadable')
@@ -32,7 +32,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
-        cy.get('[data-testid="component-66"]').click();
+        cy.get('[data-testid="component-66"]').click(25,20);
         cy.get('[data-testid="component-66"]')
             .should('contain', 'Full Credit')
             .and('contain', 'No documentation')
@@ -43,7 +43,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
-        cy.get('[data-testid="component-67"]').click();
+        cy.get('[data-testid="component-67"]').click(25,20);
         cy.get('[data-testid="component-67"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Extra credit done poorly')

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -11,7 +11,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(2).should('contain', 'Documentation');
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
-        cy.get('[data-testid="component-64"]').click();
+        cy.get('[data-testid="component-64"]').click(20,25);
         cy.get('[data-testid="component-64"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-64"]')
@@ -22,7 +22,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
-        cy.get('[data-testid="component-65"]').click();
+        cy.get('[data-testid="component-65"]').click(20,25);
         cy.get('[data-testid="component-65"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-65"]')
@@ -34,7 +34,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
-        cy.get('[data-testid="component-66"]').click();
+        cy.get('[data-testid="component-66"]').click(20,25);
         cy.get('[data-testid="component-66"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-66"]')
@@ -46,7 +46,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="grading-total"]').eq(2).should('contain', '2 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
-        cy.get('[data-testid="component-67"]').click();
+        cy.get('[data-testid="component-67"]').click(20,25);
         cy.get('[data-testid="component-67"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
         cy.get('[data-testid="component-67"]')

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -11,7 +11,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(2).should('contain', 'Documentation');
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
-        cy.get('[data-testid="component-64"]').click(25,20);
+        cy.get('[data-testid="component-64"]').click();
         cy.get('[data-testid="component-64"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Minor errors in Read Me')
@@ -21,7 +21,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
-        cy.get('[data-testid="component-65"]').click(25,20);
+        cy.get('[data-testid="component-65"]').click();
         cy.get('[data-testid="component-65"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Code is unreadable')
@@ -32,7 +32,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
-        cy.get('[data-testid="component-66"]').click(25,20);
+        cy.get('[data-testid="component-66"]').click();
         cy.get('[data-testid="component-66"]')
             .should('contain', 'Full Credit')
             .and('contain', 'No documentation')
@@ -43,7 +43,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').should('contain', 'Save');
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
-        cy.get('[data-testid="component-67"]').click(25,20);
+        cy.get('[data-testid="component-67"]').click();
         cy.get('[data-testid="component-67"]')
             .should('contain', 'Full Credit')
             .and('contain', 'Extra credit done poorly')

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -147,9 +147,9 @@ Required inputs:
                 <div class="row">
                     <div class="col-no-gutters indicator">
                         {% if mark.id in graded_component.mark_ids %}
-                            <i class="far fa-check-square fa-lg"></i>
+                            <i class="far fa-check-square fa-1g"></i>
                         {% else %}
-                            <i class="far fa-square fa-lg"></i>
+                            <i class="far fa-square fa-1g"></i>
                         {% endif %}
                     </div>
                     <div class="col-no-gutters point-value">

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -144,19 +144,21 @@ Required inputs:
         </div>
         <div class="received-marks-list container">
             {% for mark in component.marks %}
-                {% if mark.id in graded_component.mark_ids %}
-                    <div class="row">
-                        <div class="col-no-gutters indicator">
-                            <i class="far fa-check-square fa-1g"></i>
-                        </div>
-                        <div class="col-no-gutters point-value">
-                            <span>{{ mark.points }}</span>
-                        </div>
-                        <div class="col">
-                            <span>{{ mark.title|nl2br }}</span>
-                        </div>
+                <div class="row">
+                    <div class="col-no-gutters indicator">
+                        {% if mark.id in graded_component.mark_ids %}
+                            <i class="far fa-check-square fa-lg"></i>
+                        {% else %}
+                            <i class="far fa-square fa-lg"></i>
+                        {% endif %}
                     </div>
-                {% endif %}
+                    <div class="col-no-gutters point-value">
+                        <span>{{ mark.points }}</span>
+                    </div>
+                    <div class="col">
+                        <span>{{ mark.title|nl2br }}</span>
+                    </div>
+                </div>
             {% endfor %}
             {# Show the custom mark if it exists #}
             {% if graded_component.comment|length > 0 %}


### PR DESCRIPTION
Closes #10972 

### What is the current behavior?

Currently, TA's can only see what they checked:

![image](https://github.com/user-attachments/assets/5ad82238-4fbd-46e8-82c1-55e7791b4f94)


### What is the new behavior?

TA's can now see everything that they did or did not check:

![image](https://github.com/user-attachments/assets/b9b253b9-721d-482b-bdb6-526a381fb9b7)


### Other information?

To test, make a gradeable or access an already existing one, and, as a grader of that assignment, check if you can see all components, checked or unchecked.
