### PR TITLE
[Bugfix:System] Change Numeric/Text to just Numeric

### DIFF
--- a/site/app/libraries/GradeableType.php
+++ b/site/app/libraries/GradeableType.php
@@ -14,7 +14,7 @@ abstract class GradeableType {
             case static::CHECKPOINTS:
                 return "Checkpoints";
             case static::NUMERIC_TEXT:
-                return "Numeric/Text";
+                return "Numeric";
             default:
                 throw new \InvalidArgumentException("Invalid specified type");
         }

--- a/site/tests/app/libraries/GradeableTypeTester.php
+++ b/site/tests/app/libraries/GradeableTypeTester.php
@@ -11,7 +11,7 @@ class GradeableTypeTester extends \PHPUnit\Framework\TestCase {
         return [
             [GradeableType::ELECTRONIC_FILE, "Electronic File"],
             [GradeableType::CHECKPOINTS, "Checkpoints"],
-            [GradeableType::NUMERIC_TEXT, "Numeric/Text"]
+            [GradeableType::NUMERIC_TEXT, "Numeric"]
         ];
     }
 


### PR DESCRIPTION
### What is the current behavior?
Fixes #10936

This issue is due to the fact that the Numeric/Text gradeable type has two different names in the backend. The GradeableType `typeToString()` function returns `Numeric/Text`, but the gradeable creation functions, and the `stringToType()` function require just `Numeric`
### What is the new behavior?
The GradeableType `typeToString()` function now returns just `Numeric`