### PR TITLE
[Bugfix:InstructorUI] Add missing config option to upload

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -77,7 +77,7 @@ class AdminGradeableController extends AbstractController {
             'using_subdirectory' => 'false',
             'vcs_subdirectory' => '',
             'syllabus_bucket' => 'Homework',
-            'autograding_config_path' => '' 
+            'autograding_config_path' => ''
         ];
 
         if (!isset($_POST['id']) || !isset($_POST['title']) || !isset($_POST['type'])) {

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -77,6 +77,7 @@ class AdminGradeableController extends AbstractController {
             'using_subdirectory' => 'false',
             'vcs_subdirectory' => '',
             'syllabus_bucket' => 'Homework',
+            'autograding_config_path' => '' 
         ];
 
         if (!isset($_POST['id']) || !isset($_POST['title']) || !isset($_POST['type'])) {
@@ -86,6 +87,7 @@ class AdminGradeableController extends AbstractController {
         $values['id'] = $_POST['id'];
         $values['title'] = $_POST['title'];
         $values['type'] = $_POST['type'];
+        $values['autograding_config_path'] = $_POST['autograding_config_path'] ?? FileUtils::joinPaths($this->core->getConfig()->getSubmittyInstallPath(), 'more_autograding_examples/upload_only/config');
         if ($_POST['type'] === 'Electronic File') {
             if (array_key_exists('vcs', $_POST)) {
                 if (!array_key_exists('repository_type', $_POST['vcs'])) {


### PR DESCRIPTION
### What is the current behavior?
Related to #10937 but doesn't close. 
#10100 added the ability to upload a JSON file to create a gradeable. However the `autograding_config_path` config variable was forgotten.

### What is the new behavior?
This variable has been added and now correctly takes the autograding_config_path variable from the JSON file. 

