### PR TITLE
[Bugfix:SubminiPolls] Fix url-hack for polls

### DIFF
--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -138,7 +138,7 @@ class PollController extends AbstractController {
                 return new RedirectResponse($this->core->buildCourseUrl(['polls']));
             }
             if (!$poll->isVisible()) {
-                $this->core->addErrorMessage("Poll is not visible");
+                $this->core->addErrorMessage("Poll is not available");
                 return new RedirectResponse($this->core->buildCourseUrl(['polls']));
             }
             if ($poll->isHistogramAvailable()) {

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -137,6 +137,11 @@ class PollController extends AbstractController {
                 $this->core->addErrorMessage("Invalid Poll ID");
                 return new RedirectResponse($this->core->buildCourseUrl(['polls']));
             }
+            if(!$poll->isVisible()) {
+                $this->core->addErrorMessage("Poll is not visible");
+                return new RedirectResponse($this->core->buildCourseUrl(['polls']));
+            }
+
             if ($poll->isHistogramAvailable()) {
                 /** @var \app\repositories\poll\OptionRepository */
                 $option_repo = $this->core->getCourseEntityManager()->getRepository(Option::class);

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -137,11 +137,10 @@ class PollController extends AbstractController {
                 $this->core->addErrorMessage("Invalid Poll ID");
                 return new RedirectResponse($this->core->buildCourseUrl(['polls']));
             }
-            if(!$poll->isVisible()) {
+            if (!$poll->isVisible()) {
                 $this->core->addErrorMessage("Poll is not visible");
                 return new RedirectResponse($this->core->buildCourseUrl(['polls']));
             }
-
             if ($poll->isHistogramAvailable()) {
                 /** @var \app\repositories\poll\OptionRepository */
                 $option_repo = $this->core->getCourseEntityManager()->getRepository(Option::class);

--- a/site/app/repositories/poll/PollRepository.php
+++ b/site/app/repositories/poll/PollRepository.php
@@ -34,8 +34,7 @@ class PollRepository extends EntityRepository {
                 SELECT p, r, o FROM app\entities\poll\Poll p
                 LEFT JOIN p.responses r WITH r.student_id = :user_id
                 LEFT JOIN p.options o
-                WHERE p.id = :poll_id 
-                AND p.release_date <= :release_date')
+                WHERE p.id = :poll_id AND p.release_date <= :release_date')
             ->setParameter('release_date', date('Y-m-d'))
             ->setParameter('poll_id', $poll_id)
             ->setParameter('user_id', $user_id)

--- a/site/app/repositories/poll/PollRepository.php
+++ b/site/app/repositories/poll/PollRepository.php
@@ -34,7 +34,9 @@ class PollRepository extends EntityRepository {
                 SELECT p, r, o FROM app\entities\poll\Poll p
                 LEFT JOIN p.responses r WITH r.student_id = :user_id
                 LEFT JOIN p.options o
-                WHERE p.id = :poll_id AND p.release_date <= :release_date')
+                WHERE p.id = :poll_id 
+                AND p.release_date <= :release_date
+                AND p.is_visible = true')
             ->setParameter('release_date', date('Y-m-d'))
             ->setParameter('poll_id', $poll_id)
             ->setParameter('user_id', $user_id)

--- a/site/app/repositories/poll/PollRepository.php
+++ b/site/app/repositories/poll/PollRepository.php
@@ -35,8 +35,7 @@ class PollRepository extends EntityRepository {
                 LEFT JOIN p.responses r WITH r.student_id = :user_id
                 LEFT JOIN p.options o
                 WHERE p.id = :poll_id 
-                AND p.release_date <= :release_date
-                AND p.is_visible = true')
+                AND p.release_date <= :release_date')
             ->setParameter('release_date', date('Y-m-d'))
             ->setParameter('poll_id', $poll_id)
             ->setParameter('user_id', $user_id)

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -565,7 +565,19 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#tomorrow-table').contains('Poll Tomorrow').should('be.visible');
         cy.get('#future-table').contains('Poll Future').should('be.visible');
 
+        // make sure that today's polls cannot be accessed by the student
+        cy.logout();
+        cy.login('student');
+        cy.visit(['sample', 'polls']);
+        cy.get('#today-table').find('a').invoke('attr', 'href').then((href) => {
+            cy.visit(href);
+            cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'Poll is not available');
+        });
+
         // change the release date of Poll Future to tomorrow
+        cy.logout();
+        cy.login('instructor');
+        cy.visit(['sample', 'polls']);
         cy.contains('Poll Future').siblings(':nth-child(1)').children().click();
         cy.url().should('include', 'sample/polls/editPoll');
         cy.get('[data-testid="poll-date"]').clear({ force: true });

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -243,6 +243,10 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         cy.contains('Poll Cypress Test').siblings(':nth-child(3)').contains('Closed');
+        cy.contains('Poll Cypress Test').parent().find('a').invoke('attr', 'href').then((href) => {
+            cy.visit(href);
+            cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'Poll is not available');
+        });
 
         // log into instructor and change poll to visible
         cy.logout();
@@ -565,20 +569,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#tomorrow-table').contains('Poll Tomorrow').should('be.visible');
         cy.get('#future-table').contains('Poll Future').should('be.visible');
 
-        // make sure that today's polls cannot be accessed by the student
-        cy.logout();
-        cy.login('student');
-        cy.visit(['sample', 'polls']);
-        console.log(cy.get('#today-table').contains('Poll Today').parent().find('a'));
-        cy.get('#today-table').contains('Poll Today').parent().find('a').invoke('attr', 'href').then((href) => {
-            cy.visit(href);
-            cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'Poll is not available');
-        });
-
         // change the release date of Poll Future to tomorrow
-        cy.logout();
-        cy.login('instructor');
-        cy.visit(['sample', 'polls']);
         cy.contains('Poll Future').siblings(':nth-child(1)').children().click();
         cy.url().should('include', 'sample/polls/editPoll');
         cy.get('[data-testid="poll-date"]').clear({ force: true });

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -569,7 +569,8 @@ describe('Test cases revolving around polls functionality', () => {
         cy.logout();
         cy.login('student');
         cy.visit(['sample', 'polls']);
-        cy.get('#today-table').find('a').invoke('attr', 'href').then((href) => {
+        console.log(cy.get('#today-table').contains('Poll Today').parent().find('a'));
+        cy.get('#today-table').contains('Poll Today').parent().find('a').invoke('attr', 'href').then((href) => {
             cy.visit(href);
             cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'Poll is not available');
         });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fix #11135 
Polls can be url-hacked per issue #11135. This PR removes the ability to see polls that are not yet visible.

### What is the new behavior?
Adds a check that specifies that polls must be visible. 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
