### PR TITLE
[BugFix:Autograding] Fix rebuild gradeable not detecting error

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1681,9 +1681,10 @@ class AdminGradeableController extends AbstractController {
                 $logs = $this->getBuildLogs($gradeable_id);
 
                 $needle = 'The submitty configuration validator detected the above error in your config.';
+                $makeErrorNeedle = 'MAKE ERROR';
                 $haystack = $logs->json['data'][0];
 
-                if (strpos($haystack, $needle) !== false) {
+                if (strpos($haystack, $needle) !== false || strpos($haystack, $makeErrorNeedle) !== false) {
                     $status = 'warnings';
                 }
             }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -597,7 +597,7 @@ class Gradeable extends AbstractModel {
                 'build',
                 "build_{$this->id}.json"
             ));
-
+            
             // If the file could not be found, the result will be false, so don't
             //  create the config if the file can't be found
             if ($details !== false) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Fixes #11122 
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When clicking "Rebuild Gradeable", it sometimes reports back that the build completes fine despite there being an error.

### What is the new behavior?
It should properly detect an error now by checking if the string "MAKE ERROR" exists in the build logs.

### Other information?
I tested this via the suggested method by using a non-existant #include file in autograder code.
