### PR TITLE
[Bugfix:TAGrading] Checkpoint validation when max is 0

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -423,7 +423,7 @@ function setupNumericTextCells() {
             }
             // Input greater than the max_clamp for the component is not allowed
             else {
-                if (elem.data('maxclamp') && elem.data('maxclamp') < this.value) {
+                if (elem.data('maxclamp') !== null && elem.data('maxclamp') < this.value) {
                     alert(`Score should be less than or equal to the max clamp value: ${elem.data('maxclamp')}`);
                     this.value = 0;
                 }


### PR DESCRIPTION
Fixes #11269 

This PR Resolved Validation issue when maxClamp is zero .
Updated the condition to explicitly check for null to handle 0 correctly.