### PR TITLE
[Bugfix:Forum] Space between textbox labels

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -561,6 +561,7 @@
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
+    gap: 5px;
 }
 
 .email-announcement-checkbox {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Checkbox elements in the discussion forum don't have space in between the checkboxes and their labels.
![image](https://github.com/user-attachments/assets/2b77df45-7a73-4583-8612-ea548cdcdbe4)

### What is the new behavior?
They should have a little spacing in between now, as shown: 
![image](https://github.com/user-attachments/assets/50a2bda8-b4eb-40bc-b1bb-65384c1fcd2a)


### Other information?
To test, check to see if any checkbox elements in the forum look weird. The CSS rule modified should only effect checkboxes for involved in the creation of new threads and/or replies (I assume judging by the name ".new-thread-settings-wrapper")
