### PR TITLE
[Bugfix:Forum] Fix users' own posts read display

### DIFF
--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -832,11 +832,11 @@ class ForumThreadView extends AbstractView {
             $classes[] = "first_post";
         }
         $isNewPost = false;
-        if ($thread->getNewPosts($user->getId())->contains($post) || $user->getId() === $post->getAuthor()->getId()) {
+        if ($thread->getNewPosts($user->getId())->contains($post)) {
             $classes[] = "new_post";
             $isNewPost = true;
             if ($post->getAuthor()->accessGrading()) {
-                $classes[] = "important new_post important-new";
+                $classes[] = "important important-new";
             }
         }
         else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
A user's own posts are highlighted as if they're unread.

### What is the new behavior?
Removes special handling for a user's own posts. They now display read/unread like any other.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
