### PR TITLE
[Bugfix:Forum] Three dot menu wraps properly

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -237,6 +237,7 @@
     margin-top: 8px;
     margin-left: 10px;
     float: right;
+    white-space: nowrap;
 }
 
 .post-email-toggle,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
In discussion forum threads, the three dot menu next to a poster's name can appear out of line:
![image](https://github.com/user-attachments/assets/b9ff5e17-819d-4bb9-8afc-74e74985378a)

### What is the new behavior?
The three dot menu should now stay in line, no matter how scrunched the page is.
![image](https://github.com/user-attachments/assets/9fab42cd-c92f-4bde-9e48-388be9037bc9)

### Other information?
To test, go to any forum post and try to see if a user's name, the time they posted, and the three dot menu stay in the same line. 
