### PR TITLE
[Bugfix:TAGrading] Enabling Codebox Scrolling in Grader View

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -81,7 +81,7 @@
                     data-recent_submission="{{ cell.recent_submission }}"
                     data-version_submission="{{ cell.version_submission }}"
                     onkeyup="handle_input_keypress();"
-                    {% if viewing_inactive_version or is_grader_view %}
+                    {% if viewing_inactive_version %}
                         style="pointer-events:none;"
                     {% endif %}
                 >


### PR DESCRIPTION
### What is the current behavior?
Fixes #11096 
Graders are not able to scroll to see the full content of a long answer if it overflows.

### What is the new behavior?
Now the graders can scroll to see the full content of a long answer. The content stays constant (graders are not able to make changes).

### Other information?
I'm not sure exactly why pointer-events was disabled for graders in the first place, but I'm assuming that disabling scrolling was not intended behavior. I tested this by manually removing the styling through inspect element on the production site, making sure that I could not edit the content or perform any actions that would cause unexpected behavior.
