### PR TITLE
[Bugfix:InstructorUI] Dupe Poll Responses count as one answer

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -207,7 +207,7 @@ class DatabaseQueries {
         FROM posts
         ORDER BY author_user_id, timestamp desc),
         F AS
-        (SELECT student_id, count (student_id)
+        (SELECT student_id, count (DISTINCT poll_id)
         FROM poll_responses
         GROUP BY student_id),
         G AS


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fix #11234 and Fix #11223.
The old behavior was that every poll response counted as an answer for the student in the activity dashboard. This was added before the multi-select poll option, so for the same poll, the student could have answered it more than one time
### What is the new behavior?
This makes sure that we only have unique poll_id's being counted

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
