### PR TITLE
[Bugfix:SubminiPolls] Prevent Quote Escaping in Histogram

### DIFF
--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -169,7 +169,7 @@
             [window.getComputedStyle(document.body).getPropertyValue('--histogram-correct'),
                 window.getComputedStyle(document.body).getPropertyValue('--histogram-default')];
             {% for option in poll.getOptions() %}
-                data[0].x.push("{{ option.getResponse()|e('js')|replace({"\n": " ", "\r": " ", "\t": " "}) }}");
+                data[0].x.push("{{ option.getResponse()|replace({"\n": " ", "\r": " ", "\t": " "})|e('js') }}");
                 data[0].y.push({{ response_counts[option.getId()] }});
                 data[0].marker.color.push(
                     {{ option.isCorrect() and poll.isReleaseAnswer() ? 'correctColor': 'defaultColor' }}

--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -169,7 +169,7 @@
             [window.getComputedStyle(document.body).getPropertyValue('--histogram-correct'),
                 window.getComputedStyle(document.body).getPropertyValue('--histogram-default')];
             {% for option in poll.getOptions() %}
-                data[0].x.push("{{ option.getResponse() |e('js') |replace({"\n": " ", "\r": " ", "\t": " "}) }}");
+                data[0].x.push("{{ option.getResponse()|e('js')|replace({"\n": " ", "\r": " ", "\t": " "}) }}");
                 data[0].y.push({{ response_counts[option.getId()] }});
                 data[0].marker.color.push(
                     {{ option.isCorrect() and poll.isReleaseAnswer() ? 'correctColor': 'defaultColor' }}

--- a/site/app/templates/polls/ViewPoll.twig
+++ b/site/app/templates/polls/ViewPoll.twig
@@ -169,7 +169,7 @@
             [window.getComputedStyle(document.body).getPropertyValue('--histogram-correct'),
                 window.getComputedStyle(document.body).getPropertyValue('--histogram-default')];
             {% for option in poll.getOptions() %}
-                data[0].x.push("{{ option.getResponse()|replace({"\n": " ", "\r": " ", "\t": " "}) }}");
+                data[0].x.push("{{ option.getResponse() |e('js') |replace({"\n": " ", "\r": " ", "\t": " "}) }}");
                 data[0].y.push({{ response_counts[option.getId()] }});
                 data[0].marker.color.push(
                     {{ option.isCorrect() and poll.isReleaseAnswer() ? 'correctColor': 'defaultColor' }}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

Closes #11256  
### What is the current behavior?
If the x-labels of a Histogram contain strings of numbers, the quotes in the strings are being represented as `&quot;` instead of the expected `"` format.
This issue arises due to automatic escaping, which converts quotes to their HTML entity representation.
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #11256 " syntax -->

### What is the new behavior?
The x-labels of the Histogram now correctly display strings of numbers with quotes represented as `"` (double quotes)
instead of `&quot;`.

![Screenshot from 2024-12-19 17-04-57](https://github.com/user-attachments/assets/3f86207f-002e-4a22-a000-5e683cb7ddc8)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

