### PR TITLE
[Bugfix:Leaderboard] Fixed access to leaderboard

### DIFF
--- a/site/app/controllers/student/LeaderboardController.php
+++ b/site/app/controllers/student/LeaderboardController.php
@@ -19,6 +19,18 @@ class LeaderboardController extends AbstractController {
             return new RedirectResponse($this->core->buildCourseUrl([]));
         }
 
+        if (
+            !$this->core->getUser()->accessGrading()
+            && (
+                !$gradeable->isSubmissionOpen()
+                || !$gradeable->isStudentView()
+                || $gradeable->isStudentViewAfterGrades()
+                && !$gradeable->isTaGradeReleased()
+            )
+        ) {
+            return new RedirectResponse($this->core->buildCourseUrl(['gradeable', $gradeable_id]));
+        }
+
         $leaderboards = [];
 
         $autogradingConfig = $gradeable->getAutogradingConfig();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

After the instructor removes access to a gradable, a student cannot access the same, even if he has saved the link as a bookmark. However, the access to the leaderboard feature of the gradable is not restricted. A student can still access the leaderboard of the gradable if he would have earlier saved the link via a bookmark.
### What is the new behavior?
Fixes #11100 
![image](https://github.com/user-attachments/assets/ceeb37d4-72a6-4444-8583-e05b26196018)
Upon trying to access the leaderboard page of the gradable whose access has  been restricted, the student is now redirected back to the page which says "leaderboard is not a valid electronic gradable..."

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
