### PR TITLE
[Refactor:Forum] Remove unused forum queries

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -544,176 +544,6 @@ SQL;
         );
     }
 
-    /**
-     * Helper function for generating sql query according to the given requirements
-     */
-    public function buildLoadThreadQuery(
-        $categories_ids,
-        $thread_status,
-        $unread_threads,
-        $show_deleted,
-        $show_merged_thread,
-        $current_user,
-        &$query_select,
-        &$query_join,
-        &$query_where,
-        &$query_order,
-        &$query_parameters,
-        $want_categories,
-        $want_order
-    ) {
-        $query_raw_select = [];
-        $query_raw_join   = [];
-        $query_raw_where  = ["true"];
-        $query_raw_order  = [];
-        $query_parameters = [];
-
-        // Query Generation
-        if (count($categories_ids) == 0) {
-            $query_multiple_qmarks = "NULL";
-        }
-        else {
-            $query_multiple_qmarks = "?" . str_repeat(",?", count($categories_ids) - 1);
-        }
-        if (count($thread_status) == 0) {
-            $query_status = "true";
-        }
-        else {
-            $query_status = "status in (?" . str_repeat(",?", count($thread_status) - 1) . ")";
-        }
-        $query_favorite = "case when sf.user_id is NULL then false else true end";
-
-        if ($want_order) {
-            $query_raw_select[]     = "row_number() over(ORDER BY (CASE WHEN pinned_expiration >= current_timestamp THEN 1 ELSE 0 END) DESC, ({$query_favorite}) DESC, t.id DESC) AS row_number";
-        }
-        $query_raw_select[]     = "t.*";
-        $query_raw_select[]     = "({$query_favorite}) as favorite";
-        $query_raw_select[]     = "CASE
-                                    WHEN EXISTS(SELECT * FROM (posts p LEFT JOIN forum_posts_history fp ON p.id = fp.post_id AND p.author_user_id != fp.edit_author) AS pfp WHERE (pfp.author_user_id = ? OR pfp.edit_author = ?) AND pfp.thread_id = t.id) THEN true
-                                    ELSE false
-                                    END as current_user_posted";
-
-        $query_parameters[]     = $current_user;
-        $query_parameters[]     = $current_user;
-        $query_raw_join[]       = "LEFT JOIN student_favorites sf ON sf.thread_id = t.id and sf.user_id = ?";
-        $query_parameters[]     = $current_user;
-
-        if (!$show_deleted) {
-            $query_raw_where[]  = "deleted = false";
-        }
-        if (!$show_merged_thread) {
-            $query_raw_where[]  = "merged_thread_id = -1";
-        }
-
-        $query_raw_where[]  = "? = (SELECT count(*) FROM thread_categories tc WHERE tc.thread_id = t.id and category_id IN ({$query_multiple_qmarks}))";
-        $query_parameters[] = count($categories_ids);
-        $query_parameters   = array_merge($query_parameters, $categories_ids);
-        $query_raw_where[]  = "{$query_status}";
-        $query_parameters   = array_merge($query_parameters, $thread_status);
-
-        if ($want_order) {
-            $query_raw_order[]  = "row_number";
-        }
-        else {
-            $query_raw_order[]  = "true";
-        }
-
-        // Categories
-        if ($want_categories) {
-            $query_select_categories = "SELECT thread_id, array_to_string(array_agg(cl.category_id order by cl.rank nulls last, cl.category_id),'|')  as categories_ids, array_to_string(array_agg(cl.category_desc order by cl.rank nulls last, cl.category_id),'|') as categories_desc, array_to_string(array_agg(cl.color order by cl.rank nulls last, cl.category_id),'|') as categories_color FROM categories_list cl JOIN thread_categories e ON e.category_id = cl.category_id GROUP BY thread_id";
-
-            $query_raw_select[] = "categories_ids";
-            $query_raw_select[] = "categories_desc";
-            $query_raw_select[] = "categories_color";
-
-            $query_raw_join[] = "JOIN ({$query_select_categories}) AS QSC ON QSC.thread_id = t.id";
-        }
-        // Unread Threads
-        if ($unread_threads) {
-            $query_raw_where[] =
-
-            "EXISTS(
-                SELECT thread_id
-                FROM (posts LEFT JOIN forum_posts_history ON posts.id = forum_posts_history.post_id) AS jp
-                WHERE(
-                    jp.thread_id = t.id
-                    AND NOT EXISTS(
-                        SELECT thread_id
-                        FROM viewed_responses v
-                        WHERE v.thread_id = jp.thread_id
-                            AND v.user_id = ?
-                            AND (v.timestamp >= jp.timestamp
-                            AND (jp.edit_timestamp IS NULL OR (jp.edit_timestamp IS NOT NULL AND v.timestamp >= jp.edit_timestamp))))))";
-            $query_parameters[] = $current_user;
-        }
-
-        $query_select   = implode(", ", $query_raw_select);
-        $query_join     = implode(" ", $query_raw_join);
-        $query_where    = implode(" and ", $query_raw_where);
-        $query_order    = implode(", ", $query_raw_order);
-    }
-
-    /**
-     * Order: Favourite and Announcements => Announcements only => Favourite only => Others
-     *
-     * @param  int[]    $categories_ids     Filter threads having at least provided categories
-     * @param  int[]    $thread_status      Filter threads having thread status among $thread_status
-     * @param  bool     $unread_threads     Filter threads to show only unread threads
-     * @param  bool     $show_deleted       Consider deleted threads
-     * @param  bool     $show_merged_thread Consider merged threads
-     * @param  string   $current_user       user_id of current user
-     * @param  int      $blockNumber        Index of window of thread list(-1 for last)
-     * @param  int      $thread_id          If blockNumber is not known, find it using thread_id
-     * @return array    Ordered filtered threads - array('block_number' => int, 'threads' => array(threads))
-     */
-    public function loadThreadBlock($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $blockNumber, $thread_id) {
-        $blockSize = 30;
-        $loadLastPage = false;
-
-        $query_raw_select = null;
-        $query_raw_join   = null;
-        $query_raw_where  = null;
-        $query_raw_order  = null;
-        $query_parameters = null;
-        // $blockNumber is 1 based index
-        if ($blockNumber <= -1) {
-            // Find the last block
-            $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, false, false);
-            $query = "SELECT count(*) FROM (SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where})";
-            $this->course_db->query($query, $query_parameters);
-            $results = $this->course_db->rows();
-            $row_count = $results[0]['count'];
-            $blockNumber = 1 + floor(($row_count - 1) / $blockSize);
-        }
-        elseif ($blockNumber == 0) {
-            // Load first block as default
-            $blockNumber = 1;
-            if ($thread_id >= 1) {
-                // Find $blockNumber
-                $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, false, true);
-                $query = "SELECT SUBQUERY.row_number as row_number FROM (SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where} ORDER BY {$query_order}) AS SUBQUERY WHERE SUBQUERY.id = ?";
-                $query_parameters[] = $thread_id;
-                $this->course_db->query($query, $query_parameters);
-                $results = $this->course_db->rows();
-                if (count($results) > 0) {
-                    $row_number = $results[0]['row_number'];
-                    $blockNumber = 1 + floor(($row_number - 1) / $blockSize);
-                }
-            }
-        }
-        $query_offset = ($blockNumber - 1) * $blockSize;
-        $this->buildLoadThreadQuery($categories_ids, $thread_status, $unread_threads, $show_deleted, $show_merged_thread, $current_user, $query_select, $query_join, $query_where, $query_order, $query_parameters, true, true);
-        $query = "SELECT {$query_select} FROM threads t {$query_join} WHERE {$query_where} ORDER BY {$query_order} LIMIT ? OFFSET ?";
-        $query_parameters[] = $blockSize;
-        $query_parameters[] = $query_offset;
-        // Execute
-        $this->course_db->query($query, $query_parameters);
-        $results = [];
-        $results['block_number'] = $blockNumber;
-        $results['threads'] = $this->course_db->rows();
-        return $results;
-    }
-
     public function getCategoriesIdForThread($thread_id) {
         $this->course_db->query("SELECT category_id from thread_categories t where t.thread_id = ?", [$thread_id]);
         $categories_list = [];
@@ -767,96 +597,6 @@ SQL;
             }
             return ['status' => "false", 'likesCount' => 0, 'likesFromStaff' => 0];
         }
-    }
-
-    /**
-     * get what posts should be loaded in with "staff upduck" upduck
-     * returns array of posts that the staff upducked
-     *
-     * @param int[] $post_ids
-     * @return int[]
-     */
-    public function getInstructorUpduck(array $post_ids): array {
-        if (count($post_ids) === 0) {
-            return [];
-        }
-        $placeholders = $this->createParameterList(count($post_ids));
-
-        // SQL to join the forum_upducks and users tables, filter by user_group, and check against provided post_ids
-        $sql = "SELECT f.post_id
-                FROM forum_upducks f
-                JOIN users u ON f.user_id = u.user_id
-                WHERE f.post_id IN {$placeholders}
-                AND u.user_group <= 3
-                GROUP BY f.post_id";
-
-        // Execute the query with the post_ids as parameters
-        $this->course_db->query($sql, $post_ids);
-        $result = [];
-
-        // Fetch the rows and store the post_id in the result array
-        foreach ($this->course_db->rows() as $row) {
-            $result[] = $row['post_id'];
-        }
-        return $result;
-    }
-
-    /**
-     * Gets total number of upducks for each post
-     * returns an array that links each post_id with their total upducks
-     *
-     * @param int[] $post_ids
-     * @return int[]
-     */
-    public function getUpduckInfoForPosts(array $post_ids): array {
-        if (count($post_ids) === 0) {
-            return [];
-        }
-        $placeholders = $this->createParameterList(count($post_ids));
-        $sql = "SELECT post_id, COUNT(*) AS cnt FROM forum_upducks WHERE post_id IN {$placeholders} GROUP BY post_id";
-
-        $this->course_db->query($sql, $post_ids);
-        $result = [];
-
-        foreach ($post_ids as $post) {
-            $result[$post] = 0;
-        }
-        foreach ($this->course_db->rows() as $row) {
-            $result[$row['post_id']] = intval($row['cnt']);
-        }
-        return $result;
-    }
-
-    /**
-     * Gets what posts the user has upducked
-     * returns an array of what posts the user liked and what should be shown as upducked on the frontend
-     *
-     * @param int[] $post_ids
-     * @param string $current_user
-     * @return int[]
-     */
-    public function getUserLikesForPosts(array $post_ids, string $current_user): array {
-        if (count($post_ids) === 0) {
-            return [];
-        }
-        $placeholders = $this->createParameterList(count($post_ids));
-        $user_id = $current_user;
-
-        $sql = "SELECT post_id, user_id, COUNT(*) AS cnt FROM forum_upducks WHERE post_id IN {$placeholders}
-                AND user_id = ? GROUP BY (post_id, user_id)";
-        $bindParams = array_merge($post_ids, [$user_id]);
-        $this->course_db->query($sql, $bindParams);
-        $result = [];
-        $final = [];
-        foreach ($this->course_db->rows() as $row) {
-            $result[$row['post_id']] = intval($row['cnt']);
-        }
-        foreach ($result as $key => $value) {
-            if ($value >= 1) {
-                array_push($final, $key);
-            }
-        }
-        return $final;
     }
 
     public function splitPost($post_id, $title, $categories_ids) {
@@ -962,12 +702,6 @@ SQL;
         return $this->course_db->row();
     }
 
-    public function existsAnnouncementsId($thread_id) {
-        $this->course_db->query("SELECT announced from threads where id = ?", [$thread_id]);
-        $row = $this->course_db->row();
-        return count($row) > 0 && $row['announced'] != null;
-    }
-
     public function updateResolveState($thread_id, $state) {
         if (in_array($state, [-1, 0, 1])) {
             $this->course_db->query("UPDATE threads set status = ? where id = ?", [$state, $thread_id]);
@@ -1050,11 +784,6 @@ SQL;
         return $this->course_db->rows();
     }
 
-    public function getPostHistory($post_id) {
-        $this->course_db->query("SELECT * FROM forum_posts_history where post_id = ? ORDER BY edit_timestamp DESC", [$post_id]);
-        return $this->course_db->rows();
-    }
-
     public function getPostOldThread($post_id) {
         $this->course_db->query("SELECT id, merged_thread_id, title FROM threads WHERE merged_thread_id <> -1 AND merged_post_id = ?", [$post_id]);
         $rows = $this->course_db->rows();
@@ -1068,73 +797,9 @@ SQL;
         }
     }
 
-    /**
-     * Get total likes count for each thread.
-     * @return array<int, int> array with thread_id as key and total likes_count as value.
-     */
-    public function getThreadLikesSum(): array {
-        $this->course_db->query(
-            "SELECT p.thread_id, COUNT(*) AS total_likes
-            FROM posts p
-            JOIN forum_upducks f ON p.id = f.post_id
-            WHERE p.deleted = false
-            GROUP BY p.thread_id"
-        );
-
-        $likesData = $this->course_db->rows();
-        $threadLikes = [];
-        foreach ($likesData as $row) {
-            $threadLikes[$row['thread_id']] = intval($row['total_likes']);
-        }
-        return $threadLikes; // Return array with thread_id as key and total likes_count as value
-    }
-
-
-
-    /**
-     * @param int[] $post_ids
-     * @return int[] threads that have been merged
-     */
-    public function getMergedThreadIds(array $post_ids): array {
-        if (count($post_ids) === 0) {
-            return [];
-        }
-        $placeholders = $this->createParameterList(count($post_ids));
-        $this->course_db->query("SELECT id FROM threads WHERE merged_thread_id <> -1 AND merged_post_id IN {$placeholders}", $post_ids);
-        return array_column($this->course_db->rows(), "id");
-    }
-
     public function getDeletedPostsByUser($user) {
         $this->course_db->query("SELECT * FROM posts where deleted = true AND author_user_id = ?", [$user]);
         return $this->course_db->rows();
-    }
-
-    public function getFirstPostForThread($thread_id) {
-        $this->course_db->query("SELECT * FROM posts WHERE parent_id = -1 AND thread_id = ?", [$thread_id]);
-        $rows = $this->course_db->rows();
-        if (count($rows) > 0) {
-            return $rows[0];
-        }
-        else {
-            return null;
-        }
-    }
-
-    /**
-     * @param int[] $thread_ids
-     * @return null|array<int, mixed[]> array of posts, indexed by thread id.
-     */
-    public function getFirstPostForThreads(array $thread_ids): null|array {
-        if (count($thread_ids) === 0) {
-            return null;
-        }
-        $placeholders = $this->createParameterList(count($thread_ids));
-        $this->course_db->query("SELECT * FROM posts WHERE parent_id = -1 AND thread_id IN {$placeholders}", $thread_ids);
-        $return = [];
-        foreach ($this->course_db->rows() as $row) {
-            $return[$row['thread_id']] = $row;
-        }
-        return $return;
     }
 
     public function getPost($post_id) {
@@ -1161,39 +826,6 @@ SQL;
         $placeholders = $this->createParameterList(count($author_ids));
         $this->course_db->query("SELECT user_id, user_group FROM users WHERE user_id IN {$placeholders}", $author_ids);
         return $this->course_db->rows();
-    }
-
-    /**
-     * @param int[] $post_ids
-     * @return int[] ids of posts with history
-     */
-    public function getPostsWithHistory(array $post_ids): array {
-        if (count($post_ids) === 0) {
-            return [];
-        }
-        $placeholders = $this->createParameterList(count($post_ids));
-        $this->course_db->query("SELECT DISTINCT post_id FROM forum_posts_history WHERE post_id IN {$placeholders}", $post_ids);
-        return array_column($this->course_db->rows(), "post_id");
-    }
-
-    public function getUnviewedPosts($thread_id, $user_id) {
-        if ($thread_id == -1) {
-            $this->course_db->query("SELECT MAX(id) as max from threads WHERE deleted = false and merged_thread_id = -1 GROUP BY (CASE WHEN pinned_expiration >= current_timestamp THEN 1 ELSE 0 END) ORDER BY (CASE WHEN pinned_expiration >= current_timestamp THEN 1 ELSE 0 END) DESC");
-            $rows = $this->course_db->rows();
-            if (!empty($rows)) {
-                $thread_id = $rows[0]["max"];
-            }
-            else {
-                // No thread found, hence no posts found
-                return [];
-            }
-        }
-        $this->course_db->query("SELECT DISTINCT id FROM (posts LEFT JOIN forum_posts_history ON posts.id = forum_posts_history.post_id) AS pfph WHERE pfph.thread_id = ? AND NOT EXISTS(SELECT * FROM viewed_responses v WHERE v.thread_id = ? AND v.user_id = ? AND (v.timestamp >= pfph.timestamp AND (pfph.edit_timestamp IS NULL OR (pfph.edit_timestamp IS NOT NULL AND v.timestamp >= pfph.edit_timestamp))))", [$thread_id, $thread_id, $user_id]);
-        $rows = $this->course_db->rows();
-        if (empty($rows)) {
-            $rows = [];
-        }
-        return $rows;
     }
 
     /**
@@ -1235,12 +867,6 @@ SQL;
         $this->course_db->query("UPDATE threads SET announced = ? WHERE id = ?", [$now, $thread_id]);
     }
 
-    public function getThreadsBefore($timestamp, $page) {
-        // TODO: Handle request page wise
-        $this->course_db->query("SELECT t.id as id, title from threads t JOIN posts p on p.thread_id = t.id and parent_id = -1 WHERE timestamp < ? and t.deleted = false", [$timestamp]);
-        return $this->course_db->rows();
-    }
-
     public function getThread(int $thread_id) {
         $this->course_db->query("SELECT * from threads where id = ?", [$thread_id]);
         return $this->course_db->row();
@@ -1263,16 +889,6 @@ SQL;
         else {
             $this->course_db->query("DELETE FROM student_favorites where user_id=? and thread_id=?", [$user_id, $thread_id]);
         }
-    }
-
-    public function loadBookmarkedThreads(string $user_id) {
-        $this->course_db->query("SELECT * FROM student_favorites WHERE user_id = ?", [$user_id]);
-        $rows = $this->course_db->rows();
-        $favorite_threads = [];
-        foreach ($rows as $row) {
-            $favorite_threads[] = $row['thread_id'];
-        }
-        return $favorite_threads;
     }
 
     private function findChildren($post_id, $thread_id, &$children, $get_deleted = false) {
@@ -5403,47 +5019,6 @@ AND gc_id IN (
         return count($result) > 0;
     }
 
-    public function existsAnnouncements($show_deleted = false) {
-        $query_delete = $show_deleted ? "true" : "deleted = false";
-        $this->course_db->query("SELECT MAX(id) FROM threads where {$query_delete} AND  merged_thread_id = -1 AND pinned_expiration >= current_timestamp");
-        $result = $this->course_db->rows();
-        return empty($result[0]["max"]) ? -1 : $result[0]["max"];
-    }
-
-    /**
-     * @param int[] $thread_ids
-     * @return int[] thread ids that have been viewed by user
-     */
-    public function getViewedThreads(string $user, array $thread_ids): array {
-        if (count($thread_ids) === 0) {
-            return [];
-        }
-        $placeholders = $this->createParameterList(count($thread_ids));
-        $this->course_db->query(
-            "
-            SELECT * FROM viewed_responses v
-            WHERE thread_id IN {$placeholders}
-            AND user_id = ?
-            AND NOT EXISTS(
-                SELECT thread_id 
-                FROM (
-                    posts LEFT JOIN forum_posts_history 
-                    ON posts.id = forum_posts_history.post_id) 
-                    AS jp 
-                    WHERE jp.thread_id = v.thread_id 
-                    AND (
-                        jp.timestamp > v.timestamp 
-                        OR (
-                            jp.edit_timestamp IS NOT NULL 
-                            AND jp.edit_timestamp > v.timestamp
-                        )
-                    )
-                )",
-            array_merge($thread_ids, [$user])
-        );
-        return array_column($this->course_db->rows(), 'thread_id');
-    }
-
     public function getDisplayUserInfoFromUserId($user_id) {
         $this->course_db->query("SELECT user_givenname, user_preferred_givenname, user_familyname, user_preferred_familyname, user_email, user_pronouns, display_pronouns FROM users WHERE user_id = ?", [$user_id]);
         $name_rows = $this->course_db->rows()[0];
@@ -5455,31 +5030,6 @@ AND gc_id IN (
         $ar["display_pronouns"] = $name_rows["display_pronouns"];
 
         return $ar;
-    }
-
-    /**
-     * @param string[] $user_ids
-     * @return array<string, mixed[]> user info, indexed by user id.
-     */
-    public function getDisplayUserInfoFromUserIds(array $user_ids): array {
-        if (count($user_ids) === 0) {
-            return [];
-        }
-        $unique_users = array_values(array_unique($user_ids));
-        $placeholders = $this->createParameterList(count($unique_users));
-        $this->course_db->query("SELECT * FROM users WHERE user_id IN {$placeholders};", $unique_users);
-        $return = [];
-        foreach ($this->course_db->rows() as $row) {
-            $return[$row['user_id']] = [
-                "given_name" => (isset($row["user_preferred_givenname"]) && strlen($row["user_preferred_givenname"]) > 0) ? $row["user_preferred_givenname"] : $row["user_givenname"],
-                "family_name" => " " . ((isset($row["user_preferred_familyname"]) && strlen($row["user_preferred_familyname"]) > 0) ? $row["user_preferred_familyname"] : $row["user_familyname"]),
-                "user_email" => $row["user_email"],
-                "pronouns" => $row["user_pronouns"],
-                "display_pronouns" => $row["display_pronouns"],
-                "is_staff" => intval($row["user_group"]) <= User::GROUP_LIMITED_ACCESS_GRADER,
-            ];
-        }
-        return $return;
     }
 
     public function filterCategoryDesc($category_desc) {
@@ -5534,47 +5084,6 @@ AND gc_id IN (
 
     public function getCategories() {
         $this->course_db->query("SELECT *, extract(hours from now() - visible_date) as diff from categories_list ORDER BY rank ASC NULLS LAST, category_id");
-        return $this->course_db->rows();
-    }
-
-    public function getPostsForThread($current_user, $thread_id, $show_deleted = false, $option = "tree", $filterOnUser = null) {
-        $query_delete = $show_deleted ? "true" : "deleted = false";
-        $query_filter_on_user = '';
-        $param_list = [];
-        if (!empty($filterOnUser)) {
-            $query_filter_on_user = ' and author_user_id = ? ';
-            $param_list[] = $filterOnUser;
-        }
-        if ($thread_id == -1) {
-            $this->course_db->query("SELECT MAX(id) as max from threads WHERE deleted = false and merged_thread_id = -1 GROUP BY (CASE WHEN pinned_expiration >= current_timestamp THEN 1 ELSE 0 END) ORDER BY (CASE WHEN pinned_expiration >= current_timestamp THEN 1 ELSE 0 END) DESC");
-            $rows = $this->course_db->rows();
-            if (!empty($rows)) {
-                $thread_id = $rows[0]["max"];
-            }
-            else {
-                // No thread found, hence no posts found
-                return [];
-            }
-        }
-        $param_list[] = $thread_id;
-        $history_query = "LEFT JOIN forum_posts_history fph ON (fph.post_id is NULL OR (fph.post_id = posts.id and NOT EXISTS (SELECT 1 from forum_posts_history WHERE post_id = fph.post_id and edit_timestamp > fph.edit_timestamp )))";
-        if ($option == 'alpha') {
-            $this->course_db->query("SELECT posts.*, fph.edit_timestamp, users.user_familyname FROM posts INNER JOIN users ON posts.author_user_id=users.user_id {$history_query} WHERE thread_id=? AND {$query_delete} ORDER BY user_familyname, posts.timestamp, posts.id;", [$thread_id]);
-        }
-        elseif ($option == 'alpha_by_registration') {
-            $order = self::generateOrderByClause(["registration_section", "coalesce(NULLIF(u.user_preferred_familyname, ''), u.user_familyname)"], self::graded_gradeable_key_map_user);
-            $this->course_db->query("SELECT posts.*, fph.edit_timestamp, u.user_familyname FROM posts INNER JOIN users u ON posts.author_user_id=u.user_id {$history_query} WHERE thread_id=? AND {$query_delete} {$order};", [$thread_id]);
-        }
-        elseif ($option == 'alpha_by_rotating') {
-            $order = self::generateOrderByClause(["rotating_section", "coalesce(NULLIF(u.user_preferred_familyname, ''), u.user_familyname)"], self::graded_gradeable_key_map_user);
-            $this->course_db->query("SELECT posts.*, fph.edit_timestamp, u.user_familyname FROM posts INNER JOIN users u ON posts.author_user_id=u.user_id {$history_query} WHERE thread_id=? AND {$query_delete} {$order};", [$thread_id]);
-        }
-        elseif ($option == 'reverse-time') {
-            $this->course_db->query("SELECT posts.*, fph.edit_timestamp FROM posts {$history_query} WHERE thread_id=? AND {$query_delete} {$query_filter_on_user} ORDER BY timestamp DESC, id ASC", array_reverse($param_list));
-        }
-        else {
-            $this->course_db->query("SELECT posts.*, fph.edit_timestamp FROM posts {$history_query} WHERE thread_id=? AND {$query_delete} {$query_filter_on_user} ORDER BY timestamp, id ASC", array_reverse($param_list));
-        }
         return $this->course_db->rows();
     }
 

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -5097,7 +5097,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 18
+			count: 13
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
@@ -5117,12 +5117,12 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 16
+			count: 15
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 36
+			count: 27
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
@@ -5207,76 +5207,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:alreadyInAQueue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$categories_ids with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$current_user with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_join with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_order with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_parameters with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_select with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$query_where with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$show_merged_thread with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$thread_status with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$unread_threads with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$want_categories with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:buildLoadThreadQuery\\(\\) has parameter \\$want_order with no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 
@@ -5751,26 +5681,6 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncements\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncements\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncementsId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsAnnouncementsId\\(\\) has parameter \\$thread_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:existsPost\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
@@ -6112,16 +6022,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getEmailListWithIds\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getFirstPostForThread\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getFirstPostForThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 
@@ -6646,16 +6546,6 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostHistory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostHistory\\(\\) has parameter \\$post_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostOldThread\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
@@ -6667,36 +6557,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPosts\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$current_user with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$filterOnUser with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$option with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$show_deleted with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getPostsForThread\\(\\) has parameter \\$thread_id with no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 
@@ -7011,21 +6871,6 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadsBefore\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadsBefore\\(\\) has parameter \\$page with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getThreadsBefore\\(\\) has parameter \\$timestamp with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getTimeJoinedQueue\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
@@ -7117,21 +6962,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnregisteredStudentsWithRotatingSection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnviewedPosts\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnviewedPosts\\(\\) has parameter \\$thread_id with no type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:getUnviewedPosts\\(\\) has parameter \\$user_id with no type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 
@@ -7417,16 +7247,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:leaveTeam\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:loadBookmarkedThreads\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseQueries\\:\\:loadThreadBlock\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
#11029 rendered a lot of queries in DatabaseQueries.php obsolete, as their usage was replaced by ORM repositories. 

### What is the new behavior?
This removes forum-related queries in DatabaseQueries.php that are now obsolete and are no longer referenced in the codebase. No functionality should change.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
