### PR TITLE
[Bugfix:Submission] Fix Jupyter notebooks with single lines

### DIFF
--- a/site/app/libraries/NotebookUtils.php
+++ b/site/app/libraries/NotebookUtils.php
@@ -32,7 +32,7 @@ class NotebookUtils {
                         'label' => '',
                         'programming_language' => $filedata['metadata']['language_info']['name'] ?? 'python',
                         'initial_value' => is_array($cell['source']) ? implode($cell['source']) : (string) $cell['source'],
-                        'rows' => count($cell['source']),
+                        'rows' => is_array($cell['source']) ? count($cell['source']) : 1,
                         'filename' => $cell['id'] ?? 'notebook-cell-' . rand(),
                         'recent_submission' => '',
                         'version_submission' => '',


### PR DESCRIPTION
### What is the current behavior?
Jupyter notebooks with single-line code boxes generated by some types of notebook editors currently cause frog robot errors.

### What is the new behavior?
This PR resolves the issues.