### PR TITLE
[Bugfix:InstructorUI] Remove delete gradeable button

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1802,7 +1802,8 @@ class Gradeable extends AbstractModel {
      * @return bool True if the gradeable can be deleted
      */
     public function canDelete() {
-        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
+//        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
+        return false;
     }
 
     /**


### PR DESCRIPTION
As delete gradeable causing so much trouble, we are temporarily disabling delete gradeable button. 


Tested locally, and minimal code change. 

<img width="1235" alt="스크린샷 2024-11-05 오전 9 16 53" src="https://github.com/user-attachments/assets/91fe57ad-e2b2-4971-818a-fb7dd4710b76">
