### PR TITLE
[Bugfix:InstructorUI] Add Null check / override grades

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -259,8 +259,10 @@ class ReportController extends AbstractController {
                 $graded_gradeable = $user_graded_gradeables[$g->getId()];
             }
 
-            $graded_gradeable?->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);
-            $ggs[] = $graded_gradeable;
+            if($graded_gradeable != null) {
+                $graded_gradeable->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);
+                $ggs[] = $graded_gradeable;
+            }
         }
         return $ggs;
     }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -259,7 +259,7 @@ class ReportController extends AbstractController {
                 $graded_gradeable = $user_graded_gradeables[$g->getId()];
             }
 
-            $graded_gradeable->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);
+            $graded_gradeable?->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);
             $ggs[] = $graded_gradeable;
         }
         return $ggs;

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -259,7 +259,7 @@ class ReportController extends AbstractController {
                 $graded_gradeable = $user_graded_gradeables[$g->getId()];
             }
 
-            if($graded_gradeable !== null) {
+            if ($graded_gradeable !== null) {
                 $graded_gradeable->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);
                 $ggs[] = $graded_gradeable;
             }

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -259,7 +259,7 @@ class ReportController extends AbstractController {
                 $graded_gradeable = $user_graded_gradeables[$g->getId()];
             }
 
-            if($graded_gradeable != null) {
+            if($graded_gradeable !== null) {
                 $graded_gradeable->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);
                 $ggs[] = $graded_gradeable;
             }


### PR DESCRIPTION
According to Barb, 2 courses are reporting errors with generate grade summaries with similar frog robot stack trace:

Error (Code: 0) thrown in /usr/local/submitty/site/app/controllers/admin/ReportController.php (Line 262) by:

            $graded_gradeable->setOverriddenGrades($this->all_overrides[$user->getId()][$graded_gradeable->getGradeableId()] ?? null);

Message:

Call to a member function setOverriddenGrades() on null

One course uses grade overrides. The other doesn't seem to have any data in the grade override table. Both said that grade summaries was working earlier in the term (not sure when it broke or what broke it.

PHP is trying to call the setOverriddenGrades method on a variable that is null rather than an GradedGradeable type object.
I was unable to reproduce this issue locally, but adding null safe operator would fix the immediate problem. 
