### PR TITLE
[UI/UX:RainbowGrades] Always enable gradebook for instructors

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -294,7 +294,6 @@ class GlobalController extends AbstractController {
 
         if (
             $this->core->getUser()->accessAdmin()
-            && $this->core->getConfig()->displayRainbowGradesSummary()
         ) {
             $sidebar_buttons[] = new NavButton($this->core, [
                 "href" => $this->core->buildCourseUrl(["gradebook"]),

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -26,7 +26,7 @@ class ReportView extends AbstractView {
         $display_rainbow_grades_summary = $this->core->getConfig()->displayRainbowGradesSummary();
 
         return $this->core->getOutput()->renderTwigTemplate("submission/RainbowGrades.twig", [
-            "show_summary" => $display_rainbow_grades_summary && $grade_file !== null,
+            "show_summary" => $grade_file !== null,
             "grade_file" => $grade_file,
             "extra_label" => "For All Students",
             "grade_summaries_last_run" => $grade_summaries_last_run,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The visibility of both the instructor's **Gradebook** and the student's **Rainbow Grades** depends on whether 'Display Rainbow Grades Summary' is toggled on the **Course Settings** page. This prevents instructors from downloading the CSV of grades without displaying Rainbow Grades to all students.

### What is the new behavior?
The **Gradebook** is visible to instructors without regard to whether 'Display Rainbow Grades Summary' is toggled.

https://github.com/user-attachments/assets/ed597507-118d-4923-adac-438934244b3c



### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
