### PR TITLE
[Bugfix:Developer] Fix CI workflow name in Zulip notifier

### DIFF
--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -2,7 +2,7 @@ name: Notify on Main Failure
 
 on:
   workflow_run:
-    workflows: [Submitty CI]
+    workflows: [CI]
     types: [completed]
     branches:
       - 'main'


### PR DESCRIPTION
### What is the current behavior?
https://github.com/Submitty/Submitty/pull/10733 changed the name of our primary CI job, but failed to update the workflow name in our automation which sends failure notifications to Zulip.

### What is the new behavior?
This PR updates the workflow names so we continue to get failure notifications.