### PR TITLE
[Bugfix:InstructorUI] Fix Downloading Activity Link

### DIFF
--- a/site/app/controllers/admin/StudentActivityDashboardController.php
+++ b/site/app/controllers/admin/StudentActivityDashboardController.php
@@ -57,7 +57,7 @@ class StudentActivityDashboardController extends AbstractController {
     /**
      * @AccessControl(role="INSTRUCTOR")
      */
-    #[Route("/courses/{_semester}/{_course}/activity/download", methods: ["GET"])]
+    #[Route("/courses/{_semester}/{_course}/activity/download_activity", methods: ["GET"])]
     public function downloadData() {
         $data_dump = $this->core->getQueries()->getAttendanceInfo();
         $file_url = FileUtils::joinPaths(

--- a/site/app/templates/admin/users/StudentActivityDashboard.twig
+++ b/site/app/templates/admin/users/StudentActivityDashboard.twig
@@ -5,7 +5,7 @@
         
                             
         <div class="btn-wrapper">
-          <a href="{{download_link}}" class="btn btn-primary">Download as CSV</a>
+          <a href="{{download_link}}" class="btn btn-primary" data-testid="student-activity-download-csv">Download as CSV</a>
         </div>
     </header>
     <p id="in-page-doc">

--- a/site/app/views/admin/StudentActivityDashboardView.php
+++ b/site/app/views/admin/StudentActivityDashboardView.php
@@ -17,7 +17,7 @@ class StudentActivityDashboardView extends AbstractView {
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
         return $this->core->getOutput()->renderTwigTemplate("admin/users/StudentActivityDashboard.twig", [
             "data" => $data_dump,
-            "download_link" => $this->core->buildCourseUrl(['activity', 'download'])
+            "download_link" => $this->core->buildCourseUrl(['activity', 'download_activity'])
         ]);
     }
 

--- a/site/cypress/e2e/Cypress-Feature/student_activity_download.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/student_activity_download.spec.js
@@ -1,0 +1,20 @@
+const header = '"Registration Section","User ID","Given Name","Family Name","Gradeable Access Date","Gradeable Submission Date","Forum View Date","Forum Post Date","Number of Poll Responses","Office Hours Queue Date","Course Materials Access Date"';
+const row1 = '1,adamsg,Gretchen,Adams,,"9996-12-30 23:59:59-05",,,2,,';
+
+describe('Tests cases revolving around student activity download', () => {
+    it('Should download file, and have some correct values', () => {
+        cy.login('instructor');
+
+        cy.visit(['sample', 'activity']);
+
+        cy.get('[data-testid="student-activity-download-csv"]').click();
+
+        cy.readFile('cypress/downloads/Student_Activity.csv')
+            .then((data) => {
+                const rows = data.split('\n');
+
+                expect(rows[0]).to.eql(header);
+                expect(rows[1]).to.eql(row1);
+            });
+    });
+});


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Looking at the activity link, `#[Route("/courses/{_semester}/{_course}/activity/download", methods: ["GET"])]`, it conflicts with another link that was added in #10188,
`#[Route("/courses/{_semester}/{_course}/{gradeable_id}/download", methods: ["GET"])]`.

### What is the new behavior?
Change the route to download_activity, and change the download link to download_activity.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested student activity, verifies that it downloads a CSV
Tested downloading JSON on the gradeable, verifies that it downloads the gradeable JSON
