### PR TITLE
[Feature] Query Saving in SQL Toolbox

### DIFF
--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -552,6 +552,17 @@ ALTER SEQUENCE public.global_calendar_items_id_seq OWNED BY public.global_calend
 
 
 --
+-- Name: instructor_queries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.instructor_queries (
+    user_id character varying NOT NULL,
+    query_name character varying NOT NULL,
+    query character varying NOT NULL
+);
+
+
+--
 -- Name: mapped_courses; Type: TABLE; Schema: public; Owner: -
 --
 

--- a/migration/migrator/migrations/master/20241209161942_instructorQueryTable.py
+++ b/migration/migrator/migrations/master/20241209161942_instructorQueryTable.py
@@ -1,0 +1,41 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    # Create overall comment table
+    database.execute(
+        """
+       CREATE TABLE IF NOT EXISTS instructor_queries (
+            user_id character varying NOT NULL,
+            query_name character varying NOT NULL,
+            query character varying NOT NULL
+        )
+        """
+    )
+
+    pass
+
+
+def down(config, database):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute(
+        """
+        DROP TABLE instructor_queries;
+        """
+    )
+    pass

--- a/site/app/controllers/admin/SqlToolboxController.php
+++ b/site/app/controllers/admin/SqlToolboxController.php
@@ -58,4 +58,81 @@ class SqlToolboxController extends AbstractController {
             $this->core->getCourseDB()->rollback();
         }
     }
+
+    #[Route("/courses/{_semester}/{_course}/saveQuery", methods: ["POST"])]
+    public function saveQuery(): string {
+        $query = trim($_POST['sql']);
+        $name = trim($_POST['name']);
+        $user = $this->core->getUser()->getId();
+
+        if (QueryIdentifier::identify($query) !== QueryIdentifier::SELECT) {
+            return 'Invalid query, can only save SELECT queries.';
+        }
+
+        $semiColonCount = substr_count($query, ';');
+        if ($semiColonCount > 1 || ($semiColonCount === 1 && substr($query, -1) !== ';')) {
+            return 'Detected multiple queries, not saving.';
+        }
+
+        /*
+        print"YEAH THIS IS CALLED. Query: " .$query;
+        if($user == NULL){
+            print "USER IS NULL";
+        }
+        ELSE{
+            print"USER: " .$user;
+            print"QUERY NAME: " .$name;
+        }*/
+
+        try {
+            
+            $this->core->getQueries()->addSQLSavedQuery($user, $name, $query);
+            return "Saving query " .$query;
+        }
+        catch(DatabaseException $exc) {
+            print "ERROR " .$exc;
+        }
+        return "a";
+    }
+
+    #[Route("/courses/{_semester}/{_course}/removeQuery", methods: ["POST"])]
+    public function removeQuery(): string {
+        $name = trim($_POST['name']);
+        $user = $this->core->getUser()->getId();
+
+        if($user == NULL){
+            print "USER IS NULL";
+        }
+        ELSE{
+            print"USER: " .$user;
+            print"QUERY NAME: " .$name;
+        }
+
+        try {
+            
+            $this->core->getQueries()->removeSQLSavedQuery($user, $name);
+            return "Removing query named" .$name;
+        }
+        catch(DatabaseException $exc) {
+            print "ERROR " .$exc;
+        }
+        return "a";
+    }
+
+    #[Route("/courses/{_semester}/{_course}/getQueries", methods: ["GET"])]
+    public function getQueries(): JsonResponse {
+        $user = $this->core->getUser()->getId();
+
+        if($user == NULL){
+            return JsonResponse::getFailResponse('user is null');
+        }
+
+        try {
+            $queries = $this->core->getQueries()->getSQLSavedQueries($user);
+            return JsonResponse::getSuccessResponse($queries);
+        }
+        catch(DatabaseException $exc) {
+            return JsonResponse::getFailResponse('Detected errorz');
+        }
+    }
 }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -9371,4 +9371,28 @@ ORDER BY
         ");
         return $this->rowsToArray($this->submitty_db->rows());
     }
+
+    public function addSQLSavedQuery(string $user_id, string $query_name, string $query) {
+        $this->submitty_db->beginTransaction();
+        $this->submitty_db->query("
+            INSERT INTO instructor_queries (user_id, query_name, query)
+                VALUES (?, ?, ?)
+        ", [$user_id, $query_name, $query]);
+        $this->submitty_db->commit();
+    }
+
+    public function removeSQLSavedQuery(string $user_id, string $query_name) {
+        $this->submitty_db->beginTransaction();
+        $this->submitty_db->query("
+            DELETE FROM instructor_queries WHERE user_id = ? AND query_name = ?;
+        ", [$user_id, $query_name]);
+        $this->submitty_db->commit();
+    }
+
+    public function getSQLSavedQueries(string $user_id): array {
+        $this->submitty_db->query("
+            SELECT query_name,query FROM instructor_queries WHERE user_id = ?;
+        ", [$user_id]);
+        return $this->rowsToArray($this->submitty_db->rows());
+    }
 }

--- a/site/app/templates/admin/SqlToolbox.twig
+++ b/site/app/templates/admin/SqlToolbox.twig
@@ -31,6 +31,27 @@
       <br />
       <button id='run-sql-btn' class="btn btn-primary">Run Query</button>
       <button id='download-sql-btn' class="btn btn-primary" disabled>Download CSV</button>
+      <hr>
+      <h2>Load Queries</h2>
+      <p>If you have any saved queries, they will appear here.</p>
+      <div id="saved-queries">
+      </div>
+      <hr>
+      <h2>Save/Unsave Queries</h2>
+      In the box below, input the name of the query you'd like to save.
+      <br>
+      <textarea id="toolbox-namearea" name="saved-name" style="margin-bottom: 2px;" aria-label="Save SQL Name"></textarea>
+      <br />
+      In the box below, input the query you'd like to save. Once you've typed a name and query, press "Save Query".
+      <br />
+      <textarea id="toolbox-textarea" name="saved-sql" style="margin-bottom: 2px;" aria-label="Save SQL Query"></textarea>
+      <button id='save-sql-btn' class="btn btn-primary">Save Query</button>
+      <br />
+      Alternatively, input the name of a query below and press "Unsave Query" if you'd like to delete a query.
+      <br />
+      <textarea id="toolbox-namearea" name="removal-name" style="margin-bottom: 2px;" aria-label="Save SQL Name"></textarea>
+      <button id='remove-sql-btn' class="btn btn-primary">Unsave Query</button>
+      <hr>
     </div>
 
     <div>

--- a/site/public/css/sql-toolbox.css
+++ b/site/public/css/sql-toolbox.css
@@ -4,6 +4,12 @@
     resize: vertical;
 }
 
+#toolbox-namearea {
+    width: 25%;
+    min-height: 25px;
+    resize: vertical;
+}
+
 #query-results {
     overflow-x: auto;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, instructors have no way to save their queries for the SQL toolbox in submitty. They either have to type them manually each time or save them to a .txt file which is annoying.

### What is the new behavior?
Now, you can save queries and remove queries. They're loaded based solely on the user_id of the instructor, so any saved queries will always appear regardless of what course and term they open the SQL toolbox in. 

![image](https://github.com/user-attachments/assets/a2643350-c798-4160-baac-ad1bfd8cf379)

Any saved queries will appear as buttons under "Load Queries". Upon clicking one of the saved query buttons, it will load the query into the "Run Query" textbox.

### Other information?
To test, go to SQL toolbox and try saving/unsaving queries and making sure you can run them. Also make sure the queries appear when accessed through other courses.

To save, input the name of the query you'd like to save and the query in their respective textboxes. Upon clicking save, the page should immediately add it to the "Load queries" section.

To unsave/delete, input the name of the query you want to get rid of in the respective textbox, and click "Unsave Query".