### PR TITLE
[Bugfix:TAGrading] Remove Debug logging statements

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -225,8 +225,6 @@ function changeStudentArrowTooltips(data) {
             data = 'default';
         }
     }
-    console.log(inquiry_status);
-    console.log(data);
     let component_id = NO_COMPONENT_ID;
     switch (data) {
         case 'ungraded':
@@ -302,7 +300,6 @@ const orig_toggleComponent = window.toggleComponent;
 window.toggleComponent = function (component_id, saveChanges) {
     const ret = orig_toggleComponent(component_id, saveChanges);
     return ret.then(() => {
-        console.log(localStorage.getItem('general-setting-arrow-function'));
         changeStudentArrowTooltips(localStorage.getItem('general-setting-arrow-function') || 'default');
     });
 };


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
I noticed that everytime a TA grades something, there are multiple console.log statements that are being logged in console, all of which were debug logging statements

### What is the new behavior?
removed the console.log statements that serves no purpose

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
