### PR TITLE
[Feature:TAGrading] Resolve Marks Confusion in Closed View

### DIFF
--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -11,10 +11,6 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="component-container"]').eq(2).should('contain', 'Documentation');
         cy.get('[data-testid="component-container"]').eq(3).should('contain', 'Extra Credit');
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
-        cy.get('[data-testid="component-64"]')
-            .should('contain', 'Full Credit')
-            .and('contain', 'Minor errors in Read Me')
-            .and('contain', 'Major errors in Read Me or Read Me missing');
         cy.get('[data-testid="component-64"]').click(20, 25);
         cy.get('[data-testid="component-64"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -25,12 +21,11 @@ describe('Test cases for TA grading page', () => {
         cy.get('body').type('{0}');
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
         cy.get('[data-testid="save-tools-save"]').click();
-        cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
-        cy.get('[data-testid="component-65"]')
+        cy.get('[data-testid="component-64"]')
             .should('contain', 'Full Credit')
-            .and('contain', 'Code is unreadable')
-            .and('contain', 'Code is very difficult to understand')
-            .and('contain', 'Code is difficult to understand');
+            .and('contain', 'Minor errors in Read Me')
+            .and('contain', 'Major errors in Read Me or Read Me missing');
+        cy.get('[data-testid="component-65"]').should('contain', 'Coding Style');
         cy.get('[data-testid="component-65"]').click(20, 25);
         cy.get('[data-testid="component-65"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -42,12 +37,12 @@ describe('Test cases for TA grading page', () => {
         cy.get('body').type('{3}');
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
-        cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
-        cy.get('[data-testid="component-66"]')
+        cy.get('[data-testid="component-65"]')
             .should('contain', 'Full Credit')
-            .and('contain', 'No documentation')
-            .and('contain', 'Very little documentation or documentation makes no sense')
-            .and('contain', 'Way too much documentation and/or documentation makes no sense');
+            .and('contain', 'Code is unreadable')
+            .and('contain', 'Code is very difficult to understand')
+            .and('contain', 'Code is difficult to understand');
+        cy.get('[data-testid="component-66"]').should('contain', 'Documentation');
         cy.get('[data-testid="component-66"]').click(20, 25);
         cy.get('[data-testid="component-66"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -59,11 +54,12 @@ describe('Test cases for TA grading page', () => {
         cy.get('body').type('{2}');
         cy.get('[data-testid="grading-total"]').eq(2).should('contain', '2 / 5');
         cy.get('[data-testid="save-tools-save"]').click();
+        cy.get('[data-testid="component-66"]')
+            .should('contain', 'Full Credit')
+            .and('contain', 'No documentation')
+            .and('contain', 'Very little documentation or documentation makes no sense')
+            .and('contain', 'Way too much documentation and/or documentation makes no sense');
         cy.get('[data-testid="component-67"]').should('contain', 'Extra Credit');
-        cy.get('[data-testid="component-67"]')
-            .should('contain', 'No Credit')
-            .and('contain', 'Extra credit done poorly')
-            .and('contain', 'Extra credit is acceptable');
         cy.get('[data-testid="component-67"]').click(20, 25);
         cy.get('[data-testid="component-67"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');
@@ -74,6 +70,10 @@ describe('Test cases for TA grading page', () => {
         cy.get('body').type('{0}');
         cy.get('[data-testid="grading-total"]').eq(3).should('contain', '0 / 0');
         cy.get('[data-testid="save-tools-save"]').click();
+        cy.get('[data-testid="component-67"]')
+            .should('contain', 'No Credit')
+            .and('contain', 'Extra credit done poorly')
+            .and('contain', 'Extra credit is acceptable');
         cy.get('[data-testid="grading-total"]').eq(0).should('contain', '2 / 2');
         cy.get('[data-testid="grading-total"]').eq(1).should('contain', '4 / 5');
         cy.get('[data-testid="grading-total"]').eq(2).should('contain', '2 / 5');

--- a/site/public/templates/grading/GradingComponent.twig
+++ b/site/public/templates/grading/GradingComponent.twig
@@ -142,24 +142,26 @@ Required inputs:
         <div class="container">
             <div class="row divider"></div>
         </div>
-        <div class="received-marks-list container">
-            {% for mark in component.marks %}
-                <div class="row">
-                    <div class="col-no-gutters indicator">
-                        {% if mark.id in graded_component.mark_ids %}
-                            <i class="far fa-check-square fa-1g"></i>
-                        {% else %}
-                            <i class="far fa-square fa-1g"></i>
-                        {% endif %}
+        <div class="received-marks-list container" tabindex="0" onclick="{% block component_click %}{% endblock %}">
+            {% if graded_component.mark_ids|length > 0 %}
+                {% for mark in component.marks %}
+                    <div class="row">
+                        <div class="col-no-gutters indicator">
+                            {% if mark.id in graded_component.mark_ids %}
+                                <i class="far fa-check-square fa-1g"></i>
+                            {% else %}
+                                <i class="far fa-square fa-1g"></i>
+                            {% endif %}
+                        </div>
+                        <div class="col-no-gutters point-value">
+                            <span>{{ mark.points }}</span>
+                        </div>
+                        <div class="col">
+                            <span>{{ mark.title|nl2br }}</span>
+                        </div>
                     </div>
-                    <div class="col-no-gutters point-value">
-                        <span>{{ mark.points }}</span>
-                    </div>
-                    <div class="col">
-                        <span>{{ mark.title|nl2br }}</span>
-                    </div>
-                </div>
-            {% endfor %}
+                {% endfor %}
+            {% endif %}
             {# Show the custom mark if it exists #}
             {% if graded_component.comment|length > 0 %}
                 <div class="row">


### PR DESCRIPTION
Closes #11028 

### What is the current behavior?

Currently, TAs are experiencing some confusion with the feature implemented in PR #11010. The confusion mainly lies with clicking components when the entire marks lists show and interface problems.

### What is the new behavior?

This PR introduces two separate changes. For one, when a component has no graded marks, it does not show the received-marks-list container at all (as shown below):

![image](https://github.com/user-attachments/assets/f4872987-ab72-4d16-827e-3f6cc9a351ae)

Secondly, when a graded component is clicked, it will always open the container regardless of which area the TA/grader clicks. It could be the center, on the check marks, the right/left hand corners, etc.

### Other information?

To test, create or go to an already existing gradeable and open the grading page. Then, verify that the above changes work as intended.