### PR TITLE
[Testing:InstructorUI] Add tests for deleting gradeables

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1802,7 +1802,7 @@ class Gradeable extends AbstractModel {
      * @return bool True if the gradeable can be deleted
      */
     public function canDelete() {
-       return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
+        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
     }
 
     /**

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1802,8 +1802,7 @@ class Gradeable extends AbstractModel {
      * @return bool True if the gradeable can be deleted
      */
     public function canDelete() {
-//        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
-        return false;
+       return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
     }
 
     /**

--- a/site/app/templates/navigation/DeleteGradeableForm.twig
+++ b/site/app/templates/navigation/DeleteGradeableForm.twig
@@ -18,5 +18,5 @@
 {% endblock %}
 {% block buttons %}
     {{ block('close_button') }}
-    <input class="btn btn-danger" type="submit" value="Delete">
+    <input class="btn btn-danger" type="submit" value="Delete" data-testid="confirm-delete-gradeable">
 {% endblock %}

--- a/site/cypress/e2e/Cypress-Gradeable/deletion.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/deletion.spec.js
@@ -1,18 +1,21 @@
 describe('Test cases revolving around deletion of gradeables', () => {
     it('should delete gradeable', () => {
         cy.login('instructor');
-        cy.visit(['blank', 'gradeable']);
-        // Enter gradeable info
-        cy.get('[data-testid=create-gradeable-title]').type('TestGradeable');
-        cy.get('[data-testid=create-gradeable-id]').type('TestGradeable');
-        // force needed to click radio button
-        cy.get('[data-testid=radio-student-upload]').check({ force: true });
-        // Create Gradeable
-        cy.get('[data-testid=create-gradeable-btn]').click();
-        cy.visit(['blank']);
-        cy.get('[title="Delete Gradeable"]').click();
-        cy.get('[data-testid="confirm-delete-gradeable"]').click();
-        cy.get('[title="Delete Gradeable"]').should('not.exist');
+        // run twice to ensure data was fully deleted
+        cy.wrap(Array(2)).each(() => {
+            cy.visit(['sample', 'gradeable']);
+            // Enter gradeable info
+            cy.get('[data-testid=create-gradeable-title]').type('TestGradeable');
+            cy.get('[data-testid=create-gradeable-id]').type('TestGradeable');
+            // force needed to click radio button
+            cy.get('[data-testid=radio-student-upload]').check({ force: true });
+            // Create Gradeable
+            cy.get('[data-testid=create-gradeable-btn]').click();
+            cy.visit(['sample']);
+            cy.get('[data-testid="TestGradeable"] [title="Delete Gradeable"]').click();
+            cy.get('[data-testid="confirm-delete-gradeable"]').click();
+            cy.get('[data-testid="TestGradeable"] [title="Delete Gradeable"]').should('not.exist');
+        });
     });
     it('should be unable to delete gradeable with submissions', () => {
         cy.login('instructor');

--- a/site/cypress/e2e/Cypress-Gradeable/deletion.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/deletion.spec.js
@@ -1,0 +1,23 @@
+describe('Test cases revolving around deletion of gradeables', () => {
+    it('should delete gradeable', () => {
+        cy.login('instructor');
+        cy.visit(['blank', 'gradeable']);
+        // Enter gradeable info
+        cy.get('[data-testid=create-gradeable-title]').type('TestGradeable');
+        cy.get('[data-testid=create-gradeable-id]').type('TestGradeable');
+        // force needed to click radio button
+        cy.get('[data-testid=radio-student-upload]').check({ force: true });
+        // Create Gradeable
+        cy.get('[data-testid=create-gradeable-btn]').click();
+        cy.visit(['blank']);
+        cy.get('[title="Delete Gradeable"]').click();
+        cy.get('[data-testid="confirm-delete-gradeable"]').click();
+        cy.get('[title="Delete Gradeable"]').should('not.exist');
+    });
+    it('should be unable to delete gradeable with submissions', () => {
+        cy.login('instructor');
+        cy.visit(['sample']);
+        cy.get('[data-testid="no_due_date_no_release"] [title="Delete Gradeable"]').should('be.visible');
+        cy.get('[data-testid="leaderboard"] [title="Delete Gradeable"]').should('not.exist');
+    });
+});

--- a/site/cypress/e2e/Cypress-Gradeable/deletion.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/deletion.spec.js
@@ -1,5 +1,5 @@
 describe('Test cases revolving around deletion of gradeables', () => {
-    it('should delete gradeable', () => {
+    it('should delete basic electronic file gradeable', () => {
         cy.login('instructor');
         // run twice to ensure data was fully deleted
         cy.wrap(Array(2)).each(() => {
@@ -9,6 +9,44 @@ describe('Test cases revolving around deletion of gradeables', () => {
             cy.get('[data-testid=create-gradeable-id]').type('TestGradeable');
             // force needed to click radio button
             cy.get('[data-testid=radio-student-upload]').check({ force: true });
+            // Create Gradeable
+            cy.get('[data-testid=create-gradeable-btn]').click();
+            cy.visit(['sample']);
+            cy.get('[data-testid="TestGradeable"] [title="Delete Gradeable"]').click();
+            cy.get('[data-testid="confirm-delete-gradeable"]').click();
+            cy.get('[data-testid="TestGradeable"] [title="Delete Gradeable"]').should('not.exist');
+        });
+    });
+    it('should delete basic team gradeable', () => {
+        cy.login('instructor');
+        // run twice to ensure data was fully deleted
+        cy.wrap(Array(2)).each(() => {
+            cy.visit(['sample', 'gradeable']);
+            // Enter gradeable info
+            cy.get('[data-testid=create-gradeable-title]').type('TestGradeable');
+            cy.get('[data-testid=create-gradeable-id]').type('TestGradeable');
+            // force needed to click radio button
+            cy.get('#radio_ef_vcs_upload').check({ force: true });
+            cy.get('#team_yes_radio', { timeout: 20000 }).check();
+            // Create Gradeable
+            cy.get('[data-testid=create-gradeable-btn]').click();
+            cy.visit(['sample']);
+            cy.get('[data-testid="TestGradeable"] [title="Delete Gradeable"]').click();
+            cy.get('[data-testid="confirm-delete-gradeable"]').click();
+            cy.get('[data-testid="TestGradeable"] [title="Delete Gradeable"]').should('not.exist');
+        });
+    });
+    it('should delete vcs team gradeable', () => {
+        cy.login('instructor');
+        // run twice to ensure data was fully deleted
+        cy.wrap(Array(2)).each(() => {
+            cy.visit(['sample', 'gradeable']);
+            // Enter gradeable info
+            cy.get('[data-testid=create-gradeable-title]').type('TestGradeable');
+            cy.get('[data-testid=create-gradeable-id]').type('TestGradeable');
+            // force needed to click radio button
+            cy.get('[data-testid=radio-student-upload]').check({ force: true });
+            cy.get('#team_yes_radio', { timeout: 20000 }).check();
             // Create Gradeable
             cy.get('[data-testid=create-gradeable-btn]').click();
             cy.visit(['sample']);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is no test coverage for any of the gradeable deletion code.

### What is the new behavior?
Gradeable deletion has tests for both deleting successfully and making sure gradeables that should not be able to be deleted cannot be deleted. 

related PRs:
remove delete gradeable https://github.com/Submitty/Submitty/pull/11124/
add transaction for delete gradeable https://github.com/Submitty/Submitty/pull/11125/
migration to repair broken gradeables https://github.com/Submitty/Submitty/pull/11133/
fix delete gradeable https://github.com/Submitty/Submitty/pull/11133/

open issue to add even more tests: 
https://github.com/Submitty/Submitty/issues/11625

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
**This also re-enables greadeable deletion** (it needs to otherwise it is impossible to test)
