### PR TITLE
[Refactor:Forum] Remove Hard-coded colors in css

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -18,7 +18,6 @@
 .content h2 {
     margin-bottom: 10px;
 }
-
 /* stylelint-disable-next-line selector-class-pattern */
 .forum_bar {
     margin-right: 10px;
@@ -58,7 +57,7 @@
 
 /* stylelint-disable-next-line selector-class-pattern */
 .post_viewed_btn {
-    background-color: #dcdcdcb5 !important;
+    background-color: var(--standard-light-gray) !important;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -76,7 +75,7 @@
 /* stylelint-disable-next-line selector-class-pattern */
 .post_box {
     position: relative;
-    box-shadow: 0 2px 15px -5px #888888;
+    box-shadow: 0 2px 15px -5px var(--standard-medium-gray);
     padding: 7px;
     margin-top: 20px;
     word-wrap: break-word;
@@ -106,7 +105,6 @@
 .thread_box h5 {
     font-weight: normal;
 }
-
 /* stylelint-disable-next-line selector-id-pattern */
 #thread_list a {
     text-decoration: none;
@@ -120,8 +118,8 @@
     min-width: 40px;
     min-height: 40px;
     position: relative;
-    background: rgb(255 255 255 / 80%);
-    box-shadow: 2px 2px 4px -3px #dddddd;
+    background: var(--btn-default-white);
+    box-shadow: 2px 2px 4px -3px var(--standard-light-gray);
 }
 
 .reply-box {
@@ -177,13 +175,13 @@
 
 .active-thread-remove-announcement {
     display: inline-block;
-    color: orange;
+    color: var(--standard-medium-orange);
 }
 
 .active-thread-announcement-expiring {
     position: relative;
     display: inline-block;
-    color: gold;
+    color: var(--standard-tangerine-yellow);
     -webkit-text-stroke-width: 1px;
     -webkit-text-stroke-color: black;
 }
@@ -201,30 +199,29 @@
 .pinned-thread {
     position: relative;
     display: inline-block;
-    color: orange;
+    color: var(--standard-medium-orange);
 }
 
 .not-active-thread-announcement {
     position: relative;
     display: inline-block;
-    color: #e0e0e0;
+    color: var(--standard-hover-light-gray);
     -webkit-text-stroke-width: 1px;
-    -webkit-text-stroke-color: black;
+    -webkit-text-stroke-color: var(--standard-gray-black);
 }
 
 .not-active-thread-announcement i.fas,
 .pinned-thread i.fas {
-    color: #e0e0e0;
-    -webkit-text-stroke: 1px black;
+    color: var(--standard-hover-light-gray);
+    -webkit-text-stroke: 1px var(--standard-gray-black);
 }
-
 .not-active-thread-announcement:hover {
-    text-shadow: gold 0 0 5px;
+    text-shadow: var(--standard-tangerine-yellow) 0 0 5px;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
 .golden_hover {
-    color: #e0e0e0 !important;
+    color: var(--standard-hover-light-gray) !important;
 }
 
 .red-hover:hover {
@@ -234,7 +231,7 @@
 
 /* stylelint-disable-next-line selector-class-pattern */
 .reverse_golden_hover {
-    color: gold;
+    color: var(--standard-tangerine-yellow);
 }
 
 .text-decoration-none {
@@ -305,7 +302,7 @@
     position: relative;
     display: inline-block;
     -webkit-text-stroke-width: 1px;
-    -webkit-text-stroke-color: black;
+    -webkit-text-stroke-color: var(--standard-gray-black);
 }
 
 .current-favorite i.fas {
@@ -313,7 +310,7 @@
 }
 
 .active-thread-remove-expiring-announcement i.fas {
-    color: gold !important;
+    color: var(--standard-tangerine-yellow) !important;
 }
 
 .active-thread-remove-announcement i.fas {
@@ -356,7 +353,7 @@
 }
 
 .content.create-thread-message {
-    border: solid gold 4px;
+    border: solid var(--standard-tangerine-yellow) 4px;
     margin: 15px;
     padding: 20px;
     word-break: break-word;
@@ -372,11 +369,11 @@
     float: right;
     display: inline-block;
     -webkit-text-stroke-width: 1px;
-    -webkit-text-stroke-color: black;
+    -webkit-text-stroke-color: var(--standard-gray-black);
 }
 
 .thread-announcement-expiring {
-    color: gold;
+    color: var(--standard-tangerine-yellow);
 }
 
 .thread-favorite {
@@ -389,7 +386,7 @@
 
 .thread-merged,
 .thread-locked {
-    color: white;
+    color: var(--btn-default-white);
 }
 
 .thead-content {
@@ -648,14 +645,14 @@
     padding: 19px;
     margin-bottom: 20px;
     background-color: var(--attachment-box-color);
-    border: 1px solid #e3e3e3;
+    border: 1px solid var(--standard-light-gray);
     border-radius: 4px;
-    box-shadow: inset 0 1px 1px rgb(0 0 0 / 5%);
+    box-shadow: inset 0 1px 1px var(--btn-default-hover);
 }
 
 .well blockquote {
-    border-color: #dddddd;
-    border-color: rgb(0 0 0 / 15%);
+    border-color: var(--standard-light-gray);
+    border-color: var(--standard-light-gray);
 }
 
 .well-lg {
@@ -669,7 +666,7 @@
 }
 
 .attachment-img {
-    border: 1px solid #dddddd;
+    border: 1px solid var(--standard-light-gray);
     border-radius: 4px;
     padding: 5px;
     max-width: 400px;
@@ -678,7 +675,7 @@
 }
 
 .attachment-img:hover {
-    box-shadow: 0 0 2px 1px rgb(0 140 186 / 50%);
+    box-shadow: 0 0 2px 1px var(--standard-gray-blue);
     cursor: pointer;
 }
 /* stylelint-disable-next-line selector-id-pattern */
@@ -723,11 +720,10 @@
 .filter-active,
 .filter-active:hover {
     background: var(--actionable-blue);
-    color: white;
+    color: var(--always-default-white);
 }
-
 .filter-inactive {
-    background: #ffffff;
+    background: var(--always-default-white);
     color: var(--actionable-blue);
 }
 
@@ -755,13 +751,13 @@
 /* stylelint-enable selector-class-pattern */
 /* stylelint-disable-next-line selector-class-pattern */
 [data-theme="dark"] .post_box:not(.important) {
-    border: 1px solid #bbbbbb;
+    border: 1px solid var(--standard-light-medium-gray);
 }
 
 .thread-box-full {
     padding: 10px 20px;
     margin: 5px auto;
-    border: 1px solid #808080;
+    border: 1px solid var(--standard-medium-gray);
 }
 /* stylelint-disable-next-line selector-class-pattern */
 .thread_box .flex-row,

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -215,6 +215,7 @@
     color: var(--standard-hover-light-gray);
     -webkit-text-stroke: 1px var(--standard-gray-black);
 }
+
 .not-active-thread-announcement:hover {
     text-shadow: var(--standard-tangerine-yellow) 0 0 5px;
 }
@@ -652,7 +653,6 @@
 
 .well blockquote {
     border-color: var(--standard-light-gray);
-    border-color: var(--standard-light-gray);
 }
 
 .well-lg {
@@ -722,6 +722,7 @@
     background: var(--actionable-blue);
     color: var(--always-default-white);
 }
+
 .filter-inactive {
     background: var(--always-default-white);
     color: var(--actionable-blue);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #11220 
The <code>forum.css</code> had hard-coded colors different from the ones present in <code>colors.css</code>

### What is the new behavior?
Updated <code>forum.css</code> with colors similar to the existing ones in <code>colors.css</code>
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
The PR linked previously (#11222 ) failed the CI css linter. It has been fixed in this PR.
