### PR TITLE
[Bugfix:SubminiPolls] Poll Timer Cypress Student View

### DIFF
--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -149,14 +149,12 @@
 </div>
 
 <script>
-
-    {% if timer_enabled %}
-        const endTime = new Date('{{ end_time }}')
-        updateTimer(endTime);
-    {% endif %}
-
     {% if user_admin or poll.isHistogramAvailable() %}
         window.onload = function () {
+            {% if timer_enabled %}
+                const endTime = new Date('{{ end_time }}')
+                updateTimer(endTime);
+            {% endif %}
             const data = [{
                 type: "bar",
                 x: [],

--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -149,12 +149,12 @@
 </div>
 
 <script>
+    {% if timer_enabled %}
+        const endTime = new Date('{{ end_time }}')
+        updateTimer(endTime);
+    {% endif %}
     {% if user_admin or poll.isHistogramAvailable() %}
         window.onload = function () {
-            {% if timer_enabled %}
-                const endTime = new Date('{{ end_time }}')
-                updateTimer(endTime);
-            {% endif %}
             const data = [{
                 type: "bar",
                 x: [],

--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -149,10 +149,12 @@
 </div>
 
 <script>
+
     {% if timer_enabled %}
         const endTime = new Date('{{ end_time }}')
         updateTimer(endTime);
     {% endif %}
+
     {% if user_admin or poll.isHistogramAvailable() %}
         window.onload = function () {
             const data = [{

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -316,6 +316,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(3)').contains('Answer').click();
+        cy.get('[data-testid="timer"]').should('exist');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('not.be.disabled');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('be.checked');
         cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').contains('Answer 1');
@@ -440,6 +441,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(3)').contains('View Poll').click();
+        cy.get('[data-testid="timer"]').contains('Poll Ended');
         cy.get('#toggle-info-button').should('be.visible');
         cy.get('#toggle-histogram-button').should('be.visible').click();
         cy.get('#poll-histogram').should('be.visible');

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -442,7 +442,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(3)').contains('View Poll').click();
-        cy.get('[data-testid="timer"]').contains('Poll Ended');
+        cy.get('[data-testid="timer"]').should('contain', 'Poll Ended');
         cy.get('#toggle-info-button').should('be.visible');
         cy.get('#toggle-histogram-button').should('be.visible').click();
         cy.get('#poll-histogram').should('be.visible');

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -316,7 +316,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(3)').contains('Answer').click();
-        cy.get('[data-testid="timer"]').should('exist');
+        cy.get('[data-testid="timer"]').should('be.visible');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('not.be.disabled');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('be.checked');
         cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').contains('Answer 1');
@@ -433,6 +433,7 @@ describe('Test cases revolving around polls functionality', () => {
         // Validate that the poll is closed.
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().should('not.be.checked');
         cy.contains('Poll Cypress Test').siblings(':nth-child(8)').click();
+        cy.get('[data-testid="timer"]').should('be.visible');
         cy.get('[data-testid="timer"]').contains('Poll Ended');
         cy.go('back');
 


### PR DESCRIPTION
Fixes #11037 
### What is the current behavior?
If the Poll timer didn't work in the student view, the Cypress test wouldn't have found out if there was an accessibility error in the student access view poll but would have caught the mistake if it messed up the instructor access page.

### What is the new behavior?
There are valid checks for both student and instructor to ensure it catches any issues with the poll timer.
