### PR TITLE
[UI/UX:Forum] Update Upload Attachment button text

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -147,7 +147,7 @@
             {# uploadID and input-file + Index required for drag-and-drop.js #}
             <div class="upload_attachment_box cursor-pointer key_to_click" id="upload{{ post_box_id }}">
                 <div id="file_input_label_{{post_box_id}}" class="btn btn-default" tabindex="0">
-                  <label for="input-file{{ post_box_id }}" data-testid="input-file{{ post_box_id }}">Upload Attachment</label>
+                  <label for="input-file{{ post_box_id }}" data-testid="input-file{{ post_box_id }}">Attach Image</label>
                 </div>
                 <input type="file" accept="image/*" id="input-file{{ post_box_id }}" style="display: none;" onchange="addFilesFromInput({{ post_box_id }});testAndGetAttachments({{ post_box_id }}, true);" multiple />
                 <br>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The discussion forum button to upload an attachment is named "Upload Attachment" even though the uploader only accepts images.
Fixes #11170 
### What is the new behavior?
The button is now named "Attach Image"

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Screenshot after changes:
![image](https://github.com/user-attachments/assets/7f565d80-cdcb-4723-b227-7d5231a030b6)
