### PR TITLE
[Bugfix:TAGrading] Fix dark mode horizontal scroll

### DIFF
--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -4,6 +4,7 @@
     overflow: auto;
     background-color: var(--standard-pale-gray);
     border: 1px solid var(--standard-light-gray);
+    align-items: flex-start;
 }
 
 .diff-code {
@@ -11,6 +12,11 @@
     color: var(--diff-char);
     background-color: var(--diff-background-all);
     line-height: 1.8;
+    width: -webkit-fill-available;
+}
+
+.highlight {
+    display: grid;
 }
 
 .diff-code .row {

--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -1,10 +1,10 @@
 @import url("google/inconsolata.css");
 
 .diff-container-box {
+    display: flex;
     overflow: auto;
     background-color: var(--standard-pale-gray);
     border: 1px solid var(--standard-light-gray);
-    align-items: flex-start;
 }
 
 .diff-code {
@@ -12,11 +12,6 @@
     color: var(--diff-char);
     background-color: var(--diff-background-all);
     line-height: 1.8;
-    width: -webkit-fill-available;
-}
-
-.highlight {
-    display: grid;
 }
 
 .diff-code .row {

--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -1,8 +1,7 @@
 @import url("google/inconsolata.css");
 
 .diff-container-box {
-    width: fit-content;
-    display: flex;
+    display: grid;
     overflow: auto;
     background-color: var(--standard-pale-gray);
     border: 1px solid var(--standard-light-gray);

--- a/site/public/css/diff-viewer.css
+++ b/site/public/css/diff-viewer.css
@@ -1,6 +1,7 @@
 @import url("google/inconsolata.css");
 
 .diff-container-box {
+    width: fit-content;
     display: flex;
     overflow: auto;
     background-color: var(--standard-pale-gray);


### PR DESCRIPTION
Fixes #10977 

### What is the current behavior?
After scrolling horizontally in dark mode, a lot of areas are left as blank.
<img width="422" alt="image" src="https://github.com/user-attachments/assets/87c4de01-2d2e-44e7-b1a8-f851ee308423">

### What is the new behavior?
Now the dark mode color correctly applies to the whole container.

https://github.com/user-attachments/assets/51410f39-bfc6-4d5e-9c3f-bc46bbf569d5



