### PR TITLE
[Bugfix:SubminiPolls] Prevent Quote Escaping in Histogram

### DIFF
--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -169,8 +169,8 @@
             [window.getComputedStyle(document.body).getPropertyValue('--histogram-correct'),
                 window.getComputedStyle(document.body).getPropertyValue('--histogram-default')];
             {% for option in poll.getOptions() %}
-                data[0].x.push("{{ option.getResponse()|replace({"\n": " ", "\r": " ", "\t": " "}) }}");
-                data[0].y.push({{ response_counts[option.getId()] }});
+                data[0].x.push("{{ option.getResponse()|raw |escape('js') |replace({"\n": " ", "\r": " ", "\t": " "}) }}");
+                data[0].y.push({{ response_counts[ option.getId()] }});
                 data[0].marker.color.push(
                     {{ option.isCorrect() and poll.isReleaseAnswer() ? 'correctColor': 'defaultColor' }}
                 );


### PR DESCRIPTION
   * [ ] Tests for the changes have been added/updated (if possible)
   * [ ] Documentation has been updated/added if relevant
   * [x] Screenshots are attached to Github PR if visual/UI changes were made
Closes #11256 
   ### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes  #<number>" or "Closes #11256 " syntax -->
   If the x-labels of a Histogram contain strings of numbers, the quotes in the strings are being represented as `&quot;`  instead of the expected `"` format.
 This issue arises due to automatic escaping, which converts quotes to their HTML entity representation.

 ### What is the new behavior?
 The x-labels of the Histogram now correctly display strings of numbers with quotes represented as `"` (double quotes)
 instead of `&quot;`.

![Screenshot from 2024-12-19 17-04-57](https://github.com/user-attachments/assets/ff8b23e0-fba9-4af2-b9fd-8a8c4d91c738)

### Other information?
  <!-- Is this a breaking change? -->
  <!-- How did you test -->

