### PR TITLE
[Bugfix:Submission] Fix Duplicate Keys on Late Day Cache

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1935,7 +1935,8 @@ WHERE term=? AND course=? AND user_id=?",
                             public.calculate_remaining_cache_for_user(user_id::text, ?) as cache_row
                         FROM users
                         ) calculated_cache
-                    )";
+                    )
+                    ON CONFLICT DO NOTHING";
         $this->course_db->query($query, $params);
     }
 
@@ -1956,7 +1957,8 @@ WHERE term=? AND course=? AND user_id=?",
         $query = "INSERT INTO late_day_cache
                     (" . $user_or_team . ", g_id, late_day_date, late_days_allowed, submission_days_late, 
                     late_day_exceptions, late_days_remaining, late_day_status, late_days_change, reason_for_exception) 
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT DO NOTHING";
         $this->course_db->query($query, $params);
     }
 
@@ -1968,7 +1970,8 @@ WHERE term=? AND course=? AND user_id=?",
 
         $query = "INSERT INTO late_day_cache
                     (user_id, late_day_date, late_days_remaining, late_days_change) 
-                    VALUES (?, ?, ?, ?)";
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT DO NOTHING";
         $this->course_db->query($query, $params);
     }
 
@@ -2133,7 +2136,8 @@ WHERE term=? AND course=? AND user_id=?",
         $params = [$user_id, $default_late_days];
 
         $query = "INSERT INTO late_day_cache
-                    SELECT * FROM calculate_remaining_cache_for_user(?::text, ?)";
+                    SELECT * FROM calculate_remaining_cache_for_user(?::text, ?)
+                    ON CONFLICT DO NOTHING";
 
         $this->course_db->query($query, $params);
     }


### PR DESCRIPTION
### What is the current behavior?
Closes #11131 
There can be two users trying to insert things into the late day cache at the same time. There will be a race condition, where one user sees the page and the other user sees a frog robot

### What is the new behavior?
If we have a conflict, we can essentially ignore the duplicate. Since they are calculating the cache at the exact same time, we don't need to update the one that is already in there, we can just ignore the duplicate one.

### Other information?
To produce the bug on main, the following steps are followed:
1. Find a gradeable that is past due
2. Have two users click the preview grading button
3. See that one of them will have an error


Used a python script to simulate clicking things at the same time, 
```py
import pyautogui

pyautogui.click((170, 900)) # chrome
pyautogui.click((1160, 560)) # focus tab
pyautogui.click((1160, 560)) # click 
pyautogui.click((450, 500)) # focus other tab
pyautogui.click((450, 500)) # click
```
