### PR TITLE
[Bugfix:InstructorUI] Use transaction while deleting gradeable

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6303,10 +6303,12 @@ AND gc_id IN (
 
 
     public function deleteGradeable($g_id) {
+        $this->course_db->beginTransaction();
         $this->course_db->query("UPDATE electronic_gradeable SET eg_depends_on = null,
                                 eg_depends_on_points = null WHERE eg_depends_on=?", [$g_id]);
         $this->course_db->query("DELETE FROM gradeable_anon WHERE g_id=?", [$g_id]);
         $this->course_db->query("DELETE FROM gradeable WHERE g_id=?", [$g_id]);
+        $this->course_db->commit();
     }
 
     /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When deleting a gradeable, three separate database queries are made, with the possibility of the later queries failing after the first query removes the data from the database.

### What is the new behavior?
The three queries are part of a transaction, so if one fails they will all be rolled back.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tests are yet to be added.
