### PR TITLE
[Bugfix:Forum] Fix error on duplicate bookmark request

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1258,7 +1258,7 @@ SQL;
 
     public function addBookmarkedThread(string $user_id, int $thread_id, bool $added) {
         if ($added) {
-            $this->course_db->query("INSERT INTO student_favorites(user_id, thread_id) VALUES (?,?)", [$user_id, $thread_id]);
+            $this->course_db->query("INSERT INTO student_favorites(user_id, thread_id) VALUES (?,?) ON CONFLICT DO NOTHING", [$user_id, $thread_id]);
         }
         else {
             $this->course_db->query("DELETE FROM student_favorites where user_id=? and thread_id=?", [$user_id, $thread_id]);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If a user sends multiple requests to bookmark a specific thread (before the page reloads), the requests after the first will cause a keyerror in the database and throw an exception.

### What is the new behavior?
Ignore these duplicate requests; if the row to be inserted is in the database already, do nothing.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

You can reproduce the error by commenting out the `window.location.replace` line at forum.js:1883 (function bookmarkThread). Clicking the bookmark button multiple times should cause subsequent clicks to return a frog robot on main, but they should succeed with this change.
