### PR TITLE
[Dependency] Remove symfony polyfill

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -36,7 +36,6 @@
     "symfony/cache": "6.4.7",
     "symfony/config": "6.4.4",
     "symfony/http-foundation": "6.3.2",
-    "symfony/polyfill-php80": "1.30.0",
     "symfony/routing": "6.1.11",
     "textalk/websocket": "1.6.3",
     "twig/twig": "3.11.1"

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17dc0612382d36eefde0a8710b5fc800",
+    "content-hash": "a37e5506da72b310bbd790f566bedd50",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -4819,20 +4819,20 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -4879,7 +4879,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -4895,7 +4895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -7943,5 +7943,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### What is the current behavior?
We currently have symfony/polyfill-php80 which is not needed anymore since we are on PHP 8.

Closes https://github.com/Submitty/Submitty/pull/11042 since no need to update it anymore

### What is the new behavior?
symfony/polyfill-php80 is now removed from our dependencies. It is still installed due to being dependencies of our dependencies but that will eventually go away once we upgrade those dependencies. So no reason to continue to lock it ourselves.
