### PR TITLE
[Feature:Autograding] Capitalize default option 

### DIFF
--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -253,7 +253,7 @@ def main():
 
     # Check before adding a very large number of systems to the queue
     if len(grade_queue) > 50 and not args.no_input:
-        inp = input("Found {:d} matching submissions. Add to queue? [y/n]".format(len(grade_queue)))
+        inp = input("Found {:d} matching submissions. Add to queue? [y/N]".format(len(grade_queue)))
         if inp.lower() not in ["yes", "y"]:
             raise SystemExit("Aborting...")
 


### PR DESCRIPTION
It's a common practice on CLI to show the recommended/default option as capitalized.

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
When running the regrade script, one doesn't know what's the default action.

### What is the new behavior?
It shows in capital letter that the default will be No.

### Other information?
<!-- Is this a breaking change? -->
There's no changes in the functionality, only in how the prompt is shown to the user.
